### PR TITLE
perf(napi/parser, linter/plugins): use `Int32Array` in raw transfer deserializer

### DIFF
--- a/apps/oxlint/src-js/generated/constants.ts
+++ b/apps/oxlint/src-js/generated/constants.ts
@@ -17,7 +17,7 @@ export const BUFFER_ALIGN = 4294967296;
 export const ACTIVE_SIZE = 2147483552;
 
 /**
- * Byte offset of the data pointer within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the data pointer within the buffer, divided by 4 (for `Int32Array` indexing).
  */
 export const DATA_POINTER_POS_32 = 536870900;
 

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -7,6 +7,7 @@ import { getNodeLoc } from "../plugins/location.js";
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -36,6 +37,7 @@ export function deserializeProgramOnly(buffer, sourceText, sourceStartPosInput, 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -48,14 +50,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -2328,8 +2330,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let start,
       end,
       previousParent = parent,
@@ -2362,7 +2364,7 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent,
-    hasInitializer = uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0;
+    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -3248,7 +3250,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -3267,7 +3269,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -3292,7 +3294,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -3317,7 +3319,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3838,7 +3840,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5878,9 +5880,9 @@ function deserializeUpdateOperator(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len,
     isInSourceRegion = pos >= sourceStartPos;
   if (isInSourceRegion && end <= firstNonAsciiPos)
@@ -5910,8 +5912,8 @@ function deserializeStr(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -5922,8 +5924,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -5932,170 +5934,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -6104,14 +6106,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -6120,7 +6122,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -6128,18 +6130,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -6150,8 +6152,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -6160,36 +6162,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -6198,11 +6200,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -6212,8 +6214,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -6222,11 +6224,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -6234,8 +6236,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -6244,15 +6246,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -6260,110 +6262,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -6372,11 +6374,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -6390,7 +6392,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -6398,8 +6400,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -6408,17 +6410,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -6428,26 +6430,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -6456,11 +6458,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6472,8 +6474,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -6482,41 +6484,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6524,8 +6526,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -6536,8 +6538,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -6546,11 +6548,11 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6562,8 +6564,8 @@ function deserializeOptionTSAccessibility(pos) {
 function deserializeVecTSClassImplements(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 40;
@@ -6572,14 +6574,14 @@ function deserializeVecTSClassImplements(pos) {
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -6588,47 +6590,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -6638,8 +6640,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -6648,38 +6650,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -6694,8 +6696,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -6720,14 +6722,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -6736,11 +6738,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6748,8 +6750,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -6758,23 +6760,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -6782,22 +6784,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -6806,158 +6808,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -6968,8 +6970,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -6978,15 +6980,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -6996,8 +6998,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -7008,8 +7010,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -7018,14 +7020,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -7034,26 +7036,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -7066,15 +7068,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -7084,7 +7086,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -7092,7 +7094,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {

--- a/apps/oxlint/src-js/package/parse.ts
+++ b/apps/oxlint/src-js/package/parse.ts
@@ -75,7 +75,7 @@ export function parse(path: string, sourceText: string, options?: ParseOptions) 
   // Check parsing succeeded.
   // 0 is used as sentinel value to indicate parsing failed.
   // TODO: Get parsing error details from Rust to display nicely.
-  const programOffset = buffer.uint32[DATA_POINTER_POS_32];
+  const programOffset = buffer.int32[DATA_POINTER_POS_32];
   if (programOffset === 0) throw new Error("Parsing failed");
 }
 

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -60,10 +60,10 @@ export function setupSourceForFile(bufferInput: BufferWithArrays, hasBOMInput: b
  */
 export function initSourceText(): void {
   debugAssertIsNonNull(buffer);
-  const { uint32 } = buffer,
-    programPos = uint32[DATA_POINTER_POS_32];
-  sourceStartPos = uint32[(programPos + SOURCE_START_OFFSET) >> 2];
-  sourceByteLen = uint32[(programPos + SOURCE_LEN_OFFSET) >> 2];
+  const { int32 } = buffer,
+    programPos = int32[DATA_POINTER_POS_32];
+  sourceStartPos = int32[(programPos + SOURCE_START_OFFSET) >> 2];
+  sourceByteLen = int32[(programPos + SOURCE_LEN_OFFSET) >> 2];
 
   // This will throw an error "Cannot create a string longer than 0x1fffffe8 characters"
   // if `sourceByteLen > (2 ** 29 - 24)` (slightly less than 512 MiB).

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -171,8 +171,8 @@ impl ESTree for CatchParameterConverter<'_, '_> {
     ts_type = "ParamPattern[]",
     raw_deser = "
         const params = DESER[Vec<FormalParameter>](POS_OFFSET.items);
-        if (uint32[(POS_OFFSET.rest) >> 2] !== 0 && uint32[(POS_OFFSET.rest + 4) >> 2] !== 0) {
-            pos = uint32[(POS_OFFSET.rest) >> 2];
+        if (int32[(POS_OFFSET.rest) >> 2] !== 0 && int32[(POS_OFFSET.rest + 4) >> 2] !== 0) {
+            pos = int32[(POS_OFFSET.rest) >> 2];
 
             let start, end;
             const previousParent = parent;
@@ -255,7 +255,7 @@ impl ESTree for FormalParameterRest<'_> {
     raw_deser = "
         let param;
         const previousParent = parent;
-        const hasInitializer = uint32[(POS_OFFSET.initializer) >> 2] !== 0 && uint32[(POS_OFFSET.initializer + 4) >> 2] !== 0;
+        const hasInitializer = int32[(POS_OFFSET.initializer) >> 2] !== 0 && int32[(POS_OFFSET.initializer + 4) >> 2] !== 0;
 
         if (IS_TS) {
             const accessibility = DESER[Option<TSAccessibility>](POS_OFFSET.accessibility),

--- a/napi/parser/bench.bench.js
+++ b/napi/parser/bench.bench.js
@@ -189,7 +189,7 @@ for (const { filename, code } of fixtures) {
       token: TOKEN,
     };
 
-    const programPos = buffer.uint32[DATA_POINTER_POS_32] + PROGRAM_OFFSET;
+    const programPos = buffer.int32[DATA_POINTER_POS_32] + PROGRAM_OFFSET;
 
     benchRaw("parser_napi_raw_lazy_visit_only(debugger)", () => {
       ast.nodes = new Map();

--- a/napi/parser/src-js/generated/constants.js
+++ b/napi/parser/src-js/generated/constants.js
@@ -17,7 +17,7 @@ export const BUFFER_ALIGN = 4294967296;
 export const ACTIVE_SIZE = 2147483552;
 
 /**
- * Byte offset of the data pointer within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the data pointer within the buffer, divided by 4 (for `Int32Array` indexing).
  */
 export const DATA_POINTER_POS_32 = 536870900;
 

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -22,6 +23,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -33,14 +35,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -1736,8 +1738,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let rest = {
       type: "RestElement",
       argument: null,
@@ -1752,7 +1754,7 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param;
-  if (uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0) {
+  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
     param = {
       type: "AssignmentPattern",
       left: null,
@@ -2327,7 +2329,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2342,7 +2344,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2362,7 +2364,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -2382,7 +2384,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -2800,7 +2802,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -4550,9 +4552,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -4579,8 +4581,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -4589,7 +4591,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -4597,8 +4599,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -4609,8 +4611,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -4619,170 +4621,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -4791,14 +4793,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -4807,7 +4809,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -4815,18 +4817,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -4837,8 +4839,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -4847,36 +4849,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -4885,11 +4887,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -4899,8 +4901,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -4909,11 +4911,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -4921,8 +4923,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -4931,15 +4933,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -4947,110 +4949,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -5059,11 +5061,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5077,7 +5079,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5085,8 +5087,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -5095,17 +5097,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5115,26 +5117,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -5143,11 +5145,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5159,8 +5161,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -5169,41 +5171,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5211,8 +5213,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -5223,8 +5225,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -5233,24 +5235,24 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -5259,47 +5261,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -5309,8 +5311,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -5319,38 +5321,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -5365,8 +5367,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -5391,14 +5393,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -5407,11 +5409,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -5419,8 +5421,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -5429,23 +5431,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -5453,22 +5455,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -5477,158 +5479,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -5639,8 +5641,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -5649,15 +5651,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -5667,8 +5669,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -5679,8 +5681,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -5689,14 +5691,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -5705,26 +5707,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -5737,15 +5739,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -5755,7 +5757,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -5763,7 +5765,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -5771,7 +5773,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -5779,8 +5781,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -5791,8 +5793,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -5803,8 +5805,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -5815,8 +5817,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -5827,8 +5829,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -5839,8 +5841,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -5851,8 +5853,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -5863,8 +5865,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -23,6 +24,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -34,14 +36,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -1937,8 +1939,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let previousParent = parent,
       rest = (parent = {
         type: "RestElement",
@@ -1957,7 +1959,7 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent;
-  if (uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0) {
+  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
     param = parent = {
       type: "AssignmentPattern",
       left: null,
@@ -2604,7 +2606,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2621,7 +2623,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2644,7 +2646,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -2667,7 +2669,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3127,7 +3129,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5081,9 +5083,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -5110,8 +5112,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -5120,7 +5122,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5128,8 +5130,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -5140,8 +5142,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -5150,170 +5152,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -5322,14 +5324,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -5338,7 +5340,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -5346,18 +5348,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -5368,8 +5370,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -5378,36 +5380,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -5416,11 +5418,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -5430,8 +5432,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -5440,11 +5442,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5452,8 +5454,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -5462,15 +5464,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -5478,110 +5480,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -5590,11 +5592,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5608,7 +5610,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5616,8 +5618,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -5626,17 +5628,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5646,26 +5648,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -5674,11 +5676,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5690,8 +5692,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -5700,41 +5702,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5742,8 +5744,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -5754,8 +5756,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -5764,24 +5766,24 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -5790,47 +5792,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -5840,8 +5842,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -5850,38 +5852,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -5896,8 +5898,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -5922,14 +5924,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -5938,11 +5940,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -5950,8 +5952,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -5960,23 +5962,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -5984,22 +5986,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -6008,158 +6010,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -6170,8 +6172,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -6180,15 +6182,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -6198,8 +6200,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -6210,8 +6212,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -6220,14 +6222,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -6236,26 +6238,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -6268,15 +6270,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6286,7 +6288,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -6294,7 +6296,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -6302,7 +6304,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -6310,8 +6312,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -6322,8 +6324,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -6334,8 +6336,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -6346,8 +6348,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -6358,8 +6360,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -6370,8 +6372,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -6382,8 +6384,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -6394,8 +6396,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -22,6 +23,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -33,14 +35,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -1927,8 +1929,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let start,
       end,
       rest = {
@@ -1946,7 +1948,7 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param;
-  if (uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0) {
+  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
     let start, end;
     param = {
       type: "AssignmentPattern",
@@ -2587,7 +2589,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2603,7 +2605,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2624,7 +2626,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -2645,7 +2647,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3107,7 +3109,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5092,9 +5094,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -5121,8 +5123,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -5131,7 +5133,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5139,8 +5141,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -5151,8 +5153,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -5161,170 +5163,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -5333,14 +5335,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -5349,7 +5351,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -5357,18 +5359,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -5379,8 +5381,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -5389,36 +5391,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -5427,11 +5429,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -5441,8 +5443,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -5451,11 +5453,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5463,8 +5465,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -5473,15 +5475,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -5489,110 +5491,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -5601,11 +5603,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5619,7 +5621,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5627,8 +5629,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -5637,17 +5639,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5657,26 +5659,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -5685,11 +5687,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5701,8 +5703,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -5711,41 +5713,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5753,8 +5755,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -5765,8 +5767,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -5775,24 +5777,24 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -5801,47 +5803,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -5851,8 +5853,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -5861,38 +5863,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -5907,8 +5909,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -5933,14 +5935,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -5949,11 +5951,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -5961,8 +5963,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -5971,23 +5973,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -5995,22 +5997,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -6019,158 +6021,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -6181,8 +6183,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -6191,15 +6193,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -6209,8 +6211,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -6221,8 +6223,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -6231,14 +6233,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -6247,26 +6249,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -6279,15 +6281,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6297,7 +6299,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -6305,7 +6307,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -6313,7 +6315,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -6321,8 +6323,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -6333,8 +6335,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -6345,8 +6347,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -6357,8 +6359,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -6369,8 +6371,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -6381,8 +6383,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -6393,8 +6395,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -6405,8 +6407,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -23,6 +24,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -34,14 +36,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -2131,8 +2133,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let start,
       end,
       previousParent = parent,
@@ -2154,7 +2156,7 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent;
-  if (uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0) {
+  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
     let start, end;
     param = parent = {
       type: "AssignmentPattern",
@@ -2867,7 +2869,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2885,7 +2887,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2909,7 +2911,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -2933,7 +2935,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3437,7 +3439,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5626,9 +5628,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -5655,8 +5657,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -5665,7 +5667,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5673,8 +5675,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -5685,8 +5687,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -5695,170 +5697,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -5867,14 +5869,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -5883,7 +5885,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -5891,18 +5893,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -5913,8 +5915,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -5923,36 +5925,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -5961,11 +5963,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -5975,8 +5977,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -5985,11 +5987,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5997,8 +5999,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -6007,15 +6009,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -6023,110 +6025,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -6135,11 +6137,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -6153,7 +6155,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -6161,8 +6163,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -6171,17 +6173,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -6191,26 +6193,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -6219,11 +6221,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6235,8 +6237,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -6245,41 +6247,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6287,8 +6289,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -6299,8 +6301,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -6309,24 +6311,24 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -6335,47 +6337,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -6385,8 +6387,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -6395,38 +6397,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -6441,8 +6443,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -6467,14 +6469,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -6483,11 +6485,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6495,8 +6497,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -6505,23 +6507,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -6529,22 +6531,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -6553,158 +6555,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -6715,8 +6717,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -6725,15 +6727,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -6743,8 +6745,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -6755,8 +6757,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -6765,14 +6767,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -6781,26 +6783,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -6813,15 +6815,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6831,7 +6833,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -6839,7 +6841,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -6847,7 +6849,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -6855,8 +6857,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -6867,8 +6869,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -6879,8 +6881,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -6891,8 +6893,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -6903,8 +6905,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -6915,8 +6917,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -6927,8 +6929,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -6939,8 +6941,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -22,6 +23,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -33,14 +35,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -1867,8 +1869,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let end,
       rest = {
         type: "RestElement",
@@ -1893,7 +1895,7 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param,
-    hasInitializer = uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0;
+    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -2583,7 +2585,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2598,7 +2600,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2618,7 +2620,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -2638,7 +2640,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3053,7 +3055,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -4859,9 +4861,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -4888,8 +4890,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -4898,7 +4900,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -4906,8 +4908,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -4918,8 +4920,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -4928,170 +4930,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -5100,14 +5102,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -5116,7 +5118,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -5124,18 +5126,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -5146,8 +5148,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -5156,36 +5158,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -5194,11 +5196,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -5208,8 +5210,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -5218,11 +5220,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5230,8 +5232,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -5240,15 +5242,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -5256,110 +5258,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -5368,11 +5370,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5386,7 +5388,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5394,8 +5396,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -5404,17 +5406,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5424,26 +5426,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -5452,11 +5454,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5468,8 +5470,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -5478,41 +5480,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5520,8 +5522,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -5532,8 +5534,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -5542,11 +5544,11 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -5558,8 +5560,8 @@ function deserializeOptionTSAccessibility(pos) {
 function deserializeVecTSClassImplements(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 40;
@@ -5568,14 +5570,14 @@ function deserializeVecTSClassImplements(pos) {
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -5584,47 +5586,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -5634,8 +5636,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -5644,38 +5646,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -5690,8 +5692,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -5716,14 +5718,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -5732,11 +5734,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -5744,8 +5746,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -5754,23 +5756,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -5778,22 +5780,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -5802,158 +5804,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -5964,8 +5966,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -5974,15 +5976,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -5992,8 +5994,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -6004,8 +6006,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -6014,14 +6016,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -6030,26 +6032,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -6062,15 +6064,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6080,7 +6082,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -6088,7 +6090,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -6096,7 +6098,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -6104,8 +6106,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -6116,8 +6118,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -6128,8 +6130,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -6140,8 +6142,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -6152,8 +6154,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -6164,8 +6166,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -6176,8 +6178,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -6188,8 +6190,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -23,6 +24,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -34,14 +36,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -2070,8 +2072,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let end,
       previousParent = parent,
       rest = (parent = {
@@ -2100,7 +2102,7 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent,
-    hasInitializer = uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0;
+    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -2875,7 +2877,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2892,7 +2894,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2915,7 +2917,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -2938,7 +2940,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3396,7 +3398,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5417,9 +5419,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -5446,8 +5448,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -5456,7 +5458,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5464,8 +5466,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -5476,8 +5478,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -5486,170 +5488,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -5658,14 +5660,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -5674,7 +5676,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -5682,18 +5684,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -5704,8 +5706,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -5714,36 +5716,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -5752,11 +5754,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -5766,8 +5768,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -5776,11 +5778,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5788,8 +5790,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -5798,15 +5800,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -5814,110 +5816,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -5926,11 +5928,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5944,7 +5946,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5952,8 +5954,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -5962,17 +5964,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5982,26 +5984,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -6010,11 +6012,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6026,8 +6028,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -6036,41 +6038,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6078,8 +6080,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -6090,8 +6092,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -6100,11 +6102,11 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6116,8 +6118,8 @@ function deserializeOptionTSAccessibility(pos) {
 function deserializeVecTSClassImplements(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 40;
@@ -6126,14 +6128,14 @@ function deserializeVecTSClassImplements(pos) {
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -6142,47 +6144,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -6192,8 +6194,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -6202,38 +6204,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -6248,8 +6250,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -6274,14 +6276,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -6290,11 +6292,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6302,8 +6304,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -6312,23 +6314,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -6336,22 +6338,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -6360,158 +6362,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -6522,8 +6524,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -6532,15 +6534,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -6550,8 +6552,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -6562,8 +6564,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -6572,14 +6574,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -6588,26 +6590,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -6620,15 +6622,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6638,7 +6640,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -6646,7 +6648,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -6654,7 +6656,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -6662,8 +6664,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -6674,8 +6676,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -6686,8 +6688,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -6698,8 +6700,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -6710,8 +6712,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -6722,8 +6724,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -6734,8 +6736,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -6746,8 +6748,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -22,6 +23,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -33,14 +35,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -2065,8 +2067,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let start,
       end,
       rest = {
@@ -2094,7 +2096,7 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param,
-    hasInitializer = uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0;
+    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -2868,7 +2870,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2884,7 +2886,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2905,7 +2907,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -2926,7 +2928,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3384,7 +3386,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5432,9 +5434,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -5461,8 +5463,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -5471,7 +5473,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5479,8 +5481,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -5491,8 +5493,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -5501,170 +5503,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -5673,14 +5675,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -5689,7 +5691,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -5697,18 +5699,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -5719,8 +5721,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -5729,36 +5731,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -5767,11 +5769,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -5781,8 +5783,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -5791,11 +5793,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5803,8 +5805,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -5813,15 +5815,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -5829,110 +5831,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -5941,11 +5943,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5959,7 +5961,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5967,8 +5969,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -5977,17 +5979,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5997,26 +5999,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -6025,11 +6027,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6041,8 +6043,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -6051,41 +6053,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6093,8 +6095,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -6105,8 +6107,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -6115,11 +6117,11 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6131,8 +6133,8 @@ function deserializeOptionTSAccessibility(pos) {
 function deserializeVecTSClassImplements(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 40;
@@ -6141,14 +6143,14 @@ function deserializeVecTSClassImplements(pos) {
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -6157,47 +6159,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -6207,8 +6209,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -6217,38 +6219,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -6263,8 +6265,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -6289,14 +6291,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -6305,11 +6307,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6317,8 +6319,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -6327,23 +6329,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -6351,22 +6353,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -6375,158 +6377,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -6537,8 +6539,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -6547,15 +6549,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -6565,8 +6567,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -6577,8 +6579,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -6587,14 +6589,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -6603,26 +6605,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -6635,15 +6637,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6653,7 +6655,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -6661,7 +6663,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -6669,7 +6671,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -6677,8 +6679,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -6689,8 +6691,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -6701,8 +6703,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -6713,8 +6715,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -6725,8 +6727,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -6737,8 +6739,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -6749,8 +6751,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -6761,8 +6763,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -3,6 +3,7 @@
 
 let uint8,
   uint32,
+  int32,
   float64,
   sourceText,
   sourceTextLatin,
@@ -23,6 +24,7 @@ export function deserialize(buffer, sourceText, sourceByteLen) {
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
+  int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
   if (sourceText.length === sourceByteLen) {
@@ -34,14 +36,14 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(uint32[536870900]);
+  let data = deserialize(int32[536870900]);
   resetBuffer();
   return data;
 }
 
 export function resetBuffer() {
   // Clear buffer and source text strings to allow them to be garbage collected
-  uint8 = uint32 = float64 = sourceText = sourceTextLatin = void 0;
+  uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = void 0;
 }
 
 function deserializeProgram(pos) {
@@ -2267,8 +2269,8 @@ function deserializeFunctionType(pos) {
 
 function deserializeFormalParameters(pos) {
   let params = deserializeVecFormalParameter(pos + 16);
-  if (uint32[(pos + 40) >> 2] !== 0 && uint32[(pos + 44) >> 2] !== 0) {
-    pos = uint32[(pos + 40) >> 2];
+  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
+    pos = int32[(pos + 40) >> 2];
     let start,
       end,
       previousParent = parent,
@@ -2300,7 +2302,7 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent,
-    hasInitializer = uint32[(pos + 64) >> 2] !== 0 && uint32[(pos + 68) >> 2] !== 0;
+    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -3159,7 +3161,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -3177,7 +3179,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -3201,7 +3203,7 @@ function deserializeBigIntLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       bigint: null,
@@ -3225,7 +3227,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3727,7 +3729,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5990,9 +5992,9 @@ function deserializeStaticExport(pos) {
 
 function deserializeStr(pos) {
   let pos32 = pos >> 2,
-    len = uint32[pos32 + 2];
+    len = int32[pos32 + 2];
   if (len === 0) return "";
-  pos = uint32[pos32];
+  pos = int32[pos32];
   let end = pos + len;
   if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
@@ -6019,8 +6021,8 @@ function deserializeStr(pos) {
 function deserializeVecComment(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeComment(pos));
     pos += 16;
@@ -6029,7 +6031,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -6037,8 +6039,8 @@ function deserializeOptionHashbang(pos) {
 function deserializeVecDirective(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeDirective(pos));
     pos += 80;
@@ -6049,8 +6051,8 @@ function deserializeVecDirective(pos) {
 function deserializeVecStatement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeStatement(pos));
     pos += 16;
@@ -6059,170 +6061,170 @@ function deserializeVecStatement(pos) {
 }
 
 function deserializeBoxBooleanLiteral(pos) {
-  return deserializeBooleanLiteral(uint32[pos >> 2]);
+  return deserializeBooleanLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNullLiteral(pos) {
-  return deserializeNullLiteral(uint32[pos >> 2]);
+  return deserializeNullLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxNumericLiteral(pos) {
-  return deserializeNumericLiteral(uint32[pos >> 2]);
+  return deserializeNumericLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxBigIntLiteral(pos) {
-  return deserializeBigIntLiteral(uint32[pos >> 2]);
+  return deserializeBigIntLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxRegExpLiteral(pos) {
-  return deserializeRegExpLiteral(uint32[pos >> 2]);
+  return deserializeRegExpLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxStringLiteral(pos) {
-  return deserializeStringLiteral(uint32[pos >> 2]);
+  return deserializeStringLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTemplateLiteral(pos) {
-  return deserializeTemplateLiteral(uint32[pos >> 2]);
+  return deserializeTemplateLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxIdentifierReference(pos) {
-  return deserializeIdentifierReference(uint32[pos >> 2]);
+  return deserializeIdentifierReference(int32[pos >> 2]);
 }
 
 function deserializeBoxMetaProperty(pos) {
-  return deserializeMetaProperty(uint32[pos >> 2]);
+  return deserializeMetaProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxSuper(pos) {
-  return deserializeSuper(uint32[pos >> 2]);
+  return deserializeSuper(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayExpression(pos) {
-  return deserializeArrayExpression(uint32[pos >> 2]);
+  return deserializeArrayExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxArrowFunctionExpression(pos) {
-  return deserializeArrowFunctionExpression(uint32[pos >> 2]);
+  return deserializeArrowFunctionExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentExpression(pos) {
-  return deserializeAssignmentExpression(uint32[pos >> 2]);
+  return deserializeAssignmentExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxAwaitExpression(pos) {
-  return deserializeAwaitExpression(uint32[pos >> 2]);
+  return deserializeAwaitExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxBinaryExpression(pos) {
-  return deserializeBinaryExpression(uint32[pos >> 2]);
+  return deserializeBinaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxCallExpression(pos) {
-  return deserializeCallExpression(uint32[pos >> 2]);
+  return deserializeCallExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxChainExpression(pos) {
-  return deserializeChainExpression(uint32[pos >> 2]);
+  return deserializeChainExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxClass(pos) {
-  return deserializeClass(uint32[pos >> 2]);
+  return deserializeClass(int32[pos >> 2]);
 }
 
 function deserializeBoxConditionalExpression(pos) {
-  return deserializeConditionalExpression(uint32[pos >> 2]);
+  return deserializeConditionalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxFunction(pos) {
-  return deserializeFunction(uint32[pos >> 2]);
+  return deserializeFunction(int32[pos >> 2]);
 }
 
 function deserializeBoxImportExpression(pos) {
-  return deserializeImportExpression(uint32[pos >> 2]);
+  return deserializeImportExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxLogicalExpression(pos) {
-  return deserializeLogicalExpression(uint32[pos >> 2]);
+  return deserializeLogicalExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxNewExpression(pos) {
-  return deserializeNewExpression(uint32[pos >> 2]);
+  return deserializeNewExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectExpression(pos) {
-  return deserializeObjectExpression(uint32[pos >> 2]);
+  return deserializeObjectExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxParenthesizedExpression(pos) {
-  return deserializeParenthesizedExpression(uint32[pos >> 2]);
+  return deserializeParenthesizedExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxSequenceExpression(pos) {
-  return deserializeSequenceExpression(uint32[pos >> 2]);
+  return deserializeSequenceExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTaggedTemplateExpression(pos) {
-  return deserializeTaggedTemplateExpression(uint32[pos >> 2]);
+  return deserializeTaggedTemplateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxThisExpression(pos) {
-  return deserializeThisExpression(uint32[pos >> 2]);
+  return deserializeThisExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUnaryExpression(pos) {
-  return deserializeUnaryExpression(uint32[pos >> 2]);
+  return deserializeUnaryExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxUpdateExpression(pos) {
-  return deserializeUpdateExpression(uint32[pos >> 2]);
+  return deserializeUpdateExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxYieldExpression(pos) {
-  return deserializeYieldExpression(uint32[pos >> 2]);
+  return deserializeYieldExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateInExpression(pos) {
-  return deserializePrivateInExpression(uint32[pos >> 2]);
+  return deserializePrivateInExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXElement(pos) {
-  return deserializeJSXElement(uint32[pos >> 2]);
+  return deserializeJSXElement(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXFragment(pos) {
-  return deserializeJSXFragment(uint32[pos >> 2]);
+  return deserializeJSXFragment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSAsExpression(pos) {
-  return deserializeTSAsExpression(uint32[pos >> 2]);
+  return deserializeTSAsExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSatisfiesExpression(pos) {
-  return deserializeTSSatisfiesExpression(uint32[pos >> 2]);
+  return deserializeTSSatisfiesExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAssertion(pos) {
-  return deserializeTSTypeAssertion(uint32[pos >> 2]);
+  return deserializeTSTypeAssertion(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNonNullExpression(pos) {
-  return deserializeTSNonNullExpression(uint32[pos >> 2]);
+  return deserializeTSNonNullExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInstantiationExpression(pos) {
-  return deserializeTSInstantiationExpression(uint32[pos >> 2]);
+  return deserializeTSInstantiationExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxV8IntrinsicExpression(pos) {
-  return deserializeV8IntrinsicExpression(uint32[pos >> 2]);
+  return deserializeV8IntrinsicExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArrayExpressionElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeArrayExpressionElement(pos));
     pos += 24;
@@ -6231,14 +6233,14 @@ function deserializeVecArrayExpressionElement(pos) {
 }
 
 function deserializeBoxSpreadElement(pos) {
-  return deserializeSpreadElement(uint32[pos >> 2]);
+  return deserializeSpreadElement(int32[pos >> 2]);
 }
 
 function deserializeVecObjectPropertyKind(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeObjectPropertyKind(pos));
     pos += 16;
@@ -6247,7 +6249,7 @@ function deserializeVecObjectPropertyKind(pos) {
 }
 
 function deserializeBoxObjectProperty(pos) {
-  return deserializeObjectProperty(uint32[pos >> 2]);
+  return deserializeObjectProperty(int32[pos >> 2]);
 }
 
 function deserializeBool(pos) {
@@ -6255,18 +6257,18 @@ function deserializeBool(pos) {
 }
 
 function deserializeBoxIdentifierName(pos) {
-  return deserializeIdentifierName(uint32[pos >> 2]);
+  return deserializeIdentifierName(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateIdentifier(pos) {
-  return deserializePrivateIdentifier(uint32[pos >> 2]);
+  return deserializePrivateIdentifier(int32[pos >> 2]);
 }
 
 function deserializeVecTemplateElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTemplateElement(pos));
     pos += 48;
@@ -6277,8 +6279,8 @@ function deserializeVecTemplateElement(pos) {
 function deserializeVecExpression(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeExpression(pos));
     pos += 16;
@@ -6287,36 +6289,36 @@ function deserializeVecExpression(pos) {
 }
 
 function deserializeBoxTSTypeParameterInstantiation(pos) {
-  return deserializeTSTypeParameterInstantiation(uint32[pos >> 2]);
+  return deserializeTSTypeParameterInstantiation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
-  return deserializeComputedMemberExpression(uint32[pos >> 2]);
+  return deserializeComputedMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxStaticMemberExpression(pos) {
-  return deserializeStaticMemberExpression(uint32[pos >> 2]);
+  return deserializeStaticMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxPrivateFieldExpression(pos) {
-  return deserializePrivateFieldExpression(uint32[pos >> 2]);
+  return deserializePrivateFieldExpression(int32[pos >> 2]);
 }
 
 function deserializeVecArgument(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeArgument(pos));
     pos += 16;
@@ -6325,11 +6327,11 @@ function deserializeVecArgument(pos) {
 }
 
 function deserializeBoxArrayAssignmentTarget(pos) {
-  return deserializeArrayAssignmentTarget(uint32[pos >> 2]);
+  return deserializeArrayAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectAssignmentTarget(pos) {
-  return deserializeObjectAssignmentTarget(uint32[pos >> 2]);
+  return deserializeObjectAssignmentTarget(int32[pos >> 2]);
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
@@ -6339,8 +6341,8 @@ function deserializeOptionAssignmentTargetMaybeDefault(pos) {
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionAssignmentTargetMaybeDefault(pos));
     pos += 16;
@@ -6349,11 +6351,11 @@ function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
 }
 
 function deserializeBoxAssignmentTargetRest(pos) {
-  return deserializeAssignmentTargetRest(uint32[pos >> 2]);
+  return deserializeAssignmentTargetRest(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -6361,8 +6363,8 @@ function deserializeOptionBoxAssignmentTargetRest(pos) {
 function deserializeVecAssignmentTargetProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeAssignmentTargetProperty(pos));
     pos += 16;
@@ -6371,15 +6373,15 @@ function deserializeVecAssignmentTargetProperty(pos) {
 }
 
 function deserializeBoxAssignmentTargetWithDefault(pos) {
-  return deserializeAssignmentTargetWithDefault(uint32[pos >> 2]);
+  return deserializeAssignmentTargetWithDefault(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyIdentifier(pos) {
-  return deserializeAssignmentTargetPropertyIdentifier(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentTargetPropertyProperty(pos) {
-  return deserializeAssignmentTargetPropertyProperty(uint32[pos >> 2]);
+  return deserializeAssignmentTargetPropertyProperty(int32[pos >> 2]);
 }
 
 function deserializeOptionExpression(pos) {
@@ -6387,110 +6389,110 @@ function deserializeOptionExpression(pos) {
 }
 
 function deserializeBoxBlockStatement(pos) {
-  return deserializeBlockStatement(uint32[pos >> 2]);
+  return deserializeBlockStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxBreakStatement(pos) {
-  return deserializeBreakStatement(uint32[pos >> 2]);
+  return deserializeBreakStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxContinueStatement(pos) {
-  return deserializeContinueStatement(uint32[pos >> 2]);
+  return deserializeContinueStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDebuggerStatement(pos) {
-  return deserializeDebuggerStatement(uint32[pos >> 2]);
+  return deserializeDebuggerStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxDoWhileStatement(pos) {
-  return deserializeDoWhileStatement(uint32[pos >> 2]);
+  return deserializeDoWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxEmptyStatement(pos) {
-  return deserializeEmptyStatement(uint32[pos >> 2]);
+  return deserializeEmptyStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxExpressionStatement(pos) {
-  return deserializeExpressionStatement(uint32[pos >> 2]);
+  return deserializeExpressionStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForInStatement(pos) {
-  return deserializeForInStatement(uint32[pos >> 2]);
+  return deserializeForInStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForOfStatement(pos) {
-  return deserializeForOfStatement(uint32[pos >> 2]);
+  return deserializeForOfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxForStatement(pos) {
-  return deserializeForStatement(uint32[pos >> 2]);
+  return deserializeForStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxIfStatement(pos) {
-  return deserializeIfStatement(uint32[pos >> 2]);
+  return deserializeIfStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxLabeledStatement(pos) {
-  return deserializeLabeledStatement(uint32[pos >> 2]);
+  return deserializeLabeledStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxReturnStatement(pos) {
-  return deserializeReturnStatement(uint32[pos >> 2]);
+  return deserializeReturnStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxSwitchStatement(pos) {
-  return deserializeSwitchStatement(uint32[pos >> 2]);
+  return deserializeSwitchStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxThrowStatement(pos) {
-  return deserializeThrowStatement(uint32[pos >> 2]);
+  return deserializeThrowStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxTryStatement(pos) {
-  return deserializeTryStatement(uint32[pos >> 2]);
+  return deserializeTryStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWhileStatement(pos) {
-  return deserializeWhileStatement(uint32[pos >> 2]);
+  return deserializeWhileStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxWithStatement(pos) {
-  return deserializeWithStatement(uint32[pos >> 2]);
+  return deserializeWithStatement(int32[pos >> 2]);
 }
 
 function deserializeBoxVariableDeclaration(pos) {
-  return deserializeVariableDeclaration(uint32[pos >> 2]);
+  return deserializeVariableDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeAliasDeclaration(pos) {
-  return deserializeTSTypeAliasDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeAliasDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInterfaceDeclaration(pos) {
-  return deserializeTSInterfaceDeclaration(uint32[pos >> 2]);
+  return deserializeTSInterfaceDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSEnumDeclaration(pos) {
-  return deserializeTSEnumDeclaration(uint32[pos >> 2]);
+  return deserializeTSEnumDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSModuleDeclaration(pos) {
-  return deserializeTSModuleDeclaration(uint32[pos >> 2]);
+  return deserializeTSModuleDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSGlobalDeclaration(pos) {
-  return deserializeTSGlobalDeclaration(uint32[pos >> 2]);
+  return deserializeTSGlobalDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportEqualsDeclaration(pos) {
-  return deserializeTSImportEqualsDeclaration(uint32[pos >> 2]);
+  return deserializeTSImportEqualsDeclaration(int32[pos >> 2]);
 }
 
 function deserializeVecVariableDeclarator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeVariableDeclarator(pos));
     pos += 56;
@@ -6499,11 +6501,11 @@ function deserializeVecVariableDeclarator(pos) {
 }
 
 function deserializeBoxTSTypeAnnotation(pos) {
-  return deserializeTSTypeAnnotation(uint32[pos >> 2]);
+  return deserializeTSTypeAnnotation(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -6517,7 +6519,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -6525,8 +6527,8 @@ function deserializeOptionLabelIdentifier(pos) {
 function deserializeVecSwitchCase(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeSwitchCase(pos));
     pos += 56;
@@ -6535,17 +6537,17 @@ function deserializeVecSwitchCase(pos) {
 }
 
 function deserializeBoxCatchClause(pos) {
-  return deserializeCatchClause(uint32[pos >> 2]);
+  return deserializeCatchClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -6555,26 +6557,26 @@ function deserializeOptionCatchParameter(pos) {
 }
 
 function deserializeBoxBindingIdentifier(pos) {
-  return deserializeBindingIdentifier(uint32[pos >> 2]);
+  return deserializeBindingIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxObjectPattern(pos) {
-  return deserializeObjectPattern(uint32[pos >> 2]);
+  return deserializeObjectPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxArrayPattern(pos) {
-  return deserializeArrayPattern(uint32[pos >> 2]);
+  return deserializeArrayPattern(int32[pos >> 2]);
 }
 
 function deserializeBoxAssignmentPattern(pos) {
-  return deserializeAssignmentPattern(uint32[pos >> 2]);
+  return deserializeAssignmentPattern(int32[pos >> 2]);
 }
 
 function deserializeVecBindingProperty(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeBindingProperty(pos));
     pos += 48;
@@ -6583,11 +6585,11 @@ function deserializeVecBindingProperty(pos) {
 }
 
 function deserializeBoxBindingRestElement(pos) {
-  return deserializeBindingRestElement(uint32[pos >> 2]);
+  return deserializeBindingRestElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6599,8 +6601,8 @@ function deserializeOptionBindingPattern(pos) {
 function deserializeVecOptionBindingPattern(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeOptionBindingPattern(pos));
     pos += 16;
@@ -6609,41 +6611,41 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
-  return deserializeTSTypeParameterDeclaration(uint32[pos >> 2]);
+  return deserializeTSTypeParameterDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
-  return deserializeTSThisParameter(uint32[pos >> 2]);
+  return deserializeTSThisParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
-  return deserializeFormalParameters(uint32[pos >> 2]);
+  return deserializeFormalParameters(int32[pos >> 2]);
 }
 
 function deserializeBoxFunctionBody(pos) {
-  return deserializeFunctionBody(uint32[pos >> 2]);
+  return deserializeFunctionBody(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6651,8 +6653,8 @@ function deserializeOptionBoxFunctionBody(pos) {
 function deserializeVecFormalParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 72;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 72;
   for (; pos !== endPos; ) {
     arr.push(deserializeFormalParameter(pos));
     pos += 72;
@@ -6663,8 +6665,8 @@ function deserializeVecFormalParameter(pos) {
 function deserializeVecDecorator(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeDecorator(pos));
     pos += 32;
@@ -6673,11 +6675,11 @@ function deserializeVecDecorator(pos) {
 }
 
 function deserializeBoxExpression(pos) {
-  return deserializeExpression(uint32[pos >> 2]);
+  return deserializeExpression(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6689,8 +6691,8 @@ function deserializeOptionTSAccessibility(pos) {
 function deserializeVecTSClassImplements(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSClassImplements(pos));
     pos += 40;
@@ -6699,14 +6701,14 @@ function deserializeVecTSClassImplements(pos) {
 }
 
 function deserializeBoxClassBody(pos) {
-  return deserializeClassBody(uint32[pos >> 2]);
+  return deserializeClassBody(int32[pos >> 2]);
 }
 
 function deserializeVecClassElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeClassElement(pos));
     pos += 16;
@@ -6715,47 +6717,47 @@ function deserializeVecClassElement(pos) {
 }
 
 function deserializeBoxStaticBlock(pos) {
-  return deserializeStaticBlock(uint32[pos >> 2]);
+  return deserializeStaticBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxMethodDefinition(pos) {
-  return deserializeMethodDefinition(uint32[pos >> 2]);
+  return deserializeMethodDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxPropertyDefinition(pos) {
-  return deserializePropertyDefinition(uint32[pos >> 2]);
+  return deserializePropertyDefinition(int32[pos >> 2]);
 }
 
 function deserializeBoxAccessorProperty(pos) {
-  return deserializeAccessorProperty(uint32[pos >> 2]);
+  return deserializeAccessorProperty(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexSignature(pos) {
-  return deserializeTSIndexSignature(uint32[pos >> 2]);
+  return deserializeTSIndexSignature(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDeclaration(pos) {
-  return deserializeImportDeclaration(uint32[pos >> 2]);
+  return deserializeImportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportAllDeclaration(pos) {
-  return deserializeExportAllDeclaration(uint32[pos >> 2]);
+  return deserializeExportAllDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportDefaultDeclaration(pos) {
-  return deserializeExportDefaultDeclaration(uint32[pos >> 2]);
+  return deserializeExportDefaultDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxExportNamedDeclaration(pos) {
-  return deserializeExportNamedDeclaration(uint32[pos >> 2]);
+  return deserializeExportNamedDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSExportAssignment(pos) {
-  return deserializeTSExportAssignment(uint32[pos >> 2]);
+  return deserializeTSExportAssignment(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamespaceExportDeclaration(pos) {
-  return deserializeTSNamespaceExportDeclaration(uint32[pos >> 2]);
+  return deserializeTSNamespaceExportDeclaration(int32[pos >> 2]);
 }
 
 function deserializeOptionImportPhase(pos) {
@@ -6765,8 +6767,8 @@ function deserializeOptionImportPhase(pos) {
 function deserializeVecImportDeclarationSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportDeclarationSpecifier(pos));
     pos += 16;
@@ -6775,38 +6777,38 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
-  return deserializeWithClause(uint32[pos >> 2]);
+  return deserializeWithClause(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
-  return deserializeImportSpecifier(uint32[pos >> 2]);
+  return deserializeImportSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportDefaultSpecifier(pos) {
-  return deserializeImportDefaultSpecifier(uint32[pos >> 2]);
+  return deserializeImportDefaultSpecifier(int32[pos >> 2]);
 }
 
 function deserializeBoxImportNamespaceSpecifier(pos) {
-  return deserializeImportNamespaceSpecifier(uint32[pos >> 2]);
+  return deserializeImportNamespaceSpecifier(int32[pos >> 2]);
 }
 
 function deserializeVecImportAttribute(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 120;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 120;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportAttribute(pos));
     pos += 120;
@@ -6821,8 +6823,8 @@ function deserializeOptionDeclaration(pos) {
 function deserializeVecExportSpecifier(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 128;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 128;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportSpecifier(pos));
     pos += 128;
@@ -6847,14 +6849,14 @@ function deserializeU8(pos) {
 }
 
 function deserializeBoxJSXOpeningElement(pos) {
-  return deserializeJSXOpeningElement(uint32[pos >> 2]);
+  return deserializeJSXOpeningElement(int32[pos >> 2]);
 }
 
 function deserializeVecJSXChild(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXChild(pos));
     pos += 16;
@@ -6863,11 +6865,11 @@ function deserializeVecJSXChild(pos) {
 }
 
 function deserializeBoxJSXClosingElement(pos) {
-  return deserializeJSXClosingElement(uint32[pos >> 2]);
+  return deserializeJSXClosingElement(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6875,8 +6877,8 @@ function deserializeOptionBoxJSXClosingElement(pos) {
 function deserializeVecJSXAttributeItem(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeJSXAttributeItem(pos));
     pos += 16;
@@ -6885,23 +6887,23 @@ function deserializeVecJSXAttributeItem(pos) {
 }
 
 function deserializeBoxJSXIdentifier(pos) {
-  return deserializeJSXIdentifier(uint32[pos >> 2]);
+  return deserializeJSXIdentifier(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXNamespacedName(pos) {
-  return deserializeJSXNamespacedName(uint32[pos >> 2]);
+  return deserializeJSXNamespacedName(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXMemberExpression(pos) {
-  return deserializeJSXMemberExpression(uint32[pos >> 2]);
+  return deserializeJSXMemberExpression(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXAttribute(pos) {
-  return deserializeJSXAttribute(uint32[pos >> 2]);
+  return deserializeJSXAttribute(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadAttribute(pos) {
-  return deserializeJSXSpreadAttribute(uint32[pos >> 2]);
+  return deserializeJSXSpreadAttribute(int32[pos >> 2]);
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
@@ -6909,22 +6911,22 @@ function deserializeOptionJSXAttributeValue(pos) {
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
-  return deserializeJSXExpressionContainer(uint32[pos >> 2]);
+  return deserializeJSXExpressionContainer(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXText(pos) {
-  return deserializeJSXText(uint32[pos >> 2]);
+  return deserializeJSXText(int32[pos >> 2]);
 }
 
 function deserializeBoxJSXSpreadChild(pos) {
-  return deserializeJSXSpreadChild(uint32[pos >> 2]);
+  return deserializeJSXSpreadChild(int32[pos >> 2]);
 }
 
 function deserializeVecTSEnumMember(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 48;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 48;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSEnumMember(pos));
     pos += 48;
@@ -6933,158 +6935,158 @@ function deserializeVecTSEnumMember(pos) {
 }
 
 function deserializeBoxTSAnyKeyword(pos) {
-  return deserializeTSAnyKeyword(uint32[pos >> 2]);
+  return deserializeTSAnyKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBigIntKeyword(pos) {
-  return deserializeTSBigIntKeyword(uint32[pos >> 2]);
+  return deserializeTSBigIntKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSBooleanKeyword(pos) {
-  return deserializeTSBooleanKeyword(uint32[pos >> 2]);
+  return deserializeTSBooleanKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntrinsicKeyword(pos) {
-  return deserializeTSIntrinsicKeyword(uint32[pos >> 2]);
+  return deserializeTSIntrinsicKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNeverKeyword(pos) {
-  return deserializeTSNeverKeyword(uint32[pos >> 2]);
+  return deserializeTSNeverKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNullKeyword(pos) {
-  return deserializeTSNullKeyword(uint32[pos >> 2]);
+  return deserializeTSNullKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNumberKeyword(pos) {
-  return deserializeTSNumberKeyword(uint32[pos >> 2]);
+  return deserializeTSNumberKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSObjectKeyword(pos) {
-  return deserializeTSObjectKeyword(uint32[pos >> 2]);
+  return deserializeTSObjectKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSStringKeyword(pos) {
-  return deserializeTSStringKeyword(uint32[pos >> 2]);
+  return deserializeTSStringKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSSymbolKeyword(pos) {
-  return deserializeTSSymbolKeyword(uint32[pos >> 2]);
+  return deserializeTSSymbolKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUndefinedKeyword(pos) {
-  return deserializeTSUndefinedKeyword(uint32[pos >> 2]);
+  return deserializeTSUndefinedKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnknownKeyword(pos) {
-  return deserializeTSUnknownKeyword(uint32[pos >> 2]);
+  return deserializeTSUnknownKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSVoidKeyword(pos) {
-  return deserializeTSVoidKeyword(uint32[pos >> 2]);
+  return deserializeTSVoidKeyword(int32[pos >> 2]);
 }
 
 function deserializeBoxTSArrayType(pos) {
-  return deserializeTSArrayType(uint32[pos >> 2]);
+  return deserializeTSArrayType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConditionalType(pos) {
-  return deserializeTSConditionalType(uint32[pos >> 2]);
+  return deserializeTSConditionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructorType(pos) {
-  return deserializeTSConstructorType(uint32[pos >> 2]);
+  return deserializeTSConstructorType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSFunctionType(pos) {
-  return deserializeTSFunctionType(uint32[pos >> 2]);
+  return deserializeTSFunctionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSImportType(pos) {
-  return deserializeTSImportType(uint32[pos >> 2]);
+  return deserializeTSImportType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIndexedAccessType(pos) {
-  return deserializeTSIndexedAccessType(uint32[pos >> 2]);
+  return deserializeTSIndexedAccessType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSInferType(pos) {
-  return deserializeTSInferType(uint32[pos >> 2]);
+  return deserializeTSInferType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSIntersectionType(pos) {
-  return deserializeTSIntersectionType(uint32[pos >> 2]);
+  return deserializeTSIntersectionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSLiteralType(pos) {
-  return deserializeTSLiteralType(uint32[pos >> 2]);
+  return deserializeTSLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMappedType(pos) {
-  return deserializeTSMappedType(uint32[pos >> 2]);
+  return deserializeTSMappedType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSNamedTupleMember(pos) {
-  return deserializeTSNamedTupleMember(uint32[pos >> 2]);
+  return deserializeTSNamedTupleMember(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTemplateLiteralType(pos) {
-  return deserializeTSTemplateLiteralType(uint32[pos >> 2]);
+  return deserializeTSTemplateLiteralType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSThisType(pos) {
-  return deserializeTSThisType(uint32[pos >> 2]);
+  return deserializeTSThisType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTupleType(pos) {
-  return deserializeTSTupleType(uint32[pos >> 2]);
+  return deserializeTSTupleType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeLiteral(pos) {
-  return deserializeTSTypeLiteral(uint32[pos >> 2]);
+  return deserializeTSTypeLiteral(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeOperator(pos) {
-  return deserializeTSTypeOperator(uint32[pos >> 2]);
+  return deserializeTSTypeOperator(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypePredicate(pos) {
-  return deserializeTSTypePredicate(uint32[pos >> 2]);
+  return deserializeTSTypePredicate(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeQuery(pos) {
-  return deserializeTSTypeQuery(uint32[pos >> 2]);
+  return deserializeTSTypeQuery(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeReference(pos) {
-  return deserializeTSTypeReference(uint32[pos >> 2]);
+  return deserializeTSTypeReference(int32[pos >> 2]);
 }
 
 function deserializeBoxTSUnionType(pos) {
-  return deserializeTSUnionType(uint32[pos >> 2]);
+  return deserializeTSUnionType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSParenthesizedType(pos) {
-  return deserializeTSParenthesizedType(uint32[pos >> 2]);
+  return deserializeTSParenthesizedType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNullableType(pos) {
-  return deserializeJSDocNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocNonNullableType(pos) {
-  return deserializeJSDocNonNullableType(uint32[pos >> 2]);
+  return deserializeJSDocNonNullableType(int32[pos >> 2]);
 }
 
 function deserializeBoxJSDocUnknownType(pos) {
-  return deserializeJSDocUnknownType(uint32[pos >> 2]);
+  return deserializeJSDocUnknownType(int32[pos >> 2]);
 }
 
 function deserializeVecTSType(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSType(pos));
     pos += 16;
@@ -7095,8 +7097,8 @@ function deserializeVecTSType(pos) {
 function deserializeVecTSTupleElement(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTupleElement(pos));
     pos += 16;
@@ -7105,15 +7107,15 @@ function deserializeVecTSTupleElement(pos) {
 }
 
 function deserializeBoxTSOptionalType(pos) {
-  return deserializeTSOptionalType(uint32[pos >> 2]);
+  return deserializeTSOptionalType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSRestType(pos) {
-  return deserializeTSRestType(uint32[pos >> 2]);
+  return deserializeTSRestType(int32[pos >> 2]);
 }
 
 function deserializeBoxTSQualifiedName(pos) {
-  return deserializeTSQualifiedName(uint32[pos >> 2]);
+  return deserializeTSQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSType(pos) {
@@ -7123,8 +7125,8 @@ function deserializeOptionTSType(pos) {
 function deserializeVecTSTypeParameter(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSTypeParameter(pos));
     pos += 80;
@@ -7135,8 +7137,8 @@ function deserializeVecTSTypeParameter(pos) {
 function deserializeVecTSInterfaceHeritage(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSInterfaceHeritage(pos));
     pos += 40;
@@ -7145,14 +7147,14 @@ function deserializeVecTSInterfaceHeritage(pos) {
 }
 
 function deserializeBoxTSInterfaceBody(pos) {
-  return deserializeTSInterfaceBody(uint32[pos >> 2]);
+  return deserializeTSInterfaceBody(int32[pos >> 2]);
 }
 
 function deserializeVecTSSignature(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSSignature(pos));
     pos += 16;
@@ -7161,26 +7163,26 @@ function deserializeVecTSSignature(pos) {
 }
 
 function deserializeBoxTSPropertySignature(pos) {
-  return deserializeTSPropertySignature(uint32[pos >> 2]);
+  return deserializeTSPropertySignature(int32[pos >> 2]);
 }
 
 function deserializeBoxTSCallSignatureDeclaration(pos) {
-  return deserializeTSCallSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSCallSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSConstructSignatureDeclaration(pos) {
-  return deserializeTSConstructSignatureDeclaration(uint32[pos >> 2]);
+  return deserializeTSConstructSignatureDeclaration(int32[pos >> 2]);
 }
 
 function deserializeBoxTSMethodSignature(pos) {
-  return deserializeTSMethodSignature(uint32[pos >> 2]);
+  return deserializeTSMethodSignature(int32[pos >> 2]);
 }
 
 function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 40;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 40;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
     pos += 40;
@@ -7193,15 +7195,15 @@ function deserializeOptionTSModuleDeclarationBody(pos) {
 }
 
 function deserializeBoxTSModuleBlock(pos) {
-  return deserializeTSModuleBlock(uint32[pos >> 2]);
+  return deserializeTSModuleBlock(int32[pos >> 2]);
 }
 
 function deserializeBoxTSTypeParameter(pos) {
-  return deserializeTSTypeParameter(uint32[pos >> 2]);
+  return deserializeTSTypeParameter(int32[pos >> 2]);
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -7211,7 +7213,7 @@ function deserializeOptionTSImportTypeQualifier(pos) {
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
-  return deserializeTSImportTypeQualifiedName(uint32[pos >> 2]);
+  return deserializeTSImportTypeQualifiedName(int32[pos >> 2]);
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
@@ -7219,7 +7221,7 @@ function deserializeOptionTSMappedTypeModifierOperator(pos) {
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
-  return deserializeTSExternalModuleReference(uint32[pos >> 2]);
+  return deserializeTSExternalModuleReference(int32[pos >> 2]);
 }
 
 function deserializeU32(pos) {
@@ -7227,7 +7229,7 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
     ? null
     : deserializeNameSpan(pos);
 }
@@ -7235,8 +7237,8 @@ function deserializeOptionNameSpan(pos) {
 function deserializeVecError(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 80;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 80;
   for (; pos !== endPos; ) {
     arr.push(deserializeError(pos));
     pos += 80;
@@ -7247,8 +7249,8 @@ function deserializeVecError(pos) {
 function deserializeVecErrorLabel(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 24;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 24;
   for (; pos !== endPos; ) {
     arr.push(deserializeErrorLabel(pos));
     pos += 24;
@@ -7259,8 +7261,8 @@ function deserializeVecErrorLabel(pos) {
 function deserializeVecStaticImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 56;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticImport(pos));
     pos += 56;
@@ -7271,8 +7273,8 @@ function deserializeVecStaticImport(pos) {
 function deserializeVecStaticExport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 32;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 32;
   for (; pos !== endPos; ) {
     arr.push(deserializeStaticExport(pos));
     pos += 32;
@@ -7283,8 +7285,8 @@ function deserializeVecStaticExport(pos) {
 function deserializeVecDynamicImport(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 16;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 16;
   for (; pos !== endPos; ) {
     arr.push(deserializeDynamicImport(pos));
     pos += 16;
@@ -7295,8 +7297,8 @@ function deserializeVecDynamicImport(pos) {
 function deserializeVecSpan(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 8;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 8;
   for (; pos !== endPos; ) {
     arr.push(deserializeSpan(pos));
     pos += 8;
@@ -7307,8 +7309,8 @@ function deserializeVecSpan(pos) {
 function deserializeVecImportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 96;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 96;
   for (; pos !== endPos; ) {
     arr.push(deserializeImportEntry(pos));
     pos += 96;
@@ -7319,8 +7321,8 @@ function deserializeVecImportEntry(pos) {
 function deserializeVecExportEntry(pos) {
   let arr = [],
     pos32 = pos >> 2;
-  pos = uint32[pos32];
-  let endPos = pos + uint32[pos32 + 2] * 144;
+  pos = int32[pos32];
+  let endPos = pos + int32[pos32 + 2] * 144;
   for (; pos !== endPos; ) {
     arr.push(deserializeExportEntry(pos));
     pos += 144;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -226,7 +226,7 @@ fn generate_deserializers(
                 }}
             }}
 
-            const data = deserialize(uint32[{data_pointer_pos_32}]);
+            const data = deserialize(int32[{data_pointer_pos_32}]);
             resetBuffer();
             return data;
         }}
@@ -949,11 +949,11 @@ fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &
 // In linter, source text is towards the end of the buffer, and all other strings are before it.
 static STR_DESERIALIZER_BODY: &str = "
     const pos32 = pos >> 2,
-        len = uint32[pos32 + 2];
+        len = int32[pos32 + 2];
 
     if (len === 0) return '';
 
-    pos = uint32[pos32];
+    pos = int32[pos32];
 
     const end = pos + len;
 
@@ -1056,13 +1056,13 @@ fn get_option_none_condition_and_offset(
         let none_condition = match niche.size {
             1 => format!("uint8[{}] === {}", pos_offset(niche_offset), niche.value()),
             // 2 => format!("uint16[{}] === {}", pos_offset_shift(offset, 1), niche.value()),
-            4 => format!("uint32[{}] === {}", pos_offset_shift(niche_offset, 2), niche.value()),
+            4 => format!("int32[{}] === {}", pos_offset_shift(niche_offset, 2), niche.value()),
             8 => {
                 // TODO: Use `float64[pos >> 3] === 0` instead of
-                // `uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0`?
+                // `int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0`?
                 let value = niche.value();
                 format!(
-                    "uint32[{}] === {} && uint32[{}] === {}",
+                    "int32[{}] === {} && int32[{}] === {}",
                     pos_offset_shift(niche_offset, 2),
                     value & u128::from(u32::MAX),
                     pos_offset_shift(niche_offset + 4, 2),
@@ -1090,7 +1090,7 @@ fn generate_box(box_def: &BoxDef, code: &mut String, estree_derive_id: DeriveId,
     #[rustfmt::skip]
     write_it!(code, "
         function {fn_name}(pos) {{
-            return {inner_fn_name}(uint32[pos >> 2]);
+            return {inner_fn_name}(int32[pos >> 2]);
         }}
     ");
 }
@@ -1114,8 +1114,8 @@ fn generate_vec(vec_def: &VecDef, code: &mut String, estree_derive_id: DeriveId,
         function {fn_name}(pos) {{
             const arr = [],
                 pos32 = pos >> 2;
-            pos = uint32[{ptr_pos32}];
-            const endPos = pos + uint32[{len_pos32}] * {inner_type_size};
+            pos = int32[{ptr_pos32}];
+            const endPos = pos + int32[{len_pos32}] * {inner_type_size};
             while (pos !== endPos) {{
                 arr.push({inner_fn_name}(pos));
                 pos += {inner_type_size};
@@ -1498,7 +1498,7 @@ fn generate_constants(consts: Constants) -> (String, TokenStream) {
         export const ACTIVE_SIZE = {active_size};
 
         /**
-         * Byte offset of the data pointer within the buffer, divided by 4 (for `Uint32Array` indexing).
+         * Byte offset of the data pointer within the buffer, divided by 4 (for `Int32Array` indexing).
          */
         export const DATA_POINTER_POS_32 = {data_pointer_pos_32};
 


### PR DESCRIPTION
Use `int32` (`Int32Array`) instead of `uint32`(`Uint32Array`) for getting data from buffer in raw transfer deserializer. The buffer is 2 GiB in size, so all offsets within the buffer can be represented as a `u31` which can be stored in an `i32` without any loss, and with no risk of being interpreted as negative numbers.  
  
Same as in #21129, the advantage of fetching offsets from an `Int32Array` is that V8 statically knows the value can be stored in an SMI, its native integer type, without any range checks.