### PR TITLE
perf(napi/parser, linter/plugins): inline trivial raw transfer field deserializers into node object definitions

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -199,91 +199,67 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      __proto__: NodeProto,
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    __proto__: NodeProto,
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeIdentifierReference(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      __proto__: NodeProto,
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    __proto__: NodeProto,
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      __proto__: NodeProto,
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    __proto__: NodeProto,
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      __proto__: NodeProto,
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    __proto__: NodeProto,
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeThisExpression(pos) {
@@ -459,7 +435,7 @@ function deserializeObjectProperty(pos) {
       method: deserializeBool(pos + 13),
       shorthand: deserializeBool(pos + 14),
       computed: deserializeBool(pos + 15),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -467,7 +443,6 @@ function deserializeObjectProperty(pos) {
     });
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -663,7 +638,7 @@ function deserializeComputedMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -671,7 +646,6 @@ function deserializeComputedMemberExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   parent = previousParent;
   return node;
 }
@@ -686,7 +660,7 @@ function deserializeStaticMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -694,7 +668,6 @@ function deserializeStaticMemberExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -709,7 +682,7 @@ function deserializePrivateFieldExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -717,7 +690,6 @@ function deserializePrivateFieldExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -929,14 +901,13 @@ function deserializeUnaryExpression(pos) {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 12),
       argument: null,
-      prefix: null,
+      prefix: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   parent = previousParent;
   return node;
 }
@@ -970,7 +941,7 @@ function deserializePrivateInExpression(pos) {
       __proto__: NodeProto,
       type: "BinaryExpression",
       left: null,
-      operator: null,
+      operator: "in",
       right: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -978,7 +949,6 @@ function deserializePrivateInExpression(pos) {
       parent,
     });
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   parent = previousParent;
   return node;
@@ -1105,9 +1075,9 @@ function deserializeArrayAssignmentTarget(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -1117,9 +1087,7 @@ function deserializeArrayAssignmentTarget(pos) {
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1131,9 +1099,9 @@ function deserializeObjectAssignmentTarget(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -1143,9 +1111,7 @@ function deserializeObjectAssignmentTarget(pos) {
     properties = deserializeVecAssignmentTargetProperty(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1157,9 +1123,9 @@ function deserializeAssignmentTargetRest(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: (start = deserializeU32(pos)),
@@ -1167,9 +1133,7 @@ function deserializeAssignmentTargetRest(pos) {
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 16);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1210,20 +1174,18 @@ function deserializeAssignmentTargetWithDefault(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1246,13 +1208,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
-      optional: null,
+      method: false,
+      shorthand: true,
+      computed: false,
+      optional: false,
       start,
       end,
       range: [start, end],
@@ -1292,13 +1254,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     left.parent = value;
     init.parent = value;
   }
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1310,24 +1267,20 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
+      method: false,
+      shorthand: false,
       computed: deserializeBool(pos + 12),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2155,20 +2108,18 @@ function deserializeAssignmentPattern(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.left = deserializeBindingPattern(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2180,9 +2131,9 @@ function deserializeObjectPattern(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -2192,9 +2143,7 @@ function deserializeObjectPattern(pos) {
     properties = deserializeVecBindingProperty(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2206,23 +2155,20 @@ function deserializeBindingProperty(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
+      method: false,
       shorthand: deserializeBool(pos + 12),
       computed: deserializeBool(pos + 13),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2234,9 +2180,9 @@ function deserializeArrayPattern(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -2246,9 +2192,7 @@ function deserializeArrayPattern(pos) {
     elements = deserializeVecOptionBindingPattern(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2260,9 +2204,9 @@ function deserializeBindingRestElement(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: (start = deserializeU32(pos)),
@@ -2270,9 +2214,7 @@ function deserializeBindingRestElement(pos) {
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 16);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2292,7 +2234,7 @@ function deserializeFunction(pos) {
       params: null,
       returnType: null,
       body: null,
-      expression: null,
+      expression: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2308,7 +2250,6 @@ function deserializeFunction(pos) {
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 72);
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   parent = previousParent;
   return node;
 }
@@ -2525,7 +2466,7 @@ function deserializeArrowFunctionExpression(pos) {
       returnType: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2540,7 +2481,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   node.body = body;
-  node.generator = false;
   parent = previousParent;
   return node;
 }
@@ -2797,9 +2737,9 @@ function deserializeAccessorProperty(pos) {
       override: deserializeBool(pos + 15),
       definite: deserializeBool(pos + 80),
       accessibility: deserializeOptionTSAccessibility(pos + 81),
-      declare: null,
-      optional: null,
-      readonly: null,
+      declare: false,
+      optional: false,
+      readonly: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2809,9 +2749,6 @@ function deserializeAccessorProperty(pos) {
   node.key = deserializePropertyKey(pos + 40);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 56);
   node.value = deserializeOptionExpression(pos + 64);
-  node.declare = false;
-  node.optional = false;
-  node.readonly = false;
   parent = previousParent;
   return node;
 }
@@ -3014,14 +2951,13 @@ function deserializeExportDefaultDeclaration(pos) {
       __proto__: NodeProto,
       type: "ExportDefaultDeclaration",
       declaration: null,
-      exportKind: null,
+      exportKind: "value",
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 16);
-  node.exportKind = "value";
   parent = previousParent;
   return node;
 }
@@ -3225,21 +3161,17 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      __proto__: NodeProto,
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    });
-  node.raw = start === 0 && end === 0 ? null : "null";
-  parent = previousParent;
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    __proto__: NodeProto,
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -3288,26 +3220,21 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      __proto__: NodeProto,
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    }),
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  parent = previousParent;
-  return node;
+  return {
+    __proto__: NodeProto,
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -3396,7 +3323,7 @@ function deserializeJSXOpeningElement(pos) {
       name: null,
       typeArguments: null,
       attributes: null,
-      selfClosing: null,
+      selfClosing: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -3405,7 +3332,6 @@ function deserializeJSXOpeningElement(pos) {
   node.name = deserializeJSXElementName(pos + 16);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 32);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   parent = previousParent;
   return node;
 }
@@ -3451,19 +3377,15 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      __proto__: NodeProto,
-      type: "JSXOpeningFragment",
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    __proto__: NodeProto,
+    type: "JSXOpeningFragment",
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeJSXClosingFragment(pos) {
@@ -3857,18 +3779,15 @@ function deserializeTSThisParameter(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "Identifier",
-      decorators: null,
-      name: null,
-      optional: null,
+      decorators: [],
+      name: "this",
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
   return node;
@@ -3923,7 +3842,7 @@ function deserializeTSEnumMember(pos) {
       type: "TSEnumMember",
       id: null,
       initializer: null,
-      computed: null,
+      computed: deserializeU8(pos + 16) > 1,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -3931,7 +3850,6 @@ function deserializeTSEnumMember(pos) {
     });
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   parent = previousParent;
   return node;
 }
@@ -4818,7 +4736,7 @@ function deserializeTSPropertySignature(pos) {
       key: null,
       typeAnnotation: null,
       accessibility: null,
-      static: null,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4826,7 +4744,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4924,8 +4841,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4938,8 +4855,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4973,17 +4888,15 @@ function deserializeTSIndexSignatureName(pos) {
     node = (parent = {
       __proto__: NodeProto,
       type: "Identifier",
-      decorators: null,
+      decorators: [],
       name: deserializeStr(pos + 16),
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
@@ -5180,9 +5093,9 @@ function deserializeTSGlobalDeclaration(pos) {
       type: "TSModuleDeclaration",
       id: null,
       body: null,
-      kind: null,
+      kind: "global",
       declare: deserializeBool(pos + 88),
-      global: null,
+      global: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -5203,8 +5116,6 @@ function deserializeTSGlobalDeclaration(pos) {
     parent,
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   parent = previousParent;
   return node;
 }

--- a/crates/oxc_ast/src/serialize/basic.rs
+++ b/crates/oxc_ast/src/serialize/basic.rs
@@ -3,7 +3,7 @@ use oxc_estree::{ESTree, JsonSafeString, Serializer};
 
 /// Serialized as `null`.
 #[ast_meta]
-#[estree(ts_type = "null", raw_deser = "null")]
+#[estree(ts_type = "null", raw_deser = "null", raw_deser_inline)]
 pub struct Null<T>(pub T);
 
 impl<T> ESTree for Null<T> {
@@ -14,7 +14,7 @@ impl<T> ESTree for Null<T> {
 
 /// Serialized as `null`. Field only present in TS-ESTree AST.
 #[ast_meta]
-#[estree(ts_type = "null", raw_deser = "null")]
+#[estree(ts_type = "null", raw_deser = "null", raw_deser_inline)]
 #[ts]
 pub struct TsNull<T>(pub T);
 
@@ -26,7 +26,7 @@ impl<T> ESTree for TsNull<T> {
 
 /// Serialized as `true`.
 #[ast_meta]
-#[estree(ts_type = "true", raw_deser = "true")]
+#[estree(ts_type = "true", raw_deser = "true", raw_deser_inline)]
 pub struct True<T>(pub T);
 
 impl<T> ESTree for True<T> {
@@ -37,7 +37,7 @@ impl<T> ESTree for True<T> {
 
 /// Serialized as `false`.
 #[ast_meta]
-#[estree(ts_type = "false", raw_deser = "false")]
+#[estree(ts_type = "false", raw_deser = "false", raw_deser_inline)]
 pub struct False<T>(pub T);
 
 impl<T> ESTree for False<T> {
@@ -48,7 +48,7 @@ impl<T> ESTree for False<T> {
 
 /// Serialized as `false`. Field only present in JS ESTree AST (not TS-ESTree).
 #[ast_meta]
-#[estree(ts_type = "false", raw_deser = "false")]
+#[estree(ts_type = "false", raw_deser = "false", raw_deser_inline)]
 #[js_only]
 pub struct JsFalse<T>(pub T);
 
@@ -60,7 +60,7 @@ impl<T> ESTree for JsFalse<T> {
 
 /// Serialized as `false`. Field only present in TS-ESTree AST.
 #[ast_meta]
-#[estree(ts_type = "false", raw_deser = "false")]
+#[estree(ts_type = "false", raw_deser = "false", raw_deser_inline)]
 #[ts]
 pub struct TsFalse<T>(pub T);
 
@@ -72,7 +72,7 @@ impl<T> ESTree for TsFalse<T> {
 
 /// Serialized as `"value"`.
 #[ast_meta]
-#[estree(ts_type = "'value'", raw_deser = "'value'")]
+#[estree(ts_type = "'value'", raw_deser = "'value'", raw_deser_inline)]
 #[ts]
 pub struct TsValue<T>(pub T);
 
@@ -84,7 +84,7 @@ impl<T> ESTree for TsValue<T> {
 
 /// Serialized as `"in"`.
 #[ast_meta]
-#[estree(ts_type = "'in'", raw_deser = "'in'")]
+#[estree(ts_type = "'in'", raw_deser = "'in'", raw_deser_inline)]
 pub struct In<T>(pub T);
 
 impl<T> ESTree for In<T> {
@@ -95,7 +95,7 @@ impl<T> ESTree for In<T> {
 
 /// Serialized as `"init"`.
 #[ast_meta]
-#[estree(ts_type = "'init'", raw_deser = "'init'")]
+#[estree(ts_type = "'init'", raw_deser = "'init'", raw_deser_inline)]
 pub struct Init<T>(pub T);
 
 impl<T> ESTree for Init<T> {
@@ -106,7 +106,7 @@ impl<T> ESTree for Init<T> {
 
 /// Serialized as `"this"`.
 #[ast_meta]
-#[estree(ts_type = "'this'", raw_deser = "'this'")]
+#[estree(ts_type = "'this'", raw_deser = "'this'", raw_deser_inline)]
 pub struct This<T>(pub T);
 
 impl<T> ESTree for This<T> {
@@ -117,7 +117,7 @@ impl<T> ESTree for This<T> {
 
 /// Serialized as `"global"`.
 #[ast_meta]
-#[estree(ts_type = "'global'", raw_deser = "'global'")]
+#[estree(ts_type = "'global'", raw_deser = "'global'", raw_deser_inline)]
 pub struct Global<T>(pub T);
 
 impl<T> ESTree for Global<T> {
@@ -128,7 +128,7 @@ impl<T> ESTree for Global<T> {
 
 /// Serialized as `[]`.
 #[ast_meta]
-#[estree(ts_type = "[]", raw_deser = "[]")]
+#[estree(ts_type = "[]", raw_deser = "[]", raw_deser_inline)]
 pub struct EmptyArray<T>(pub T);
 
 impl<T> ESTree for EmptyArray<T> {
@@ -139,7 +139,7 @@ impl<T> ESTree for EmptyArray<T> {
 
 /// Serialized as `[]`. Field only present in JS ESTree AST (not TS-ESTree).
 #[ast_meta]
-#[estree(ts_type = "[]", raw_deser = "[]")]
+#[estree(ts_type = "[]", raw_deser = "[]", raw_deser_inline)]
 #[js_only]
 pub struct JsEmptyArray<T>(pub T);
 
@@ -151,7 +151,7 @@ impl<T> ESTree for JsEmptyArray<T> {
 
 /// Serialized as `[]`. Field only present in TS-ESTree AST.
 #[ast_meta]
-#[estree(ts_type = "[]", raw_deser = "[]")]
+#[estree(ts_type = "[]", raw_deser = "[]", raw_deser_inline)]
 #[ts]
 pub struct TsEmptyArray<T>(pub T);
 

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -42,7 +42,7 @@ impl ESTree for JSXElementOpeningElement<'_, '_> {
 /// This type is only required to add `selfClosing: boolean` to TS type def,
 /// and provide default value of `false` for raw transfer deserializer.
 #[ast_meta]
-#[estree(ts_type = "boolean", raw_deser = "false")]
+#[estree(ts_type = "boolean", raw_deser = "false", raw_deser_inline)]
 pub struct JSXOpeningElementSelfClosing<'a, 'b>(#[expect(dead_code)] pub &'b JSXOpeningElement<'a>);
 
 impl ESTree for JSXOpeningElementSelfClosing<'_, '_> {

--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -36,7 +36,8 @@ impl ESTree for BooleanLiteralRaw<'_> {
 #[ast_meta]
 #[estree(
     ts_type = "'null' | null",
-    raw_deser = "(THIS.start === 0 && THIS.end === 0) ? null : 'null'"
+    raw_deser = "(THIS.start === 0 && THIS.end === 0) ? null : 'null'",
+    raw_deser_inline
 )]
 pub struct NullLiteralRaw<'b>(pub &'b NullLiteral);
 
@@ -100,7 +101,8 @@ impl StringLiteralValue<'_, '_> {
     raw_deser = "
         const bigint = DESER[Str](POS_OFFSET.value);
         BigInt(bigint)
-    "
+    ",
+    raw_deser_inline
 )]
 pub struct BigIntLiteralValue<'a, 'b>(#[expect(dead_code)] pub &'b BigIntLiteral<'a>);
 
@@ -118,7 +120,7 @@ impl ESTree for BigIntLiteralValue<'_, '_> {
 ///
 /// `bigint` var in `raw_deser` comes from `BigIntLiteralValue` serializer.
 #[ast_meta]
-#[estree(ts_type = "string", raw_deser = "bigint")]
+#[estree(ts_type = "string", raw_deser = "bigint", raw_deser_inline)]
 pub struct BigIntLiteralBigint<'a, 'b>(pub &'b BigIntLiteral<'a>);
 
 impl ESTree for BigIntLiteralBigint<'_, '_> {

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -246,7 +246,8 @@ fn get_ts_start_span(program: &Program<'_>) -> u32 {
 #[ast_meta]
 #[estree(
     ts_type = "string",
-    raw_deser = "SOURCE_TEXT.slice(THIS.start + 2, THIS.end - (THIS.type === 'Line' ? 0 : 2))"
+    raw_deser = "SOURCE_TEXT.slice(THIS.start + 2, THIS.end - (THIS.type === 'Line' ? 0 : 2))",
+    raw_deser_inline
 )]
 pub struct CommentValue<'b>(#[expect(dead_code)] pub &'b Comment);
 

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -15,7 +15,7 @@ use super::Null;
 // TODO: Not ideal to have to include the enum discriminant's value here explicitly.
 // Need a "macro" e.g. `ENUM_MATCHES(id, ComputedString | ComputedTemplateString)`.
 #[ast_meta]
-#[estree(ts_type = "boolean", raw_deser = "DESER[u8](POS_OFFSET.id) > 1")]
+#[estree(ts_type = "boolean", raw_deser = "DESER[u8](POS_OFFSET.id) > 1", raw_deser_inline)]
 pub struct TSEnumMemberComputed<'a, 'b>(pub &'b TSEnumMember<'a>);
 
 impl ESTree for TSEnumMemberComputed<'_, '_> {
@@ -32,7 +32,7 @@ impl ESTree for TSEnumMemberComputed<'_, '_> {
 ///
 /// This field is always `null`, and only appears in the TS-ESTree AST, not JS ESTree.
 #[ast_meta]
-#[estree(ts_type = "string | null", raw_deser = "null")]
+#[estree(ts_type = "string | null", raw_deser = "null", raw_deser_inline)]
 #[ts]
 pub struct ExpressionStatementDirective<'a, 'b>(
     #[expect(dead_code)] pub &'b ExpressionStatement<'a>,

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -517,13 +517,12 @@ function deserializeComputedMemberExpression(pos) {
     object: null,
     property: null,
     optional: deserializeBool(pos + 12),
-    computed: null,
+    computed: true,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   return node;
 }
 
@@ -533,13 +532,12 @@ function deserializeStaticMemberExpression(pos) {
     object: null,
     property: null,
     optional: deserializeBool(pos + 12),
-    computed: null,
+    computed: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -549,13 +547,12 @@ function deserializePrivateFieldExpression(pos) {
     object: null,
     property: null,
     optional: deserializeBool(pos + 12),
-    computed: null,
+    computed: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -723,12 +720,11 @@ function deserializeUnaryExpression(pos) {
     type: "UnaryExpression",
     operator: deserializeUnaryOperator(pos + 12),
     argument: null,
-    prefix: null,
+    prefix: true,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   return node;
 }
 
@@ -750,13 +746,12 @@ function deserializePrivateInExpression(pos) {
   let node = {
     type: "BinaryExpression",
     left: null,
-    operator: null,
+    operator: "in",
     right: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   return node;
 }
@@ -951,12 +946,12 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     end = deserializeU32(pos + 4),
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
+      method: false,
+      shorthand: true,
+      computed: false,
       start,
       end,
     },
@@ -976,32 +971,25 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       start,
       end,
     });
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
   return node;
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
   let node = {
     type: "Property",
-    kind: null,
+    kind: "init",
     key: null,
     value: null,
-    method: null,
-    shorthand: null,
+    method: false,
+    shorthand: false,
     computed: deserializeBool(pos + 12),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
   return node;
 }
 
@@ -1660,19 +1648,17 @@ function deserializeObjectPattern(pos) {
 function deserializeBindingProperty(pos) {
   let node = {
     type: "Property",
-    kind: null,
+    kind: "init",
     key: null,
     value: null,
-    method: null,
+    method: false,
     shorthand: deserializeBool(pos + 12),
     computed: deserializeBool(pos + 13),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
   return node;
 }
 
@@ -1709,7 +1695,7 @@ function deserializeFunction(pos) {
       async: deserializeBool(pos + 90),
       params: null,
       body: null,
-      expression: null,
+      expression: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
     },
@@ -1717,7 +1703,6 @@ function deserializeFunction(pos) {
   node.id = deserializeOptionBindingIdentifier(pos + 16);
   node.params = params;
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   return node;
 }
 
@@ -1790,7 +1775,7 @@ function deserializeArrowFunctionExpression(pos) {
       params: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
     },
@@ -1798,7 +1783,6 @@ function deserializeArrowFunctionExpression(pos) {
   expression === true && (body = body.body[0].expression);
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.body = body;
-  node.generator = false;
   return node;
 }
 
@@ -2310,16 +2294,14 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-    };
-  node.raw = start === 0 && end === 0 ? null : "null";
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -2360,21 +2342,18 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-    },
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -2446,13 +2425,12 @@ function deserializeJSXOpeningElement(pos) {
     type: "JSXOpeningElement",
     name: null,
     attributes: null,
-    selfClosing: null,
+    selfClosing: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.name = deserializeJSXElementName(pos + 16);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   return node;
 }
 
@@ -2483,16 +2461,13 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let node = {
+  return {
     type: "JSXOpeningFragment",
-    attributes: null,
-    selfClosing: null,
+    attributes: [],
+    selfClosing: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.attributes = [];
-  node.selfClosing = false;
-  return node;
 }
 
 function deserializeJSXClosingFragment(pos) {
@@ -2813,16 +2788,13 @@ function deserializeJSXText(pos) {
 function deserializeTSThisParameter(pos) {
   let node = {
     type: "Identifier",
-    decorators: null,
-    name: null,
-    optional: null,
+    decorators: [],
+    name: "this",
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   return node;
 }
@@ -2858,13 +2830,12 @@ function deserializeTSEnumMember(pos) {
     type: "TSEnumMember",
     id: null,
     initializer: null,
-    computed: null,
+    computed: deserializeU8(pos + 16) > 1,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   return node;
 }
 
@@ -3482,13 +3453,12 @@ function deserializeTSPropertySignature(pos) {
     key: null,
     typeAnnotation: null,
     accessibility: null,
-    static: null,
+    static: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   return node;
 }
 
@@ -3567,8 +3537,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
     },
@@ -3579,8 +3549,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   return node;
 }
 
@@ -3602,15 +3570,13 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 function deserializeTSIndexSignatureName(pos) {
   let node = {
     type: "Identifier",
-    decorators: null,
+    decorators: [],
     name: deserializeStr(pos + 16),
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   return node;
 }
@@ -3760,9 +3726,9 @@ function deserializeTSGlobalDeclaration(pos) {
     type: "TSModuleDeclaration",
     id: null,
     body: null,
-    kind: null,
+    kind: "global",
     declare: deserializeBool(pos + 88),
-    global: null,
+    global: true,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
@@ -3773,8 +3739,6 @@ function deserializeTSGlobalDeclaration(pos) {
     end: deserializeU32(pos + 20),
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -158,55 +158,43 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeIdentifierReference(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeThisExpression(pos) {
@@ -554,14 +542,13 @@ function deserializeComputedMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: true,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   parent = previousParent;
   return node;
 }
@@ -573,14 +560,13 @@ function deserializeStaticMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -592,14 +578,13 @@ function deserializePrivateFieldExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -784,13 +769,12 @@ function deserializeUnaryExpression(pos) {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 12),
       argument: null,
-      prefix: null,
+      prefix: true,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   parent = previousParent;
   return node;
 }
@@ -817,14 +801,13 @@ function deserializePrivateInExpression(pos) {
     node = (parent = {
       type: "BinaryExpression",
       left: null,
-      operator: null,
+      operator: "in",
       right: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   parent = previousParent;
   return node;
@@ -1042,12 +1025,12 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
+      method: false,
+      shorthand: true,
+      computed: false,
       start,
       end,
       parent,
@@ -1074,12 +1057,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     left.parent = value;
     init.parent = value;
   }
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -1088,21 +1067,18 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
+      method: false,
+      shorthand: false,
       computed: deserializeBool(pos + 12),
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
   parent = previousParent;
   return node;
 }
@@ -1850,20 +1826,18 @@ function deserializeBindingProperty(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
+      method: false,
       shorthand: deserializeBool(pos + 12),
       computed: deserializeBool(pos + 13),
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
   parent = previousParent;
   return node;
 }
@@ -1908,7 +1882,7 @@ function deserializeFunction(pos) {
       async: deserializeBool(pos + 90),
       params: null,
       body: null,
-      expression: null,
+      expression: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -1917,7 +1891,6 @@ function deserializeFunction(pos) {
   node.id = deserializeOptionBindingIdentifier(pos + 16);
   node.params = params;
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   parent = previousParent;
   return node;
 }
@@ -2001,7 +1974,7 @@ function deserializeArrowFunctionExpression(pos) {
       params: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -2013,7 +1986,6 @@ function deserializeArrowFunctionExpression(pos) {
   }
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.body = body;
-  node.generator = false;
   parent = previousParent;
   return node;
 }
@@ -2584,19 +2556,15 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-      parent,
-    });
-  node.raw = start === 0 && end === 0 ? null : "null";
-  parent = previousParent;
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+    parent,
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -2641,24 +2609,19 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-      parent,
-    }),
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+    parent,
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -2737,14 +2700,13 @@ function deserializeJSXOpeningElement(pos) {
       type: "JSXOpeningElement",
       name: null,
       attributes: null,
-      selfClosing: null,
+      selfClosing: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.name = deserializeJSXElementName(pos + 16);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   parent = previousParent;
   return node;
 }
@@ -2782,19 +2744,14 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "JSXOpeningFragment",
-      attributes: null,
-      selfClosing: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  node.attributes = [];
-  node.selfClosing = false;
-  parent = previousParent;
-  return node;
+  return {
+    type: "JSXOpeningFragment",
+    attributes: [],
+    selfClosing: false,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeJSXClosingFragment(pos) {
@@ -3142,17 +3099,14 @@ function deserializeTSThisParameter(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
-      name: null,
-      optional: null,
+      decorators: [],
+      name: "this",
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
   return node;
@@ -3196,14 +3150,13 @@ function deserializeTSEnumMember(pos) {
       type: "TSEnumMember",
       id: null,
       initializer: null,
-      computed: null,
+      computed: deserializeU8(pos + 16) > 1,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   parent = previousParent;
   return node;
 }
@@ -3902,14 +3855,13 @@ function deserializeTSPropertySignature(pos) {
       key: null,
       typeAnnotation: null,
       accessibility: null,
-      static: null,
+      static: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -3996,8 +3948,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -4009,8 +3961,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4037,16 +3987,14 @@ function deserializeTSIndexSignatureName(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
+      decorators: [],
       name: deserializeStr(pos + 16),
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
@@ -4221,9 +4169,9 @@ function deserializeTSGlobalDeclaration(pos) {
       type: "TSModuleDeclaration",
       id: null,
       body: null,
-      kind: null,
+      kind: "global",
       declare: deserializeBool(pos + 88),
-      global: null,
+      global: true,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -4236,8 +4184,6 @@ function deserializeTSGlobalDeclaration(pos) {
     parent,
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   parent = previousParent;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -546,14 +546,13 @@ function deserializeComputedMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   return node;
 }
 
@@ -565,14 +564,13 @@ function deserializeStaticMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -584,14 +582,13 @@ function deserializePrivateFieldExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -776,13 +773,12 @@ function deserializeUnaryExpression(pos) {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 12),
       argument: null,
-      prefix: null,
+      prefix: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   return node;
 }
 
@@ -809,14 +805,13 @@ function deserializePrivateInExpression(pos) {
     node = {
       type: "BinaryExpression",
       left: null,
-      operator: null,
+      operator: "in",
       right: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   return node;
 }
@@ -1032,12 +1027,12 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     end = deserializeU32(pos + 4),
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
+      method: false,
+      shorthand: true,
+      computed: false,
       start,
       end,
       range: [start, end],
@@ -1062,12 +1057,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       end,
       range: [start, end],
     });
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
   return node;
 }
 
@@ -1076,21 +1067,18 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     end,
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
+      method: false,
+      shorthand: false,
       computed: deserializeBool(pos + 12),
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
   return node;
 }
 
@@ -1841,20 +1829,18 @@ function deserializeBindingProperty(pos) {
     end,
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
+      method: false,
       shorthand: deserializeBool(pos + 12),
       computed: deserializeBool(pos + 13),
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
   return node;
 }
 
@@ -1899,7 +1885,7 @@ function deserializeFunction(pos) {
       async: deserializeBool(pos + 90),
       params: null,
       body: null,
-      expression: null,
+      expression: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -1908,7 +1894,6 @@ function deserializeFunction(pos) {
   node.id = deserializeOptionBindingIdentifier(pos + 16);
   node.params = params;
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   return node;
 }
 
@@ -1991,7 +1976,7 @@ function deserializeArrowFunctionExpression(pos) {
       params: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2000,7 +1985,6 @@ function deserializeArrowFunctionExpression(pos) {
   expression === true && (body = body.body[0].expression);
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.body = body;
-  node.generator = false;
   return node;
 }
 
@@ -2569,17 +2553,15 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-      range: [start, end],
-    };
-  node.raw = start === 0 && end === 0 ? null : "null";
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -2622,22 +2604,19 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-      range: [start, end],
-    },
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -2715,14 +2694,13 @@ function deserializeJSXOpeningElement(pos) {
       type: "JSXOpeningElement",
       name: null,
       attributes: null,
-      selfClosing: null,
+      selfClosing: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.name = deserializeJSXElementName(pos + 16);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   return node;
 }
 
@@ -2759,19 +2737,15 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start,
-    end,
-    node = {
-      type: "JSXOpeningFragment",
-      attributes: null,
-      selfClosing: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-    };
-  node.attributes = [];
-  node.selfClosing = false;
-  return node;
+  let start, end;
+  return {
+    type: "JSXOpeningFragment",
+    attributes: [],
+    selfClosing: false,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+  };
 }
 
 function deserializeJSXClosingFragment(pos) {
@@ -3123,17 +3097,14 @@ function deserializeTSThisParameter(pos) {
     end,
     node = {
       type: "Identifier",
-      decorators: null,
-      name: null,
-      optional: null,
+      decorators: [],
+      name: "this",
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   return node;
 }
@@ -3177,14 +3148,13 @@ function deserializeTSEnumMember(pos) {
       type: "TSEnumMember",
       id: null,
       initializer: null,
-      computed: null,
+      computed: deserializeU8(pos + 16) > 1,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   return node;
 }
 
@@ -3896,14 +3866,13 @@ function deserializeTSPropertySignature(pos) {
       key: null,
       typeAnnotation: null,
       accessibility: null,
-      static: null,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   return node;
 }
 
@@ -3990,8 +3959,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4003,8 +3972,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   return node;
 }
 
@@ -4031,16 +3998,14 @@ function deserializeTSIndexSignatureName(pos) {
     end,
     node = {
       type: "Identifier",
-      decorators: null,
+      decorators: [],
       name: deserializeStr(pos + 16),
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   return node;
 }
@@ -4204,9 +4169,9 @@ function deserializeTSGlobalDeclaration(pos) {
       type: "TSModuleDeclaration",
       id: null,
       body: null,
-      kind: null,
+      kind: "global",
       declare: deserializeBool(pos + 88),
-      global: null,
+      global: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4221,8 +4186,6 @@ function deserializeTSGlobalDeclaration(pos) {
     range: [keywordStart, keywordEnd],
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -159,67 +159,51 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeIdentifierReference(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      name: deserializeStr(pos + 16),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    name: deserializeStr(pos + 16),
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeThisExpression(pos) {
@@ -587,7 +571,7 @@ function deserializeComputedMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -595,7 +579,6 @@ function deserializeComputedMemberExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   parent = previousParent;
   return node;
 }
@@ -609,7 +592,7 @@ function deserializeStaticMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -617,7 +600,6 @@ function deserializeStaticMemberExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -631,7 +613,7 @@ function deserializePrivateFieldExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -639,7 +621,6 @@ function deserializePrivateFieldExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -841,14 +822,13 @@ function deserializeUnaryExpression(pos) {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 12),
       argument: null,
-      prefix: null,
+      prefix: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   parent = previousParent;
   return node;
 }
@@ -880,7 +860,7 @@ function deserializePrivateInExpression(pos) {
     node = (parent = {
       type: "BinaryExpression",
       left: null,
-      operator: null,
+      operator: "in",
       right: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -888,7 +868,6 @@ function deserializePrivateInExpression(pos) {
       parent,
     });
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   parent = previousParent;
   return node;
@@ -1127,12 +1106,12 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
+      method: false,
+      shorthand: true,
+      computed: false,
       start,
       end,
       range: [start, end],
@@ -1164,12 +1143,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     left.parent = value;
     init.parent = value;
   }
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -1180,22 +1155,19 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
+      method: false,
+      shorthand: false,
       computed: deserializeBool(pos + 12),
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
   parent = previousParent;
   return node;
 }
@@ -2034,10 +2006,10 @@ function deserializeBindingProperty(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
+      method: false,
       shorthand: deserializeBool(pos + 12),
       computed: deserializeBool(pos + 13),
       start: (start = deserializeU32(pos)),
@@ -2045,10 +2017,8 @@ function deserializeBindingProperty(pos) {
       range: [start, end],
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
   parent = previousParent;
   return node;
 }
@@ -2101,7 +2071,7 @@ function deserializeFunction(pos) {
       async: deserializeBool(pos + 90),
       params: null,
       body: null,
-      expression: null,
+      expression: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2111,7 +2081,6 @@ function deserializeFunction(pos) {
   node.id = deserializeOptionBindingIdentifier(pos + 16);
   node.params = params;
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   parent = previousParent;
   return node;
 }
@@ -2205,7 +2174,7 @@ function deserializeArrowFunctionExpression(pos) {
       params: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2218,7 +2187,6 @@ function deserializeArrowFunctionExpression(pos) {
   }
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.body = body;
-  node.generator = false;
   parent = previousParent;
   return node;
 }
@@ -2846,20 +2814,16 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    });
-  node.raw = start === 0 && end === 0 ? null : "null";
-  parent = previousParent;
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -2906,25 +2870,20 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    }),
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -3009,7 +2968,7 @@ function deserializeJSXOpeningElement(pos) {
       type: "JSXOpeningElement",
       name: null,
       attributes: null,
-      selfClosing: null,
+      selfClosing: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -3017,7 +2976,6 @@ function deserializeJSXOpeningElement(pos) {
     });
   node.name = deserializeJSXElementName(pos + 16);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   parent = previousParent;
   return node;
 }
@@ -3061,22 +3019,16 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "JSXOpeningFragment",
-      attributes: null,
-      selfClosing: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.attributes = [];
-  node.selfClosing = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "JSXOpeningFragment",
+    attributes: [],
+    selfClosing: false,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeJSXClosingFragment(pos) {
@@ -3455,18 +3407,15 @@ function deserializeTSThisParameter(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
-      name: null,
-      optional: null,
+      decorators: [],
+      name: "this",
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
   return node;
@@ -3518,7 +3467,7 @@ function deserializeTSEnumMember(pos) {
       type: "TSEnumMember",
       id: null,
       initializer: null,
-      computed: null,
+      computed: deserializeU8(pos + 16) > 1,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -3526,7 +3475,6 @@ function deserializeTSEnumMember(pos) {
     });
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   parent = previousParent;
   return node;
 }
@@ -4318,7 +4266,7 @@ function deserializeTSPropertySignature(pos) {
       key: null,
       typeAnnotation: null,
       accessibility: null,
-      static: null,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4326,7 +4274,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4421,8 +4368,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4435,8 +4382,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4468,17 +4413,15 @@ function deserializeTSIndexSignatureName(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
+      decorators: [],
       name: deserializeStr(pos + 16),
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
@@ -4668,9 +4611,9 @@ function deserializeTSGlobalDeclaration(pos) {
       type: "TSModuleDeclaration",
       id: null,
       body: null,
-      kind: null,
+      kind: "global",
       declare: deserializeBool(pos + 88),
-      global: null,
+      global: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4687,8 +4630,6 @@ function deserializeTSGlobalDeclaration(pos) {
     parent,
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   parent = previousParent;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -174,63 +174,51 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let node = {
+  return {
     type: "Identifier",
-    decorators: null,
+    decorators: [],
     name: deserializeStr(pos + 16),
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.optional = false;
-  return node;
 }
 
 function deserializeIdentifierReference(pos) {
-  let node = {
+  return {
     type: "Identifier",
-    decorators: null,
+    decorators: [],
     name: deserializeStr(pos + 16),
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.optional = false;
-  return node;
 }
 
 function deserializeBindingIdentifier(pos) {
-  let node = {
+  return {
     type: "Identifier",
-    decorators: null,
+    decorators: [],
     name: deserializeStr(pos + 16),
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.optional = false;
-  return node;
 }
 
 function deserializeLabelIdentifier(pos) {
-  let node = {
+  return {
     type: "Identifier",
-    decorators: null,
+    decorators: [],
     name: deserializeStr(pos + 16),
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.optional = false;
-  return node;
 }
 
 function deserializeThisExpression(pos) {
@@ -384,13 +372,12 @@ function deserializeObjectProperty(pos) {
     method: deserializeBool(pos + 13),
     shorthand: deserializeBool(pos + 14),
     computed: deserializeBool(pos + 15),
-    optional: null,
+    optional: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeExpression(pos + 32);
-  node.optional = false;
   return node;
 }
 
@@ -564,13 +551,12 @@ function deserializeComputedMemberExpression(pos) {
     object: null,
     property: null,
     optional: deserializeBool(pos + 12),
-    computed: null,
+    computed: true,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   return node;
 }
 
@@ -580,13 +566,12 @@ function deserializeStaticMemberExpression(pos) {
     object: null,
     property: null,
     optional: deserializeBool(pos + 12),
-    computed: null,
+    computed: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -596,13 +581,12 @@ function deserializePrivateFieldExpression(pos) {
     object: null,
     property: null,
     optional: deserializeBool(pos + 12),
-    computed: null,
+    computed: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -774,12 +758,11 @@ function deserializeUnaryExpression(pos) {
     type: "UnaryExpression",
     operator: deserializeUnaryOperator(pos + 12),
     argument: null,
-    prefix: null,
+    prefix: true,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   return node;
 }
 
@@ -801,13 +784,12 @@ function deserializePrivateInExpression(pos) {
   let node = {
     type: "BinaryExpression",
     left: null,
-    operator: null,
+    operator: "in",
     right: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   return node;
 }
@@ -908,9 +890,9 @@ function deserializeSimpleAssignmentTarget(pos) {
 function deserializeArrayAssignmentTarget(pos) {
   let node = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -918,18 +900,16 @@ function deserializeArrayAssignmentTarget(pos) {
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   return node;
 }
 
 function deserializeObjectAssignmentTarget(pos) {
   let node = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -937,26 +917,22 @@ function deserializeObjectAssignmentTarget(pos) {
     properties = deserializeVecAssignmentTargetProperty(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   return node;
 }
 
 function deserializeAssignmentTargetRest(pos) {
   let node = {
     type: "RestElement",
-    decorators: null,
+    decorators: [],
     argument: null,
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     value: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 16);
-  node.optional = false;
   return node;
 }
 
@@ -992,18 +968,16 @@ function deserializeAssignmentTargetMaybeDefault(pos) {
 function deserializeAssignmentTargetWithDefault(pos) {
   let node = {
     type: "AssignmentPattern",
-    decorators: null,
+    decorators: [],
     left: null,
     right: null,
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   return node;
 }
 
@@ -1023,13 +997,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     end = deserializeU32(pos + 4),
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
-      optional: null,
+      method: false,
+      shorthand: true,
+      computed: false,
+      optional: false,
       start,
       end,
     },
@@ -1055,35 +1029,26 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       start,
       end,
     });
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
-  node.optional = false;
   return node;
 }
 
 function deserializeAssignmentTargetPropertyProperty(pos) {
   let node = {
     type: "Property",
-    kind: null,
+    kind: "init",
     key: null,
     value: null,
-    method: null,
-    shorthand: null,
+    method: false,
+    shorthand: false,
     computed: deserializeBool(pos + 12),
-    optional: null,
+    optional: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
-  node.optional = false;
   return node;
 }
 
@@ -1732,27 +1697,25 @@ function deserializeBindingPattern(pos) {
 function deserializeAssignmentPattern(pos) {
   let node = {
     type: "AssignmentPattern",
-    decorators: null,
+    decorators: [],
     left: null,
     right: null,
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
   node.left = deserializeBindingPattern(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   return node;
 }
 
 function deserializeObjectPattern(pos) {
   let node = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -1760,39 +1723,34 @@ function deserializeObjectPattern(pos) {
     properties = deserializeVecBindingProperty(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   return node;
 }
 
 function deserializeBindingProperty(pos) {
   let node = {
     type: "Property",
-    kind: null,
+    kind: "init",
     key: null,
     value: null,
-    method: null,
+    method: false,
     shorthand: deserializeBool(pos + 12),
     computed: deserializeBool(pos + 13),
-    optional: null,
+    optional: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
-  node.optional = false;
   return node;
 }
 
 function deserializeArrayPattern(pos) {
   let node = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -1800,26 +1758,22 @@ function deserializeArrayPattern(pos) {
     elements = deserializeVecOptionBindingPattern(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   return node;
 }
 
 function deserializeBindingRestElement(pos) {
   let node = {
     type: "RestElement",
-    decorators: null,
+    decorators: [],
     argument: null,
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     value: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 16);
-  node.optional = false;
   return node;
 }
 
@@ -1834,7 +1788,7 @@ function deserializeFunction(pos) {
       params: null,
       returnType: null,
       body: null,
-      expression: null,
+      expression: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
     },
@@ -1848,7 +1802,6 @@ function deserializeFunction(pos) {
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 72);
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   return node;
 }
 
@@ -2007,7 +1960,7 @@ function deserializeArrowFunctionExpression(pos) {
       returnType: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
     },
@@ -2017,7 +1970,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   node.body = body;
-  node.generator = false;
   return node;
 }
 
@@ -2223,9 +2175,9 @@ function deserializeAccessorProperty(pos) {
     override: deserializeBool(pos + 15),
     definite: deserializeBool(pos + 80),
     accessibility: deserializeOptionTSAccessibility(pos + 81),
-    declare: null,
-    optional: null,
-    readonly: null,
+    declare: false,
+    optional: false,
+    readonly: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
@@ -2233,9 +2185,6 @@ function deserializeAccessorProperty(pos) {
   node.key = deserializePropertyKey(pos + 40);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 56);
   node.value = deserializeOptionExpression(pos + 64);
-  node.declare = false;
-  node.optional = false;
-  node.readonly = false;
   return node;
 }
 
@@ -2384,12 +2333,11 @@ function deserializeExportDefaultDeclaration(pos) {
   let node = {
     type: "ExportDefaultDeclaration",
     declaration: null,
-    exportKind: null,
+    exportKind: "value",
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 16);
-  node.exportKind = "value";
   return node;
 }
 
@@ -2566,16 +2514,14 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-    };
-  node.raw = start === 0 && end === 0 ? null : "null";
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -2616,21 +2562,18 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-    },
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -2703,14 +2646,13 @@ function deserializeJSXOpeningElement(pos) {
     name: null,
     typeArguments: null,
     attributes: null,
-    selfClosing: null,
+    selfClosing: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.name = deserializeJSXElementName(pos + 16);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 32);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   return node;
 }
 
@@ -3066,16 +3008,13 @@ function deserializeJSXText(pos) {
 function deserializeTSThisParameter(pos) {
   let node = {
     type: "Identifier",
-    decorators: null,
-    name: null,
-    optional: null,
+    decorators: [],
+    name: "this",
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   return node;
 }
@@ -3111,13 +3050,12 @@ function deserializeTSEnumMember(pos) {
     type: "TSEnumMember",
     id: null,
     initializer: null,
-    computed: null,
+    computed: deserializeU8(pos + 16) > 1,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   return node;
 }
 
@@ -3788,13 +3726,12 @@ function deserializeTSPropertySignature(pos) {
     key: null,
     typeAnnotation: null,
     accessibility: null,
-    static: null,
+    static: false,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   return node;
 }
 
@@ -3873,8 +3810,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
     },
@@ -3885,8 +3822,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   return node;
 }
 
@@ -3908,15 +3843,13 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 function deserializeTSIndexSignatureName(pos) {
   let node = {
     type: "Identifier",
-    decorators: null,
+    decorators: [],
     name: deserializeStr(pos + 16),
-    optional: null,
+    optional: false,
     typeAnnotation: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   return node;
 }
@@ -4066,9 +3999,9 @@ function deserializeTSGlobalDeclaration(pos) {
     type: "TSModuleDeclaration",
     id: null,
     body: null,
-    kind: null,
+    kind: "global",
     declare: deserializeBool(pos + 88),
-    global: null,
+    global: true,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
@@ -4082,8 +4015,6 @@ function deserializeTSGlobalDeclaration(pos) {
     end: deserializeU32(pos + 20),
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -177,75 +177,55 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeIdentifierReference(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeThisExpression(pos) {
@@ -407,14 +387,13 @@ function deserializeObjectProperty(pos) {
       method: deserializeBool(pos + 13),
       shorthand: deserializeBool(pos + 14),
       computed: deserializeBool(pos + 15),
-      optional: null,
+      optional: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -597,14 +576,13 @@ function deserializeComputedMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: true,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   parent = previousParent;
   return node;
 }
@@ -616,14 +594,13 @@ function deserializeStaticMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -635,14 +612,13 @@ function deserializePrivateFieldExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -831,13 +807,12 @@ function deserializeUnaryExpression(pos) {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 12),
       argument: null,
-      prefix: null,
+      prefix: true,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   parent = previousParent;
   return node;
 }
@@ -864,14 +839,13 @@ function deserializePrivateInExpression(pos) {
     node = (parent = {
       type: "BinaryExpression",
       left: null,
-      operator: null,
+      operator: "in",
       right: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   parent = previousParent;
   return node;
@@ -983,9 +957,9 @@ function deserializeArrayAssignmentTarget(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -994,9 +968,7 @@ function deserializeArrayAssignmentTarget(pos) {
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1005,9 +977,9 @@ function deserializeObjectAssignmentTarget(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -1016,9 +988,7 @@ function deserializeObjectAssignmentTarget(pos) {
     properties = deserializeVecAssignmentTargetProperty(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1027,18 +997,16 @@ function deserializeAssignmentTargetRest(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 16);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1076,19 +1044,17 @@ function deserializeAssignmentTargetWithDefault(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1110,13 +1076,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
-      optional: null,
+      method: false,
+      shorthand: true,
+      computed: false,
+      optional: false,
       start,
       end,
       parent,
@@ -1149,13 +1115,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     left.parent = value;
     init.parent = value;
   }
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1164,23 +1125,19 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
+      method: false,
+      shorthand: false,
       computed: deserializeBool(pos + 12),
-      optional: null,
+      optional: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1918,19 +1875,17 @@ function deserializeAssignmentPattern(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
   node.left = deserializeBindingPattern(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1939,9 +1894,9 @@ function deserializeObjectPattern(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -1950,9 +1905,7 @@ function deserializeObjectPattern(pos) {
     properties = deserializeVecBindingProperty(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1961,22 +1914,19 @@ function deserializeBindingProperty(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
+      method: false,
       shorthand: deserializeBool(pos + 12),
       computed: deserializeBool(pos + 13),
-      optional: null,
+      optional: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1985,9 +1935,9 @@ function deserializeArrayPattern(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
@@ -1996,9 +1946,7 @@ function deserializeArrayPattern(pos) {
     elements = deserializeVecOptionBindingPattern(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2007,18 +1955,16 @@ function deserializeBindingRestElement(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 16);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2035,7 +1981,7 @@ function deserializeFunction(pos) {
       params: null,
       returnType: null,
       body: null,
-      expression: null,
+      expression: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -2050,7 +1996,6 @@ function deserializeFunction(pos) {
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 72);
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   parent = previousParent;
   return node;
 }
@@ -2233,7 +2178,7 @@ function deserializeArrowFunctionExpression(pos) {
       returnType: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -2247,7 +2192,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   node.body = body;
-  node.generator = false;
   parent = previousParent;
   return node;
 }
@@ -2474,9 +2418,9 @@ function deserializeAccessorProperty(pos) {
       override: deserializeBool(pos + 15),
       definite: deserializeBool(pos + 80),
       accessibility: deserializeOptionTSAccessibility(pos + 81),
-      declare: null,
-      optional: null,
-      readonly: null,
+      declare: false,
+      optional: false,
+      readonly: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -2485,9 +2429,6 @@ function deserializeAccessorProperty(pos) {
   node.key = deserializePropertyKey(pos + 40);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 56);
   node.value = deserializeOptionExpression(pos + 64);
-  node.declare = false;
-  node.optional = false;
-  node.readonly = false;
   parent = previousParent;
   return node;
 }
@@ -2659,13 +2600,12 @@ function deserializeExportDefaultDeclaration(pos) {
     node = (parent = {
       type: "ExportDefaultDeclaration",
       declaration: null,
-      exportKind: null,
+      exportKind: "value",
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 16);
-  node.exportKind = "value";
   parent = previousParent;
   return node;
 }
@@ -2855,19 +2795,15 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-      parent,
-    });
-  node.raw = start === 0 && end === 0 ? null : "null";
-  parent = previousParent;
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+    parent,
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -2912,24 +2848,19 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-      parent,
-    }),
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+    parent,
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -3009,7 +2940,7 @@ function deserializeJSXOpeningElement(pos) {
       name: null,
       typeArguments: null,
       attributes: null,
-      selfClosing: null,
+      selfClosing: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -3017,7 +2948,6 @@ function deserializeJSXOpeningElement(pos) {
   node.name = deserializeJSXElementName(pos + 16);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 32);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   parent = previousParent;
   return node;
 }
@@ -3055,15 +2985,12 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let previousParent = parent,
-    node = (parent = {
-      type: "JSXOpeningFragment",
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  return {
+    type: "JSXOpeningFragment",
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    parent,
+  };
 }
 
 function deserializeJSXClosingFragment(pos) {
@@ -3411,17 +3338,14 @@ function deserializeTSThisParameter(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
-      name: null,
-      optional: null,
+      decorators: [],
+      name: "this",
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
   return node;
@@ -3465,14 +3389,13 @@ function deserializeTSEnumMember(pos) {
       type: "TSEnumMember",
       id: null,
       initializer: null,
-      computed: null,
+      computed: deserializeU8(pos + 16) > 1,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   parent = previousParent;
   return node;
 }
@@ -4235,14 +4158,13 @@ function deserializeTSPropertySignature(pos) {
       key: null,
       typeAnnotation: null,
       accessibility: null,
-      static: null,
+      static: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4329,8 +4251,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -4342,8 +4264,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4370,16 +4290,14 @@ function deserializeTSIndexSignatureName(pos) {
   let previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
+      decorators: [],
       name: deserializeStr(pos + 16),
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
     });
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
@@ -4554,9 +4472,9 @@ function deserializeTSGlobalDeclaration(pos) {
       type: "TSModuleDeclaration",
       id: null,
       body: null,
-      kind: null,
+      kind: "global",
       declare: deserializeBool(pos + 88),
-      global: null,
+      global: true,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
       parent,
@@ -4572,8 +4490,6 @@ function deserializeTSGlobalDeclaration(pos) {
     parent,
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   parent = previousParent;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -175,75 +175,59 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start,
-    end,
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-    };
-  node.decorators = [];
-  node.optional = false;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+  };
 }
 
 function deserializeIdentifierReference(pos) {
-  let start,
-    end,
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-    };
-  node.decorators = [];
-  node.optional = false;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+  };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start,
-    end,
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-    };
-  node.decorators = [];
-  node.optional = false;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+  };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start,
-    end,
-    node = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-    };
-  node.decorators = [];
-  node.optional = false;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+  };
 }
 
 function deserializeThisExpression(pos) {
@@ -407,14 +391,13 @@ function deserializeObjectProperty(pos) {
       method: deserializeBool(pos + 13),
       shorthand: deserializeBool(pos + 14),
       computed: deserializeBool(pos + 15),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeExpression(pos + 32);
-  node.optional = false;
   return node;
 }
 
@@ -597,14 +580,13 @@ function deserializeComputedMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   return node;
 }
 
@@ -616,14 +598,13 @@ function deserializeStaticMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -635,14 +616,13 @@ function deserializePrivateFieldExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   return node;
 }
 
@@ -831,13 +811,12 @@ function deserializeUnaryExpression(pos) {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 12),
       argument: null,
-      prefix: null,
+      prefix: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   return node;
 }
 
@@ -864,14 +843,13 @@ function deserializePrivateInExpression(pos) {
     node = {
       type: "BinaryExpression",
       left: null,
-      operator: null,
+      operator: "in",
       right: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   return node;
 }
@@ -983,9 +961,9 @@ function deserializeArrayAssignmentTarget(pos) {
     end,
     node = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -994,9 +972,7 @@ function deserializeArrayAssignmentTarget(pos) {
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   return node;
 }
 
@@ -1005,9 +981,9 @@ function deserializeObjectAssignmentTarget(pos) {
     end,
     node = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -1016,9 +992,7 @@ function deserializeObjectAssignmentTarget(pos) {
     properties = deserializeVecAssignmentTargetProperty(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   return node;
 }
 
@@ -1027,18 +1001,16 @@ function deserializeAssignmentTargetRest(pos) {
     end,
     node = {
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 16);
-  node.optional = false;
   return node;
 }
 
@@ -1076,19 +1048,17 @@ function deserializeAssignmentTargetWithDefault(pos) {
     end,
     node = {
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   return node;
 }
 
@@ -1108,13 +1078,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     end = deserializeU32(pos + 4),
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
-      optional: null,
+      method: false,
+      shorthand: true,
+      computed: false,
+      optional: false,
       start,
       end,
       range: [start, end],
@@ -1145,13 +1115,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
       end,
       range: [start, end],
     });
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
-  node.optional = false;
   return node;
 }
 
@@ -1160,23 +1125,19 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     end,
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
+      method: false,
+      shorthand: false,
       computed: deserializeBool(pos + 12),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
-  node.optional = false;
   return node;
 }
 
@@ -1914,19 +1875,17 @@ function deserializeAssignmentPattern(pos) {
     end,
     node = {
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
   node.left = deserializeBindingPattern(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   return node;
 }
 
@@ -1935,9 +1894,9 @@ function deserializeObjectPattern(pos) {
     end,
     node = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -1946,9 +1905,7 @@ function deserializeObjectPattern(pos) {
     properties = deserializeVecBindingProperty(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   return node;
 }
 
@@ -1957,22 +1914,19 @@ function deserializeBindingProperty(pos) {
     end,
     node = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
+      method: false,
       shorthand: deserializeBool(pos + 12),
       computed: deserializeBool(pos + 13),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
-  node.optional = false;
   return node;
 }
 
@@ -1981,9 +1935,9 @@ function deserializeArrayPattern(pos) {
     end,
     node = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -1992,9 +1946,7 @@ function deserializeArrayPattern(pos) {
     elements = deserializeVecOptionBindingPattern(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   return node;
 }
 
@@ -2003,18 +1955,16 @@ function deserializeBindingRestElement(pos) {
     end,
     node = {
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 16);
-  node.optional = false;
   return node;
 }
 
@@ -2031,7 +1981,7 @@ function deserializeFunction(pos) {
       params: null,
       returnType: null,
       body: null,
-      expression: null,
+      expression: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2046,7 +1996,6 @@ function deserializeFunction(pos) {
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 72);
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   return node;
 }
 
@@ -2233,7 +2182,7 @@ function deserializeArrowFunctionExpression(pos) {
       returnType: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2244,7 +2193,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   node.body = body;
-  node.generator = false;
   return node;
 }
 
@@ -2472,9 +2420,9 @@ function deserializeAccessorProperty(pos) {
       override: deserializeBool(pos + 15),
       definite: deserializeBool(pos + 80),
       accessibility: deserializeOptionTSAccessibility(pos + 81),
-      declare: null,
-      optional: null,
-      readonly: null,
+      declare: false,
+      optional: false,
+      readonly: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2483,9 +2431,6 @@ function deserializeAccessorProperty(pos) {
   node.key = deserializePropertyKey(pos + 40);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 56);
   node.value = deserializeOptionExpression(pos + 64);
-  node.declare = false;
-  node.optional = false;
-  node.readonly = false;
   return node;
 }
 
@@ -2657,13 +2602,12 @@ function deserializeExportDefaultDeclaration(pos) {
     node = {
       type: "ExportDefaultDeclaration",
       declaration: null,
-      exportKind: null,
+      exportKind: "value",
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 16);
-  node.exportKind = "value";
   return node;
 }
 
@@ -2850,17 +2794,15 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-      range: [start, end],
-    };
-  node.raw = start === 0 && end === 0 ? null : "null";
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -2903,22 +2845,19 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    node = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-      range: [start, end],
-    },
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+    range: [start, end],
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -2997,7 +2936,7 @@ function deserializeJSXOpeningElement(pos) {
       name: null,
       typeArguments: null,
       attributes: null,
-      selfClosing: null,
+      selfClosing: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -3005,7 +2944,6 @@ function deserializeJSXOpeningElement(pos) {
   node.name = deserializeJSXElementName(pos + 16);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 32);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   return node;
 }
 
@@ -3400,17 +3338,14 @@ function deserializeTSThisParameter(pos) {
     end,
     node = {
       type: "Identifier",
-      decorators: null,
-      name: null,
-      optional: null,
+      decorators: [],
+      name: "this",
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   return node;
 }
@@ -3454,14 +3389,13 @@ function deserializeTSEnumMember(pos) {
       type: "TSEnumMember",
       id: null,
       initializer: null,
-      computed: null,
+      computed: deserializeU8(pos + 16) > 1,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   return node;
 }
 
@@ -4233,14 +4167,13 @@ function deserializeTSPropertySignature(pos) {
       key: null,
       typeAnnotation: null,
       accessibility: null,
-      static: null,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   return node;
 }
 
@@ -4327,8 +4260,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4340,8 +4273,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   return node;
 }
 
@@ -4368,16 +4299,14 @@ function deserializeTSIndexSignatureName(pos) {
     end,
     node = {
       type: "Identifier",
-      decorators: null,
+      decorators: [],
       name: deserializeStr(pos + 16),
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
     };
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   return node;
 }
@@ -4541,9 +4470,9 @@ function deserializeTSGlobalDeclaration(pos) {
       type: "TSModuleDeclaration",
       id: null,
       body: null,
-      kind: null,
+      kind: "global",
       declare: deserializeBool(pos + 88),
-      global: null,
+      global: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4561,8 +4490,6 @@ function deserializeTSGlobalDeclaration(pos) {
     range: [keywordStart, keywordEnd],
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -178,87 +178,63 @@ function deserializeExpression(pos) {
 }
 
 function deserializeIdentifierName(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeIdentifierReference(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeBindingIdentifier(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeLabelIdentifier(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "Identifier",
-      decorators: null,
-      name: deserializeStr(pos + 16),
-      optional: null,
-      typeAnnotation: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  node.decorators = [];
-  node.optional = false;
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: deserializeStr(pos + 16),
+    optional: false,
+    typeAnnotation: null,
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeThisExpression(pos) {
@@ -430,7 +406,7 @@ function deserializeObjectProperty(pos) {
       method: deserializeBool(pos + 13),
       shorthand: deserializeBool(pos + 14),
       computed: deserializeBool(pos + 15),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -438,7 +414,6 @@ function deserializeObjectProperty(pos) {
     });
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -630,7 +605,7 @@ function deserializeComputedMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -638,7 +613,6 @@ function deserializeComputedMemberExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeExpression(pos + 32);
-  node.computed = true;
   parent = previousParent;
   return node;
 }
@@ -652,7 +626,7 @@ function deserializeStaticMemberExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -660,7 +634,6 @@ function deserializeStaticMemberExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializeIdentifierName(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -674,7 +647,7 @@ function deserializePrivateFieldExpression(pos) {
       object: null,
       property: null,
       optional: deserializeBool(pos + 12),
-      computed: null,
+      computed: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -682,7 +655,6 @@ function deserializePrivateFieldExpression(pos) {
     });
   node.object = deserializeExpression(pos + 16);
   node.property = deserializePrivateIdentifier(pos + 32);
-  node.computed = false;
   parent = previousParent;
   return node;
 }
@@ -888,14 +860,13 @@ function deserializeUnaryExpression(pos) {
       type: "UnaryExpression",
       operator: deserializeUnaryOperator(pos + 12),
       argument: null,
-      prefix: null,
+      prefix: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
   node.argument = deserializeExpression(pos + 16);
-  node.prefix = true;
   parent = previousParent;
   return node;
 }
@@ -927,7 +898,7 @@ function deserializePrivateInExpression(pos) {
     node = (parent = {
       type: "BinaryExpression",
       left: null,
-      operator: null,
+      operator: "in",
       right: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -935,7 +906,6 @@ function deserializePrivateInExpression(pos) {
       parent,
     });
   node.left = deserializePrivateIdentifier(pos + 16);
-  node.operator = "in";
   node.right = deserializeExpression(pos + 48);
   parent = previousParent;
   return node;
@@ -1058,9 +1028,9 @@ function deserializeArrayAssignmentTarget(pos) {
     previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -1070,9 +1040,7 @@ function deserializeArrayAssignmentTarget(pos) {
     elements = deserializeVecOptionAssignmentTargetMaybeDefault(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1083,9 +1051,9 @@ function deserializeObjectAssignmentTarget(pos) {
     previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -1095,9 +1063,7 @@ function deserializeObjectAssignmentTarget(pos) {
     properties = deserializeVecAssignmentTargetProperty(pos + 16),
     rest = deserializeOptionBoxAssignmentTargetRest(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1108,9 +1074,9 @@ function deserializeAssignmentTargetRest(pos) {
     previousParent = parent,
     node = (parent = {
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: (start = deserializeU32(pos)),
@@ -1118,9 +1084,7 @@ function deserializeAssignmentTargetRest(pos) {
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.argument = deserializeAssignmentTarget(pos + 16);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1160,20 +1124,18 @@ function deserializeAssignmentTargetWithDefault(pos) {
     previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.left = deserializeAssignmentTarget(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1195,13 +1157,13 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
-      computed: null,
-      optional: null,
+      method: false,
+      shorthand: true,
+      computed: false,
+      optional: false,
       start,
       end,
       range: [start, end],
@@ -1239,13 +1201,8 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     left.parent = value;
     init.parent = value;
   }
-  node.kind = "init";
   node.key = key;
   node.value = value;
-  node.method = false;
-  node.shorthand = true;
-  node.computed = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -1256,24 +1213,20 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
-      shorthand: null,
+      method: false,
+      shorthand: false,
       computed: deserializeBool(pos + 12),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeAssignmentTargetMaybeDefault(pos + 32);
-  node.method = false;
-  node.shorthand = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2099,20 +2052,18 @@ function deserializeAssignmentPattern(pos) {
     previousParent = parent,
     node = (parent = {
       type: "AssignmentPattern",
-      decorators: null,
+      decorators: [],
       left: null,
       right: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.left = deserializeBindingPattern(pos + 16);
   node.right = deserializeExpression(pos + 32);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2123,9 +2074,9 @@ function deserializeObjectPattern(pos) {
     previousParent = parent,
     node = (parent = {
       type: "ObjectPattern",
-      decorators: null,
+      decorators: [],
       properties: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -2135,9 +2086,7 @@ function deserializeObjectPattern(pos) {
     properties = deserializeVecBindingProperty(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && properties.push(rest);
-  node.decorators = [];
   node.properties = properties;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2148,23 +2097,20 @@ function deserializeBindingProperty(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Property",
-      kind: null,
+      kind: "init",
       key: null,
       value: null,
-      method: null,
+      method: false,
       shorthand: deserializeBool(pos + 12),
       computed: deserializeBool(pos + 13),
-      optional: null,
+      optional: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.kind = "init";
   node.key = deserializePropertyKey(pos + 16);
   node.value = deserializeBindingPattern(pos + 32);
-  node.method = false;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2175,9 +2121,9 @@ function deserializeArrayPattern(pos) {
     previousParent = parent,
     node = (parent = {
       type: "ArrayPattern",
-      decorators: null,
+      decorators: [],
       elements: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
@@ -2187,9 +2133,7 @@ function deserializeArrayPattern(pos) {
     elements = deserializeVecOptionBindingPattern(pos + 16),
     rest = deserializeOptionBoxBindingRestElement(pos + 40);
   rest !== null && elements.push(rest);
-  node.decorators = [];
   node.elements = elements;
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2200,9 +2144,9 @@ function deserializeBindingRestElement(pos) {
     previousParent = parent,
     node = (parent = {
       type: "RestElement",
-      decorators: null,
+      decorators: [],
       argument: null,
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       value: null,
       start: (start = deserializeU32(pos)),
@@ -2210,9 +2154,7 @@ function deserializeBindingRestElement(pos) {
       range: [start, end],
       parent,
     });
-  node.decorators = [];
   node.argument = deserializeBindingPattern(pos + 16);
-  node.optional = false;
   parent = previousParent;
   return node;
 }
@@ -2231,7 +2173,7 @@ function deserializeFunction(pos) {
       params: null,
       returnType: null,
       body: null,
-      expression: null,
+      expression: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2247,7 +2189,6 @@ function deserializeFunction(pos) {
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 72);
   node.body = deserializeOptionBoxFunctionBody(pos + 80);
-  node.expression = false;
   parent = previousParent;
   return node;
 }
@@ -2458,7 +2399,7 @@ function deserializeArrowFunctionExpression(pos) {
       returnType: null,
       body: null,
       id: null,
-      generator: null,
+      generator: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2473,7 +2414,6 @@ function deserializeArrowFunctionExpression(pos) {
   node.params = deserializeBoxFormalParameters(pos + 24);
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   node.body = body;
-  node.generator = false;
   parent = previousParent;
   return node;
 }
@@ -2722,9 +2662,9 @@ function deserializeAccessorProperty(pos) {
       override: deserializeBool(pos + 15),
       definite: deserializeBool(pos + 80),
       accessibility: deserializeOptionTSAccessibility(pos + 81),
-      declare: null,
-      optional: null,
-      readonly: null,
+      declare: false,
+      optional: false,
+      readonly: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -2734,9 +2674,6 @@ function deserializeAccessorProperty(pos) {
   node.key = deserializePropertyKey(pos + 40);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 56);
   node.value = deserializeOptionExpression(pos + 64);
-  node.declare = false;
-  node.optional = false;
-  node.readonly = false;
   parent = previousParent;
   return node;
 }
@@ -2931,14 +2868,13 @@ function deserializeExportDefaultDeclaration(pos) {
     node = (parent = {
       type: "ExportDefaultDeclaration",
       declaration: null,
-      exportKind: null,
+      exportKind: "value",
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
   node.declaration = deserializeExportDefaultDeclarationKind(pos + 16);
-  node.exportKind = "value";
   parent = previousParent;
   return node;
 }
@@ -3138,20 +3074,16 @@ function deserializeBooleanLiteral(pos) {
 
 function deserializeNullLiteral(pos) {
   let start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    });
-  node.raw = start === 0 && end === 0 ? null : "null";
-  parent = previousParent;
-  return node;
+    end = deserializeU32(pos + 4);
+  return {
+    type: "Literal",
+    value: null,
+    raw: start === 0 && end === 0 ? null : "null",
+    start,
+    end,
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeNumericLiteral(pos) {
@@ -3198,25 +3130,20 @@ function deserializeStringLiteral(pos) {
 function deserializeBigIntLiteral(pos) {
   let start = deserializeU32(pos),
     end = deserializeU32(pos + 4),
-    previousParent = parent,
-    node = (parent = {
-      type: "Literal",
-      value: null,
-      raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
-          ? null
-          : sourceText.slice(start, end),
-      bigint: null,
-      start,
-      end,
-      range: [start, end],
-      parent,
-    }),
     bigint = deserializeStr(pos + 16);
-  node.value = BigInt(bigint);
-  node.bigint = bigint;
-  parent = previousParent;
-  return node;
+  return {
+    type: "Literal",
+    value: BigInt(bigint),
+    raw:
+      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    bigint,
+    start,
+    end,
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeRegExpLiteral(pos) {
@@ -3302,7 +3229,7 @@ function deserializeJSXOpeningElement(pos) {
       name: null,
       typeArguments: null,
       attributes: null,
-      selfClosing: null,
+      selfClosing: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -3311,7 +3238,6 @@ function deserializeJSXOpeningElement(pos) {
   node.name = deserializeJSXElementName(pos + 16);
   node.typeArguments = deserializeOptionBoxTSTypeParameterInstantiation(pos + 32);
   node.attributes = deserializeVecJSXAttributeItem(pos + 40);
-  node.selfClosing = false;
   parent = previousParent;
   return node;
 }
@@ -3355,18 +3281,14 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  let start,
-    end,
-    previousParent = parent,
-    node = (parent = {
-      type: "JSXOpeningFragment",
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
-      range: [start, end],
-      parent,
-    });
-  parent = previousParent;
-  return node;
+  let start, end;
+  return {
+    type: "JSXOpeningFragment",
+    start: (start = deserializeU32(pos)),
+    end: (end = deserializeU32(pos + 4)),
+    range: [start, end],
+    parent,
+  };
 }
 
 function deserializeJSXClosingFragment(pos) {
@@ -3745,18 +3667,15 @@ function deserializeTSThisParameter(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
-      name: null,
-      optional: null,
+      decorators: [],
+      name: "this",
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
-  node.name = "this";
-  node.optional = false;
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
   parent = previousParent;
   return node;
@@ -3808,7 +3727,7 @@ function deserializeTSEnumMember(pos) {
       type: "TSEnumMember",
       id: null,
       initializer: null,
-      computed: null,
+      computed: deserializeU8(pos + 16) > 1,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -3816,7 +3735,6 @@ function deserializeTSEnumMember(pos) {
     });
   node.id = deserializeTSEnumMemberName(pos + 16);
   node.initializer = deserializeOptionExpression(pos + 32);
-  node.computed = deserializeU8(pos + 16) > 1;
   parent = previousParent;
   return node;
 }
@@ -4679,7 +4597,7 @@ function deserializeTSPropertySignature(pos) {
       key: null,
       typeAnnotation: null,
       accessibility: null,
-      static: null,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4687,7 +4605,6 @@ function deserializeTSPropertySignature(pos) {
     });
   node.key = deserializePropertyKey(pos + 16);
   node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4782,8 +4699,8 @@ function deserializeTSMethodSignature(pos) {
       params: null,
       returnType: null,
       accessibility: null,
-      readonly: null,
-      static: null,
+      readonly: false,
+      static: false,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -4796,8 +4713,6 @@ function deserializeTSMethodSignature(pos) {
   node.typeParameters = deserializeOptionBoxTSTypeParameterDeclaration(pos + 32);
   node.params = params;
   node.returnType = deserializeOptionBoxTSTypeAnnotation(pos + 56);
-  node.readonly = false;
-  node.static = false;
   parent = previousParent;
   return node;
 }
@@ -4829,17 +4744,15 @@ function deserializeTSIndexSignatureName(pos) {
     previousParent = parent,
     node = (parent = {
       type: "Identifier",
-      decorators: null,
+      decorators: [],
       name: deserializeStr(pos + 16),
-      optional: null,
+      optional: false,
       typeAnnotation: null,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
       parent,
     });
-  node.decorators = [];
-  node.optional = false;
   node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
@@ -5029,9 +4942,9 @@ function deserializeTSGlobalDeclaration(pos) {
       type: "TSModuleDeclaration",
       id: null,
       body: null,
-      kind: null,
+      kind: "global",
       declare: deserializeBool(pos + 88),
-      global: null,
+      global: true,
       start: (start = deserializeU32(pos)),
       end: (end = deserializeU32(pos + 4)),
       range: [start, end],
@@ -5051,8 +4964,6 @@ function deserializeTSGlobalDeclaration(pos) {
     parent,
   };
   node.body = deserializeTSModuleBlock(pos + 24);
-  node.kind = "global";
-  node.global = true;
   parent = previousParent;
   return node;
 }


### PR DESCRIPTION
Utilize the `#[estree(raw_deser_inline)]` attribute introduced in #21134 to mark all custom deserializers which do not depend on `parent` as inline-able.

This reduces deserializer code size, as well as being more performant in some cases, by avoiding write boundary checks.