### PR TITLE
perf(linter/plugins): use `Int32Array`s for tokens and comments buffers

### DIFF
--- a/apps/oxlint/src-js/generated/constants.ts
+++ b/apps/oxlint/src-js/generated/constants.ts
@@ -37,12 +37,12 @@ export const IS_JSX_FLAG_POS = 2147483613;
 export const HAS_BOM_FLAG_POS = 2147483614;
 
 /**
- * Byte offset of the tokens offset within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens offset within the buffer, divided by 4 (for `Int32Array` indexing).
  */
 export const TOKENS_OFFSET_POS_32 = 536870901;
 
 /**
- * Byte offset of the tokens length within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens length within the buffer, divided by 4 (for `Int32Array` indexing).
  */
 export const TOKENS_LEN_POS_32 = 536870902;
 

--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -14,7 +14,7 @@ import {
 } from "../generated/constants.ts";
 import { computeLoc } from "./location.ts";
 import { FLAG_NOT_DESERIALIZED, FLAG_DESERIALIZED } from "./tokens.ts";
-import { EMPTY_UINT8_ARRAY, EMPTY_UINT32_ARRAY } from "../utils/typed_arrays.ts";
+import { EMPTY_UINT8_ARRAY, EMPTY_INT32_ARRAY } from "../utils/typed_arrays.ts";
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Location, Span } from "./location.ts";
@@ -37,7 +37,7 @@ export let comments: CommentType[] | null = null;
 // Typed array views over the comments region of the buffer.
 // These persist for the lifetime of the file (cleared in `resetComments`).
 let commentsUint8: Uint8Array | null = null;
-export let commentsUint32: Uint32Array | null = null;
+export let commentsInt32: Int32Array | null = null;
 
 // Number of comments for the current file.
 export let commentsLen = 0;
@@ -62,13 +62,13 @@ let activeCommentsWithLocCount = 0;
 // preventing source text strings from being held alive by stale `value` slices.
 //
 // Pre-allocated in `initCommentsBuffer` to avoid growth during deserialization.
-// `Uint32Array` rather than `Array` to avoid GC tracing and write barriers.
+// `Int32Array` rather than `Array` to avoid GC tracing and write barriers.
 //
 // `deserializedCommentsLen` is the number of deserialized comments in current file.
 // If all comments have been deserialized (`allCommentsDeserialized === true`), `deserializedCommentsLen` is 0,
 // and no further indexes are written to `deserializedCommentIndexes`. `resetComments` will reset all comments,
 // up to `commentsLen`.
-let deserializedCommentIndexes = EMPTY_UINT32_ARRAY;
+let deserializedCommentIndexes = EMPTY_INT32_ARRAY;
 let deserializedCommentsLen = 0;
 
 // Minimum capacity (in `u32`s) of `deserializedCommentIndexes`, when not empty.
@@ -181,7 +181,7 @@ export function initComments(): void {
 export function deserializeComments(): void {
   debugAssert(!allCommentsDeserialized, "Comments already deserialized");
 
-  if (commentsUint32 === null) initCommentsBuffer();
+  if (commentsInt32 === null) initCommentsBuffer();
 
   for (let i = 0; i < commentsLen; i++) {
     deserializeCommentIfNeeded(i);
@@ -197,14 +197,14 @@ export function deserializeComments(): void {
 /**
  * Initialize typed array views over the comments region of the buffer.
  *
- * Populates `commentsUint8`, `commentsUint32`, and `commentsLen`, and grows `cachedComments` if needed.
+ * Populates `commentsUint8`, `commentsInt32`, and `commentsLen`, and grows `cachedComments` if needed.
  * Does NOT deserialize comments - they are deserialized lazily via `deserializeCommentIfNeeded`.
  *
  * Exception: If the file has a hashbang, eagerly deserializes the first comment and sets its type to `Shebang`.
  */
 export function initCommentsBuffer(): void {
   debugAssert(
-    commentsUint8 === null && commentsUint32 === null,
+    commentsUint8 === null && commentsInt32 === null,
     "Comments buffer already initialized",
   );
 
@@ -217,16 +217,16 @@ export function initCommentsBuffer(): void {
   if (sourceText === null) initSourceText();
   debugAssertIsNonNull(sourceText);
 
-  const { uint32 } = buffer;
-  const programPos32 = uint32[DATA_POINTER_POS_32] >> 2;
-  const commentsPos = uint32[programPos32 + (COMMENTS_OFFSET >> 2)];
-  commentsLen = uint32[programPos32 + (COMMENTS_LEN_OFFSET >> 2)];
+  const { int32 } = buffer;
+  const programPos32 = int32[DATA_POINTER_POS_32] >> 2;
+  const commentsPos = int32[programPos32 + (COMMENTS_OFFSET >> 2)];
+  commentsLen = int32[programPos32 + (COMMENTS_LEN_OFFSET >> 2)];
 
   // Fast path for files with no comments
   if (commentsLen === 0) {
     comments = EMPTY_COMMENTS;
     commentsUint8 = EMPTY_UINT8_ARRAY;
-    commentsUint32 = EMPTY_UINT32_ARRAY;
+    commentsInt32 = EMPTY_INT32_ARRAY;
     allCommentsDeserialized = true;
     return;
   }
@@ -236,7 +236,7 @@ export function initCommentsBuffer(): void {
   const arrayBuffer = buffer.buffer,
     absolutePos = buffer.byteOffset + commentsPos;
   commentsUint8 = new Uint8Array(arrayBuffer, absolutePos, commentsLen * COMMENT_SIZE);
-  commentsUint32 = new Uint32Array(arrayBuffer, absolutePos, commentsLen * (COMMENT_SIZE >> 2));
+  commentsInt32 = new Int32Array(arrayBuffer, absolutePos, commentsLen * (COMMENT_SIZE >> 2));
 
   // Grow caches if needed. After first few files, caches should have grown large enough to service all files.
   // Later files will skip this step, and allocations stop.
@@ -246,11 +246,11 @@ export function initCommentsBuffer(): void {
     } while (cachedComments.length < commentsLen);
 
     // Grow `deserializedCommentIndexes` if needed.
-    // `Uint32Array`s can't grow in place, so allocate a new one.
+    // `Int32Array`s can't grow in place, so allocate a new one.
     // First allocation uses minimum capacity. Subsequent growths double, to avoid frequent reallocations.
     const indexesLen = deserializedCommentIndexes.length;
     if (indexesLen < commentsLen) {
-      deserializedCommentIndexes = new Uint32Array(
+      deserializedCommentIndexes = new Int32Array(
         Math.max(
           commentsLen,
           indexesLen === 0 ? DESERIALIZED_COMMENT_INDEXES_MIN_CAPACITY : indexesLen << 1,
@@ -263,8 +263,8 @@ export function initCommentsBuffer(): void {
   // We do this here instead of lazily when comment 0 is deserialized, to remove code
   // from `deserializeCommentIfNeeded`, which can be called many times.
   // Rust side adds hashbang comment to start of comments `Vec` as a `Line` comment.
-  // `commentsUint32[0]` is the start of the first comment.
-  if (commentsUint32[0] === 0 && sourceText.startsWith("#!")) {
+  // `commentsInt32[0]` is the start of the first comment.
+  if (commentsInt32[0] === 0 && sourceText.startsWith("#!")) {
     getComment(0).type = "Shebang";
   }
 
@@ -324,8 +324,8 @@ function deserializeCommentIfNeeded(index: number): Comment | null {
   const isBlock = commentsUint8![pos + COMMENT_KIND_OFFSET] !== COMMENT_LINE_KIND;
 
   const pos32 = pos >> 2,
-    start = commentsUint32![pos32],
-    end = commentsUint32![pos32 + 1];
+    start = commentsInt32![pos32],
+    end = commentsInt32![pos32 + 1];
 
   comment.type = isBlock ? "Block" : "Line";
   // Line comments: `// text` -> slice `start + 2..end`
@@ -348,8 +348,8 @@ function debugCheckValidRanges(): void {
   let lastEnd = 0;
   for (let i = 0; i < commentsLen; i++) {
     const pos32 = i << 2;
-    const start = commentsUint32![pos32];
-    const end = commentsUint32![pos32 + 1];
+    const start = commentsInt32![pos32];
+    const end = commentsInt32![pos32 + 1];
     if (end <= start) throw new Error(`Invalid comment range: ${start}-${end}`);
     if (start < lastEnd) {
       throw new Error(`Overlapping comments: last end: ${lastEnd}, next start: ${start}`);
@@ -398,7 +398,7 @@ function debugCheckDeserializedComments(): void {
  */
 export function resetComments(): void {
   // Early exit if comments were never accessed (e.g. no rules used comments-related methods)
-  if (commentsUint32 === null) {
+  if (commentsInt32 === null) {
     debugAssertAllCommentsCleared();
     return;
   }
@@ -437,7 +437,7 @@ export function resetComments(): void {
   // Reset other state
   comments = null;
   commentsUint8 = null;
-  commentsUint32 = null;
+  commentsInt32 = null;
   commentsLen = 0;
 
   debugAssertAllCommentsCleared();

--- a/apps/oxlint/src-js/plugins/comments_methods.ts
+++ b/apps/oxlint/src-js/plugins/comments_methods.ts
@@ -5,7 +5,7 @@
 import {
   cachedComments,
   comments,
-  commentsUint32,
+  commentsInt32,
   commentsLen,
   getComment,
   initComments,
@@ -13,7 +13,7 @@ import {
 } from "./comments.ts";
 import {
   initTokensAndCommentsBuffer,
-  tokensAndCommentsUint32,
+  tokensAndCommentsInt32,
   tokensAndCommentsLen,
   MERGED_SIZE32,
   MERGED_SIZE32_SHIFT,
@@ -57,8 +57,8 @@ debugAssert(MERGED_TYPE_OFFSET32 > 0, "`getCommentsBefore` relies on this");
  * @returns Array of `Comment`s in occurrence order.
  */
 export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
-  if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-  debugAssertIsNonNull(tokensAndCommentsUint32);
+  if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+  debugAssertIsNonNull(tokensAndCommentsInt32);
 
   // Early exit for files with no comments
   if (commentsLen === 0) return [];
@@ -67,7 +67,7 @@ export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
 
   // Binary search merged buffer for first entry at or after target's start
   const searchIndex = firstTokenAtOrAfter(
-    tokensAndCommentsUint32,
+    tokensAndCommentsInt32,
     targetStart,
     0,
     tokensAndCommentsLen,
@@ -81,7 +81,7 @@ export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
   let typePos32 = startTypePos32;
   // `MERGED_TYPE_OFFSET32` is greater than 0 (checked by debug assert above), so `typePos32 > 0` is right check.
   // If `MERGED_TYPE_OFFSET32` was zero, it'd be `typePos32 >= 0`.
-  while (typePos32 > 0 && tokensAndCommentsUint32[typePos32] !== MERGED_TYPE_TOKEN) {
+  while (typePos32 > 0 && tokensAndCommentsInt32[typePos32] !== MERGED_TYPE_TOKEN) {
     typePos32 -= MERGED_SIZE32;
   }
 
@@ -91,7 +91,7 @@ export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
   // Read `originalIndex` of earliest comment, calculate slice end from how far we walked.
   // `typePos32` is at the entry before the first comment.
   const sliceStart =
-    tokensAndCommentsUint32[
+    tokensAndCommentsInt32[
       typePos32 + (MERGED_SIZE32 - MERGED_TYPE_OFFSET32 + MERGED_ORIGINAL_INDEX_OFFSET32)
     ];
   const sliceEnd = sliceStart + (count32 >> MERGED_SIZE32_SHIFT);
@@ -121,8 +121,8 @@ export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
  * @returns Array of `Comment`s in occurrence order.
  */
 export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
-  if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-  debugAssertIsNonNull(tokensAndCommentsUint32);
+  if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+  debugAssertIsNonNull(tokensAndCommentsInt32);
 
   // Early exit for files with no comments
   if (commentsLen === 0) return [];
@@ -131,7 +131,7 @@ export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
 
   // Binary search merged buffer for first entry at or after target's end.
   const searchIndex = firstTokenAtOrAfter(
-    tokensAndCommentsUint32,
+    tokensAndCommentsInt32,
     targetEnd,
     0,
     tokensAndCommentsLen,
@@ -144,7 +144,7 @@ export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
   // valid entry in `initTokensAndCommentsBuffer`, so the loop terminates naturally.
   const startTypePos32 = (searchIndex << MERGED_SIZE32_SHIFT) + MERGED_TYPE_OFFSET32;
   let typePos32 = startTypePos32;
-  while (tokensAndCommentsUint32[typePos32] !== MERGED_TYPE_TOKEN) {
+  while (tokensAndCommentsInt32[typePos32] !== MERGED_TYPE_TOKEN) {
     typePos32 += MERGED_SIZE32;
   }
 
@@ -153,7 +153,7 @@ export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
 
   // Read `originalIndex` of earliest comment, calculate slice end from how far we walked
   const sliceStart =
-    tokensAndCommentsUint32[
+    tokensAndCommentsInt32[
       startTypePos32 - (MERGED_TYPE_OFFSET32 - MERGED_ORIGINAL_INDEX_OFFSET32)
     ];
   const sliceEnd = sliceStart + (count32 >> MERGED_SIZE32_SHIFT);
@@ -170,8 +170,8 @@ export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
  * @returns Array of `Comment`s in occurrence order.
  */
 export function getCommentsInside(node: Node): Comment[] {
-  if (commentsUint32 === null) initCommentsBuffer();
-  debugAssertIsNonNull(commentsUint32);
+  if (commentsInt32 === null) initCommentsBuffer();
+  debugAssertIsNonNull(commentsInt32);
 
   // Early exit for files with no comments
   if (commentsLen === 0) return [];
@@ -181,10 +181,10 @@ export function getCommentsInside(node: Node): Comment[] {
     rangeEnd = range[1];
 
   // Binary search for first comment within `node`'s range
-  const sliceStart = firstTokenAtOrAfter(commentsUint32, rangeStart, 0, commentsLen);
+  const sliceStart = firstTokenAtOrAfter(commentsInt32, rangeStart, 0, commentsLen);
   // Binary search for first comment outside `node`'s range.
   // Its index is used as `sliceEnd`, which is exclusive of the slice.
-  const sliceEnd = firstTokenAtOrAfter(commentsUint32, rangeEnd, sliceStart, commentsLen);
+  const sliceEnd = firstTokenAtOrAfter(commentsInt32, rangeEnd, sliceStart, commentsLen);
 
   // Deserialize only the comments we're returning
   for (let i = sliceStart; i < sliceEnd; i++) {
@@ -203,26 +203,21 @@ export function commentsExistBetween(
   nodeOrToken1: NodeOrToken,
   nodeOrToken2: NodeOrToken,
 ): boolean {
-  if (commentsUint32 === null) initCommentsBuffer();
-  debugAssertIsNonNull(commentsUint32);
+  if (commentsInt32 === null) initCommentsBuffer();
+  debugAssertIsNonNull(commentsInt32);
 
   // Early exit for files with no comments
   if (commentsLen === 0) return false;
 
   // Find the first comment after `nodeOrToken1` ends.
   const betweenRangeStart = nodeOrToken1.range[1];
-  const firstCommentBetween = firstTokenAtOrAfter(
-    commentsUint32,
-    betweenRangeStart,
-    0,
-    commentsLen,
-  );
+  const firstCommentBetween = firstTokenAtOrAfter(commentsInt32, betweenRangeStart, 0, commentsLen);
 
   // Check if its end is before `nodeOrToken2` starts.
   // Read `end` from buffer: u32 at offset 1 of the entry.
   return (
     firstCommentBetween < commentsLen &&
-    commentsUint32[(firstCommentBetween << 2) + 1] <= nodeOrToken2.range[0]
+    commentsInt32[(firstCommentBetween << 2) + 1] <= nodeOrToken2.range[0]
   );
 }
 

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -10,7 +10,7 @@ import {
   TOKENS_OFFSET_POS_32,
   TOKENS_LEN_POS_32,
 } from "../generated/constants.ts";
-import { EMPTY_UINT32_ARRAY } from "../utils/typed_arrays.ts";
+import { EMPTY_INT32_ARRAY } from "../utils/typed_arrays.ts";
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Location, Span } from "./location.ts";
@@ -102,7 +102,7 @@ export let tokens: TokenType[] | null = null;
 // Typed array views over the tokens region of the buffer.
 // These persist for the lifetime of the file (cleared in `resetTokens`).
 let tokensUint8: Uint8Array | null = null;
-export let tokensUint32: Uint32Array | null = null;
+export let tokensInt32: Int32Array | null = null;
 
 // Number of tokens for the current file.
 export let tokensLen = 0;
@@ -128,10 +128,10 @@ const regexObjects: Regex[] = [];
 
 // Indices of tokens whose `regex` property was set, and therefore needs clearing on reset.
 // Regex tokens are rare, so this array is almost always very small.
-// `Uint32Array` rather than `Array` to avoid GC tracing and write barriers.
+// `Int32Array` rather than `Array` to avoid GC tracing and write barriers.
 // `activeTokensWithRegexCount` also serves as the index into `regexObjects`
 // for the next regex descriptor object which can be reused.
-let tokensWithRegexIndexes = EMPTY_UINT32_ARRAY;
+let tokensWithRegexIndexes = EMPTY_INT32_ARRAY;
 let activeTokensWithRegexCount = 0;
 
 // Minimum capacity of `tokensWithRegexIndexes` array when not empty.
@@ -142,13 +142,13 @@ const REGEX_INDEXES_MIN_CAPACITY = 16;
 // preventing source text strings from being held alive by stale `value` slices.
 //
 // Pre-allocated in `initTokensBuffer` to avoid growth during deserialization.
-// `Uint32Array` rather than `Array` to avoid GC tracing and write barriers.
+// `Int32Array` rather than `Array` to avoid GC tracing and write barriers.
 //
 // `deserializedTokensLen` is the number of deserialized tokens in current file.
 // If all tokens have been deserialized (`allTokensDeserialized === true`), `deserializedTokensLen` is 0,
 // and no further indexes are written to `deserializedTokenIndexes`. `resetTokens` will reset all tokens,
 // up to `tokensLen`.
-let deserializedTokenIndexes = EMPTY_UINT32_ARRAY;
+let deserializedTokenIndexes = EMPTY_INT32_ARRAY;
 let deserializedTokensLen = 0;
 
 // Minimum capacity (in `u32`s) of `deserializedTokenIndexes`, when not empty.
@@ -290,7 +290,7 @@ export function initTokens(): void {
 export function deserializeTokens(): void {
   debugAssert(!allTokensDeserialized, "Tokens already deserialized");
 
-  if (tokensUint32 === null) initTokensBuffer();
+  if (tokensInt32 === null) initTokensBuffer();
 
   for (let i = 0; i < tokensLen; i++) {
     deserializeTokenIfNeeded(i);
@@ -306,11 +306,11 @@ export function deserializeTokens(): void {
 /**
  * Initialize typed array views over the tokens region of the buffer.
  *
- * Populates `tokensUint8`, `tokensUint32`, and `tokensLen`, and grows `cachedTokens` if needed.
+ * Populates `tokensUint8`, `tokensInt32`, and `tokensLen`, and grows `cachedTokens` if needed.
  * Does NOT deserialize tokens - they are deserialized lazily via `deserializeTokenIfNeeded`.
  */
 export function initTokensBuffer(): void {
-  debugAssert(tokensUint8 === null && tokensUint32 === null, "Tokens buffer already initialized");
+  debugAssert(tokensUint8 === null && tokensInt32 === null, "Tokens buffer already initialized");
 
   debugAssertIsNonNull(buffer);
 
@@ -319,9 +319,9 @@ export function initTokensBuffer(): void {
   if (sourceText === null) initSourceText();
   debugAssertIsNonNull(sourceText);
 
-  const { uint32 } = buffer;
-  const tokensPos = uint32[TOKENS_OFFSET_POS_32];
-  tokensLen = uint32[TOKENS_LEN_POS_32];
+  const { int32 } = buffer;
+  const tokensPos = int32[TOKENS_OFFSET_POS_32];
+  tokensLen = int32[TOKENS_LEN_POS_32];
 
   // Create typed array views over just the tokens region of the buffer.
   // These are zero-copy views over the same underlying `ArrayBuffer`.
@@ -329,7 +329,7 @@ export function initTokensBuffer(): void {
   const arrayBuffer = buffer.buffer,
     absolutePos = buffer.byteOffset + tokensPos;
   tokensUint8 = new Uint8Array(arrayBuffer, absolutePos, tokensLen << TOKEN_SIZE_SHIFT);
-  tokensUint32 = new Uint32Array(arrayBuffer, absolutePos, tokensLen << (TOKEN_SIZE_SHIFT - 2));
+  tokensInt32 = new Int32Array(arrayBuffer, absolutePos, tokensLen << (TOKEN_SIZE_SHIFT - 2));
 
   // Grow caches if needed. After first few files, caches should have grown large enough to service all files.
   // Later files will skip this step, and allocations stop.
@@ -339,11 +339,11 @@ export function initTokensBuffer(): void {
     } while (cachedTokens.length < tokensLen);
 
     // Grow `deserializedTokenIndexes` if needed.
-    // `Uint32Array`s can't grow in place, so allocate a new one.
+    // `Int32Array`s can't grow in place, so allocate a new one.
     // First allocation uses minimum capacity. Subsequent growths double, to avoid frequent reallocations.
     const indexesLen = deserializedTokenIndexes.length;
     if (indexesLen < tokensLen) {
-      deserializedTokenIndexes = new Uint32Array(
+      deserializedTokenIndexes = new Int32Array(
         Math.max(
           tokensLen,
           indexesLen === 0 ? DESERIALIZED_TOKEN_INDEXES_MIN_CAPACITY : indexesLen << 1,
@@ -408,8 +408,8 @@ function deserializeTokenIfNeeded(index: number): Token | null {
   const kind = tokensUint8![pos + KIND_FIELD_OFFSET];
 
   const pos32 = pos >> 2,
-    start = tokensUint32![pos32],
-    end = tokensUint32![pos32 + 1];
+    start = tokensInt32![pos32],
+    end = tokensInt32![pos32 + 1];
 
   // Get `value` as slice of source text `start..end`.
   // Slice `start + 1..end` for private identifiers, to strip leading `#`.
@@ -433,11 +433,11 @@ function deserializeTokenIfNeeded(index: number): Token | null {
     } else {
       regexObjects.push((regex = { pattern: null!, flags: null! }));
 
-      // Grow `tokensWithRegexIndexes` if full. `Uint32Array`s can't grow in place,
+      // Grow `tokensWithRegexIndexes` if full. `Int32Array`s can't grow in place,
       // so allocate a new one (doubled, min 16), and copy the existing entries into it.
       const indexesLen = tokensWithRegexIndexes.length;
       if (indexesLen === activeTokensWithRegexCount) {
-        const newArr = new Uint32Array(
+        const newArr = new Int32Array(
           indexesLen === 0 ? REGEX_INDEXES_MIN_CAPACITY : indexesLen << 1,
         );
         newArr.set(tokensWithRegexIndexes, 0);
@@ -488,8 +488,8 @@ function debugCheckValidRanges(): void {
   let lastEnd = 0;
   for (let i = 0; i < tokensLen; i++) {
     const pos32 = i << 2;
-    const start = tokensUint32![pos32];
-    const end = tokensUint32![pos32 + 1];
+    const start = tokensInt32![pos32];
+    const end = tokensInt32![pos32 + 1];
     if (end <= start) throw new Error(`Invalid token range: ${start}-${end}`);
     if (start < lastEnd) {
       throw new Error(`Overlapping tokens: last end: ${lastEnd}, next start: ${start}`);
@@ -532,7 +532,7 @@ function debugCheckDeserializedTokens(): void {
  */
 export function resetTokens() {
   // Early exit if tokens were never accessed (e.g. no rules used tokens-related methods)
-  if (tokensUint32 === null) {
+  if (tokensInt32 === null) {
     debugAssertAllTokensCleared();
     return;
   }
@@ -586,7 +586,7 @@ export function resetTokens() {
   // Clear other state
   tokens = null;
   tokensUint8 = null;
-  tokensUint32 = null;
+  tokensInt32 = null;
   tokensLen = 0;
 
   debugAssertAllTokensCleared();

--- a/apps/oxlint/src-js/plugins/tokens_and_comments.ts
+++ b/apps/oxlint/src-js/plugins/tokens_and_comments.ts
@@ -6,7 +6,7 @@ import {
   allCommentsDeserialized,
   cachedComments,
   comments,
-  commentsUint32,
+  commentsInt32,
   commentsLen,
   deserializeComments,
   getComment,
@@ -22,10 +22,10 @@ import {
   initTokensBuffer,
   tokens,
   tokensLen,
-  tokensUint32,
+  tokensInt32,
 } from "./tokens.ts";
 import { COMMENT_SIZE } from "../generated/constants.ts";
-import { EMPTY_UINT32_ARRAY } from "../utils/typed_arrays.ts";
+import { EMPTY_INT32_ARRAY } from "../utils/typed_arrays.ts";
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Comment } from "./comments.ts";
@@ -33,7 +33,7 @@ import type { Token } from "./tokens.ts";
 
 export type TokenOrComment = Token | Comment;
 
-// `tokensAndCommentsUint32` is a buffer containing 16-byte entries,
+// `tokensAndCommentsInt32` is a buffer containing 16-byte entries,
 // representing merged set of all tokens and comments, interleaved in source order.
 //
 // If they were Rust structs, they would be defined like this:
@@ -57,7 +57,7 @@ export type TokenOrComment = Token | Comment;
 // }
 // ```
 //
-// These constants define the shape of the data stored in `tokensAndCommentsUint32` as per the above.
+// These constants define the shape of the data stored in `tokensAndCommentsInt32` as per the above.
 const MERGED_SIZE = 16;
 export const MERGED_SIZE32_SHIFT = 2; // 4 x u32s per entry (16 bytes)
 export const MERGED_SIZE32 = 1 << MERGED_SIZE32_SHIFT; // 4 x u32s per entry
@@ -83,17 +83,17 @@ let previousTokensAndComments: TokenOrComment[] = [];
 
 // Merged tokens-and-comments buffer (created lazily by `initTokensAndCommentsBuffer`).
 // Each entry is 4 x u32s: `{ start, index, is_comment, padding }`.
-export let tokensAndCommentsUint32: Uint32Array | null = null;
+export let tokensAndCommentsInt32: Int32Array | null = null;
 
 // Number of entries in the tokens-and-comments buffer.
 export let tokensAndCommentsLen = 0;
 
 // Backing buffer reused across files.
 // Grows when needed (doubled), never shrinks.
-// `tokensAndCommentsUint32` is a view over this buffer's prefix.
-let tokensAndCommentsBackingUint32 = EMPTY_UINT32_ARRAY;
+// `tokensAndCommentsInt32` is a view over this buffer's prefix.
+let tokensAndCommentsBackingInt32 = EMPTY_INT32_ARRAY;
 
-// Minimum capacity (in `u32`s) of `tokensAndCommentsBackingUint32`, when not empty.
+// Minimum capacity (in `u32`s) of `tokensAndCommentsBackingInt32`, when not empty.
 // 256 elements = 1 KiB.
 const MERGED_BACKING_MIN_CAPACITY = 256;
 
@@ -104,52 +104,52 @@ const MERGED_BACKING_MIN_CAPACITY = 256;
  *
  * Each token/comment in the input buffers is 16 bytes, with `start` as the first `u32`.
  *
- * `tokensAndCommentsUint32` contains 16-byte entries with the layout:
+ * `tokensAndCommentsInt32` contains 16-byte entries with the layout:
  * `{ start: u32, index: u32, type: u32, 4 bytes padding }`.
  *
  * `index` is the index of the token/comment within its original buffer (in 16-byte units).
  */
 export function initTokensAndCommentsBuffer(): void {
-  debugAssert(tokensAndCommentsUint32 === null, "`tokensAndComments` already initialized");
+  debugAssert(tokensAndCommentsInt32 === null, "`tokensAndComments` already initialized");
 
   // Ensure tokens and comments are initialized
-  if (tokensUint32 === null) initTokensBuffer();
-  debugAssertIsNonNull(tokensUint32);
+  if (tokensInt32 === null) initTokensBuffer();
+  debugAssertIsNonNull(tokensInt32);
 
-  if (commentsUint32 === null) initCommentsBuffer();
-  debugAssertIsNonNull(commentsUint32);
+  if (commentsInt32 === null) initCommentsBuffer();
+  debugAssertIsNonNull(commentsInt32);
 
   tokensAndCommentsLen = tokensLen + commentsLen;
 
   // Reuse backing buffer across files. Grow if needed, never shrink.
   // After warm-up over first few files, the buffer will be large enough to hold all tokens and comments
   // for all files, so we avoid allocating a large buffer each time.
-  // `Uint32Array`s can't grow in place, so allocate a new one.
+  // `Int32Array`s can't grow in place, so allocate a new one.
   // First allocation uses minimum capacity. Subsequent growths double, to avoid frequent reallocations.
   // +1 entry for sentinel (see below).
   const requiredLen32 = (tokensAndCommentsLen + 1) << MERGED_SIZE32_SHIFT;
-  const backingLen = tokensAndCommentsBackingUint32.length;
+  const backingLen = tokensAndCommentsBackingInt32.length;
   if (backingLen < requiredLen32) {
-    tokensAndCommentsBackingUint32 = new Uint32Array(
+    tokensAndCommentsBackingInt32 = new Int32Array(
       Math.max(requiredLen32, backingLen === 0 ? MERGED_BACKING_MIN_CAPACITY : backingLen << 1),
     );
   }
 
-  tokensAndCommentsUint32 = tokensAndCommentsBackingUint32;
+  tokensAndCommentsInt32 = tokensAndCommentsBackingInt32;
 
   // Fast paths for files containing no comments, and no tokens (empty file except for comments)
   if (commentsLen === 0) {
-    fillMergedEntries(MERGED_TYPE_TOKEN, tokensUint32, 0, 0, tokensLen);
+    fillMergedEntries(MERGED_TYPE_TOKEN, tokensInt32, 0, 0, tokensLen);
   } else if (tokensLen === 0) {
-    fillMergedEntries(MERGED_TYPE_COMMENT, commentsUint32, 0, 0, commentsLen);
+    fillMergedEntries(MERGED_TYPE_COMMENT, commentsInt32, 0, 0, commentsLen);
   } else {
-    mergeTokensAndComments(tokensUint32, commentsUint32);
+    mergeTokensAndComments(tokensInt32, commentsInt32);
   }
 
   // Write a sentinel `MERGED_TYPE_TOKEN` entry immediately after the last valid entry.
   // This allows `getCommentsAfter`'s forward walk to terminate without an explicit bounds check
   // against `tokensAndCommentsLen` on every iteration - the sentinel acts as a natural stop.
-  tokensAndCommentsUint32[(tokensAndCommentsLen << MERGED_SIZE32_SHIFT) + MERGED_TYPE_OFFSET32] =
+  tokensAndCommentsInt32[(tokensAndCommentsLen << MERGED_SIZE32_SHIFT) + MERGED_TYPE_OFFSET32] =
     MERGED_TYPE_TOKEN;
 
   debugCheckMergedOrder();
@@ -162,22 +162,22 @@ export function initTokensAndCommentsBuffer(): void {
  * so the branch predictor sees a consistent "continue" pattern within each run,
  * only mispredicting once at each run transition.
  */
-function mergeTokensAndComments(tokensUint32: Uint32Array, commentsUint32: Uint32Array): void {
+function mergeTokensAndComments(tokensInt32: Int32Array, commentsInt32: Int32Array): void {
   let tokenIndex = 0,
     commentIndex = 0,
     mergedPos32 = 0;
-  let tokenStart = tokensUint32[0],
-    commentStart = commentsUint32[0];
+  let tokenStart = tokensInt32[0],
+    commentStart = commentsInt32[0];
 
   // Push any leading comments
   while (commentStart < tokenStart) {
     writeMergedEntry(MERGED_TYPE_COMMENT, mergedPos32, commentIndex, commentStart);
     mergedPos32 += MERGED_SIZE32;
     if (++commentIndex === commentsLen) {
-      fillMergedEntries(MERGED_TYPE_TOKEN, tokensUint32, mergedPos32, tokenIndex, tokensLen);
+      fillMergedEntries(MERGED_TYPE_TOKEN, tokensInt32, mergedPos32, tokenIndex, tokensLen);
       return;
     }
-    commentStart = commentsUint32[commentIndex << MERGED_SIZE32_SHIFT];
+    commentStart = commentsInt32[commentIndex << MERGED_SIZE32_SHIFT];
   }
 
   // Alternate between runs of tokens and runs of comments
@@ -189,14 +189,14 @@ function mergeTokensAndComments(tokensUint32: Uint32Array, commentsUint32: Uint3
       if (++tokenIndex === tokensLen) {
         fillMergedEntries(
           MERGED_TYPE_COMMENT,
-          commentsUint32,
+          commentsInt32,
           mergedPos32,
           commentIndex,
           commentsLen,
         );
         return;
       }
-      tokenStart = tokensUint32[tokenIndex << MERGED_SIZE32_SHIFT];
+      tokenStart = tokensInt32[tokenIndex << MERGED_SIZE32_SHIFT];
     } while (tokenStart < commentStart);
 
     // Process run of comments
@@ -204,10 +204,10 @@ function mergeTokensAndComments(tokensUint32: Uint32Array, commentsUint32: Uint3
       writeMergedEntry(MERGED_TYPE_COMMENT, mergedPos32, commentIndex, commentStart);
       mergedPos32 += MERGED_SIZE32;
       if (++commentIndex === commentsLen) {
-        fillMergedEntries(MERGED_TYPE_TOKEN, tokensUint32, mergedPos32, tokenIndex, tokensLen);
+        fillMergedEntries(MERGED_TYPE_TOKEN, tokensInt32, mergedPos32, tokenIndex, tokensLen);
         return;
       }
-      commentStart = commentsUint32[commentIndex << MERGED_SIZE32_SHIFT];
+      commentStart = commentsInt32[commentIndex << MERGED_SIZE32_SHIFT];
     } while (commentStart < tokenStart);
   }
 }
@@ -222,7 +222,7 @@ function debugCheckMergedOrder(): void {
 
   let lastStart = -1;
   for (let i = 0; i < tokensAndCommentsLen; i++) {
-    const start = tokensAndCommentsUint32![i << MERGED_SIZE32_SHIFT];
+    const start = tokensAndCommentsInt32![i << MERGED_SIZE32_SHIFT];
     if (start <= lastStart) {
       throw new Error(
         `Merged tokens/comments not in order: entry ${i} start ${start} <= previous start ${lastStart}`,
@@ -241,9 +241,9 @@ function writeMergedEntry(
   originalIndex: number,
   start: number,
 ): void {
-  tokensAndCommentsUint32![mergedPos32] = start;
-  tokensAndCommentsUint32![mergedPos32 + MERGED_ORIGINAL_INDEX_OFFSET32] = originalIndex;
-  tokensAndCommentsUint32![mergedPos32 + MERGED_TYPE_OFFSET32] = type;
+  tokensAndCommentsInt32![mergedPos32] = start;
+  tokensAndCommentsInt32![mergedPos32 + MERGED_ORIGINAL_INDEX_OFFSET32] = originalIndex;
+  tokensAndCommentsInt32![mergedPos32 + MERGED_TYPE_OFFSET32] = type;
   // out[outPos + 3] is padding, no need to write it
 }
 
@@ -253,7 +253,7 @@ function writeMergedEntry(
  */
 function fillMergedEntries(
   type: MergedType,
-  srcUint32: Uint32Array,
+  srcInt32: Int32Array,
   mergedPos32: number,
   srcIndex: number,
   srcLen: number,
@@ -261,9 +261,9 @@ function fillMergedEntries(
   let srcPos32 = srcIndex << MERGED_SIZE32_SHIFT;
 
   for (; srcIndex < srcLen; srcIndex++) {
-    tokensAndCommentsUint32![mergedPos32] = srcUint32[srcPos32];
-    tokensAndCommentsUint32![mergedPos32 + MERGED_ORIGINAL_INDEX_OFFSET32] = srcIndex;
-    tokensAndCommentsUint32![mergedPos32 + MERGED_TYPE_OFFSET32] = type;
+    tokensAndCommentsInt32![mergedPos32] = srcInt32[srcPos32];
+    tokensAndCommentsInt32![mergedPos32 + MERGED_ORIGINAL_INDEX_OFFSET32] = srcIndex;
+    tokensAndCommentsInt32![mergedPos32 + MERGED_TYPE_OFFSET32] = type;
     mergedPos32 += MERGED_SIZE32;
     srcPos32 += MERGED_SIZE32;
   }
@@ -278,9 +278,9 @@ function fillMergedEntries(
  */
 export function getTokenOrComment(index: number): TokenOrComment {
   const pos32 = index << MERGED_SIZE32_SHIFT;
-  const originalIndex = tokensAndCommentsUint32![pos32 + MERGED_ORIGINAL_INDEX_OFFSET32];
+  const originalIndex = tokensAndCommentsInt32![pos32 + MERGED_ORIGINAL_INDEX_OFFSET32];
 
-  return tokensAndCommentsUint32![pos32 + MERGED_TYPE_OFFSET32] === MERGED_TYPE_TOKEN
+  return tokensAndCommentsInt32![pos32 + MERGED_TYPE_OFFSET32] === MERGED_TYPE_TOKEN
     ? getToken(originalIndex)
     : getComment(originalIndex);
 }
@@ -294,12 +294,12 @@ export function getTokenOrComment(index: number): TokenOrComment {
  */
 export function getTokenOrCommentEnd(entryIndex: number): number {
   const pos32 = entryIndex << MERGED_SIZE32_SHIFT;
-  const originalIndex = tokensAndCommentsUint32![pos32 + MERGED_ORIGINAL_INDEX_OFFSET32];
+  const originalIndex = tokensAndCommentsInt32![pos32 + MERGED_ORIGINAL_INDEX_OFFSET32];
   const originalEndPos32 = (originalIndex << MERGED_SIZE32_SHIFT) + 1;
 
-  return tokensAndCommentsUint32![pos32 + MERGED_TYPE_OFFSET32] === MERGED_TYPE_TOKEN
-    ? tokensUint32![originalEndPos32]
-    : commentsUint32![originalEndPos32];
+  return tokensAndCommentsInt32![pos32 + MERGED_TYPE_OFFSET32] === MERGED_TYPE_TOKEN
+    ? tokensInt32![originalEndPos32]
+    : commentsInt32![originalEndPos32];
 }
 
 /**
@@ -315,8 +315,8 @@ export function getTokensAndComments(): TokenOrComment[] {
   if (tokensAndComments !== null) return tokensAndComments;
 
   // Init tokens and comments (to get lengths), but don't build `tokens`/`comments` arrays yet
-  if (tokensUint32 === null) initTokensBuffer();
-  if (commentsUint32 === null) initCommentsBuffer();
+  if (tokensInt32 === null) initTokensBuffer();
+  if (commentsInt32 === null) initCommentsBuffer();
 
   // Fast path: No comments - build `tokens` array and return it directly
   if (commentsLen === 0) {
@@ -338,8 +338,8 @@ export function getTokensAndComments(): TokenOrComment[] {
   if (!allCommentsDeserialized) deserializeComments();
 
   // Ensure merged buffer is built
-  if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-  debugAssertIsNonNull(tokensAndCommentsUint32);
+  if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+  debugAssertIsNonNull(tokensAndCommentsInt32);
 
   // Since `deserializeTokens` and `deserializeComments` are called first, all entries are already deserialized.
   // We just need to look up entries from `cachedTokens` and `cachedComments` by index.
@@ -364,9 +364,9 @@ export function getTokensAndComments(): TokenOrComment[] {
 
   for (let i = 0; i < tokensAndCommentsLen; i++) {
     const pos32 = i << MERGED_SIZE32_SHIFT;
-    const originalIndex = tokensAndCommentsUint32[pos32 + MERGED_ORIGINAL_INDEX_OFFSET32];
+    const originalIndex = tokensAndCommentsInt32[pos32 + MERGED_ORIGINAL_INDEX_OFFSET32];
     tokensAndComments[i] =
-      tokensAndCommentsUint32[pos32 + MERGED_TYPE_OFFSET32] === MERGED_TYPE_TOKEN
+      tokensAndCommentsInt32[pos32 + MERGED_TYPE_OFFSET32] === MERGED_TYPE_TOKEN
         ? (cachedTokens[originalIndex] as Token)
         : cachedComments[originalIndex];
   }
@@ -379,6 +379,6 @@ export function getTokensAndComments(): TokenOrComment[] {
  */
 export function resetTokensAndComments() {
   tokensAndComments = null;
-  tokensAndCommentsUint32 = null;
+  tokensAndCommentsInt32 = null;
   tokensAndCommentsLen = 0;
 }

--- a/apps/oxlint/src-js/plugins/tokens_methods.ts
+++ b/apps/oxlint/src-js/plugins/tokens_methods.ts
@@ -2,9 +2,9 @@
  * `SourceCode` methods related to tokens.
  */
 
-import { cachedTokens, tokensUint32, tokensLen, initTokensBuffer, getToken } from "./tokens.ts";
+import { cachedTokens, tokensInt32, tokensLen, initTokensBuffer, getToken } from "./tokens.ts";
 import {
-  tokensAndCommentsUint32,
+  tokensAndCommentsInt32,
   tokensAndCommentsLen,
   getTokenOrComment,
   getTokenOrCommentEnd,
@@ -118,16 +118,16 @@ export function getTokens<Options extends CountOptions | number | FilterFn | nul
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -136,9 +136,9 @@ export function getTokens<Options extends CountOptions | number | FilterFn | nul
     rangeEnd = range[1];
 
   // Binary search for first token past `node`'s start
-  let sliceStart = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  let sliceStart = firstTokenAtOrAfter(int32, rangeStart, 0, len);
   // Binary search for first token past `node`'s end
-  let sliceEnd = firstTokenAtOrAfter(uint32, rangeEnd, sliceStart, len);
+  let sliceEnd = firstTokenAtOrAfter(int32, rangeEnd, sliceStart, len);
 
   sliceStart = Math.max(0, sliceStart - beforeCount);
   sliceEnd = Math.min(sliceEnd + afterCount, len);
@@ -203,16 +203,16 @@ export function getFirstToken<Options extends SkipOptions | number | FilterFn | 
 
   const includeComments = getIncludeComments(skipOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -221,24 +221,24 @@ export function getFirstToken<Options extends SkipOptions | number | FilterFn | 
     rangeEnd = range[1];
 
   // Binary search for first token past `node`'s start
-  const startIndex = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  const startIndex = firstTokenAtOrAfter(int32, rangeStart, 0, len);
 
   if (typeof filter !== "function") {
     const skipTo = startIndex + (skip ?? 0);
     if (skipTo >= len) return null;
-    if (entryStart(skipTo, uint32) >= rangeEnd) return null;
+    if (entryStart(skipTo, int32) >= rangeEnd) return null;
     return getEntry(skipTo, includeComments) as Result;
   }
 
   if (typeof skip !== "number") {
     for (let i = startIndex; i < len; i++) {
-      if (entryStart(i, uint32) >= rangeEnd) return null;
+      if (entryStart(i, int32) >= rangeEnd) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) return token as Result;
     }
   } else {
     for (let i = startIndex; i < len; i++) {
-      if (entryStart(i, uint32) >= rangeEnd) return null;
+      if (entryStart(i, int32) >= rangeEnd) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) {
         if (skip <= 0) return token as Result;
@@ -282,16 +282,16 @@ export function getFirstTokens<Options extends CountOptions | number | FilterFn 
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -300,9 +300,9 @@ export function getFirstTokens<Options extends CountOptions | number | FilterFn 
     rangeEnd = range[1];
 
   // Binary search for first token past `node`'s start
-  const sliceStart = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  const sliceStart = firstTokenAtOrAfter(int32, rangeStart, 0, len);
   // Binary search for first token past `node`'s end
-  const sliceEnd = firstTokenAtOrAfter(uint32, rangeEnd, sliceStart, len);
+  const sliceEnd = firstTokenAtOrAfter(int32, rangeEnd, sliceStart, len);
 
   if (typeof filter !== "function") {
     if (typeof count !== "number") {
@@ -363,16 +363,16 @@ export function getLastToken<Options extends SkipOptions | number | FilterFn | n
 
   const includeComments = getIncludeComments(skipOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -381,24 +381,24 @@ export function getLastToken<Options extends SkipOptions | number | FilterFn | n
     rangeEnd = range[1];
 
   // Binary search for token immediately before `node`'s end
-  const lastTokenIndex = firstTokenAtOrAfter(uint32, rangeEnd, 0, len) - 1;
+  const lastTokenIndex = firstTokenAtOrAfter(int32, rangeEnd, 0, len) - 1;
 
   if (typeof filter !== "function") {
     const skipTo = lastTokenIndex - (skip ?? 0);
     if (skipTo < 0) return null;
-    if (entryStart(skipTo, uint32) < rangeStart) return null;
+    if (entryStart(skipTo, int32) < rangeStart) return null;
     return getEntry(skipTo, includeComments) as Result;
   }
 
   if (typeof skip !== "number") {
     for (let i = lastTokenIndex; i >= 0; i--) {
-      if (entryStart(i, uint32) < rangeStart) return null;
+      if (entryStart(i, int32) < rangeStart) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) return token as Result;
     }
   } else {
     for (let i = lastTokenIndex; i >= 0; i--) {
-      if (entryStart(i, uint32) < rangeStart) return null;
+      if (entryStart(i, int32) < rangeStart) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) {
         if (skip <= 0) return token as Result;
@@ -444,16 +444,16 @@ export function getLastTokens<Options extends CountOptions | number | FilterFn |
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -462,9 +462,9 @@ export function getLastTokens<Options extends CountOptions | number | FilterFn |
     rangeEnd = range[1];
 
   // Binary search for first token past `node`'s start
-  const sliceStart = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  const sliceStart = firstTokenAtOrAfter(int32, rangeStart, 0, len);
   // Binary search for first token past `node`'s end
-  const sliceEnd = firstTokenAtOrAfter(uint32, rangeEnd, sliceStart, len);
+  const sliceEnd = firstTokenAtOrAfter(int32, rangeEnd, sliceStart, len);
 
   if (typeof filter !== "function") {
     if (typeof count !== "number") {
@@ -526,23 +526,23 @@ export function getTokenBefore<Options extends SkipOptions | number | FilterFn |
 
   const includeComments = getIncludeComments(skipOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
   const nodeStart = nodeOrToken.range[0];
 
   // Binary search for token immediately before the given node, token, or comment
-  let beforeIndex = firstTokenAtOrAfter(uint32, nodeStart, 0, len) - 1;
+  let beforeIndex = firstTokenAtOrAfter(int32, nodeStart, 0, len) - 1;
 
   if (typeof filter !== "function") {
     const skipTo = beforeIndex - (skip ?? 0);
@@ -622,23 +622,23 @@ export function getTokensBefore<
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
   const targetStart = nodeOrToken.range[0];
 
   // Binary search for first token past `nodeOrToken`'s start
-  const sliceEnd = firstTokenAtOrAfter(uint32, targetStart, 0, len);
+  const sliceEnd = firstTokenAtOrAfter(int32, targetStart, 0, len);
 
   // Fast path for the common case
   if (typeof filter !== "function") {
@@ -695,23 +695,23 @@ export function getTokenAfter<Options extends SkipOptions | number | FilterFn | 
 
   const includeComments = getIncludeComments(skipOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
   const rangeEnd = nodeOrToken.range[1];
 
   // Binary search for first token past `nodeOrToken`'s end
-  const startIndex = firstTokenAtOrAfter(uint32, rangeEnd, 0, len);
+  const startIndex = firstTokenAtOrAfter(int32, rangeEnd, 0, len);
 
   // Fast path for the common case
   if (typeof filter !== "function") {
@@ -789,23 +789,23 @@ export function getTokensAfter<Options extends CountOptions | number | FilterFn 
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
   const rangeEnd = nodeOrToken.range[1];
 
   // Binary search for first token past `nodeOrToken`'s end
-  const sliceStart = firstTokenAtOrAfter(uint32, rangeEnd, 0, len);
+  const sliceStart = firstTokenAtOrAfter(int32, rangeEnd, 0, len);
 
   // Fast path for the common case
   if (typeof filter !== "function") {
@@ -865,16 +865,16 @@ export function getTokensBetween<
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -885,9 +885,9 @@ export function getTokensBetween<
     rangeEnd = right.range[0];
 
   // Binary search for first token past "between" range start
-  let sliceStart = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  let sliceStart = firstTokenAtOrAfter(int32, rangeStart, 0, len);
   // Binary search for first token past "between" range end
-  let sliceEnd = firstTokenAtOrAfter(uint32, rangeEnd, sliceStart, len);
+  let sliceEnd = firstTokenAtOrAfter(int32, rangeEnd, sliceStart, len);
 
   // Apply padding
   sliceStart = Math.max(0, sliceStart - padding);
@@ -952,16 +952,16 @@ export function getFirstTokenBetween<
 
   const includeComments = getIncludeComments(skipOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -972,24 +972,24 @@ export function getFirstTokenBetween<
     rangeEnd = right.range[0];
 
   // Binary search for token immediately following `left`
-  const firstTokenIndex = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  const firstTokenIndex = firstTokenAtOrAfter(int32, rangeStart, 0, len);
 
   if (typeof filter !== "function") {
     const skipTo = firstTokenIndex + (skip ?? 0);
     if (skipTo >= len) return null;
-    if (entryStart(skipTo, uint32) >= rangeEnd) return null;
+    if (entryStart(skipTo, int32) >= rangeEnd) return null;
     return getEntry(skipTo, includeComments) as Result;
   }
 
   if (typeof skip !== "number") {
     for (let i = firstTokenIndex; i < len; i++) {
-      if (entryStart(i, uint32) >= rangeEnd) return null;
+      if (entryStart(i, int32) >= rangeEnd) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) return token as Result;
     }
   } else {
     for (let i = firstTokenIndex; i < len; i++) {
-      if (entryStart(i, uint32) >= rangeEnd) return null;
+      if (entryStart(i, int32) >= rangeEnd) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) {
         if (skip <= 0) return token as Result;
@@ -1033,16 +1033,16 @@ export function getFirstTokensBetween<
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -1053,9 +1053,9 @@ export function getFirstTokensBetween<
     rangeEnd = right.range[0];
 
   // Find the first token after `left`
-  const sliceStart = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  const sliceStart = firstTokenAtOrAfter(int32, rangeStart, 0, len);
   // Find the first token at or after `right`
-  const sliceEnd = firstTokenAtOrAfter(uint32, rangeEnd, sliceStart, len);
+  const sliceEnd = firstTokenAtOrAfter(int32, rangeEnd, sliceStart, len);
 
   if (typeof filter !== "function") {
     if (typeof count !== "number") {
@@ -1116,16 +1116,16 @@ export function getLastTokenBetween<
 
   const includeComments = getIncludeComments(skipOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -1137,25 +1137,25 @@ export function getLastTokenBetween<
 
   // Binary search for token immediately preceding `right`.
   // The found token may be within the left node if there are no entries between the nodes.
-  const lastTokenIndex = firstTokenAtOrAfter(uint32, rangeEnd, 0, len) - 1;
+  const lastTokenIndex = firstTokenAtOrAfter(int32, rangeEnd, 0, len) - 1;
 
   // Fast path for the common case
   if (typeof filter !== "function") {
     const skipTo = lastTokenIndex - (skip ?? 0);
     if (skipTo < 0) return null;
-    if (entryStart(skipTo, uint32) < rangeStart) return null;
+    if (entryStart(skipTo, int32) < rangeStart) return null;
     return getEntry(skipTo, includeComments) as Result;
   }
 
   if (typeof skip !== "number") {
     for (let i = lastTokenIndex; i >= 0; i--) {
-      if (entryStart(i, uint32) < rangeStart) return null;
+      if (entryStart(i, int32) < rangeStart) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) return token as Result;
     }
   } else {
     for (let i = lastTokenIndex; i >= 0; i--) {
-      if (entryStart(i, uint32) < rangeStart) return null;
+      if (entryStart(i, int32) < rangeStart) return null;
       const token = getEntry(i, includeComments);
       if (filter(token)) {
         if (skip <= 0) return token as Result;
@@ -1199,16 +1199,16 @@ export function getLastTokensBetween<
 
   const includeComments = getIncludeComments(countOptions);
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -1219,9 +1219,9 @@ export function getLastTokensBetween<
     rangeEnd = right.range[0];
 
   // Binary search for first token past "between" range start
-  const sliceStart = firstTokenAtOrAfter(uint32, rangeStart, 0, len);
+  const sliceStart = firstTokenAtOrAfter(int32, rangeStart, 0, len);
   // Binary search for first token past "between" range end
-  const sliceEnd = firstTokenAtOrAfter(uint32, rangeEnd, sliceStart, len);
+  const sliceEnd = firstTokenAtOrAfter(int32, rangeEnd, sliceStart, len);
 
   // Fast path for the common case
   if (typeof filter !== "function") {
@@ -1271,16 +1271,16 @@ export function getTokenByRangeStart<Options extends RangeOptions | null | undef
     "includeComments" in rangeOptions &&
     !!rangeOptions.includeComments;
 
-  let uint32: Uint32Array, len: number;
+  let int32: Int32Array, len: number;
   if (includeComments === false) {
-    if (tokensUint32 === null) initTokensBuffer();
-    debugAssertIsNonNull(tokensUint32);
-    uint32 = tokensUint32;
+    if (tokensInt32 === null) initTokensBuffer();
+    debugAssertIsNonNull(tokensInt32);
+    int32 = tokensInt32;
     len = tokensLen;
   } else {
-    if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-    debugAssertIsNonNull(tokensAndCommentsUint32);
-    uint32 = tokensAndCommentsUint32;
+    if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+    debugAssertIsNonNull(tokensAndCommentsInt32);
+    int32 = tokensAndCommentsInt32;
     len = tokensAndCommentsLen;
   }
 
@@ -1290,7 +1290,7 @@ export function getTokenByRangeStart<Options extends RangeOptions | null | undef
   // This makes it safe to use `>> 1` for division by 2 (which is faster than `>>> 1`).
   for (let lo = 0, hi = len; lo < hi; ) {
     const mid = (lo + hi) >> 1;
-    const tokenStart = uint32[mid << 2];
+    const tokenStart = int32[mid << 2];
     if (tokenStart < offset) {
       lo = mid + 1;
     } else if (tokenStart > offset) {
@@ -1320,8 +1320,8 @@ const JSX_WHITESPACE_REGEXP = /\s/u;
  *   any of the tokens found between the two given nodes or tokens.
  */
 export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean {
-  if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-  debugAssertIsNonNull(tokensAndCommentsUint32);
+  if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+  debugAssertIsNonNull(tokensAndCommentsInt32);
 
   const range1 = first.range,
     range2 = second.range;
@@ -1354,10 +1354,10 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
   // Binary search for the first token past `rangeStart`.
   // Unless `first` and `second` are adjacent or overlapping,
   // the token will be the first token/comment between the two nodes.
-  let index = firstTokenAtOrAfter(tokensAndCommentsUint32, rangeStart, 0, tokensAndCommentsLen);
+  let index = firstTokenAtOrAfter(tokensAndCommentsInt32, rangeStart, 0, tokensAndCommentsLen);
 
   for (let lastTokenEnd = rangeStart; index < tokensAndCommentsLen; index++) {
-    const tokenStart = tokensAndCommentsUint32[index << 2];
+    const tokenStart = tokensAndCommentsInt32[index << 2];
     // The first token of the later node should undergo the check in the second branch
     if (tokenStart > rangeEnd) break;
     if (tokenStart !== lastTokenEnd) return true;
@@ -1388,8 +1388,8 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
  *   any of the tokens found between the two given nodes or tokens.
  */
 export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): boolean {
-  if (tokensAndCommentsUint32 === null) initTokensAndCommentsBuffer();
-  debugAssertIsNonNull(tokensAndCommentsUint32);
+  if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();
+  debugAssertIsNonNull(tokensAndCommentsInt32);
 
   const range1 = first.range,
     range2 = second.range;
@@ -1410,10 +1410,10 @@ export function isSpaceBetweenTokens(first: NodeOrToken, second: NodeOrToken): b
   // Binary search for the first token past `rangeStart`.
   // Unless `first` and `second` are adjacent or overlapping,
   // the token will be the first token/comment between the two nodes.
-  let index = firstTokenAtOrAfter(tokensAndCommentsUint32, rangeStart, 0, tokensAndCommentsLen);
+  let index = firstTokenAtOrAfter(tokensAndCommentsInt32, rangeStart, 0, tokensAndCommentsLen);
 
   for (let lastTokenEnd = rangeStart; index < tokensAndCommentsLen; index++) {
-    const tokenStart = tokensAndCommentsUint32[index << 2];
+    const tokenStart = tokensAndCommentsInt32[index << 2];
 
     // The first token of the later node should undergo the check in the second branch
     if (tokenStart > rangeEnd) break;
@@ -1465,23 +1465,23 @@ function getEntry(index: number, includeComments: boolean): TokenOrComment {
  * Get `start` offset of token/comment at `index` from the given buffer.
  *
  * @param index - Entry index
- * @param uint32 - The `Uint32Array` buffer (tokens or merged)
+ * @param int32 - The `Int32Array` buffer (tokens or merged)
  * @returns Start offset in source text
  */
-function entryStart(index: number, uint32: Uint32Array): number {
-  return uint32[index << 2];
+function entryStart(index: number, int32: Int32Array): number {
+  return int32[index << 2];
 }
 
 /**
  * Get `end` offset of token/comment at `index`.
- * For tokens-only, reads from `tokensUint32`. For `includeComments`, looks up from the original buffer.
+ * For tokens-only, reads from `tokensInt32`. For `includeComments`, looks up from the original buffer.
  *
  * @param index - Entry index in the tokens or merged buffer
  * @param includeComments - Whether to use the merged tokens-and-comments buffer
  * @returns End offset in source text
  */
 function entryEnd(index: number, includeComments: boolean): number {
-  return includeComments === true ? getTokenOrCommentEnd(index) : tokensUint32![(index << 2) + 1];
+  return includeComments === true ? getTokenOrCommentEnd(index) : tokensInt32![(index << 2) + 1];
 }
 
 /**
@@ -1524,7 +1524,7 @@ function collectEntries(
 }
 
 /**
- * Find the index of the first entry in a `Uint32Array` buffer whose `start` is >= `offset`, via binary search.
+ * Find the index of the first entry in a `Int32Array` buffer whose `start` is >= `offset`, via binary search.
  *
  * Each entry occupies 4 x u32s (16 bytes), with `start` as the first u32.
  * Searched range starts at `startIndex` and ends at `length`.
@@ -1534,21 +1534,21 @@ function collectEntries(
  * Note: Source text is limited to 1 GiB max, so number of tokens cannot exceed 2^30.
  * This makes it safe to use `>> 1` for division by 2 below (which is faster than `>>> 1`).
  *
- * @param uint32 - Uint32Array buffer (tokens, comments, or tokensAndComments)
+ * @param int32 - `Int32Array` buffer (tokens, comments, or tokensAndComments)
  * @param offset - Source offset to search for
  * @param startIndex - Starting entry index for the search
  * @param length - Total number of entries in the buffer
  * @returns Index of first entry with `start >= offset`
  */
 export function firstTokenAtOrAfter(
-  uint32: Uint32Array,
+  int32: Int32Array,
   offset: number,
   startIndex: number,
   length: number,
 ): number {
   for (let endIndex = length; startIndex < endIndex; ) {
     const mid = (startIndex + endIndex) >> 1;
-    if (uint32[mid << 2] < offset) {
+    if (int32[mid << 2] < offset) {
       startIndex = mid + 1;
     } else {
       endIndex = mid;

--- a/apps/oxlint/src-js/utils/typed_arrays.ts
+++ b/apps/oxlint/src-js/utils/typed_arrays.ts
@@ -2,6 +2,6 @@
 // Avoids pointlessly creating multiple `Uint8Array`s.
 export const EMPTY_UINT8_ARRAY = new Uint8Array(0);
 
-// Empty `Uint32Array`, used for all vars which begin as an empty `Uint32Array`.
-// Avoids pointlessly creating multiple `Uint32Array`s.
-export const EMPTY_UINT32_ARRAY = new Uint32Array(0);
+// Empty `Int32Array`, used for all vars which begin as an empty `Int32Array`.
+// Avoids pointlessly creating multiple `Int32Array`s.
+export const EMPTY_INT32_ARRAY = new Int32Array(0);

--- a/apps/oxlint/tsdown_plugins/inline_search.ts
+++ b/apps/oxlint/tsdown_plugins/inline_search.ts
@@ -32,13 +32,13 @@ const { fnParams, returnParamIndex, fnBodySource } = extractInlinedFunction(
  *
  * ```ts
  * // Original code
- * const index = firstTokenAtOrAfter(uint32, rangeStart, searchFromIndex, length);
+ * const index = firstTokenAtOrAfter(int32, rangeStart, searchFromIndex, length);
  *
  * // After transform
  * let index = searchFromIndex;
  * for (let endIndex = length; index < endIndex; ) {
  *   const mid = (index + endIndex) >> 1;
- *   if (uint32[mid << 2] < rangeStart) {
+ *   if (int32[mid << 2] < rangeStart) {
  *     index = mid + 1;
  *   } else {
  *     endIndex = mid;

--- a/napi/parser/src-js/generated/constants.js
+++ b/napi/parser/src-js/generated/constants.js
@@ -37,12 +37,12 @@ export const IS_JSX_FLAG_POS = 2147483613;
 export const HAS_BOM_FLAG_POS = 2147483614;
 
 /**
- * Byte offset of the tokens offset within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens offset within the buffer, divided by 4 (for `Int32Array` indexing).
  */
 export const TOKENS_OFFSET_POS_32 = 536870901;
 
 /**
- * Byte offset of the tokens length within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens length within the buffer, divided by 4 (for `Int32Array` indexing).
  */
 export const TOKENS_LEN_POS_32 = 536870902;
 

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -1539,12 +1539,12 @@ fn generate_constants(consts: Constants) -> (String, TokenStream) {
         export const HAS_BOM_FLAG_POS = {has_bom_pos};
 
         /**
-         * Byte offset of the tokens offset within the buffer, divided by 4 (for `Uint32Array` indexing).
+         * Byte offset of the tokens offset within the buffer, divided by 4 (for `Int32Array` indexing).
          */
         export const TOKENS_OFFSET_POS_32 = {tokens_offset_pos_32};
 
         /**
-         * Byte offset of the tokens length within the buffer, divided by 4 (for `Uint32Array` indexing).
+         * Byte offset of the tokens length within the buffer, divided by 4 (for `Int32Array` indexing).
          */
         export const TOKENS_LEN_POS_32 = {tokens_len_pos_32};
 


### PR DESCRIPTION
Continuation of #21132. Use `Int32Array` view of the buffer for all operations related to tokens and comments.