### PR TITLE
perf(napi/parser, linter/plugins): remove `uint32` buffer view

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.d.ts
+++ b/apps/oxlint/src-js/generated/deserialize.d.ts
@@ -4,7 +4,6 @@
 import type { Program } from "./types.d.ts";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/apps/oxlint/src-js/package/parse.ts
+++ b/apps/oxlint/src-js/package/parse.ts
@@ -99,7 +99,6 @@ export function initBuffer() {
   const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
   const offset = getBufferOffset(new Uint8Array(arrayBuffer));
   buffer = new Uint8Array(arrayBuffer, offset, BUFFER_SIZE) as BufferWithArrays;
-  buffer.uint32 = new Uint32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.int32 = new Int32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
 

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -132,7 +132,6 @@ export function lintFileImpl(
   } else {
     typeAssertIs<BufferWithArrays>(buffer);
     const { buffer: arrayBuffer, byteOffset } = buffer;
-    buffer.uint32 = new Uint32Array(arrayBuffer, byteOffset);
     buffer.int32 = new Int32Array(arrayBuffer, byteOffset);
     buffer.float64 = new Float64Array(arrayBuffer, byteOffset);
 

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -25,7 +25,6 @@ export type NodeOrToken = Node | Token | Comment;
 
 // Buffer with typed array views of itself stored as properties.
 export interface BufferWithArrays extends Uint8Array {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 }

--- a/napi/parser/src-js/generated/deserialize/js.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/generated/deserialize/js_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js_parent.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/generated/deserialize/js_range.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js_range.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/generated/deserialize/ts.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/generated/deserialize/ts_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/generated/deserialize/ts_range.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts_range.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.d.ts
@@ -4,7 +4,6 @@
 import type * as ESTree from "@oxc-project/types";
 
 type BufferWithArrays = Uint8Array & {
-  uint32: Uint32Array;
   int32: Int32Array;
   float64: Float64Array;
 };

--- a/napi/parser/src-js/raw-transfer/common.js
+++ b/napi/parser/src-js/raw-transfer/common.js
@@ -270,7 +270,6 @@ function createBuffer() {
   const arrayBuffer = new ArrayBuffer(ARRAY_BUFFER_SIZE);
   const offset = getBufferOffset(new Uint8Array(arrayBuffer));
   const buffer = new Uint8Array(arrayBuffer, offset, BUFFER_SIZE);
-  buffer.uint32 = new Uint32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.int32 = new Int32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
   return buffer;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -144,7 +144,7 @@ fn generate_deserializers(
         import {{ getNodeLoc }} from '../plugins/location.js';
         /* END_IF */
 
-        let uint8, uint32, int32, float64, sourceText, sourceTextLatin,
+        let uint8, int32, float64, sourceText, sourceTextLatin,
             sourceStartPos = 0, sourceEndPos = 0, firstNonAsciiPos = 0;
 
         let parent = null;
@@ -189,7 +189,6 @@ fn generate_deserializers(
 
         function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {{
             uint8 = buffer;
-            uint32 = buffer.uint32;
             int32 = buffer.int32;
             float64 = buffer.float64;
 
@@ -233,7 +232,7 @@ fn generate_deserializers(
 
         export function resetBuffer() {{
             // Clear buffer and source text strings to allow them to be garbage collected
-            uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = undefined;
+            uint8 = int32 = float64 = sourceText = sourceTextLatin = undefined;
         }}
     ");
 
@@ -243,7 +242,6 @@ fn generate_deserializers(
         import type { Program } from './types.d.ts';
 
         type BufferWithArrays = Uint8Array & {
-            uint32: Uint32Array;
             int32: Int32Array;
             float64: Float64Array;
         };
@@ -264,7 +262,6 @@ fn generate_deserializers(
         import type * as ESTree from '@oxc-project/types';
 
         type BufferWithArrays = Uint8Array & {
-            uint32: Uint32Array;
             int32: Int32Array;
             float64: Float64Array;
         };
@@ -928,23 +925,23 @@ fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &
         "bool" => "return uint8[pos] === 1;",
         "u8" => "return uint8[pos];",
         // "u16" => "return uint16[pos >> 1];",
-        "u32" => "return uint32[pos >> 2];",
+        "u32" => "return int32[pos >> 2] >>> 0;",
         "i32" => "return int32[pos >> 2];",
         // Will be approximate if larger than `Number.MAX_SAFE_INTEGER`
         #[rustfmt::skip]
         "u64" => "
             const pos32 = pos >> 2;
-            return uint32[pos32]
-                + uint32[pos32 + 1] * /* 2^32 */ 4294967296;
+            return (int32[pos32] >>> 0)
+                + (int32[pos32 + 1] >>> 0) * /* 2^32 */ 4294967296;
         ",
         // Will be approximate if larger than `Number.MAX_SAFE_INTEGER`
         #[rustfmt::skip]
         "u128" => "
             const pos32 = pos >> 2;
-            return uint32[pos32]
-                + uint32[pos32 + 1] * /* 2^32 */ 4294967296
-                + uint32[pos32 + 2] * /* 2^64 */ 18446744073709551616
-                + uint32[pos32 + 3] * /* 2^96 */ 79228162514264337593543950336;
+            return (int32[pos32] >>> 0)
+                + (int32[pos32 + 1] >>> 0) * /* 2^32 */ 4294967296
+                + (int32[pos32 + 2] >>> 0) * /* 2^64 */ 18446744073709551616
+                + (int32[pos32 + 3] >>> 0) * /* 2^96 */ 79228162514264337593543950336;
         ",
         "f64" => "return float64[pos >> 3];",
         "&str" => STR_DESERIALIZER_BODY,


### PR DESCRIPTION
Continuation of #21132. All uses of the `Uint32Array` view of the buffer in raw transfer code have been removed in preceding PRs. So we can now remove it entirely.