### PR TITLE
perf(napi/parser, linter/plugins): shift before add when calculating positions in raw transfer deserializer

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -2268,9 +2268,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let start,
       end,
       previousParent = parent,
@@ -2303,7 +2304,8 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent,
-    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
+    initializerFieldPos32 = (pos >> 2) + 16,
+    hasInitializer = int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -3180,7 +3182,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -3199,7 +3201,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -3224,7 +3226,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -3244,7 +3246,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3760,7 +3762,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -6075,13 +6077,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -6137,7 +6139,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -6287,7 +6289,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -6301,7 +6303,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -6323,13 +6325,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -6371,7 +6373,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6393,7 +6395,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -6403,7 +6405,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -6413,7 +6415,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -6427,7 +6429,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6461,7 +6463,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6559,7 +6561,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -6569,7 +6571,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -6651,7 +6653,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6985,7 +6987,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -171,8 +171,9 @@ impl ESTree for CatchParameterConverter<'_, '_> {
     ts_type = "ParamPattern[]",
     raw_deser = "
         const params = DESER[Vec<FormalParameter>](POS_OFFSET.items);
-        if (int32[(POS_OFFSET.rest) >> 2] !== 0 && int32[(POS_OFFSET.rest + 4) >> 2] !== 0) {
-            pos = int32[(POS_OFFSET.rest) >> 2];
+        const restFieldPos32 = POS_OFFSET.rest >> 2;
+        if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+            pos = int32[restFieldPos32];
 
             let start, end;
             const previousParent = parent;
@@ -255,7 +256,8 @@ impl ESTree for FormalParameterRest<'_> {
     raw_deser = "
         let param;
         const previousParent = parent;
-        const hasInitializer = int32[(POS_OFFSET.initializer) >> 2] !== 0 && int32[(POS_OFFSET.initializer + 4) >> 2] !== 0;
+        const initializerFieldPos32 = POS_OFFSET.initializer >> 2;
+        const hasInitializer = int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0;
 
         if (IS_TS) {
             const accessibility = DESER[Option<TSAccessibility>](POS_OFFSET.accessibility),

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -1720,9 +1720,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let rest = {
       type: "RestElement",
       argument: null,
@@ -1736,8 +1737,9 @@ function deserializeFormalParameters(pos) {
 }
 
 function deserializeFormalParameter(pos) {
-  let param;
-  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
+  let param,
+    initializerFieldPos32 = (pos >> 2) + 16;
+  if (int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0) {
     param = {
       type: "AssignmentPattern",
       left: null,
@@ -2309,7 +2311,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2324,7 +2326,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2345,7 +2347,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -2361,7 +2363,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -2775,7 +2777,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -4553,7 +4555,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -4815,13 +4817,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -4877,7 +4879,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5027,7 +5029,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5041,7 +5043,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5063,13 +5065,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5111,7 +5113,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5133,7 +5135,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -5143,7 +5145,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -5153,7 +5155,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -5167,7 +5169,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5201,7 +5203,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -5283,7 +5285,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -5293,7 +5295,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -5375,7 +5377,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -5709,7 +5711,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -5735,7 +5737,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -1909,9 +1909,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let previousParent = parent,
       rest = (parent = {
         type: "RestElement",
@@ -1929,8 +1930,9 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param,
-    previousParent = parent;
-  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
+    previousParent = parent,
+    initializerFieldPos32 = (pos >> 2) + 16;
+  if (int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0) {
     param = parent = {
       type: "AssignmentPattern",
       left: null,
@@ -2572,7 +2574,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2589,7 +2591,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2612,7 +2614,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -2630,7 +2632,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3084,7 +3086,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5066,7 +5068,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5328,13 +5330,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5390,7 +5392,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5540,7 +5542,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5554,7 +5556,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5576,13 +5578,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5624,7 +5626,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5646,7 +5648,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -5656,7 +5658,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -5666,7 +5668,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -5680,7 +5682,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5714,7 +5716,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -5796,7 +5798,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -5806,7 +5808,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -5888,7 +5890,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6222,7 +6224,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6248,7 +6250,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -1911,9 +1911,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let start,
       end,
       rest = {
@@ -1930,8 +1931,9 @@ function deserializeFormalParameters(pos) {
 }
 
 function deserializeFormalParameter(pos) {
-  let param;
-  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
+  let param,
+    initializerFieldPos32 = (pos >> 2) + 16;
+  if (int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0) {
     let start, end;
     param = {
       type: "AssignmentPattern",
@@ -2569,7 +2571,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2585,7 +2587,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2607,7 +2609,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -2624,7 +2626,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3081,7 +3083,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5094,7 +5096,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5356,13 +5358,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5418,7 +5420,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5568,7 +5570,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5582,7 +5584,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5604,13 +5606,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5652,7 +5654,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5674,7 +5676,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -5684,7 +5686,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -5694,7 +5696,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -5708,7 +5710,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5742,7 +5744,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -5824,7 +5826,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -5834,7 +5836,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -5916,7 +5918,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6250,7 +6252,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6276,7 +6278,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -2099,9 +2099,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let start,
       end,
       previousParent = parent,
@@ -2122,8 +2123,9 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param,
-    previousParent = parent;
-  if (int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0) {
+    previousParent = parent,
+    initializerFieldPos32 = (pos >> 2) + 16;
+  if (int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0) {
     let start, end;
     param = parent = {
       type: "AssignmentPattern",
@@ -2831,7 +2833,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2849,7 +2851,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2873,7 +2875,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -2892,7 +2894,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3389,7 +3391,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5606,7 +5608,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5868,13 +5870,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5930,7 +5932,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -6080,7 +6082,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -6094,7 +6096,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -6116,13 +6118,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -6164,7 +6166,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6186,7 +6188,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -6196,7 +6198,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -6206,7 +6208,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -6220,7 +6222,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6254,7 +6256,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6336,7 +6338,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -6346,7 +6348,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -6428,7 +6430,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6762,7 +6764,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6788,7 +6790,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -1819,9 +1819,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let end,
       rest = {
         type: "RestElement",
@@ -1846,7 +1847,8 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param,
-    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
+    initializerFieldPos32 = (pos >> 2) + 16,
+    hasInitializer = int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -2529,7 +2531,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2544,7 +2546,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2565,7 +2567,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -2581,7 +2583,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -2995,7 +2997,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -4829,7 +4831,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5091,13 +5093,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5153,7 +5155,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5303,7 +5305,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5317,7 +5319,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5339,13 +5341,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5387,7 +5389,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5409,7 +5411,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -5419,7 +5421,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -5429,7 +5431,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -5443,7 +5445,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -5477,7 +5479,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -5575,7 +5577,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -5585,7 +5587,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -5667,7 +5669,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6001,7 +6003,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6027,7 +6029,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -2014,9 +2014,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let end,
       previousParent = parent,
       rest = (parent = {
@@ -2045,7 +2046,8 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent,
-    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
+    initializerFieldPos32 = (pos >> 2) + 16,
+    hasInitializer = int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -2811,7 +2813,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2828,7 +2830,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2851,7 +2853,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -2869,7 +2871,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3323,7 +3325,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5372,7 +5374,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5634,13 +5636,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5696,7 +5698,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5846,7 +5848,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5860,7 +5862,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5882,13 +5884,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5930,7 +5932,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5952,7 +5954,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -5962,7 +5964,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -5972,7 +5974,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -5986,7 +5988,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6020,7 +6022,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6118,7 +6120,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -6128,7 +6130,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -6210,7 +6212,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6544,7 +6546,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6570,7 +6572,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -2013,9 +2013,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let start,
       end,
       rest = {
@@ -2043,7 +2044,8 @@ function deserializeFormalParameters(pos) {
 
 function deserializeFormalParameter(pos) {
   let param,
-    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
+    initializerFieldPos32 = (pos >> 2) + 16,
+    hasInitializer = int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -2810,7 +2812,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -2826,7 +2828,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -2848,7 +2850,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -2865,7 +2867,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3322,7 +3324,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5398,7 +5400,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -5660,13 +5662,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5722,7 +5724,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -5872,7 +5874,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -5886,7 +5888,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -5908,13 +5910,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -5956,7 +5958,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -5978,7 +5980,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -5988,7 +5990,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -5998,7 +6000,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -6012,7 +6014,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6046,7 +6048,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6144,7 +6146,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -6154,7 +6156,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -6236,7 +6238,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -6570,7 +6572,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -6596,7 +6598,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -2207,9 +2207,10 @@ function deserializeFunctionType(pos) {
 }
 
 function deserializeFormalParameters(pos) {
-  let params = deserializeVecFormalParameter(pos + 16);
-  if (int32[(pos + 40) >> 2] !== 0 && int32[(pos + 44) >> 2] !== 0) {
-    pos = int32[(pos + 40) >> 2];
+  let params = deserializeVecFormalParameter(pos + 16),
+    restFieldPos32 = (pos >> 2) + 10;
+  if (int32[restFieldPos32] !== 0 && int32[restFieldPos32 + 1] !== 0) {
+    pos = int32[restFieldPos32];
     let start,
       end,
       previousParent = parent,
@@ -2241,7 +2242,8 @@ function deserializeFormalParameters(pos) {
 function deserializeFormalParameter(pos) {
   let param,
     previousParent = parent,
-    hasInitializer = int32[(pos + 64) >> 2] !== 0 && int32[(pos + 68) >> 2] !== 0;
+    initializerFieldPos32 = (pos >> 2) + 16,
+    hasInitializer = int32[initializerFieldPos32] !== 0 && int32[initializerFieldPos32 + 1] !== 0;
   {
     let accessibility = deserializeOptionTSAccessibility(pos + 13),
       readonly = deserializeBool(pos + 14),
@@ -3091,7 +3093,7 @@ function deserializeNumericLiteral(pos) {
     type: "Literal",
     value: deserializeF64(pos + 32),
     raw:
-      int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+      int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -3109,7 +3111,7 @@ function deserializeStringLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+        int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
           ? null
           : sourceText.slice(start, end),
       start,
@@ -3133,7 +3135,7 @@ function deserializeBigIntLiteral(pos) {
     type: "Literal",
     value: BigInt(bigint),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     bigint,
@@ -3152,7 +3154,7 @@ function deserializeRegExpLiteral(pos) {
       type: "Literal",
       value: null,
       raw:
-        int32[(pos + 48) >> 2] === 0 && int32[(pos + 52) >> 2] === 0
+        int32[(pos >> 2) + 12] === 0 && int32[(pos >> 2) + 13] === 0
           ? null
           : sourceText.slice(start, end),
       regex: null,
@@ -3649,7 +3651,7 @@ function deserializeJSXText(pos) {
     type: "JSXText",
     value: deserializeStr(pos + 16),
     raw:
-      int32[(pos + 32) >> 2] === 0 && int32[(pos + 36) >> 2] === 0
+      int32[(pos >> 2) + 8] === 0 && int32[(pos >> 2) + 9] === 0
         ? null
         : sourceText.slice(start, end),
     start,
@@ -5940,7 +5942,7 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeHashbang(pos);
 }
@@ -6202,13 +6204,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -6264,7 +6266,7 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxAssignmentTargetRest(pos);
 }
@@ -6414,7 +6416,7 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeAnnotation(pos);
 }
@@ -6428,7 +6430,7 @@ function deserializeOptionForStatementInit(pos) {
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeLabelIdentifier(pos);
 }
@@ -6450,13 +6452,13 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBlockStatement(pos);
 }
@@ -6498,7 +6500,7 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxBindingRestElement(pos);
 }
@@ -6520,7 +6522,7 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  return int32[(pos + 16) >> 2] === 0 && int32[(pos + 20) >> 2] === 0
+  return int32[(pos >> 2) + 4] === 0 && int32[(pos >> 2) + 5] === 0
     ? null
     : deserializeBindingIdentifier(pos);
 }
@@ -6530,7 +6532,7 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSTypeParameterDeclaration(pos);
 }
@@ -6540,7 +6542,7 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxTSThisParameter(pos);
 }
@@ -6554,7 +6556,7 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxFunctionBody(pos);
 }
@@ -6588,7 +6590,7 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxExpression(pos);
 }
@@ -6686,7 +6688,7 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeVecImportDeclarationSpecifier(pos);
 }
@@ -6696,7 +6698,7 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxWithClause(pos);
 }
@@ -6778,7 +6780,7 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxJSXClosingElement(pos);
 }
@@ -7112,7 +7114,7 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  return int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0
+  return int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0
     ? null
     : deserializeBoxObjectExpression(pos);
 }
@@ -7138,7 +7140,7 @@ function deserializeI32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  return int32[(pos + 8) >> 2] === 0 && int32[(pos + 12) >> 2] === 0
+  return int32[(pos >> 2) + 2] === 0 && int32[(pos >> 2) + 3] === 0
     ? null
     : deserializeNameSpan(pos);
 }

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -12672,8 +12672,7 @@ function constructComment(pos, ast) {
 }
 
 function constructOptionHashbang(pos, ast) {
-  if (ast.buffer.int32[(pos + 16) >> 2] === 0 && ast.buffer.int32[(pos + 20) >> 2] === 0)
-    return null;
+  if (ast.buffer.int32[(pos >> 2) + 4] === 0 && ast.buffer.int32[(pos >> 2) + 5] === 0) return null;
   return new Hashbang(pos, ast);
 }
 
@@ -12906,12 +12905,12 @@ function constructBoxTSTypeParameterInstantiation(pos, ast) {
 }
 
 function constructOptionBoxTSTypeParameterInstantiation(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxTSTypeParameterInstantiation(pos, ast);
 }
 
 function constructOptionStr(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructStr(pos, ast);
 }
 
@@ -12963,7 +12962,7 @@ function constructBoxAssignmentTargetRest(pos, ast) {
 }
 
 function constructOptionBoxAssignmentTargetRest(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxAssignmentTargetRest(pos, ast);
 }
 
@@ -13105,7 +13104,7 @@ function constructBoxTSTypeAnnotation(pos, ast) {
 }
 
 function constructOptionBoxTSTypeAnnotation(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxTSTypeAnnotation(pos, ast);
 }
 
@@ -13120,8 +13119,7 @@ function constructOptionForStatementInit(pos, ast) {
 }
 
 function constructOptionLabelIdentifier(pos, ast) {
-  if (ast.buffer.int32[(pos + 16) >> 2] === 0 && ast.buffer.int32[(pos + 20) >> 2] === 0)
-    return null;
+  if (ast.buffer.int32[(pos >> 2) + 4] === 0 && ast.buffer.int32[(pos >> 2) + 5] === 0) return null;
   return new LabelIdentifier(pos, ast);
 }
 
@@ -13140,12 +13138,12 @@ function constructBoxCatchClause(pos, ast) {
 }
 
 function constructOptionBoxCatchClause(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxCatchClause(pos, ast);
 }
 
 function constructOptionBoxBlockStatement(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxBlockStatement(pos, ast);
 }
 
@@ -13185,7 +13183,7 @@ function constructBoxBindingRestElement(pos, ast) {
 }
 
 function constructOptionBoxBindingRestElement(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxBindingRestElement(pos, ast);
 }
 
@@ -13201,8 +13199,7 @@ function constructVecOptionBindingPattern(pos, ast) {
 }
 
 function constructOptionBindingIdentifier(pos, ast) {
-  if (ast.buffer.int32[(pos + 16) >> 2] === 0 && ast.buffer.int32[(pos + 20) >> 2] === 0)
-    return null;
+  if (ast.buffer.int32[(pos >> 2) + 4] === 0 && ast.buffer.int32[(pos >> 2) + 5] === 0) return null;
   return new BindingIdentifier(pos, ast);
 }
 
@@ -13211,7 +13208,7 @@ function constructBoxTSTypeParameterDeclaration(pos, ast) {
 }
 
 function constructOptionBoxTSTypeParameterDeclaration(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxTSTypeParameterDeclaration(pos, ast);
 }
 
@@ -13220,7 +13217,7 @@ function constructBoxTSThisParameter(pos, ast) {
 }
 
 function constructOptionBoxTSThisParameter(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxTSThisParameter(pos, ast);
 }
 
@@ -13233,7 +13230,7 @@ function constructBoxFunctionBody(pos, ast) {
 }
 
 function constructOptionBoxFunctionBody(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxFunctionBody(pos, ast);
 }
 
@@ -13262,7 +13259,7 @@ function constructBoxExpression(pos, ast) {
 }
 
 function constructOptionBoxExpression(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxExpression(pos, ast);
 }
 
@@ -13353,7 +13350,7 @@ function constructVecImportDeclarationSpecifier(pos, ast) {
 }
 
 function constructOptionVecImportDeclarationSpecifier(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructVecImportDeclarationSpecifier(pos, ast);
 }
 
@@ -13362,7 +13359,7 @@ function constructBoxWithClause(pos, ast) {
 }
 
 function constructOptionBoxWithClause(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxWithClause(pos, ast);
 }
 
@@ -13436,7 +13433,7 @@ function constructBoxJSXClosingElement(pos, ast) {
 }
 
 function constructOptionBoxJSXClosingElement(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxJSXClosingElement(pos, ast);
 }
 
@@ -13740,7 +13737,7 @@ function constructBoxTSTypeParameter(pos, ast) {
 }
 
 function constructOptionBoxObjectExpression(pos, ast) {
-  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0) return null;
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
   return constructBoxObjectExpression(pos, ast);
 }
 
@@ -13782,8 +13779,7 @@ function constructI32(pos, ast) {
 }
 
 function constructOptionNameSpan(pos, ast) {
-  if (ast.buffer.int32[(pos + 8) >> 2] === 0 && ast.buffer.int32[(pos + 12) >> 2] === 0)
-    return null;
+  if (ast.buffer.int32[(pos >> 2) + 2] === 0 && ast.buffer.int32[(pos >> 2) + 3] === 0) return null;
   return new NameSpan(pos, ast);
 }
 

--- a/napi/parser/src-js/generated/lazy/walk.js
+++ b/napi/parser/src-js/generated/lazy/walk.js
@@ -4720,7 +4720,7 @@ function walkJSDocUnknownType(pos, ast, visitors) {
 }
 
 function walkOptionHashbang(pos, ast, visitors) {
-  if (!(ast.buffer.int32[(pos + 16) >> 2] === 0 && ast.buffer.int32[(pos + 20) >> 2] === 0))
+  if (!(ast.buffer.int32[(pos >> 2) + 4] === 0 && ast.buffer.int32[(pos >> 2) + 5] === 0))
     walkHashbang(pos, ast, visitors);
 }
 
@@ -4960,7 +4960,7 @@ function walkBoxTSTypeParameterInstantiation(pos, ast, visitors) {
 }
 
 function walkOptionBoxTSTypeParameterInstantiation(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxTSTypeParameterInstantiation(pos, ast, visitors);
 }
 
@@ -5153,7 +5153,7 @@ function walkBoxTSTypeAnnotation(pos, ast, visitors) {
 }
 
 function walkOptionBoxTSTypeAnnotation(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxTSTypeAnnotation(pos, ast, visitors);
 }
 
@@ -5166,7 +5166,7 @@ function walkOptionForStatementInit(pos, ast, visitors) {
 }
 
 function walkOptionLabelIdentifier(pos, ast, visitors) {
-  if (!(ast.buffer.int32[(pos + 16) >> 2] === 0 && ast.buffer.int32[(pos + 20) >> 2] === 0))
+  if (!(ast.buffer.int32[(pos >> 2) + 4] === 0 && ast.buffer.int32[(pos >> 2) + 5] === 0))
     walkLabelIdentifier(pos, ast, visitors);
 }
 
@@ -5186,12 +5186,12 @@ function walkBoxCatchClause(pos, ast, visitors) {
 }
 
 function walkOptionBoxCatchClause(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxCatchClause(pos, ast, visitors);
 }
 
 function walkOptionBoxBlockStatement(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxBlockStatement(pos, ast, visitors);
 }
 
@@ -5242,7 +5242,7 @@ function walkVecOptionBindingPattern(pos, ast, visitors) {
 }
 
 function walkOptionBindingIdentifier(pos, ast, visitors) {
-  if (!(ast.buffer.int32[(pos + 16) >> 2] === 0 && ast.buffer.int32[(pos + 20) >> 2] === 0))
+  if (!(ast.buffer.int32[(pos >> 2) + 4] === 0 && ast.buffer.int32[(pos >> 2) + 5] === 0))
     walkBindingIdentifier(pos, ast, visitors);
 }
 
@@ -5251,7 +5251,7 @@ function walkBoxTSTypeParameterDeclaration(pos, ast, visitors) {
 }
 
 function walkOptionBoxTSTypeParameterDeclaration(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxTSTypeParameterDeclaration(pos, ast, visitors);
 }
 
@@ -5264,7 +5264,7 @@ function walkBoxFunctionBody(pos, ast, visitors) {
 }
 
 function walkOptionBoxFunctionBody(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxFunctionBody(pos, ast, visitors);
 }
 
@@ -5295,7 +5295,7 @@ function walkBoxExpression(pos, ast, visitors) {
 }
 
 function walkOptionBoxExpression(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxExpression(pos, ast, visitors);
 }
 
@@ -5381,7 +5381,7 @@ function walkVecImportDeclarationSpecifier(pos, ast, visitors) {
 }
 
 function walkOptionVecImportDeclarationSpecifier(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkVecImportDeclarationSpecifier(pos, ast, visitors);
 }
 
@@ -5390,7 +5390,7 @@ function walkBoxWithClause(pos, ast, visitors) {
 }
 
 function walkOptionBoxWithClause(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxWithClause(pos, ast, visitors);
 }
 
@@ -5460,7 +5460,7 @@ function walkBoxJSXClosingElement(pos, ast, visitors) {
 }
 
 function walkOptionBoxJSXClosingElement(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxJSXClosingElement(pos, ast, visitors);
 }
 
@@ -5785,7 +5785,7 @@ function walkBoxTSTypeParameter(pos, ast, visitors) {
 }
 
 function walkOptionBoxObjectExpression(pos, ast, visitors) {
-  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos + 4) >> 2] === 0))
+  if (!(ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0))
     walkBoxObjectExpression(pos, ast, visitors);
 }
 

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -1077,7 +1077,7 @@ fn get_option_none_condition_and_offset(
             4 => format!("int32[{}] === {}", pos_offset_shift(niche_offset, 2), niche.value()),
             8 => {
                 // TODO: Use `float64[pos >> 3] === 0` instead of
-                // `int32[pos >> 2] === 0 && int32[(pos + 4) >> 2] === 0`?
+                // `int32[pos >> 2] === 0 && int32[(pos >> 2) + 1] === 0`?
                 let value = niche.value();
                 format!(
                     "int32[{}] === {} && int32[{}] === {}",
@@ -1178,7 +1178,7 @@ where
 /// * If `offset == 0` and `shift == 0` -> `pos`.
 /// * If `offset == 0` -> `pos >> <shift>` (e.g. `pos >> 2`).
 /// * If `shift == 0` -> `pos + <offset>` (e.g. `pos + 8`).
-/// * Otherwise -> `(pos + <offset>) >> <shift>` (e.g. `(pos + 8) >> 2`).
+/// * Otherwise -> `(pos >> <shift>) + <offset shifted>` (e.g. `(pos >> 2) + 2`).
 pub(super) fn pos_offset_shift<O, S>(offset: O, shift: S) -> Cow<'static, str>
 where
     O: TryInto<u64>,
@@ -1192,7 +1192,10 @@ where
         (0, 0) => Cow::Borrowed("pos"),
         (0, _) => format_cow!("pos >> {shift}"),
         (_, 0) => format_cow!("pos + {offset}"),
-        (_, _) => format_cow!("(pos + {offset}) >> {shift}"),
+        (_, _) => {
+            let shifted_offset = offset >> shift;
+            format_cow!("(pos >> {shift}) + {shifted_offset}")
+        }
     }
 }
 
@@ -1293,8 +1296,9 @@ impl Replacer for PosReplacer {
     }
 }
 
-static POS_OFFSET_REGEX: Lazy<Regex> =
-    lazy_regex!(r"POS_OFFSET(?:<([A-Za-z]+)>)?\.([a-zA-Z_]+(?:\.[a-zA-Z_]+)*)(?:\s*\+\s*(\d+))?");
+static POS_OFFSET_REGEX: Lazy<Regex> = lazy_regex!(
+    r"POS_OFFSET(?:<([A-Za-z]+)>)?\.([a-zA-Z_]+(?:\.[a-zA-Z_]+)*)(?:\s*(\+|>>)\s*(\d+))?"
+);
 
 struct PosOffsetReplacer<'s, 'd> {
     schema: &'s Schema,
@@ -1314,7 +1318,7 @@ impl<'s, 'd> PosOffsetReplacer<'s, 'd> {
 
 impl Replacer for PosOffsetReplacer<'_, '_> {
     fn replace_append(&mut self, caps: &Captures, dst: &mut String) {
-        assert_eq!(caps.len(), 4);
+        assert_eq!(caps.len(), 5);
 
         let struct_def = if let Some(struct_name) = caps.get(1) {
             self.schema.type_by_name(struct_name.as_str()).as_struct().unwrap()
@@ -1334,8 +1338,20 @@ impl Replacer for PosOffsetReplacer<'_, '_> {
             type_def = field.type_def(self.schema);
         }
 
-        if let Some(add) = caps.get(3) {
-            offset += str::parse::<u32>(add.as_str()).unwrap();
+        if let Some(operator) = caps.get(3) {
+            let right = str::parse::<u32>(caps.get(4).unwrap().as_str()).unwrap();
+
+            if operator.as_str() == ">>" {
+                if offset == 0 {
+                    write_it!(dst, "pos >> {right}");
+                } else {
+                    let offset_shifted = offset >> right;
+                    write_it!(dst, "(pos >> {right}) + {offset_shifted}");
+                }
+                return;
+            }
+
+            offset += right;
         }
 
         if offset == 0 {


### PR DESCRIPTION
Small perf optimization to raw transfer. When calculating a `u32` offset, shift first then add (`(pos >> 2) + 4`) instead of adding first (`(pos + 16) >> 2`). If a function contains multiple `pos >> 2` calculations, V8 may be able to combine them into a single calculation. Previously it couldn't prove that `pos` is a multiple of 4, so couldn't make this optimization.