### PR TITLE
fix(formatter): preserve newline between self-closing JSX element and single-char text

### DIFF
--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -143,6 +143,11 @@ impl FormatJsxChildList {
                 // A new line between some JSX text and an element
                 JsxChild::Newline => {
                     let is_soft_break = {
+                        // Prettier's single-character heuristic: punctuation connectors (e.g. `,`,
+                        // `.`) adjacent to a JSX element use a soft break; a single alphabetic
+                        // character starting a text run (e.g. `I` in `I have...`) uses a hard
+                        // break to preserve semantic whitespace between siblings.
+                        //
                         // Here we handle the case when we have a newline between a single-character word and a jsx element
                         // We need to use the previous and the next element
                         // [JsxChild::Word, JsxChild::Newline, JsxChild::NonText]
@@ -180,6 +185,15 @@ impl FormatJsxChildList {
                                 matches!(child.as_ref(), JSXChild::Element(element) if
                                     element.closing_element.is_none())
                             );
+                            // When a single alphabetic character (e.g. "I", "a") is
+                            // followed by more words, it is the start of a text run
+                            // (e.g. "I have...") and the newline must be preserved as a
+                            // hard break. Punctuation (e.g. ",", ".") is a connector and
+                            // may still use a soft break.
+                            let is_next_next_word =
+                                matches!(next_next_element, Some(JsxChild::Word(_)));
+                            let is_single_char_alphabetic =
+                                next_word.is_single_alphabetic_character();
                             let has_new_line_and_self_closing = is_next_next_element_new_line
                                 && matches!(
                                     children_iter.peek_next_next(),
@@ -191,6 +205,7 @@ impl FormatJsxChildList {
                             !has_new_line_and_self_closing
                                 && !is_next_next_element_self_closing
                                 && next_word.is_single_character()
+                                && (!is_single_char_alphabetic || !is_next_next_word)
                         } else {
                             false
                         }

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -200,6 +200,11 @@ impl<'a> JsxWord<'a> {
     pub(crate) fn is_single_character(&self) -> bool {
         self.text.chars().count() == 1
     }
+
+    pub(crate) fn is_single_alphabetic_character(&self) -> bool {
+        let mut chars = self.text.chars();
+        matches!(chars.next(), Some(c) if c.is_alphabetic()) && chars.next().is_none()
+    }
 }
 
 impl<'a> Format<'a> for JsxWord<'a> {

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/issue-21149.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/issue-21149.jsx
@@ -1,0 +1,17 @@
+// Punctuation after self-closing element — should soft break (collapse)
+const PunctuationThenText = () => (
+  <div>
+    <Comp />
+    , more text here
+  </div>
+);
+
+// Single alphabetic char starting a text run — should hard break (preserve)
+const App = () => (
+  <div>
+    I have a footnote.
+    <FootnoteRef i18nKey="footnote1" />
+    I have another footnote.
+    <FootnoteRef i18nKey="footnote2" />
+  </div>
+);

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/issue-21149.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/issue-21149.jsx.snap
@@ -1,0 +1,64 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Punctuation after self-closing element — should soft break (collapse)
+const PunctuationThenText = () => (
+  <div>
+    <Comp />
+    , more text here
+  </div>
+);
+
+// Single alphabetic char starting a text run — should hard break (preserve)
+const App = () => (
+  <div>
+    I have a footnote.
+    <FootnoteRef i18nKey="footnote1" />
+    I have another footnote.
+    <FootnoteRef i18nKey="footnote2" />
+  </div>
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Punctuation after self-closing element — should soft break (collapse)
+const PunctuationThenText = () => (
+  <div>
+    <Comp />, more text here
+  </div>
+);
+
+// Single alphabetic char starting a text run — should hard break (preserve)
+const App = () => (
+  <div>
+    I have a footnote.
+    <FootnoteRef i18nKey="footnote1" />
+    I have another footnote.
+    <FootnoteRef i18nKey="footnote2" />
+  </div>
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Punctuation after self-closing element — should soft break (collapse)
+const PunctuationThenText = () => (
+  <div>
+    <Comp />, more text here
+  </div>
+);
+
+// Single alphabetic char starting a text run — should hard break (preserve)
+const App = () => (
+  <div>
+    I have a footnote.
+    <FootnoteRef i18nKey="footnote1" />
+    I have another footnote.
+    <FootnoteRef i18nKey="footnote2" />
+  </div>
+);
+
+===================== End =====================


### PR DESCRIPTION
## Summary

Fixes #21148

When a self-closing JSX element is followed by a newline and text whose first word is a single alphabetic character (e.g. `I have another footnote.`), the formatter incorrectly treated the newline as a soft break — collapsing it and merging the element and text onto the same line. This is a **semantic change**: JSX renders newlines between siblings as spaces in the DOM, so removing the newline alters the rendered output.

### Input
```tsx
const App = () => (
  <div>
    I have a footnote.
    <FootnoteRef i18nKey="footnote1" />
    I have another footnote.
    <FootnoteRef i18nKey="footnote2" />
  </div>
);
```

### Before (incorrect)
```tsx
const App = () => (
  <div>
    I have a footnote.
    <FootnoteRef i18nKey="footnote1" />I have another footnote.
    <FootnoteRef i18nKey="footnote2" />
  </div>
);
```

### After (matches Prettier)
```tsx
const App = () => (
  <div>
    I have a footnote.
    <FootnoteRef i18nKey="footnote1" />
    I have another footnote.
    <FootnoteRef i18nKey="footnote2" />
  </div>
);
```

## Root cause

In the `Newline` arm of the JSX child list formatter (`child_list.rs`), there is a heuristic that treats a newline as a soft break when the next word is a single character. This was designed for the punctuation-connector pattern — e.g. `<div>First</div>\n,<div>Second</div>` — where a single-char punctuation like `,` or `-` connects two JSX elements.

However, the heuristic also fired when the single-character word was the **start of a text run** followed by more words (e.g. `"I"` in `"I have another footnote."`), because it didn't check what followed the single-char word.

## Fix

The fix distinguishes between punctuation connectors and alphabetic text starters:

- **Punctuation** (`,`, `.`, etc.) → always a soft break, regardless of what follows
- **Single alphabetic character** (`I`, `a`, etc.) followed by more words → hard break (text content, semantically significant newline)

Added `is_single_alphabetic_character()` to `JsxWord` and updated the soft-break condition to `(!is_single_char_alphabetic || !is_next_next_word)`.

Prettier conformance: **no regressions** (746/753 JS, 591/601 TS — unchanged).

## AI Disclosure

This PR was co-authored with Claude Code (AI assistant), as noted in the commit. The fix was reviewed, tested against the full Prettier conformance suite, and verified to produce no regressions.