### PR TITLE
fix(formatter): preserve trailing comma in TSX arrow functions with default type params

### DIFF
--- a/crates/oxc_formatter/src/print/type_parameters.rs
+++ b/crates/oxc_formatter/src/print/type_parameters.rs
@@ -102,8 +102,9 @@ fn should_force_trailing_comma_for_arrow_function(
         return false;
     }
 
-    // Ignore type parameters with a constraint or default type.
-    if params.first().is_some_and(|t| t.constraint().is_some() || t.default().is_some()) {
+    // Ignore type parameters with a constraint (extends clause).
+    // A default type alone does not disambiguate from JSX, so the comma is still required.
+    if params.first().is_some_and(|t| t.constraint().is_some()) {
         return false;
     }
 

--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-21150.tsx
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-21150.tsx
@@ -1,0 +1,9 @@
+const AppWrapper = <Options = any,>({
+  appName,
+}: {
+  appName: string;
+}) => null;
+
+const getProps = <T = Record<string, unknown>,>(
+  option: T | undefined,
+): Partial<T> => ({});

--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-21150.tsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-21150.tsx.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const AppWrapper = <Options = any,>({
+  appName,
+}: {
+  appName: string;
+}) => null;
+
+const getProps = <T = Record<string, unknown>,>(
+  option: T | undefined,
+): Partial<T> => ({});
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const AppWrapper = <Options = any,>({ appName }: { appName: string }) => null;
+
+const getProps = <T = Record<string, unknown>,>(
+  option: T | undefined,
+): Partial<T> => ({});
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const AppWrapper = <Options = any,>({ appName }: { appName: string }) => null;
+
+const getProps = <T = Record<string, unknown>,>(option: T | undefined): Partial<T> => ({});
+
+===================== End =====================


### PR DESCRIPTION
## Summary

Fixes #21150

When a single-parameter generic arrow function in a `.tsx` file has a **default type** (e.g. `<Options = any>`), the formatter was incorrectly removing the trailing comma. Prettier preserves it as `<Options = any,>`.

The existing `should_force_trailing_comma_for_arrow_function` logic handles the simple case (`<T,>`) correctly, but it also skipped forcing the comma when the parameter had a default type. Prettier's equivalent only skips the forced comma when a **constraint** (`extends` clause) is present — not for default types. This PR aligns with that behavior.

### Input
```tsx
const AppWrapper = <Options = any,>({
  appName,
}: {
  appName: string;
}) => null;

const getProps = <T = Record<string, unknown>,>(
  option: T | undefined,
): Partial<T> => ({});
```

### Before (incorrect)
```tsx
const AppWrapper = <Options = any>({ appName }: { appName: string }) => null;

const getProps = <T = Record<string, unknown>>(
  option: T | undefined,
): Partial<T> => ({});
```

### After (matches Prettier)
```tsx
const AppWrapper = <Options = any,>({ appName }: { appName: string }) => null;

const getProps = <T = Record<string, unknown>,>(
  option: T | undefined,
): Partial<T> => ({});
```

## Root cause

In `should_force_trailing_comma_for_arrow_function` (`type_parameters.rs`), the early-return condition checked for both a constraint **and** a default type:

```rust
// Before
if params.first().is_some_and(|t| t.constraint().is_some() || t.default().is_some()) {
    return false;
}
```

Prettier's equivalent only skips forcing the comma when a **constraint** is present. See [Prettier source](https://github.com/prettier/prettier/blob/070c89bba46235f4948560ed612a11e89ccd2da9/src/language-js/print/type-parameters.js#L33-L42).

## Fix

Removed `|| t.default().is_some()` from the condition:

```rust
// After
if params.first().is_some_and(|t| t.constraint().is_some()) {
    return false;
}
```

Prettier conformance: **no regressions** (746/753 JS, 591/601 TS — unchanged).

## AI Disclosure

This PR was co-authored with Claude Code (AI assistant), as noted in the commit. The fix was reviewed, tested against the full Prettier conformance suite, and verified to produce no regressions.