### PR TITLE
fix(linter/unicorn): do not report on optionals in `no-single-promise-in-promise-methods`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -134,7 +134,22 @@ impl Rule for NoSinglePromiseInPromiseMethods {
 }
 
 fn is_promise_method_with_single_argument(call_expr: &CallExpression) -> bool {
-    is_method_call(call_expr, Some(&["Promise"]), Some(&["all", "any", "race"]), Some(1), Some(1))
+    if !is_method_call(
+        call_expr,
+        Some(&["Promise"]),
+        Some(&["all", "any", "race"]),
+        Some(1),
+        Some(1),
+    ) || call_expr.optional
+    {
+        return false;
+    }
+
+    let Some(member_expr) = call_expr.callee.get_member_expr() else {
+        return false;
+    };
+
+    !member_expr.optional() && !member_expr.is_computed()
 }
 
 fn is_fixable(call_node_id: NodeId, ctx: &LintContext<'_>) -> bool {
@@ -183,17 +198,15 @@ fn test() {
         "Promise[race]([promise])",
         "Promise.race([,])",
         "NotPromise.race([promise])",
-        // TODO: These should be valid but Oxlint currently flags them
-        // "Promise?.race([promise])",
-        // "Promise.race?.([promise])",
+        "Promise?.race([promise])",
+        "Promise.race?.([promise])",
         "Promise.race(...[promise])",
         "Promise.race([promise], extraArguments)",
         "Promise.race()",
         "new Promise.race([promise])",
         // We are not checking these cases
         "globalThis.Promise.race([promise])",
-        // TODO: This should be valid but Oxlint currently flags it
-        // r#"Promise["race"]([promise])"#,
+        r#"Promise["race"]([promise])"#,
         // This can't be checked
         "Promise.allSettled([promise])",
     ];


### PR DESCRIPTION
fixes commented out tests with optionals for `unicorn/no-single-promise-in-promise-methods` rule