### PR TITLE
feat(linter): Implemented `valid-expect-in-promise` vitest and jest rule

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -44,5 +44,6 @@
   "require-top-level-describe",
   "valid-describe-callback",
   "valid-expect",
+  "valid-expect-in-promise",
   "valid-title"
 ]

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2363,6 +2363,11 @@ impl RuleRunner for crate::rules::jest::valid_expect::ValidExpect {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::jest::valid_expect_in_promise::ValidExpectInPromise {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::jest::valid_title::ValidTitle {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -268,6 +268,7 @@ pub use crate::rules::jest::require_to_throw_message::RequireToThrowMessage as J
 pub use crate::rules::jest::require_top_level_describe::RequireTopLevelDescribe as JestRequireTopLevelDescribe;
 pub use crate::rules::jest::valid_describe_callback::ValidDescribeCallback as JestValidDescribeCallback;
 pub use crate::rules::jest::valid_expect::ValidExpect as JestValidExpect;
+pub use crate::rules::jest::valid_expect_in_promise::ValidExpectInPromise as JestValidExpectInPromise;
 pub use crate::rules::jest::valid_title::ValidTitle as JestValidTitle;
 pub use crate::rules::jsdoc::check_access::CheckAccess as JsdocCheckAccess;
 pub use crate::rules::jsdoc::check_property_names::CheckPropertyNames as JsdocCheckPropertyNames;
@@ -1104,6 +1105,7 @@ pub enum RuleEnum {
     JestRequireTopLevelDescribe(JestRequireTopLevelDescribe),
     JestValidDescribeCallback(JestValidDescribeCallback),
     JestValidExpect(JestValidExpect),
+    JestValidExpectInPromise(JestValidExpectInPromise),
     JestValidTitle(JestValidTitle),
     ReactButtonHasType(ReactButtonHasType),
     ReactCheckedRequiresOnchangeOrReadonly(ReactCheckedRequiresOnchangeOrReadonly),
@@ -1869,7 +1871,8 @@ const JEST_REQUIRE_TO_THROW_MESSAGE_ID: usize = JEST_REQUIRE_HOOK_ID + 1usize;
 const JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID: usize = JEST_REQUIRE_TO_THROW_MESSAGE_ID + 1usize;
 const JEST_VALID_DESCRIBE_CALLBACK_ID: usize = JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID + 1usize;
 const JEST_VALID_EXPECT_ID: usize = JEST_VALID_DESCRIBE_CALLBACK_ID + 1usize;
-const JEST_VALID_TITLE_ID: usize = JEST_VALID_EXPECT_ID + 1usize;
+const JEST_VALID_EXPECT_IN_PROMISE_ID: usize = JEST_VALID_EXPECT_ID + 1usize;
+const JEST_VALID_TITLE_ID: usize = JEST_VALID_EXPECT_IN_PROMISE_ID + 1usize;
 const REACT_BUTTON_HAS_TYPE_ID: usize = JEST_VALID_TITLE_ID + 1usize;
 const REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID: usize = REACT_BUTTON_HAS_TYPE_ID + 1usize;
 const REACT_DISPLAY_NAME_ID: usize = REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID + 1usize;
@@ -2701,6 +2704,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID,
             Self::JestValidDescribeCallback(_) => JEST_VALID_DESCRIBE_CALLBACK_ID,
             Self::JestValidExpect(_) => JEST_VALID_EXPECT_ID,
+            Self::JestValidExpectInPromise(_) => JEST_VALID_EXPECT_IN_PROMISE_ID,
             Self::JestValidTitle(_) => JEST_VALID_TITLE_ID,
             Self::ReactButtonHasType(_) => REACT_BUTTON_HAS_TYPE_ID,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -3530,6 +3534,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => JestRequireTopLevelDescribe::NAME,
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::NAME,
             Self::JestValidExpect(_) => JestValidExpect::NAME,
+            Self::JestValidExpectInPromise(_) => JestValidExpectInPromise::NAME,
             Self::JestValidTitle(_) => JestValidTitle::NAME,
             Self::ReactButtonHasType(_) => ReactButtonHasType::NAME,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -4373,6 +4378,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => JestRequireTopLevelDescribe::CATEGORY,
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::CATEGORY,
             Self::JestValidExpect(_) => JestValidExpect::CATEGORY,
+            Self::JestValidExpectInPromise(_) => JestValidExpectInPromise::CATEGORY,
             Self::JestValidTitle(_) => JestValidTitle::CATEGORY,
             Self::ReactButtonHasType(_) => ReactButtonHasType::CATEGORY,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -5223,6 +5229,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => JestRequireTopLevelDescribe::FIX,
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::FIX,
             Self::JestValidExpect(_) => JestValidExpect::FIX,
+            Self::JestValidExpectInPromise(_) => JestValidExpectInPromise::FIX,
             Self::JestValidTitle(_) => JestValidTitle::FIX,
             Self::ReactButtonHasType(_) => ReactButtonHasType::FIX,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -6141,6 +6148,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => JestRequireTopLevelDescribe::documentation(),
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::documentation(),
             Self::JestValidExpect(_) => JestValidExpect::documentation(),
+            Self::JestValidExpectInPromise(_) => JestValidExpectInPromise::documentation(),
             Self::JestValidTitle(_) => JestValidTitle::documentation(),
             Self::ReactButtonHasType(_) => ReactButtonHasType::documentation(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -7692,6 +7700,8 @@ impl RuleEnum {
             }
             Self::JestValidExpect(_) => JestValidExpect::config_schema(generator)
                 .or_else(|| JestValidExpect::schema(generator)),
+            Self::JestValidExpectInPromise(_) => JestValidExpectInPromise::config_schema(generator)
+                .or_else(|| JestValidExpectInPromise::schema(generator)),
             Self::JestValidTitle(_) => JestValidTitle::config_schema(generator)
                 .or_else(|| JestValidTitle::schema(generator)),
             Self::ReactButtonHasType(_) => ReactButtonHasType::config_schema(generator)
@@ -9065,6 +9075,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => "jest",
             Self::JestValidDescribeCallback(_) => "jest",
             Self::JestValidExpect(_) => "jest",
+            Self::JestValidExpectInPromise(_) => "jest",
             Self::JestValidTitle(_) => "jest",
             Self::ReactButtonHasType(_) => "react",
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => "react",
@@ -10609,6 +10620,9 @@ impl RuleEnum {
             Self::JestValidExpect(_) => {
                 Ok(Self::JestValidExpect(JestValidExpect::from_configuration(value)?))
             }
+            Self::JestValidExpectInPromise(_) => Ok(Self::JestValidExpectInPromise(
+                JestValidExpectInPromise::from_configuration(value)?,
+            )),
             Self::JestValidTitle(_) => {
                 Ok(Self::JestValidTitle(JestValidTitle::from_configuration(value)?))
             }
@@ -12100,6 +12114,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(rule) => rule.to_configuration(),
             Self::JestValidDescribeCallback(rule) => rule.to_configuration(),
             Self::JestValidExpect(rule) => rule.to_configuration(),
+            Self::JestValidExpectInPromise(rule) => rule.to_configuration(),
             Self::JestValidTitle(rule) => rule.to_configuration(),
             Self::ReactButtonHasType(rule) => rule.to_configuration(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.to_configuration(),
@@ -12823,6 +12838,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(rule) => rule.run(node, ctx),
             Self::JestValidDescribeCallback(rule) => rule.run(node, ctx),
             Self::JestValidExpect(rule) => rule.run(node, ctx),
+            Self::JestValidExpectInPromise(rule) => rule.run(node, ctx),
             Self::JestValidTitle(rule) => rule.run(node, ctx),
             Self::ReactButtonHasType(rule) => rule.run(node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run(node, ctx),
@@ -13544,6 +13560,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(rule) => rule.run_once(ctx),
             Self::JestValidDescribeCallback(rule) => rule.run_once(ctx),
             Self::JestValidExpect(rule) => rule.run_once(ctx),
+            Self::JestValidExpectInPromise(rule) => rule.run_once(ctx),
             Self::JestValidTitle(rule) => rule.run_once(ctx),
             Self::ReactButtonHasType(rule) => rule.run_once(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_once(ctx),
@@ -14333,6 +14350,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidDescribeCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JestValidExpectInPromise(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactButtonHasType(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
@@ -15088,6 +15106,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(rule) => rule.should_run(ctx),
             Self::JestValidDescribeCallback(rule) => rule.should_run(ctx),
             Self::JestValidExpect(rule) => rule.should_run(ctx),
+            Self::JestValidExpectInPromise(rule) => rule.should_run(ctx),
             Self::JestValidTitle(rule) => rule.should_run(ctx),
             Self::ReactButtonHasType(rule) => rule.should_run(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.should_run(ctx),
@@ -15971,6 +15990,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => JestRequireTopLevelDescribe::IS_TSGOLINT_RULE,
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::IS_TSGOLINT_RULE,
             Self::JestValidExpect(_) => JestValidExpect::IS_TSGOLINT_RULE,
+            Self::JestValidExpectInPromise(_) => JestValidExpectInPromise::IS_TSGOLINT_RULE,
             Self::JestValidTitle(_) => JestValidTitle::IS_TSGOLINT_RULE,
             Self::ReactButtonHasType(_) => ReactButtonHasType::IS_TSGOLINT_RULE,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -16947,6 +16967,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(_) => JestRequireTopLevelDescribe::HAS_CONFIG,
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::HAS_CONFIG,
             Self::JestValidExpect(_) => JestValidExpect::HAS_CONFIG,
+            Self::JestValidExpectInPromise(_) => JestValidExpectInPromise::HAS_CONFIG,
             Self::JestValidTitle(_) => JestValidTitle::HAS_CONFIG,
             Self::ReactButtonHasType(_) => ReactButtonHasType::HAS_CONFIG,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -17744,6 +17765,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(rule) => rule.types_info(),
             Self::JestValidDescribeCallback(rule) => rule.types_info(),
             Self::JestValidExpect(rule) => rule.types_info(),
+            Self::JestValidExpectInPromise(rule) => rule.types_info(),
             Self::JestValidTitle(rule) => rule.types_info(),
             Self::ReactButtonHasType(rule) => rule.types_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.types_info(),
@@ -18465,6 +18487,7 @@ impl RuleEnum {
             Self::JestRequireTopLevelDescribe(rule) => rule.run_info(),
             Self::JestValidDescribeCallback(rule) => rule.run_info(),
             Self::JestValidExpect(rule) => rule.run_info(),
+            Self::JestValidExpectInPromise(rule) => rule.run_info(),
             Self::JestValidTitle(rule) => rule.run_info(),
             Self::ReactButtonHasType(rule) => rule.run_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_info(),
@@ -19272,6 +19295,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestRequireTopLevelDescribe(JestRequireTopLevelDescribe::default()),
         RuleEnum::JestValidDescribeCallback(JestValidDescribeCallback::default()),
         RuleEnum::JestValidExpect(JestValidExpect::default()),
+        RuleEnum::JestValidExpectInPromise(JestValidExpectInPromise::default()),
         RuleEnum::JestValidTitle(JestValidTitle::default()),
         RuleEnum::ReactButtonHasType(ReactButtonHasType::default()),
         RuleEnum::ReactCheckedRequiresOnchangeOrReadonly(

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -382,6 +382,7 @@ pub(crate) mod jest {
     pub mod require_top_level_describe;
     pub mod valid_describe_callback;
     pub mod valid_expect;
+    pub mod valid_expect_in_promise;
     pub mod valid_title;
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
@@ -41,26 +41,53 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// it('tests something', () => {
-    ///   somePromise.then(value => {
-    ///     expect(value).toBe('foo');
-    ///   });
-    /// });
+    /// test('promise test', async () => {
+    ///   something().then((value) => {
+    ///     expect(value).toBe('red')
+    ///   })
+    /// })
+    ///
+    /// test('promises test', () => {
+    ///   const onePromise = something().then((value) => {
+    ///     expect(value).toBe('red')
+    ///   })
+    ///   const twoPromise = something().then((value) => {
+    ///     expect(value).toBe('blue')
+    ///   })
+    ///
+    ///   return Promise.any([onePromise, twoPromise])
+    /// })
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
-    /// it('tests something', async () => {
-    ///   await somePromise.then(value => {
-    ///     expect(value).toBe('foo');
-    ///   });
-    /// });
+    /// test('promise test', async () => {
+    ///   await something().then((value) => {
+    ///     expect(value).toBe('red')
+    ///   })
+    /// })
     ///
-    /// it('tests something', () => {
-    ///   return somePromise.then(value => {
-    ///     expect(value).toBe('foo');
-    ///   });
-    /// });
+    /// test('promises test', () => {
+    ///   const onePromise = something().then((value) => {
+    ///     expect(value).toBe('red')
+    ///   })
+    ///   const twoPromise = something().then((value) => {
+    ///     expect(value).toBe('blue')
+    ///   })
+    ///
+    ///   return Promise.all([onePromise, twoPromise])
+    /// })
+    /// ```
+    ///
+    /// This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-expect-in-promise.md),
+    /// to use it, add the following configuration to your `.oxlintrc.json`:
+    ///
+    /// ```json
+    /// {
+    ///   "rules": {
+    ///     "vitest/valid-expect-in-promise": "error"
+    ///   }
+    /// }
     /// ```
     ValidExpectInPromise,
     jest,
@@ -172,57 +199,51 @@ fn process_statements<'a>(
                     }
                 }
             }
-            Statement::ExpressionStatement(expr_stmt) => {
-                match &expr_stmt.expression {
-                    Expression::AssignmentExpression(assign_expr) => {
-                        if let Some(name) =
-                            assign_expr.left.as_simple_assignment_target()
-                                .and_then(|t| t.get_identifier_name())
-                        {
-                            let rhs_references_self =
-                                expression_contains_identifier(&assign_expr.right, name);
+            Statement::ExpressionStatement(expr_stmt) => match &expr_stmt.expression {
+                Expression::AssignmentExpression(assign_expr) => {
+                    if let Some(name) = assign_expr
+                        .left
+                        .as_simple_assignment_target()
+                        .and_then(|t| t.get_identifier_name())
+                    {
+                        let rhs_references_self =
+                            expression_contains_identifier(&assign_expr.right, name);
 
-                            if !rhs_references_self {
-                                if let Some(old_span) =
-                                    pending_promises.remove(CompactStr::from(name).as_str())
-                                {
-                                    ctx.diagnostic(expect_in_unhandled_promise(old_span));
-                                }
+                        if !rhs_references_self {
+                            if let Some(old_span) =
+                                pending_promises.remove(CompactStr::from(name).as_str())
+                            {
+                                ctx.diagnostic(expect_in_unhandled_promise(old_span));
                             }
+                        }
 
-                            let mut assign_scanner = PromiseExpectScanner::new();
-                            assign_scanner.visit_expression(&assign_expr.right);
-                            if assign_scanner.found_expect_in_promise {
-                                pending_promises
-                                    .insert(CompactStr::from(name), expr_stmt.span);
-                            }
-                        } else {
-                            if scanner.found_expect_in_promise {
-                                ctx.diagnostic(expect_in_unhandled_promise(
-                                    expr_stmt.span,
-                                ));
-                            }
+                        let mut assign_scanner = PromiseExpectScanner::new();
+                        assign_scanner.visit_expression(&assign_expr.right);
+                        if assign_scanner.found_expect_in_promise {
+                            pending_promises.insert(CompactStr::from(name), expr_stmt.span);
                         }
-                    }
-                    Expression::AwaitExpression(_) => {
-                        for name in &scanner.resolved_names {
-                            pending_promises.remove(name.as_str());
-                        }
-                    }
-                    _ => {
-                        for name in &scanner.resolved_names {
-                            pending_promises.remove(name.as_str());
-                        }
-                        if scanner.found_expect_in_promise
-                            && is_top_level_promise_chain(&expr_stmt.expression)
-                        {
-                            ctx.diagnostic(expect_in_unhandled_promise(
-                                expr_stmt.span,
-                            ));
+                    } else {
+                        if scanner.found_expect_in_promise {
+                            ctx.diagnostic(expect_in_unhandled_promise(expr_stmt.span));
                         }
                     }
                 }
-            }
+                Expression::AwaitExpression(_) => {
+                    for name in &scanner.resolved_names {
+                        pending_promises.remove(name.as_str());
+                    }
+                }
+                _ => {
+                    for name in &scanner.resolved_names {
+                        pending_promises.remove(name.as_str());
+                    }
+                    if scanner.found_expect_in_promise
+                        && is_top_level_promise_chain(&expr_stmt.expression)
+                    {
+                        ctx.diagnostic(expect_in_unhandled_promise(expr_stmt.span));
+                    }
+                }
+            },
             Statement::ReturnStatement(return_stmt) => {
                 if let Some(arg) = &return_stmt.argument {
                     if let Some(name) = ident_name_of(arg) {
@@ -236,12 +257,7 @@ fn process_statements<'a>(
             }
             // Block statements — recurse to handle reassignments inside blocks
             Statement::BlockStatement(block) => {
-                process_statements(
-                    &block.body,
-                    pending_promises,
-                    return_found,
-                    ctx,
-                );
+                process_statements(&block.body, pending_promises, return_found, ctx);
             }
             _ => {
                 for name in &scanner.resolved_names {
@@ -265,7 +281,9 @@ fn ident_name_of<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
 /// Walks down the callee chain of `expect(x).resolves.not.toBe(2)` to find
 /// the arguments of the innermost `expect(...)` call.
 /// Handles arbitrary depth of member expression chains.
-fn find_expect_args<'a>(call_expr: &'a CallExpression<'a>) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
+fn find_expect_args<'a>(
+    call_expr: &'a CallExpression<'a>,
+) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
     if let Expression::Identifier(ident) = &call_expr.callee {
         if ident.name == "expect" {
             return Some(&call_expr.arguments);
@@ -276,7 +294,9 @@ fn find_expect_args<'a>(call_expr: &'a CallExpression<'a>) -> Option<&'a oxc_all
     find_expect_call_in_chain(&call_expr.callee)
 }
 
-fn find_expect_call_in_chain<'a>(expr: &'a Expression<'a>) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
+fn find_expect_call_in_chain<'a>(
+    expr: &'a Expression<'a>,
+) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
     match expr {
         Expression::CallExpression(call) => find_expect_args(call),
         _ => {
@@ -402,7 +422,9 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
                     if matches!(prop, Some("all" | "allSettled" | "race" | "any")) {
                         // First arg is an array: Promise.all([p1, p2])
                         if let Some(first_arg) = call_expr.arguments.first() {
-                            if let Some(Expression::ArrayExpression(arr)) = first_arg.as_expression() {
+                            if let Some(Expression::ArrayExpression(arr)) =
+                                first_arg.as_expression()
+                            {
                                 for elem in &arr.elements {
                                     if let Some(expr) = elem.as_expression() {
                                         if let Some(name) = ident_name_of(expr) {
@@ -476,7 +498,7 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![
+    let mut pass = vec![
         ("test('something', () => Promise.resolve().then(() => expect(1).toBe(2)));", None, None),
         ("Promise.resolve().then(() => expect(1).toBe(2))", None, None),
         ("const x = Promise.resolve().then(() => expect(1).toBe(2))", None, None),
@@ -1399,7 +1421,7 @@ fn test() {
         ),
     ];
 
-    let fail = vec![
+    let mut fail = vec![
         (
             "const myFn = () => {
               Promise.resolve().then(() => {
@@ -1970,7 +1992,1888 @@ fn test() {
          */
     ];
 
+    let vitest_pass = vec![
+        ("test('something', () => Promise.resolve().then(() => expect(1).toBe(2)));", None, None),
+        ("Promise.resolve().then(() => expect(1).toBe(2))", None, None),
+        ("const x = Promise.resolve().then(() => expect(1).toBe(2))", None, None),
+        (
+            "
+                  it('is valid', () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect(promise).resolves.toBe(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect(promise).resolves.not.toBe(2);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect(promise).rejects.toBe(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect(promise).rejects.not.toBe(2);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect(await promise).toBeGreaterThan(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect(await promise).resolves.toBeGreaterThan(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect(1).toBeGreaterThan(await promise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect.this.that.is(await promise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    expect(await loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    })).toBeGreaterThan(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect([await promise]).toHaveLength(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect([,,await promise,,]).toHaveLength(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    expect([[await promise]]).toHaveLength(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return number + 1;
+                    });
+
+                    logValue(await promise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promise = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+
+                      return 1;
+                    });
+
+                    expect.assertions(await promise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    await loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => new Promise((done) => {
+                    test()
+                      .then(() => {
+                        expect(someThing).toEqual(true);
+                        done();
+                      });
+                  }));
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => {
+                    return new Promise(done => {
+                      test().then(() => {
+                        expect(someThing).toEqual(true);
+                        done();
+                      });
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('passes', () => {
+                    Promise.resolve().then(() => {
+                      grabber.grabSomething();
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('passes', async () => {
+                    const grabbing = Promise.resolve().then(() => {
+                      grabber.grabSomething();
+                    });
+
+                    await grabbing;
+
+                    expect(grabber.grabbedItems).toHaveLength(1);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  const myFn = () => {
+                    Promise.resolve().then(() => {
+                      expect(true).toBe(false);
+                    });
+                  };
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  const myFn = () => {
+                    Promise.resolve().then(() => {
+                      subject.invokeMethod();
+                    });
+                  };
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  const myFn = () => {
+                    Promise.resolve().then(() => {
+                      expect(true).toBe(false);
+                    });
+                  };
+
+                  it('it1', () => {
+                    return somePromise.then(() => {
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => new Promise((done) => {
+                    test()
+                      .finally(() => {
+                        expect(someThing).toEqual(true);
+                        done();
+                      });
+                  }));
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => {
+                    return somePromise.then(() => {
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => {
+                    return somePromise.finally(() => {
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function() {
+                    return somePromise.catch(function() {
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  xtest('it1', function() {
+                    return somePromise.catch(function() {
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function() {
+                    return somePromise.then(function() {
+                      doSomeThingButNotExpect();
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function() {
+                    return getSomeThing().getPromise().then(function() {
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function() {
+                    return Promise.resolve().then(function() {
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function () {
+                    return Promise.resolve().then(function () {
+                      /*fulfillment*/
+                      expect(someThing).toEqual(true);
+                    }, function () {
+                      /*rejection*/
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function () {
+                    Promise.resolve().then(/*fulfillment*/ function () {
+                    }, undefined, /*rejection*/ function () {
+                      expect(someThing).toEqual(true)
+                    })
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function () {
+                    return Promise.resolve().then(function () {
+                      /*fulfillment*/
+                    }, function () {
+                      /*rejection*/
+                      expect(someThing).toEqual(true);
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', function () {
+                    return somePromise.then()
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', async () => {
+                    await Promise.resolve().then(function () {
+                      expect(someThing).toEqual(true)
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', async () => {
+                    await somePromise.then(() => {
+                      expect(someThing).toEqual(true)
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', async () => {
+                    await getSomeThing().getPromise().then(function () {
+                      expect(someThing).toEqual(true)
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => {
+                    return somePromise.then(() => {
+                      expect(someThing).toEqual(true);
+                    })
+                    .then(() => {
+                      expect(someThing).toEqual(true);
+                    })
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => {
+                    return somePromise.then(() => {
+                      return value;
+                    })
+                    .then(value => {
+                      expect(someThing).toEqual(value);
+                    })
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => {
+                    return somePromise.then(() => {
+                      expect(someThing).toEqual(true);
+                    })
+                    .then(() => {
+                      console.log('this is silly');
+                    })
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('it1', () => {
+                    return somePromise.then(() => {
+                      expect(someThing).toEqual(true);
+                    })
+                    .catch(() => {
+                      expect(someThing).toEqual(false);
+                    })
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('later return', () => {
+                    const promise = something().then(value => {
+                      expect(value).toBe('red');
+                    });
+
+                    return promise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('later return', async () => {
+                    const promise = something().then(value => {
+                      expect(value).toBe('red');
+                    });
+
+                    await promise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test.only('later return', () => {
+                    const promise = something().then(value => {
+                      expect(value).toBe('red');
+                    });
+
+                    return promise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('that we bailout if destructuring is used', () => {
+                    const [promise] = something().then(value => {
+                      expect(value).toBe('red');
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('that we bailout if destructuring is used', async () => {
+                    const [promise] = await something().then(value => {
+                      expect(value).toBe('red');
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('that we bailout if destructuring is used', () => {
+                    const [promise] = [
+                      something().then(value => {
+                        expect(value).toBe('red');
+                      })
+                    ];
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('that we bailout if destructuring is used', () => {
+                    const {promise} = {
+                      promise: something().then(value => {
+                        expect(value).toBe('red');
+                      })
+                    };
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('that we bailout in complex cases', () => {
+                    promiseSomething({
+                      timeout: 500,
+                      promise: something().then(value => {
+                        expect(value).toBe('red');
+                      })
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('shorthand arrow', () =>
+                    something().then(value => {
+                      expect(() => {
+                        value();
+                      }).toThrow();
+                    })
+                  );
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('crawls for files based on patterns', () => {
+                    const promise = nodeCrawl({}).then(data => {
+                      expect(childProcess.spawn).lastCalledWith('find');
+                    });
+                    return promise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is a test', async () => {
+                    const value = await somePromise().then(response => {
+                      expect(response).toHaveProperty('data');
+
+                      return response.data;
+                    });
+
+                    expect(value).toBe('hello world');
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is a test', async () => {
+                    return await somePromise().then(response => {
+                      expect(response).toHaveProperty('data');
+
+                      return response.data;
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is a test', async () => {
+                    return somePromise().then(response => {
+                      expect(response).toHaveProperty('data');
+
+                      return response.data;
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is a test', async () => {
+                    await somePromise().then(response => {
+                      expect(response).toHaveProperty('data');
+
+                      return response.data;
+                    });
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it(
+                    'test function',
+                    () => {
+                      return Builder
+                        .getPromiseBuilder()
+                        .get().build()
+                        .then((data) => {
+                          expect(data).toEqual('Hi');
+                        });
+                    }
+                  );
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  notATestFunction(
+                    'not a test function',
+                    () => {
+                      Builder
+                        .getPromiseBuilder()
+                        .get()
+                        .build()
+                        .then((data) => {
+                          expect(data).toEqual('Hi');
+                        });
+                    }
+                  );
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('is valid', async () => {
+                    const promiseOne = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+                    });
+                    const promiseTwo = loadNumber().then(number => {
+                      expect(typeof number).toBe('number');
+                    });
+
+                    await promiseTwo;
+                    await promiseOne;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            r#"
+                  it("it1", () => somePromise.then(() => {
+                    expect(someThing).toEqual(true)
+                  }))
+                "#,
+            None,
+            None,
+        ),
+        (r#"it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))"#, None, None),
+        (
+            "
+                  it('promise test with done', (done) => {
+                    const promise = getPromise();
+                    promise.then(() => expect(someThing).toEqual(true));
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it('name of done param does not matter', (nameDoesNotMatter) => {
+                    const promise = getPromise();
+                    promise.then(() => expect(someThing).toEqual(true));
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it.each([])('name of done param does not matter', (nameDoesNotMatter) => {
+                    const promise = getPromise();
+                    promise.then(() => expect(someThing).toEqual(true));
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  it.each``('name of done param does not matter', ({}, nameDoesNotMatter) => {
+                    const promise = getPromise();
+                    promise.then(() => expect(someThing).toEqual(true));
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('valid-expect-in-promise', async () => {
+                    const text = await fetch('url')
+                        .then(res => res.text())
+                        .then(text => text);
+
+                    expect(text).toBe('text');
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    }), x = 1;
+
+                    await somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let x = 1, somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await somePromise;
+
+                    somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await somePromise;
+
+                    somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    return somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    {}
+
+                    await somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    const somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    {
+                      await somePromise;
+                    }
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    {
+                      await somePromise;
+
+                      somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      await somePromise;
+                    }
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await somePromise;
+
+                    {
+                      somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      await somePromise;
+                    }
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    somePromise = somePromise.then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    somePromise = somePromise
+                      .then((data) => data)
+                      .then((data) => data)
+                      .then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                    await somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    somePromise = somePromise
+                      .then((data) => data)
+                      .then((data) => data)
+
+                    await somePromise;
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    let somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await somePromise;
+
+                    {
+                      somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      {
+                        await somePromise;
+                      }
+                    }
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    const somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await Promise.all([somePromise]);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    const somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    return Promise.all([somePromise]);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    const somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    return Promise.resolve(somePromise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    const somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    return Promise.reject(somePromise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    const somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await Promise.resolve(somePromise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('promise test', async function () {
+                    const somePromise = getPromise().then((data) => {
+                      expect(data).toEqual('foo');
+                    });
+
+                    await Promise.reject(somePromise);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('later return', async () => {
+                    const onePromise = something().then(value => {
+                      console.log(value);
+                    });
+                    const twoPromise = something().then(value => {
+                      expect(value).toBe('red');
+                    });
+
+                    return Promise.all([onePromise, twoPromise]);
+                  });
+                ",
+            None,
+            None,
+        ),
+        (
+            "
+                  test('later return', async () => {
+                    const onePromise = something().then(value => {
+                      console.log(value);
+                    });
+                    const twoPromise = something().then(value => {
+                      expect(value).toBe('red');
+                    });
+
+                    return Promise.allSettled([onePromise, twoPromise]);
+                  });
+                ",
+            None,
+            None,
+        ),
+    ];
+
+    pass.extend(vitest_pass);
+
+    let vitest_fail = vec![
+        (
+            "
+                    const myFn = () => {
+                      Promise.resolve().then(() => {
+                        expect(true).toBe(false);
+                      });
+                    };
+
+                    it('it1', () => {
+                      somePromise.then(() => {
+                        expect(someThing).toEqual(true);
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', () => {
+                      somePromise.then(() => {
+                        expect(someThing).toEqual(true);
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', () => {
+                      somePromise.finally(() => {
+                        expect(someThing).toEqual(true);
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                   it('it1', () => {
+                     somePromise['then'](() => {
+                       expect(someThing).toEqual(true);
+                     });
+                   });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', function() {
+                      getSomeThing().getPromise().then(function() {
+                        expect(someThing).toEqual(true);
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', function() {
+                      Promise.resolve().then(function() {
+                        expect(someThing).toEqual(true);
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', function() {
+                      somePromise.catch(function() {
+                        expect(someThing).toEqual(true)
+                      })
+                    })
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    xtest('it1', function() {
+                      somePromise.catch(function() {
+                        expect(someThing).toEqual(true)
+                      })
+                    })
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', function() {
+                      somePromise.then(function() {
+                        expect(someThing).toEqual(true)
+                      })
+                    })
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', function () {
+                      Promise.resolve().then(/*fulfillment*/ function () {
+                        expect(someThing).toEqual(true);
+                      }, /*rejection*/ function () {
+                        expect(someThing).toEqual(true);
+                      })
+                    })
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', function () {
+                      Promise.resolve().then(/*fulfillment*/ function () {
+                      }, /*rejection*/ function () {
+                        expect(someThing).toEqual(true)
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('test function', () => {
+                      Builder.getPromiseBuilder()
+                        .get()
+                        .build()
+                        .then(data => expect(data).toEqual('Hi'));
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('test function', async () => {
+                      Builder.getPromiseBuilder()
+                        .get()
+                        .build()
+                        .then(data => expect(data).toEqual('Hi'));
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', () => {
+                      somePromise.then(() => {
+                        doSomeOperation();
+                        expect(someThing).toEqual(true);
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise
+                        .then(() => {})
+                        .then(() => expect(someThing).toEqual(value))
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise
+                        .then(() => expect(someThing).toEqual(value))
+                        .then(() => {})
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise.then(() => {
+                        return value;
+                      })
+                      .then(value => {
+                        expect(someThing).toEqual(value);
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise.then(() => {
+                        expect(someThing).toEqual(true);
+                      })
+                      .then(() => {
+                        console.log('this is silly');
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise.then(() => {
+                        // return value;
+                      })
+                      .then(value => {
+                        expect(someThing).toEqual(value);
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise.then(() => {
+                        return value;
+                      })
+                      .then(value => {
+                        expect(someThing).toEqual(value);
+                      })
+
+                      return anotherPromise.then(() => expect(x).toBe(y));
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise
+                        .then(() => 1)
+                        .then(x => x + 1)
+                        .catch(() => -1)
+                        .then(v => expect(v).toBe(2));
+
+                      return anotherPromise.then(() => expect(x).toBe(y));
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is a test', () => {
+                      somePromise
+                        .then(() => 1)
+                        .then(v => expect(v).toBe(2))
+                        .then(x => x + 1)
+                        .catch(() => -1);
+
+                      return anotherPromise.then(() => expect(x).toBe(y));
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('it1', () => {
+                      somePromise.finally(() => {
+                        doSomeOperation();
+                        expect(someThing).toEqual(true);
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            r#"
+                    test('invalid return', () => {
+                      const promise = something().then(value => {
+                        const foo = "foo";
+                        return expect(value).toBe('red');
+                      });
+                    });
+                  "#,
+            None,
+            None,
+        ),
+        (
+            "
+                    fit('it1', () => {
+                      somePromise.then(() => {
+                        doSomeOperation();
+                        expect(someThing).toEqual(true);
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it.skip('it1', () => {
+                      somePromise.then(() => {
+                        doSomeOperation();
+                        expect(someThing).toEqual(true);
+                      })
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      promise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      return;
+
+                      await promise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      return 1;
+
+                      await promise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      return [];
+
+                      await promise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      return Promise.all([anotherPromise]);
+
+                      await promise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      return {};
+
+                      await promise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      return Promise.all([]);
+
+                      await promise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      await 1;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      await [];
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      await Promise.all([anotherPromise]);
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      await {};
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      await Promise.all([]);
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      }), x = 1;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('later return', async () => {
+                      const x = 1, promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    import { test } from 'vitest';
+
+                    test('later return', async () => {
+                      const x = 1, promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ), // { "parserOptions": { "sourceType": "module" }, },
+        (
+            "
+                    it('promise test', () => {
+                      const somePromise = getThatPromise();
+                      somePromise.then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+                      expect(somePromise).toBeDefined();
+                      return somePromise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('promise test', function () {
+                      let somePromise = getThatPromise();
+                      somePromise.then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+                      expect(somePromise).toBeDefined();
+                      return somePromise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('promise test', async function () {
+                      let somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      somePromise = null;
+
+                      await somePromise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('promise test', async function () {
+                      let somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      await somePromise;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('promise test', async function () {
+                      let somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      ({ somePromise } = {})
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('promise test', async function () {
+                      let somePromise = getPromise().then((data) => {
+                        expect(data).toEqual('foo');
+                      });
+
+                      {
+                        somePromise = getPromise().then((data) => {
+                          expect(data).toEqual('foo');
+                        });
+
+                        await somePromise;
+                      }
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('that we error on this destructuring', async () => {
+                      [promise] = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    test('that we error on this', () => {
+                      const promise = something().then(value => {
+                        expect(value).toBe('red');
+                      });
+
+                      log(promise);
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is valid', async () => {
+                      const promise = loadNumber().then(number => {
+                        expect(typeof number).toBe('number');
+
+                        return number + 1;
+                      });
+
+                      expect(promise).toBeInstanceOf(Promise);
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('is valid', async () => {
+                      const promise = loadNumber().then(number => {
+                        expect(typeof number).toBe('number');
+
+                        return number + 1;
+                      });
+
+                      expect(anotherPromise).resolves.toBe(1);
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    import { it as promiseThatThis } from 'vitest';
+
+                    promiseThatThis('is valid', async () => {
+                      const promise = loadNumber().then(number => {
+                        expect(typeof number).toBe('number');
+
+                        return number + 1;
+                      });
+
+                      expect(anotherPromise).resolves.toBe(1);
+                    });
+                  ",
+            None,
+            None,
+        ), // { "parserOptions": { "sourceType": "module" } },
+           /*
+           (
+               "
+                    promiseThatThis('is valid', async () => {
+                      const promise = loadNumber().then(number => {
+                        expect(typeof number).toBe('number');
+
+                        return number + 1;
+                      });
+
+                      expect(anotherPromise).resolves.toBe(1);
+                    });
+                  ",
+               None,
+               Some(
+                   serde_json::json!({ "settings": { "vitest": { "globalAliases": { "xit": ["promiseThatThis"] } } } }),
+               ),
+           ),
+            */
+    ];
+
+    fail.extend(vitest_fail);
+
     Tester::new(ValidExpectInPromise::NAME, ValidExpectInPromise::PLUGIN, pass, fail)
         .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
@@ -21,6 +21,12 @@ fn expect_in_unhandled_promise(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
+fn expect_in_promise_after_return(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Expect in a promise chain is unreachable after a `return` statement")
+        .with_help("Move the promise before the `return` and ensure it is awaited or returned.")
+        .with_label(span)
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct ValidExpectInPromise;
 
@@ -97,10 +103,10 @@ declare_oxc_lint!(
 impl Rule for ValidExpectInPromise {
     fn run_on_jest_node<'a, 'c>(
         &self,
-        jest_node: &PossibleJestNode<'a, 'c>,
+        possible_jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
-        let node = jest_node.node;
+        let node = possible_jest_node.node;
 
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -110,7 +116,8 @@ impl Rule for ValidExpectInPromise {
             return;
         }
 
-        let Some(parsed_jest_fn) = parse_general_jest_fn_call(call_expr, jest_node, ctx) else {
+        let Some(parsed_jest_fn) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
             return;
         };
 
@@ -126,22 +133,9 @@ impl Rule for ValidExpectInPromise {
             return;
         };
 
-        let Some(callback_body) = get_callback_body(callback) else {
+        let Some(callback_body) = get_checkable_callback_body(callback) else {
             return;
         };
-
-        // If the callback has any parameters, the test uses callback-style async
-        // (the param is `done`) — promise handling is not required.
-        // For `.each()` variants, the original rule also bails on any param.
-        if get_callback_param_count(callback) > 0 {
-            return;
-        }
-
-        // Arrow with expression body: `() => expr` — the expression is implicitly returned.
-        // This is always valid (the promise is returned from the test).
-        if is_expression_arrow(callback) {
-            return;
-        }
 
         let mut pending_promises: FxHashMap<CompactStr, Span> = FxHashMap::default();
         let mut return_found = false;
@@ -153,9 +147,8 @@ impl Rule for ValidExpectInPromise {
             ctx,
         );
 
-        // Everything still in pending_promises was never properly awaited or returned
-        for (_name, span) in &pending_promises {
-            ctx.diagnostic(expect_in_unhandled_promise(*span));
+        for &span in pending_promises.values().into_iter() {
+            ctx.diagnostic(expect_in_unhandled_promise(span));
         }
     }
 }
@@ -167,30 +160,37 @@ fn process_statements<'a>(
     ctx: &LintContext<'a>,
 ) {
     for statement in statements {
-        // Single-pass scan: detect promise+expect AND resolved identifiers
         let mut scanner = PromiseExpectScanner::new();
         scanner.visit_statement(statement);
 
         // After a return, any statement with expect-in-promise is unreachable.
         if *return_found {
             if scanner.found_expect_in_promise {
-                ctx.diagnostic(expect_in_unhandled_promise(statement.span()));
+                ctx.diagnostic(expect_in_promise_after_return(statement.span()));
             }
             continue;
         }
 
+        let is_assignment = matches!(
+            statement,
+            Statement::ExpressionStatement(e)
+                if matches!(e.expression, Expression::AssignmentExpression(_))
+        );
+        let is_block = matches!(statement, Statement::BlockStatement(_));
+
+        // Assignments handle resolution manually (reassignment may invalidate old promises).
+        // Blocks recurse into `process_statements` instead.
+        if !is_assignment && !is_block {
+            resolve_pending_promises(pending_promises, &scanner.resolved_names);
+        }
+
         match statement {
             Statement::VariableDeclaration(decl) => {
-                for name in &scanner.resolved_names {
-                    pending_promises.remove(name.as_str());
-                }
                 for declarator in &decl.declarations {
-                    let Some(init) = &declarator.init else {
-                        continue;
-                    };
-                    let Some(ident) = declarator.id.get_binding_identifier() else {
-                        continue;
-                    };
+                    let Some(init) = &declarator.init else { continue };
+                    let Some(ident) = declarator.id.get_binding_identifier() else { continue };
+                    // Per-declarator scan: `let x = 1, promise = getPromise().then(...)` —
+                    // only track the declarator that actually has expect-in-promise.
                     let mut init_scanner = PromiseExpectScanner::new();
                     init_scanner.visit_expression(init);
                     if init_scanner.found_expect_in_promise {
@@ -199,88 +199,62 @@ fn process_statements<'a>(
                     }
                 }
             }
-            Statement::ExpressionStatement(expr_stmt) => match &expr_stmt.expression {
-                Expression::AssignmentExpression(assign_expr) => {
+            Statement::ExpressionStatement(expr_stmt) => {
+                if let Expression::AssignmentExpression(assign_expr) = &expr_stmt.expression {
                     if let Some(name) = assign_expr
                         .left
                         .as_simple_assignment_target()
                         .and_then(|t| t.get_identifier_name())
                     {
-                        let rhs_references_self =
-                            expression_contains_identifier(&assign_expr.right, name);
-
-                        if !rhs_references_self {
+                        if !expression_contains_identifier(&assign_expr.right, name) {
                             if let Some(old_span) =
                                 pending_promises.remove(CompactStr::from(name).as_str())
                             {
                                 ctx.diagnostic(expect_in_unhandled_promise(old_span));
                             }
                         }
-
-                        let mut assign_scanner = PromiseExpectScanner::new();
-                        assign_scanner.visit_expression(&assign_expr.right);
-                        if assign_scanner.found_expect_in_promise {
+                        if scanner.found_expect_in_promise {
                             pending_promises.insert(CompactStr::from(name), expr_stmt.span);
                         }
-                    } else {
-                        if scanner.found_expect_in_promise {
-                            ctx.diagnostic(expect_in_unhandled_promise(expr_stmt.span));
-                        }
-                    }
-                }
-                Expression::AwaitExpression(_) => {
-                    for name in &scanner.resolved_names {
-                        pending_promises.remove(name.as_str());
-                    }
-                }
-                _ => {
-                    for name in &scanner.resolved_names {
-                        pending_promises.remove(name.as_str());
-                    }
-                    if scanner.found_expect_in_promise
-                        && is_top_level_promise_chain(&expr_stmt.expression)
-                    {
+                    } else if scanner.found_expect_in_promise {
                         ctx.diagnostic(expect_in_unhandled_promise(expr_stmt.span));
                     }
+                } else if scanner.found_expect_in_promise
+                    && is_top_level_promise_chain(&expr_stmt.expression)
+                {
+                    ctx.diagnostic(expect_in_unhandled_promise(expr_stmt.span));
                 }
-            },
+            }
             Statement::ReturnStatement(return_stmt) => {
-                if let Some(arg) = &return_stmt.argument {
-                    if let Some(name) = ident_name_of(arg) {
-                        pending_promises.remove(name);
-                    }
-                }
-                for name in &scanner.resolved_names {
-                    pending_promises.remove(name.as_str());
+                if let Some(name) = return_stmt.argument.as_ref().and_then(|arg| ident_name_of(arg))
+                {
+                    pending_promises.remove(name);
                 }
                 *return_found = true;
             }
-            // Block statements — recurse to handle reassignments inside blocks
             Statement::BlockStatement(block) => {
                 process_statements(&block.body, pending_promises, return_found, ctx);
             }
-            _ => {
-                for name in &scanner.resolved_names {
-                    pending_promises.remove(name.as_str());
-                }
-            }
+            _ => {}
         }
     }
 }
 
-/// Extracts the identifier name from simple expressions:
-/// - `promise` → Some("promise")
-/// Does NOT handle member expressions or calls — just plain identifiers.
-fn ident_name_of<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
-    match expr {
-        Expression::Identifier(ident) => Some(ident.name.as_str()),
-        _ => None,
+fn resolve_pending_promises(
+    pending_promises: &mut FxHashMap<CompactStr, Span>,
+    resolved_names: &FxHashSet<CompactStr>,
+) {
+    for name in resolved_names {
+        pending_promises.remove(name.as_str());
     }
+}
+
+fn ident_name_of<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
+    if let Expression::Identifier(ident) = expr { Some(ident.name.as_str()) } else { None }
 }
 
 /// Walks down the callee chain of `expect(x).resolves.not.toBe(2)` to find
 /// the arguments of the innermost `expect(...)` call.
-/// Handles arbitrary depth of member expression chains.
 fn find_expect_args<'a>(
     call_expr: &'a CallExpression<'a>,
 ) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
@@ -289,20 +263,15 @@ fn find_expect_args<'a>(
             return Some(&call_expr.arguments);
         }
     }
-    // Walk through member chain: the callee may be `expect(x).resolves.not.toBe`
-    // We need to find the CallExpression for `expect(x)` inside this chain.
-    find_expect_call_in_chain(&call_expr.callee)
+    find_inner_expect(&call_expr.callee)
 }
 
-fn find_expect_call_in_chain<'a>(
+fn find_inner_expect<'a>(
     expr: &'a Expression<'a>,
 ) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
     match expr {
         Expression::CallExpression(call) => find_expect_args(call),
-        _ => {
-            let member = expr.as_member_expression()?;
-            find_expect_call_in_chain(member.object())
-        }
+        _ => find_inner_expect(expr.as_member_expression()?.object()),
     }
 }
 
@@ -327,51 +296,49 @@ impl<'a, 'b> Visit<'a> for IdentifierFinder<'b> {
     }
 }
 
-/// Returns `true` if the expression is directly a promise chain call (`.then/.catch/.finally`)
-/// at the top level, not nested inside object literals or other function arguments.
-/// Follows the chain: `x.then(cb).catch(cb2)` → walks down `.catch` → `.then` → true.
+/// Checks whether the expression statement's outermost call is itself a promise
+/// chain (`.then/.catch/.finally`). This prevents false positives when a `.then()`
+/// with `expect()` is nested deep inside unrelated structures like:
+///
+/// ```js
+/// promiseSomething({
+///   promise: something().then(value => { expect(value).toBe('red'); })
+/// });
+/// ```
+///
+/// Here the scanner finds `expect` inside `.then()`, but the statement's top-level
+/// expression is `promiseSomething(...)` — not a promise chain we can track for
+/// return/await. Since there's no way to ensure this buried promise is handled,
+/// we bail out and don't report.
 fn is_top_level_promise_chain(expr: &Expression) -> bool {
     let Expression::CallExpression(call_expr) = expr else {
         return false;
     };
-    let Some(member) = call_expr.callee.as_member_expression() else {
-        return false;
-    };
-    let Some(prop) = member.static_property_name() else {
-        return false;
-    };
-    if matches!(prop, "then" | "catch" | "finally") {
-        return true;
-    }
-    // Could be `somePromise.then(cb).someOtherMethod()` — check the object
-    false
+    call_expr
+        .callee
+        .as_member_expression()
+        .and_then(|member| member.static_property_name())
+        .is_some_and(|prop| matches!(prop, "then" | "catch" | "finally"))
 }
 
-/// Returns `true` if the callback is an arrow function with an expression body
-/// (i.e. `() => expr` rather than `() => { ... }`), meaning the expression is implicitly returned.
-fn is_expression_arrow(callback: &Argument) -> bool {
-    matches!(callback, Argument::ArrowFunctionExpression(arrow) if arrow.expression)
-}
-
-fn get_callback_body<'a>(callback_argument: &'a Argument<'a>) -> Option<&'a FunctionBody<'a>> {
-    match callback_argument {
-        Argument::ArrowFunctionExpression(arrow_fn) => Some(&arrow_fn.body),
-        Argument::FunctionExpression(fn_expr) => fn_expr.body.as_ref().map(AsRef::as_ref),
+fn get_checkable_callback_body<'a>(callback: &'a Argument<'a>) -> Option<&'a FunctionBody<'a>> {
+    match callback {
+        Argument::ArrowFunctionExpression(arrow) => {
+            if arrow.expression || !arrow.params.items.is_empty() {
+                return None;
+            }
+            Some(&arrow.body)
+        }
+        Argument::FunctionExpression(func) => {
+            if !func.params.items.is_empty() {
+                return None;
+            }
+            func.body.as_ref().map(AsRef::as_ref)
+        }
         _ => None,
     }
 }
 
-fn get_callback_param_count(callback: &Argument) -> usize {
-    match callback {
-        Argument::ArrowFunctionExpression(arrow_fn) => arrow_fn.params.items.len(),
-        Argument::FunctionExpression(fn_expr) => fn_expr.params.items.len(),
-        _ => 0,
-    }
-}
-
-/// Single-pass visitor that walks an expression/statement subtree and detects:
-/// 1. Promise chains (`.then/.catch/.finally`) containing `expect()` calls
-/// 2. Identifiers that are "resolved" — awaited or used in `expect(x).resolves/rejects`
 struct PromiseExpectScanner {
     /// Whether we are currently inside a promise chain callback.
     in_promise_chain: bool,
@@ -393,6 +360,40 @@ impl PromiseExpectScanner {
             resolved_names: FxHashSet::default(),
         }
     }
+
+    fn resolve_ident(&mut self, expr: &Expression) {
+        if let Some(name) = ident_name_of(expr) {
+            self.resolved_names.insert(CompactStr::from(name));
+        }
+    }
+
+    fn collect_resolved_from_promise_wrapper(&mut self, call_expr: &CallExpression) {
+        let Some(member) = call_expr.callee.as_member_expression() else { return };
+        let Expression::Identifier(obj) = member.object() else { return };
+        if obj.name != "Promise" {
+            return;
+        }
+
+        let first_arg = call_expr.arguments.first().and_then(|a| a.as_expression());
+
+        match member.static_property_name() {
+            Some("all" | "allSettled" | "race" | "any") => {
+                if let Some(Expression::ArrayExpression(arr)) = first_arg {
+                    for elem in &arr.elements {
+                        if let Some(expr) = elem.as_expression() {
+                            self.resolve_ident(expr);
+                        }
+                    }
+                }
+            }
+            Some("resolve" | "reject") => {
+                if let Some(expr) = first_arg {
+                    self.resolve_ident(expr);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 impl<'a> Visit<'a> for PromiseExpectScanner {
@@ -402,53 +403,16 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
         if callee_name.first().is_some_and(|n| n == "expect")
             && callee_name.iter().any(|n| n == "resolves" || n == "rejects")
         {
-            if let Some(inner_args) = find_expect_args(call_expr) {
-                if let Some(first_arg) = inner_args.first() {
-                    if let Some(expr) = first_arg.as_expression() {
-                        if let Some(name) = ident_name_of(expr) {
-                            self.resolved_names.insert(CompactStr::from(name));
-                        }
-                    }
-                }
+            if let Some(expr) = find_expect_args(call_expr)
+                .and_then(|args| args.first())
+                .and_then(|arg| arg.as_expression())
+            {
+                self.resolve_ident(expr);
             }
         }
 
-        // Check for `Promise.all([p1, p2])`, `Promise.resolve(p)`, etc.
-        // These resolve the identifiers passed as arguments.
-        if let Some(member) = call_expr.callee.as_member_expression() {
-            if let Expression::Identifier(obj) = member.object() {
-                if obj.name == "Promise" {
-                    let prop = member.static_property_name();
-                    if matches!(prop, Some("all" | "allSettled" | "race" | "any")) {
-                        // First arg is an array: Promise.all([p1, p2])
-                        if let Some(first_arg) = call_expr.arguments.first() {
-                            if let Some(Expression::ArrayExpression(arr)) =
-                                first_arg.as_expression()
-                            {
-                                for elem in &arr.elements {
-                                    if let Some(expr) = elem.as_expression() {
-                                        if let Some(name) = ident_name_of(expr) {
-                                            self.resolved_names.insert(CompactStr::from(name));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    } else if matches!(prop, Some("resolve" | "reject")) {
-                        // First arg is a single value: Promise.resolve(p)
-                        if let Some(first_arg) = call_expr.arguments.first() {
-                            if let Some(expr) = first_arg.as_expression() {
-                                if let Some(name) = ident_name_of(expr) {
-                                    self.resolved_names.insert(CompactStr::from(name));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        self.collect_resolved_from_promise_wrapper(call_expr);
 
-        // Check if this call is to `.then()`, `.catch()`, or `.finally()`
         let is_chain_call = call_expr
             .callee
             .as_member_expression()
@@ -457,10 +421,12 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
 
         if is_chain_call {
             let was_in_chain = self.in_promise_chain;
+
             // Only flag as promise chain if not already inside an await
             self.in_promise_chain = !self.in_await;
-            // Walk the callee (handles chaining: x.then(cb1).catch(cb2))
+
             self.visit_expression(&call_expr.callee);
+
             // Only walk the first 2 arguments of .then/.catch/.finally
             // (.then takes at most 2 callbacks; 3rd+ args are non-standard)
             for arg in call_expr.arguments.iter().take(2) {
@@ -470,7 +436,6 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
             return;
         }
 
-        // If we're inside a promise chain and see `expect(...)`, flag it
         if self.in_promise_chain {
             if callee_name.first().is_some_and(|n| n == "expect") {
                 self.found_expect_in_promise = true;
@@ -482,11 +447,7 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
     }
 
     fn visit_await_expression(&mut self, await_expr: &oxc_ast::ast::AwaitExpression<'a>) {
-        // `await promise` → mark identifier as resolved
-        if let Some(name) = ident_name_of(&await_expr.argument) {
-            self.resolved_names.insert(CompactStr::from(name));
-        }
-        // Mark that we're inside await — any promise chain inside is already handled
+        self.resolve_ident(&await_expr.argument);
         let was_in_await = self.in_await;
         self.in_await = true;
         walk::walk_await_expression(self, await_expr);

--- a/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
@@ -1,6 +1,9 @@
 use oxc_ast::{
     AstKind,
-    ast::{Argument, CallExpression, Expression, FunctionBody, Statement},
+    ast::{
+        Argument, CallExpression, Expression, FunctionBody, MemberExpression,
+        SimpleAssignmentTarget, Statement,
+    },
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_diagnostics::OxcDiagnostic;
@@ -127,7 +130,7 @@ impl Rule for ValidExpectInPromise {
             .is_some_and(|test_kind| matches!(test_kind, JestGeneralFnKind::Describe))
         {
             return;
-        };
+        }
 
         let Some(callback) = call_expr.arguments.get(1) else {
             return;
@@ -147,7 +150,7 @@ impl Rule for ValidExpectInPromise {
             ctx,
         );
 
-        for &span in pending_promises.values().into_iter() {
+        for &span in pending_promises.values() {
             ctx.diagnostic(expect_in_unhandled_promise(span));
         }
     }
@@ -204,14 +207,13 @@ fn process_statements<'a>(
                     if let Some(name) = assign_expr
                         .left
                         .as_simple_assignment_target()
-                        .and_then(|t| t.get_identifier_name())
+                        .and_then(SimpleAssignmentTarget::get_identifier_name)
                     {
-                        if !expression_contains_identifier(&assign_expr.right, name) {
-                            if let Some(old_span) =
+                        if !expression_contains_identifier(&assign_expr.right, name)
+                            && let Some(old_span) =
                                 pending_promises.remove(CompactStr::from(name).as_str())
-                            {
-                                ctx.diagnostic(expect_in_unhandled_promise(old_span));
-                            }
+                        {
+                            ctx.diagnostic(expect_in_unhandled_promise(old_span));
                         }
                         if scanner.found_expect_in_promise {
                             pending_promises.insert(CompactStr::from(name), expr_stmt.span);
@@ -258,10 +260,10 @@ fn ident_name_of<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
 fn find_expect_args<'a>(
     call_expr: &'a CallExpression<'a>,
 ) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
-    if let Expression::Identifier(ident) = &call_expr.callee {
-        if ident.name == "expect" {
-            return Some(&call_expr.arguments);
-        }
+    if let Expression::Identifier(ident) = &call_expr.callee
+        && ident.name == "expect"
+    {
+        return Some(&call_expr.arguments);
     }
     find_inner_expect(&call_expr.callee)
 }
@@ -288,7 +290,7 @@ struct IdentifierFinder<'b> {
     found: bool,
 }
 
-impl<'a, 'b> Visit<'a> for IdentifierFinder<'b> {
+impl<'a> Visit<'a> for IdentifierFinder<'_> {
     fn visit_identifier_reference(&mut self, ident: &oxc_ast::ast::IdentifierReference<'a>) {
         if ident.name == self.name {
             self.found = true;
@@ -314,11 +316,7 @@ fn is_top_level_promise_chain(expr: &Expression) -> bool {
     let Expression::CallExpression(call_expr) = expr else {
         return false;
     };
-    call_expr
-        .callee
-        .as_member_expression()
-        .and_then(|member| member.static_property_name())
-        .is_some_and(|prop| matches!(prop, "then" | "catch" | "finally"))
+    is_promise_call_expression(call_expr)
 }
 
 fn get_checkable_callback_body<'a>(callback: &'a Argument<'a>) -> Option<&'a FunctionBody<'a>> {
@@ -396,30 +394,33 @@ impl PromiseExpectScanner {
     }
 }
 
+fn is_promise_call_expression(call_expr: &CallExpression<'_>) -> bool {
+    call_expr
+        .callee
+        .as_member_expression()
+        .and_then(MemberExpression::static_property_name)
+        .is_some_and(|prop| matches!(prop, "then" | "catch" | "finally"))
+}
+
 impl<'a> Visit<'a> for PromiseExpectScanner {
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         // Check for `expect(promise).resolves/rejects` — resolves the promise variable
         let callee_name = get_node_name_vec(&call_expr.callee);
-        if callee_name.first().is_some_and(|n| n == "expect")
-            && callee_name.iter().any(|n| n == "resolves" || n == "rejects")
-        {
-            if let Some(expr) = find_expect_args(call_expr)
+        let is_expect_node = callee_name.first().is_some_and(|n| n == "expect");
+        let is_expecting_promise =
+            is_expect_node && callee_name.iter().any(|n| n == "resolves" || n == "rejects");
+
+        if is_expecting_promise
+            && let Some(expr) = find_expect_args(call_expr)
                 .and_then(|args| args.first())
                 .and_then(|arg| arg.as_expression())
-            {
-                self.resolve_ident(expr);
-            }
+        {
+            self.resolve_ident(expr);
         }
 
         self.collect_resolved_from_promise_wrapper(call_expr);
 
-        let is_chain_call = call_expr
-            .callee
-            .as_member_expression()
-            .and_then(|member| member.static_property_name())
-            .is_some_and(|prop| matches!(prop, "then" | "catch" | "finally"));
-
-        if is_chain_call {
+        if is_promise_call_expression(call_expr) {
             let was_in_chain = self.in_promise_chain;
 
             // Only flag as promise chain if not already inside an await
@@ -436,11 +437,9 @@ impl<'a> Visit<'a> for PromiseExpectScanner {
             return;
         }
 
-        if self.in_promise_chain {
-            if callee_name.first().is_some_and(|n| n == "expect") {
-                self.found_expect_in_promise = true;
-                return;
-            }
+        if self.in_promise_chain && is_expect_node {
+            self.found_expect_in_promise = true;
+            return;
         }
 
         walk::walk_call_expression(self, call_expr);

--- a/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect_in_promise.rs
@@ -1,0 +1,1976 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, CallExpression, Expression, FunctionBody, Statement},
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{CompactStr, GetSpan, Span};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    rules::PossibleJestNode,
+    utils::{JestGeneralFnKind, get_node_name_vec, parse_general_jest_fn_call},
+};
+
+fn expect_in_unhandled_promise(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Expect in a promise chain must be awaited or returned")
+        .with_help("Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ValidExpectInPromise;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that `expect` calls inside promise chains (`.then()`, `.catch()`,
+    /// `.finally()`) are properly awaited or returned from the test.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When `expect` is called inside a promise callback that is not awaited or
+    /// returned, the test may pass even if the assertion fails because the test
+    /// completes before the promise resolves. This leads to silently passing
+    /// tests with broken assertions.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// it('tests something', () => {
+    ///   somePromise.then(value => {
+    ///     expect(value).toBe('foo');
+    ///   });
+    /// });
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// it('tests something', async () => {
+    ///   await somePromise.then(value => {
+    ///     expect(value).toBe('foo');
+    ///   });
+    /// });
+    ///
+    /// it('tests something', () => {
+    ///   return somePromise.then(value => {
+    ///     expect(value).toBe('foo');
+    ///   });
+    /// });
+    /// ```
+    ValidExpectInPromise,
+    jest,
+    correctness
+);
+
+impl Rule for ValidExpectInPromise {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        let node = jest_node.node;
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if call_expr.arguments.len() < 2 {
+            return;
+        }
+
+        let Some(parsed_jest_fn) = parse_general_jest_fn_call(call_expr, jest_node, ctx) else {
+            return;
+        };
+
+        if parsed_jest_fn
+            .kind
+            .to_general()
+            .is_some_and(|test_kind| matches!(test_kind, JestGeneralFnKind::Describe))
+        {
+            return;
+        };
+
+        let Some(callback) = call_expr.arguments.get(1) else {
+            return;
+        };
+
+        let Some(callback_body) = get_callback_body(callback) else {
+            return;
+        };
+
+        // If the callback has any parameters, the test uses callback-style async
+        // (the param is `done`) — promise handling is not required.
+        // For `.each()` variants, the original rule also bails on any param.
+        if get_callback_param_count(callback) > 0 {
+            return;
+        }
+
+        // Arrow with expression body: `() => expr` — the expression is implicitly returned.
+        // This is always valid (the promise is returned from the test).
+        if is_expression_arrow(callback) {
+            return;
+        }
+
+        let mut pending_promises: FxHashMap<CompactStr, Span> = FxHashMap::default();
+        let mut return_found = false;
+
+        process_statements(
+            &callback_body.statements,
+            &mut pending_promises,
+            &mut return_found,
+            ctx,
+        );
+
+        // Everything still in pending_promises was never properly awaited or returned
+        for (_name, span) in &pending_promises {
+            ctx.diagnostic(expect_in_unhandled_promise(*span));
+        }
+    }
+}
+
+fn process_statements<'a>(
+    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+    pending_promises: &mut FxHashMap<CompactStr, Span>,
+    return_found: &mut bool,
+    ctx: &LintContext<'a>,
+) {
+    for statement in statements {
+        // Single-pass scan: detect promise+expect AND resolved identifiers
+        let mut scanner = PromiseExpectScanner::new();
+        scanner.visit_statement(statement);
+
+        // After a return, any statement with expect-in-promise is unreachable.
+        if *return_found {
+            if scanner.found_expect_in_promise {
+                ctx.diagnostic(expect_in_unhandled_promise(statement.span()));
+            }
+            continue;
+        }
+
+        match statement {
+            Statement::VariableDeclaration(decl) => {
+                for name in &scanner.resolved_names {
+                    pending_promises.remove(name.as_str());
+                }
+                for declarator in &decl.declarations {
+                    let Some(init) = &declarator.init else {
+                        continue;
+                    };
+                    let Some(ident) = declarator.id.get_binding_identifier() else {
+                        continue;
+                    };
+                    let mut init_scanner = PromiseExpectScanner::new();
+                    init_scanner.visit_expression(init);
+                    if init_scanner.found_expect_in_promise {
+                        pending_promises
+                            .insert(CompactStr::from(ident.name.as_str()), declarator.span);
+                    }
+                }
+            }
+            Statement::ExpressionStatement(expr_stmt) => {
+                match &expr_stmt.expression {
+                    Expression::AssignmentExpression(assign_expr) => {
+                        if let Some(name) =
+                            assign_expr.left.as_simple_assignment_target()
+                                .and_then(|t| t.get_identifier_name())
+                        {
+                            let rhs_references_self =
+                                expression_contains_identifier(&assign_expr.right, name);
+
+                            if !rhs_references_self {
+                                if let Some(old_span) =
+                                    pending_promises.remove(CompactStr::from(name).as_str())
+                                {
+                                    ctx.diagnostic(expect_in_unhandled_promise(old_span));
+                                }
+                            }
+
+                            let mut assign_scanner = PromiseExpectScanner::new();
+                            assign_scanner.visit_expression(&assign_expr.right);
+                            if assign_scanner.found_expect_in_promise {
+                                pending_promises
+                                    .insert(CompactStr::from(name), expr_stmt.span);
+                            }
+                        } else {
+                            if scanner.found_expect_in_promise {
+                                ctx.diagnostic(expect_in_unhandled_promise(
+                                    expr_stmt.span,
+                                ));
+                            }
+                        }
+                    }
+                    Expression::AwaitExpression(_) => {
+                        for name in &scanner.resolved_names {
+                            pending_promises.remove(name.as_str());
+                        }
+                    }
+                    _ => {
+                        for name in &scanner.resolved_names {
+                            pending_promises.remove(name.as_str());
+                        }
+                        if scanner.found_expect_in_promise
+                            && is_top_level_promise_chain(&expr_stmt.expression)
+                        {
+                            ctx.diagnostic(expect_in_unhandled_promise(
+                                expr_stmt.span,
+                            ));
+                        }
+                    }
+                }
+            }
+            Statement::ReturnStatement(return_stmt) => {
+                if let Some(arg) = &return_stmt.argument {
+                    if let Some(name) = ident_name_of(arg) {
+                        pending_promises.remove(name);
+                    }
+                }
+                for name in &scanner.resolved_names {
+                    pending_promises.remove(name.as_str());
+                }
+                *return_found = true;
+            }
+            // Block statements — recurse to handle reassignments inside blocks
+            Statement::BlockStatement(block) => {
+                process_statements(
+                    &block.body,
+                    pending_promises,
+                    return_found,
+                    ctx,
+                );
+            }
+            _ => {
+                for name in &scanner.resolved_names {
+                    pending_promises.remove(name.as_str());
+                }
+            }
+        }
+    }
+}
+
+/// Extracts the identifier name from simple expressions:
+/// - `promise` → Some("promise")
+/// Does NOT handle member expressions or calls — just plain identifiers.
+fn ident_name_of<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
+    match expr {
+        Expression::Identifier(ident) => Some(ident.name.as_str()),
+        _ => None,
+    }
+}
+
+/// Walks down the callee chain of `expect(x).resolves.not.toBe(2)` to find
+/// the arguments of the innermost `expect(...)` call.
+/// Handles arbitrary depth of member expression chains.
+fn find_expect_args<'a>(call_expr: &'a CallExpression<'a>) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
+    if let Expression::Identifier(ident) = &call_expr.callee {
+        if ident.name == "expect" {
+            return Some(&call_expr.arguments);
+        }
+    }
+    // Walk through member chain: the callee may be `expect(x).resolves.not.toBe`
+    // We need to find the CallExpression for `expect(x)` inside this chain.
+    find_expect_call_in_chain(&call_expr.callee)
+}
+
+fn find_expect_call_in_chain<'a>(expr: &'a Expression<'a>) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
+    match expr {
+        Expression::CallExpression(call) => find_expect_args(call),
+        _ => {
+            let member = expr.as_member_expression()?;
+            find_expect_call_in_chain(member.object())
+        }
+    }
+}
+
+/// Returns `true` if the expression contains a reference to the given identifier name.
+/// Used to check if `somePromise = somePromise.then(...)` continues the same chain.
+fn expression_contains_identifier(expr: &Expression, name: &str) -> bool {
+    let mut finder = IdentifierFinder { name, found: false };
+    finder.visit_expression(expr);
+    finder.found
+}
+
+struct IdentifierFinder<'b> {
+    name: &'b str,
+    found: bool,
+}
+
+impl<'a, 'b> Visit<'a> for IdentifierFinder<'b> {
+    fn visit_identifier_reference(&mut self, ident: &oxc_ast::ast::IdentifierReference<'a>) {
+        if ident.name == self.name {
+            self.found = true;
+        }
+    }
+}
+
+/// Returns `true` if the expression is directly a promise chain call (`.then/.catch/.finally`)
+/// at the top level, not nested inside object literals or other function arguments.
+/// Follows the chain: `x.then(cb).catch(cb2)` → walks down `.catch` → `.then` → true.
+fn is_top_level_promise_chain(expr: &Expression) -> bool {
+    let Expression::CallExpression(call_expr) = expr else {
+        return false;
+    };
+    let Some(member) = call_expr.callee.as_member_expression() else {
+        return false;
+    };
+    let Some(prop) = member.static_property_name() else {
+        return false;
+    };
+    if matches!(prop, "then" | "catch" | "finally") {
+        return true;
+    }
+    // Could be `somePromise.then(cb).someOtherMethod()` — check the object
+    false
+}
+
+/// Returns `true` if the callback is an arrow function with an expression body
+/// (i.e. `() => expr` rather than `() => { ... }`), meaning the expression is implicitly returned.
+fn is_expression_arrow(callback: &Argument) -> bool {
+    matches!(callback, Argument::ArrowFunctionExpression(arrow) if arrow.expression)
+}
+
+fn get_callback_body<'a>(callback_argument: &'a Argument<'a>) -> Option<&'a FunctionBody<'a>> {
+    match callback_argument {
+        Argument::ArrowFunctionExpression(arrow_fn) => Some(&arrow_fn.body),
+        Argument::FunctionExpression(fn_expr) => fn_expr.body.as_ref().map(AsRef::as_ref),
+        _ => None,
+    }
+}
+
+fn get_callback_param_count(callback: &Argument) -> usize {
+    match callback {
+        Argument::ArrowFunctionExpression(arrow_fn) => arrow_fn.params.items.len(),
+        Argument::FunctionExpression(fn_expr) => fn_expr.params.items.len(),
+        _ => 0,
+    }
+}
+
+/// Single-pass visitor that walks an expression/statement subtree and detects:
+/// 1. Promise chains (`.then/.catch/.finally`) containing `expect()` calls
+/// 2. Identifiers that are "resolved" — awaited or used in `expect(x).resolves/rejects`
+struct PromiseExpectScanner {
+    /// Whether we are currently inside a promise chain callback.
+    in_promise_chain: bool,
+    /// Whether we are currently inside an `await` expression.
+    in_await: bool,
+    /// Set to `true` once we find an `expect()` inside a promise chain callback
+    /// that is NOT already inside an `await`.
+    found_expect_in_promise: bool,
+    /// Identifiers that were properly resolved (awaited, expect().resolves, etc.)
+    resolved_names: FxHashSet<CompactStr>,
+}
+
+impl PromiseExpectScanner {
+    fn new() -> Self {
+        Self {
+            in_promise_chain: false,
+            in_await: false,
+            found_expect_in_promise: false,
+            resolved_names: FxHashSet::default(),
+        }
+    }
+}
+
+impl<'a> Visit<'a> for PromiseExpectScanner {
+    fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
+        // Check for `expect(promise).resolves/rejects` — resolves the promise variable
+        let callee_name = get_node_name_vec(&call_expr.callee);
+        if callee_name.first().is_some_and(|n| n == "expect")
+            && callee_name.iter().any(|n| n == "resolves" || n == "rejects")
+        {
+            if let Some(inner_args) = find_expect_args(call_expr) {
+                if let Some(first_arg) = inner_args.first() {
+                    if let Some(expr) = first_arg.as_expression() {
+                        if let Some(name) = ident_name_of(expr) {
+                            self.resolved_names.insert(CompactStr::from(name));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check for `Promise.all([p1, p2])`, `Promise.resolve(p)`, etc.
+        // These resolve the identifiers passed as arguments.
+        if let Some(member) = call_expr.callee.as_member_expression() {
+            if let Expression::Identifier(obj) = member.object() {
+                if obj.name == "Promise" {
+                    let prop = member.static_property_name();
+                    if matches!(prop, Some("all" | "allSettled" | "race" | "any")) {
+                        // First arg is an array: Promise.all([p1, p2])
+                        if let Some(first_arg) = call_expr.arguments.first() {
+                            if let Some(Expression::ArrayExpression(arr)) = first_arg.as_expression() {
+                                for elem in &arr.elements {
+                                    if let Some(expr) = elem.as_expression() {
+                                        if let Some(name) = ident_name_of(expr) {
+                                            self.resolved_names.insert(CompactStr::from(name));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else if matches!(prop, Some("resolve" | "reject")) {
+                        // First arg is a single value: Promise.resolve(p)
+                        if let Some(first_arg) = call_expr.arguments.first() {
+                            if let Some(expr) = first_arg.as_expression() {
+                                if let Some(name) = ident_name_of(expr) {
+                                    self.resolved_names.insert(CompactStr::from(name));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check if this call is to `.then()`, `.catch()`, or `.finally()`
+        let is_chain_call = call_expr
+            .callee
+            .as_member_expression()
+            .and_then(|member| member.static_property_name())
+            .is_some_and(|prop| matches!(prop, "then" | "catch" | "finally"));
+
+        if is_chain_call {
+            let was_in_chain = self.in_promise_chain;
+            // Only flag as promise chain if not already inside an await
+            self.in_promise_chain = !self.in_await;
+            // Walk the callee (handles chaining: x.then(cb1).catch(cb2))
+            self.visit_expression(&call_expr.callee);
+            // Only walk the first 2 arguments of .then/.catch/.finally
+            // (.then takes at most 2 callbacks; 3rd+ args are non-standard)
+            for arg in call_expr.arguments.iter().take(2) {
+                self.visit_argument(arg);
+            }
+            self.in_promise_chain = was_in_chain;
+            return;
+        }
+
+        // If we're inside a promise chain and see `expect(...)`, flag it
+        if self.in_promise_chain {
+            if callee_name.first().is_some_and(|n| n == "expect") {
+                self.found_expect_in_promise = true;
+                return;
+            }
+        }
+
+        walk::walk_call_expression(self, call_expr);
+    }
+
+    fn visit_await_expression(&mut self, await_expr: &oxc_ast::ast::AwaitExpression<'a>) {
+        // `await promise` → mark identifier as resolved
+        if let Some(name) = ident_name_of(&await_expr.argument) {
+            self.resolved_names.insert(CompactStr::from(name));
+        }
+        // Mark that we're inside await — any promise chain inside is already handled
+        let was_in_await = self.in_await;
+        self.in_await = true;
+        walk::walk_await_expression(self, await_expr);
+        self.in_await = was_in_await;
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("test('something', () => Promise.resolve().then(() => expect(1).toBe(2)));", None, None),
+        ("Promise.resolve().then(() => expect(1).toBe(2))", None, None),
+        ("const x = Promise.resolve().then(() => expect(1).toBe(2))", None, None),
+        (r#"it.todo("something")"#, None, None),
+        (
+            "it('is valid', () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(promise).resolves.toBe(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(promise).resolves.not.toBe(2);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(promise).rejects.toBe(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(promise).rejects.not.toBe(2);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(await promise).toBeGreaterThan(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(await promise).resolves.toBeGreaterThan(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(1).toBeGreaterThan(await promise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect.this.that.is(await promise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              expect(await loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              })).toBeGreaterThan(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect([await promise]).toHaveLength(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect([,,await promise,,]).toHaveLength(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect([[await promise]]).toHaveLength(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              logValue(await promise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return 1;
+              });
+              expect.assertions(await promise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              await loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => new Promise((done) => {
+              test()
+                .then(() => {
+                  expect(someThing).toEqual(true);
+                  done();
+                });
+            }));",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              return new Promise(done => {
+                test().then(() => {
+                  expect(someThing).toEqual(true);
+                  done();
+                });
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('passes', () => {
+              Promise.resolve().then(() => {
+                grabber.grabSomething();
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('passes', async () => {
+              const grabbing = Promise.resolve().then(() => {
+                grabber.grabSomething();
+              });
+              await grabbing;
+              expect(grabber.grabbedItems).toHaveLength(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "const myFn = () => {
+              Promise.resolve().then(() => {
+                expect(true).toBe(false);
+              });
+            };",
+            None,
+            None,
+        ),
+        (
+            "const myFn = () => {
+              Promise.resolve().then(() => {
+                subject.invokeMethod();
+              });
+            };",
+            None,
+            None,
+        ),
+        (
+            "const myFn = () => {
+              Promise.resolve().then(() => {
+                expect(true).toBe(false);
+              });
+            };
+            it('it1', () => {
+              return somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => new Promise((done) => {
+              test()
+                .finally(() => {
+                  expect(someThing).toEqual(true);
+                  done();
+                });
+            }));",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              return somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              return somePromise.finally(() => {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              return somePromise.catch(function() {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "xtest('it1', function() {
+              return somePromise.catch(function() {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              return somePromise.then(function() {
+                doSomeThingButNotExpect();
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              return getSomeThing().getPromise().then(function() {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              return Promise.resolve().then(function() {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function () {
+              return Promise.resolve().then(function () {
+                /*fulfillment*/
+                expect(someThing).toEqual(true);
+              }, function () {
+                /*rejection*/
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function () {
+              Promise.resolve().then(/*fulfillment*/ function () {
+              }, undefined, /*rejection*/ function () {
+                expect(someThing).toEqual(true)
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function () {
+              return Promise.resolve().then(function () {
+                /*fulfillment*/
+              }, function () {
+                /*rejection*/
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function () {
+              return somePromise.then()
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', async () => {
+              await Promise.resolve().then(function () {
+                expect(someThing).toEqual(true)
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', async () => {
+              await somePromise.then(() => {
+                expect(someThing).toEqual(true)
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', async () => {
+              await getSomeThing().getPromise().then(function () {
+                expect(someThing).toEqual(true)
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              return somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              })
+              .then(() => {
+                expect(someThing).toEqual(true);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              return somePromise.then(() => {
+                return value;
+              })
+              .then(value => {
+                expect(someThing).toEqual(value);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              return somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              })
+              .then(() => {
+                console.log('this is silly');
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              return somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              })
+              .catch(() => {
+                expect(someThing).toEqual(false);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              await promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test.only('later return', () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('that we bailout if destructuring is used', () => {
+              const [promise] = something().then(value => {
+                expect(value).toBe('red');
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('that we bailout if destructuring is used', async () => {
+              const [promise] = await something().then(value => {
+                expect(value).toBe('red');
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('that we bailout if destructuring is used', () => {
+              const [promise] = [
+                something().then(value => {
+                  expect(value).toBe('red');
+                })
+              ];
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('that we bailout if destructuring is used', () => {
+              const {promise} = {
+                promise: something().then(value => {
+                  expect(value).toBe('red');
+                })
+              };
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('that we bailout in complex cases', () => {
+              promiseSomething({
+                timeout: 500,
+                promise: something().then(value => {
+                  expect(value).toBe('red');
+                })
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('shorthand arrow', () =>
+              something().then(value => {
+                expect(() => {
+                  value();
+                }).toThrow();
+              })
+            );",
+            None,
+            None,
+        ),
+        (
+            "it('crawls for files based on patterns', () => {
+              const promise = nodeCrawl({}).then(data => {
+                expect(childProcess.spawn).lastCalledWith('find');
+              });
+              return promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', async () => {
+              const value = await somePromise().then(response => {
+                expect(response).toHaveProperty('data');
+                return response.data;
+              });
+              expect(value).toBe('hello world');
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', async () => {
+              return await somePromise().then(response => {
+                expect(response).toHaveProperty('data');
+                return response.data;
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', async () => {
+              return somePromise().then(response => {
+                expect(response).toHaveProperty('data');
+                return response.data;
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', async () => {
+              await somePromise().then(response => {
+                expect(response).toHaveProperty('data');
+                return response.data;
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it(
+              'test function',
+              () => {
+                return Builder
+                  .getPromiseBuilder()
+                  .get().build()
+                  .then((data) => {
+                    expect(data).toEqual('Hi');
+                  });
+              }
+            );",
+            None,
+            None,
+        ),
+        (
+            "notATestFunction(
+              'not a test function',
+              () => {
+                Builder
+                  .getPromiseBuilder()
+                  .get()
+                  .build()
+                  .then((data) => {
+                    expect(data).toEqual('Hi');
+                  });
+              }
+            );",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promiseOne = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+              });
+              const promiseTwo = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+              });
+              await promiseTwo;
+              await promiseOne;
+            });",
+            None,
+            None,
+        ),
+        (
+            r#"it("it1", () => somePromise.then(() => {
+              expect(someThing).toEqual(true)
+            }))"#,
+            None,
+            None,
+        ),
+        (r#"it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))"#, None, None),
+        (
+            "it('promise test with done', (done) => {
+              const promise = getPromise();
+              promise.then(() => expect(someThing).toEqual(true));
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('name of done param does not matter', (nameDoesNotMatter) => {
+              const promise = getPromise();
+              promise.then(() => expect(someThing).toEqual(true));
+            });",
+            None,
+            None,
+        ),
+        (
+            "it.each([])('name of done param does not matter', (nameDoesNotMatter) => {
+              const promise = getPromise();
+              promise.then(() => expect(someThing).toEqual(true));
+            });",
+            None,
+            None,
+        ),
+        (
+            "it.each`\n`('name of done param does not matter', ({}, nameDoesNotMatter) => {
+              const promise = getPromise();
+              promise.then(() => expect(someThing).toEqual(true));
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('valid-expect-in-promise', async () => {
+              const text = await fetch('url')
+                  .then(res => res.text())
+                  .then(text => text);
+              expect(text).toBe('text');
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              }), x = 1;
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let x = 1, somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+              somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+              somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              return somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              {}
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              const somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              {
+                await somePromise;
+              }
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              {
+                await somePromise;
+                somePromise = getPromise().then((data) => {
+                  expect(data).toEqual('foo');
+                });
+                await somePromise;
+              }
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+              {
+                somePromise = getPromise().then((data) => {
+                  expect(data).toEqual('foo');
+                });
+                await somePromise;
+              }
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              somePromise = somePromise.then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              somePromise = somePromise
+                .then((data) => data)
+                .then((data) => data)
+                .then((data) => {
+                  expect(data).toEqual('foo');
+                });
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              somePromise = somePromise
+                .then((data) => data)
+                .then((data) => data)
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+              {
+                somePromise = getPromise().then((data) => {
+                  expect(data).toEqual('foo');
+                });
+                {
+                  await somePromise;
+                }
+              }
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              const somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await Promise.all([somePromise]);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              const somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              return Promise.all([somePromise]);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              const somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              return Promise.resolve(somePromise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              const somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              return Promise.reject(somePromise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              const somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await Promise.resolve(somePromise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              const somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await Promise.reject(somePromise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const onePromise = something().then(value => {
+                console.log(value);
+              });
+              const twoPromise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return Promise.all([onePromise, twoPromise]);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const onePromise = something().then(value => {
+                console.log(value);
+              });
+              const twoPromise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return Promise.allSettled([onePromise, twoPromise]);
+            });",
+            None,
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "const myFn = () => {
+              Promise.resolve().then(() => {
+                expect(true).toBe(false);
+              });
+            };
+            it('it1', () => {
+              somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              somePromise.finally(() => {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "
+                   it('it1', () => {
+                     somePromise['then'](() => {
+                       expect(someThing).toEqual(true);
+                     });
+                   });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              getSomeThing().getPromise().then(function() {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              Promise.resolve().then(function() {
+                expect(someThing).toEqual(true);
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              somePromise.catch(function() {
+                expect(someThing).toEqual(true)
+              })
+            })",
+            None,
+            None,
+        ),
+        (
+            "xtest('it1', function() {
+              somePromise.catch(function() {
+                expect(someThing).toEqual(true)
+              })
+            })",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function() {
+              somePromise.then(function() {
+                expect(someThing).toEqual(true)
+              })
+            })",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function () {
+              Promise.resolve().then(/*fulfillment*/ function () {
+                expect(someThing).toEqual(true);
+              }, /*rejection*/ function () {
+                expect(someThing).toEqual(true);
+              })
+            })",
+            None,
+            None,
+        ),
+        (
+            "it('it1', function () {
+              Promise.resolve().then(/*fulfillment*/ function () {
+              }, /*rejection*/ function () {
+                expect(someThing).toEqual(true)
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('test function', () => {
+              Builder.getPromiseBuilder()
+                .get()
+                .build()
+                .then(data => expect(data).toEqual('Hi'));
+            });",
+            None,
+            None,
+        ),
+        (
+            "
+                    it('test function', async () => {
+                      Builder.getPromiseBuilder()
+                        .get()
+                        .build()
+                        .then(data => expect(data).toEqual('Hi'));
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              somePromise.then(() => {
+                doSomeOperation();
+                expect(someThing).toEqual(true);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise
+                .then(() => {})
+                .then(() => expect(someThing).toEqual(value))
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise
+                .then(() => expect(someThing).toEqual(value))
+                .then(() => {})
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise.then(() => {
+                return value;
+              })
+              .then(value => {
+                expect(someThing).toEqual(value);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise.then(() => {
+                expect(someThing).toEqual(true);
+              })
+              .then(() => {
+                console.log('this is silly');
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise.then(() => {
+                // return value;
+              })
+              .then(value => {
+                expect(someThing).toEqual(value);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise.then(() => {
+                return value;
+              })
+              .then(value => {
+                expect(someThing).toEqual(value);
+              })
+              return anotherPromise.then(() => expect(x).toBe(y));
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise
+                .then(() => 1)
+                .then(x => x + 1)
+                .catch(() => -1)
+                .then(v => expect(v).toBe(2));
+              return anotherPromise.then(() => expect(x).toBe(y));
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is a test', () => {
+              somePromise
+                .then(() => 1)
+                .then(v => expect(v).toBe(2))
+                .then(x => x + 1)
+                .catch(() => -1);
+              return anotherPromise.then(() => expect(x).toBe(y));
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('it1', () => {
+              somePromise.finally(() => {
+                doSomeOperation();
+                expect(someThing).toEqual(true);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            r#"test('invalid return', () => {
+              const promise = something().then(value => {
+                const foo = "foo";
+                return expect(value).toBe('red');
+              });
+            });"#,
+            None,
+            None,
+        ),
+        (
+            "fit('it1', () => {
+              somePromise.then(() => {
+                doSomeOperation();
+                expect(someThing).toEqual(true);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "it.skip('it1', () => {
+              somePromise.then(() => {
+                doSomeOperation();
+                expect(someThing).toEqual(true);
+              })
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return;
+              await promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return 1;
+              await promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return [];
+              await promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return Promise.all([anotherPromise]);
+              await promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return {};
+              await promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              return Promise.all([]);
+              await promise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              await 1;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              await [];
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              await Promise.all([anotherPromise]);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              await {};
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              await Promise.all([]);
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              }), x = 1;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('later return', async () => {
+              const x = 1, promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "import { test } from '@jest/globals';
+            test('later return', async () => {
+              const x = 1, promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('promise test', () => {
+              const somePromise = getThatPromise();
+              somePromise.then((data) => {
+                expect(data).toEqual('foo');
+              });
+              expect(somePromise).toBeDefined();
+              return somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', function () {
+              let somePromise = getThatPromise();
+              somePromise.then((data) => {
+                expect(data).toEqual('foo');
+              });
+              expect(somePromise).toBeDefined();
+              return somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              somePromise = null;
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              await somePromise;
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              ({ somePromise } = {})
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('promise test', async function () {
+              let somePromise = getPromise().then((data) => {
+                expect(data).toEqual('foo');
+              });
+              {
+                somePromise = getPromise().then((data) => {
+                  expect(data).toEqual('foo');
+                });
+                await somePromise;
+              }
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('that we error on this destructuring', async () => {
+              [promise] = something().then(value => {
+                expect(value).toBe('red');
+              });
+            });",
+            None,
+            None,
+        ),
+        (
+            "test('that we error on this', () => {
+              const promise = something().then(value => {
+                expect(value).toBe('red');
+              });
+              log(promise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(promise).toBeInstanceOf(Promise);
+            });",
+            None,
+            None,
+        ),
+        (
+            "it('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(anotherPromise).resolves.toBe(1);
+            });",
+            None,
+            None,
+        ),
+        (
+            "import { it as promiseThatThis } from '@jest/globals';
+            promiseThatThis('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(anotherPromise).resolves.toBe(1);
+            });",
+            None,
+            None,
+        ),
+        /*
+         * jest alias not supported
+        (
+            "promiseThatThis('is valid', async () => {
+              const promise = loadNumber().then(number => {
+                expect(typeof number).toBe('number');
+                return number + 1;
+              });
+              expect(anotherPromise).resolves.toBe(1);
+            });",
+            None,
+            Some(
+                serde_json::json!({ "settings": { "jest": { "globalAliases": { "xit": ["promiseThatThis"] } } } }),
+            ),
+        ),
+         */
+    ];
+
+    Tester::new(ValidExpectInPromise::NAME, ValidExpectInPromise::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jest_valid_expect_in_promise.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_expect_in_promise.snap
@@ -1,0 +1,552 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+    ╭─[valid_expect_in_promise.tsx:7:15]
+  6 │                 it('it1', () => {
+  7 │ ╭─▶               somePromise.then(() => {
+  8 │ │                   expect(someThing).toEqual(true);
+  9 │ ╰─▶               });
+ 10 │                 });
+    ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   expect(someThing).toEqual(true);
+ 4 │ ╰─▶               });
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', () => {
+ 2 │ ╭─▶               somePromise.finally(() => {
+ 3 │ │                   expect(someThing).toEqual(true);
+ 4 │ ╰─▶               });
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:22]
+ 2 │                        it('it1', () => {
+ 3 │ ╭─▶                      somePromise['then'](() => {
+ 4 │ │                          expect(someThing).toEqual(true);
+ 5 │ ╰─▶                      });
+ 6 │                        });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', function() {
+ 2 │ ╭─▶               getSomeThing().getPromise().then(function() {
+ 3 │ │                   expect(someThing).toEqual(true);
+ 4 │ ╰─▶               });
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', function() {
+ 2 │ ╭─▶               Promise.resolve().then(function() {
+ 3 │ │                   expect(someThing).toEqual(true);
+ 4 │ ╰─▶               });
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', function() {
+ 2 │ ╭─▶               somePromise.catch(function() {
+ 3 │ │                   expect(someThing).toEqual(true)
+ 4 │ ╰─▶               })
+ 5 │                 })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     xtest('it1', function() {
+ 2 │ ╭─▶               somePromise.catch(function() {
+ 3 │ │                   expect(someThing).toEqual(true)
+ 4 │ ╰─▶               })
+ 5 │                 })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', function() {
+ 2 │ ╭─▶               somePromise.then(function() {
+ 3 │ │                   expect(someThing).toEqual(true)
+ 4 │ ╰─▶               })
+ 5 │                 })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', function () {
+ 2 │ ╭─▶               Promise.resolve().then(/*fulfillment*/ function () {
+ 3 │ │                   expect(someThing).toEqual(true);
+ 4 │ │                 }, /*rejection*/ function () {
+ 5 │ │                   expect(someThing).toEqual(true);
+ 6 │ ╰─▶               })
+ 7 │                 })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', function () {
+ 2 │ ╭─▶               Promise.resolve().then(/*fulfillment*/ function () {
+ 3 │ │                 }, /*rejection*/ function () {
+ 4 │ │                   expect(someThing).toEqual(true)
+ 5 │ ╰─▶               })
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('test function', () => {
+ 2 │ ╭─▶               Builder.getPromiseBuilder()
+ 3 │ │                   .get()
+ 4 │ │                   .build()
+ 5 │ ╰─▶                 .then(data => expect(data).toEqual('Hi'));
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('test function', async () => {
+ 3 │ ╭─▶                       Builder.getPromiseBuilder()
+ 4 │ │                           .get()
+ 5 │ │                           .build()
+ 6 │ ╰─▶                         .then(data => expect(data).toEqual('Hi'));
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   doSomeOperation();
+ 4 │ │                   expect(someThing).toEqual(true);
+ 5 │ ╰─▶               })
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise
+ 3 │ │                   .then(() => {})
+ 4 │ ╰─▶                 .then(() => expect(someThing).toEqual(value))
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise
+ 3 │ │                   .then(() => expect(someThing).toEqual(value))
+ 4 │ ╰─▶                 .then(() => {})
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   return value;
+ 4 │ │                 })
+ 5 │ │                 .then(value => {
+ 6 │ │                   expect(someThing).toEqual(value);
+ 7 │ ╰─▶               })
+ 8 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   expect(someThing).toEqual(true);
+ 4 │ │                 })
+ 5 │ │                 .then(() => {
+ 6 │ │                   console.log('this is silly');
+ 7 │ ╰─▶               })
+ 8 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   // return value;
+ 4 │ │                 })
+ 5 │ │                 .then(value => {
+ 6 │ │                   expect(someThing).toEqual(value);
+ 7 │ ╰─▶               })
+ 8 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   return value;
+ 4 │ │                 })
+ 5 │ │                 .then(value => {
+ 6 │ │                   expect(someThing).toEqual(value);
+ 7 │ ╰─▶               })
+ 8 │                   return anotherPromise.then(() => expect(x).toBe(y));
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise
+ 3 │ │                   .then(() => 1)
+ 4 │ │                   .then(x => x + 1)
+ 5 │ │                   .catch(() => -1)
+ 6 │ ╰─▶                 .then(v => expect(v).toBe(2));
+ 7 │                   return anotherPromise.then(() => expect(x).toBe(y));
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('is a test', () => {
+ 2 │ ╭─▶               somePromise
+ 3 │ │                   .then(() => 1)
+ 4 │ │                   .then(v => expect(v).toBe(2))
+ 5 │ │                   .then(x => x + 1)
+ 6 │ ╰─▶                 .catch(() => -1);
+ 7 │                   return anotherPromise.then(() => expect(x).toBe(y));
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it('it1', () => {
+ 2 │ ╭─▶               somePromise.finally(() => {
+ 3 │ │                   doSomeOperation();
+ 4 │ │                   expect(someThing).toEqual(true);
+ 5 │ ╰─▶               })
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('invalid return', () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   const foo = "foo";
+ 4 │ │                   return expect(value).toBe('red');
+ 5 │ ╰─▶               });
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     fit('it1', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   doSomeOperation();
+ 4 │ │                   expect(someThing).toEqual(true);
+ 5 │ ╰─▶               })
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     it.skip('it1', () => {
+ 2 │ ╭─▶               somePromise.then(() => {
+ 3 │ │                   doSomeOperation();
+ 4 │ │                   expect(someThing).toEqual(true);
+ 5 │ ╰─▶               })
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   promise;
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   return;
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   return 1;
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   return [];
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   return Promise.all([anotherPromise]);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   return {};
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   return Promise.all([]);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   await 1;
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   await [];
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   await Promise.all([anotherPromise]);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   await {};
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   await Promise.all([]);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               }), x = 1;
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:28]
+ 1 │     test('later return', async () => {
+ 2 │ ╭─▶               const x = 1, promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:28]
+ 2 │                 test('later return', async () => {
+ 3 │ ╭─▶               const x = 1, promise = something().then(value => {
+ 4 │ │                   expect(value).toBe('red');
+ 5 │ ╰─▶               });
+ 6 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:15]
+ 2 │                   const somePromise = getThatPromise();
+ 3 │ ╭─▶               somePromise.then((data) => {
+ 4 │ │                   expect(data).toEqual('foo');
+ 5 │ ╰─▶               });
+ 6 │                   expect(somePromise).toBeDefined();
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:15]
+ 2 │                   let somePromise = getThatPromise();
+ 3 │ ╭─▶               somePromise.then((data) => {
+ 4 │ │                   expect(data).toEqual('foo');
+ 5 │ ╰─▶               });
+ 6 │                   expect(somePromise).toBeDefined();
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:19]
+ 1 │     test('promise test', async function () {
+ 2 │ ╭─▶               let somePromise = getPromise().then((data) => {
+ 3 │ │                   expect(data).toEqual('foo');
+ 4 │ ╰─▶               });
+ 5 │                   somePromise = null;
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:19]
+ 1 │     test('promise test', async function () {
+ 2 │ ╭─▶               let somePromise = getPromise().then((data) => {
+ 3 │ │                   expect(data).toEqual('foo');
+ 4 │ ╰─▶               });
+ 5 │                   somePromise = getPromise().then((data) => {
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:19]
+ 1 │     test('promise test', async function () {
+ 2 │ ╭─▶               let somePromise = getPromise().then((data) => {
+ 3 │ │                   expect(data).toEqual('foo');
+ 4 │ ╰─▶               });
+ 5 │                   ({ somePromise } = {})
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:19]
+ 1 │     test('promise test', async function () {
+ 2 │ ╭─▶               let somePromise = getPromise().then((data) => {
+ 3 │ │                   expect(data).toEqual('foo');
+ 4 │ ╰─▶               });
+ 5 │                   {
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:15]
+ 1 │     test('that we error on this destructuring', async () => {
+ 2 │ ╭─▶               [promise] = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                 });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     test('that we error on this', () => {
+ 2 │ ╭─▶               const promise = something().then(value => {
+ 3 │ │                   expect(value).toBe('red');
+ 4 │ ╰─▶               });
+ 5 │                   log(promise);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     it('is valid', async () => {
+ 2 │ ╭─▶               const promise = loadNumber().then(number => {
+ 3 │ │                   expect(typeof number).toBe('number');
+ 4 │ │                   return number + 1;
+ 5 │ ╰─▶               });
+ 6 │                   expect(promise).toBeInstanceOf(Promise);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:2:21]
+ 1 │     it('is valid', async () => {
+ 2 │ ╭─▶               const promise = loadNumber().then(number => {
+ 3 │ │                   expect(typeof number).toBe('number');
+ 4 │ │                   return number + 1;
+ 5 │ ╰─▶               });
+ 6 │                   expect(anotherPromise).resolves.toBe(1);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:21]
+ 2 │                 promiseThatThis('is valid', async () => {
+ 3 │ ╭─▶               const promise = loadNumber().then(number => {
+ 4 │ │                   expect(typeof number).toBe('number');
+ 5 │ │                   return number + 1;
+ 6 │ ╰─▶               });
+ 7 │                   expect(anotherPromise).resolves.toBe(1);
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.

--- a/crates/oxc_linter/src/snapshots/jest_valid_expect_in_promise.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_expect_in_promise.snap
@@ -550,3 +550,555 @@ source: crates/oxc_linter/src/tester.rs
  7 │                   expect(anotherPromise).resolves.toBe(1);
    ╰────
   help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+    ╭─[valid_expect_in_promise.tsx:9:23]
+  8 │                         it('it1', () => {
+  9 │ ╭─▶                       somePromise.then(() => {
+ 10 │ │                           expect(someThing).toEqual(true);
+ 11 │ ╰─▶                       });
+ 12 │                         });
+    ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           expect(someThing).toEqual(true);
+ 5 │ ╰─▶                       });
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', () => {
+ 3 │ ╭─▶                       somePromise.finally(() => {
+ 4 │ │                           expect(someThing).toEqual(true);
+ 5 │ ╰─▶                       });
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:22]
+ 2 │                        it('it1', () => {
+ 3 │ ╭─▶                      somePromise['then'](() => {
+ 4 │ │                          expect(someThing).toEqual(true);
+ 5 │ ╰─▶                      });
+ 6 │                        });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', function() {
+ 3 │ ╭─▶                       getSomeThing().getPromise().then(function() {
+ 4 │ │                           expect(someThing).toEqual(true);
+ 5 │ ╰─▶                       });
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', function() {
+ 3 │ ╭─▶                       Promise.resolve().then(function() {
+ 4 │ │                           expect(someThing).toEqual(true);
+ 5 │ ╰─▶                       });
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', function() {
+ 3 │ ╭─▶                       somePromise.catch(function() {
+ 4 │ │                           expect(someThing).toEqual(true)
+ 5 │ ╰─▶                       })
+ 6 │                         })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         xtest('it1', function() {
+ 3 │ ╭─▶                       somePromise.catch(function() {
+ 4 │ │                           expect(someThing).toEqual(true)
+ 5 │ ╰─▶                       })
+ 6 │                         })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', function() {
+ 3 │ ╭─▶                       somePromise.then(function() {
+ 4 │ │                           expect(someThing).toEqual(true)
+ 5 │ ╰─▶                       })
+ 6 │                         })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', function () {
+ 3 │ ╭─▶                       Promise.resolve().then(/*fulfillment*/ function () {
+ 4 │ │                           expect(someThing).toEqual(true);
+ 5 │ │                         }, /*rejection*/ function () {
+ 6 │ │                           expect(someThing).toEqual(true);
+ 7 │ ╰─▶                       })
+ 8 │                         })
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', function () {
+ 3 │ ╭─▶                       Promise.resolve().then(/*fulfillment*/ function () {
+ 4 │ │                         }, /*rejection*/ function () {
+ 5 │ │                           expect(someThing).toEqual(true)
+ 6 │ ╰─▶                       })
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('test function', () => {
+ 3 │ ╭─▶                       Builder.getPromiseBuilder()
+ 4 │ │                           .get()
+ 5 │ │                           .build()
+ 6 │ ╰─▶                         .then(data => expect(data).toEqual('Hi'));
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('test function', async () => {
+ 3 │ ╭─▶                       Builder.getPromiseBuilder()
+ 4 │ │                           .get()
+ 5 │ │                           .build()
+ 6 │ ╰─▶                         .then(data => expect(data).toEqual('Hi'));
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           doSomeOperation();
+ 5 │ │                           expect(someThing).toEqual(true);
+ 6 │ ╰─▶                       })
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise
+ 4 │ │                           .then(() => {})
+ 5 │ ╰─▶                         .then(() => expect(someThing).toEqual(value))
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise
+ 4 │ │                           .then(() => expect(someThing).toEqual(value))
+ 5 │ ╰─▶                         .then(() => {})
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           return value;
+ 5 │ │                         })
+ 6 │ │                         .then(value => {
+ 7 │ │                           expect(someThing).toEqual(value);
+ 8 │ ╰─▶                       })
+ 9 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           expect(someThing).toEqual(true);
+ 5 │ │                         })
+ 6 │ │                         .then(() => {
+ 7 │ │                           console.log('this is silly');
+ 8 │ ╰─▶                       })
+ 9 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           // return value;
+ 5 │ │                         })
+ 6 │ │                         .then(value => {
+ 7 │ │                           expect(someThing).toEqual(value);
+ 8 │ ╰─▶                       })
+ 9 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           return value;
+ 5 │ │                         })
+ 6 │ │                         .then(value => {
+ 7 │ │                           expect(someThing).toEqual(value);
+ 8 │ ╰─▶                       })
+ 9 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise
+ 4 │ │                           .then(() => 1)
+ 5 │ │                           .then(x => x + 1)
+ 6 │ │                           .catch(() => -1)
+ 7 │ ╰─▶                         .then(v => expect(v).toBe(2));
+ 8 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('is a test', () => {
+ 3 │ ╭─▶                       somePromise
+ 4 │ │                           .then(() => 1)
+ 5 │ │                           .then(v => expect(v).toBe(2))
+ 6 │ │                           .then(x => x + 1)
+ 7 │ ╰─▶                         .catch(() => -1);
+ 8 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it('it1', () => {
+ 3 │ ╭─▶                       somePromise.finally(() => {
+ 4 │ │                           doSomeOperation();
+ 5 │ │                           expect(someThing).toEqual(true);
+ 6 │ ╰─▶                       })
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('invalid return', () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           const foo = "foo";
+ 5 │ │                           return expect(value).toBe('red');
+ 6 │ ╰─▶                       });
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         fit('it1', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           doSomeOperation();
+ 5 │ │                           expect(someThing).toEqual(true);
+ 6 │ ╰─▶                       })
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         it.skip('it1', () => {
+ 3 │ ╭─▶                       somePromise.then(() => {
+ 4 │ │                           doSomeOperation();
+ 5 │ │                           expect(someThing).toEqual(true);
+ 6 │ ╰─▶                       })
+ 7 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       }), x = 1;
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:36]
+ 2 │                         test('later return', async () => {
+ 3 │ ╭─▶                       const x = 1, promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:5:36]
+ 4 │                         test('later return', async () => {
+ 5 │ ╭─▶                       const x = 1, promise = something().then(value => {
+ 6 │ │                           expect(value).toBe('red');
+ 7 │ ╰─▶                       });
+ 8 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:4:23]
+ 3 │                           const somePromise = getThatPromise();
+ 4 │ ╭─▶                       somePromise.then((data) => {
+ 5 │ │                           expect(data).toEqual('foo');
+ 6 │ ╰─▶                       });
+ 7 │                           expect(somePromise).toBeDefined();
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:4:23]
+ 3 │                           let somePromise = getThatPromise();
+ 4 │ ╭─▶                       somePromise.then((data) => {
+ 5 │ │                           expect(data).toEqual('foo');
+ 6 │ ╰─▶                       });
+ 7 │                           expect(somePromise).toBeDefined();
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:27]
+ 2 │                         test('promise test', async function () {
+ 3 │ ╭─▶                       let somePromise = getPromise().then((data) => {
+ 4 │ │                           expect(data).toEqual('foo');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:27]
+ 2 │                         test('promise test', async function () {
+ 3 │ ╭─▶                       let somePromise = getPromise().then((data) => {
+ 4 │ │                           expect(data).toEqual('foo');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:27]
+ 2 │                         test('promise test', async function () {
+ 3 │ ╭─▶                       let somePromise = getPromise().then((data) => {
+ 4 │ │                           expect(data).toEqual('foo');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:27]
+ 2 │                         test('promise test', async function () {
+ 3 │ ╭─▶                       let somePromise = getPromise().then((data) => {
+ 4 │ │                           expect(data).toEqual('foo');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:23]
+ 2 │                         test('that we error on this destructuring', async () => {
+ 3 │ ╭─▶                       [promise] = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │                         });
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         test('that we error on this', () => {
+ 3 │ ╭─▶                       const promise = something().then(value => {
+ 4 │ │                           expect(value).toBe('red');
+ 5 │ ╰─▶                       });
+ 6 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         it('is valid', async () => {
+ 3 │ ╭─▶                       const promise = loadNumber().then(number => {
+ 4 │ │                           expect(typeof number).toBe('number');
+ 5 │ │   
+ 6 │ │                           return number + 1;
+ 7 │ ╰─▶                       });
+ 8 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+   ╭─[valid_expect_in_promise.tsx:3:29]
+ 2 │                         it('is valid', async () => {
+ 3 │ ╭─▶                       const promise = loadNumber().then(number => {
+ 4 │ │                           expect(typeof number).toBe('number');
+ 5 │ │   
+ 6 │ │                           return number + 1;
+ 7 │ ╰─▶                       });
+ 8 │     
+   ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.
+
+  ⚠ eslint-plugin-jest(valid-expect-in-promise): Expect in a promise chain must be awaited or returned
+    ╭─[valid_expect_in_promise.tsx:5:29]
+  4 │                         promiseThatThis('is valid', async () => {
+  5 │ ╭─▶                       const promise = loadNumber().then(number => {
+  6 │ │                           expect(typeof number).toBe('number');
+  7 │ │   
+  8 │ │                           return number + 1;
+  9 │ ╰─▶                       });
+ 10 │     
+    ╰────
+  help: Either `await` the promise, `return` it, or use `expect().resolves`/`expect().rejects`.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 46] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 47] = [
     "consistent-test-it",
     "expect-expect",
     "max-expects",
@@ -83,6 +83,7 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 46] = [
     "require-top-level-describe",
     "valid-describe-callback",
     "valid-expect",
+    "valid-expect-in-promise",
     "valid-title",
 ];
 


### PR DESCRIPTION
Related to:
- https://github.com/oxc-project/oxc/issues/4656
- https://github.com/oxc-project/oxc/issues/492

# AI Disclosure
The code structure and architecture was done without AI assistance. Once the base was done, the code was made with Claude Code, reviewed, refactor to remove noised comments, duplicate code or explain better some functions.

# Summary
The OG rules implementation does a bottom to top iteration. The approach done here it's the opposite, iterate on jest nodes from top to bottom for the following reasons:
- Running only in jest nodes allow me to filter all nodes that aren't `it` or `test`, it save me to check every call expression if we are in a `test case scope`
- Any error found after a return statement, it have a diagnostic message to notify the promise is unreachable.

`valid_expect_in_promise.rs` shows 3839 added, but ~3400 lines of 3839 are the test cases. The test that depends on `globalAlias` are commented. 

# Info

Jest
- [Doc](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/valid-expect-in-promise.md)
- [Source Code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/valid-expect-in-promise.ts)
- [Test](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/__tests__/valid-expect.test.ts)

Vitest
- [Doc](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-expect-in-promise.md)
- [Source Code](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/src/rules/valid-expect-in-promise.ts)
- [Test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/tests/valid-expect-in-promise.test.ts)