### PR TITLE
feat(linter): add JSON/CSS linting infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1530,7 +1530,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2072,6 +2072,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "smallvec",
+ "spdx",
  "url",
 ]
 
@@ -2992,7 +2993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3087,7 +3088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3290,6 +3291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,7 +3386,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3856,7 +3866,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ simdutf8 = { version = "0.1.5", features = ["aarch64_neon"] } # SIMD UTF-8 valid
 similar = "2.7.0" # Text diffing
 similar-asserts = "1.7.0" # Test diff assertions
 smallvec = { version = "1.15.1", features = ["union", "serde"] } # Stack-allocated vectors
+spdx = "0.13.4" # SPDX expression and identifier validation
 tempfile = "3.24.0" # Temporary files
 tokio = { version = "1.49.0", default-features = false } # Async runtime
 toml = { version = "1.0.0" }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -73,6 +73,7 @@ serde_json = { workspace = true, features = [
 ] } # preserve_order: print config with ordered keys.
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
+spdx = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -636,7 +636,7 @@ mod test {
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT | LintPlugins::UNICORN));
         let config: Oxlintrc =
-            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue"] }"#).unwrap();
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue", "json", "css"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::all()));
 
         let config: Oxlintrc =

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -94,6 +94,10 @@ bitflags! {
         const NODE = 1 << 12;
         /// `eslint-plugin-vue`
         const VUE = 1 << 13;
+        /// JSON linting rules
+        const JSON = 1 << 14;
+        /// CSS linting rules
+        const CSS = 1 << 15;
     }
 }
 
@@ -158,6 +162,8 @@ impl TryFrom<&str> for LintPlugins {
             "promise" => Ok(LintPlugins::PROMISE),
             "node" => Ok(LintPlugins::NODE),
             "vue" => Ok(LintPlugins::VUE),
+            "json" => Ok(LintPlugins::JSON),
+            "css" => Ok(LintPlugins::CSS),
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
             "eslint" => Ok(LintPlugins::ESLINT),
@@ -183,6 +189,8 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::PROMISE => "promise",
             LintPlugins::NODE => "node",
             LintPlugins::VUE => "vue",
+            LintPlugins::JSON => "json",
+            LintPlugins::CSS => "css",
             _ => "",
         }
     }
@@ -254,6 +262,8 @@ impl JsonSchema for LintPlugins {
             Promise,
             Node,
             Vue,
+            Json,
+            Css,
         }
 
         let enum_schema = r#gen.subschema_for::<LintPluginOptionsSchema>();

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -150,6 +150,8 @@ pub struct ContextHost<'a> {
     pub(crate) fix: FixKind,
     /// Path to the file being linted.
     pub(super) file_path: Box<Path>,
+    /// Original full source text of the file being linted.
+    pub(super) full_source_text: &'a str,
     /// Extension of the file being linted.
     file_extension: Option<Box<OsStr>>,
     /// Global linter configuration, such as globals to include and the target
@@ -171,6 +173,7 @@ impl<'a> ContextHost<'a> {
     pub fn new<P: AsRef<Path>>(
         file_path: P,
         sub_hosts: Vec<ContextSubHost<'a>>,
+        full_source_text: &'a str,
         options: LintOptions,
         config: Arc<LintConfig>,
     ) -> Self {
@@ -190,6 +193,7 @@ impl<'a> ContextHost<'a> {
             diagnostics: RefCell::new(Vec::with_capacity(DIAGNOSTICS_INITIAL_CAPACITY)),
             fix: options.fix,
             file_path,
+            full_source_text,
             file_extension,
             config,
             frameworks: options.framework_hints,
@@ -252,6 +256,12 @@ impl<'a> ContextHost<'a> {
     #[inline]
     pub fn file_path(&self) -> &Path {
         &self.file_path
+    }
+
+    /// Original full source text of the file being linted.
+    #[inline]
+    pub fn full_source_text(&self) -> &'a str {
+        self.full_source_text
     }
 
     /// Extension of the file currently being linted, without the leading dot.
@@ -506,5 +516,41 @@ impl<'a> ContextHost<'a> {
 impl<'a> From<ContextHost<'a>> for Vec<Message> {
     fn from(ctx_host: ContextHost<'a>) -> Self {
         ctx_host.diagnostics.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{rc::Rc, sync::Arc};
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_semantic::SemanticBuilder;
+    use oxc_span::SourceType;
+
+    use super::{ContextHost, ContextSubHost};
+    use crate::{ModuleRecord, options::LintOptions};
+
+    #[test]
+    fn test_full_source_text_preserves_original_file_text() {
+        let allocator = Allocator::default();
+        let section_source = "const section = 1;";
+        let full_source = "header\nconst section = 1;\nfooter";
+
+        let parser_ret = Parser::new(&allocator, section_source, SourceType::default()).parse();
+        let program = allocator.alloc(parser_ret.program);
+        let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
+
+        let ctx = Rc::new(ContextHost::new(
+            "fixture.vue",
+            vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 7)],
+            full_source,
+            LintOptions::default(),
+            Arc::default(),
+        ))
+        .spawn_for_test();
+
+        assert_eq!(ctx.source_text(), section_source);
+        assert_eq!(ctx.full_source_text(), full_source);
     }
 }

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -133,6 +133,22 @@ impl<'a> LintContext<'a> {
         span.source_text(self.parent.semantic().source_text())
     }
 
+    /// Get a snippet of original file text covered by the given [`Span`].
+    #[inline]
+    pub fn full_source_range(&self, span: Span) -> &'a str {
+        span.source_text(self.parent.full_source_text())
+    }
+
+    /// Original full source text of the file currently being linted.
+    ///
+    /// This differs from the semantic source text for partial-loader files and
+    /// future non-JS file pipelines, where the parsed section may represent only
+    /// one part of the original file.
+    #[inline]
+    pub fn full_source_text(&self) -> &'a str {
+        self.parent.full_source_text()
+    }
+
     /// Finds the next occurrence of the given token in the source code,
     /// starting from the specified position, skipping over comments.
     #[expect(clippy::cast_possible_truncation)]

--- a/crates/oxc_linter/src/css_parser.rs
+++ b/crates/oxc_linter/src/css_parser.rs
@@ -1,0 +1,578 @@
+//! Lightweight span-preserving CSS parser for linting.
+//!
+//! Parses plain CSS into a tree of stylesheet nodes with exact source spans.
+//! Designed for lint rules, not for full CSS spec compliance. Handles:
+//! - Qualified rules (selector + declaration block)
+//! - At-rules (@media, @import, etc.)
+//! - Declarations (property: value)
+//! - Comments (/* ... */)
+
+use oxc_span::Span;
+
+// ── AST ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct CssStylesheet<'a> {
+    pub rules: Vec<CssRule<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum CssRule<'a> {
+    QualifiedRule(CssQualifiedRule<'a>),
+    AtRule(CssAtRule<'a>),
+    Comment(CssComment<'a>),
+}
+
+impl CssRule<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::QualifiedRule(r) => r.span,
+            Self::AtRule(r) => r.span,
+            Self::Comment(c) => c.span,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CssQualifiedRule<'a> {
+    /// The raw selector text (e.g., `.foo > bar`).
+    pub selector: &'a str,
+    pub selector_span: Span,
+    pub block: CssDeclarationBlock<'a>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssAtRule<'a> {
+    /// The at-rule name without `@` (e.g., `media`, `import`).
+    pub name: &'a str,
+    pub name_span: Span,
+    /// The prelude text between the name and `{` or `;`.
+    pub prelude: &'a str,
+    pub prelude_span: Span,
+    /// Body block, if present (at-rules like @import have no block).
+    pub block: Option<CssRuleBlock<'a>>,
+    pub span: Span,
+}
+
+/// A block that can contain nested rules (e.g., @media body).
+#[derive(Debug)]
+pub struct CssRuleBlock<'a> {
+    pub rules: Vec<CssRule<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssDeclarationBlock<'a> {
+    pub declarations: Vec<CssDeclaration<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssDeclaration<'a> {
+    pub property: &'a str,
+    pub property_span: Span,
+    pub value: &'a str,
+    pub value_span: Span,
+    pub important: bool,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssComment<'a> {
+    pub text: &'a str,
+    pub span: Span,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct CssParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct CssParseResult<'a> {
+    pub stylesheet: Option<CssStylesheet<'a>>,
+    pub errors: Vec<CssParseError>,
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+pub fn parse_css(source: &str) -> CssParseResult<'_> {
+    let mut parser = Parser::new(source);
+    let rules = parser.parse_rule_list();
+    let span = Span::new(0, source.len() as u32);
+    CssParseResult { stylesheet: Some(CssStylesheet { rules, span }), errors: parser.errors }
+}
+
+struct Parser<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    errors: Vec<CssParseError>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source, bytes: source.as_bytes(), pos: 0, errors: Vec::new() }
+    }
+
+    fn parse_rule_list(&mut self) -> Vec<CssRule<'a>> {
+        let mut rules = Vec::new();
+        loop {
+            self.skip_whitespace();
+            if self.pos >= self.bytes.len() {
+                break;
+            }
+            // Stop if we hit a closing brace (end of containing block)
+            if self.peek() == Some(b'}') {
+                break;
+            }
+            let before = self.pos;
+            if let Some(rule) = self.parse_rule() {
+                rules.push(rule);
+            } else if self.pos == before {
+                // No progress — skip one byte to avoid infinite loop
+                self.pos += 1;
+            }
+        }
+        rules
+    }
+
+    fn parse_rule(&mut self) -> Option<CssRule<'a>> {
+        self.skip_whitespace();
+        if self.pos >= self.bytes.len() {
+            return None;
+        }
+
+        // Comment
+        if self.starts_with(b"/*") {
+            return self.parse_comment().map(CssRule::Comment);
+        }
+
+        // At-rule
+        if self.peek() == Some(b'@') {
+            return self.parse_at_rule().map(CssRule::AtRule);
+        }
+
+        // Closing brace (end of nested block)
+        if self.peek() == Some(b'}') {
+            return None;
+        }
+
+        // Qualified rule
+        self.parse_qualified_rule().map(CssRule::QualifiedRule)
+    }
+
+    fn parse_comment(&mut self) -> Option<CssComment<'a>> {
+        let start = self.pos;
+        self.pos += 2; // skip /*
+        let text_start = self.pos;
+        loop {
+            if self.pos + 1 >= self.bytes.len() {
+                self.errors.push(CssParseError {
+                    message: "Unterminated comment".to_string(),
+                    span: Span::new(start as u32, self.bytes.len() as u32),
+                });
+                let text = &self.source[text_start..self.bytes.len()];
+                self.pos = self.bytes.len();
+                return Some(CssComment {
+                    text,
+                    span: Span::new(start as u32, self.bytes.len() as u32),
+                });
+            }
+            if self.bytes[self.pos] == b'*' && self.bytes[self.pos + 1] == b'/' {
+                let text = &self.source[text_start..self.pos];
+                self.pos += 2; // skip */
+                return Some(CssComment { text, span: Span::new(start as u32, self.pos as u32) });
+            }
+            self.pos += 1;
+        }
+    }
+
+    fn parse_at_rule(&mut self) -> Option<CssAtRule<'a>> {
+        let start = self.pos;
+        self.pos += 1; // skip @
+
+        // Parse name
+        let name_start = self.pos;
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_alphanumeric()
+            || self.pos < self.bytes.len() && self.bytes[self.pos] == b'-'
+        {
+            self.pos += 1;
+        }
+        let name = &self.source[name_start..self.pos];
+        let name_span = Span::new((start) as u32, self.pos as u32); // includes @
+
+        // Parse prelude (everything until { or ;)
+        self.skip_whitespace();
+        let prelude_start = self.pos;
+        let mut depth = 0u32;
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b'{' if depth == 0 => break,
+                b';' if depth == 0 => break,
+                b'(' => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                b')' => {
+                    depth = depth.saturating_sub(1);
+                    self.pos += 1;
+                }
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let prelude_end = self.pos;
+        let prelude = self.source[prelude_start..prelude_end].trim();
+        let prelude_span = Span::new(prelude_start as u32, prelude_end as u32);
+
+        if self.pos >= self.bytes.len() {
+            return Some(CssAtRule {
+                name,
+                name_span,
+                prelude,
+                prelude_span,
+                block: None,
+                span: Span::new(start as u32, self.pos as u32),
+            });
+        }
+
+        // Semicolon-terminated at-rule (e.g., @import)
+        if self.bytes[self.pos] == b';' {
+            self.pos += 1;
+            return Some(CssAtRule {
+                name,
+                name_span,
+                prelude,
+                prelude_span,
+                block: None,
+                span: Span::new(start as u32, self.pos as u32),
+            });
+        }
+
+        // Block at-rule (e.g., @media)
+        let block = self.parse_rule_block();
+        Some(CssAtRule {
+            name,
+            name_span,
+            prelude,
+            prelude_span,
+            block: Some(block),
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn parse_rule_block(&mut self) -> CssRuleBlock<'a> {
+        let block_start = self.pos;
+        self.pos += 1; // skip {
+        let rules = self.parse_rule_list();
+        self.skip_whitespace();
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b'}' {
+            self.pos += 1;
+        }
+        CssRuleBlock { rules, span: Span::new(block_start as u32, self.pos as u32) }
+    }
+
+    fn parse_qualified_rule(&mut self) -> Option<CssQualifiedRule<'a>> {
+        let start = self.pos;
+
+        // Parse selector (everything until {)
+        let selector_start = self.pos;
+        while self.pos < self.bytes.len() && self.bytes[self.pos] != b'{' {
+            match self.bytes[self.pos] {
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let selector_end = self.pos;
+        let selector = self.source[selector_start..selector_end].trim();
+        let selector_span = Span::new(selector_start as u32, selector_end as u32);
+
+        if self.pos >= self.bytes.len() {
+            self.errors.push(CssParseError {
+                message: "Expected '{' after selector".to_string(),
+                span: Span::new(start as u32, self.pos as u32),
+            });
+            return None;
+        }
+
+        let block = self.parse_declaration_block();
+
+        Some(CssQualifiedRule {
+            selector,
+            selector_span,
+            block,
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn parse_declaration_block(&mut self) -> CssDeclarationBlock<'a> {
+        let block_start = self.pos;
+        self.pos += 1; // skip {
+        let mut declarations = Vec::new();
+
+        loop {
+            self.skip_whitespace();
+            if self.pos >= self.bytes.len() || self.bytes[self.pos] == b'}' {
+                break;
+            }
+
+            // Skip comments inside blocks
+            if self.starts_with(b"/*") {
+                self.parse_comment();
+                continue;
+            }
+
+            if let Some(decl) = self.parse_declaration() {
+                declarations.push(decl);
+            }
+        }
+
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b'}' {
+            self.pos += 1;
+        }
+
+        CssDeclarationBlock { declarations, span: Span::new(block_start as u32, self.pos as u32) }
+    }
+
+    fn parse_declaration(&mut self) -> Option<CssDeclaration<'a>> {
+        let start = self.pos;
+
+        // Parse property name
+        let prop_start = self.pos;
+        while self.pos < self.bytes.len()
+            && self.bytes[self.pos] != b':'
+            && self.bytes[self.pos] != b'}'
+            && self.bytes[self.pos] != b';'
+        {
+            self.pos += 1;
+        }
+        let property = self.source[prop_start..self.pos].trim();
+        let property_span = Span::new(prop_start as u32, self.pos as u32);
+
+        if property.is_empty() || self.pos >= self.bytes.len() || self.bytes[self.pos] != b':' {
+            // Not a valid declaration — skip to next ; or }
+            while self.pos < self.bytes.len()
+                && self.bytes[self.pos] != b';'
+                && self.bytes[self.pos] != b'}'
+            {
+                self.pos += 1;
+            }
+            if self.pos < self.bytes.len() && self.bytes[self.pos] == b';' {
+                self.pos += 1;
+            }
+            return None;
+        }
+
+        self.pos += 1; // skip :
+        self.skip_whitespace();
+
+        // Parse value (everything until ; or })
+        let value_start = self.pos;
+        let mut depth = 0u32;
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b';' if depth == 0 => break,
+                b'}' if depth == 0 => break,
+                b'(' => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                b')' => {
+                    depth = depth.saturating_sub(1);
+                    self.pos += 1;
+                }
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let value_end = self.pos;
+        let raw_value = self.source[value_start..value_end].trim();
+        let value_span = Span::new(value_start as u32, value_end as u32);
+
+        let important = raw_value.ends_with("!important") || raw_value.ends_with("! important");
+        let value = if important {
+            raw_value.trim_end_matches("!important").trim_end_matches("! important").trim()
+        } else {
+            raw_value
+        };
+
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b';' {
+            self.pos += 1;
+        }
+
+        Some(CssDeclaration {
+            property,
+            property_span,
+            value,
+            value_span,
+            important,
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn skip_string(&mut self) {
+        let quote = self.bytes[self.pos];
+        self.pos += 1;
+        while self.pos < self.bytes.len() {
+            if self.bytes[self.pos] == b'\\' {
+                self.pos += 2;
+                continue;
+            }
+            if self.bytes[self.pos] == quote {
+                self.pos += 1;
+                return;
+            }
+            self.pos += 1;
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn starts_with(&self, prefix: &[u8]) -> bool {
+        self.bytes[self.pos..].starts_with(prefix)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_rule() {
+        let css = "body { color: red; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        assert_eq!(sheet.rules.len(), 1);
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.selector, "body");
+            assert_eq!(rule.block.declarations.len(), 1);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[0].value, "red");
+            assert!(!rule.block.declarations[0].important);
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_important() {
+        let css = ".x { color: red !important; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations[0].value, "red");
+            assert!(rule.block.declarations[0].important);
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_multiple_declarations() {
+        let css = "h1 { color: blue; font-size: 16px; margin: 0; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations.len(), 3);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[1].property, "font-size");
+            assert_eq!(rule.block.declarations[2].property, "margin");
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_at_rule_import() {
+        let css = "@import url('styles.css');";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::AtRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.name, "import");
+            assert!(rule.prelude.contains("styles.css"));
+            assert!(rule.block.is_none());
+        } else {
+            panic!("Expected at-rule");
+        }
+    }
+
+    #[test]
+    fn parse_at_rule_media() {
+        let css = "@media (max-width: 768px) { body { color: red; } }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::AtRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.name, "media");
+            assert!(rule.block.is_some());
+            let block = rule.block.as_ref().unwrap();
+            assert_eq!(block.rules.len(), 1);
+        } else {
+            panic!("Expected at-rule");
+        }
+    }
+
+    #[test]
+    fn parse_comment() {
+        let css = "/* hello */ body { color: red; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        assert_eq!(sheet.rules.len(), 2);
+        if let CssRule::Comment(c) = &sheet.rules[0] {
+            assert_eq!(c.text, " hello ");
+        } else {
+            panic!("Expected comment");
+        }
+    }
+
+    #[test]
+    fn parse_duplicate_properties() {
+        let css = ".a { color: red; color: blue; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations.len(), 2);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[1].property, "color");
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_empty_block() {
+        let css = ".empty { }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert!(rule.block.declarations.is_empty());
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+}

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -75,6 +75,12 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self.ctx.source_range(span)
     }
 
+    /// Get a snippet of original file text covered by the given [`Span`].
+    #[inline]
+    pub fn full_source_range(&self, span: Span) -> &'a str {
+        self.ctx.full_source_range(span)
+    }
+
     /// Create a [`RuleFix`] that deletes the text covered by the given [`Span`]
     /// or AST node.
     #[inline]
@@ -125,6 +131,30 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
             fixer.new_fix(CompositeFix::Single(fix), message)
         }
+        inner(self, target, replacement.into())
+    }
+
+    /// Replace a span in the original full file text.
+    pub fn replace_full_source_range<S: Into<Cow<'static, str>>>(
+        &self,
+        target: Span,
+        replacement: S,
+    ) -> RuleFix {
+        fn inner(
+            fixer: &RuleFixer<'_, '_>,
+            target: Span,
+            replacement: Cow<'static, str>,
+        ) -> RuleFix {
+            let fix = Fix::new(replacement, target);
+            let target_text = fixer.possibly_truncate_full_source_range(target);
+            let content = fixer.possibly_truncate_snippet(&fix.content);
+            let message = fixer.auto_message.then(|| {
+                Cow::Owned(format_replace_message(target_text.as_ref(), content.as_ref()))
+            });
+
+            fixer.new_fix(CompositeFix::Single(fix), message)
+        }
+
         inner(self, target, replacement.into())
     }
 
@@ -203,6 +233,11 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
     fn possibly_truncate_range(&self, span: Span) -> Cow<'a, str> {
         let snippet = self.ctx.source_range(span);
+        self.possibly_truncate_snippet(snippet)
+    }
+
+    fn possibly_truncate_full_source_range(&self, span: Span) -> Cow<'a, str> {
+        let snippet = self.ctx.full_source_range(span);
         self.possibly_truncate_snippet(snippet)
     }
 

--- a/crates/oxc_linter/src/json_parser.rs
+++ b/crates/oxc_linter/src/json_parser.rs
@@ -1,0 +1,544 @@
+//! Lightweight span-preserving JSON parser for linting.
+//!
+//! Unlike `serde_json`, this parser preserves the exact source spans for every
+//! key, value, property, object, and array in the JSON document. This enables
+//! precise diagnostics and autofixes for JSON lint rules.
+
+use oxc_span::Span;
+
+// ── AST ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum JsonValue<'a> {
+    Object(JsonObject<'a>),
+    Array(JsonArray<'a>),
+    /// (unescaped value, span of the full quoted string including quotes)
+    String(&'a str, Span),
+    /// (raw text, span)
+    Number(&'a str, Span),
+    Boolean(bool, Span),
+    Null(Span),
+}
+
+impl JsonValue<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Object(obj) => obj.span,
+            Self::Array(arr) => arr.span,
+            Self::String(_, span)
+            | Self::Number(_, span)
+            | Self::Boolean(_, span)
+            | Self::Null(span) => *span,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&JsonObject<'_>> {
+        if let Self::Object(obj) = self { Some(obj) } else { None }
+    }
+
+    pub fn as_array(&self) -> Option<&JsonArray<'_>> {
+        if let Self::Array(arr) = self { Some(arr) } else { None }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        if let Self::String(s, _) = self { Some(s) } else { None }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        if let Self::Boolean(b, _) = self { Some(*b) } else { None }
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonProperty<'a> {
+    /// The key string (without quotes).
+    pub key: &'a str,
+    /// Span of the full quoted key including quotes.
+    pub key_span: Span,
+    /// The value.
+    pub value: JsonValue<'a>,
+    /// Full span from key start to value end.
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct JsonObject<'a> {
+    pub properties: Vec<JsonProperty<'a>>,
+    pub span: Span,
+}
+
+impl<'a> JsonObject<'a> {
+    pub fn get(&self, key: &str) -> Option<&JsonValue<'a>> {
+        self.properties.iter().find(|p| p.key == key).map(|p| &p.value)
+    }
+
+    pub fn get_property(&self, key: &str) -> Option<&JsonProperty<'a>> {
+        self.properties.iter().find(|p| p.key == key)
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonArray<'a> {
+    pub elements: Vec<JsonValue<'a>>,
+    pub span: Span,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct JsonParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct JsonParseResult<'a> {
+    pub root: Option<JsonValue<'a>>,
+    pub errors: Vec<JsonParseError>,
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+pub fn parse_json(source: &str) -> JsonParseResult<'_> {
+    let mut parser = Parser::new(source);
+    let root = parser.parse_value();
+    parser.skip_whitespace();
+    if parser.pos < parser.source.len() && parser.errors.is_empty() {
+        parser.errors.push(JsonParseError {
+            message: "Unexpected content after JSON value".to_string(),
+            span: Span::new(parser.pos as u32, (parser.pos + 1) as u32),
+        });
+    }
+    JsonParseResult { root, errors: parser.errors }
+}
+
+struct Parser<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    errors: Vec<JsonParseError>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source, bytes: source.as_bytes(), pos: 0, errors: Vec::new() }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b' ' | b'\t' | b'\n' | b'\r' => self.pos += 1,
+                _ => break,
+            }
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let b = self.bytes.get(self.pos).copied()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn expect(&mut self, expected: u8) -> bool {
+        if self.peek() == Some(expected) {
+            self.pos += 1;
+            true
+        } else {
+            self.errors.push(JsonParseError {
+                message: format!(
+                    "Expected '{}', found {}",
+                    expected as char,
+                    self.peek().map_or("end of input".to_string(), |b| format!("'{}'", b as char))
+                ),
+                span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+            });
+            false
+        }
+    }
+
+    fn parse_value(&mut self) -> Option<JsonValue<'a>> {
+        self.skip_whitespace();
+        match self.peek()? {
+            b'{' => self.parse_object().map(JsonValue::Object),
+            b'[' => self.parse_array().map(JsonValue::Array),
+            b'"' => self.parse_string().map(|(s, span)| JsonValue::String(s, span)),
+            b't' | b'f' => self.parse_boolean(),
+            b'n' => self.parse_null(),
+            b'-' | b'0'..=b'9' => self.parse_number(),
+            c => {
+                self.errors.push(JsonParseError {
+                    message: format!("Unexpected character '{}'", c as char),
+                    span: Span::new(self.pos as u32, (self.pos + 1) as u32),
+                });
+                None
+            }
+        }
+    }
+
+    fn parse_object(&mut self) -> Option<JsonObject<'a>> {
+        let start = self.pos;
+        self.advance(); // skip '{'
+        self.skip_whitespace();
+
+        let mut properties = Vec::new();
+
+        if self.peek() == Some(b'}') {
+            self.advance();
+            return Some(JsonObject { properties, span: Span::new(start as u32, self.pos as u32) });
+        }
+
+        loop {
+            self.skip_whitespace();
+            let prop_start = self.pos;
+
+            // Parse key
+            if self.peek() != Some(b'"') {
+                self.errors.push(JsonParseError {
+                    message: "Expected string key".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            let (key, key_span) = self.parse_string()?;
+
+            self.skip_whitespace();
+            if !self.expect(b':') {
+                return None;
+            }
+
+            // Parse value
+            let value = self.parse_value()?;
+            let prop_end = self.pos;
+
+            properties.push(JsonProperty {
+                key,
+                key_span,
+                span: Span::new(prop_start as u32, prop_end as u32),
+                value,
+            });
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b'}') => {
+                    self.advance();
+                    break;
+                }
+                _ => {
+                    self.errors.push(JsonParseError {
+                        message: "Expected ',' or '}'".to_string(),
+                        span: Span::new(
+                            self.pos as u32,
+                            (self.pos + 1).min(self.source.len()) as u32,
+                        ),
+                    });
+                    return None;
+                }
+            }
+        }
+
+        Some(JsonObject { properties, span: Span::new(start as u32, self.pos as u32) })
+    }
+
+    fn parse_array(&mut self) -> Option<JsonArray<'a>> {
+        let start = self.pos;
+        self.advance(); // skip '['
+        self.skip_whitespace();
+
+        let mut elements = Vec::new();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Some(JsonArray { elements, span: Span::new(start as u32, self.pos as u32) });
+        }
+
+        loop {
+            let value = self.parse_value()?;
+            elements.push(value);
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b']') => {
+                    self.advance();
+                    break;
+                }
+                _ => {
+                    self.errors.push(JsonParseError {
+                        message: "Expected ',' or ']'".to_string(),
+                        span: Span::new(
+                            self.pos as u32,
+                            (self.pos + 1).min(self.source.len()) as u32,
+                        ),
+                    });
+                    return None;
+                }
+            }
+        }
+
+        Some(JsonArray { elements, span: Span::new(start as u32, self.pos as u32) })
+    }
+
+    fn parse_string(&mut self) -> Option<(&'a str, Span)> {
+        let start = self.pos;
+        self.advance(); // skip opening '"'
+
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b'"' => {
+                    let value = &self.source[start + 1..self.pos];
+                    self.pos += 1; // skip closing '"'
+                    let span = Span::new(start as u32, self.pos as u32);
+                    return Some((value, span));
+                }
+                b'\\' => {
+                    self.pos += 1; // skip backslash
+                    if self.pos < self.bytes.len() {
+                        // Skip the escaped character
+                        if self.bytes[self.pos] == b'u' {
+                            // \uXXXX — skip 4 hex digits
+                            self.pos += 1;
+                            for _ in 0..4 {
+                                if self.pos < self.bytes.len() {
+                                    self.pos += 1;
+                                }
+                            }
+                        } else {
+                            self.pos += 1;
+                        }
+                    }
+                }
+                _ => {
+                    self.pos += 1;
+                }
+            }
+        }
+
+        self.errors.push(JsonParseError {
+            message: "Unterminated string".to_string(),
+            span: Span::new(start as u32, self.source.len() as u32),
+        });
+        None
+    }
+
+    fn parse_number(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+
+        if self.peek() == Some(b'-') {
+            self.advance();
+        }
+
+        // Integer part
+        match self.peek() {
+            Some(b'0') => {
+                self.advance();
+            }
+            Some(b'1'..=b'9') => {
+                self.advance();
+                while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                    self.pos += 1;
+                }
+            }
+            _ => {
+                self.errors.push(JsonParseError {
+                    message: "Invalid number".to_string(),
+                    span: Span::new(start as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+        }
+
+        // Fraction
+        if self.peek() == Some(b'.') {
+            self.advance();
+            if !self.peek().is_some_and(|b| b.is_ascii_digit()) {
+                self.errors.push(JsonParseError {
+                    message: "Expected digit after decimal point".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+
+        // Exponent
+        if self.peek().is_some_and(|b| b == b'e' || b == b'E') {
+            self.advance();
+            if self.peek().is_some_and(|b| b == b'+' || b == b'-') {
+                self.advance();
+            }
+            if !self.peek().is_some_and(|b| b.is_ascii_digit()) {
+                self.errors.push(JsonParseError {
+                    message: "Expected digit in exponent".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+
+        let raw = &self.source[start..self.pos];
+        let span = Span::new(start as u32, self.pos as u32);
+        Some(JsonValue::Number(raw, span))
+    }
+
+    fn parse_boolean(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+        if self.source[self.pos..].starts_with("true") {
+            self.pos += 4;
+            Some(JsonValue::Boolean(true, Span::new(start as u32, self.pos as u32)))
+        } else if self.source[self.pos..].starts_with("false") {
+            self.pos += 5;
+            Some(JsonValue::Boolean(false, Span::new(start as u32, self.pos as u32)))
+        } else {
+            self.errors.push(JsonParseError {
+                message: "Invalid boolean".to_string(),
+                span: Span::new(start as u32, (start + 1) as u32),
+            });
+            None
+        }
+    }
+
+    fn parse_null(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+        if self.source[self.pos..].starts_with("null") {
+            self.pos += 4;
+            Some(JsonValue::Null(Span::new(start as u32, self.pos as u32)))
+        } else {
+            self.errors.push(JsonParseError {
+                message: "Invalid null".to_string(),
+                span: Span::new(start as u32, (start + 1) as u32),
+            });
+            None
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_object() {
+        let result = parse_json("{}");
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert!(obj.properties.is_empty());
+        assert_eq!(obj.span, Span::new(0, 2));
+    }
+
+    #[test]
+    fn test_simple_object() {
+        let src = r#"{"name": "test", "version": 1}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.properties.len(), 2);
+        assert_eq!(obj.properties[0].key, "name");
+        assert_eq!(obj.properties[0].key_span, Span::new(1, 7)); // "name"
+        assert_eq!(obj.properties[0].value.as_str(), Some("test"));
+        assert_eq!(obj.properties[1].key, "version");
+    }
+
+    #[test]
+    fn test_nested_object() {
+        let src = r#"{"a": {"b": true}}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let outer = root.as_object().unwrap();
+        let inner = outer.properties[0].value.as_object().unwrap();
+        assert_eq!(inner.properties[0].key, "b");
+        assert_eq!(inner.properties[0].value.as_bool(), Some(true));
+    }
+
+    #[test]
+    fn test_array() {
+        let src = r#"[1, "two", true, null]"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let arr = root.as_array().unwrap();
+        assert_eq!(arr.elements.len(), 4);
+    }
+
+    #[test]
+    fn test_number_spans() {
+        let src = "42";
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        if let JsonValue::Number(raw, span) = result.root.unwrap() {
+            assert_eq!(raw, "42");
+            assert_eq!(span, Span::new(0, 2));
+        } else {
+            panic!("expected number");
+        }
+    }
+
+    #[test]
+    fn test_string_with_escapes() {
+        let src = r#""hello \"world\"""#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let result = parse_json("{invalid}");
+        assert!(!result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_keys() {
+        let src = r#"{"a": 1, "a": 2}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty()); // parser allows duplicate keys
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.properties.len(), 2);
+        assert_eq!(obj.properties[0].key, "a");
+        assert_eq!(obj.properties[1].key, "a");
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let result = parse_json("");
+        assert!(result.root.is_none());
+    }
+
+    #[test]
+    fn test_whitespace_only() {
+        let result = parse_json("  \n\t  ");
+        assert!(result.root.is_none());
+    }
+
+    #[test]
+    fn test_negative_number() {
+        let result = parse_json("-3.14e2");
+        assert!(result.errors.is_empty());
+        if let JsonValue::Number(raw, span) = result.root.unwrap() {
+            assert_eq!(raw, "-3.14e2");
+            assert_eq!(span, Span::new(0, 7));
+        } else {
+            panic!("expected number");
+        }
+    }
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -31,12 +31,14 @@ use oxc_span::Span;
 mod ast_util;
 mod config;
 mod context;
+pub mod css_parser;
 mod disable_directives;
 mod external_linter;
 mod external_plugin_store;
 mod fixer;
 mod frameworks;
 mod globals;
+pub mod json_parser;
 mod module_graph_visitor;
 mod module_record;
 mod options;
@@ -192,9 +194,34 @@ impl Linter {
         allocator: &'a Allocator,
         js_allocator_pool: Option<&AllocatorPool>,
     ) -> (Vec<Message>, Option<DisableDirectives>) {
+        let full_source_text =
+            context_sub_hosts.first().map_or("", |sub_host| sub_host.semantic().source_text());
+        self.run_with_full_source_text_and_disable_directives(
+            path,
+            context_sub_hosts,
+            full_source_text,
+            allocator,
+            js_allocator_pool,
+        )
+    }
+
+    pub(crate) fn run_with_full_source_text_and_disable_directives<'a>(
+        &self,
+        path: &Path,
+        context_sub_hosts: Vec<ContextSubHost<'a>>,
+        full_source_text: &'a str,
+        allocator: &'a Allocator,
+        js_allocator_pool: Option<&AllocatorPool>,
+    ) -> (Vec<Message>, Option<DisableDirectives>) {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
 
-        let mut ctx_host = Rc::new(ContextHost::new(path, context_sub_hosts, self.options, config));
+        let mut ctx_host = Rc::new(ContextHost::new(
+            path,
+            context_sub_hosts,
+            full_source_text,
+            self.options,
+            config,
+        ));
 
         #[cfg(debug_assertions)]
         let mut current_diagnostic_index = 0;
@@ -202,12 +229,18 @@ impl Linter {
         let is_partial_loader_file = ctx_host
             .file_extension()
             .is_some_and(|ext| LINT_PARTIAL_LOADER_EXTENSIONS.iter().any(|e| e == &ext));
+        let is_json_file =
+            ctx_host.file_extension().is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
 
         loop {
             let semantic = ctx_host.semantic();
             let rules = rules
                 .iter()
                 .filter(|(rule, _)| {
+                    if is_json_file && rule.plugin_name() != "oxc" {
+                        return false;
+                    }
+
                     if rule.is_tsgolint_rule() {
                         return false;
                     }
@@ -249,16 +282,35 @@ impl Linter {
                 //
                 // See https://github.com/oxc-project/oxc/pull/6600 for more context.
                 if semantic.nodes().len() > 200_000 {
-                    // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
-                    // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
-                    // compile-time since we know all of the rules and their AST node type information ahead of time.
+                    // Pre-compute the number of rules that map to each AST type so we can
+                    // allocate buckets with the right capacity and avoid reallocs.
                     //
                     // Use boxed array to help compiler see that indexing into it with an `AstType`
                     // cannot go out of bounds, and remove bounds checks.
+                    let mut counts = boxed_array![0usize; AST_TYPE_MAX as usize + 1];
+                    let mut any_count = 0usize;
+                    for (rule, _) in &rules {
+                        let rule = *rule;
+                        let run_info = rule.run_info();
+                        if with_runtime_optimization
+                            && let Some(ast_types) = rule.types_info()
+                            && run_info.is_run_implemented()
+                        {
+                            for ty in ast_types {
+                                counts[ty as usize] += 1;
+                            }
+                        } else {
+                            any_count += 1;
+                        }
+                    }
+
                     let mut rules_by_ast_type = boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
-                    // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
-                    // node types, but it at least guarantees we won't need to realloc.
-                    let mut rules_any_ast_type = Vec::with_capacity(rules.len());
+                    for (i, count) in counts.iter().enumerate() {
+                        if *count > 0 {
+                            rules_by_ast_type[i] = Vec::with_capacity(*count);
+                        }
+                    }
+                    let mut rules_any_ast_type = Vec::with_capacity(any_count);
 
                     for (rule, ctx) in &rules {
                         let rule = *rule;

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -1,5 +1,5 @@
 use memchr::{memmem::Finder, memmem::FinderRev};
-use oxc_span::VALID_EXTENSIONS;
+use oxc_span::{SourceType, VALID_EXTENSIONS};
 
 use crate::loader::JavaScriptSource;
 
@@ -15,9 +15,12 @@ const SCRIPT_END: &str = "</script>";
 const COMMENT_START: &str = "<!--";
 const COMMENT_END: &str = "-->";
 
-/// File extensions that can contain JS/TS code in certain parts, such as in `<script>` tags, and can
-/// be loaded using the [`PartialLoader`].
-pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte"];
+/// File extensions that require special loading beyond direct JS/TS parsing.
+///
+/// Some contain embedded script sections (`.vue`, `.astro`, `.svelte`), while
+/// others use non-JS raw-file rules backed by a placeholder semantic section
+/// (`.json`).
+pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte", "json", "css"];
 
 /// All valid JavaScript/TypeScript extensions, plus additional framework files that
 /// contain JavaScript/TypeScript code in them (e.g., Vue, Astro, Svelte, etc.).
@@ -34,6 +37,8 @@ impl PartialLoader {
             "vue" => Some(VuePartialLoader::new(source_text).parse()),
             "astro" => Some(AstroPartialLoader::new(source_text).parse()),
             "svelte" => Some(SveltePartialLoader::new(source_text).parse()),
+            "json" => Some(vec![JavaScriptSource::partial("", SourceType::default(), 0)]),
+            "css" => Some(vec![JavaScriptSource::partial("", SourceType::default(), 0)]),
             _ => None,
         }
     }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -725,7 +725,7 @@ impl Runtime {
                 None,
                 |me, mut module_to_lint| {
                     module_to_lint.content.with_dependent_mut(
-                    |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
+                    |allocator_guard, ModuleContentDependent { source_text, section_contents }| {
                         assert_eq!(
                             module_to_lint.section_module_records.len(),
                             section_contents.len()
@@ -766,7 +766,13 @@ impl Runtime {
 
                         let (section_messages, disable_directives) = me
                             .linter
-                            .run_with_disable_directives(path, context_sub_hosts, allocator_guard, me.js_allocator_pool());
+                            .run_with_full_source_text_and_disable_directives(
+                                path,
+                                context_sub_hosts,
+                                source_text,
+                                allocator_guard,
+                                me.js_allocator_pool(),
+                            );
 
                         if let Some(disable_directives) = disable_directives {
                             me.disable_directives_map
@@ -804,7 +810,7 @@ impl Runtime {
         rayon::scope(|scope| {
             self.resolve_modules(file_system, &paths_set, scope, check_syntax_errors, Some(tx_error), |me, mut module| {
                 module.content.with_dependent_mut(
-                    |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
+                    |allocator_guard, ModuleContentDependent { source_text, section_contents }| {
                         assert_eq!(module.section_module_records.len(), section_contents.len());
 
                         let context_sub_hosts: Vec<ContextSubHost<'_>> = module
@@ -839,12 +845,15 @@ impl Runtime {
                         }
 
                         messages.lock().unwrap().extend(
-                            me.linter.run(
-                                Path::new(&module.path),
-                                context_sub_hosts,
-                                allocator_guard
-                            )
-                            ,
+                            me.linter
+                                .run_with_full_source_text_and_disable_directives(
+                                    Path::new(&module.path),
+                                    context_sub_hosts,
+                                    source_text,
+                                    allocator_guard,
+                                    None,
+                                )
+                                .0,
                         );
                     },
                 );

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -337,6 +337,7 @@ mod test {
             Rc::new(ContextHost::new(
                 path,
                 vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 0)],
+                "",
                 LintOptions::default(),
                 Arc::default(),
             ))


### PR DESCRIPTION
## Summary

Add foundational infrastructure for linting JSON and CSS files:

- **Context API**: Add `full_source_text()` to `LintContext` and `ContextHost` for rules that need access to original file content (Vue, Astro, JSON, CSS)
- **Fixer API**: Add `full_source_range()` and `replace_full_source_range()` to `RuleFixer`
- **Linter runtime**: Add `run_with_full_source_text_and_disable_directives()`
- **JSON parser** (544 lines): Span-preserving JSON parser for precise diagnostics
- **CSS parser** (578 lines): Span-preserving CSS parser for precise diagnostics
- **Partial loader**: Extend to support `.json` and `.css` file extensions
- **Plugin flags**: Add `JSON` and `CSS` to `LintPlugins`
- **Dependency**: Add `spdx` crate for SPDX license validation

This PR contains no new rules — it provides the infrastructure that subsequent PRs will use to add JSON, CSS, and package.json validation rules.

## Test plan

- [x] `cargo test -p oxc_linter` — all tests pass (including new context and parser tests)
- [x] `just fmt` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)