### PR TITLE
feat(linter): add security detection rules

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3923,6 +3923,91 @@ impl RuleRunner for crate::rules::oxc::uninvoked_array_callback::UninvokedArrayC
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::oxc::depend_ban_dependencies::DependBanDependencies {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ImportDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_buffer_noassert::DetectBufferNoassert {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_child_process::DetectChildProcess {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_disable_mustache_escape::DetectDisableMustacheEscape {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ObjectProperty]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_eval_with_expression::DetectEvalWithExpression {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_new_buffer::DetectNewBuffer {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::oxc::detect_no_csrf_before_method_override::DetectNoCsrfBeforeMethodOverride
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_non_literal_fs_filename::DetectNonLiteralFsFilename {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_non_literal_regexp::DetectNonLiteralRegexp {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_non_literal_require::DetectNonLiteralRequire {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_object_injection::DetectObjectInjection {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ComputedMemberExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_possible_timing_attacks::DetectPossibleTimingAttacks {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_pseudo_random_bytes::DetectPseudoRandomBytes {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::detect_unsafe_regex::DetectUnsafeRegex {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NewExpression, AstType::RegExpLiteral]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::nextjs::google_font_display::GoogleFontDisplay {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -353,6 +353,20 @@ pub use crate::rules::oxc::bad_object_literal_comparison::BadObjectLiteralCompar
 pub use crate::rules::oxc::bad_replace_all_arg::BadReplaceAllArg as OxcBadReplaceAllArg;
 pub use crate::rules::oxc::branches_sharing_code::BranchesSharingCode as OxcBranchesSharingCode;
 pub use crate::rules::oxc::const_comparisons::ConstComparisons as OxcConstComparisons;
+pub use crate::rules::oxc::depend_ban_dependencies::DependBanDependencies as OxcDependBanDependencies;
+pub use crate::rules::oxc::detect_buffer_noassert::DetectBufferNoassert as OxcDetectBufferNoassert;
+pub use crate::rules::oxc::detect_child_process::DetectChildProcess as OxcDetectChildProcess;
+pub use crate::rules::oxc::detect_disable_mustache_escape::DetectDisableMustacheEscape as OxcDetectDisableMustacheEscape;
+pub use crate::rules::oxc::detect_eval_with_expression::DetectEvalWithExpression as OxcDetectEvalWithExpression;
+pub use crate::rules::oxc::detect_new_buffer::DetectNewBuffer as OxcDetectNewBuffer;
+pub use crate::rules::oxc::detect_no_csrf_before_method_override::DetectNoCsrfBeforeMethodOverride as OxcDetectNoCsrfBeforeMethodOverride;
+pub use crate::rules::oxc::detect_non_literal_fs_filename::DetectNonLiteralFsFilename as OxcDetectNonLiteralFsFilename;
+pub use crate::rules::oxc::detect_non_literal_regexp::DetectNonLiteralRegexp as OxcDetectNonLiteralRegexp;
+pub use crate::rules::oxc::detect_non_literal_require::DetectNonLiteralRequire as OxcDetectNonLiteralRequire;
+pub use crate::rules::oxc::detect_object_injection::DetectObjectInjection as OxcDetectObjectInjection;
+pub use crate::rules::oxc::detect_possible_timing_attacks::DetectPossibleTimingAttacks as OxcDetectPossibleTimingAttacks;
+pub use crate::rules::oxc::detect_pseudo_random_bytes::DetectPseudoRandomBytes as OxcDetectPseudoRandomBytes;
+pub use crate::rules::oxc::detect_unsafe_regex::DetectUnsafeRegex as OxcDetectUnsafeRegex;
 pub use crate::rules::oxc::double_comparisons::DoubleComparisons as OxcDoubleComparisons;
 pub use crate::rules::oxc::erasing_op::ErasingOp as OxcErasingOp;
 pub use crate::rules::oxc::misrefactored_assign_op::MisrefactoredAssignOp as OxcMisrefactoredAssignOp;
@@ -1339,6 +1353,20 @@ pub enum RuleEnum {
     OxcNumberArgOutOfRange(OxcNumberArgOutOfRange),
     OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion),
     OxcUninvokedArrayCallback(OxcUninvokedArrayCallback),
+    OxcDependBanDependencies(OxcDependBanDependencies),
+    OxcDetectBufferNoassert(OxcDetectBufferNoassert),
+    OxcDetectChildProcess(OxcDetectChildProcess),
+    OxcDetectDisableMustacheEscape(OxcDetectDisableMustacheEscape),
+    OxcDetectEvalWithExpression(OxcDetectEvalWithExpression),
+    OxcDetectNewBuffer(OxcDetectNewBuffer),
+    OxcDetectNoCsrfBeforeMethodOverride(OxcDetectNoCsrfBeforeMethodOverride),
+    OxcDetectNonLiteralFsFilename(OxcDetectNonLiteralFsFilename),
+    OxcDetectNonLiteralRegexp(OxcDetectNonLiteralRegexp),
+    OxcDetectNonLiteralRequire(OxcDetectNonLiteralRequire),
+    OxcDetectObjectInjection(OxcDetectObjectInjection),
+    OxcDetectPossibleTimingAttacks(OxcDetectPossibleTimingAttacks),
+    OxcDetectPseudoRandomBytes(OxcDetectPseudoRandomBytes),
+    OxcDetectUnsafeRegex(OxcDetectUnsafeRegex),
     NextjsGoogleFontDisplay(NextjsGoogleFontDisplay),
     NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect),
     NextjsInlineScriptId(NextjsInlineScriptId),
@@ -2132,7 +2160,22 @@ const OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID: usize = OXC_NO_REST_SPREAD_PROPERTIES
 const OXC_NUMBER_ARG_OUT_OF_RANGE_ID: usize = OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID + 1usize;
 const OXC_ONLY_USED_IN_RECURSION_ID: usize = OXC_NUMBER_ARG_OUT_OF_RANGE_ID + 1usize;
 const OXC_UNINVOKED_ARRAY_CALLBACK_ID: usize = OXC_ONLY_USED_IN_RECURSION_ID + 1usize;
-const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_DEPEND_BAN_DEPENDENCIES_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_DETECT_BUFFER_NOASSERT_ID: usize = OXC_DEPEND_BAN_DEPENDENCIES_ID + 1usize;
+const OXC_DETECT_CHILD_PROCESS_ID: usize = OXC_DETECT_BUFFER_NOASSERT_ID + 1usize;
+const OXC_DETECT_DISABLE_MUSTACHE_ESCAPE_ID: usize = OXC_DETECT_CHILD_PROCESS_ID + 1usize;
+const OXC_DETECT_EVAL_WITH_EXPRESSION_ID: usize = OXC_DETECT_DISABLE_MUSTACHE_ESCAPE_ID + 1usize;
+const OXC_DETECT_NEW_BUFFER_ID: usize = OXC_DETECT_EVAL_WITH_EXPRESSION_ID + 1usize;
+const OXC_DETECT_NO_CSRF_BEFORE_METHOD_OVERRIDE_ID: usize = OXC_DETECT_NEW_BUFFER_ID + 1usize;
+const OXC_DETECT_NON_LITERAL_FS_FILENAME_ID: usize =
+    OXC_DETECT_NO_CSRF_BEFORE_METHOD_OVERRIDE_ID + 1usize;
+const OXC_DETECT_NON_LITERAL_REGEXP_ID: usize = OXC_DETECT_NON_LITERAL_FS_FILENAME_ID + 1usize;
+const OXC_DETECT_NON_LITERAL_REQUIRE_ID: usize = OXC_DETECT_NON_LITERAL_REGEXP_ID + 1usize;
+const OXC_DETECT_OBJECT_INJECTION_ID: usize = OXC_DETECT_NON_LITERAL_REQUIRE_ID + 1usize;
+const OXC_DETECT_POSSIBLE_TIMING_ATTACKS_ID: usize = OXC_DETECT_OBJECT_INJECTION_ID + 1usize;
+const OXC_DETECT_PSEUDO_RANDOM_BYTES_ID: usize = OXC_DETECT_POSSIBLE_TIMING_ATTACKS_ID + 1usize;
+const OXC_DETECT_UNSAFE_REGEX_ID: usize = OXC_DETECT_PSEUDO_RANDOM_BYTES_ID + 1usize;
+const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_DETECT_UNSAFE_REGEX_ID + 1usize;
 const NEXTJS_GOOGLE_FONT_PRECONNECT_ID: usize = NEXTJS_GOOGLE_FONT_DISPLAY_ID + 1usize;
 const NEXTJS_INLINE_SCRIPT_ID_ID: usize = NEXTJS_GOOGLE_FONT_PRECONNECT_ID + 1usize;
 const NEXTJS_NEXT_SCRIPT_FOR_GA_ID: usize = NEXTJS_INLINE_SCRIPT_ID_ID + 1usize;
@@ -2954,6 +2997,22 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OXC_NUMBER_ARG_OUT_OF_RANGE_ID,
             Self::OxcOnlyUsedInRecursion(_) => OXC_ONLY_USED_IN_RECURSION_ID,
             Self::OxcUninvokedArrayCallback(_) => OXC_UNINVOKED_ARRAY_CALLBACK_ID,
+            Self::OxcDependBanDependencies(_) => OXC_DEPEND_BAN_DEPENDENCIES_ID,
+            Self::OxcDetectBufferNoassert(_) => OXC_DETECT_BUFFER_NOASSERT_ID,
+            Self::OxcDetectChildProcess(_) => OXC_DETECT_CHILD_PROCESS_ID,
+            Self::OxcDetectDisableMustacheEscape(_) => OXC_DETECT_DISABLE_MUSTACHE_ESCAPE_ID,
+            Self::OxcDetectEvalWithExpression(_) => OXC_DETECT_EVAL_WITH_EXPRESSION_ID,
+            Self::OxcDetectNewBuffer(_) => OXC_DETECT_NEW_BUFFER_ID,
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OXC_DETECT_NO_CSRF_BEFORE_METHOD_OVERRIDE_ID
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => OXC_DETECT_NON_LITERAL_FS_FILENAME_ID,
+            Self::OxcDetectNonLiteralRegexp(_) => OXC_DETECT_NON_LITERAL_REGEXP_ID,
+            Self::OxcDetectNonLiteralRequire(_) => OXC_DETECT_NON_LITERAL_REQUIRE_ID,
+            Self::OxcDetectObjectInjection(_) => OXC_DETECT_OBJECT_INJECTION_ID,
+            Self::OxcDetectPossibleTimingAttacks(_) => OXC_DETECT_POSSIBLE_TIMING_ATTACKS_ID,
+            Self::OxcDetectPseudoRandomBytes(_) => OXC_DETECT_PSEUDO_RANDOM_BYTES_ID,
+            Self::OxcDetectUnsafeRegex(_) => OXC_DETECT_UNSAFE_REGEX_ID,
             Self::NextjsGoogleFontDisplay(_) => NEXTJS_GOOGLE_FONT_DISPLAY_ID,
             Self::NextjsGoogleFontPreconnect(_) => NEXTJS_GOOGLE_FONT_PRECONNECT_ID,
             Self::NextjsInlineScriptId(_) => NEXTJS_INLINE_SCRIPT_ID_ID,
@@ -3764,6 +3823,22 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::NAME,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::NAME,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::NAME,
+            Self::OxcDependBanDependencies(_) => OxcDependBanDependencies::NAME,
+            Self::OxcDetectBufferNoassert(_) => OxcDetectBufferNoassert::NAME,
+            Self::OxcDetectChildProcess(_) => OxcDetectChildProcess::NAME,
+            Self::OxcDetectDisableMustacheEscape(_) => OxcDetectDisableMustacheEscape::NAME,
+            Self::OxcDetectEvalWithExpression(_) => OxcDetectEvalWithExpression::NAME,
+            Self::OxcDetectNewBuffer(_) => OxcDetectNewBuffer::NAME,
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OxcDetectNoCsrfBeforeMethodOverride::NAME
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => OxcDetectNonLiteralFsFilename::NAME,
+            Self::OxcDetectNonLiteralRegexp(_) => OxcDetectNonLiteralRegexp::NAME,
+            Self::OxcDetectNonLiteralRequire(_) => OxcDetectNonLiteralRequire::NAME,
+            Self::OxcDetectObjectInjection(_) => OxcDetectObjectInjection::NAME,
+            Self::OxcDetectPossibleTimingAttacks(_) => OxcDetectPossibleTimingAttacks::NAME,
+            Self::OxcDetectPseudoRandomBytes(_) => OxcDetectPseudoRandomBytes::NAME,
+            Self::OxcDetectUnsafeRegex(_) => OxcDetectUnsafeRegex::NAME,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::NAME,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::NAME,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::NAME,
@@ -4616,6 +4691,22 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::CATEGORY,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::CATEGORY,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::CATEGORY,
+            Self::OxcDependBanDependencies(_) => OxcDependBanDependencies::CATEGORY,
+            Self::OxcDetectBufferNoassert(_) => OxcDetectBufferNoassert::CATEGORY,
+            Self::OxcDetectChildProcess(_) => OxcDetectChildProcess::CATEGORY,
+            Self::OxcDetectDisableMustacheEscape(_) => OxcDetectDisableMustacheEscape::CATEGORY,
+            Self::OxcDetectEvalWithExpression(_) => OxcDetectEvalWithExpression::CATEGORY,
+            Self::OxcDetectNewBuffer(_) => OxcDetectNewBuffer::CATEGORY,
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OxcDetectNoCsrfBeforeMethodOverride::CATEGORY
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => OxcDetectNonLiteralFsFilename::CATEGORY,
+            Self::OxcDetectNonLiteralRegexp(_) => OxcDetectNonLiteralRegexp::CATEGORY,
+            Self::OxcDetectNonLiteralRequire(_) => OxcDetectNonLiteralRequire::CATEGORY,
+            Self::OxcDetectObjectInjection(_) => OxcDetectObjectInjection::CATEGORY,
+            Self::OxcDetectPossibleTimingAttacks(_) => OxcDetectPossibleTimingAttacks::CATEGORY,
+            Self::OxcDetectPseudoRandomBytes(_) => OxcDetectPseudoRandomBytes::CATEGORY,
+            Self::OxcDetectUnsafeRegex(_) => OxcDetectUnsafeRegex::CATEGORY,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::CATEGORY,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::CATEGORY,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::CATEGORY,
@@ -5435,6 +5526,22 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::FIX,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::FIX,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::FIX,
+            Self::OxcDependBanDependencies(_) => OxcDependBanDependencies::FIX,
+            Self::OxcDetectBufferNoassert(_) => OxcDetectBufferNoassert::FIX,
+            Self::OxcDetectChildProcess(_) => OxcDetectChildProcess::FIX,
+            Self::OxcDetectDisableMustacheEscape(_) => OxcDetectDisableMustacheEscape::FIX,
+            Self::OxcDetectEvalWithExpression(_) => OxcDetectEvalWithExpression::FIX,
+            Self::OxcDetectNewBuffer(_) => OxcDetectNewBuffer::FIX,
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OxcDetectNoCsrfBeforeMethodOverride::FIX
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => OxcDetectNonLiteralFsFilename::FIX,
+            Self::OxcDetectNonLiteralRegexp(_) => OxcDetectNonLiteralRegexp::FIX,
+            Self::OxcDetectNonLiteralRequire(_) => OxcDetectNonLiteralRequire::FIX,
+            Self::OxcDetectObjectInjection(_) => OxcDetectObjectInjection::FIX,
+            Self::OxcDetectPossibleTimingAttacks(_) => OxcDetectPossibleTimingAttacks::FIX,
+            Self::OxcDetectPseudoRandomBytes(_) => OxcDetectPseudoRandomBytes::FIX,
+            Self::OxcDetectUnsafeRegex(_) => OxcDetectUnsafeRegex::FIX,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::FIX,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::FIX,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::FIX,
@@ -6432,6 +6539,28 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::documentation(),
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::documentation(),
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::documentation(),
+            Self::OxcDependBanDependencies(_) => OxcDependBanDependencies::documentation(),
+            Self::OxcDetectBufferNoassert(_) => OxcDetectBufferNoassert::documentation(),
+            Self::OxcDetectChildProcess(_) => OxcDetectChildProcess::documentation(),
+            Self::OxcDetectDisableMustacheEscape(_) => {
+                OxcDetectDisableMustacheEscape::documentation()
+            }
+            Self::OxcDetectEvalWithExpression(_) => OxcDetectEvalWithExpression::documentation(),
+            Self::OxcDetectNewBuffer(_) => OxcDetectNewBuffer::documentation(),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OxcDetectNoCsrfBeforeMethodOverride::documentation()
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => {
+                OxcDetectNonLiteralFsFilename::documentation()
+            }
+            Self::OxcDetectNonLiteralRegexp(_) => OxcDetectNonLiteralRegexp::documentation(),
+            Self::OxcDetectNonLiteralRequire(_) => OxcDetectNonLiteralRequire::documentation(),
+            Self::OxcDetectObjectInjection(_) => OxcDetectObjectInjection::documentation(),
+            Self::OxcDetectPossibleTimingAttacks(_) => {
+                OxcDetectPossibleTimingAttacks::documentation()
+            }
+            Self::OxcDetectPseudoRandomBytes(_) => OxcDetectPseudoRandomBytes::documentation(),
+            Self::OxcDetectUnsafeRegex(_) => OxcDetectUnsafeRegex::documentation(),
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::documentation(),
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::documentation(),
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::documentation(),
@@ -8313,6 +8442,50 @@ impl RuleEnum {
                 OxcUninvokedArrayCallback::config_schema(generator)
                     .or_else(|| OxcUninvokedArrayCallback::schema(generator))
             }
+            Self::OxcDependBanDependencies(_) => OxcDependBanDependencies::config_schema(generator)
+                .or_else(|| OxcDependBanDependencies::schema(generator)),
+            Self::OxcDetectBufferNoassert(_) => OxcDetectBufferNoassert::config_schema(generator)
+                .or_else(|| OxcDetectBufferNoassert::schema(generator)),
+            Self::OxcDetectChildProcess(_) => OxcDetectChildProcess::config_schema(generator)
+                .or_else(|| OxcDetectChildProcess::schema(generator)),
+            Self::OxcDetectDisableMustacheEscape(_) => {
+                OxcDetectDisableMustacheEscape::config_schema(generator)
+                    .or_else(|| OxcDetectDisableMustacheEscape::schema(generator))
+            }
+            Self::OxcDetectEvalWithExpression(_) => {
+                OxcDetectEvalWithExpression::config_schema(generator)
+                    .or_else(|| OxcDetectEvalWithExpression::schema(generator))
+            }
+            Self::OxcDetectNewBuffer(_) => OxcDetectNewBuffer::config_schema(generator)
+                .or_else(|| OxcDetectNewBuffer::schema(generator)),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OxcDetectNoCsrfBeforeMethodOverride::config_schema(generator)
+                    .or_else(|| OxcDetectNoCsrfBeforeMethodOverride::schema(generator))
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => {
+                OxcDetectNonLiteralFsFilename::config_schema(generator)
+                    .or_else(|| OxcDetectNonLiteralFsFilename::schema(generator))
+            }
+            Self::OxcDetectNonLiteralRegexp(_) => {
+                OxcDetectNonLiteralRegexp::config_schema(generator)
+                    .or_else(|| OxcDetectNonLiteralRegexp::schema(generator))
+            }
+            Self::OxcDetectNonLiteralRequire(_) => {
+                OxcDetectNonLiteralRequire::config_schema(generator)
+                    .or_else(|| OxcDetectNonLiteralRequire::schema(generator))
+            }
+            Self::OxcDetectObjectInjection(_) => OxcDetectObjectInjection::config_schema(generator)
+                .or_else(|| OxcDetectObjectInjection::schema(generator)),
+            Self::OxcDetectPossibleTimingAttacks(_) => {
+                OxcDetectPossibleTimingAttacks::config_schema(generator)
+                    .or_else(|| OxcDetectPossibleTimingAttacks::schema(generator))
+            }
+            Self::OxcDetectPseudoRandomBytes(_) => {
+                OxcDetectPseudoRandomBytes::config_schema(generator)
+                    .or_else(|| OxcDetectPseudoRandomBytes::schema(generator))
+            }
+            Self::OxcDetectUnsafeRegex(_) => OxcDetectUnsafeRegex::config_schema(generator)
+                .or_else(|| OxcDetectUnsafeRegex::schema(generator)),
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::config_schema(generator)
                 .or_else(|| NextjsGoogleFontDisplay::schema(generator)),
             Self::NextjsGoogleFontPreconnect(_) => {
@@ -9197,6 +9370,20 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => "oxc",
             Self::OxcOnlyUsedInRecursion(_) => "oxc",
             Self::OxcUninvokedArrayCallback(_) => "oxc",
+            Self::OxcDependBanDependencies(_) => "oxc",
+            Self::OxcDetectBufferNoassert(_) => "oxc",
+            Self::OxcDetectChildProcess(_) => "oxc",
+            Self::OxcDetectDisableMustacheEscape(_) => "oxc",
+            Self::OxcDetectEvalWithExpression(_) => "oxc",
+            Self::OxcDetectNewBuffer(_) => "oxc",
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => "oxc",
+            Self::OxcDetectNonLiteralFsFilename(_) => "oxc",
+            Self::OxcDetectNonLiteralRegexp(_) => "oxc",
+            Self::OxcDetectNonLiteralRequire(_) => "oxc",
+            Self::OxcDetectObjectInjection(_) => "oxc",
+            Self::OxcDetectPossibleTimingAttacks(_) => "oxc",
+            Self::OxcDetectPseudoRandomBytes(_) => "oxc",
+            Self::OxcDetectUnsafeRegex(_) => "oxc",
             Self::NextjsGoogleFontDisplay(_) => "nextjs",
             Self::NextjsGoogleFontPreconnect(_) => "nextjs",
             Self::NextjsInlineScriptId(_) => "nextjs",
@@ -11272,6 +11459,50 @@ impl RuleEnum {
             Self::OxcUninvokedArrayCallback(_) => Ok(Self::OxcUninvokedArrayCallback(
                 OxcUninvokedArrayCallback::from_configuration(value)?,
             )),
+            Self::OxcDependBanDependencies(_) => Ok(Self::OxcDependBanDependencies(
+                OxcDependBanDependencies::from_configuration(value)?,
+            )),
+            Self::OxcDetectBufferNoassert(_) => Ok(Self::OxcDetectBufferNoassert(
+                OxcDetectBufferNoassert::from_configuration(value)?,
+            )),
+            Self::OxcDetectChildProcess(_) => {
+                Ok(Self::OxcDetectChildProcess(OxcDetectChildProcess::from_configuration(value)?))
+            }
+            Self::OxcDetectDisableMustacheEscape(_) => Ok(Self::OxcDetectDisableMustacheEscape(
+                OxcDetectDisableMustacheEscape::from_configuration(value)?,
+            )),
+            Self::OxcDetectEvalWithExpression(_) => Ok(Self::OxcDetectEvalWithExpression(
+                OxcDetectEvalWithExpression::from_configuration(value)?,
+            )),
+            Self::OxcDetectNewBuffer(_) => {
+                Ok(Self::OxcDetectNewBuffer(OxcDetectNewBuffer::from_configuration(value)?))
+            }
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                Ok(Self::OxcDetectNoCsrfBeforeMethodOverride(
+                    OxcDetectNoCsrfBeforeMethodOverride::from_configuration(value)?,
+                ))
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => Ok(Self::OxcDetectNonLiteralFsFilename(
+                OxcDetectNonLiteralFsFilename::from_configuration(value)?,
+            )),
+            Self::OxcDetectNonLiteralRegexp(_) => Ok(Self::OxcDetectNonLiteralRegexp(
+                OxcDetectNonLiteralRegexp::from_configuration(value)?,
+            )),
+            Self::OxcDetectNonLiteralRequire(_) => Ok(Self::OxcDetectNonLiteralRequire(
+                OxcDetectNonLiteralRequire::from_configuration(value)?,
+            )),
+            Self::OxcDetectObjectInjection(_) => Ok(Self::OxcDetectObjectInjection(
+                OxcDetectObjectInjection::from_configuration(value)?,
+            )),
+            Self::OxcDetectPossibleTimingAttacks(_) => Ok(Self::OxcDetectPossibleTimingAttacks(
+                OxcDetectPossibleTimingAttacks::from_configuration(value)?,
+            )),
+            Self::OxcDetectPseudoRandomBytes(_) => Ok(Self::OxcDetectPseudoRandomBytes(
+                OxcDetectPseudoRandomBytes::from_configuration(value)?,
+            )),
+            Self::OxcDetectUnsafeRegex(_) => {
+                Ok(Self::OxcDetectUnsafeRegex(OxcDetectUnsafeRegex::from_configuration(value)?))
+            }
             Self::NextjsGoogleFontDisplay(_) => Ok(Self::NextjsGoogleFontDisplay(
                 NextjsGoogleFontDisplay::from_configuration(value)?,
             )),
@@ -12198,6 +12429,20 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.to_configuration(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.to_configuration(),
             Self::OxcUninvokedArrayCallback(rule) => rule.to_configuration(),
+            Self::OxcDependBanDependencies(rule) => rule.to_configuration(),
+            Self::OxcDetectBufferNoassert(rule) => rule.to_configuration(),
+            Self::OxcDetectChildProcess(rule) => rule.to_configuration(),
+            Self::OxcDetectDisableMustacheEscape(rule) => rule.to_configuration(),
+            Self::OxcDetectEvalWithExpression(rule) => rule.to_configuration(),
+            Self::OxcDetectNewBuffer(rule) => rule.to_configuration(),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(rule) => rule.to_configuration(),
+            Self::OxcDetectNonLiteralFsFilename(rule) => rule.to_configuration(),
+            Self::OxcDetectNonLiteralRegexp(rule) => rule.to_configuration(),
+            Self::OxcDetectNonLiteralRequire(rule) => rule.to_configuration(),
+            Self::OxcDetectObjectInjection(rule) => rule.to_configuration(),
+            Self::OxcDetectPossibleTimingAttacks(rule) => rule.to_configuration(),
+            Self::OxcDetectPseudoRandomBytes(rule) => rule.to_configuration(),
+            Self::OxcDetectUnsafeRegex(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontDisplay(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.to_configuration(),
             Self::NextjsInlineScriptId(rule) => rule.to_configuration(),
@@ -12914,6 +13159,20 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run(node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run(node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run(node, ctx),
+            Self::OxcDependBanDependencies(rule) => rule.run(node, ctx),
+            Self::OxcDetectBufferNoassert(rule) => rule.run(node, ctx),
+            Self::OxcDetectChildProcess(rule) => rule.run(node, ctx),
+            Self::OxcDetectDisableMustacheEscape(rule) => rule.run(node, ctx),
+            Self::OxcDetectEvalWithExpression(rule) => rule.run(node, ctx),
+            Self::OxcDetectNewBuffer(rule) => rule.run(node, ctx),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(rule) => rule.run(node, ctx),
+            Self::OxcDetectNonLiteralFsFilename(rule) => rule.run(node, ctx),
+            Self::OxcDetectNonLiteralRegexp(rule) => rule.run(node, ctx),
+            Self::OxcDetectNonLiteralRequire(rule) => rule.run(node, ctx),
+            Self::OxcDetectObjectInjection(rule) => rule.run(node, ctx),
+            Self::OxcDetectPossibleTimingAttacks(rule) => rule.run(node, ctx),
+            Self::OxcDetectPseudoRandomBytes(rule) => rule.run(node, ctx),
+            Self::OxcDetectUnsafeRegex(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run(node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run(node, ctx),
@@ -13628,6 +13887,20 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_once(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_once(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_once(ctx),
+            Self::OxcDependBanDependencies(rule) => rule.run_once(ctx),
+            Self::OxcDetectBufferNoassert(rule) => rule.run_once(ctx),
+            Self::OxcDetectChildProcess(rule) => rule.run_once(ctx),
+            Self::OxcDetectDisableMustacheEscape(rule) => rule.run_once(ctx),
+            Self::OxcDetectEvalWithExpression(rule) => rule.run_once(ctx),
+            Self::OxcDetectNewBuffer(rule) => rule.run_once(ctx),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(rule) => rule.run_once(ctx),
+            Self::OxcDetectNonLiteralFsFilename(rule) => rule.run_once(ctx),
+            Self::OxcDetectNonLiteralRegexp(rule) => rule.run_once(ctx),
+            Self::OxcDetectNonLiteralRequire(rule) => rule.run_once(ctx),
+            Self::OxcDetectObjectInjection(rule) => rule.run_once(ctx),
+            Self::OxcDetectPossibleTimingAttacks(rule) => rule.run_once(ctx),
+            Self::OxcDetectPseudoRandomBytes(rule) => rule.run_once(ctx),
+            Self::OxcDetectUnsafeRegex(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_once(ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_once(ctx),
@@ -14438,6 +14711,22 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDependBanDependencies(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectBufferNoassert(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectChildProcess(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectDisableMustacheEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectEvalWithExpression(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectNewBuffer(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::OxcDetectNonLiteralFsFilename(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectNonLiteralRegexp(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectNonLiteralRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectObjectInjection(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectPossibleTimingAttacks(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectPseudoRandomBytes(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcDetectUnsafeRegex(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15156,6 +15445,20 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.should_run(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.should_run(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.should_run(ctx),
+            Self::OxcDependBanDependencies(rule) => rule.should_run(ctx),
+            Self::OxcDetectBufferNoassert(rule) => rule.should_run(ctx),
+            Self::OxcDetectChildProcess(rule) => rule.should_run(ctx),
+            Self::OxcDetectDisableMustacheEscape(rule) => rule.should_run(ctx),
+            Self::OxcDetectEvalWithExpression(rule) => rule.should_run(ctx),
+            Self::OxcDetectNewBuffer(rule) => rule.should_run(ctx),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(rule) => rule.should_run(ctx),
+            Self::OxcDetectNonLiteralFsFilename(rule) => rule.should_run(ctx),
+            Self::OxcDetectNonLiteralRegexp(rule) => rule.should_run(ctx),
+            Self::OxcDetectNonLiteralRequire(rule) => rule.should_run(ctx),
+            Self::OxcDetectObjectInjection(rule) => rule.should_run(ctx),
+            Self::OxcDetectPossibleTimingAttacks(rule) => rule.should_run(ctx),
+            Self::OxcDetectPseudoRandomBytes(rule) => rule.should_run(ctx),
+            Self::OxcDetectUnsafeRegex(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.should_run(ctx),
             Self::NextjsInlineScriptId(rule) => rule.should_run(ctx),
@@ -16148,6 +16451,28 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::IS_TSGOLINT_RULE,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::IS_TSGOLINT_RULE,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::IS_TSGOLINT_RULE,
+            Self::OxcDependBanDependencies(_) => OxcDependBanDependencies::IS_TSGOLINT_RULE,
+            Self::OxcDetectBufferNoassert(_) => OxcDetectBufferNoassert::IS_TSGOLINT_RULE,
+            Self::OxcDetectChildProcess(_) => OxcDetectChildProcess::IS_TSGOLINT_RULE,
+            Self::OxcDetectDisableMustacheEscape(_) => {
+                OxcDetectDisableMustacheEscape::IS_TSGOLINT_RULE
+            }
+            Self::OxcDetectEvalWithExpression(_) => OxcDetectEvalWithExpression::IS_TSGOLINT_RULE,
+            Self::OxcDetectNewBuffer(_) => OxcDetectNewBuffer::IS_TSGOLINT_RULE,
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OxcDetectNoCsrfBeforeMethodOverride::IS_TSGOLINT_RULE
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => {
+                OxcDetectNonLiteralFsFilename::IS_TSGOLINT_RULE
+            }
+            Self::OxcDetectNonLiteralRegexp(_) => OxcDetectNonLiteralRegexp::IS_TSGOLINT_RULE,
+            Self::OxcDetectNonLiteralRequire(_) => OxcDetectNonLiteralRequire::IS_TSGOLINT_RULE,
+            Self::OxcDetectObjectInjection(_) => OxcDetectObjectInjection::IS_TSGOLINT_RULE,
+            Self::OxcDetectPossibleTimingAttacks(_) => {
+                OxcDetectPossibleTimingAttacks::IS_TSGOLINT_RULE
+            }
+            Self::OxcDetectPseudoRandomBytes(_) => OxcDetectPseudoRandomBytes::IS_TSGOLINT_RULE,
+            Self::OxcDetectUnsafeRegex(_) => OxcDetectUnsafeRegex::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::IS_TSGOLINT_RULE,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::IS_TSGOLINT_RULE,
@@ -17049,6 +17374,22 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::HAS_CONFIG,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::HAS_CONFIG,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::HAS_CONFIG,
+            Self::OxcDependBanDependencies(_) => OxcDependBanDependencies::HAS_CONFIG,
+            Self::OxcDetectBufferNoassert(_) => OxcDetectBufferNoassert::HAS_CONFIG,
+            Self::OxcDetectChildProcess(_) => OxcDetectChildProcess::HAS_CONFIG,
+            Self::OxcDetectDisableMustacheEscape(_) => OxcDetectDisableMustacheEscape::HAS_CONFIG,
+            Self::OxcDetectEvalWithExpression(_) => OxcDetectEvalWithExpression::HAS_CONFIG,
+            Self::OxcDetectNewBuffer(_) => OxcDetectNewBuffer::HAS_CONFIG,
+            Self::OxcDetectNoCsrfBeforeMethodOverride(_) => {
+                OxcDetectNoCsrfBeforeMethodOverride::HAS_CONFIG
+            }
+            Self::OxcDetectNonLiteralFsFilename(_) => OxcDetectNonLiteralFsFilename::HAS_CONFIG,
+            Self::OxcDetectNonLiteralRegexp(_) => OxcDetectNonLiteralRegexp::HAS_CONFIG,
+            Self::OxcDetectNonLiteralRequire(_) => OxcDetectNonLiteralRequire::HAS_CONFIG,
+            Self::OxcDetectObjectInjection(_) => OxcDetectObjectInjection::HAS_CONFIG,
+            Self::OxcDetectPossibleTimingAttacks(_) => OxcDetectPossibleTimingAttacks::HAS_CONFIG,
+            Self::OxcDetectPseudoRandomBytes(_) => OxcDetectPseudoRandomBytes::HAS_CONFIG,
+            Self::OxcDetectUnsafeRegex(_) => OxcDetectUnsafeRegex::HAS_CONFIG,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::HAS_CONFIG,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::HAS_CONFIG,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::HAS_CONFIG,
@@ -17775,6 +18116,20 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.types_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.types_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.types_info(),
+            Self::OxcDependBanDependencies(rule) => rule.types_info(),
+            Self::OxcDetectBufferNoassert(rule) => rule.types_info(),
+            Self::OxcDetectChildProcess(rule) => rule.types_info(),
+            Self::OxcDetectDisableMustacheEscape(rule) => rule.types_info(),
+            Self::OxcDetectEvalWithExpression(rule) => rule.types_info(),
+            Self::OxcDetectNewBuffer(rule) => rule.types_info(),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(rule) => rule.types_info(),
+            Self::OxcDetectNonLiteralFsFilename(rule) => rule.types_info(),
+            Self::OxcDetectNonLiteralRegexp(rule) => rule.types_info(),
+            Self::OxcDetectNonLiteralRequire(rule) => rule.types_info(),
+            Self::OxcDetectObjectInjection(rule) => rule.types_info(),
+            Self::OxcDetectPossibleTimingAttacks(rule) => rule.types_info(),
+            Self::OxcDetectPseudoRandomBytes(rule) => rule.types_info(),
+            Self::OxcDetectUnsafeRegex(rule) => rule.types_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.types_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.types_info(),
             Self::NextjsInlineScriptId(rule) => rule.types_info(),
@@ -18489,6 +18844,20 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_info(),
+            Self::OxcDependBanDependencies(rule) => rule.run_info(),
+            Self::OxcDetectBufferNoassert(rule) => rule.run_info(),
+            Self::OxcDetectChildProcess(rule) => rule.run_info(),
+            Self::OxcDetectDisableMustacheEscape(rule) => rule.run_info(),
+            Self::OxcDetectEvalWithExpression(rule) => rule.run_info(),
+            Self::OxcDetectNewBuffer(rule) => rule.run_info(),
+            Self::OxcDetectNoCsrfBeforeMethodOverride(rule) => rule.run_info(),
+            Self::OxcDetectNonLiteralFsFilename(rule) => rule.run_info(),
+            Self::OxcDetectNonLiteralRegexp(rule) => rule.run_info(),
+            Self::OxcDetectNonLiteralRequire(rule) => rule.run_info(),
+            Self::OxcDetectObjectInjection(rule) => rule.run_info(),
+            Self::OxcDetectPossibleTimingAttacks(rule) => rule.run_info(),
+            Self::OxcDetectPseudoRandomBytes(rule) => rule.run_info(),
+            Self::OxcDetectUnsafeRegex(rule) => rule.run_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_info(),
             Self::NextjsInlineScriptId(rule) => rule.run_info(),
@@ -19317,6 +19686,22 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::OxcNumberArgOutOfRange(OxcNumberArgOutOfRange::default()),
         RuleEnum::OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion::default()),
         RuleEnum::OxcUninvokedArrayCallback(OxcUninvokedArrayCallback::default()),
+        RuleEnum::OxcDependBanDependencies(OxcDependBanDependencies::default()),
+        RuleEnum::OxcDetectBufferNoassert(OxcDetectBufferNoassert::default()),
+        RuleEnum::OxcDetectChildProcess(OxcDetectChildProcess::default()),
+        RuleEnum::OxcDetectDisableMustacheEscape(OxcDetectDisableMustacheEscape::default()),
+        RuleEnum::OxcDetectEvalWithExpression(OxcDetectEvalWithExpression::default()),
+        RuleEnum::OxcDetectNewBuffer(OxcDetectNewBuffer::default()),
+        RuleEnum::OxcDetectNoCsrfBeforeMethodOverride(
+            OxcDetectNoCsrfBeforeMethodOverride::default(),
+        ),
+        RuleEnum::OxcDetectNonLiteralFsFilename(OxcDetectNonLiteralFsFilename::default()),
+        RuleEnum::OxcDetectNonLiteralRegexp(OxcDetectNonLiteralRegexp::default()),
+        RuleEnum::OxcDetectNonLiteralRequire(OxcDetectNonLiteralRequire::default()),
+        RuleEnum::OxcDetectObjectInjection(OxcDetectObjectInjection::default()),
+        RuleEnum::OxcDetectPossibleTimingAttacks(OxcDetectPossibleTimingAttacks::default()),
+        RuleEnum::OxcDetectPseudoRandomBytes(OxcDetectPseudoRandomBytes::default()),
+        RuleEnum::OxcDetectUnsafeRegex(OxcDetectUnsafeRegex::default()),
         RuleEnum::NextjsGoogleFontDisplay(NextjsGoogleFontDisplay::default()),
         RuleEnum::NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect::default()),
         RuleEnum::NextjsInlineScriptId(NextjsInlineScriptId::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -639,6 +639,21 @@ pub(crate) mod oxc {
     pub mod number_arg_out_of_range;
     pub mod only_used_in_recursion;
     pub mod uninvoked_array_callback;
+
+    pub mod depend_ban_dependencies;
+    pub mod detect_buffer_noassert;
+    pub mod detect_child_process;
+    pub mod detect_disable_mustache_escape;
+    pub mod detect_eval_with_expression;
+    pub mod detect_new_buffer;
+    pub mod detect_no_csrf_before_method_override;
+    pub mod detect_non_literal_fs_filename;
+    pub mod detect_non_literal_regexp;
+    pub mod detect_non_literal_require;
+    pub mod detect_object_injection;
+    pub mod detect_possible_timing_attacks;
+    pub mod detect_pseudo_random_bytes;
+    pub mod detect_unsafe_regex;
 }
 
 pub(crate) mod nextjs {

--- a/crates/oxc_linter/src/rules/oxc/depend_ban_dependencies.rs
+++ b/crates/oxc_linter/src/rules/oxc/depend_ban_dependencies.rs
@@ -1,0 +1,169 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn depend_ban_dependencies_diagnostic(span: Span, pkg: &str, reason: &str) -> OxcDiagnostic {
+    let message = if reason.is_empty() {
+        format!("Package \"{pkg}\" is banned")
+    } else {
+        format!("Package \"{pkg}\" is banned: {reason}")
+    };
+    OxcDiagnostic::warn(message)
+        .with_help(format!("Remove the import of \"{pkg}\" and use the suggested alternative."))
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct BannedPackage {
+    pub name: String,
+    #[serde(default)]
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct DependBanDependenciesConfig {
+    banned: Vec<BannedPackage>,
+}
+
+impl Default for DependBanDependenciesConfig {
+    fn default() -> Self {
+        Self {
+            banned: vec![
+                BannedPackage {
+                    name: "moment".to_string(),
+                    reason: "Use date-fns or dayjs instead".to_string(),
+                },
+                BannedPackage {
+                    name: "lodash".to_string(),
+                    reason: "Use native Array/Object methods or lodash-es for tree-shaking"
+                        .to_string(),
+                },
+                BannedPackage {
+                    name: "underscore".to_string(),
+                    reason: "Use native Array/Object methods instead".to_string(),
+                },
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DependBanDependencies(Box<DependBanDependenciesConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Bans imports of specific packages that have better alternatives.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Some packages are outdated, bloated, or have better alternatives.
+    /// Banning them encourages the use of modern, lighter, or more
+    /// performant replacements.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule (with default config):
+    /// ```js
+    /// import moment from "moment";
+    /// const _ = require("lodash");
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import { format } from "date-fns";
+    /// import { map } from "lodash-es";
+    /// ```
+    DependBanDependencies,
+    oxc,
+    restriction,
+    none,
+    config = DependBanDependenciesConfig
+);
+
+impl Rule for DependBanDependencies {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<DependBanDependenciesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::ImportDeclaration(import) => {
+                let source = import.source.value.as_str();
+                self.check_source(source, import.source.span, ctx);
+            }
+            AstKind::CallExpression(call_expr) => {
+                let Expression::Identifier(callee) = &call_expr.callee else {
+                    return;
+                };
+                if callee.name != "require" {
+                    return;
+                }
+                let Some(Expression::StringLiteral(arg)) =
+                    call_expr.arguments.first().and_then(|a| a.as_expression())
+                else {
+                    return;
+                };
+                self.check_source(arg.value.as_str(), arg.span, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl DependBanDependencies {
+    fn check_source(&self, source: &str, span: Span, ctx: &LintContext<'_>) {
+        for banned in &self.0.banned {
+            if source == banned.name || source.starts_with(&format!("{}/", banned.name)) {
+                ctx.diagnostic(depend_ban_dependencies_diagnostic(
+                    span,
+                    &banned.name,
+                    &banned.reason,
+                ));
+                return;
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"import { format } from "date-fns";"#, None),
+        (r#"import { map } from "lodash-es";"#, None),
+        (r#"const x = require("safe-package");"#, None),
+    ];
+
+    let fail = vec![
+        (r#"import moment from "moment";"#, None),
+        (r#"const _ = require("lodash");"#, None),
+        (r#"import _ from "underscore";"#, None),
+        (r#"import merge from "lodash/merge";"#, None),
+        (
+            r#"import banned from "my-banned-pkg";"#,
+            Some(
+                json!([{ "banned": [{ "name": "my-banned-pkg", "reason": "Use something else" }] }]),
+            ),
+        ),
+    ];
+
+    Tester::new(DependBanDependencies::NAME, DependBanDependencies::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_buffer_noassert.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_buffer_noassert.rs
@@ -1,0 +1,149 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_buffer_noassert_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Buffer read/write called with noAssert flag")
+        .with_help("Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectBufferNoassert;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects calls to Buffer read/write methods with the `noAssert` flag set to `true`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Passing `true` as the last argument to Buffer read/write methods disables
+    /// bounds checking. This can lead to out-of-bounds reads and writes, potentially
+    /// exposing sensitive memory or causing crashes.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// buf.readUInt8(0, true);
+    /// buf.writeUInt32BE(value, 0, true);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// buf.readUInt8(0);
+    /// buf.writeUInt32BE(value, 0);
+    /// ```
+    DetectBufferNoassert,
+    oxc,
+    suspicious,
+    none
+);
+
+const BUFFER_METHODS: &[&str] = &[
+    "readUInt8",
+    "readUInt16LE",
+    "readUInt16BE",
+    "readUInt32LE",
+    "readUInt32BE",
+    "readInt8",
+    "readInt16LE",
+    "readInt16BE",
+    "readInt32LE",
+    "readInt32BE",
+    "readFloatLE",
+    "readFloatBE",
+    "readDoubleLE",
+    "readDoubleBE",
+    "writeUInt8",
+    "writeUInt16LE",
+    "writeUInt16BE",
+    "writeUInt32LE",
+    "writeUInt32BE",
+    "writeInt8",
+    "writeInt16LE",
+    "writeInt16BE",
+    "writeInt32LE",
+    "writeInt32BE",
+    "writeFloatLE",
+    "writeFloatBE",
+    "writeDoubleLE",
+    "writeDoubleBE",
+];
+
+impl Rule for DetectBufferNoassert {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::StaticMemberExpression(member) = &call_expr.callee else {
+            return;
+        };
+
+        if !BUFFER_METHODS.contains(&member.property.name.as_str()) {
+            return;
+        }
+
+        let Some(last_arg) = call_expr.arguments.last().and_then(|a| a.as_expression()) else {
+            return;
+        };
+
+        if let Expression::BooleanLiteral(lit) = last_arg
+            && lit.value
+        {
+            ctx.diagnostic(detect_buffer_noassert_diagnostic(call_expr.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "buf.readUInt8(0)",
+        "buf.writeUInt32BE(value, 0)",
+        "buf.readUInt8(0, false)",
+        "buf.foo(0, true)",
+        "obj.someMethod(true)",
+    ];
+
+    let fail = vec![
+        "buf.readUInt8(0, true)",
+        "buf.readUInt16LE(0, true)",
+        "buf.readUInt16BE(0, true)",
+        "buf.readUInt32LE(0, true)",
+        "buf.readUInt32BE(0, true)",
+        "buf.readInt8(0, true)",
+        "buf.readInt16LE(0, true)",
+        "buf.readInt16BE(0, true)",
+        "buf.readInt32LE(0, true)",
+        "buf.readInt32BE(0, true)",
+        "buf.readFloatLE(0, true)",
+        "buf.readFloatBE(0, true)",
+        "buf.readDoubleLE(0, true)",
+        "buf.readDoubleBE(0, true)",
+        "buf.writeUInt8(0, 0, true)",
+        "buf.writeUInt16LE(0, 0, true)",
+        "buf.writeUInt16BE(0, 0, true)",
+        "buf.writeUInt32LE(0, 0, true)",
+        "buf.writeUInt32BE(0, 0, true)",
+        "buf.writeInt8(0, 0, true)",
+        "buf.writeInt16LE(0, 0, true)",
+        "buf.writeInt16BE(0, 0, true)",
+        "buf.writeInt32LE(0, 0, true)",
+        "buf.writeInt32BE(0, 0, true)",
+        "buf.writeFloatLE(0, 0, true)",
+        "buf.writeFloatBE(0, 0, true)",
+        "buf.writeDoubleLE(0, 0, true)",
+        "buf.writeDoubleBE(0, 0, true)",
+    ];
+
+    Tester::new(DetectBufferNoassert::NAME, DetectBufferNoassert::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_child_process.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_child_process.rs
@@ -1,0 +1,107 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_child_process_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("child_process.exec() called with a non-literal argument")
+        .with_help("Avoid calling child_process.exec() with dynamic expressions. Use child_process.execFile() or spawn() with an argument array instead.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectChildProcess;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects calls to `child_process.exec()` with non-literal arguments.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `child_process.exec()` runs a command in a shell. If the command string
+    /// is constructed from user input, it can lead to command injection attacks.
+    /// Use `child_process.execFile()` or `child_process.spawn()` with an argument
+    /// array instead.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// child_process.exec(userInput);
+    /// cp.exec(cmd);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// child_process.exec("ls -la");
+    /// child_process.execFile("/bin/ls", ["-la"]);
+    /// ```
+    DetectChildProcess,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectChildProcess {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::StaticMemberExpression(member) = &call_expr.callee else {
+            return;
+        };
+
+        if member.property.name != "exec" {
+            return;
+        }
+
+        // Only flag when the object name suggests child_process
+        if let Expression::Identifier(obj) = &member.object {
+            let name = obj.name.as_str();
+            if name != "child_process" && name != "childProcess" && name != "cp" {
+                return;
+            }
+        }
+
+        let Some(arg) = call_expr.arguments.first().and_then(|a| a.as_expression()) else {
+            return;
+        };
+
+        match arg {
+            Expression::StringLiteral(_) => return,
+            Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => return,
+            _ => {}
+        }
+
+        ctx.diagnostic(detect_child_process_diagnostic(call_expr.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"child_process.exec("ls -la")"#,
+        r#"cp.exec("echo hello")"#,
+        "child_process.exec(`static-command`)",
+        "child_process.execFile('/bin/ls', ['-la'])",
+        "child_process.spawn('ls', ['-la'])",
+        "obj.exec(variable)",
+        "db.exec(query)",
+    ];
+
+    let fail = vec![
+        "child_process.exec(userInput)",
+        "cp.exec(cmd)",
+        "child_process.exec(getCommand())",
+        "child_process.exec(`${cmd} -la`)",
+    ];
+
+    Tester::new(DetectChildProcess::NAME, DetectChildProcess::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_disable_mustache_escape.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_disable_mustache_escape.rs
@@ -1,0 +1,86 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_disable_mustache_escape_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Mustache escaping is being disabled")
+        .with_help("Setting escapeMarkup to false or escape to false disables HTML escaping and can lead to XSS vulnerabilities.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectDisableMustacheEscape;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects when HTML escaping is disabled in template engines by setting
+    /// `escapeMarkup: false` or `escape: false`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Disabling HTML escaping in template engines allows raw HTML to be injected
+    /// into the output, which can lead to Cross-Site Scripting (XSS) vulnerabilities.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const options = { escapeMarkup: false };
+    /// const opts = { escape: false };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const options = { escapeMarkup: true };
+    /// const options = { escape: myEscapeFunction };
+    /// ```
+    DetectDisableMustacheEscape,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectDisableMustacheEscape {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ObjectProperty(prop) = node.kind() else {
+            return;
+        };
+
+        let key_name = match &prop.key {
+            oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => &ident.name,
+            _ => return,
+        };
+
+        if key_name != "escapeMarkup" && key_name != "escape" {
+            return;
+        }
+
+        if let Expression::BooleanLiteral(lit) = &prop.value
+            && !lit.value
+        {
+            ctx.diagnostic(detect_disable_mustache_escape_diagnostic(prop.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "const options = { escapeMarkup: true }",
+        "const options = { escape: true }",
+        "const options = { escapeMarkup: myFunc }",
+        "const options = { unrelated: false }",
+    ];
+
+    let fail = vec!["const options = { escapeMarkup: false }", "const options = { escape: false }"];
+
+    Tester::new(DetectDisableMustacheEscape::NAME, DetectDisableMustacheEscape::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_eval_with_expression.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_eval_with_expression.rs
@@ -1,0 +1,85 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_eval_with_expression_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("eval() called with a non-literal argument")
+        .with_help("Avoid calling eval() with dynamic expressions. This can lead to code injection vulnerabilities.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectEvalWithExpression;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects calls to `eval()` where the argument is not a string literal.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Calling `eval()` with dynamic expressions allows arbitrary code execution
+    /// and is a common code injection vector. If the argument comes from user
+    /// input or an untrusted source, an attacker can execute arbitrary JavaScript.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// eval(userInput);
+    /// eval(a + b);
+    /// eval(getCode());
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// eval("var x = 1");
+    /// ```
+    DetectEvalWithExpression,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectEvalWithExpression {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::Identifier(callee) = &call_expr.callee else {
+            return;
+        };
+
+        if callee.name != "eval" {
+            return;
+        }
+
+        let Some(arg) = call_expr.arguments.first().and_then(|a| a.as_expression()) else {
+            return;
+        };
+
+        match arg {
+            Expression::StringLiteral(_) => return,
+            Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => return,
+            _ => {}
+        }
+
+        ctx.diagnostic(detect_eval_with_expression_diagnostic(call_expr.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![r#"eval("var x = 1")"#, "console.log('hello')", "let x = 1;"];
+
+    let fail = vec!["eval(userInput)", "eval(a + b)", "eval(getCode())"];
+
+    Tester::new(DetectEvalWithExpression::NAME, DetectEvalWithExpression::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_new_buffer.rs
@@ -1,0 +1,86 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_new_buffer_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("new Buffer() is deprecated and unsafe")
+        .with_help("Use Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() instead of the deprecated Buffer constructor.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectNewBuffer;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects use of the `new Buffer()` constructor.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `Buffer` constructor is deprecated due to security and usability issues.
+    /// When called with a number, `new Buffer(n)` returns uninitialized memory that
+    /// may contain sensitive data. Use `Buffer.alloc()`, `Buffer.allocUnsafe()`, or
+    /// `Buffer.from()` instead.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// new Buffer(16);
+    /// new Buffer("string");
+    /// new Buffer([1, 2, 3]);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// Buffer.alloc(16);
+    /// Buffer.from("string");
+    /// Buffer.from([1, 2, 3]);
+    /// ```
+    DetectNewBuffer,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectNewBuffer {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::NewExpression(new_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::Identifier(callee) = &new_expr.callee else {
+            return;
+        };
+
+        if callee.name == "Buffer" {
+            ctx.diagnostic(detect_new_buffer_diagnostic(new_expr.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "Buffer.alloc(16)",
+        "Buffer.from('string')",
+        "Buffer.from([1, 2, 3])",
+        "new Map()",
+        "Buffer.allocUnsafe(16)",
+    ];
+
+    let fail = vec![
+        "new Buffer(16)",
+        "new Buffer('string')",
+        "new Buffer([1, 2, 3])",
+        "new Buffer(variable)",
+    ];
+
+    Tester::new(DetectNewBuffer::NAME, DetectNewBuffer::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_no_csrf_before_method_override.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_no_csrf_before_method_override.rs
@@ -1,0 +1,118 @@
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn detect_no_csrf_before_method_override_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("CSRF middleware found before method-override")
+        .with_help("Ensure that CSRF protection middleware is applied after method-override, not before. Otherwise method-override can bypass CSRF checks.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectNoCsrfBeforeMethodOverride;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects Express applications where CSRF middleware (`csrf()`) is applied
+    /// before `methodOverride()`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// If `method-override` middleware is applied after CSRF protection, it can
+    /// be used to change the HTTP method of a request after the CSRF check has
+    /// already passed, effectively bypassing the protection.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// app.use(csrf());
+    /// app.use(methodOverride());
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// app.use(methodOverride());
+    /// app.use(csrf());
+    /// ```
+    DetectNoCsrfBeforeMethodOverride,
+    oxc,
+    suspicious,
+    none
+);
+
+/// Extract the middleware name from `app.use(name())` pattern.
+fn get_middleware_name<'a>(expr: &'a Expression<'a>) -> Option<(&'a str, Span)> {
+    let Expression::CallExpression(call_expr) = expr else {
+        return None;
+    };
+
+    let Expression::StaticMemberExpression(member) = &call_expr.callee else {
+        return None;
+    };
+
+    if member.property.name != "use" {
+        return None;
+    }
+
+    let arg = call_expr.arguments.first()?.as_expression()?;
+    let Expression::CallExpression(inner_call) = arg else {
+        return None;
+    };
+
+    let Expression::Identifier(callee) = &inner_call.callee else {
+        return None;
+    };
+
+    Some((callee.name.as_str(), call_expr.span))
+}
+
+impl Rule for DetectNoCsrfBeforeMethodOverride {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let mut found_csrf = false;
+
+        for stmt in &ctx.semantic().nodes().program().body {
+            let oxc_ast::ast::Statement::ExpressionStatement(expr_stmt) = stmt else {
+                continue;
+            };
+
+            let Some((name, span)) = get_middleware_name(&expr_stmt.expression) else {
+                continue;
+            };
+
+            if name == "csrf" {
+                found_csrf = true;
+            }
+
+            if name == "methodOverride" && found_csrf {
+                ctx.diagnostic(detect_no_csrf_before_method_override_diagnostic(span));
+                return;
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "app.use(methodOverride()); app.use(csrf());",
+        "app.use(helmet()); app.use(methodOverride());",
+        "app.use(bodyParser());",
+    ];
+
+    let fail = vec!["app.use(csrf()); app.use(methodOverride());"];
+
+    Tester::new(
+        DetectNoCsrfBeforeMethodOverride::NAME,
+        DetectNoCsrfBeforeMethodOverride::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_non_literal_fs_filename.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_non_literal_fs_filename.rs
@@ -1,0 +1,177 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_non_literal_fs_filename_diagnostic(span: Span, method: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("fs.{method}() called with a non-literal file path"))
+        .with_help("Avoid passing dynamic values as file paths to fs methods. This can allow an attacker to access arbitrary files on the file system.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectNonLiteralFsFilename;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects calls to `fs` methods where the filename argument is not a string literal.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Passing user-controlled values as file paths to `fs` methods can allow
+    /// path traversal attacks, enabling an attacker to read, write, or delete
+    /// arbitrary files on the file system.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// fs.readFile(userInput, callback);
+    /// fs.writeFileSync(filePath, data);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// fs.readFile("./config.json", callback);
+    /// fs.writeFileSync("output.txt", data);
+    /// ```
+    DetectNonLiteralFsFilename,
+    oxc,
+    suspicious,
+    none
+);
+
+const FS_METHODS: &[&str] = &[
+    "access",
+    "appendFile",
+    "chmod",
+    "chown",
+    "close",
+    "copyFile",
+    "createReadStream",
+    "createWriteStream",
+    "exists",
+    "fchmod",
+    "fchown",
+    "fdatasync",
+    "fstat",
+    "fsync",
+    "ftruncate",
+    "futimes",
+    "lchmod",
+    "lchown",
+    "link",
+    "lstat",
+    "mkdir",
+    "mkdtemp",
+    "open",
+    "read",
+    "readFile",
+    "readdir",
+    "readlink",
+    "realpath",
+    "rename",
+    "rmdir",
+    "stat",
+    "symlink",
+    "truncate",
+    "unlink",
+    "unwatchFile",
+    "utimes",
+    "watch",
+    "watchFile",
+    "write",
+    "writeFile",
+    // Sync variants
+    "accessSync",
+    "appendFileSync",
+    "chmodSync",
+    "chownSync",
+    "closeSync",
+    "copyFileSync",
+    "existsSync",
+    "fchmodSync",
+    "fchownSync",
+    "fdatasyncSync",
+    "fstatSync",
+    "fsyncSync",
+    "ftruncateSync",
+    "futimesSync",
+    "lchmodSync",
+    "lchownSync",
+    "linkSync",
+    "lstatSync",
+    "mkdirSync",
+    "mkdtempSync",
+    "openSync",
+    "readFileSync",
+    "readSync",
+    "readdirSync",
+    "readlinkSync",
+    "realpathSync",
+    "renameSync",
+    "rmdirSync",
+    "statSync",
+    "symlinkSync",
+    "truncateSync",
+    "unlinkSync",
+    "utimesSync",
+    "writeFileSync",
+    "writeSync",
+];
+
+impl Rule for DetectNonLiteralFsFilename {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::StaticMemberExpression(member) = &call_expr.callee else {
+            return;
+        };
+
+        let method_name = member.property.name.as_str();
+        if !FS_METHODS.contains(&method_name) {
+            return;
+        }
+
+        let Some(arg) = call_expr.arguments.first().and_then(|a| a.as_expression()) else {
+            return;
+        };
+
+        match arg {
+            Expression::StringLiteral(_) => return,
+            Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => return,
+            _ => {}
+        }
+
+        ctx.diagnostic(detect_non_literal_fs_filename_diagnostic(call_expr.span, method_name));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"fs.readFile("./config.json", cb)"#,
+        r#"fs.writeFileSync("output.txt", data)"#,
+        "fs.readFile(`static-path`, cb)",
+        "obj.customMethod(variable)",
+        "fs.readFile()",
+    ];
+
+    let fail = vec![
+        "fs.readFile(userInput, cb)",
+        "fs.writeFileSync(filePath, data)",
+        "fs.readFile(getPath(), cb)",
+        "fs.unlink(dynamicFile, cb)",
+        "fs.readFile(`${dir}/file`, cb)",
+    ];
+
+    Tester::new(DetectNonLiteralFsFilename::NAME, DetectNonLiteralFsFilename::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_non_literal_regexp.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_non_literal_regexp.rs
@@ -1,0 +1,96 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_non_literal_regexp_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("new RegExp() called with a non-literal argument")
+        .with_help("Avoid constructing regular expressions from dynamic values. This can lead to ReDoS or injection attacks.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectNonLiteralRegexp;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects `new RegExp()` calls where the pattern argument is not a string literal.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Constructing regular expressions from untrusted input can lead to Regular
+    /// Expression Denial of Service (ReDoS) attacks, where a crafted pattern
+    /// causes catastrophic backtracking.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// new RegExp(userInput);
+    /// new RegExp(pattern, "gi");
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// new RegExp("^[a-z]+$");
+    /// /^[a-z]+$/;
+    /// ```
+    DetectNonLiteralRegexp,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectNonLiteralRegexp {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::NewExpression(new_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::Identifier(callee) = &new_expr.callee else {
+            return;
+        };
+
+        if callee.name != "RegExp" {
+            return;
+        }
+
+        let Some(arg) = new_expr.arguments.first().and_then(|a| a.as_expression()) else {
+            return;
+        };
+
+        match arg {
+            Expression::StringLiteral(_) => return,
+            Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => return,
+            _ => {}
+        }
+
+        ctx.diagnostic(detect_non_literal_regexp_diagnostic(new_expr.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"new RegExp("^[a-z]+$")"#,
+        r#"new RegExp("test", "gi")"#,
+        "new RegExp(`static`)",
+        "/^[a-z]+$/",
+        "new Map()",
+    ];
+
+    let fail = vec![
+        "new RegExp(userInput)",
+        "new RegExp(pattern, 'gi')",
+        "new RegExp(getPattern())",
+        "new RegExp(`dynamic-${name}`)",
+    ];
+
+    Tester::new(DetectNonLiteralRegexp::NAME, DetectNonLiteralRegexp::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_non_literal_require.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_non_literal_require.rs
@@ -1,0 +1,95 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_non_literal_require_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("require() called with a non-literal argument")
+        .with_help("Avoid calling require() with dynamic expressions. This can lead to arbitrary module loading.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectNonLiteralRequire;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects calls to `require()` where the argument is not a string literal.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Calling `require()` with a non-literal argument allows an attacker to load
+    /// arbitrary modules if they can control the input. This can lead to remote
+    /// code execution.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// require(userInput);
+    /// require(path + "/module");
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// require("fs");
+    /// require("./myModule");
+    /// ```
+    DetectNonLiteralRequire,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectNonLiteralRequire {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::Identifier(callee) = &call_expr.callee else {
+            return;
+        };
+
+        if callee.name != "require" {
+            return;
+        }
+
+        let Some(arg) = call_expr.arguments.first().and_then(|a| a.as_expression()) else {
+            return;
+        };
+
+        match arg {
+            Expression::StringLiteral(_) => return,
+            Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => return,
+            _ => {}
+        }
+
+        ctx.diagnostic(detect_non_literal_require_diagnostic(call_expr.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"require("fs")"#,
+        r#"require("./myModule")"#,
+        "require(`static-template`)",
+        "console.log('hello')",
+    ];
+
+    let fail = vec![
+        "require(userInput)",
+        "require(path + '/module')",
+        "require(getModuleName())",
+        "require(`dynamic-${name}`)",
+    ];
+
+    Tester::new(DetectNonLiteralRequire::NAME, DetectNonLiteralRequire::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_object_injection.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_object_injection.rs
@@ -1,0 +1,112 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn variable_assigned_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Variable Assigned to Object Injection Sink")
+        .with_help(
+            "Avoid indexing objects with untrusted dynamic keys without validating the key first.",
+        )
+        .with_label(span)
+}
+
+fn function_call_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Function Call Object Injection Sink")
+        .with_help("Avoid passing dynamically indexed object access into security-sensitive flows without validating the key first.")
+        .with_label(span)
+}
+
+fn generic_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Generic Object Injection Sink")
+        .with_help(
+            "Avoid indexing objects with untrusted dynamic keys without validating the key first.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectObjectInjection;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects computed object member access with identifier keys such as `object[key]`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Dynamically indexing objects with attacker-controlled keys can lead to
+    /// prototype pollution, unexpected property access, or other unsafe behavior
+    /// when the key is not validated first.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const value = object[key];
+    /// object[key] = nextValue;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const value = object.safeKey;
+    /// const value = object["fixed-key"];
+    /// ```
+    DetectObjectInjection,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectObjectInjection {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ComputedMemberExpression(member_expr) = node.kind() else {
+            return;
+        };
+
+        if !matches!(&member_expr.expression, Expression::Identifier(_)) {
+            return;
+        }
+
+        match ctx.nodes().parent_kind(node.id()) {
+            AstKind::VariableDeclarator(_) => {
+                ctx.diagnostic(variable_assigned_diagnostic(member_expr.span));
+            }
+            AstKind::CallExpression(_) => {
+                ctx.diagnostic(function_call_diagnostic(member_expr.span));
+            }
+            _ => {
+                ctx.diagnostic(generic_diagnostic(member_expr.span));
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "const obj = {};",
+        "const value = obj.staticKey;",
+        "const value = obj['static-key'];",
+        "const value = obj[0];",
+        "const value = obj[key + suffix];",
+        "const value = obj[getKey()];",
+        "obj['safe']();",
+    ];
+
+    let fail = vec![
+        "const value = obj[key];",
+        "foo(obj[key]);",
+        "obj[key] = nextValue;",
+        "return obj[key];",
+        "obj[key]();",
+    ];
+
+    Tester::new(DetectObjectInjection::NAME, DetectObjectInjection::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_possible_timing_attacks.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_possible_timing_attacks.rs
@@ -1,0 +1,159 @@
+use cow_utils::CowUtils;
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_possible_timing_attacks_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Possible timing attack")
+        .with_help("Use a constant-time comparison function (e.g., crypto.timingSafeEqual) instead of == or === when comparing security-sensitive values like passwords, tokens, or secrets.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectPossibleTimingAttacks;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects direct string comparisons using `==` or `===` with variables whose
+    /// names suggest they contain security-sensitive values (passwords, secrets,
+    /// tokens, etc.).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Standard string comparison operators like `==` and `===` may short-circuit,
+    /// returning early when the first differing character is found. An attacker can
+    /// measure the time these comparisons take to infer correct characters one by
+    /// one. Use a constant-time comparison function instead.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// if (password === userInput) {}
+    /// if (token == guess) {}
+    /// if (secret === input) {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// if (crypto.timingSafeEqual(Buffer.from(password), Buffer.from(userInput))) {}
+    /// ```
+    DetectPossibleTimingAttacks,
+    oxc,
+    suspicious,
+    none
+);
+
+const SENSITIVE_NAMES: &[&str] = &[
+    "password",
+    "secret",
+    "api_key",
+    "apiKey",
+    "api_secret",
+    "apiSecret",
+    "token",
+    "auth_token",
+    "authToken",
+    "access_token",
+    "accessToken",
+    "refresh_token",
+    "refreshToken",
+    "hash",
+    "signature",
+    "csrf",
+    "csrfToken",
+    "csrf_token",
+    "session_id",
+    "sessionId",
+    "session",
+    "privateKey",
+    "private_key",
+    "secretKey",
+    "secret_key",
+];
+
+fn is_sensitive_name(name: &str) -> bool {
+    let lower = name.cow_to_ascii_lowercase();
+    SENSITIVE_NAMES.iter().any(|s| lower.contains(&*s.cow_to_ascii_lowercase()))
+}
+
+fn is_sensitive_expression(expr: &Expression) -> bool {
+    match expr {
+        Expression::Identifier(ident) => is_sensitive_name(ident.name.as_str()),
+        Expression::StaticMemberExpression(member) => {
+            is_sensitive_name(member.property.name.as_str())
+        }
+        _ => false,
+    }
+}
+
+fn is_non_literal(expr: &Expression) -> bool {
+    !matches!(
+        expr,
+        Expression::StringLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+    )
+}
+
+impl Rule for DetectPossibleTimingAttacks {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::BinaryExpression(bin_expr) = node.kind() else {
+            return;
+        };
+
+        if !matches!(
+            bin_expr.operator,
+            oxc_syntax::operator::BinaryOperator::Equality
+                | oxc_syntax::operator::BinaryOperator::StrictEquality
+                | oxc_syntax::operator::BinaryOperator::Inequality
+                | oxc_syntax::operator::BinaryOperator::StrictInequality
+        ) {
+            return;
+        }
+
+        let left_sensitive = is_sensitive_expression(&bin_expr.left);
+        let right_sensitive = is_sensitive_expression(&bin_expr.right);
+
+        if !left_sensitive && !right_sensitive {
+            return;
+        }
+
+        // Both sides must be non-literal for a timing attack to be relevant
+        if !is_non_literal(&bin_expr.left) || !is_non_literal(&bin_expr.right) {
+            return;
+        }
+
+        ctx.diagnostic(detect_possible_timing_attacks_diagnostic(bin_expr.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"if (password === "literal") {}"#,
+        "if (x === y) {}",
+        "if (count === 5) {}",
+        r#"if (name === "admin") {}"#,
+        "if (password === null) {}",
+    ];
+
+    let fail = vec![
+        "if (password === userInput) {}",
+        "if (token == guess) {}",
+        "if (secret === input) {}",
+        "if (user.apiKey === req.body.key) {}",
+        "if (hash !== computedHash) {}",
+    ];
+
+    Tester::new(DetectPossibleTimingAttacks::NAME, DetectPossibleTimingAttacks::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_pseudo_random_bytes.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_pseudo_random_bytes.rs
@@ -1,0 +1,70 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_pseudo_random_bytes_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("crypto.pseudoRandomBytes() is not cryptographically secure")
+        .with_help("Use crypto.randomBytes() instead of crypto.pseudoRandomBytes().")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectPseudoRandomBytes;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects calls to `crypto.pseudoRandomBytes()`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `pseudoRandomBytes` is not guaranteed to be cryptographically secure.
+    /// Use `crypto.randomBytes()` instead for security-sensitive operations.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// crypto.pseudoRandomBytes(16);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// crypto.randomBytes(16);
+    /// ```
+    DetectPseudoRandomBytes,
+    oxc,
+    suspicious,
+    none
+);
+
+impl Rule for DetectPseudoRandomBytes {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::StaticMemberExpression(member) = &call_expr.callee else {
+            return;
+        };
+
+        if member.property.name == "pseudoRandomBytes" {
+            ctx.diagnostic(detect_pseudo_random_bytes_diagnostic(call_expr.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["crypto.randomBytes(16)", "foo.bar()", "pseudoRandomBytes(16)"];
+
+    let fail = vec!["crypto.pseudoRandomBytes(16)", "obj.pseudoRandomBytes(32)"];
+
+    Tester::new(DetectPseudoRandomBytes::NAME, DetectPseudoRandomBytes::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/detect_unsafe_regex.rs
+++ b/crates/oxc_linter/src/rules/oxc/detect_unsafe_regex.rs
@@ -1,0 +1,143 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn detect_unsafe_regex_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unsafe regular expression: potential ReDoS vulnerability")
+        .with_help("Avoid regular expressions with nested quantifiers or overlapping alternations that can cause catastrophic backtracking. Simplify the regex or use a linear-time regex engine.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DetectUnsafeRegex;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects regular expressions that are potentially vulnerable to Regular
+    /// Expression Denial of Service (ReDoS).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Regular expressions with certain patterns (nested quantifiers, overlapping
+    /// alternations) can take exponential time to evaluate on crafted input. An
+    /// attacker can exploit this to cause denial of service.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const re = /(a+)+$/;
+    /// const re = /([a-zA-Z]+)*$/;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const re = /^[a-z]+$/;
+    /// const re = /^\d{1,10}$/;
+    /// ```
+    DetectUnsafeRegex,
+    oxc,
+    suspicious,
+    none
+);
+
+/// Simple heuristic check for potentially unsafe regex patterns.
+/// Looks for nested quantifiers like (a+)+, (a*)+, (a+)*, etc.
+fn is_unsafe_pattern(pattern: &str) -> bool {
+    // Check for nested quantifiers: a group with a quantifier followed by another quantifier
+    // Patterns like (x+)+, (x+)*, (x*)+, (x*)*
+    let bytes = pattern.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        if bytes[i] == b'(' {
+            // Find matching closing paren
+            let mut depth = 1;
+            let mut j = i + 1;
+            let mut has_quantifier_inside = false;
+
+            while j < len && depth > 0 {
+                match bytes[j] {
+                    b'\\' => {
+                        j += 1; // skip escaped char
+                    }
+                    b'(' => depth += 1,
+                    b')' => depth -= 1,
+                    b'+' | b'*' if depth == 1 => {
+                        has_quantifier_inside = true;
+                    }
+                    _ => {}
+                }
+                j += 1;
+            }
+
+            // j is now past the closing paren
+            if has_quantifier_inside
+                && j < len
+                && (bytes[j] == b'+' || bytes[j] == b'*' || bytes[j] == b'{')
+            {
+                return true;
+            }
+        }
+        i += 1;
+    }
+
+    false
+}
+
+impl Rule for DetectUnsafeRegex {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::RegExpLiteral(regexp) => {
+                if is_unsafe_pattern(regexp.regex.pattern.text.as_str()) {
+                    ctx.diagnostic(detect_unsafe_regex_diagnostic(regexp.span));
+                }
+            }
+            AstKind::NewExpression(new_expr) => {
+                let Expression::Identifier(callee) = &new_expr.callee else {
+                    return;
+                };
+                if callee.name != "RegExp" {
+                    return;
+                }
+                let Some(Expression::StringLiteral(pattern)) =
+                    new_expr.arguments.first().and_then(|a| a.as_expression())
+                else {
+                    return;
+                };
+                if is_unsafe_pattern(pattern.value.as_str()) {
+                    ctx.diagnostic(detect_unsafe_regex_diagnostic(new_expr.span));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "const re = /^[a-z]+$/",
+        r"const re = /^\d{1,10}$/",
+        "const re = /foo|bar/",
+        r"const re = /\w+/",
+        r#"const re = new RegExp("^[a-z]+$")"#,
+    ];
+
+    let fail = vec![
+        "const re = /(a+)+$/",
+        "const re = /([a-zA-Z]+)*$/",
+        "const re = /(a+){2,}/",
+        r#"const re = new RegExp("(a+)+$")"#,
+    ];
+
+    Tester::new(DetectUnsafeRegex::NAME, DetectUnsafeRegex::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/oxc_depend_ban_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_depend_ban_dependencies.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(depend-ban-dependencies): Package "moment" is banned: Use date-fns or dayjs instead
+   ╭─[depend_ban_dependencies.tsx:1:20]
+ 1 │ import moment from "moment";
+   ·                    ────────
+   ╰────
+  help: Remove the import of "moment" and use the suggested alternative.
+
+  ⚠ oxc(depend-ban-dependencies): Package "lodash" is banned: Use native Array/Object methods or lodash-es for tree-shaking
+   ╭─[depend_ban_dependencies.tsx:1:19]
+ 1 │ const _ = require("lodash");
+   ·                   ────────
+   ╰────
+  help: Remove the import of "lodash" and use the suggested alternative.
+
+  ⚠ oxc(depend-ban-dependencies): Package "underscore" is banned: Use native Array/Object methods instead
+   ╭─[depend_ban_dependencies.tsx:1:15]
+ 1 │ import _ from "underscore";
+   ·               ────────────
+   ╰────
+  help: Remove the import of "underscore" and use the suggested alternative.
+
+  ⚠ oxc(depend-ban-dependencies): Package "lodash" is banned: Use native Array/Object methods or lodash-es for tree-shaking
+   ╭─[depend_ban_dependencies.tsx:1:19]
+ 1 │ import merge from "lodash/merge";
+   ·                   ──────────────
+   ╰────
+  help: Remove the import of "lodash" and use the suggested alternative.
+
+  ⚠ oxc(depend-ban-dependencies): Package "my-banned-pkg" is banned: Use something else
+   ╭─[depend_ban_dependencies.tsx:1:20]
+ 1 │ import banned from "my-banned-pkg";
+   ·                    ───────────────
+   ╰────
+  help: Remove the import of "my-banned-pkg" and use the suggested alternative.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_buffer_noassert.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_buffer_noassert.snap
@@ -1,0 +1,200 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readUInt8(0, true)
+   · ──────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readUInt16LE(0, true)
+   · ─────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readUInt16BE(0, true)
+   · ─────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readUInt32LE(0, true)
+   · ─────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readUInt32BE(0, true)
+   · ─────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readInt8(0, true)
+   · ─────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readInt16LE(0, true)
+   · ────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readInt16BE(0, true)
+   · ────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readInt32LE(0, true)
+   · ────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readInt32BE(0, true)
+   · ────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readFloatLE(0, true)
+   · ────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readFloatBE(0, true)
+   · ────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readDoubleLE(0, true)
+   · ─────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.readDoubleBE(0, true)
+   · ─────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeUInt8(0, 0, true)
+   · ──────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeUInt16LE(0, 0, true)
+   · ─────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeUInt16BE(0, 0, true)
+   · ─────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeUInt32LE(0, 0, true)
+   · ─────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeUInt32BE(0, 0, true)
+   · ─────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeInt8(0, 0, true)
+   · ─────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeInt16LE(0, 0, true)
+   · ────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeInt16BE(0, 0, true)
+   · ────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeInt32LE(0, 0, true)
+   · ────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeInt32BE(0, 0, true)
+   · ────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeFloatLE(0, 0, true)
+   · ────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeFloatBE(0, 0, true)
+   · ────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeDoubleLE(0, 0, true)
+   · ─────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.
+
+  ⚠ oxc(detect-buffer-noassert): Buffer read/write called with noAssert flag
+   ╭─[detect_buffer_noassert.tsx:1:1]
+ 1 │ buf.writeDoubleBE(0, 0, true)
+   · ─────────────────────────────
+   ╰────
+  help: Do not pass true as the last argument (noAssert) to Buffer read/write methods. This disables bounds checking and can lead to out-of-bounds access.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_child_process.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_child_process.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-child-process): child_process.exec() called with a non-literal argument
+   ╭─[detect_child_process.tsx:1:1]
+ 1 │ child_process.exec(userInput)
+   · ─────────────────────────────
+   ╰────
+  help: Avoid calling child_process.exec() with dynamic expressions. Use child_process.execFile() or spawn() with an argument array instead.
+
+  ⚠ oxc(detect-child-process): child_process.exec() called with a non-literal argument
+   ╭─[detect_child_process.tsx:1:1]
+ 1 │ cp.exec(cmd)
+   · ────────────
+   ╰────
+  help: Avoid calling child_process.exec() with dynamic expressions. Use child_process.execFile() or spawn() with an argument array instead.
+
+  ⚠ oxc(detect-child-process): child_process.exec() called with a non-literal argument
+   ╭─[detect_child_process.tsx:1:1]
+ 1 │ child_process.exec(getCommand())
+   · ────────────────────────────────
+   ╰────
+  help: Avoid calling child_process.exec() with dynamic expressions. Use child_process.execFile() or spawn() with an argument array instead.
+
+  ⚠ oxc(detect-child-process): child_process.exec() called with a non-literal argument
+   ╭─[detect_child_process.tsx:1:1]
+ 1 │ child_process.exec(`${cmd} -la`)
+   · ────────────────────────────────
+   ╰────
+  help: Avoid calling child_process.exec() with dynamic expressions. Use child_process.execFile() or spawn() with an argument array instead.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_disable_mustache_escape.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_disable_mustache_escape.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-disable-mustache-escape): Mustache escaping is being disabled
+   ╭─[detect_disable_mustache_escape.tsx:1:19]
+ 1 │ const options = { escapeMarkup: false }
+   ·                   ───────────────────
+   ╰────
+  help: Setting escapeMarkup to false or escape to false disables HTML escaping and can lead to XSS vulnerabilities.
+
+  ⚠ oxc(detect-disable-mustache-escape): Mustache escaping is being disabled
+   ╭─[detect_disable_mustache_escape.tsx:1:19]
+ 1 │ const options = { escape: false }
+   ·                   ─────────────
+   ╰────
+  help: Setting escapeMarkup to false or escape to false disables HTML escaping and can lead to XSS vulnerabilities.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_eval_with_expression.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_eval_with_expression.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-eval-with-expression): eval() called with a non-literal argument
+   ╭─[detect_eval_with_expression.tsx:1:1]
+ 1 │ eval(userInput)
+   · ───────────────
+   ╰────
+  help: Avoid calling eval() with dynamic expressions. This can lead to code injection vulnerabilities.
+
+  ⚠ oxc(detect-eval-with-expression): eval() called with a non-literal argument
+   ╭─[detect_eval_with_expression.tsx:1:1]
+ 1 │ eval(a + b)
+   · ───────────
+   ╰────
+  help: Avoid calling eval() with dynamic expressions. This can lead to code injection vulnerabilities.
+
+  ⚠ oxc(detect-eval-with-expression): eval() called with a non-literal argument
+   ╭─[detect_eval_with_expression.tsx:1:1]
+ 1 │ eval(getCode())
+   · ───────────────
+   ╰────
+  help: Avoid calling eval() with dynamic expressions. This can lead to code injection vulnerabilities.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_new_buffer.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_new_buffer.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-new-buffer): new Buffer() is deprecated and unsafe
+   ╭─[detect_new_buffer.tsx:1:1]
+ 1 │ new Buffer(16)
+   · ──────────────
+   ╰────
+  help: Use Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() instead of the deprecated Buffer constructor.
+
+  ⚠ oxc(detect-new-buffer): new Buffer() is deprecated and unsafe
+   ╭─[detect_new_buffer.tsx:1:1]
+ 1 │ new Buffer('string')
+   · ────────────────────
+   ╰────
+  help: Use Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() instead of the deprecated Buffer constructor.
+
+  ⚠ oxc(detect-new-buffer): new Buffer() is deprecated and unsafe
+   ╭─[detect_new_buffer.tsx:1:1]
+ 1 │ new Buffer([1, 2, 3])
+   · ─────────────────────
+   ╰────
+  help: Use Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() instead of the deprecated Buffer constructor.
+
+  ⚠ oxc(detect-new-buffer): new Buffer() is deprecated and unsafe
+   ╭─[detect_new_buffer.tsx:1:1]
+ 1 │ new Buffer(variable)
+   · ────────────────────
+   ╰────
+  help: Use Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() instead of the deprecated Buffer constructor.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_no_csrf_before_method_override.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_no_csrf_before_method_override.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-no-csrf-before-method-override): CSRF middleware found before method-override
+   ╭─[detect_no_csrf_before_method_override.tsx:1:18]
+ 1 │ app.use(csrf()); app.use(methodOverride());
+   ·                  ─────────────────────────
+   ╰────
+  help: Ensure that CSRF protection middleware is applied after method-override, not before. Otherwise method-override can bypass CSRF checks.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_non_literal_fs_filename.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_non_literal_fs_filename.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-non-literal-fs-filename): fs.readFile() called with a non-literal file path
+   ╭─[detect_non_literal_fs_filename.tsx:1:1]
+ 1 │ fs.readFile(userInput, cb)
+   · ──────────────────────────
+   ╰────
+  help: Avoid passing dynamic values as file paths to fs methods. This can allow an attacker to access arbitrary files on the file system.
+
+  ⚠ oxc(detect-non-literal-fs-filename): fs.writeFileSync() called with a non-literal file path
+   ╭─[detect_non_literal_fs_filename.tsx:1:1]
+ 1 │ fs.writeFileSync(filePath, data)
+   · ────────────────────────────────
+   ╰────
+  help: Avoid passing dynamic values as file paths to fs methods. This can allow an attacker to access arbitrary files on the file system.
+
+  ⚠ oxc(detect-non-literal-fs-filename): fs.readFile() called with a non-literal file path
+   ╭─[detect_non_literal_fs_filename.tsx:1:1]
+ 1 │ fs.readFile(getPath(), cb)
+   · ──────────────────────────
+   ╰────
+  help: Avoid passing dynamic values as file paths to fs methods. This can allow an attacker to access arbitrary files on the file system.
+
+  ⚠ oxc(detect-non-literal-fs-filename): fs.unlink() called with a non-literal file path
+   ╭─[detect_non_literal_fs_filename.tsx:1:1]
+ 1 │ fs.unlink(dynamicFile, cb)
+   · ──────────────────────────
+   ╰────
+  help: Avoid passing dynamic values as file paths to fs methods. This can allow an attacker to access arbitrary files on the file system.
+
+  ⚠ oxc(detect-non-literal-fs-filename): fs.readFile() called with a non-literal file path
+   ╭─[detect_non_literal_fs_filename.tsx:1:1]
+ 1 │ fs.readFile(`${dir}/file`, cb)
+   · ──────────────────────────────
+   ╰────
+  help: Avoid passing dynamic values as file paths to fs methods. This can allow an attacker to access arbitrary files on the file system.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_non_literal_regexp.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_non_literal_regexp.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-non-literal-regexp): new RegExp() called with a non-literal argument
+   ╭─[detect_non_literal_regexp.tsx:1:1]
+ 1 │ new RegExp(userInput)
+   · ─────────────────────
+   ╰────
+  help: Avoid constructing regular expressions from dynamic values. This can lead to ReDoS or injection attacks.
+
+  ⚠ oxc(detect-non-literal-regexp): new RegExp() called with a non-literal argument
+   ╭─[detect_non_literal_regexp.tsx:1:1]
+ 1 │ new RegExp(pattern, 'gi')
+   · ─────────────────────────
+   ╰────
+  help: Avoid constructing regular expressions from dynamic values. This can lead to ReDoS or injection attacks.
+
+  ⚠ oxc(detect-non-literal-regexp): new RegExp() called with a non-literal argument
+   ╭─[detect_non_literal_regexp.tsx:1:1]
+ 1 │ new RegExp(getPattern())
+   · ────────────────────────
+   ╰────
+  help: Avoid constructing regular expressions from dynamic values. This can lead to ReDoS or injection attacks.
+
+  ⚠ oxc(detect-non-literal-regexp): new RegExp() called with a non-literal argument
+   ╭─[detect_non_literal_regexp.tsx:1:1]
+ 1 │ new RegExp(`dynamic-${name}`)
+   · ─────────────────────────────
+   ╰────
+  help: Avoid constructing regular expressions from dynamic values. This can lead to ReDoS or injection attacks.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_non_literal_require.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_non_literal_require.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-non-literal-require): require() called with a non-literal argument
+   ╭─[detect_non_literal_require.tsx:1:1]
+ 1 │ require(userInput)
+   · ──────────────────
+   ╰────
+  help: Avoid calling require() with dynamic expressions. This can lead to arbitrary module loading.
+
+  ⚠ oxc(detect-non-literal-require): require() called with a non-literal argument
+   ╭─[detect_non_literal_require.tsx:1:1]
+ 1 │ require(path + '/module')
+   · ─────────────────────────
+   ╰────
+  help: Avoid calling require() with dynamic expressions. This can lead to arbitrary module loading.
+
+  ⚠ oxc(detect-non-literal-require): require() called with a non-literal argument
+   ╭─[detect_non_literal_require.tsx:1:1]
+ 1 │ require(getModuleName())
+   · ────────────────────────
+   ╰────
+  help: Avoid calling require() with dynamic expressions. This can lead to arbitrary module loading.
+
+  ⚠ oxc(detect-non-literal-require): require() called with a non-literal argument
+   ╭─[detect_non_literal_require.tsx:1:1]
+ 1 │ require(`dynamic-${name}`)
+   · ──────────────────────────
+   ╰────
+  help: Avoid calling require() with dynamic expressions. This can lead to arbitrary module loading.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_object_injection.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_object_injection.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-object-injection): Variable Assigned to Object Injection Sink
+   ╭─[detect_object_injection.ts:1:15]
+ 1 │ const value = obj[key];
+   ·               ────────
+   ╰────
+  help: Avoid indexing objects with untrusted dynamic keys without validating the key first.
+
+  ⚠ oxc(detect-object-injection): Function Call Object Injection Sink
+   ╭─[detect_object_injection.ts:1:5]
+ 1 │ foo(obj[key]);
+   ·     ────────
+   ╰────
+  help: Avoid passing dynamically indexed object access into security-sensitive flows without validating the key first.
+
+  ⚠ oxc(detect-object-injection): Generic Object Injection Sink
+   ╭─[detect_object_injection.ts:1:1]
+ 1 │ obj[key] = nextValue;
+   · ────────
+   ╰────
+  help: Avoid indexing objects with untrusted dynamic keys without validating the key first.
+
+  ⚠ oxc(detect-object-injection): Generic Object Injection Sink
+   ╭─[detect_object_injection.ts:1:8]
+ 1 │ return obj[key];
+   ·        ────────
+   ╰────
+  help: Avoid indexing objects with untrusted dynamic keys without validating the key first.
+
+  ⚠ oxc(detect-object-injection): Function Call Object Injection Sink
+   ╭─[detect_object_injection.ts:1:1]
+ 1 │ obj[key]();
+   · ────────
+   ╰────
+  help: Avoid passing dynamically indexed object access into security-sensitive flows without validating the key first.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_possible_timing_attacks.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_possible_timing_attacks.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-possible-timing-attacks): Possible timing attack
+   ╭─[detect_possible_timing_attacks.tsx:1:5]
+ 1 │ if (password === userInput) {}
+   ·     ──────────────────────
+   ╰────
+  help: Use a constant-time comparison function (e.g., crypto.timingSafeEqual) instead of == or === when comparing security-sensitive values like passwords, tokens, or secrets.
+
+  ⚠ oxc(detect-possible-timing-attacks): Possible timing attack
+   ╭─[detect_possible_timing_attacks.tsx:1:5]
+ 1 │ if (token == guess) {}
+   ·     ──────────────
+   ╰────
+  help: Use a constant-time comparison function (e.g., crypto.timingSafeEqual) instead of == or === when comparing security-sensitive values like passwords, tokens, or secrets.
+
+  ⚠ oxc(detect-possible-timing-attacks): Possible timing attack
+   ╭─[detect_possible_timing_attacks.tsx:1:5]
+ 1 │ if (secret === input) {}
+   ·     ────────────────
+   ╰────
+  help: Use a constant-time comparison function (e.g., crypto.timingSafeEqual) instead of == or === when comparing security-sensitive values like passwords, tokens, or secrets.
+
+  ⚠ oxc(detect-possible-timing-attacks): Possible timing attack
+   ╭─[detect_possible_timing_attacks.tsx:1:5]
+ 1 │ if (user.apiKey === req.body.key) {}
+   ·     ────────────────────────────
+   ╰────
+  help: Use a constant-time comparison function (e.g., crypto.timingSafeEqual) instead of == or === when comparing security-sensitive values like passwords, tokens, or secrets.
+
+  ⚠ oxc(detect-possible-timing-attacks): Possible timing attack
+   ╭─[detect_possible_timing_attacks.tsx:1:5]
+ 1 │ if (hash !== computedHash) {}
+   ·     ─────────────────────
+   ╰────
+  help: Use a constant-time comparison function (e.g., crypto.timingSafeEqual) instead of == or === when comparing security-sensitive values like passwords, tokens, or secrets.

--- a/crates/oxc_linter/src/snapshots/oxc_detect_pseudo_random_bytes.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_pseudo_random_bytes.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-pseudo-random-bytes): crypto.pseudoRandomBytes() is not cryptographically secure
+   ╭─[detect_pseudo_random_bytes.tsx:1:1]
+ 1 │ crypto.pseudoRandomBytes(16)
+   · ────────────────────────────
+   ╰────
+  help: Use crypto.randomBytes() instead of crypto.pseudoRandomBytes().
+
+  ⚠ oxc(detect-pseudo-random-bytes): crypto.pseudoRandomBytes() is not cryptographically secure
+   ╭─[detect_pseudo_random_bytes.tsx:1:1]
+ 1 │ obj.pseudoRandomBytes(32)
+   · ─────────────────────────
+   ╰────
+  help: Use crypto.randomBytes() instead of crypto.pseudoRandomBytes().

--- a/crates/oxc_linter/src/snapshots/oxc_detect_unsafe_regex.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_detect_unsafe_regex.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(detect-unsafe-regex): Unsafe regular expression: potential ReDoS vulnerability
+   ╭─[detect_unsafe_regex.tsx:1:12]
+ 1 │ const re = /(a+)+$/
+   ·            ────────
+   ╰────
+  help: Avoid regular expressions with nested quantifiers or overlapping alternations that can cause catastrophic backtracking. Simplify the regex or use a linear-time regex engine.
+
+  ⚠ oxc(detect-unsafe-regex): Unsafe regular expression: potential ReDoS vulnerability
+   ╭─[detect_unsafe_regex.tsx:1:12]
+ 1 │ const re = /([a-zA-Z]+)*$/
+   ·            ───────────────
+   ╰────
+  help: Avoid regular expressions with nested quantifiers or overlapping alternations that can cause catastrophic backtracking. Simplify the regex or use a linear-time regex engine.
+
+  ⚠ oxc(detect-unsafe-regex): Unsafe regular expression: potential ReDoS vulnerability
+   ╭─[detect_unsafe_regex.tsx:1:12]
+ 1 │ const re = /(a+){2,}/
+   ·            ──────────
+   ╰────
+  help: Avoid regular expressions with nested quantifiers or overlapping alternations that can cause catastrophic backtracking. Simplify the regex or use a linear-time regex engine.
+
+  ⚠ oxc(detect-unsafe-regex): Unsafe regular expression: potential ReDoS vulnerability
+   ╭─[detect_unsafe_regex.tsx:1:12]
+ 1 │ const re = new RegExp("(a+)+$")
+   ·            ────────────────────
+   ╰────
+  help: Avoid regular expressions with nested quantifiers or overlapping alternations that can cause catastrophic backtracking. Simplify the regex or use a linear-time regex engine.


### PR DESCRIPTION
## Summary

Add 14 new security-focused rules to the oxc plugin for detecting common vulnerabilities in Node.js applications:

- `detect-buffer-noassert` — deprecated Buffer methods without assertion
- `detect-child-process` — child process spawning
- `detect-disable-mustache-escape` — disabled HTML escaping
- `detect-eval-with-expression` — eval() with dynamic expressions
- `detect-new-buffer` — deprecated `new Buffer()` constructor
- `detect-no-csrf-before-method-override` — CSRF vulnerability patterns
- `detect-non-literal-fs-filename` — file system ops with non-literal paths
- `detect-non-literal-regexp` — RegExp from non-literal sources
- `detect-non-literal-require` — dynamic require() calls
- `detect-object-injection` — unsafe object property injection
- `detect-possible-timing-attacks` — timing attack patterns
- `detect-pseudo-random-bytes` — weak random number generators
- `detect-unsafe-regex` — ReDoS-prone regular expressions
- `depend-ban-dependencies` — ban specific dependency imports

## Test plan

- [x] `cargo test -p oxc_linter` — all 14 rule tests pass
- [x] `cargo lintgen` — generated files up to date
- [x] `just fmt` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)