### PR TITLE
feat(linter): add package.json, JSON, and i18n validation rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1530,7 +1530,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2072,6 +2072,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "smallvec",
+ "spdx",
  "url",
 ]
 
@@ -2992,7 +2993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3087,7 +3088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3290,6 +3291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,7 +3386,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3856,7 +3866,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ simdutf8 = { version = "0.1.5", features = ["aarch64_neon"] } # SIMD UTF-8 valid
 similar = "2.7.0" # Text diffing
 similar-asserts = "1.7.0" # Test diff assertions
 smallvec = { version = "1.15.1", features = ["union", "serde"] } # Stack-allocated vectors
+spdx = "0.13.4" # SPDX expression and identifier validation
 tempfile = "3.24.0" # Temporary files
 tokio = { version = "1.49.0", default-features = false } # Async runtime
 toml = { version = "1.0.0" }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -73,6 +73,7 @@ serde_json = { workspace = true, features = [
 ] } # preserve_order: print config with ordered keys.
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
+spdx = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_linter/fixtures/import/i18n_catalog/en/common.json
+++ b/crates/oxc_linter/fixtures/import/i18n_catalog/en/common.json
@@ -1,0 +1,7 @@
+{
+  "actions": {
+    "cancel": "Cancel",
+    "save": "Save"
+  },
+  "title": "Dashboard"
+}

--- a/crates/oxc_linter/fixtures/import/i18n_catalog/en/messages.json
+++ b/crates/oxc_linter/fixtures/import/i18n_catalog/en/messages.json
@@ -1,0 +1,5 @@
+{
+  "greeting": "Hello {name}",
+  "count": "{count} items",
+  "simple": "Dashboard"
+}

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -636,7 +636,7 @@ mod test {
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT | LintPlugins::UNICORN));
         let config: Oxlintrc =
-            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue"] }"#).unwrap();
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue", "json", "css"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::all()));
 
         let config: Oxlintrc =

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -94,6 +94,10 @@ bitflags! {
         const NODE = 1 << 12;
         /// `eslint-plugin-vue`
         const VUE = 1 << 13;
+        /// JSON linting rules
+        const JSON = 1 << 14;
+        /// CSS linting rules
+        const CSS = 1 << 15;
     }
 }
 
@@ -158,6 +162,8 @@ impl TryFrom<&str> for LintPlugins {
             "promise" => Ok(LintPlugins::PROMISE),
             "node" => Ok(LintPlugins::NODE),
             "vue" => Ok(LintPlugins::VUE),
+            "json" => Ok(LintPlugins::JSON),
+            "css" => Ok(LintPlugins::CSS),
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
             "eslint" => Ok(LintPlugins::ESLINT),
@@ -183,6 +189,8 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::PROMISE => "promise",
             LintPlugins::NODE => "node",
             LintPlugins::VUE => "vue",
+            LintPlugins::JSON => "json",
+            LintPlugins::CSS => "css",
             _ => "",
         }
     }
@@ -254,6 +262,8 @@ impl JsonSchema for LintPlugins {
             Promise,
             Node,
             Vue,
+            Json,
+            Css,
         }
 
         let enum_schema = r#gen.subschema_for::<LintPluginOptionsSchema>();

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -150,6 +150,8 @@ pub struct ContextHost<'a> {
     pub(crate) fix: FixKind,
     /// Path to the file being linted.
     pub(super) file_path: Box<Path>,
+    /// Original full source text of the file being linted.
+    pub(super) full_source_text: &'a str,
     /// Extension of the file being linted.
     file_extension: Option<Box<OsStr>>,
     /// Global linter configuration, such as globals to include and the target
@@ -171,6 +173,7 @@ impl<'a> ContextHost<'a> {
     pub fn new<P: AsRef<Path>>(
         file_path: P,
         sub_hosts: Vec<ContextSubHost<'a>>,
+        full_source_text: &'a str,
         options: LintOptions,
         config: Arc<LintConfig>,
     ) -> Self {
@@ -190,6 +193,7 @@ impl<'a> ContextHost<'a> {
             diagnostics: RefCell::new(Vec::with_capacity(DIAGNOSTICS_INITIAL_CAPACITY)),
             fix: options.fix,
             file_path,
+            full_source_text,
             file_extension,
             config,
             frameworks: options.framework_hints,
@@ -252,6 +256,12 @@ impl<'a> ContextHost<'a> {
     #[inline]
     pub fn file_path(&self) -> &Path {
         &self.file_path
+    }
+
+    /// Original full source text of the file being linted.
+    #[inline]
+    pub fn full_source_text(&self) -> &'a str {
+        self.full_source_text
     }
 
     /// Extension of the file currently being linted, without the leading dot.
@@ -506,5 +516,41 @@ impl<'a> ContextHost<'a> {
 impl<'a> From<ContextHost<'a>> for Vec<Message> {
     fn from(ctx_host: ContextHost<'a>) -> Self {
         ctx_host.diagnostics.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{rc::Rc, sync::Arc};
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_semantic::SemanticBuilder;
+    use oxc_span::SourceType;
+
+    use super::{ContextHost, ContextSubHost};
+    use crate::{ModuleRecord, options::LintOptions};
+
+    #[test]
+    fn test_full_source_text_preserves_original_file_text() {
+        let allocator = Allocator::default();
+        let section_source = "const section = 1;";
+        let full_source = "header\nconst section = 1;\nfooter";
+
+        let parser_ret = Parser::new(&allocator, section_source, SourceType::default()).parse();
+        let program = allocator.alloc(parser_ret.program);
+        let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
+
+        let ctx = Rc::new(ContextHost::new(
+            "fixture.vue",
+            vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 7)],
+            full_source,
+            LintOptions::default(),
+            Arc::default(),
+        ))
+        .spawn_for_test();
+
+        assert_eq!(ctx.source_text(), section_source);
+        assert_eq!(ctx.full_source_text(), full_source);
     }
 }

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -133,6 +133,22 @@ impl<'a> LintContext<'a> {
         span.source_text(self.parent.semantic().source_text())
     }
 
+    /// Get a snippet of original file text covered by the given [`Span`].
+    #[inline]
+    pub fn full_source_range(&self, span: Span) -> &'a str {
+        span.source_text(self.parent.full_source_text())
+    }
+
+    /// Original full source text of the file currently being linted.
+    ///
+    /// This differs from the semantic source text for partial-loader files and
+    /// future non-JS file pipelines, where the parsed section may represent only
+    /// one part of the original file.
+    #[inline]
+    pub fn full_source_text(&self) -> &'a str {
+        self.parent.full_source_text()
+    }
+
     /// Finds the next occurrence of the given token in the source code,
     /// starting from the specified position, skipping over comments.
     #[expect(clippy::cast_possible_truncation)]

--- a/crates/oxc_linter/src/css_parser.rs
+++ b/crates/oxc_linter/src/css_parser.rs
@@ -1,0 +1,578 @@
+//! Lightweight span-preserving CSS parser for linting.
+//!
+//! Parses plain CSS into a tree of stylesheet nodes with exact source spans.
+//! Designed for lint rules, not for full CSS spec compliance. Handles:
+//! - Qualified rules (selector + declaration block)
+//! - At-rules (@media, @import, etc.)
+//! - Declarations (property: value)
+//! - Comments (/* ... */)
+
+use oxc_span::Span;
+
+// ── AST ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct CssStylesheet<'a> {
+    pub rules: Vec<CssRule<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum CssRule<'a> {
+    QualifiedRule(CssQualifiedRule<'a>),
+    AtRule(CssAtRule<'a>),
+    Comment(CssComment<'a>),
+}
+
+impl CssRule<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::QualifiedRule(r) => r.span,
+            Self::AtRule(r) => r.span,
+            Self::Comment(c) => c.span,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CssQualifiedRule<'a> {
+    /// The raw selector text (e.g., `.foo > bar`).
+    pub selector: &'a str,
+    pub selector_span: Span,
+    pub block: CssDeclarationBlock<'a>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssAtRule<'a> {
+    /// The at-rule name without `@` (e.g., `media`, `import`).
+    pub name: &'a str,
+    pub name_span: Span,
+    /// The prelude text between the name and `{` or `;`.
+    pub prelude: &'a str,
+    pub prelude_span: Span,
+    /// Body block, if present (at-rules like @import have no block).
+    pub block: Option<CssRuleBlock<'a>>,
+    pub span: Span,
+}
+
+/// A block that can contain nested rules (e.g., @media body).
+#[derive(Debug)]
+pub struct CssRuleBlock<'a> {
+    pub rules: Vec<CssRule<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssDeclarationBlock<'a> {
+    pub declarations: Vec<CssDeclaration<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssDeclaration<'a> {
+    pub property: &'a str,
+    pub property_span: Span,
+    pub value: &'a str,
+    pub value_span: Span,
+    pub important: bool,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssComment<'a> {
+    pub text: &'a str,
+    pub span: Span,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct CssParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct CssParseResult<'a> {
+    pub stylesheet: Option<CssStylesheet<'a>>,
+    pub errors: Vec<CssParseError>,
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+pub fn parse_css(source: &str) -> CssParseResult<'_> {
+    let mut parser = Parser::new(source);
+    let rules = parser.parse_rule_list();
+    let span = Span::new(0, source.len() as u32);
+    CssParseResult { stylesheet: Some(CssStylesheet { rules, span }), errors: parser.errors }
+}
+
+struct Parser<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    errors: Vec<CssParseError>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source, bytes: source.as_bytes(), pos: 0, errors: Vec::new() }
+    }
+
+    fn parse_rule_list(&mut self) -> Vec<CssRule<'a>> {
+        let mut rules = Vec::new();
+        loop {
+            self.skip_whitespace();
+            if self.pos >= self.bytes.len() {
+                break;
+            }
+            // Stop if we hit a closing brace (end of containing block)
+            if self.peek() == Some(b'}') {
+                break;
+            }
+            let before = self.pos;
+            if let Some(rule) = self.parse_rule() {
+                rules.push(rule);
+            } else if self.pos == before {
+                // No progress — skip one byte to avoid infinite loop
+                self.pos += 1;
+            }
+        }
+        rules
+    }
+
+    fn parse_rule(&mut self) -> Option<CssRule<'a>> {
+        self.skip_whitespace();
+        if self.pos >= self.bytes.len() {
+            return None;
+        }
+
+        // Comment
+        if self.starts_with(b"/*") {
+            return self.parse_comment().map(CssRule::Comment);
+        }
+
+        // At-rule
+        if self.peek() == Some(b'@') {
+            return self.parse_at_rule().map(CssRule::AtRule);
+        }
+
+        // Closing brace (end of nested block)
+        if self.peek() == Some(b'}') {
+            return None;
+        }
+
+        // Qualified rule
+        self.parse_qualified_rule().map(CssRule::QualifiedRule)
+    }
+
+    fn parse_comment(&mut self) -> Option<CssComment<'a>> {
+        let start = self.pos;
+        self.pos += 2; // skip /*
+        let text_start = self.pos;
+        loop {
+            if self.pos + 1 >= self.bytes.len() {
+                self.errors.push(CssParseError {
+                    message: "Unterminated comment".to_string(),
+                    span: Span::new(start as u32, self.bytes.len() as u32),
+                });
+                let text = &self.source[text_start..self.bytes.len()];
+                self.pos = self.bytes.len();
+                return Some(CssComment {
+                    text,
+                    span: Span::new(start as u32, self.bytes.len() as u32),
+                });
+            }
+            if self.bytes[self.pos] == b'*' && self.bytes[self.pos + 1] == b'/' {
+                let text = &self.source[text_start..self.pos];
+                self.pos += 2; // skip */
+                return Some(CssComment { text, span: Span::new(start as u32, self.pos as u32) });
+            }
+            self.pos += 1;
+        }
+    }
+
+    fn parse_at_rule(&mut self) -> Option<CssAtRule<'a>> {
+        let start = self.pos;
+        self.pos += 1; // skip @
+
+        // Parse name
+        let name_start = self.pos;
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_alphanumeric()
+            || self.pos < self.bytes.len() && self.bytes[self.pos] == b'-'
+        {
+            self.pos += 1;
+        }
+        let name = &self.source[name_start..self.pos];
+        let name_span = Span::new((start) as u32, self.pos as u32); // includes @
+
+        // Parse prelude (everything until { or ;)
+        self.skip_whitespace();
+        let prelude_start = self.pos;
+        let mut depth = 0u32;
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b'{' if depth == 0 => break,
+                b';' if depth == 0 => break,
+                b'(' => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                b')' => {
+                    depth = depth.saturating_sub(1);
+                    self.pos += 1;
+                }
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let prelude_end = self.pos;
+        let prelude = self.source[prelude_start..prelude_end].trim();
+        let prelude_span = Span::new(prelude_start as u32, prelude_end as u32);
+
+        if self.pos >= self.bytes.len() {
+            return Some(CssAtRule {
+                name,
+                name_span,
+                prelude,
+                prelude_span,
+                block: None,
+                span: Span::new(start as u32, self.pos as u32),
+            });
+        }
+
+        // Semicolon-terminated at-rule (e.g., @import)
+        if self.bytes[self.pos] == b';' {
+            self.pos += 1;
+            return Some(CssAtRule {
+                name,
+                name_span,
+                prelude,
+                prelude_span,
+                block: None,
+                span: Span::new(start as u32, self.pos as u32),
+            });
+        }
+
+        // Block at-rule (e.g., @media)
+        let block = self.parse_rule_block();
+        Some(CssAtRule {
+            name,
+            name_span,
+            prelude,
+            prelude_span,
+            block: Some(block),
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn parse_rule_block(&mut self) -> CssRuleBlock<'a> {
+        let block_start = self.pos;
+        self.pos += 1; // skip {
+        let rules = self.parse_rule_list();
+        self.skip_whitespace();
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b'}' {
+            self.pos += 1;
+        }
+        CssRuleBlock { rules, span: Span::new(block_start as u32, self.pos as u32) }
+    }
+
+    fn parse_qualified_rule(&mut self) -> Option<CssQualifiedRule<'a>> {
+        let start = self.pos;
+
+        // Parse selector (everything until {)
+        let selector_start = self.pos;
+        while self.pos < self.bytes.len() && self.bytes[self.pos] != b'{' {
+            match self.bytes[self.pos] {
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let selector_end = self.pos;
+        let selector = self.source[selector_start..selector_end].trim();
+        let selector_span = Span::new(selector_start as u32, selector_end as u32);
+
+        if self.pos >= self.bytes.len() {
+            self.errors.push(CssParseError {
+                message: "Expected '{' after selector".to_string(),
+                span: Span::new(start as u32, self.pos as u32),
+            });
+            return None;
+        }
+
+        let block = self.parse_declaration_block();
+
+        Some(CssQualifiedRule {
+            selector,
+            selector_span,
+            block,
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn parse_declaration_block(&mut self) -> CssDeclarationBlock<'a> {
+        let block_start = self.pos;
+        self.pos += 1; // skip {
+        let mut declarations = Vec::new();
+
+        loop {
+            self.skip_whitespace();
+            if self.pos >= self.bytes.len() || self.bytes[self.pos] == b'}' {
+                break;
+            }
+
+            // Skip comments inside blocks
+            if self.starts_with(b"/*") {
+                self.parse_comment();
+                continue;
+            }
+
+            if let Some(decl) = self.parse_declaration() {
+                declarations.push(decl);
+            }
+        }
+
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b'}' {
+            self.pos += 1;
+        }
+
+        CssDeclarationBlock { declarations, span: Span::new(block_start as u32, self.pos as u32) }
+    }
+
+    fn parse_declaration(&mut self) -> Option<CssDeclaration<'a>> {
+        let start = self.pos;
+
+        // Parse property name
+        let prop_start = self.pos;
+        while self.pos < self.bytes.len()
+            && self.bytes[self.pos] != b':'
+            && self.bytes[self.pos] != b'}'
+            && self.bytes[self.pos] != b';'
+        {
+            self.pos += 1;
+        }
+        let property = self.source[prop_start..self.pos].trim();
+        let property_span = Span::new(prop_start as u32, self.pos as u32);
+
+        if property.is_empty() || self.pos >= self.bytes.len() || self.bytes[self.pos] != b':' {
+            // Not a valid declaration — skip to next ; or }
+            while self.pos < self.bytes.len()
+                && self.bytes[self.pos] != b';'
+                && self.bytes[self.pos] != b'}'
+            {
+                self.pos += 1;
+            }
+            if self.pos < self.bytes.len() && self.bytes[self.pos] == b';' {
+                self.pos += 1;
+            }
+            return None;
+        }
+
+        self.pos += 1; // skip :
+        self.skip_whitespace();
+
+        // Parse value (everything until ; or })
+        let value_start = self.pos;
+        let mut depth = 0u32;
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b';' if depth == 0 => break,
+                b'}' if depth == 0 => break,
+                b'(' => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                b')' => {
+                    depth = depth.saturating_sub(1);
+                    self.pos += 1;
+                }
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let value_end = self.pos;
+        let raw_value = self.source[value_start..value_end].trim();
+        let value_span = Span::new(value_start as u32, value_end as u32);
+
+        let important = raw_value.ends_with("!important") || raw_value.ends_with("! important");
+        let value = if important {
+            raw_value.trim_end_matches("!important").trim_end_matches("! important").trim()
+        } else {
+            raw_value
+        };
+
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b';' {
+            self.pos += 1;
+        }
+
+        Some(CssDeclaration {
+            property,
+            property_span,
+            value,
+            value_span,
+            important,
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn skip_string(&mut self) {
+        let quote = self.bytes[self.pos];
+        self.pos += 1;
+        while self.pos < self.bytes.len() {
+            if self.bytes[self.pos] == b'\\' {
+                self.pos += 2;
+                continue;
+            }
+            if self.bytes[self.pos] == quote {
+                self.pos += 1;
+                return;
+            }
+            self.pos += 1;
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn starts_with(&self, prefix: &[u8]) -> bool {
+        self.bytes[self.pos..].starts_with(prefix)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_rule() {
+        let css = "body { color: red; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        assert_eq!(sheet.rules.len(), 1);
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.selector, "body");
+            assert_eq!(rule.block.declarations.len(), 1);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[0].value, "red");
+            assert!(!rule.block.declarations[0].important);
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_important() {
+        let css = ".x { color: red !important; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations[0].value, "red");
+            assert!(rule.block.declarations[0].important);
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_multiple_declarations() {
+        let css = "h1 { color: blue; font-size: 16px; margin: 0; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations.len(), 3);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[1].property, "font-size");
+            assert_eq!(rule.block.declarations[2].property, "margin");
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_at_rule_import() {
+        let css = "@import url('styles.css');";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::AtRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.name, "import");
+            assert!(rule.prelude.contains("styles.css"));
+            assert!(rule.block.is_none());
+        } else {
+            panic!("Expected at-rule");
+        }
+    }
+
+    #[test]
+    fn parse_at_rule_media() {
+        let css = "@media (max-width: 768px) { body { color: red; } }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::AtRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.name, "media");
+            assert!(rule.block.is_some());
+            let block = rule.block.as_ref().unwrap();
+            assert_eq!(block.rules.len(), 1);
+        } else {
+            panic!("Expected at-rule");
+        }
+    }
+
+    #[test]
+    fn parse_comment() {
+        let css = "/* hello */ body { color: red; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        assert_eq!(sheet.rules.len(), 2);
+        if let CssRule::Comment(c) = &sheet.rules[0] {
+            assert_eq!(c.text, " hello ");
+        } else {
+            panic!("Expected comment");
+        }
+    }
+
+    #[test]
+    fn parse_duplicate_properties() {
+        let css = ".a { color: red; color: blue; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations.len(), 2);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[1].property, "color");
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_empty_block() {
+        let css = ".empty { }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert!(rule.block.declarations.is_empty());
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+}

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -75,6 +75,12 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self.ctx.source_range(span)
     }
 
+    /// Get a snippet of original file text covered by the given [`Span`].
+    #[inline]
+    pub fn full_source_range(&self, span: Span) -> &'a str {
+        self.ctx.full_source_range(span)
+    }
+
     /// Create a [`RuleFix`] that deletes the text covered by the given [`Span`]
     /// or AST node.
     #[inline]
@@ -125,6 +131,30 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
             fixer.new_fix(CompositeFix::Single(fix), message)
         }
+        inner(self, target, replacement.into())
+    }
+
+    /// Replace a span in the original full file text.
+    pub fn replace_full_source_range<S: Into<Cow<'static, str>>>(
+        &self,
+        target: Span,
+        replacement: S,
+    ) -> RuleFix {
+        fn inner(
+            fixer: &RuleFixer<'_, '_>,
+            target: Span,
+            replacement: Cow<'static, str>,
+        ) -> RuleFix {
+            let fix = Fix::new(replacement, target);
+            let target_text = fixer.possibly_truncate_full_source_range(target);
+            let content = fixer.possibly_truncate_snippet(&fix.content);
+            let message = fixer.auto_message.then(|| {
+                Cow::Owned(format_replace_message(target_text.as_ref(), content.as_ref()))
+            });
+
+            fixer.new_fix(CompositeFix::Single(fix), message)
+        }
+
         inner(self, target, replacement.into())
     }
 
@@ -203,6 +233,11 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
     fn possibly_truncate_range(&self, span: Span) -> Cow<'a, str> {
         let snippet = self.ctx.source_range(span);
+        self.possibly_truncate_snippet(snippet)
+    }
+
+    fn possibly_truncate_full_source_range(&self, span: Span) -> Cow<'a, str> {
+        let snippet = self.ctx.full_source_range(span);
         self.possibly_truncate_snippet(snippet)
     }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3923,6 +3923,149 @@ impl RuleRunner for crate::rules::oxc::uninvoked_array_callback::UninvokedArrayC
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::oxc::identical_keys::IdenticalKeys {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::identical_placeholders::IdenticalPlaceholders {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::json_no_comments::JsonNoComments {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::json_no_duplicate_keys::JsonNoDuplicateKeys {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::json_no_trailing_commas::JsonNoTrailingCommas {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::json_parse_validation::JsonParseValidation {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_no_duplicate_dependencies::PackageJsonNoDuplicateDependencies {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_no_empty_fields::PackageJsonNoEmptyFields {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_no_redundant_publish_config::PackageJsonNoRedundantPublishConfig {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_order_properties::PackageJsonOrderProperties {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner
+    for crate::rules::oxc::package_json_repository_shorthand::PackageJsonRepositoryShorthand
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_require_type::PackageJsonRequireType {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_require_version::PackageJsonRequireVersion {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_sort_collections::PackageJsonSortCollections {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_bin::PackageJsonValidBin {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_description::PackageJsonValidDescription {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_engines::PackageJsonValidEngines {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_keywords::PackageJsonValidKeywords {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_license::PackageJsonValidLicense {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_man::PackageJsonValidMan {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_name::PackageJsonValidName {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_private::PackageJsonValidPrivate {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_repository::PackageJsonValidRepository {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_type::PackageJsonValidType {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::package_json_valid_version::PackageJsonValidVersion {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::sorted_json_keys::SortedJsonKeys {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::valid_json::ValidJson {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::valid_message_syntax::ValidMessageSyntax {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::nextjs::google_font_display::GoogleFontDisplay {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -355,6 +355,12 @@ pub use crate::rules::oxc::branches_sharing_code::BranchesSharingCode as OxcBran
 pub use crate::rules::oxc::const_comparisons::ConstComparisons as OxcConstComparisons;
 pub use crate::rules::oxc::double_comparisons::DoubleComparisons as OxcDoubleComparisons;
 pub use crate::rules::oxc::erasing_op::ErasingOp as OxcErasingOp;
+pub use crate::rules::oxc::identical_keys::IdenticalKeys as OxcIdenticalKeys;
+pub use crate::rules::oxc::identical_placeholders::IdenticalPlaceholders as OxcIdenticalPlaceholders;
+pub use crate::rules::oxc::json_no_comments::JsonNoComments as OxcJsonNoComments;
+pub use crate::rules::oxc::json_no_duplicate_keys::JsonNoDuplicateKeys as OxcJsonNoDuplicateKeys;
+pub use crate::rules::oxc::json_no_trailing_commas::JsonNoTrailingCommas as OxcJsonNoTrailingCommas;
+pub use crate::rules::oxc::json_parse_validation::JsonParseValidation as OxcJsonParseValidation;
 pub use crate::rules::oxc::misrefactored_assign_op::MisrefactoredAssignOp as OxcMisrefactoredAssignOp;
 pub use crate::rules::oxc::missing_throw::MissingThrow as OxcMissingThrow;
 pub use crate::rules::oxc::no_accumulating_spread::NoAccumulatingSpread as OxcNoAccumulatingSpread;
@@ -368,7 +374,29 @@ pub use crate::rules::oxc::no_rest_spread_properties::NoRestSpreadProperties as 
 pub use crate::rules::oxc::no_this_in_exported_function::NoThisInExportedFunction as OxcNoThisInExportedFunction;
 pub use crate::rules::oxc::number_arg_out_of_range::NumberArgOutOfRange as OxcNumberArgOutOfRange;
 pub use crate::rules::oxc::only_used_in_recursion::OnlyUsedInRecursion as OxcOnlyUsedInRecursion;
+pub use crate::rules::oxc::package_json_no_duplicate_dependencies::PackageJsonNoDuplicateDependencies as OxcPackageJsonNoDuplicateDependencies;
+pub use crate::rules::oxc::package_json_no_empty_fields::PackageJsonNoEmptyFields as OxcPackageJsonNoEmptyFields;
+pub use crate::rules::oxc::package_json_no_redundant_publish_config::PackageJsonNoRedundantPublishConfig as OxcPackageJsonNoRedundantPublishConfig;
+pub use crate::rules::oxc::package_json_order_properties::PackageJsonOrderProperties as OxcPackageJsonOrderProperties;
+pub use crate::rules::oxc::package_json_repository_shorthand::PackageJsonRepositoryShorthand as OxcPackageJsonRepositoryShorthand;
+pub use crate::rules::oxc::package_json_require_type::PackageJsonRequireType as OxcPackageJsonRequireType;
+pub use crate::rules::oxc::package_json_require_version::PackageJsonRequireVersion as OxcPackageJsonRequireVersion;
+pub use crate::rules::oxc::package_json_sort_collections::PackageJsonSortCollections as OxcPackageJsonSortCollections;
+pub use crate::rules::oxc::package_json_valid_bin::PackageJsonValidBin as OxcPackageJsonValidBin;
+pub use crate::rules::oxc::package_json_valid_description::PackageJsonValidDescription as OxcPackageJsonValidDescription;
+pub use crate::rules::oxc::package_json_valid_engines::PackageJsonValidEngines as OxcPackageJsonValidEngines;
+pub use crate::rules::oxc::package_json_valid_keywords::PackageJsonValidKeywords as OxcPackageJsonValidKeywords;
+pub use crate::rules::oxc::package_json_valid_license::PackageJsonValidLicense as OxcPackageJsonValidLicense;
+pub use crate::rules::oxc::package_json_valid_man::PackageJsonValidMan as OxcPackageJsonValidMan;
+pub use crate::rules::oxc::package_json_valid_name::PackageJsonValidName as OxcPackageJsonValidName;
+pub use crate::rules::oxc::package_json_valid_private::PackageJsonValidPrivate as OxcPackageJsonValidPrivate;
+pub use crate::rules::oxc::package_json_valid_repository::PackageJsonValidRepository as OxcPackageJsonValidRepository;
+pub use crate::rules::oxc::package_json_valid_type::PackageJsonValidType as OxcPackageJsonValidType;
+pub use crate::rules::oxc::package_json_valid_version::PackageJsonValidVersion as OxcPackageJsonValidVersion;
+pub use crate::rules::oxc::sorted_json_keys::SortedJsonKeys as OxcSortedJsonKeys;
 pub use crate::rules::oxc::uninvoked_array_callback::UninvokedArrayCallback as OxcUninvokedArrayCallback;
+pub use crate::rules::oxc::valid_json::ValidJson as OxcValidJson;
+pub use crate::rules::oxc::valid_message_syntax::ValidMessageSyntax as OxcValidMessageSyntax;
 pub use crate::rules::promise::always_return::AlwaysReturn as PromiseAlwaysReturn;
 pub use crate::rules::promise::avoid_new::AvoidNew as PromiseAvoidNew;
 pub use crate::rules::promise::catch_or_return::CatchOrReturn as PromiseCatchOrReturn;
@@ -1339,6 +1367,34 @@ pub enum RuleEnum {
     OxcNumberArgOutOfRange(OxcNumberArgOutOfRange),
     OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion),
     OxcUninvokedArrayCallback(OxcUninvokedArrayCallback),
+    OxcIdenticalKeys(OxcIdenticalKeys),
+    OxcIdenticalPlaceholders(OxcIdenticalPlaceholders),
+    OxcJsonNoComments(OxcJsonNoComments),
+    OxcJsonNoDuplicateKeys(OxcJsonNoDuplicateKeys),
+    OxcJsonNoTrailingCommas(OxcJsonNoTrailingCommas),
+    OxcJsonParseValidation(OxcJsonParseValidation),
+    OxcPackageJsonNoDuplicateDependencies(OxcPackageJsonNoDuplicateDependencies),
+    OxcPackageJsonNoEmptyFields(OxcPackageJsonNoEmptyFields),
+    OxcPackageJsonNoRedundantPublishConfig(OxcPackageJsonNoRedundantPublishConfig),
+    OxcPackageJsonOrderProperties(OxcPackageJsonOrderProperties),
+    OxcPackageJsonRepositoryShorthand(OxcPackageJsonRepositoryShorthand),
+    OxcPackageJsonRequireType(OxcPackageJsonRequireType),
+    OxcPackageJsonRequireVersion(OxcPackageJsonRequireVersion),
+    OxcPackageJsonSortCollections(OxcPackageJsonSortCollections),
+    OxcPackageJsonValidBin(OxcPackageJsonValidBin),
+    OxcPackageJsonValidDescription(OxcPackageJsonValidDescription),
+    OxcPackageJsonValidEngines(OxcPackageJsonValidEngines),
+    OxcPackageJsonValidKeywords(OxcPackageJsonValidKeywords),
+    OxcPackageJsonValidLicense(OxcPackageJsonValidLicense),
+    OxcPackageJsonValidMan(OxcPackageJsonValidMan),
+    OxcPackageJsonValidName(OxcPackageJsonValidName),
+    OxcPackageJsonValidPrivate(OxcPackageJsonValidPrivate),
+    OxcPackageJsonValidRepository(OxcPackageJsonValidRepository),
+    OxcPackageJsonValidType(OxcPackageJsonValidType),
+    OxcPackageJsonValidVersion(OxcPackageJsonValidVersion),
+    OxcSortedJsonKeys(OxcSortedJsonKeys),
+    OxcValidJson(OxcValidJson),
+    OxcValidMessageSyntax(OxcValidMessageSyntax),
     NextjsGoogleFontDisplay(NextjsGoogleFontDisplay),
     NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect),
     NextjsInlineScriptId(NextjsInlineScriptId),
@@ -2132,7 +2188,39 @@ const OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID: usize = OXC_NO_REST_SPREAD_PROPERTIES
 const OXC_NUMBER_ARG_OUT_OF_RANGE_ID: usize = OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID + 1usize;
 const OXC_ONLY_USED_IN_RECURSION_ID: usize = OXC_NUMBER_ARG_OUT_OF_RANGE_ID + 1usize;
 const OXC_UNINVOKED_ARRAY_CALLBACK_ID: usize = OXC_ONLY_USED_IN_RECURSION_ID + 1usize;
-const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_IDENTICAL_KEYS_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_IDENTICAL_PLACEHOLDERS_ID: usize = OXC_IDENTICAL_KEYS_ID + 1usize;
+const OXC_JSON_NO_COMMENTS_ID: usize = OXC_IDENTICAL_PLACEHOLDERS_ID + 1usize;
+const OXC_JSON_NO_DUPLICATE_KEYS_ID: usize = OXC_JSON_NO_COMMENTS_ID + 1usize;
+const OXC_JSON_NO_TRAILING_COMMAS_ID: usize = OXC_JSON_NO_DUPLICATE_KEYS_ID + 1usize;
+const OXC_JSON_PARSE_VALIDATION_ID: usize = OXC_JSON_NO_TRAILING_COMMAS_ID + 1usize;
+const OXC_PACKAGE_JSON_NO_DUPLICATE_DEPENDENCIES_ID: usize = OXC_JSON_PARSE_VALIDATION_ID + 1usize;
+const OXC_PACKAGE_JSON_NO_EMPTY_FIELDS_ID: usize =
+    OXC_PACKAGE_JSON_NO_DUPLICATE_DEPENDENCIES_ID + 1usize;
+const OXC_PACKAGE_JSON_NO_REDUNDANT_PUBLISH_CONFIG_ID: usize =
+    OXC_PACKAGE_JSON_NO_EMPTY_FIELDS_ID + 1usize;
+const OXC_PACKAGE_JSON_ORDER_PROPERTIES_ID: usize =
+    OXC_PACKAGE_JSON_NO_REDUNDANT_PUBLISH_CONFIG_ID + 1usize;
+const OXC_PACKAGE_JSON_REPOSITORY_SHORTHAND_ID: usize =
+    OXC_PACKAGE_JSON_ORDER_PROPERTIES_ID + 1usize;
+const OXC_PACKAGE_JSON_REQUIRE_TYPE_ID: usize = OXC_PACKAGE_JSON_REPOSITORY_SHORTHAND_ID + 1usize;
+const OXC_PACKAGE_JSON_REQUIRE_VERSION_ID: usize = OXC_PACKAGE_JSON_REQUIRE_TYPE_ID + 1usize;
+const OXC_PACKAGE_JSON_SORT_COLLECTIONS_ID: usize = OXC_PACKAGE_JSON_REQUIRE_VERSION_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_BIN_ID: usize = OXC_PACKAGE_JSON_SORT_COLLECTIONS_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_DESCRIPTION_ID: usize = OXC_PACKAGE_JSON_VALID_BIN_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_ENGINES_ID: usize = OXC_PACKAGE_JSON_VALID_DESCRIPTION_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_KEYWORDS_ID: usize = OXC_PACKAGE_JSON_VALID_ENGINES_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_LICENSE_ID: usize = OXC_PACKAGE_JSON_VALID_KEYWORDS_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_MAN_ID: usize = OXC_PACKAGE_JSON_VALID_LICENSE_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_NAME_ID: usize = OXC_PACKAGE_JSON_VALID_MAN_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_PRIVATE_ID: usize = OXC_PACKAGE_JSON_VALID_NAME_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_REPOSITORY_ID: usize = OXC_PACKAGE_JSON_VALID_PRIVATE_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_TYPE_ID: usize = OXC_PACKAGE_JSON_VALID_REPOSITORY_ID + 1usize;
+const OXC_PACKAGE_JSON_VALID_VERSION_ID: usize = OXC_PACKAGE_JSON_VALID_TYPE_ID + 1usize;
+const OXC_SORTED_JSON_KEYS_ID: usize = OXC_PACKAGE_JSON_VALID_VERSION_ID + 1usize;
+const OXC_VALID_JSON_ID: usize = OXC_SORTED_JSON_KEYS_ID + 1usize;
+const OXC_VALID_MESSAGE_SYNTAX_ID: usize = OXC_VALID_JSON_ID + 1usize;
+const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_VALID_MESSAGE_SYNTAX_ID + 1usize;
 const NEXTJS_GOOGLE_FONT_PRECONNECT_ID: usize = NEXTJS_GOOGLE_FONT_DISPLAY_ID + 1usize;
 const NEXTJS_INLINE_SCRIPT_ID_ID: usize = NEXTJS_GOOGLE_FONT_PRECONNECT_ID + 1usize;
 const NEXTJS_NEXT_SCRIPT_FOR_GA_ID: usize = NEXTJS_INLINE_SCRIPT_ID_ID + 1usize;
@@ -2954,6 +3042,38 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OXC_NUMBER_ARG_OUT_OF_RANGE_ID,
             Self::OxcOnlyUsedInRecursion(_) => OXC_ONLY_USED_IN_RECURSION_ID,
             Self::OxcUninvokedArrayCallback(_) => OXC_UNINVOKED_ARRAY_CALLBACK_ID,
+            Self::OxcIdenticalKeys(_) => OXC_IDENTICAL_KEYS_ID,
+            Self::OxcIdenticalPlaceholders(_) => OXC_IDENTICAL_PLACEHOLDERS_ID,
+            Self::OxcJsonNoComments(_) => OXC_JSON_NO_COMMENTS_ID,
+            Self::OxcJsonNoDuplicateKeys(_) => OXC_JSON_NO_DUPLICATE_KEYS_ID,
+            Self::OxcJsonNoTrailingCommas(_) => OXC_JSON_NO_TRAILING_COMMAS_ID,
+            Self::OxcJsonParseValidation(_) => OXC_JSON_PARSE_VALIDATION_ID,
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OXC_PACKAGE_JSON_NO_DUPLICATE_DEPENDENCIES_ID
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => OXC_PACKAGE_JSON_NO_EMPTY_FIELDS_ID,
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OXC_PACKAGE_JSON_NO_REDUNDANT_PUBLISH_CONFIG_ID
+            }
+            Self::OxcPackageJsonOrderProperties(_) => OXC_PACKAGE_JSON_ORDER_PROPERTIES_ID,
+            Self::OxcPackageJsonRepositoryShorthand(_) => OXC_PACKAGE_JSON_REPOSITORY_SHORTHAND_ID,
+            Self::OxcPackageJsonRequireType(_) => OXC_PACKAGE_JSON_REQUIRE_TYPE_ID,
+            Self::OxcPackageJsonRequireVersion(_) => OXC_PACKAGE_JSON_REQUIRE_VERSION_ID,
+            Self::OxcPackageJsonSortCollections(_) => OXC_PACKAGE_JSON_SORT_COLLECTIONS_ID,
+            Self::OxcPackageJsonValidBin(_) => OXC_PACKAGE_JSON_VALID_BIN_ID,
+            Self::OxcPackageJsonValidDescription(_) => OXC_PACKAGE_JSON_VALID_DESCRIPTION_ID,
+            Self::OxcPackageJsonValidEngines(_) => OXC_PACKAGE_JSON_VALID_ENGINES_ID,
+            Self::OxcPackageJsonValidKeywords(_) => OXC_PACKAGE_JSON_VALID_KEYWORDS_ID,
+            Self::OxcPackageJsonValidLicense(_) => OXC_PACKAGE_JSON_VALID_LICENSE_ID,
+            Self::OxcPackageJsonValidMan(_) => OXC_PACKAGE_JSON_VALID_MAN_ID,
+            Self::OxcPackageJsonValidName(_) => OXC_PACKAGE_JSON_VALID_NAME_ID,
+            Self::OxcPackageJsonValidPrivate(_) => OXC_PACKAGE_JSON_VALID_PRIVATE_ID,
+            Self::OxcPackageJsonValidRepository(_) => OXC_PACKAGE_JSON_VALID_REPOSITORY_ID,
+            Self::OxcPackageJsonValidType(_) => OXC_PACKAGE_JSON_VALID_TYPE_ID,
+            Self::OxcPackageJsonValidVersion(_) => OXC_PACKAGE_JSON_VALID_VERSION_ID,
+            Self::OxcSortedJsonKeys(_) => OXC_SORTED_JSON_KEYS_ID,
+            Self::OxcValidJson(_) => OXC_VALID_JSON_ID,
+            Self::OxcValidMessageSyntax(_) => OXC_VALID_MESSAGE_SYNTAX_ID,
             Self::NextjsGoogleFontDisplay(_) => NEXTJS_GOOGLE_FONT_DISPLAY_ID,
             Self::NextjsGoogleFontPreconnect(_) => NEXTJS_GOOGLE_FONT_PRECONNECT_ID,
             Self::NextjsInlineScriptId(_) => NEXTJS_INLINE_SCRIPT_ID_ID,
@@ -3764,6 +3884,38 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::NAME,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::NAME,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::NAME,
+            Self::OxcIdenticalKeys(_) => OxcIdenticalKeys::NAME,
+            Self::OxcIdenticalPlaceholders(_) => OxcIdenticalPlaceholders::NAME,
+            Self::OxcJsonNoComments(_) => OxcJsonNoComments::NAME,
+            Self::OxcJsonNoDuplicateKeys(_) => OxcJsonNoDuplicateKeys::NAME,
+            Self::OxcJsonNoTrailingCommas(_) => OxcJsonNoTrailingCommas::NAME,
+            Self::OxcJsonParseValidation(_) => OxcJsonParseValidation::NAME,
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OxcPackageJsonNoDuplicateDependencies::NAME
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => OxcPackageJsonNoEmptyFields::NAME,
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OxcPackageJsonNoRedundantPublishConfig::NAME
+            }
+            Self::OxcPackageJsonOrderProperties(_) => OxcPackageJsonOrderProperties::NAME,
+            Self::OxcPackageJsonRepositoryShorthand(_) => OxcPackageJsonRepositoryShorthand::NAME,
+            Self::OxcPackageJsonRequireType(_) => OxcPackageJsonRequireType::NAME,
+            Self::OxcPackageJsonRequireVersion(_) => OxcPackageJsonRequireVersion::NAME,
+            Self::OxcPackageJsonSortCollections(_) => OxcPackageJsonSortCollections::NAME,
+            Self::OxcPackageJsonValidBin(_) => OxcPackageJsonValidBin::NAME,
+            Self::OxcPackageJsonValidDescription(_) => OxcPackageJsonValidDescription::NAME,
+            Self::OxcPackageJsonValidEngines(_) => OxcPackageJsonValidEngines::NAME,
+            Self::OxcPackageJsonValidKeywords(_) => OxcPackageJsonValidKeywords::NAME,
+            Self::OxcPackageJsonValidLicense(_) => OxcPackageJsonValidLicense::NAME,
+            Self::OxcPackageJsonValidMan(_) => OxcPackageJsonValidMan::NAME,
+            Self::OxcPackageJsonValidName(_) => OxcPackageJsonValidName::NAME,
+            Self::OxcPackageJsonValidPrivate(_) => OxcPackageJsonValidPrivate::NAME,
+            Self::OxcPackageJsonValidRepository(_) => OxcPackageJsonValidRepository::NAME,
+            Self::OxcPackageJsonValidType(_) => OxcPackageJsonValidType::NAME,
+            Self::OxcPackageJsonValidVersion(_) => OxcPackageJsonValidVersion::NAME,
+            Self::OxcSortedJsonKeys(_) => OxcSortedJsonKeys::NAME,
+            Self::OxcValidJson(_) => OxcValidJson::NAME,
+            Self::OxcValidMessageSyntax(_) => OxcValidMessageSyntax::NAME,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::NAME,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::NAME,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::NAME,
@@ -4616,6 +4768,40 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::CATEGORY,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::CATEGORY,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::CATEGORY,
+            Self::OxcIdenticalKeys(_) => OxcIdenticalKeys::CATEGORY,
+            Self::OxcIdenticalPlaceholders(_) => OxcIdenticalPlaceholders::CATEGORY,
+            Self::OxcJsonNoComments(_) => OxcJsonNoComments::CATEGORY,
+            Self::OxcJsonNoDuplicateKeys(_) => OxcJsonNoDuplicateKeys::CATEGORY,
+            Self::OxcJsonNoTrailingCommas(_) => OxcJsonNoTrailingCommas::CATEGORY,
+            Self::OxcJsonParseValidation(_) => OxcJsonParseValidation::CATEGORY,
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OxcPackageJsonNoDuplicateDependencies::CATEGORY
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => OxcPackageJsonNoEmptyFields::CATEGORY,
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OxcPackageJsonNoRedundantPublishConfig::CATEGORY
+            }
+            Self::OxcPackageJsonOrderProperties(_) => OxcPackageJsonOrderProperties::CATEGORY,
+            Self::OxcPackageJsonRepositoryShorthand(_) => {
+                OxcPackageJsonRepositoryShorthand::CATEGORY
+            }
+            Self::OxcPackageJsonRequireType(_) => OxcPackageJsonRequireType::CATEGORY,
+            Self::OxcPackageJsonRequireVersion(_) => OxcPackageJsonRequireVersion::CATEGORY,
+            Self::OxcPackageJsonSortCollections(_) => OxcPackageJsonSortCollections::CATEGORY,
+            Self::OxcPackageJsonValidBin(_) => OxcPackageJsonValidBin::CATEGORY,
+            Self::OxcPackageJsonValidDescription(_) => OxcPackageJsonValidDescription::CATEGORY,
+            Self::OxcPackageJsonValidEngines(_) => OxcPackageJsonValidEngines::CATEGORY,
+            Self::OxcPackageJsonValidKeywords(_) => OxcPackageJsonValidKeywords::CATEGORY,
+            Self::OxcPackageJsonValidLicense(_) => OxcPackageJsonValidLicense::CATEGORY,
+            Self::OxcPackageJsonValidMan(_) => OxcPackageJsonValidMan::CATEGORY,
+            Self::OxcPackageJsonValidName(_) => OxcPackageJsonValidName::CATEGORY,
+            Self::OxcPackageJsonValidPrivate(_) => OxcPackageJsonValidPrivate::CATEGORY,
+            Self::OxcPackageJsonValidRepository(_) => OxcPackageJsonValidRepository::CATEGORY,
+            Self::OxcPackageJsonValidType(_) => OxcPackageJsonValidType::CATEGORY,
+            Self::OxcPackageJsonValidVersion(_) => OxcPackageJsonValidVersion::CATEGORY,
+            Self::OxcSortedJsonKeys(_) => OxcSortedJsonKeys::CATEGORY,
+            Self::OxcValidJson(_) => OxcValidJson::CATEGORY,
+            Self::OxcValidMessageSyntax(_) => OxcValidMessageSyntax::CATEGORY,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::CATEGORY,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::CATEGORY,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::CATEGORY,
@@ -5435,6 +5621,38 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::FIX,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::FIX,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::FIX,
+            Self::OxcIdenticalKeys(_) => OxcIdenticalKeys::FIX,
+            Self::OxcIdenticalPlaceholders(_) => OxcIdenticalPlaceholders::FIX,
+            Self::OxcJsonNoComments(_) => OxcJsonNoComments::FIX,
+            Self::OxcJsonNoDuplicateKeys(_) => OxcJsonNoDuplicateKeys::FIX,
+            Self::OxcJsonNoTrailingCommas(_) => OxcJsonNoTrailingCommas::FIX,
+            Self::OxcJsonParseValidation(_) => OxcJsonParseValidation::FIX,
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OxcPackageJsonNoDuplicateDependencies::FIX
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => OxcPackageJsonNoEmptyFields::FIX,
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OxcPackageJsonNoRedundantPublishConfig::FIX
+            }
+            Self::OxcPackageJsonOrderProperties(_) => OxcPackageJsonOrderProperties::FIX,
+            Self::OxcPackageJsonRepositoryShorthand(_) => OxcPackageJsonRepositoryShorthand::FIX,
+            Self::OxcPackageJsonRequireType(_) => OxcPackageJsonRequireType::FIX,
+            Self::OxcPackageJsonRequireVersion(_) => OxcPackageJsonRequireVersion::FIX,
+            Self::OxcPackageJsonSortCollections(_) => OxcPackageJsonSortCollections::FIX,
+            Self::OxcPackageJsonValidBin(_) => OxcPackageJsonValidBin::FIX,
+            Self::OxcPackageJsonValidDescription(_) => OxcPackageJsonValidDescription::FIX,
+            Self::OxcPackageJsonValidEngines(_) => OxcPackageJsonValidEngines::FIX,
+            Self::OxcPackageJsonValidKeywords(_) => OxcPackageJsonValidKeywords::FIX,
+            Self::OxcPackageJsonValidLicense(_) => OxcPackageJsonValidLicense::FIX,
+            Self::OxcPackageJsonValidMan(_) => OxcPackageJsonValidMan::FIX,
+            Self::OxcPackageJsonValidName(_) => OxcPackageJsonValidName::FIX,
+            Self::OxcPackageJsonValidPrivate(_) => OxcPackageJsonValidPrivate::FIX,
+            Self::OxcPackageJsonValidRepository(_) => OxcPackageJsonValidRepository::FIX,
+            Self::OxcPackageJsonValidType(_) => OxcPackageJsonValidType::FIX,
+            Self::OxcPackageJsonValidVersion(_) => OxcPackageJsonValidVersion::FIX,
+            Self::OxcSortedJsonKeys(_) => OxcSortedJsonKeys::FIX,
+            Self::OxcValidJson(_) => OxcValidJson::FIX,
+            Self::OxcValidMessageSyntax(_) => OxcValidMessageSyntax::FIX,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::FIX,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::FIX,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::FIX,
@@ -6432,6 +6650,48 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::documentation(),
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::documentation(),
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::documentation(),
+            Self::OxcIdenticalKeys(_) => OxcIdenticalKeys::documentation(),
+            Self::OxcIdenticalPlaceholders(_) => OxcIdenticalPlaceholders::documentation(),
+            Self::OxcJsonNoComments(_) => OxcJsonNoComments::documentation(),
+            Self::OxcJsonNoDuplicateKeys(_) => OxcJsonNoDuplicateKeys::documentation(),
+            Self::OxcJsonNoTrailingCommas(_) => OxcJsonNoTrailingCommas::documentation(),
+            Self::OxcJsonParseValidation(_) => OxcJsonParseValidation::documentation(),
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OxcPackageJsonNoDuplicateDependencies::documentation()
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => OxcPackageJsonNoEmptyFields::documentation(),
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OxcPackageJsonNoRedundantPublishConfig::documentation()
+            }
+            Self::OxcPackageJsonOrderProperties(_) => {
+                OxcPackageJsonOrderProperties::documentation()
+            }
+            Self::OxcPackageJsonRepositoryShorthand(_) => {
+                OxcPackageJsonRepositoryShorthand::documentation()
+            }
+            Self::OxcPackageJsonRequireType(_) => OxcPackageJsonRequireType::documentation(),
+            Self::OxcPackageJsonRequireVersion(_) => OxcPackageJsonRequireVersion::documentation(),
+            Self::OxcPackageJsonSortCollections(_) => {
+                OxcPackageJsonSortCollections::documentation()
+            }
+            Self::OxcPackageJsonValidBin(_) => OxcPackageJsonValidBin::documentation(),
+            Self::OxcPackageJsonValidDescription(_) => {
+                OxcPackageJsonValidDescription::documentation()
+            }
+            Self::OxcPackageJsonValidEngines(_) => OxcPackageJsonValidEngines::documentation(),
+            Self::OxcPackageJsonValidKeywords(_) => OxcPackageJsonValidKeywords::documentation(),
+            Self::OxcPackageJsonValidLicense(_) => OxcPackageJsonValidLicense::documentation(),
+            Self::OxcPackageJsonValidMan(_) => OxcPackageJsonValidMan::documentation(),
+            Self::OxcPackageJsonValidName(_) => OxcPackageJsonValidName::documentation(),
+            Self::OxcPackageJsonValidPrivate(_) => OxcPackageJsonValidPrivate::documentation(),
+            Self::OxcPackageJsonValidRepository(_) => {
+                OxcPackageJsonValidRepository::documentation()
+            }
+            Self::OxcPackageJsonValidType(_) => OxcPackageJsonValidType::documentation(),
+            Self::OxcPackageJsonValidVersion(_) => OxcPackageJsonValidVersion::documentation(),
+            Self::OxcSortedJsonKeys(_) => OxcSortedJsonKeys::documentation(),
+            Self::OxcValidJson(_) => OxcValidJson::documentation(),
+            Self::OxcValidMessageSyntax(_) => OxcValidMessageSyntax::documentation(),
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::documentation(),
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::documentation(),
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::documentation(),
@@ -8313,6 +8573,93 @@ impl RuleEnum {
                 OxcUninvokedArrayCallback::config_schema(generator)
                     .or_else(|| OxcUninvokedArrayCallback::schema(generator))
             }
+            Self::OxcIdenticalKeys(_) => OxcIdenticalKeys::config_schema(generator)
+                .or_else(|| OxcIdenticalKeys::schema(generator)),
+            Self::OxcIdenticalPlaceholders(_) => OxcIdenticalPlaceholders::config_schema(generator)
+                .or_else(|| OxcIdenticalPlaceholders::schema(generator)),
+            Self::OxcJsonNoComments(_) => OxcJsonNoComments::config_schema(generator)
+                .or_else(|| OxcJsonNoComments::schema(generator)),
+            Self::OxcJsonNoDuplicateKeys(_) => OxcJsonNoDuplicateKeys::config_schema(generator)
+                .or_else(|| OxcJsonNoDuplicateKeys::schema(generator)),
+            Self::OxcJsonNoTrailingCommas(_) => OxcJsonNoTrailingCommas::config_schema(generator)
+                .or_else(|| OxcJsonNoTrailingCommas::schema(generator)),
+            Self::OxcJsonParseValidation(_) => OxcJsonParseValidation::config_schema(generator)
+                .or_else(|| OxcJsonParseValidation::schema(generator)),
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OxcPackageJsonNoDuplicateDependencies::config_schema(generator)
+                    .or_else(|| OxcPackageJsonNoDuplicateDependencies::schema(generator))
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => {
+                OxcPackageJsonNoEmptyFields::config_schema(generator)
+                    .or_else(|| OxcPackageJsonNoEmptyFields::schema(generator))
+            }
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OxcPackageJsonNoRedundantPublishConfig::config_schema(generator)
+                    .or_else(|| OxcPackageJsonNoRedundantPublishConfig::schema(generator))
+            }
+            Self::OxcPackageJsonOrderProperties(_) => {
+                OxcPackageJsonOrderProperties::config_schema(generator)
+                    .or_else(|| OxcPackageJsonOrderProperties::schema(generator))
+            }
+            Self::OxcPackageJsonRepositoryShorthand(_) => {
+                OxcPackageJsonRepositoryShorthand::config_schema(generator)
+                    .or_else(|| OxcPackageJsonRepositoryShorthand::schema(generator))
+            }
+            Self::OxcPackageJsonRequireType(_) => {
+                OxcPackageJsonRequireType::config_schema(generator)
+                    .or_else(|| OxcPackageJsonRequireType::schema(generator))
+            }
+            Self::OxcPackageJsonRequireVersion(_) => {
+                OxcPackageJsonRequireVersion::config_schema(generator)
+                    .or_else(|| OxcPackageJsonRequireVersion::schema(generator))
+            }
+            Self::OxcPackageJsonSortCollections(_) => {
+                OxcPackageJsonSortCollections::config_schema(generator)
+                    .or_else(|| OxcPackageJsonSortCollections::schema(generator))
+            }
+            Self::OxcPackageJsonValidBin(_) => OxcPackageJsonValidBin::config_schema(generator)
+                .or_else(|| OxcPackageJsonValidBin::schema(generator)),
+            Self::OxcPackageJsonValidDescription(_) => {
+                OxcPackageJsonValidDescription::config_schema(generator)
+                    .or_else(|| OxcPackageJsonValidDescription::schema(generator))
+            }
+            Self::OxcPackageJsonValidEngines(_) => {
+                OxcPackageJsonValidEngines::config_schema(generator)
+                    .or_else(|| OxcPackageJsonValidEngines::schema(generator))
+            }
+            Self::OxcPackageJsonValidKeywords(_) => {
+                OxcPackageJsonValidKeywords::config_schema(generator)
+                    .or_else(|| OxcPackageJsonValidKeywords::schema(generator))
+            }
+            Self::OxcPackageJsonValidLicense(_) => {
+                OxcPackageJsonValidLicense::config_schema(generator)
+                    .or_else(|| OxcPackageJsonValidLicense::schema(generator))
+            }
+            Self::OxcPackageJsonValidMan(_) => OxcPackageJsonValidMan::config_schema(generator)
+                .or_else(|| OxcPackageJsonValidMan::schema(generator)),
+            Self::OxcPackageJsonValidName(_) => OxcPackageJsonValidName::config_schema(generator)
+                .or_else(|| OxcPackageJsonValidName::schema(generator)),
+            Self::OxcPackageJsonValidPrivate(_) => {
+                OxcPackageJsonValidPrivate::config_schema(generator)
+                    .or_else(|| OxcPackageJsonValidPrivate::schema(generator))
+            }
+            Self::OxcPackageJsonValidRepository(_) => {
+                OxcPackageJsonValidRepository::config_schema(generator)
+                    .or_else(|| OxcPackageJsonValidRepository::schema(generator))
+            }
+            Self::OxcPackageJsonValidType(_) => OxcPackageJsonValidType::config_schema(generator)
+                .or_else(|| OxcPackageJsonValidType::schema(generator)),
+            Self::OxcPackageJsonValidVersion(_) => {
+                OxcPackageJsonValidVersion::config_schema(generator)
+                    .or_else(|| OxcPackageJsonValidVersion::schema(generator))
+            }
+            Self::OxcSortedJsonKeys(_) => OxcSortedJsonKeys::config_schema(generator)
+                .or_else(|| OxcSortedJsonKeys::schema(generator)),
+            Self::OxcValidJson(_) => {
+                OxcValidJson::config_schema(generator).or_else(|| OxcValidJson::schema(generator))
+            }
+            Self::OxcValidMessageSyntax(_) => OxcValidMessageSyntax::config_schema(generator)
+                .or_else(|| OxcValidMessageSyntax::schema(generator)),
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::config_schema(generator)
                 .or_else(|| NextjsGoogleFontDisplay::schema(generator)),
             Self::NextjsGoogleFontPreconnect(_) => {
@@ -9197,6 +9544,34 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => "oxc",
             Self::OxcOnlyUsedInRecursion(_) => "oxc",
             Self::OxcUninvokedArrayCallback(_) => "oxc",
+            Self::OxcIdenticalKeys(_) => "oxc",
+            Self::OxcIdenticalPlaceholders(_) => "oxc",
+            Self::OxcJsonNoComments(_) => "oxc",
+            Self::OxcJsonNoDuplicateKeys(_) => "oxc",
+            Self::OxcJsonNoTrailingCommas(_) => "oxc",
+            Self::OxcJsonParseValidation(_) => "oxc",
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => "oxc",
+            Self::OxcPackageJsonNoEmptyFields(_) => "oxc",
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => "oxc",
+            Self::OxcPackageJsonOrderProperties(_) => "oxc",
+            Self::OxcPackageJsonRepositoryShorthand(_) => "oxc",
+            Self::OxcPackageJsonRequireType(_) => "oxc",
+            Self::OxcPackageJsonRequireVersion(_) => "oxc",
+            Self::OxcPackageJsonSortCollections(_) => "oxc",
+            Self::OxcPackageJsonValidBin(_) => "oxc",
+            Self::OxcPackageJsonValidDescription(_) => "oxc",
+            Self::OxcPackageJsonValidEngines(_) => "oxc",
+            Self::OxcPackageJsonValidKeywords(_) => "oxc",
+            Self::OxcPackageJsonValidLicense(_) => "oxc",
+            Self::OxcPackageJsonValidMan(_) => "oxc",
+            Self::OxcPackageJsonValidName(_) => "oxc",
+            Self::OxcPackageJsonValidPrivate(_) => "oxc",
+            Self::OxcPackageJsonValidRepository(_) => "oxc",
+            Self::OxcPackageJsonValidType(_) => "oxc",
+            Self::OxcPackageJsonValidVersion(_) => "oxc",
+            Self::OxcSortedJsonKeys(_) => "oxc",
+            Self::OxcValidJson(_) => "oxc",
+            Self::OxcValidMessageSyntax(_) => "oxc",
             Self::NextjsGoogleFontDisplay(_) => "nextjs",
             Self::NextjsGoogleFontPreconnect(_) => "nextjs",
             Self::NextjsInlineScriptId(_) => "nextjs",
@@ -11272,6 +11647,96 @@ impl RuleEnum {
             Self::OxcUninvokedArrayCallback(_) => Ok(Self::OxcUninvokedArrayCallback(
                 OxcUninvokedArrayCallback::from_configuration(value)?,
             )),
+            Self::OxcIdenticalKeys(_) => {
+                Ok(Self::OxcIdenticalKeys(OxcIdenticalKeys::from_configuration(value)?))
+            }
+            Self::OxcIdenticalPlaceholders(_) => Ok(Self::OxcIdenticalPlaceholders(
+                OxcIdenticalPlaceholders::from_configuration(value)?,
+            )),
+            Self::OxcJsonNoComments(_) => {
+                Ok(Self::OxcJsonNoComments(OxcJsonNoComments::from_configuration(value)?))
+            }
+            Self::OxcJsonNoDuplicateKeys(_) => {
+                Ok(Self::OxcJsonNoDuplicateKeys(OxcJsonNoDuplicateKeys::from_configuration(value)?))
+            }
+            Self::OxcJsonNoTrailingCommas(_) => Ok(Self::OxcJsonNoTrailingCommas(
+                OxcJsonNoTrailingCommas::from_configuration(value)?,
+            )),
+            Self::OxcJsonParseValidation(_) => {
+                Ok(Self::OxcJsonParseValidation(OxcJsonParseValidation::from_configuration(value)?))
+            }
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                Ok(Self::OxcPackageJsonNoDuplicateDependencies(
+                    OxcPackageJsonNoDuplicateDependencies::from_configuration(value)?,
+                ))
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => Ok(Self::OxcPackageJsonNoEmptyFields(
+                OxcPackageJsonNoEmptyFields::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                Ok(Self::OxcPackageJsonNoRedundantPublishConfig(
+                    OxcPackageJsonNoRedundantPublishConfig::from_configuration(value)?,
+                ))
+            }
+            Self::OxcPackageJsonOrderProperties(_) => Ok(Self::OxcPackageJsonOrderProperties(
+                OxcPackageJsonOrderProperties::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonRepositoryShorthand(_) => {
+                Ok(Self::OxcPackageJsonRepositoryShorthand(
+                    OxcPackageJsonRepositoryShorthand::from_configuration(value)?,
+                ))
+            }
+            Self::OxcPackageJsonRequireType(_) => Ok(Self::OxcPackageJsonRequireType(
+                OxcPackageJsonRequireType::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonRequireVersion(_) => Ok(Self::OxcPackageJsonRequireVersion(
+                OxcPackageJsonRequireVersion::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonSortCollections(_) => Ok(Self::OxcPackageJsonSortCollections(
+                OxcPackageJsonSortCollections::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidBin(_) => {
+                Ok(Self::OxcPackageJsonValidBin(OxcPackageJsonValidBin::from_configuration(value)?))
+            }
+            Self::OxcPackageJsonValidDescription(_) => Ok(Self::OxcPackageJsonValidDescription(
+                OxcPackageJsonValidDescription::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidEngines(_) => Ok(Self::OxcPackageJsonValidEngines(
+                OxcPackageJsonValidEngines::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidKeywords(_) => Ok(Self::OxcPackageJsonValidKeywords(
+                OxcPackageJsonValidKeywords::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidLicense(_) => Ok(Self::OxcPackageJsonValidLicense(
+                OxcPackageJsonValidLicense::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidMan(_) => {
+                Ok(Self::OxcPackageJsonValidMan(OxcPackageJsonValidMan::from_configuration(value)?))
+            }
+            Self::OxcPackageJsonValidName(_) => Ok(Self::OxcPackageJsonValidName(
+                OxcPackageJsonValidName::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidPrivate(_) => Ok(Self::OxcPackageJsonValidPrivate(
+                OxcPackageJsonValidPrivate::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidRepository(_) => Ok(Self::OxcPackageJsonValidRepository(
+                OxcPackageJsonValidRepository::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidType(_) => Ok(Self::OxcPackageJsonValidType(
+                OxcPackageJsonValidType::from_configuration(value)?,
+            )),
+            Self::OxcPackageJsonValidVersion(_) => Ok(Self::OxcPackageJsonValidVersion(
+                OxcPackageJsonValidVersion::from_configuration(value)?,
+            )),
+            Self::OxcSortedJsonKeys(_) => {
+                Ok(Self::OxcSortedJsonKeys(OxcSortedJsonKeys::from_configuration(value)?))
+            }
+            Self::OxcValidJson(_) => {
+                Ok(Self::OxcValidJson(OxcValidJson::from_configuration(value)?))
+            }
+            Self::OxcValidMessageSyntax(_) => {
+                Ok(Self::OxcValidMessageSyntax(OxcValidMessageSyntax::from_configuration(value)?))
+            }
             Self::NextjsGoogleFontDisplay(_) => Ok(Self::NextjsGoogleFontDisplay(
                 NextjsGoogleFontDisplay::from_configuration(value)?,
             )),
@@ -12198,6 +12663,34 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.to_configuration(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.to_configuration(),
             Self::OxcUninvokedArrayCallback(rule) => rule.to_configuration(),
+            Self::OxcIdenticalKeys(rule) => rule.to_configuration(),
+            Self::OxcIdenticalPlaceholders(rule) => rule.to_configuration(),
+            Self::OxcJsonNoComments(rule) => rule.to_configuration(),
+            Self::OxcJsonNoDuplicateKeys(rule) => rule.to_configuration(),
+            Self::OxcJsonNoTrailingCommas(rule) => rule.to_configuration(),
+            Self::OxcJsonParseValidation(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonNoDuplicateDependencies(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonNoEmptyFields(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonNoRedundantPublishConfig(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonOrderProperties(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonRepositoryShorthand(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonRequireType(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonRequireVersion(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonSortCollections(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidBin(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidDescription(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidEngines(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidKeywords(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidLicense(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidMan(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidName(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidPrivate(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidRepository(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidType(rule) => rule.to_configuration(),
+            Self::OxcPackageJsonValidVersion(rule) => rule.to_configuration(),
+            Self::OxcSortedJsonKeys(rule) => rule.to_configuration(),
+            Self::OxcValidJson(rule) => rule.to_configuration(),
+            Self::OxcValidMessageSyntax(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontDisplay(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.to_configuration(),
             Self::NextjsInlineScriptId(rule) => rule.to_configuration(),
@@ -12914,6 +13407,34 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run(node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run(node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run(node, ctx),
+            Self::OxcIdenticalKeys(rule) => rule.run(node, ctx),
+            Self::OxcIdenticalPlaceholders(rule) => rule.run(node, ctx),
+            Self::OxcJsonNoComments(rule) => rule.run(node, ctx),
+            Self::OxcJsonNoDuplicateKeys(rule) => rule.run(node, ctx),
+            Self::OxcJsonNoTrailingCommas(rule) => rule.run(node, ctx),
+            Self::OxcJsonParseValidation(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonNoDuplicateDependencies(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonNoEmptyFields(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonNoRedundantPublishConfig(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonOrderProperties(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonRepositoryShorthand(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonRequireType(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonRequireVersion(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonSortCollections(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidBin(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidDescription(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidEngines(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidKeywords(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidLicense(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidMan(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidName(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidPrivate(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidRepository(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidType(rule) => rule.run(node, ctx),
+            Self::OxcPackageJsonValidVersion(rule) => rule.run(node, ctx),
+            Self::OxcSortedJsonKeys(rule) => rule.run(node, ctx),
+            Self::OxcValidJson(rule) => rule.run(node, ctx),
+            Self::OxcValidMessageSyntax(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run(node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run(node, ctx),
@@ -13628,6 +14149,34 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_once(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_once(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_once(ctx),
+            Self::OxcIdenticalKeys(rule) => rule.run_once(ctx),
+            Self::OxcIdenticalPlaceholders(rule) => rule.run_once(ctx),
+            Self::OxcJsonNoComments(rule) => rule.run_once(ctx),
+            Self::OxcJsonNoDuplicateKeys(rule) => rule.run_once(ctx),
+            Self::OxcJsonNoTrailingCommas(rule) => rule.run_once(ctx),
+            Self::OxcJsonParseValidation(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonNoDuplicateDependencies(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonNoEmptyFields(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonNoRedundantPublishConfig(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonOrderProperties(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonRepositoryShorthand(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonRequireType(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonRequireVersion(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonSortCollections(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidBin(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidDescription(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidEngines(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidKeywords(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidLicense(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidMan(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidName(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidPrivate(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidRepository(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidType(rule) => rule.run_once(ctx),
+            Self::OxcPackageJsonValidVersion(rule) => rule.run_once(ctx),
+            Self::OxcSortedJsonKeys(rule) => rule.run_once(ctx),
+            Self::OxcValidJson(rule) => rule.run_once(ctx),
+            Self::OxcValidMessageSyntax(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_once(ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_once(ctx),
@@ -14438,6 +14987,38 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcIdenticalKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcIdenticalPlaceholders(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcJsonNoComments(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcJsonNoDuplicateKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcJsonNoTrailingCommas(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcJsonParseValidation(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonNoDuplicateDependencies(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::OxcPackageJsonNoEmptyFields(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonNoRedundantPublishConfig(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::OxcPackageJsonOrderProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonRepositoryShorthand(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonRequireType(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonRequireVersion(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonSortCollections(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidBin(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidEngines(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidKeywords(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidLicense(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidMan(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidName(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidPrivate(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidRepository(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidType(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPackageJsonValidVersion(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortedJsonKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcValidJson(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcValidMessageSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15156,6 +15737,34 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.should_run(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.should_run(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.should_run(ctx),
+            Self::OxcIdenticalKeys(rule) => rule.should_run(ctx),
+            Self::OxcIdenticalPlaceholders(rule) => rule.should_run(ctx),
+            Self::OxcJsonNoComments(rule) => rule.should_run(ctx),
+            Self::OxcJsonNoDuplicateKeys(rule) => rule.should_run(ctx),
+            Self::OxcJsonNoTrailingCommas(rule) => rule.should_run(ctx),
+            Self::OxcJsonParseValidation(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonNoDuplicateDependencies(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonNoEmptyFields(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonNoRedundantPublishConfig(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonOrderProperties(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonRepositoryShorthand(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonRequireType(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonRequireVersion(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonSortCollections(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidBin(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidDescription(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidEngines(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidKeywords(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidLicense(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidMan(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidName(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidPrivate(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidRepository(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidType(rule) => rule.should_run(ctx),
+            Self::OxcPackageJsonValidVersion(rule) => rule.should_run(ctx),
+            Self::OxcSortedJsonKeys(rule) => rule.should_run(ctx),
+            Self::OxcValidJson(rule) => rule.should_run(ctx),
+            Self::OxcValidMessageSyntax(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.should_run(ctx),
             Self::NextjsInlineScriptId(rule) => rule.should_run(ctx),
@@ -16148,6 +16757,48 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::IS_TSGOLINT_RULE,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::IS_TSGOLINT_RULE,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::IS_TSGOLINT_RULE,
+            Self::OxcIdenticalKeys(_) => OxcIdenticalKeys::IS_TSGOLINT_RULE,
+            Self::OxcIdenticalPlaceholders(_) => OxcIdenticalPlaceholders::IS_TSGOLINT_RULE,
+            Self::OxcJsonNoComments(_) => OxcJsonNoComments::IS_TSGOLINT_RULE,
+            Self::OxcJsonNoDuplicateKeys(_) => OxcJsonNoDuplicateKeys::IS_TSGOLINT_RULE,
+            Self::OxcJsonNoTrailingCommas(_) => OxcJsonNoTrailingCommas::IS_TSGOLINT_RULE,
+            Self::OxcJsonParseValidation(_) => OxcJsonParseValidation::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OxcPackageJsonNoDuplicateDependencies::IS_TSGOLINT_RULE
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => OxcPackageJsonNoEmptyFields::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OxcPackageJsonNoRedundantPublishConfig::IS_TSGOLINT_RULE
+            }
+            Self::OxcPackageJsonOrderProperties(_) => {
+                OxcPackageJsonOrderProperties::IS_TSGOLINT_RULE
+            }
+            Self::OxcPackageJsonRepositoryShorthand(_) => {
+                OxcPackageJsonRepositoryShorthand::IS_TSGOLINT_RULE
+            }
+            Self::OxcPackageJsonRequireType(_) => OxcPackageJsonRequireType::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonRequireVersion(_) => OxcPackageJsonRequireVersion::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonSortCollections(_) => {
+                OxcPackageJsonSortCollections::IS_TSGOLINT_RULE
+            }
+            Self::OxcPackageJsonValidBin(_) => OxcPackageJsonValidBin::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidDescription(_) => {
+                OxcPackageJsonValidDescription::IS_TSGOLINT_RULE
+            }
+            Self::OxcPackageJsonValidEngines(_) => OxcPackageJsonValidEngines::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidKeywords(_) => OxcPackageJsonValidKeywords::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidLicense(_) => OxcPackageJsonValidLicense::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidMan(_) => OxcPackageJsonValidMan::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidName(_) => OxcPackageJsonValidName::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidPrivate(_) => OxcPackageJsonValidPrivate::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidRepository(_) => {
+                OxcPackageJsonValidRepository::IS_TSGOLINT_RULE
+            }
+            Self::OxcPackageJsonValidType(_) => OxcPackageJsonValidType::IS_TSGOLINT_RULE,
+            Self::OxcPackageJsonValidVersion(_) => OxcPackageJsonValidVersion::IS_TSGOLINT_RULE,
+            Self::OxcSortedJsonKeys(_) => OxcSortedJsonKeys::IS_TSGOLINT_RULE,
+            Self::OxcValidJson(_) => OxcValidJson::IS_TSGOLINT_RULE,
+            Self::OxcValidMessageSyntax(_) => OxcValidMessageSyntax::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::IS_TSGOLINT_RULE,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::IS_TSGOLINT_RULE,
@@ -17049,6 +17700,40 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::HAS_CONFIG,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::HAS_CONFIG,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::HAS_CONFIG,
+            Self::OxcIdenticalKeys(_) => OxcIdenticalKeys::HAS_CONFIG,
+            Self::OxcIdenticalPlaceholders(_) => OxcIdenticalPlaceholders::HAS_CONFIG,
+            Self::OxcJsonNoComments(_) => OxcJsonNoComments::HAS_CONFIG,
+            Self::OxcJsonNoDuplicateKeys(_) => OxcJsonNoDuplicateKeys::HAS_CONFIG,
+            Self::OxcJsonNoTrailingCommas(_) => OxcJsonNoTrailingCommas::HAS_CONFIG,
+            Self::OxcJsonParseValidation(_) => OxcJsonParseValidation::HAS_CONFIG,
+            Self::OxcPackageJsonNoDuplicateDependencies(_) => {
+                OxcPackageJsonNoDuplicateDependencies::HAS_CONFIG
+            }
+            Self::OxcPackageJsonNoEmptyFields(_) => OxcPackageJsonNoEmptyFields::HAS_CONFIG,
+            Self::OxcPackageJsonNoRedundantPublishConfig(_) => {
+                OxcPackageJsonNoRedundantPublishConfig::HAS_CONFIG
+            }
+            Self::OxcPackageJsonOrderProperties(_) => OxcPackageJsonOrderProperties::HAS_CONFIG,
+            Self::OxcPackageJsonRepositoryShorthand(_) => {
+                OxcPackageJsonRepositoryShorthand::HAS_CONFIG
+            }
+            Self::OxcPackageJsonRequireType(_) => OxcPackageJsonRequireType::HAS_CONFIG,
+            Self::OxcPackageJsonRequireVersion(_) => OxcPackageJsonRequireVersion::HAS_CONFIG,
+            Self::OxcPackageJsonSortCollections(_) => OxcPackageJsonSortCollections::HAS_CONFIG,
+            Self::OxcPackageJsonValidBin(_) => OxcPackageJsonValidBin::HAS_CONFIG,
+            Self::OxcPackageJsonValidDescription(_) => OxcPackageJsonValidDescription::HAS_CONFIG,
+            Self::OxcPackageJsonValidEngines(_) => OxcPackageJsonValidEngines::HAS_CONFIG,
+            Self::OxcPackageJsonValidKeywords(_) => OxcPackageJsonValidKeywords::HAS_CONFIG,
+            Self::OxcPackageJsonValidLicense(_) => OxcPackageJsonValidLicense::HAS_CONFIG,
+            Self::OxcPackageJsonValidMan(_) => OxcPackageJsonValidMan::HAS_CONFIG,
+            Self::OxcPackageJsonValidName(_) => OxcPackageJsonValidName::HAS_CONFIG,
+            Self::OxcPackageJsonValidPrivate(_) => OxcPackageJsonValidPrivate::HAS_CONFIG,
+            Self::OxcPackageJsonValidRepository(_) => OxcPackageJsonValidRepository::HAS_CONFIG,
+            Self::OxcPackageJsonValidType(_) => OxcPackageJsonValidType::HAS_CONFIG,
+            Self::OxcPackageJsonValidVersion(_) => OxcPackageJsonValidVersion::HAS_CONFIG,
+            Self::OxcSortedJsonKeys(_) => OxcSortedJsonKeys::HAS_CONFIG,
+            Self::OxcValidJson(_) => OxcValidJson::HAS_CONFIG,
+            Self::OxcValidMessageSyntax(_) => OxcValidMessageSyntax::HAS_CONFIG,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::HAS_CONFIG,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::HAS_CONFIG,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::HAS_CONFIG,
@@ -17775,6 +18460,34 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.types_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.types_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.types_info(),
+            Self::OxcIdenticalKeys(rule) => rule.types_info(),
+            Self::OxcIdenticalPlaceholders(rule) => rule.types_info(),
+            Self::OxcJsonNoComments(rule) => rule.types_info(),
+            Self::OxcJsonNoDuplicateKeys(rule) => rule.types_info(),
+            Self::OxcJsonNoTrailingCommas(rule) => rule.types_info(),
+            Self::OxcJsonParseValidation(rule) => rule.types_info(),
+            Self::OxcPackageJsonNoDuplicateDependencies(rule) => rule.types_info(),
+            Self::OxcPackageJsonNoEmptyFields(rule) => rule.types_info(),
+            Self::OxcPackageJsonNoRedundantPublishConfig(rule) => rule.types_info(),
+            Self::OxcPackageJsonOrderProperties(rule) => rule.types_info(),
+            Self::OxcPackageJsonRepositoryShorthand(rule) => rule.types_info(),
+            Self::OxcPackageJsonRequireType(rule) => rule.types_info(),
+            Self::OxcPackageJsonRequireVersion(rule) => rule.types_info(),
+            Self::OxcPackageJsonSortCollections(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidBin(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidDescription(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidEngines(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidKeywords(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidLicense(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidMan(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidName(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidPrivate(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidRepository(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidType(rule) => rule.types_info(),
+            Self::OxcPackageJsonValidVersion(rule) => rule.types_info(),
+            Self::OxcSortedJsonKeys(rule) => rule.types_info(),
+            Self::OxcValidJson(rule) => rule.types_info(),
+            Self::OxcValidMessageSyntax(rule) => rule.types_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.types_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.types_info(),
             Self::NextjsInlineScriptId(rule) => rule.types_info(),
@@ -18489,6 +19202,34 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_info(),
+            Self::OxcIdenticalKeys(rule) => rule.run_info(),
+            Self::OxcIdenticalPlaceholders(rule) => rule.run_info(),
+            Self::OxcJsonNoComments(rule) => rule.run_info(),
+            Self::OxcJsonNoDuplicateKeys(rule) => rule.run_info(),
+            Self::OxcJsonNoTrailingCommas(rule) => rule.run_info(),
+            Self::OxcJsonParseValidation(rule) => rule.run_info(),
+            Self::OxcPackageJsonNoDuplicateDependencies(rule) => rule.run_info(),
+            Self::OxcPackageJsonNoEmptyFields(rule) => rule.run_info(),
+            Self::OxcPackageJsonNoRedundantPublishConfig(rule) => rule.run_info(),
+            Self::OxcPackageJsonOrderProperties(rule) => rule.run_info(),
+            Self::OxcPackageJsonRepositoryShorthand(rule) => rule.run_info(),
+            Self::OxcPackageJsonRequireType(rule) => rule.run_info(),
+            Self::OxcPackageJsonRequireVersion(rule) => rule.run_info(),
+            Self::OxcPackageJsonSortCollections(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidBin(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidDescription(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidEngines(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidKeywords(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidLicense(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidMan(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidName(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidPrivate(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidRepository(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidType(rule) => rule.run_info(),
+            Self::OxcPackageJsonValidVersion(rule) => rule.run_info(),
+            Self::OxcSortedJsonKeys(rule) => rule.run_info(),
+            Self::OxcValidJson(rule) => rule.run_info(),
+            Self::OxcValidMessageSyntax(rule) => rule.run_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_info(),
             Self::NextjsInlineScriptId(rule) => rule.run_info(),
@@ -19317,6 +20058,38 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::OxcNumberArgOutOfRange(OxcNumberArgOutOfRange::default()),
         RuleEnum::OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion::default()),
         RuleEnum::OxcUninvokedArrayCallback(OxcUninvokedArrayCallback::default()),
+        RuleEnum::OxcIdenticalKeys(OxcIdenticalKeys::default()),
+        RuleEnum::OxcIdenticalPlaceholders(OxcIdenticalPlaceholders::default()),
+        RuleEnum::OxcJsonNoComments(OxcJsonNoComments::default()),
+        RuleEnum::OxcJsonNoDuplicateKeys(OxcJsonNoDuplicateKeys::default()),
+        RuleEnum::OxcJsonNoTrailingCommas(OxcJsonNoTrailingCommas::default()),
+        RuleEnum::OxcJsonParseValidation(OxcJsonParseValidation::default()),
+        RuleEnum::OxcPackageJsonNoDuplicateDependencies(
+            OxcPackageJsonNoDuplicateDependencies::default(),
+        ),
+        RuleEnum::OxcPackageJsonNoEmptyFields(OxcPackageJsonNoEmptyFields::default()),
+        RuleEnum::OxcPackageJsonNoRedundantPublishConfig(
+            OxcPackageJsonNoRedundantPublishConfig::default(),
+        ),
+        RuleEnum::OxcPackageJsonOrderProperties(OxcPackageJsonOrderProperties::default()),
+        RuleEnum::OxcPackageJsonRepositoryShorthand(OxcPackageJsonRepositoryShorthand::default()),
+        RuleEnum::OxcPackageJsonRequireType(OxcPackageJsonRequireType::default()),
+        RuleEnum::OxcPackageJsonRequireVersion(OxcPackageJsonRequireVersion::default()),
+        RuleEnum::OxcPackageJsonSortCollections(OxcPackageJsonSortCollections::default()),
+        RuleEnum::OxcPackageJsonValidBin(OxcPackageJsonValidBin::default()),
+        RuleEnum::OxcPackageJsonValidDescription(OxcPackageJsonValidDescription::default()),
+        RuleEnum::OxcPackageJsonValidEngines(OxcPackageJsonValidEngines::default()),
+        RuleEnum::OxcPackageJsonValidKeywords(OxcPackageJsonValidKeywords::default()),
+        RuleEnum::OxcPackageJsonValidLicense(OxcPackageJsonValidLicense::default()),
+        RuleEnum::OxcPackageJsonValidMan(OxcPackageJsonValidMan::default()),
+        RuleEnum::OxcPackageJsonValidName(OxcPackageJsonValidName::default()),
+        RuleEnum::OxcPackageJsonValidPrivate(OxcPackageJsonValidPrivate::default()),
+        RuleEnum::OxcPackageJsonValidRepository(OxcPackageJsonValidRepository::default()),
+        RuleEnum::OxcPackageJsonValidType(OxcPackageJsonValidType::default()),
+        RuleEnum::OxcPackageJsonValidVersion(OxcPackageJsonValidVersion::default()),
+        RuleEnum::OxcSortedJsonKeys(OxcSortedJsonKeys::default()),
+        RuleEnum::OxcValidJson(OxcValidJson::default()),
+        RuleEnum::OxcValidMessageSyntax(OxcValidMessageSyntax::default()),
         RuleEnum::NextjsGoogleFontDisplay(NextjsGoogleFontDisplay::default()),
         RuleEnum::NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect::default()),
         RuleEnum::NextjsInlineScriptId(NextjsInlineScriptId::default()),

--- a/crates/oxc_linter/src/json_parser.rs
+++ b/crates/oxc_linter/src/json_parser.rs
@@ -1,0 +1,544 @@
+//! Lightweight span-preserving JSON parser for linting.
+//!
+//! Unlike `serde_json`, this parser preserves the exact source spans for every
+//! key, value, property, object, and array in the JSON document. This enables
+//! precise diagnostics and autofixes for JSON lint rules.
+
+use oxc_span::Span;
+
+// ── AST ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum JsonValue<'a> {
+    Object(JsonObject<'a>),
+    Array(JsonArray<'a>),
+    /// (unescaped value, span of the full quoted string including quotes)
+    String(&'a str, Span),
+    /// (raw text, span)
+    Number(&'a str, Span),
+    Boolean(bool, Span),
+    Null(Span),
+}
+
+impl JsonValue<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Object(obj) => obj.span,
+            Self::Array(arr) => arr.span,
+            Self::String(_, span)
+            | Self::Number(_, span)
+            | Self::Boolean(_, span)
+            | Self::Null(span) => *span,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&JsonObject<'_>> {
+        if let Self::Object(obj) = self { Some(obj) } else { None }
+    }
+
+    pub fn as_array(&self) -> Option<&JsonArray<'_>> {
+        if let Self::Array(arr) = self { Some(arr) } else { None }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        if let Self::String(s, _) = self { Some(s) } else { None }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        if let Self::Boolean(b, _) = self { Some(*b) } else { None }
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonProperty<'a> {
+    /// The key string (without quotes).
+    pub key: &'a str,
+    /// Span of the full quoted key including quotes.
+    pub key_span: Span,
+    /// The value.
+    pub value: JsonValue<'a>,
+    /// Full span from key start to value end.
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct JsonObject<'a> {
+    pub properties: Vec<JsonProperty<'a>>,
+    pub span: Span,
+}
+
+impl<'a> JsonObject<'a> {
+    pub fn get(&self, key: &str) -> Option<&JsonValue<'a>> {
+        self.properties.iter().find(|p| p.key == key).map(|p| &p.value)
+    }
+
+    pub fn get_property(&self, key: &str) -> Option<&JsonProperty<'a>> {
+        self.properties.iter().find(|p| p.key == key)
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonArray<'a> {
+    pub elements: Vec<JsonValue<'a>>,
+    pub span: Span,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct JsonParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct JsonParseResult<'a> {
+    pub root: Option<JsonValue<'a>>,
+    pub errors: Vec<JsonParseError>,
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+pub fn parse_json(source: &str) -> JsonParseResult<'_> {
+    let mut parser = Parser::new(source);
+    let root = parser.parse_value();
+    parser.skip_whitespace();
+    if parser.pos < parser.source.len() && parser.errors.is_empty() {
+        parser.errors.push(JsonParseError {
+            message: "Unexpected content after JSON value".to_string(),
+            span: Span::new(parser.pos as u32, (parser.pos + 1) as u32),
+        });
+    }
+    JsonParseResult { root, errors: parser.errors }
+}
+
+struct Parser<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    errors: Vec<JsonParseError>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source, bytes: source.as_bytes(), pos: 0, errors: Vec::new() }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b' ' | b'\t' | b'\n' | b'\r' => self.pos += 1,
+                _ => break,
+            }
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let b = self.bytes.get(self.pos).copied()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn expect(&mut self, expected: u8) -> bool {
+        if self.peek() == Some(expected) {
+            self.pos += 1;
+            true
+        } else {
+            self.errors.push(JsonParseError {
+                message: format!(
+                    "Expected '{}', found {}",
+                    expected as char,
+                    self.peek().map_or("end of input".to_string(), |b| format!("'{}'", b as char))
+                ),
+                span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+            });
+            false
+        }
+    }
+
+    fn parse_value(&mut self) -> Option<JsonValue<'a>> {
+        self.skip_whitespace();
+        match self.peek()? {
+            b'{' => self.parse_object().map(JsonValue::Object),
+            b'[' => self.parse_array().map(JsonValue::Array),
+            b'"' => self.parse_string().map(|(s, span)| JsonValue::String(s, span)),
+            b't' | b'f' => self.parse_boolean(),
+            b'n' => self.parse_null(),
+            b'-' | b'0'..=b'9' => self.parse_number(),
+            c => {
+                self.errors.push(JsonParseError {
+                    message: format!("Unexpected character '{}'", c as char),
+                    span: Span::new(self.pos as u32, (self.pos + 1) as u32),
+                });
+                None
+            }
+        }
+    }
+
+    fn parse_object(&mut self) -> Option<JsonObject<'a>> {
+        let start = self.pos;
+        self.advance(); // skip '{'
+        self.skip_whitespace();
+
+        let mut properties = Vec::new();
+
+        if self.peek() == Some(b'}') {
+            self.advance();
+            return Some(JsonObject { properties, span: Span::new(start as u32, self.pos as u32) });
+        }
+
+        loop {
+            self.skip_whitespace();
+            let prop_start = self.pos;
+
+            // Parse key
+            if self.peek() != Some(b'"') {
+                self.errors.push(JsonParseError {
+                    message: "Expected string key".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            let (key, key_span) = self.parse_string()?;
+
+            self.skip_whitespace();
+            if !self.expect(b':') {
+                return None;
+            }
+
+            // Parse value
+            let value = self.parse_value()?;
+            let prop_end = self.pos;
+
+            properties.push(JsonProperty {
+                key,
+                key_span,
+                span: Span::new(prop_start as u32, prop_end as u32),
+                value,
+            });
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b'}') => {
+                    self.advance();
+                    break;
+                }
+                _ => {
+                    self.errors.push(JsonParseError {
+                        message: "Expected ',' or '}'".to_string(),
+                        span: Span::new(
+                            self.pos as u32,
+                            (self.pos + 1).min(self.source.len()) as u32,
+                        ),
+                    });
+                    return None;
+                }
+            }
+        }
+
+        Some(JsonObject { properties, span: Span::new(start as u32, self.pos as u32) })
+    }
+
+    fn parse_array(&mut self) -> Option<JsonArray<'a>> {
+        let start = self.pos;
+        self.advance(); // skip '['
+        self.skip_whitespace();
+
+        let mut elements = Vec::new();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Some(JsonArray { elements, span: Span::new(start as u32, self.pos as u32) });
+        }
+
+        loop {
+            let value = self.parse_value()?;
+            elements.push(value);
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b']') => {
+                    self.advance();
+                    break;
+                }
+                _ => {
+                    self.errors.push(JsonParseError {
+                        message: "Expected ',' or ']'".to_string(),
+                        span: Span::new(
+                            self.pos as u32,
+                            (self.pos + 1).min(self.source.len()) as u32,
+                        ),
+                    });
+                    return None;
+                }
+            }
+        }
+
+        Some(JsonArray { elements, span: Span::new(start as u32, self.pos as u32) })
+    }
+
+    fn parse_string(&mut self) -> Option<(&'a str, Span)> {
+        let start = self.pos;
+        self.advance(); // skip opening '"'
+
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b'"' => {
+                    let value = &self.source[start + 1..self.pos];
+                    self.pos += 1; // skip closing '"'
+                    let span = Span::new(start as u32, self.pos as u32);
+                    return Some((value, span));
+                }
+                b'\\' => {
+                    self.pos += 1; // skip backslash
+                    if self.pos < self.bytes.len() {
+                        // Skip the escaped character
+                        if self.bytes[self.pos] == b'u' {
+                            // \uXXXX — skip 4 hex digits
+                            self.pos += 1;
+                            for _ in 0..4 {
+                                if self.pos < self.bytes.len() {
+                                    self.pos += 1;
+                                }
+                            }
+                        } else {
+                            self.pos += 1;
+                        }
+                    }
+                }
+                _ => {
+                    self.pos += 1;
+                }
+            }
+        }
+
+        self.errors.push(JsonParseError {
+            message: "Unterminated string".to_string(),
+            span: Span::new(start as u32, self.source.len() as u32),
+        });
+        None
+    }
+
+    fn parse_number(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+
+        if self.peek() == Some(b'-') {
+            self.advance();
+        }
+
+        // Integer part
+        match self.peek() {
+            Some(b'0') => {
+                self.advance();
+            }
+            Some(b'1'..=b'9') => {
+                self.advance();
+                while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                    self.pos += 1;
+                }
+            }
+            _ => {
+                self.errors.push(JsonParseError {
+                    message: "Invalid number".to_string(),
+                    span: Span::new(start as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+        }
+
+        // Fraction
+        if self.peek() == Some(b'.') {
+            self.advance();
+            if !self.peek().is_some_and(|b| b.is_ascii_digit()) {
+                self.errors.push(JsonParseError {
+                    message: "Expected digit after decimal point".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+
+        // Exponent
+        if self.peek().is_some_and(|b| b == b'e' || b == b'E') {
+            self.advance();
+            if self.peek().is_some_and(|b| b == b'+' || b == b'-') {
+                self.advance();
+            }
+            if !self.peek().is_some_and(|b| b.is_ascii_digit()) {
+                self.errors.push(JsonParseError {
+                    message: "Expected digit in exponent".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+
+        let raw = &self.source[start..self.pos];
+        let span = Span::new(start as u32, self.pos as u32);
+        Some(JsonValue::Number(raw, span))
+    }
+
+    fn parse_boolean(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+        if self.source[self.pos..].starts_with("true") {
+            self.pos += 4;
+            Some(JsonValue::Boolean(true, Span::new(start as u32, self.pos as u32)))
+        } else if self.source[self.pos..].starts_with("false") {
+            self.pos += 5;
+            Some(JsonValue::Boolean(false, Span::new(start as u32, self.pos as u32)))
+        } else {
+            self.errors.push(JsonParseError {
+                message: "Invalid boolean".to_string(),
+                span: Span::new(start as u32, (start + 1) as u32),
+            });
+            None
+        }
+    }
+
+    fn parse_null(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+        if self.source[self.pos..].starts_with("null") {
+            self.pos += 4;
+            Some(JsonValue::Null(Span::new(start as u32, self.pos as u32)))
+        } else {
+            self.errors.push(JsonParseError {
+                message: "Invalid null".to_string(),
+                span: Span::new(start as u32, (start + 1) as u32),
+            });
+            None
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_object() {
+        let result = parse_json("{}");
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert!(obj.properties.is_empty());
+        assert_eq!(obj.span, Span::new(0, 2));
+    }
+
+    #[test]
+    fn test_simple_object() {
+        let src = r#"{"name": "test", "version": 1}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.properties.len(), 2);
+        assert_eq!(obj.properties[0].key, "name");
+        assert_eq!(obj.properties[0].key_span, Span::new(1, 7)); // "name"
+        assert_eq!(obj.properties[0].value.as_str(), Some("test"));
+        assert_eq!(obj.properties[1].key, "version");
+    }
+
+    #[test]
+    fn test_nested_object() {
+        let src = r#"{"a": {"b": true}}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let outer = root.as_object().unwrap();
+        let inner = outer.properties[0].value.as_object().unwrap();
+        assert_eq!(inner.properties[0].key, "b");
+        assert_eq!(inner.properties[0].value.as_bool(), Some(true));
+    }
+
+    #[test]
+    fn test_array() {
+        let src = r#"[1, "two", true, null]"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let arr = root.as_array().unwrap();
+        assert_eq!(arr.elements.len(), 4);
+    }
+
+    #[test]
+    fn test_number_spans() {
+        let src = "42";
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        if let JsonValue::Number(raw, span) = result.root.unwrap() {
+            assert_eq!(raw, "42");
+            assert_eq!(span, Span::new(0, 2));
+        } else {
+            panic!("expected number");
+        }
+    }
+
+    #[test]
+    fn test_string_with_escapes() {
+        let src = r#""hello \"world\"""#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let result = parse_json("{invalid}");
+        assert!(!result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_keys() {
+        let src = r#"{"a": 1, "a": 2}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty()); // parser allows duplicate keys
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.properties.len(), 2);
+        assert_eq!(obj.properties[0].key, "a");
+        assert_eq!(obj.properties[1].key, "a");
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let result = parse_json("");
+        assert!(result.root.is_none());
+    }
+
+    #[test]
+    fn test_whitespace_only() {
+        let result = parse_json("  \n\t  ");
+        assert!(result.root.is_none());
+    }
+
+    #[test]
+    fn test_negative_number() {
+        let result = parse_json("-3.14e2");
+        assert!(result.errors.is_empty());
+        if let JsonValue::Number(raw, span) = result.root.unwrap() {
+            assert_eq!(raw, "-3.14e2");
+            assert_eq!(span, Span::new(0, 7));
+        } else {
+            panic!("expected number");
+        }
+    }
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -31,12 +31,14 @@ use oxc_span::Span;
 mod ast_util;
 mod config;
 mod context;
+pub mod css_parser;
 mod disable_directives;
 mod external_linter;
 mod external_plugin_store;
 mod fixer;
 mod frameworks;
 mod globals;
+pub mod json_parser;
 mod module_graph_visitor;
 mod module_record;
 mod options;
@@ -192,9 +194,34 @@ impl Linter {
         allocator: &'a Allocator,
         js_allocator_pool: Option<&AllocatorPool>,
     ) -> (Vec<Message>, Option<DisableDirectives>) {
+        let full_source_text =
+            context_sub_hosts.first().map_or("", |sub_host| sub_host.semantic().source_text());
+        self.run_with_full_source_text_and_disable_directives(
+            path,
+            context_sub_hosts,
+            full_source_text,
+            allocator,
+            js_allocator_pool,
+        )
+    }
+
+    pub(crate) fn run_with_full_source_text_and_disable_directives<'a>(
+        &self,
+        path: &Path,
+        context_sub_hosts: Vec<ContextSubHost<'a>>,
+        full_source_text: &'a str,
+        allocator: &'a Allocator,
+        js_allocator_pool: Option<&AllocatorPool>,
+    ) -> (Vec<Message>, Option<DisableDirectives>) {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
 
-        let mut ctx_host = Rc::new(ContextHost::new(path, context_sub_hosts, self.options, config));
+        let mut ctx_host = Rc::new(ContextHost::new(
+            path,
+            context_sub_hosts,
+            full_source_text,
+            self.options,
+            config,
+        ));
 
         #[cfg(debug_assertions)]
         let mut current_diagnostic_index = 0;
@@ -202,12 +229,18 @@ impl Linter {
         let is_partial_loader_file = ctx_host
             .file_extension()
             .is_some_and(|ext| LINT_PARTIAL_LOADER_EXTENSIONS.iter().any(|e| e == &ext));
+        let is_json_file =
+            ctx_host.file_extension().is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
 
         loop {
             let semantic = ctx_host.semantic();
             let rules = rules
                 .iter()
                 .filter(|(rule, _)| {
+                    if is_json_file && rule.plugin_name() != "oxc" {
+                        return false;
+                    }
+
                     if rule.is_tsgolint_rule() {
                         return false;
                     }
@@ -249,16 +282,35 @@ impl Linter {
                 //
                 // See https://github.com/oxc-project/oxc/pull/6600 for more context.
                 if semantic.nodes().len() > 200_000 {
-                    // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
-                    // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
-                    // compile-time since we know all of the rules and their AST node type information ahead of time.
+                    // Pre-compute the number of rules that map to each AST type so we can
+                    // allocate buckets with the right capacity and avoid reallocs.
                     //
                     // Use boxed array to help compiler see that indexing into it with an `AstType`
                     // cannot go out of bounds, and remove bounds checks.
+                    let mut counts = boxed_array![0usize; AST_TYPE_MAX as usize + 1];
+                    let mut any_count = 0usize;
+                    for (rule, _) in &rules {
+                        let rule = *rule;
+                        let run_info = rule.run_info();
+                        if with_runtime_optimization
+                            && let Some(ast_types) = rule.types_info()
+                            && run_info.is_run_implemented()
+                        {
+                            for ty in ast_types {
+                                counts[ty as usize] += 1;
+                            }
+                        } else {
+                            any_count += 1;
+                        }
+                    }
+
                     let mut rules_by_ast_type = boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
-                    // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
-                    // node types, but it at least guarantees we won't need to realloc.
-                    let mut rules_any_ast_type = Vec::with_capacity(rules.len());
+                    for (i, count) in counts.iter().enumerate() {
+                        if *count > 0 {
+                            rules_by_ast_type[i] = Vec::with_capacity(*count);
+                        }
+                    }
+                    let mut rules_any_ast_type = Vec::with_capacity(any_count);
 
                     for (rule, ctx) in &rules {
                         let rule = *rule;

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -1,5 +1,5 @@
 use memchr::{memmem::Finder, memmem::FinderRev};
-use oxc_span::VALID_EXTENSIONS;
+use oxc_span::{SourceType, VALID_EXTENSIONS};
 
 use crate::loader::JavaScriptSource;
 
@@ -15,9 +15,12 @@ const SCRIPT_END: &str = "</script>";
 const COMMENT_START: &str = "<!--";
 const COMMENT_END: &str = "-->";
 
-/// File extensions that can contain JS/TS code in certain parts, such as in `<script>` tags, and can
-/// be loaded using the [`PartialLoader`].
-pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte"];
+/// File extensions that require special loading beyond direct JS/TS parsing.
+///
+/// Some contain embedded script sections (`.vue`, `.astro`, `.svelte`), while
+/// others use non-JS raw-file rules backed by a placeholder semantic section
+/// (`.json`).
+pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte", "json", "css"];
 
 /// All valid JavaScript/TypeScript extensions, plus additional framework files that
 /// contain JavaScript/TypeScript code in them (e.g., Vue, Astro, Svelte, etc.).
@@ -34,6 +37,8 @@ impl PartialLoader {
             "vue" => Some(VuePartialLoader::new(source_text).parse()),
             "astro" => Some(AstroPartialLoader::new(source_text).parse()),
             "svelte" => Some(SveltePartialLoader::new(source_text).parse()),
+            "json" => Some(vec![JavaScriptSource::partial("", SourceType::default(), 0)]),
+            "css" => Some(vec![JavaScriptSource::partial("", SourceType::default(), 0)]),
             _ => None,
         }
     }

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -639,6 +639,36 @@ pub(crate) mod oxc {
     pub mod number_arg_out_of_range;
     pub mod only_used_in_recursion;
     pub mod uninvoked_array_callback;
+
+    pub mod identical_keys;
+    pub mod identical_placeholders;
+    pub mod json_no_comments;
+    pub mod json_no_duplicate_keys;
+    pub mod json_no_trailing_commas;
+    pub mod json_parse_validation;
+    mod json_utils;
+    pub mod package_json_no_duplicate_dependencies;
+    pub mod package_json_no_empty_fields;
+    pub mod package_json_no_redundant_publish_config;
+    pub mod package_json_order_properties;
+    pub mod package_json_repository_shorthand;
+    pub mod package_json_require_type;
+    pub mod package_json_require_version;
+    pub mod package_json_sort_collections;
+    pub mod package_json_valid_bin;
+    pub mod package_json_valid_description;
+    pub mod package_json_valid_engines;
+    pub mod package_json_valid_keywords;
+    pub mod package_json_valid_license;
+    pub mod package_json_valid_man;
+    pub mod package_json_valid_name;
+    pub mod package_json_valid_private;
+    pub mod package_json_valid_repository;
+    pub mod package_json_valid_type;
+    pub mod package_json_valid_version;
+    pub mod sorted_json_keys;
+    pub mod valid_json;
+    pub mod valid_message_syntax;
 }
 
 pub(crate) mod nextjs {

--- a/crates/oxc_linter/src/rules/oxc/identical_keys.rs
+++ b/crates/oxc_linter/src/rules/oxc/identical_keys.rs
@@ -1,0 +1,226 @@
+use std::{collections::BTreeMap, path::Path};
+
+use super::json_utils::{
+    JsonShapeDiff, compare_json_shapes, file_start_span, is_json_file, resolve_reference_path,
+};
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    context::LintContext,
+    json_parser::parse_json,
+    rule::{DefaultRuleConfig, Rule},
+    utils::read_to_string,
+};
+
+fn identical_keys_diagnostic(
+    reference_path: &Path,
+    summary: &str,
+    span: oxc_span::Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "JSON keys do not match the reference locale file `{}`.",
+        reference_path.display()
+    ))
+    .with_help(summary.to_string())
+    .with_label(span)
+}
+
+fn unreadable_reference_diagnostic(
+    reference_path: &Path,
+    error: &std::io::Error,
+    span: oxc_span::Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Configured reference locale file `{}` could not be read.",
+        reference_path.display()
+    ))
+    .with_help(error.to_string())
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct IdenticalKeysConfig {
+    file_path: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct IdenticalKeys(Box<IdenticalKeysConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures locale JSON files have the same key structure as a configured
+    /// reference catalog.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Missing or extra locale keys create partial translations and hard to
+    /// debug runtime fallbacks.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "title": "Dashboard" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "title": "Dashboard", "subtitle": "Ready" }
+    /// ```
+    IdenticalKeys,
+    oxc,
+    correctness,
+    config = IdenticalKeysConfig
+);
+
+impl Rule for IdenticalKeys {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<IdenticalKeysConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(file_name) = ctx.file_path().file_name().and_then(|name| name.to_str()) else {
+            return;
+        };
+        let Some(raw_reference_path) = self.0.file_path.get(file_name) else {
+            return;
+        };
+
+        let source_text = ctx.full_source_text();
+        let candidate_result = parse_json(source_text);
+        let Some(candidate) = &candidate_result.root else {
+            return;
+        };
+
+        let reference_path = resolve_reference_path(ctx.file_path(), raw_reference_path);
+        if reference_path == ctx.file_path() {
+            return;
+        }
+
+        let span = file_start_span(source_text);
+        let reference_source = match read_to_string(&reference_path) {
+            Ok(reference_source) => reference_source,
+            Err(error) => {
+                ctx.diagnostic(unreadable_reference_diagnostic(&reference_path, &error, span));
+                return;
+            }
+        };
+        let reference_result = parse_json(&reference_source);
+        let Some(reference) = &reference_result.root else {
+            return;
+        };
+
+        let mut diff = JsonShapeDiff::default();
+        compare_json_shapes(reference, candidate, "", &mut diff);
+
+        if diff.missing.is_empty() && diff.extra.is_empty() && diff.type_mismatches.is_empty() {
+            return;
+        }
+
+        ctx.diagnostic(identical_keys_diagnostic(&reference_path, &build_summary(&diff), span));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && is_json_file(ctx.file_path())
+    }
+}
+
+fn build_summary(diff: &JsonShapeDiff) -> String {
+    let mut parts = Vec::new();
+
+    if !diff.missing.is_empty() {
+        parts.push(format!(
+            "Missing {} key(s): {}",
+            diff.missing.len(),
+            summarize_paths(&diff.missing)
+        ));
+    }
+
+    if !diff.extra.is_empty() {
+        parts.push(format!("Extra {} key(s): {}", diff.extra.len(), summarize_paths(&diff.extra)));
+    }
+
+    if !diff.type_mismatches.is_empty() {
+        parts.push(format!(
+            "Type mismatches at {} path(s): {}",
+            diff.type_mismatches.len(),
+            summarize_paths(&diff.type_mismatches)
+        ));
+    }
+
+    parts.join(" ")
+}
+
+fn summarize_paths(paths: &[String]) -> String {
+    const MAX_PATHS: usize = 5;
+
+    let mut summary = paths.iter().take(MAX_PATHS).cloned().collect::<Vec<_>>().join(", ");
+    if paths.len() > MAX_PATHS {
+        use std::fmt::Write;
+        write!(summary, ", and {} more", paths.len() - MAX_PATHS).unwrap();
+    }
+    summary
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let config = Some(json!([{
+        "filePath": {
+            "common.json": "../en/common.json"
+        }
+    }]));
+
+    let pass = vec![
+        (
+            r#"{"actions":{"cancel":"Annuler","save":"Enregistrer"},"title":"Tableau de bord"}"#,
+            config.clone(),
+            None,
+            Some(PathBuf::from("i18n_catalog/fr/common.json")),
+        ),
+        (
+            r#"{"actions":{"cancel":"Dashboard","save":"Save"},"title":"Dashboard"}"#,
+            config.clone(),
+            None,
+            Some(PathBuf::from("i18n_catalog/en/common.json")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            r#"{"actions":{"cancel":"Annuler"},"title":"Tableau de bord"}"#,
+            config.clone(),
+            None,
+            Some(PathBuf::from("i18n_catalog/fr/common.json")),
+        ),
+        (
+            r#"{"actions":{"cancel":"Annuler","save":"Enregistrer","submit":"Envoyer"},"title":"Tableau de bord"}"#,
+            config.clone(),
+            None,
+            Some(PathBuf::from("i18n_catalog/fr/common.json")),
+        ),
+        (
+            r#"{"actions":"Annuler","title":"Tableau de bord"}"#,
+            config,
+            None,
+            Some(PathBuf::from("i18n_catalog/fr/common.json")),
+        ),
+    ];
+
+    Tester::new(IdenticalKeys::NAME, IdenticalKeys::PLUGIN, pass, fail)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/identical_placeholders.rs
+++ b/crates/oxc_linter/src/rules/oxc/identical_placeholders.rs
@@ -1,0 +1,244 @@
+use std::{collections::BTreeMap, collections::BTreeSet, path::Path};
+
+use super::json_utils::{file_start_span, is_json_file, resolve_reference_path};
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::{DefaultRuleConfig, Rule},
+    utils::read_to_string,
+};
+
+static PLACEHOLDER_REGEX: Lazy<Regex> = lazy_regex!(r"\{[^}]+\}");
+
+fn placeholder_mismatch_diagnostic(
+    reference_path: &Path,
+    key: &str,
+    summary: &str,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Placeholders at `{key}` do not match reference locale `{}`.",
+        reference_path.display()
+    ))
+    .with_help(summary.to_string())
+    .with_label(span)
+}
+
+fn unreadable_reference_diagnostic(
+    reference_path: &Path,
+    error: &std::io::Error,
+    span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Configured reference locale file `{}` could not be read.",
+        reference_path.display()
+    ))
+    .with_help(error.to_string())
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct IdenticalPlaceholdersConfig {
+    file_path: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct IdenticalPlaceholders(Box<IdenticalPlaceholdersConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures locale JSON files use the same ICU/i18n placeholders as a
+    /// configured reference catalog.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Missing or extra placeholders in translations cause runtime formatting
+    /// errors or display raw placeholder syntax to end-users.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "greeting": "Bonjour" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "greeting": "Bonjour {name}" }
+    /// ```
+    IdenticalPlaceholders,
+    oxc,
+    correctness,
+    config = IdenticalPlaceholdersConfig
+);
+
+impl Rule for IdenticalPlaceholders {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<IdenticalPlaceholdersConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(file_name) = ctx.file_path().file_name().and_then(|name| name.to_str()) else {
+            return;
+        };
+        let Some(raw_reference_path) = self.0.file_path.get(file_name) else {
+            return;
+        };
+
+        let source_text = ctx.full_source_text();
+        let candidate_result = parse_json(source_text);
+        let Some(candidate) = &candidate_result.root else {
+            return;
+        };
+
+        let reference_path = resolve_reference_path(ctx.file_path(), raw_reference_path);
+        if reference_path == ctx.file_path() {
+            return;
+        }
+
+        let span = file_start_span(source_text);
+        let reference_source = match read_to_string(&reference_path) {
+            Ok(s) => s,
+            Err(error) => {
+                ctx.diagnostic(unreadable_reference_diagnostic(&reference_path, &error, span));
+                return;
+            }
+        };
+        let reference_result = parse_json(&reference_source);
+        let Some(reference) = &reference_result.root else {
+            return;
+        };
+
+        compare_placeholders(ctx, &reference_path, reference, candidate, "");
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && is_json_file(ctx.file_path())
+    }
+}
+
+fn compare_placeholders(
+    ctx: &LintContext<'_>,
+    reference_path: &Path,
+    reference: &JsonValue<'_>,
+    candidate: &JsonValue<'_>,
+    path: &str,
+) {
+    match (reference, candidate) {
+        (JsonValue::Object(ref_obj), JsonValue::Object(cand_obj)) => {
+            for ref_prop in &ref_obj.properties {
+                let child_path = if path.is_empty() {
+                    ref_prop.key.to_string()
+                } else {
+                    format!("{path}.{}", ref_prop.key)
+                };
+
+                if let Some(cand_value) = cand_obj.get(ref_prop.key) {
+                    compare_placeholders(
+                        ctx,
+                        reference_path,
+                        &ref_prop.value,
+                        cand_value,
+                        &child_path,
+                    );
+                }
+            }
+        }
+        (JsonValue::String(ref_str, _), JsonValue::String(cand_str, cand_span)) => {
+            let ref_placeholders = extract_placeholders(ref_str);
+            let cand_placeholders = extract_placeholders(cand_str);
+
+            if ref_placeholders != cand_placeholders {
+                let missing: Vec<_> =
+                    ref_placeholders.difference(&cand_placeholders).cloned().collect();
+                let extra: Vec<_> =
+                    cand_placeholders.difference(&ref_placeholders).cloned().collect();
+
+                let mut parts = Vec::new();
+                if !missing.is_empty() {
+                    parts.push(format!("missing: {}", missing.join(", ")));
+                }
+                if !extra.is_empty() {
+                    parts.push(format!("extra: {}", extra.join(", ")));
+                }
+
+                ctx.diagnostic(placeholder_mismatch_diagnostic(
+                    reference_path,
+                    path,
+                    &parts.join("; "),
+                    *cand_span,
+                ));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn extract_placeholders(message: &str) -> BTreeSet<String> {
+    PLACEHOLDER_REGEX.find_iter(message).map(|m| m.as_str().to_string()).collect()
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let config = Some(json!([{
+        "filePath": {
+            "messages.json": "../en/messages.json"
+        }
+    }]));
+
+    let pass = vec![
+        // Placeholders match reference
+        (
+            r#"{"greeting":"Bonjour {name}","count":"{count} éléments","simple":"Tableau de bord"}"#,
+            config.clone(),
+            None,
+            Some(PathBuf::from("i18n_catalog/fr/messages.json")),
+        ),
+        // Self-reference (skipped)
+        (
+            r#"{"greeting":"Hello {name}","count":"{count} items","simple":"Dashboard"}"#,
+            config.clone(),
+            None,
+            Some(PathBuf::from("i18n_catalog/en/messages.json")),
+        ),
+    ];
+
+    let fail = vec![
+        // Missing {name} placeholder
+        (
+            r#"{"greeting":"Bonjour","count":"{count} éléments","simple":"Tableau de bord"}"#,
+            config.clone(),
+            None,
+            Some(PathBuf::from("i18n_catalog/fr/messages.json")),
+        ),
+        // Extra {extra} placeholder
+        (
+            r#"{"greeting":"Bonjour {name} {extra}","count":"{count} éléments","simple":"Tableau de bord"}"#,
+            config,
+            None,
+            Some(PathBuf::from("i18n_catalog/fr/messages.json")),
+        ),
+    ];
+
+    Tester::new(IdenticalPlaceholders::NAME, IdenticalPlaceholders::PLUGIN, pass, fail)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/json_no_comments.rs
+++ b/crates/oxc_linter/src/rules/oxc/json_no_comments.rs
@@ -1,0 +1,122 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, rules::oxc::json_utils::is_json_file};
+
+fn json_no_comments_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Comments are not allowed in JSON")
+        .with_help("Remove the comment. Standard JSON (RFC 8259) does not support comments. Use JSONC if you need comments.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsonNoComments;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects JavaScript-style comments (`//` and `/* */`) in JSON files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Standard JSON (RFC 8259) does not allow comments. Most strict JSON
+    /// parsers will reject files containing comments.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** JSON:
+    /// ```json
+    /// {
+    ///     // This is a comment
+    ///     "name": "foo"
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** JSON:
+    /// ```json
+    /// { "name": "foo" }
+    /// ```
+    JsonNoComments,
+    oxc,
+    correctness,
+    none
+);
+
+impl Rule for JsonNoComments {
+    #[expect(clippy::cast_possible_truncation)] // Span uses u32 by design
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source = ctx.full_source_text();
+        let bytes = source.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+        let mut in_string = false;
+
+        while i < len {
+            match bytes[i] {
+                b'"' if !in_string => {
+                    in_string = true;
+                    i += 1;
+                }
+                b'"' if in_string => {
+                    in_string = false;
+                    i += 1;
+                }
+                b'\\' if in_string => {
+                    i += 2;
+                }
+                b'/' if !in_string && i + 1 < len => {
+                    match bytes[i + 1] {
+                        b'/' => {
+                            // Single-line comment
+                            let start = i;
+                            i += 2;
+                            while i < len && bytes[i] != b'\n' {
+                                i += 1;
+                            }
+                            ctx.diagnostic(json_no_comments_diagnostic(Span::new(
+                                start as u32,
+                                i as u32,
+                            )));
+                        }
+                        b'*' => {
+                            // Block comment
+                            let start = i;
+                            i += 2;
+                            while i + 1 < len {
+                                if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                                    i += 2;
+                                    break;
+                                }
+                                i += 1;
+                            }
+                            ctx.diagnostic(json_no_comments_diagnostic(Span::new(
+                                start as u32,
+                                i as u32,
+                            )));
+                        }
+                        _ => i += 1,
+                    }
+                }
+                _ => i += 1,
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        is_json_file(ctx.file_path())
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![r#"{"name": "foo"}"#, r#"{"url": "https://example.com"}"#, "{}"];
+
+    let fail = vec!["{\n// comment\n\"a\": 1\n}", "{\n/* block */\n\"a\": 1\n}"];
+
+    Tester::new(JsonNoComments::NAME, JsonNoComments::PLUGIN, pass, fail)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/json_no_duplicate_keys.rs
+++ b/crates/oxc_linter/src/rules/oxc/json_no_duplicate_keys.rs
@@ -1,0 +1,112 @@
+use rustc_hash::FxHashMap;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+    rules::oxc::json_utils::is_json_file,
+};
+
+fn json_no_duplicate_keys_diagnostic(span: Span, key: &str, first_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Duplicate key \"{key}\" in JSON object"))
+        .with_help("Remove one of the duplicate keys. The last value will be used by JSON parsers.")
+        .with_labels([span.label("duplicate key here"), first_span.label("first occurrence")])
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsonNoDuplicateKeys;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects duplicate keys in JSON objects.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Duplicate keys in JSON objects are technically allowed by the spec but
+    /// the behavior is undefined — most parsers silently use the last value.
+    /// This can hide bugs and cause confusion.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** JSON:
+    /// ```json
+    /// { "name": "foo", "name": "bar" }
+    /// ```
+    ///
+    /// Examples of **correct** JSON:
+    /// ```json
+    /// { "name": "foo", "alias": "bar" }
+    /// ```
+    JsonNoDuplicateKeys,
+    oxc,
+    correctness,
+    none
+);
+
+impl Rule for JsonNoDuplicateKeys {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+
+        if let Some(root) = &result.root {
+            check_value(root, ctx);
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        is_json_file(ctx.file_path())
+    }
+}
+
+fn check_value(value: &JsonValue<'_>, ctx: &LintContext<'_>) {
+    match value {
+        JsonValue::Object(obj) => {
+            let mut seen: FxHashMap<&str, Span> = FxHashMap::default();
+            for prop in &obj.properties {
+                if let Some(&first_span) = seen.get(prop.key) {
+                    ctx.diagnostic(json_no_duplicate_keys_diagnostic(
+                        prop.key_span,
+                        prop.key,
+                        first_span,
+                    ));
+                } else {
+                    seen.insert(prop.key, prop.key_span);
+                }
+                check_value(&prop.value, ctx);
+            }
+        }
+        JsonValue::Array(arr) => {
+            for elem in &arr.elements {
+                check_value(elem, ctx);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"name": "foo", "version": "1.0"}"#,
+        r#"{"a": 1, "b": 2, "c": 3}"#,
+        r#"[1, 2, 3]"#,
+        r#"{}"#,
+    ];
+
+    let fail = vec![
+        r#"{"name": "foo", "name": "bar"}"#,
+        r#"{"a": 1, "b": 2, "a": 3}"#,
+        r#"{"outer": {"inner": 1, "inner": 2}}"#,
+    ];
+
+    Tester::new(JsonNoDuplicateKeys::NAME, JsonNoDuplicateKeys::PLUGIN, pass, fail)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/json_no_trailing_commas.rs
+++ b/crates/oxc_linter/src/rules/oxc/json_no_trailing_commas.rs
@@ -1,0 +1,102 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule, rules::oxc::json_utils::is_json_file};
+
+fn json_no_trailing_commas_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Trailing comma in JSON")
+        .with_help("Remove the trailing comma. Trailing commas are not allowed in JSON.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsonNoTrailingCommas;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects trailing commas in JSON objects and arrays.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Trailing commas are not allowed in strict JSON per RFC 8259.
+    /// Most JSON parsers will reject files with trailing commas.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** JSON:
+    /// ```json
+    /// { "name": "foo", }
+    /// [1, 2, 3,]
+    /// ```
+    ///
+    /// Examples of **correct** JSON:
+    /// ```json
+    /// { "name": "foo" }
+    /// [1, 2, 3]
+    /// ```
+    JsonNoTrailingCommas,
+    oxc,
+    correctness,
+    none
+);
+
+impl Rule for JsonNoTrailingCommas {
+    #[expect(clippy::cast_possible_truncation)] // Span uses u32 by design
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source = ctx.full_source_text();
+        let bytes = source.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+        let mut in_string = false;
+
+        while i < len {
+            match bytes[i] {
+                b'"' if !in_string => {
+                    in_string = true;
+                    i += 1;
+                }
+                b'"' if in_string => {
+                    in_string = false;
+                    i += 1;
+                }
+                b'\\' if in_string => {
+                    i += 2; // skip escaped char
+                }
+                b',' if !in_string => {
+                    // Check if this comma is followed by a closing bracket/brace
+                    let mut j = i + 1;
+                    while j < len && matches!(bytes[j], b' ' | b'\t' | b'\n' | b'\r') {
+                        j += 1;
+                    }
+                    if j < len && (bytes[j] == b'}' || bytes[j] == b']') {
+                        ctx.diagnostic(json_no_trailing_commas_diagnostic(Span::new(
+                            i as u32,
+                            (i + 1) as u32,
+                        )));
+                    }
+                    i += 1;
+                }
+                _ => i += 1,
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        is_json_file(ctx.file_path())
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![r#"{"name": "foo"}"#, r#"[1, 2, 3]"#, r#"{"a": [1, 2]}"#, "{}", "[]"];
+
+    let fail = vec![r#"{"name": "foo",}"#, "[1, 2, 3,]", r#"{"a": 1, "b": 2,}"#];
+
+    Tester::new(JsonNoTrailingCommas::NAME, JsonNoTrailingCommas::PLUGIN, pass, fail)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/json_parse_validation.rs
+++ b/crates/oxc_linter/src/rules/oxc/json_parse_validation.rs
@@ -1,0 +1,228 @@
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Statement},
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+const MAX_VALIDATION_LOOKAHEAD: usize = 3;
+
+fn json_parse_validation_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Validate `JSON.parse()` results before using them.")
+        .with_help(
+            "Wrap `JSON.parse(...)` with `safeParse(...)`/`parse(...)`, or validate the assigned value within the next few statements.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct JsonParseValidation;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires runtime validation of `JSON.parse()` results.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Parsed JSON is untrusted input. Requiring an immediate schema validation
+    /// step makes the data safe to use and prevents unchecked assumptions from
+    /// spreading through the program.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// const data = JSON.parse(text);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// const result = v.safeParse(MySchema, JSON.parse(text));
+    /// ```
+    JsonParseValidation,
+    oxc,
+    correctness,
+    none
+);
+
+impl Rule for JsonParseValidation {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if !call_expr.callee.is_specific_member_access("JSON", "parse") {
+            return;
+        }
+
+        if is_immediately_validated(node.id(), ctx) {
+            return;
+        }
+
+        if get_assigned_identifier_name(node.id(), ctx)
+            .is_some_and(|name| is_validated_soon(node.id(), name, ctx))
+        {
+            return;
+        }
+
+        ctx.diagnostic(json_parse_validation_diagnostic(call_expr.span));
+    }
+}
+
+fn is_immediately_validated(node_id: oxc_syntax::node::NodeId, ctx: &LintContext<'_>) -> bool {
+    match ctx.nodes().parent_kind(node_id) {
+        AstKind::CallExpression(parent_call) => is_validation_call(parent_call),
+        _ => false,
+    }
+}
+
+fn get_assigned_identifier_name<'a>(
+    node_id: oxc_syntax::node::NodeId,
+    ctx: &LintContext<'a>,
+) -> Option<&'a str> {
+    match ctx.nodes().parent_kind(node_id) {
+        AstKind::VariableDeclarator(declarator) => {
+            declarator.id.get_identifier_name().map(|ident| ident.as_str())
+        }
+        AstKind::AssignmentExpression(assignment) => assignment.left.get_identifier_name(),
+        _ => None,
+    }
+}
+
+fn is_validated_soon(node_id: oxc_syntax::node::NodeId, name: &str, ctx: &LintContext<'_>) -> bool {
+    let Some((statements, statement_index)) = find_enclosing_statement_body(node_id, ctx) else {
+        return false;
+    };
+
+    statements
+        .iter()
+        .skip(statement_index + 1)
+        .take(MAX_VALIDATION_LOOKAHEAD)
+        .any(|statement| statement_contains_validation_of_identifier(statement, name))
+}
+
+fn find_enclosing_statement_body<'a>(
+    node_id: oxc_syntax::node::NodeId,
+    ctx: &LintContext<'a>,
+) -> Option<(&'a [Statement<'a>], usize)> {
+    let mut child = ctx.nodes().get_node(node_id);
+
+    for ancestor in ctx.nodes().ancestors(node_id) {
+        match ancestor.kind() {
+            AstKind::BlockStatement(block) => {
+                let body = block.body.as_slice();
+                let statement_span = child.kind().span();
+                let statement_index =
+                    body.iter().position(|statement| statement.span() == statement_span)?;
+                return Some((body, statement_index));
+            }
+            AstKind::Program(program) => {
+                let body = program.body.as_slice();
+                let statement_span = child.kind().span();
+                let statement_index =
+                    body.iter().position(|statement| statement.span() == statement_span)?;
+                return Some((body, statement_index));
+            }
+            _ => {
+                child = ancestor;
+            }
+        }
+    }
+
+    None
+}
+
+fn is_validation_call(call_expr: &CallExpression) -> bool {
+    match &call_expr.callee {
+        oxc_ast::ast::Expression::Identifier(ident) => {
+            matches!(ident.name.as_str(), "safeParse" | "parse")
+        }
+        callee if callee.is_member_expression() => callee
+            .to_member_expression()
+            .static_property_name()
+            .is_some_and(|name| matches!(name, "safeParse" | "parse")),
+        oxc_ast::ast::Expression::ChainExpression(chain) => chain
+            .expression
+            .as_member_expression()
+            .and_then(oxc_ast::ast::MemberExpression::static_property_name)
+            .is_some_and(|name| matches!(name, "safeParse" | "parse")),
+        _ => false,
+    }
+}
+
+fn statement_contains_validation_of_identifier(statement: &Statement<'_>, name: &str) -> bool {
+    let mut visitor = ValidationUsageVisitor { name, found: false };
+    visitor.visit_statement(statement);
+    visitor.found
+}
+
+struct ValidationUsageVisitor<'a> {
+    name: &'a str,
+    found: bool,
+}
+
+impl ValidationUsageVisitor<'_> {
+    fn call_uses_target_identifier(&self, call_expr: &CallExpression<'_>) -> bool {
+        call_expr.arguments.iter().filter_map(|argument| argument.as_expression()).any(
+            |expression| match expression.get_inner_expression() {
+                oxc_ast::ast::Expression::Identifier(ident) => ident.name == self.name,
+                _ => false,
+            },
+        )
+    }
+}
+
+impl<'a> Visit<'a> for ValidationUsageVisitor<'_> {
+    fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
+        if self.found {
+            return;
+        }
+
+        if is_validation_call(call_expr) && self.call_uses_target_identifier(call_expr) {
+            self.found = true;
+            return;
+        }
+
+        walk::walk_call_expression(self, call_expr);
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::Value;
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass: Vec<(&str, Option<Value>)> = vec![
+        ("const result = safeParse(MySchema, JSON.parse(text));", None),
+        ("const result = parse(MySchema, JSON.parse(text), 'context label');", None),
+        ("const result = v.safeParse(MySchema, JSON.parse(text));", None),
+        ("const raw = JSON.parse(text); const result = v.safeParse(MySchema, raw);", None),
+        ("let raw; raw = JSON.parse(text); const result = parse(MySchema, raw, 'ctx');", None),
+        (
+            "const raw = JSON.parse(text); foo(); bar(); v.safeParse(MySchema, raw);",
+            Some(json!([])),
+        ),
+    ];
+
+    let fail: Vec<(&str, Option<Value>)> = vec![
+        ("const data = JSON.parse(text);", None),
+        ("handle(JSON.parse(text));", None),
+        ("const raw = JSON.parse(text); doSomething(raw);", None),
+        ("let raw; raw = JSON.parse(text); doSomething(raw);", None),
+        (
+            "const raw = JSON.parse(text); foo(); bar(); baz(); qux(); v.safeParse(MySchema, raw);",
+            None,
+        ),
+    ];
+
+    Tester::new(JsonParseValidation::NAME, JsonParseValidation::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/json_utils.rs
+++ b/crates/oxc_linter/src/rules/oxc/json_utils.rs
@@ -1,0 +1,155 @@
+use std::{
+    ffi::OsStr,
+    path::{Component, Path, PathBuf},
+};
+
+use oxc_span::Span;
+
+use crate::json_parser::{JsonObject, JsonProperty, JsonValue};
+
+pub(super) fn is_json_file(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| ext == OsStr::new("json"))
+}
+
+pub(super) fn file_start_span(source_text: &str) -> Span {
+    if source_text.is_empty() { Span::default() } else { Span::new(0, 1) }
+}
+
+/// Compute the span to delete for a JSON property, including its associated
+/// comma and surrounding whitespace so that the remaining JSON stays valid.
+#[expect(clippy::cast_possible_truncation)] // Span uses u32 by design
+pub(super) fn property_deletion_span(
+    source_text: &str,
+    object: &JsonObject<'_>,
+    prop: &JsonProperty<'_>,
+    index: usize,
+) -> Span {
+    let prop_start = prop.span.start as usize;
+    let prop_end = prop.span.end as usize;
+    let obj_end = object.span.end as usize;
+
+    // Try to consume trailing comma + whitespace
+    let after = &source_text[prop_end..obj_end];
+    let trimmed_after = after.trim_start();
+    if trimmed_after.starts_with(',') {
+        let comma_pos = prop_end + (after.len() - trimmed_after.len());
+        let after_comma = &source_text[comma_pos + 1..obj_end];
+        let ws_after_comma = after_comma.len() - after_comma.trim_start().len();
+        return Span::new(prop_start as u32, (comma_pos + 1 + ws_after_comma) as u32);
+    }
+
+    // Last property — consume leading comma + whitespace before it
+    if index > 0 {
+        let prev_end = object.properties[index - 1].span.end as usize;
+        let before = &source_text[prev_end..prop_start];
+        let trimmed_before = before.trim_end();
+        if trimmed_before.ends_with(',') {
+            let comma_pos = prev_end + trimmed_before.len() - 1;
+            return Span::new(comma_pos as u32, prop_end as u32);
+        }
+    }
+
+    // Only property — just delete it
+    Span::new(prop_start as u32, prop_end as u32)
+}
+
+fn join_object_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() { key.to_string() } else { format!("{parent}.{key}") }
+}
+
+fn join_array_path(parent: &str, index: usize) -> String {
+    if parent.is_empty() { format!("[{index}]") } else { format!("{parent}[{index}]") }
+}
+
+fn display_path(path: &str) -> &str {
+    if path.is_empty() { "<root>" } else { path }
+}
+
+pub(super) fn resolve_reference_path(current_file: &Path, raw_path: &str) -> PathBuf {
+    let reference_path = Path::new(raw_path);
+    if reference_path.is_absolute() {
+        return normalize_path(reference_path);
+    }
+
+    let combined = current_file
+        .parent()
+        .map_or_else(|| reference_path.to_path_buf(), |parent| parent.join(reference_path));
+
+    normalize_path(&combined)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
+#[derive(Debug, Default)]
+pub(super) struct JsonShapeDiff {
+    pub missing: Vec<String>,
+    pub extra: Vec<String>,
+    pub type_mismatches: Vec<String>,
+}
+
+pub(super) fn compare_json_shapes(
+    reference: &JsonValue<'_>,
+    candidate: &JsonValue<'_>,
+    path: &str,
+    diff: &mut JsonShapeDiff,
+) {
+    match (reference, candidate) {
+        (JsonValue::Object(reference), JsonValue::Object(candidate)) => {
+            for ref_prop in &reference.properties {
+                let child_path = join_object_path(path, ref_prop.key);
+                match candidate.get(ref_prop.key) {
+                    Some(candidate_value) => {
+                        compare_json_shapes(&ref_prop.value, candidate_value, &child_path, diff);
+                    }
+                    None => diff.missing.push(child_path),
+                }
+            }
+
+            for cand_prop in &candidate.properties {
+                if reference.get(cand_prop.key).is_none() {
+                    diff.extra.push(join_object_path(path, cand_prop.key));
+                }
+            }
+        }
+        (JsonValue::Array(reference), JsonValue::Array(candidate)) => {
+            let shared_len = reference.elements.len().min(candidate.elements.len());
+            for index in 0..shared_len {
+                compare_json_shapes(
+                    &reference.elements[index],
+                    &candidate.elements[index],
+                    &join_array_path(path, index),
+                    diff,
+                );
+            }
+
+            for index in shared_len..reference.elements.len() {
+                diff.missing.push(join_array_path(path, index));
+            }
+
+            for index in shared_len..candidate.elements.len() {
+                diff.extra.push(join_array_path(path, index));
+            }
+        }
+        (JsonValue::Object(_) | JsonValue::Array(_), _)
+        | (_, JsonValue::Object(_) | JsonValue::Array(_)) => {
+            diff.type_mismatches.push(display_path(path).to_string());
+        }
+        _ => {}
+    }
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_no_duplicate_dependencies.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_no_duplicate_dependencies.rs
@@ -1,0 +1,114 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn duplicate_dependency_diagnostic(name: &str, span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{name}` is listed in both `dependencies` and `devDependencies`."))
+        .with_help("Remove the package from one of the dependency groups.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonNoDuplicateDependencies;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects packages listed in both `dependencies` and `devDependencies`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Listing a package in both groups is redundant and confusing. npm
+    /// ignores `devDependencies` entries that overlap `dependencies`, but the
+    /// intent becomes unclear and can mask version conflicts.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// {
+    ///   "dependencies": { "lodash": "^4.17.0" },
+    ///   "devDependencies": { "lodash": "^4.17.0" }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// {
+    ///   "dependencies": { "lodash": "^4.17.0" },
+    ///   "devDependencies": { "vitest": "^1.0.0" }
+    /// }
+    /// ```
+    PackageJsonNoDuplicateDependencies,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonNoDuplicateDependencies {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(root)) = &result.root else {
+            return;
+        };
+
+        let Some(deps) = root.get("dependencies") else {
+            return;
+        };
+        let JsonValue::Object(deps) = deps else {
+            return;
+        };
+
+        let Some(dev_deps_prop) = root.get_property("devDependencies") else {
+            return;
+        };
+        let JsonValue::Object(dev_deps) = &dev_deps_prop.value else {
+            return;
+        };
+
+        for entry in &dev_deps.properties {
+            if deps.get_property(entry.key).is_some() {
+                ctx.diagnostic(duplicate_dependency_diagnostic(entry.key, entry.key_span));
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"dependencies":{"lodash":"^4.17.0"},"devDependencies":{"vitest":"^1.0.0"}}"#,
+        r#"{"dependencies":{"lodash":"^4.17.0"}}"#,
+        r#"{"devDependencies":{"vitest":"^1.0.0"}}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"dependencies":{"lodash":"^4.17.0"},"devDependencies":{"lodash":"^4.17.0"}}"#,
+        r#"{"dependencies":{"lodash":"^4.17.0","react":"^18.0.0"},"devDependencies":{"lodash":"^4.17.0","vitest":"^1.0.0"}}"#,
+    ];
+
+    Tester::new(
+        PackageJsonNoDuplicateDependencies::NAME,
+        PackageJsonNoDuplicateDependencies::PLUGIN,
+        pass,
+        fail,
+    )
+    .change_rule_path("package.json")
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_no_empty_fields.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_no_empty_fields.rs
@@ -1,0 +1,115 @@
+use super::json_utils::{is_json_file, property_deletion_span};
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+fn empty_package_json_field_diagnostic(
+    field_name: &str,
+    field_kind: &str,
+    span: oxc_span::Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The `{field_name}` field in package.json should not be an empty {field_kind}."
+    ))
+    .with_help("Remove empty package.json fields that do not carry any information.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonNoEmptyFields;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Reports unnecessary empty top-level arrays and objects in package.json.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Empty package fields add noise without changing package behavior.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "keywords": [] }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "keywords": ["oxlint"] }
+    /// ```
+    PackageJsonNoEmptyFields,
+    oxc,
+    correctness,
+    fix
+);
+
+impl Rule for PackageJsonNoEmptyFields {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+
+        for (index, prop) in object.properties.iter().enumerate() {
+            let kind = match &prop.value {
+                JsonValue::Array(arr) if arr.elements.is_empty() => "array",
+                JsonValue::Object(obj) if obj.properties.is_empty() => "object",
+                _ => continue,
+            };
+
+            let delete_span = property_deletion_span(source_text, object, prop, index);
+            ctx.diagnostic_with_fix(
+                empty_package_json_field_diagnostic(prop.key, kind, prop.value.span()),
+                |fixer| fixer.delete_range(delete_span),
+            );
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"name":"demo"}"#,
+        r#"{"keywords":["oxlint"]}"#,
+        r#"{"publishConfig":{"access":"public"}}"#,
+        r#"{"exports":{"." :"./dist/index.js"}}"#,
+    ];
+
+    let fail = vec![
+        r#"{"keywords":[]}"#,
+        r#"{"publishConfig":{}}"#,
+        r#"{"files":[],"scripts":{}}"#,
+        r#"{"name":"demo","keywords":[]}"#,
+        r#"{"keywords":[],"name":"demo"}"#,
+    ];
+
+    let fix = vec![
+        // Only property
+        (r#"{"keywords":[]}"#, r#"{}"#, None),
+        (r#"{"publishConfig":{}}"#, r#"{}"#, None),
+        // First property with trailing comma — remove property + comma
+        (r#"{"keywords":[],"name":"demo"}"#, r#"{"name":"demo"}"#, None),
+        // Last property with leading comma — remove comma + property
+        (r#"{"name":"demo","keywords":[]}"#, r#"{"name":"demo"}"#, None),
+    ];
+
+    Tester::new(PackageJsonNoEmptyFields::NAME, PackageJsonNoEmptyFields::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_no_redundant_publish_config.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_no_redundant_publish_config.rs
@@ -1,0 +1,160 @@
+use super::json_utils::{file_start_span, is_json_file};
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn redundant_publish_config_access_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "`publishConfig.access` is redundant for unscoped packages because they are always public.",
+    )
+    .with_help("Remove the redundant `publishConfig.access` field.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonNoRedundantPublishConfig;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Warns when `publishConfig.access` is used in unscoped packages.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unscoped npm packages are always public, so `publishConfig.access`
+    /// has no effect there.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "name": "demo", "publishConfig": { "access": "public" } }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "name": "@scope/demo", "publishConfig": { "access": "public" } }
+    /// ```
+    PackageJsonNoRedundantPublishConfig,
+    oxc,
+    correctness,
+    fix
+);
+
+impl Rule for PackageJsonNoRedundantPublishConfig {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let Ok(value) = serde_json::from_str::<Value>(source_text) else {
+            return;
+        };
+        let Some(object) = value.as_object() else {
+            return;
+        };
+
+        let Some(Value::String(package_name)) = object.get("name") else {
+            return;
+        };
+        if package_name.starts_with('@') {
+            return;
+        }
+
+        let Some(Value::Object(publish_config)) = object.get("publishConfig") else {
+            return;
+        };
+        if !publish_config.contains_key("access") {
+            return;
+        }
+
+        let Some(updated) = remove_publish_config_access(&value) else {
+            return;
+        };
+        let Some(expected) = serialize_updated_json(&updated, source_text) else {
+            return;
+        };
+
+        #[expect(clippy::cast_possible_truncation)]
+        let file_span = oxc_span::Span::new(0, source_text.len() as u32);
+        ctx.diagnostic_with_fix(
+            redundant_publish_config_access_diagnostic(file_start_span(source_text)),
+            |fixer| fixer.replace_full_source_range(file_span, expected),
+        );
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn remove_publish_config_access(value: &Value) -> Option<Value> {
+    let mut object = value.as_object()?.clone();
+    let Value::Object(publish_config) = object.get("publishConfig")?.clone() else {
+        return None;
+    };
+
+    let mut publish_config = publish_config;
+    publish_config.remove("access");
+    object.insert("publishConfig".to_string(), Value::Object(publish_config));
+    Some(Value::Object(object))
+}
+
+fn serialize_updated_json(value: &Value, source_text: &str) -> Option<String> {
+    let indent = vec![b' '; 2];
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(&indent);
+    let mut output = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    value.serialize(&mut serializer).ok()?;
+    let mut formatted = String::from_utf8(output).ok()?;
+    if source_text.ends_with('\n') {
+        formatted.push('\n');
+    }
+    Some(formatted)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"name":"@scope/demo","publishConfig":{"access":"public"}}"#,
+        r#"{"name":"demo","publishConfig":{"registry":"https://example.com"}}"#,
+        r#"{"name":"demo"}"#,
+        r#"{"publishConfig":{"access":"public"}}"#,
+    ];
+
+    let fail = vec![
+        r#"{"name":"demo","publishConfig":{"access":"public"}}"#,
+        r#"{"name":"demo","publishConfig":{"access":"restricted"}}"#,
+        r#"{"name":"demo","publishConfig":{"access":"public","registry":"https://example.com"}}"#,
+    ];
+
+    let fix = vec![
+        (
+            r#"{"name":"demo","publishConfig":{"access":"public"}}"#,
+            "{\n  \"name\": \"demo\",\n  \"publishConfig\": {}\n}",
+        ),
+        (
+            r#"{"name":"demo","publishConfig":{"access":"restricted"}}"#,
+            "{\n  \"name\": \"demo\",\n  \"publishConfig\": {}\n}",
+        ),
+        (
+            r#"{"name":"demo","publishConfig":{"access":"public","registry":"https://example.com"}}"#,
+            "{\n  \"name\": \"demo\",\n  \"publishConfig\": {\n    \"registry\": \"https://example.com\"\n  }\n}",
+        ),
+    ];
+
+    Tester::new(
+        PackageJsonNoRedundantPublishConfig::NAME,
+        PackageJsonNoRedundantPublishConfig::PLUGIN,
+        pass,
+        fail,
+    )
+    .expect_fix(fix)
+    .change_rule_path("package.json")
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_order_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_order_properties.rs
@@ -1,0 +1,385 @@
+use std::ffi::OsStr;
+
+use rustc_hash::FxHashSet;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+const LEGACY_ORDER: &[&str] = &[
+    "name",
+    "version",
+    "private",
+    "publishConfig",
+    "description",
+    "main",
+    "exports",
+    "browser",
+    "files",
+    "bin",
+    "directories",
+    "man",
+    "scripts",
+    "repository",
+    "keywords",
+    "author",
+    "license",
+    "bugs",
+    "homepage",
+    "config",
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+    "bundledDependencies",
+    "engines",
+    "os",
+    "cpu",
+];
+
+const SORT_PACKAGE_JSON_ORDER: &[&str] = &[
+    "$schema",
+    "name",
+    "displayName",
+    "version",
+    "stableVersion",
+    "private",
+    "description",
+    "categories",
+    "keywords",
+    "homepage",
+    "bugs",
+    "repository",
+    "funding",
+    "license",
+    "qna",
+    "author",
+    "maintainers",
+    "contributors",
+    "publisher",
+    "sideEffects",
+    "type",
+    "imports",
+    "exports",
+    "main",
+    "svelte",
+    "umd:main",
+    "jsdelivr",
+    "unpkg",
+    "module",
+    "source",
+    "jsnext:main",
+    "browser",
+    "react-native",
+    "types",
+    "typesVersions",
+    "typings",
+    "style",
+    "example",
+    "examplestyle",
+    "assets",
+    "bin",
+    "man",
+    "directories",
+    "files",
+    "workspaces",
+    "binary",
+    "scripts",
+    "betterScripts",
+    "l10n",
+    "contributes",
+    "activationEvents",
+    "husky",
+    "simple-git-hooks",
+    "pre-commit",
+    "commitlint",
+    "lint-staged",
+    "nano-staged",
+    "config",
+    "nodemonConfig",
+    "browserify",
+    "babel",
+    "browserslist",
+    "xo",
+    "prettier",
+    "eslintConfig",
+    "eslintIgnore",
+    "npmpkgjsonlint",
+    "npmPackageJsonLintConfig",
+    "npmpackagejsonlint",
+    "release",
+    "remarkConfig",
+    "stylelint",
+    "ava",
+    "jest",
+    "jest-junit",
+    "jest-stare",
+    "mocha",
+    "nyc",
+    "c8",
+    "tap",
+    "oclif",
+    "resolutions",
+    "overrides",
+    "dependencies",
+    "devDependencies",
+    "dependenciesMeta",
+    "peerDependencies",
+    "peerDependenciesMeta",
+    "optionalDependencies",
+    "bundledDependencies",
+    "bundleDependencies",
+    "extensionPack",
+    "extensionDependencies",
+    "flat",
+    "packageManager",
+    "engines",
+    "engineStrict",
+    "devEngines",
+    "volta",
+    "languageName",
+    "os",
+    "cpu",
+    "preferGlobal",
+    "publishConfig",
+    "icon",
+    "badges",
+    "galleryBanner",
+    "preview",
+    "markdown",
+    "pnpm",
+];
+
+fn incorrect_order_diagnostic(property: &str, span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Top-level property `{property}` is not ordered in the standard way."
+    ))
+    .with_help("Reorder top-level package.json properties consistently.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum PackageJsonPropertyOrderPreset {
+    Legacy,
+    #[default]
+    SortPackageJson,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum PackageJsonPropertyOrder {
+    Preset(PackageJsonPropertyOrderPreset),
+    Custom(Vec<String>),
+}
+
+impl Default for PackageJsonPropertyOrder {
+    fn default() -> Self {
+        Self::Preset(PackageJsonPropertyOrderPreset::SortPackageJson)
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct PackageJsonOrderPropertiesConfig {
+    order: PackageJsonPropertyOrder,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonOrderProperties(Box<PackageJsonOrderPropertiesConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces a conventional order for top-level `package.json` properties.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Consistent top-level package metadata order improves readability and
+    /// reduces noisy diffs across many packages.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "version": "1.0.0", "name": "demo" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "name": "demo", "version": "1.0.0" }
+    /// ```
+    PackageJsonOrderProperties,
+    oxc,
+    style,
+    fix,
+    config = PackageJsonOrderPropertiesConfig
+);
+
+impl Rule for PackageJsonOrderProperties {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<PackageJsonOrderPropertiesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let Ok(value) = serde_json::from_str::<Value>(source_text) else {
+            return;
+        };
+        let Some(object) = value.as_object() else {
+            return;
+        };
+
+        let ordered_keys = ordered_keys_for_config(object, &self.0.order);
+        let current_keys = object.keys().map(String::as_str).collect::<Vec<_>>();
+        let expected_keys = ordered_keys.iter().map(String::as_str).collect::<Vec<_>>();
+        if current_keys == expected_keys {
+            return;
+        }
+
+        let Some(first_mismatch_index) = current_keys
+            .iter()
+            .zip(expected_keys.iter())
+            .position(|(current, expected)| current != expected)
+        else {
+            return;
+        };
+
+        let property = current_keys[first_mismatch_index];
+        let Some(updated) = reorder_top_level_object(object, &ordered_keys) else {
+            return;
+        };
+        let Some(expected) = serialize_updated_json(&updated, source_text) else {
+            return;
+        };
+
+        #[expect(clippy::cast_possible_truncation)]
+        let file_span = oxc_span::Span::new(0, source_text.len() as u32);
+        ctx.diagnostic_with_fix(
+            incorrect_order_diagnostic(property, oxc_span::Span::new(0, 1)),
+            |fixer| fixer.replace_full_source_range(file_span, expected),
+        );
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && ctx.file_extension().is_some_and(|ext| ext == OsStr::new("json"))
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn ordered_keys_for_config(
+    object: &Map<String, Value>,
+    order: &PackageJsonPropertyOrder,
+) -> Vec<String> {
+    let explicit_order = match order {
+        PackageJsonPropertyOrder::Preset(PackageJsonPropertyOrderPreset::Legacy) => {
+            LEGACY_ORDER.iter().copied().map(str::to_string).collect::<Vec<_>>()
+        }
+        PackageJsonPropertyOrder::Preset(PackageJsonPropertyOrderPreset::SortPackageJson) => {
+            SORT_PACKAGE_JSON_ORDER.iter().copied().map(str::to_string).collect::<Vec<_>>()
+        }
+        PackageJsonPropertyOrder::Custom(custom) => {
+            let mut order = custom.clone();
+            order.extend(SORT_PACKAGE_JSON_ORDER.iter().copied().map(str::to_string));
+            order
+        }
+    };
+
+    let mut seen = FxHashSet::default();
+    let mut ordered_keys = explicit_order
+        .into_iter()
+        .filter(|key| seen.insert(key.clone()) && object.contains_key(key))
+        .collect::<Vec<_>>();
+
+    let mut remainder =
+        object.keys().map(String::as_str).filter(|key| !seen.contains(*key)).collect::<Vec<_>>();
+    remainder.sort_unstable();
+
+    ordered_keys.extend(remainder.into_iter().map(str::to_string));
+    ordered_keys
+}
+
+fn reorder_top_level_object(object: &Map<String, Value>, ordered_keys: &[String]) -> Option<Value> {
+    let mut reordered = Map::with_capacity(object.len());
+    for key in ordered_keys {
+        reordered.insert(key.clone(), object.get(key)?.clone());
+    }
+    Some(Value::Object(reordered))
+}
+
+fn serialize_updated_json(value: &Value, source_text: &str) -> Option<String> {
+    let indent = vec![b' '; 2];
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(&indent);
+    let mut output = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    value.serialize(&mut serializer).ok()?;
+    let mut formatted = String::from_utf8(output).ok()?;
+    if source_text.ends_with('\n') {
+        formatted.push('\n');
+    }
+    Some(formatted)
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"{"name":"demo","version":"1.0.0"}"#, None),
+        (
+            r#"{"name":"demo","version":"1.0.0","publishConfig":{},"description":"x"}"#,
+            Some(json!([{ "order": "legacy" }])),
+        ),
+        (
+            r#"{"name":"demo","version":"1.0.0","foo":"x","zzz":"y"}"#,
+            Some(json!([{ "order": ["name", "version"] }])),
+        ),
+    ];
+
+    let fail = vec![
+        (r#"{"version":"1.0.0","name":"demo"}"#, None),
+        (
+            r#"{"description":"x","name":"demo","version":"1.0.0"}"#,
+            Some(json!([{ "order": "legacy" }])),
+        ),
+        (
+            r#"{"foo":"x","name":"demo","version":"1.0.0"}"#,
+            Some(json!([{ "order": ["name", "version"] }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            r#"{"version":"1.0.0","name":"demo"}"#,
+            "{\n  \"name\": \"demo\",\n  \"version\": \"1.0.0\"\n}",
+            None,
+        ),
+        (
+            r#"{"description":"x","name":"demo","version":"1.0.0"}"#,
+            "{\n  \"name\": \"demo\",\n  \"version\": \"1.0.0\",\n  \"description\": \"x\"\n}",
+            Some(json!([{ "order": "legacy" }])),
+        ),
+        (
+            r#"{"foo":"x","name":"demo","version":"1.0.0"}"#,
+            "{\n  \"name\": \"demo\",\n  \"version\": \"1.0.0\",\n  \"foo\": \"x\"\n}",
+            Some(json!([{ "order": ["name", "version"] }])),
+        ),
+    ];
+
+    Tester::new(PackageJsonOrderProperties::NAME, PackageJsonOrderProperties::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_repository_shorthand.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_repository_shorthand.rs
@@ -1,0 +1,374 @@
+use super::json_utils::{file_start_span, is_json_file};
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+static BITBUCKET_REGEX: Lazy<Regex> =
+    lazy_regex!(r"^(?:git\+)?(?:ssh://git@|https?://)?(?:www\.)?bitbucket\.org/");
+static GIST_REGEX: Lazy<Regex> =
+    lazy_regex!(r"^(?:git\+)?(?:ssh://git@|https?://)?(?:www\.)?gist\.github\.com/");
+static GITHUB_REGEX: Lazy<Regex> =
+    lazy_regex!(r"^(?:git\+)?(?:ssh://git@|https?://)?(?:www\.)?github\.com/");
+static GITLAB_REGEX: Lazy<Regex> =
+    lazy_regex!(r"^(?:git\+)?(?:ssh://git@|https?://)?(?:www\.)?gitlab\.com/");
+
+fn prefer_object_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer an object locator for a repository.")
+        .with_help("Use `{ \"type\": \"git\", \"url\": \"...\" }` for the `repository` field.")
+        .with_label(span)
+}
+
+fn prefer_shorthand_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer a shorthand locator for a supported repository provider.")
+        .with_help("Use provider shorthand such as `github:user/repo` when the repository URL can be normalized safely.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum RepositoryForm {
+    #[default]
+    Object,
+    Shorthand,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct RepositoryShorthandConfig {
+    form: RepositoryForm,
+}
+
+impl Default for RepositoryShorthandConfig {
+    fn default() -> Self {
+        Self { form: RepositoryForm::Object }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonRepositoryShorthand(Box<RepositoryShorthandConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces either object or shorthand declaration for `repository`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Consistent repository metadata keeps package manifests easier to audit
+    /// and aligns with npm normalization behavior.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "repository": "npm/example" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "repository": { "type": "git", "url": "https://github.com/npm/example" } }
+    /// ```
+    PackageJsonRepositoryShorthand,
+    oxc,
+    style,
+    fix,
+    config = RepositoryShorthandConfig
+);
+
+impl Rule for PackageJsonRepositoryShorthand {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<RepositoryShorthandConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let Ok(value) = serde_json::from_str::<Value>(source_text) else {
+            return;
+        };
+        let Some(object) = value.as_object() else {
+            return;
+        };
+        let Some(repository) = object.get("repository") else {
+            return;
+        };
+
+        match self.0.form {
+            RepositoryForm::Object => self.run_object_form(ctx, source_text, &value, repository),
+            RepositoryForm::Shorthand => {
+                self.run_shorthand_form(ctx, source_text, &value, repository);
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+impl PackageJsonRepositoryShorthand {
+    #[expect(clippy::unused_self)]
+    fn run_object_form(
+        &self,
+        ctx: &LintContext<'_>,
+        source_text: &str,
+        value: &Value,
+        repository: &Value,
+    ) {
+        let Value::String(repository) = repository else {
+            return;
+        };
+
+        let diagnostic = prefer_object_diagnostic(file_start_span(source_text));
+        let Some(updated) = replace_repository(value, create_repository_object_value(repository))
+        else {
+            ctx.diagnostic(diagnostic);
+            return;
+        };
+        let Some(expected) = serialize_updated_json(&updated, source_text) else {
+            ctx.diagnostic(diagnostic);
+            return;
+        };
+
+        #[expect(clippy::cast_possible_truncation)]
+        let file_span = oxc_span::Span::new(0, source_text.len() as u32);
+        ctx.diagnostic_with_fix(diagnostic, |fixer| {
+            fixer.replace_full_source_range(file_span, expected)
+        });
+    }
+
+    #[expect(clippy::unused_self)]
+    fn run_shorthand_form(
+        &self,
+        ctx: &LintContext<'_>,
+        source_text: &str,
+        value: &Value,
+        repository: &Value,
+    ) {
+        let Some(shorthand) = extract_shorthand_repository(repository) else {
+            return;
+        };
+
+        let Some(updated) = replace_repository(value, Some(Value::String(shorthand))) else {
+            return;
+        };
+        let Some(expected) = serialize_updated_json(&updated, source_text) else {
+            return;
+        };
+
+        #[expect(clippy::cast_possible_truncation)]
+        let file_span = oxc_span::Span::new(0, source_text.len() as u32);
+        ctx.diagnostic_with_fix(
+            prefer_shorthand_diagnostic(file_start_span(source_text)),
+            |fixer| fixer.replace_full_source_range(file_span, expected),
+        );
+    }
+}
+
+fn create_repository_object_value(repository: &str) -> Option<Value> {
+    if repository.split('/').filter(|segment| !segment.is_empty()).count() != 2 {
+        return None;
+    }
+
+    let mut object = Map::with_capacity(2);
+    object.insert("type".to_string(), Value::String("git".to_string()));
+    object.insert("url".to_string(), Value::String(create_url(repository)));
+    Some(Value::Object(object))
+}
+
+fn extract_shorthand_repository(repository: &Value) -> Option<String> {
+    match repository {
+        Value::String(value) => {
+            let provider = get_provider_from_url(value)?;
+            Some(create_shorthand(value, provider))
+        }
+        Value::Object(object) => {
+            if object.contains_key("directory") {
+                return None;
+            }
+
+            let type_value = object.get("type")?;
+            if !matches!(type_value, Value::String(kind) if kind == "git") {
+                return None;
+            }
+
+            let Value::String(url) = object.get("url")? else {
+                return None;
+            };
+            let provider = get_provider_from_url(url)?;
+            Some(create_shorthand(url, provider))
+        }
+        _ => None,
+    }
+}
+
+fn replace_repository(value: &Value, repository: Option<Value>) -> Option<Value> {
+    let repository = repository?;
+    let mut object = value.as_object()?.clone();
+    object.insert("repository".to_string(), repository);
+    Some(Value::Object(object))
+}
+
+fn serialize_updated_json(value: &Value, source_text: &str) -> Option<String> {
+    let indent = vec![b' '; 2];
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(&indent);
+    let mut output = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    value.serialize(&mut serializer).ok()?;
+    let mut formatted = String::from_utf8(output).ok()?;
+    if source_text.ends_with('\n') {
+        formatted.push('\n');
+    }
+    Some(formatted)
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RepositoryProvider {
+    Bitbucket,
+    Gist,
+    GitHub,
+    GitLab,
+}
+
+fn get_provider_from_url(url: &str) -> Option<RepositoryProvider> {
+    if BITBUCKET_REGEX.is_match(url) {
+        Some(RepositoryProvider::Bitbucket)
+    } else if GIST_REGEX.is_match(url) {
+        Some(RepositoryProvider::Gist)
+    } else if GITHUB_REGEX.is_match(url) {
+        Some(RepositoryProvider::GitHub)
+    } else if GITLAB_REGEX.is_match(url) {
+        Some(RepositoryProvider::GitLab)
+    } else {
+        None
+    }
+}
+
+fn create_shorthand(url: &str, provider: RepositoryProvider) -> String {
+    let repo = clean_url(url, provider);
+    format!("{}:{repo}", provider_name(provider))
+}
+
+fn clean_url(url: &str, provider: RepositoryProvider) -> String {
+    let cleaned = match provider {
+        RepositoryProvider::Bitbucket => BITBUCKET_REGEX.replace(url, ""),
+        RepositoryProvider::Gist => GIST_REGEX.replace(url, ""),
+        RepositoryProvider::GitHub => GITHUB_REGEX.replace(url, ""),
+        RepositoryProvider::GitLab => GITLAB_REGEX.replace(url, ""),
+    };
+    cleaned.trim_end_matches(".git").to_string()
+}
+
+fn create_url(shorthand: &str) -> String {
+    if let Some((provider, repo)) = shorthand.split_once(':')
+        && let Some(provider) = parse_provider(provider)
+    {
+        return format!("{}{repo}", provider_url(provider));
+    }
+
+    format!("{}{}", provider_url(RepositoryProvider::GitHub), shorthand)
+}
+
+fn parse_provider(provider: &str) -> Option<RepositoryProvider> {
+    match provider {
+        "bitbucket" => Some(RepositoryProvider::Bitbucket),
+        "gist" => Some(RepositoryProvider::Gist),
+        "github" => Some(RepositoryProvider::GitHub),
+        "gitlab" => Some(RepositoryProvider::GitLab),
+        _ => None,
+    }
+}
+
+fn provider_name(provider: RepositoryProvider) -> &'static str {
+    match provider {
+        RepositoryProvider::Bitbucket => "bitbucket",
+        RepositoryProvider::Gist => "gist",
+        RepositoryProvider::GitHub => "github",
+        RepositoryProvider::GitLab => "gitlab",
+    }
+}
+
+fn provider_url(provider: RepositoryProvider) -> &'static str {
+    match provider {
+        RepositoryProvider::Bitbucket => "https://bitbucket.org/",
+        RepositoryProvider::Gist => "https://gist.github.com/",
+        RepositoryProvider::GitHub => "https://github.com/",
+        RepositoryProvider::GitLab => "https://gitlab.com/",
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"{"repository":{"type":"git","url":"https://github.com/npm/example"}}"#, None),
+        (r#"{"repository":"github:npm/example"}"#, Some(json!([{ "form": "shorthand" }]))),
+        (
+            r#"{"repository":{"type":"git","url":"https://github.com/npm/cli","directory":"workspaces/libnpmpublish"}}"#,
+            Some(json!([{ "form": "shorthand" }])),
+        ),
+        (r#"{"repository":"gist:11081aaa281"}"#, Some(json!([{ "form": "shorthand" }]))),
+        (r#"{"name":"demo"}"#, None),
+    ];
+
+    let fail = vec![
+        (r#"{"repository":"npm/example"}"#, None),
+        (r#"{"repository":"github:npm/example"}"#, None),
+        (
+            r#"{"repository":{"type":"git","url":"https://github.com/npm/example"}}"#,
+            Some(json!([{ "form": "shorthand" }])),
+        ),
+        (
+            r#"{"repository":"https://gitlab.com/user/repo.git"}"#,
+            Some(json!([{ "form": "shorthand" }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            r#"{"repository":"npm/example"}"#,
+            "{\n  \"repository\": {\n    \"type\": \"git\",\n    \"url\": \"https://github.com/npm/example\"\n  }\n}",
+            None,
+        ),
+        (
+            r#"{"repository":"github:npm/example"}"#,
+            "{\n  \"repository\": {\n    \"type\": \"git\",\n    \"url\": \"https://github.com/npm/example\"\n  }\n}",
+            None,
+        ),
+        (
+            r#"{"repository":{"type":"git","url":"https://github.com/npm/example"}}"#,
+            "{\n  \"repository\": \"github:npm/example\"\n}",
+            Some(json!([{ "form": "shorthand" }])),
+        ),
+        (
+            r#"{"repository":"https://gitlab.com/user/repo.git"}"#,
+            "{\n  \"repository\": \"gitlab:user/repo\"\n}",
+            Some(json!([{ "form": "shorthand" }])),
+        ),
+    ];
+
+    Tester::new(
+        PackageJsonRepositoryShorthand::NAME,
+        PackageJsonRepositoryShorthand::PLUGIN,
+        pass,
+        fail,
+    )
+    .expect_fix(fix)
+    .change_rule_path("package.json")
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_require_type.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_require_type.rs
@@ -1,0 +1,81 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn missing_package_json_type_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("package.json should declare a `type` field.")
+        .with_help("Add `\"type\": \"module\"` or `\"type\": \"commonjs\"` to package.json.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonRequireType;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires the `type` field to be present in package.json.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// An explicit package type makes Node module behavior easier to reason
+    /// about and aligns package manifests across a monorepo.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "name": "demo" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "name": "demo", "type": "module" }
+    /// ```
+    PackageJsonRequireType,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonRequireType {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+
+        if object.get("type").is_some() {
+            return;
+        }
+
+        ctx.diagnostic(missing_package_json_type_diagnostic(Span::new(0, 1)));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![r#"{"name":"demo","type":"module"}"#, r#"{"name":"demo","type":"commonjs"}"#];
+
+    let fail = vec![r#"{"name":"demo"}"#, r#"{"version":"1.0.0"}"#];
+
+    Tester::new(PackageJsonRequireType::NAME, PackageJsonRequireType::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_require_version.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_require_version.rs
@@ -1,0 +1,82 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn missing_package_json_version_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("package.json should declare a `version` field.")
+        .with_help("Add a package version such as `\"version\": \"1.0.0\"`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonRequireVersion;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires the `version` field to be present in package.json.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// An explicit version keeps package metadata complete and matches npm
+    /// package manifest expectations.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "name": "demo" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "name": "demo", "version": "1.0.0" }
+    /// ```
+    PackageJsonRequireVersion,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonRequireVersion {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+
+        if object.get("version").is_some() {
+            return;
+        }
+
+        ctx.diagnostic(missing_package_json_version_diagnostic(Span::new(0, 1)));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass =
+        vec![r#"{"name":"demo","version":"1.0.0"}"#, r#"{"version":"0.1.0","type":"module"}"#];
+
+    let fail = vec![r#"{"name":"demo"}"#, r#"{"type":"module"}"#];
+
+    Tester::new(PackageJsonRequireVersion::NAME, PackageJsonRequireVersion::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_sort_collections.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_sort_collections.rs
@@ -1,0 +1,345 @@
+use std::ffi::OsStr;
+
+use rustc_hash::FxHashSet;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+const DEFAULT_COLLECTIONS: &[&str] = &[
+    "config",
+    "dependencies",
+    "devDependencies",
+    "exports",
+    "optionalDependencies",
+    "overrides",
+    "peerDependencies",
+    "peerDependenciesMeta",
+    "scripts",
+];
+
+const DEFAULT_NPM_SCRIPTS: &[&str] = &[
+    "install",
+    "pack",
+    "prepare",
+    "publish",
+    "restart",
+    "shrinkwrap",
+    "start",
+    "stop",
+    "test",
+    "uninstall",
+    "version",
+];
+
+fn unsorted_keys_diagnostic(key: &str, span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Entries in `{key}` are not in lexicographical order."))
+        .with_help("Sort the collection consistently to reduce noisy diffs.")
+        .with_label(span)
+}
+
+fn unsorted_scripts_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Entries in `scripts` are not in lifecycle-aware lexicographical order.")
+        .with_help(
+            "Group `pre<name>`, `<name>`, and `post<name>` scripts together in a stable order.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(transparent)]
+pub struct PackageJsonSortCollectionsConfig(Vec<String>);
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonSortCollections(Box<PackageJsonSortCollectionsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces deterministic ordering for selected `package.json` collections.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Manually edited dependency and script objects tend to drift out of
+    /// order, which creates noisy follow-up diffs.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "dependencies": { "zod": "^1.0.0", "bun": "^1.0.0" } }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "dependencies": { "bun": "^1.0.0", "zod": "^1.0.0" } }
+    /// ```
+    PackageJsonSortCollections,
+    oxc,
+    style,
+    fix,
+    config = PackageJsonSortCollectionsConfig
+);
+
+impl Rule for PackageJsonSortCollections {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<PackageJsonSortCollectionsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let Ok(value) = serde_json::from_str::<Value>(source_text) else {
+            return;
+        };
+        let configured_paths = if self.0.0.is_empty() {
+            DEFAULT_COLLECTIONS.iter().map(|path| (*path).to_string()).collect::<Vec<_>>()
+        } else {
+            self.0.0.clone()
+        };
+
+        let Some((updated, first_unsorted_path)) = sort_collections(&value, &configured_paths)
+        else {
+            return;
+        };
+        let Some(expected) = serialize_updated_json(&updated, source_text) else {
+            return;
+        };
+
+        #[expect(clippy::cast_possible_truncation)]
+        let file_span = oxc_span::Span::new(0, source_text.len() as u32);
+        let diagnostic = if path_targets_scripts(&first_unsorted_path) {
+            unsorted_scripts_diagnostic(oxc_span::Span::new(0, 1))
+        } else {
+            unsorted_keys_diagnostic(&first_unsorted_path, oxc_span::Span::new(0, 1))
+        };
+
+        ctx.diagnostic_with_fix(diagnostic, |fixer| {
+            fixer.replace_full_source_range(file_span, expected)
+        });
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && ctx.file_extension().is_some_and(|ext| ext == OsStr::new("json"))
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn sort_collections(value: &Value, configured_paths: &[String]) -> Option<(Value, String)> {
+    let mut first_unsorted_path: Option<String> = None;
+    let (updated, changed) =
+        sort_collections_in_value(value, configured_paths, "", &mut first_unsorted_path)?;
+    if !changed {
+        return None;
+    }
+    first_unsorted_path.map(|path| (updated, path))
+}
+
+fn sort_collections_in_value(
+    value: &Value,
+    configured_paths: &[String],
+    current_path: &str,
+    first_unsorted_path: &mut Option<String>,
+) -> Option<(Value, bool)> {
+    match value {
+        Value::Object(object) => {
+            let mut changed = false;
+            let mut updated = Map::with_capacity(object.len());
+
+            for (key, child_value) in object {
+                let path = join_path(current_path, key);
+                let (mut next_value, child_changed) = sort_collections_in_value(
+                    child_value,
+                    configured_paths,
+                    &path,
+                    first_unsorted_path,
+                )?;
+                changed |= child_changed;
+
+                if configured_paths.iter().any(|candidate| candidate == &path)
+                    && let Value::Object(collection) = &next_value
+                    && let Some(sorted_collection) = maybe_sort_collection(&path, collection)
+                {
+                    next_value = Value::Object(sorted_collection);
+                    changed = true;
+                    if first_unsorted_path.is_none() {
+                        *first_unsorted_path = Some(path.clone());
+                    }
+                }
+
+                updated.insert(key.clone(), next_value);
+            }
+
+            if changed {
+                Some((Value::Object(updated), true))
+            } else {
+                Some((value.clone(), false))
+            }
+        }
+        _ => Some((value.clone(), false)),
+    }
+}
+
+fn maybe_sort_collection(path: &str, object: &Map<String, Value>) -> Option<Map<String, Value>> {
+    let current_keys = object.keys().cloned().collect::<Vec<_>>();
+    let expected_keys = if path_targets_scripts(path) {
+        sort_script_names(&current_keys)
+    } else {
+        let mut keys = current_keys.clone();
+        keys.sort_unstable();
+        keys
+    };
+
+    if current_keys == expected_keys {
+        return None;
+    }
+
+    let mut sorted = Map::with_capacity(object.len());
+    for key in expected_keys {
+        sorted.insert(key.clone(), object.get(&key)?.clone());
+    }
+    Some(sorted)
+}
+
+fn path_targets_scripts(path: &str) -> bool {
+    path.split('.').next_back().is_some_and(|segment| segment == "scripts")
+}
+
+fn join_path(parent: &str, key: &str) -> String {
+    if parent.is_empty() { key.to_string() } else { format!("{parent}.{key}") }
+}
+
+fn sort_script_names(keys: &[String]) -> Vec<String> {
+    let default_scripts = DEFAULT_NPM_SCRIPTS.iter().copied().collect::<FxHashSet<_>>();
+    let original_keys = keys.iter().cloned().collect::<FxHashSet<_>>();
+    let mut transformed = Vec::with_capacity(keys.len());
+    let mut prefixable = FxHashSet::<String>::default();
+
+    for key in keys {
+        let omitted: String =
+            key.strip_prefix("pre").or_else(|| key.strip_prefix("post")).unwrap_or(key).to_string();
+
+        if default_scripts.contains(omitted.as_str()) || original_keys.contains(&omitted) {
+            prefixable.insert(omitted.clone());
+            transformed.push(omitted);
+        } else {
+            transformed.push(key.clone());
+        }
+    }
+
+    let names = sort_script_groups(transformed);
+    let mut expanded = Vec::new();
+    let mut seen = FxHashSet::<String>::default();
+    for key in names {
+        if prefixable.contains(&key) {
+            for candidate in [format!("pre{key}"), key.clone(), format!("post{key}")] {
+                if original_keys.contains(&candidate) && seen.insert(candidate.clone()) {
+                    expanded.push(candidate);
+                }
+            }
+        } else if original_keys.contains(&key) && seen.insert(key.clone()) {
+            expanded.push(key);
+        }
+    }
+
+    expanded
+}
+
+fn sort_script_groups(keys: Vec<String>) -> Vec<String> {
+    let mut group_map = std::collections::BTreeMap::<String, Vec<String>>::new();
+
+    for key in keys {
+        let base = key.split_once(':').map_or_else(|| key.clone(), |(head, _)| head.to_string());
+        group_map.entry(base).or_default().push(key);
+    }
+
+    let mut result = Vec::new();
+    for (_group, mut children) in group_map {
+        let has_nested = children.iter().any(|key| key.contains(':'));
+        if has_nested && children.len() > 1 {
+            let mut direct =
+                children.iter().filter(|key| !key.contains(':')).cloned().collect::<Vec<_>>();
+            direct.sort_unstable();
+
+            let nested = children.into_iter().filter(|key| key.contains(':')).collect::<Vec<_>>();
+
+            result.extend(direct);
+            result.extend(sort_script_groups(nested));
+        } else {
+            children.sort_unstable();
+            result.extend(children);
+        }
+    }
+
+    result
+}
+
+fn serialize_updated_json(value: &Value, source_text: &str) -> Option<String> {
+    let indent = vec![b' '; 2];
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(&indent);
+    let mut output = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    value.serialize(&mut serializer).ok()?;
+    let mut formatted = String::from_utf8(output).ok()?;
+    if source_text.ends_with('\n') {
+        formatted.push('\n');
+    }
+    Some(formatted)
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"{"dependencies":{"a":"1","b":"1"}}"#, None),
+        (r#"{"scripts":{"prebuild":"x","build":"x","postbuild":"x","lint":"x"}}"#, None),
+        (
+            r#"{"pnpm":{"patchedDependencies":{"a":"patch","b":"patch"}}}"#,
+            Some(json!([["pnpm.patchedDependencies"]])),
+        ),
+    ];
+
+    let fail = vec![
+        (r#"{"dependencies":{"b":"1","a":"1"}}"#, None),
+        (r#"{"scripts":{"build":"x","postbuild":"x","prebuild":"x"}}"#, None),
+        (
+            r#"{"pnpm":{"patchedDependencies":{"b":"patch","a":"patch"}}}"#,
+            Some(json!([["pnpm.patchedDependencies"]])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            r#"{"dependencies":{"b":"1","a":"1"}}"#,
+            "{\n  \"dependencies\": {\n    \"a\": \"1\",\n    \"b\": \"1\"\n  }\n}",
+            None,
+        ),
+        (
+            r#"{"scripts":{"build":"x","postbuild":"x","prebuild":"x"}}"#,
+            "{\n  \"scripts\": {\n    \"prebuild\": \"x\",\n    \"build\": \"x\",\n    \"postbuild\": \"x\"\n  }\n}",
+            None,
+        ),
+        (
+            r#"{"pnpm":{"patchedDependencies":{"b":"patch","a":"patch"}}}"#,
+            "{\n  \"pnpm\": {\n    \"patchedDependencies\": {\n      \"a\": \"patch\",\n      \"b\": \"patch\"\n    }\n  }\n}",
+            Some(json!([["pnpm.patchedDependencies"]])),
+        ),
+    ];
+
+    Tester::new(PackageJsonSortCollections::NAME, PackageJsonSortCollections::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_bin.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_bin.rs
@@ -1,0 +1,108 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn invalid_package_json_bin_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `bin` field in package.json is invalid.")
+        .with_help("Use a non-empty string or an object whose values are non-empty strings.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidBin;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `bin` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid `bin` metadata can break CLI installation and command
+    /// resolution for published packages.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "bin": { "demo": 123 } }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "bin": "./bin/demo.js" }
+    /// ```
+    PackageJsonValidBin,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidBin {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("bin") else {
+            return;
+        };
+
+        if is_valid_bin_value(&prop.value) {
+            return;
+        }
+
+        ctx.diagnostic(invalid_package_json_bin_diagnostic(prop.value.span()));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn is_valid_bin_value(value: &JsonValue<'_>) -> bool {
+    match value {
+        JsonValue::String(value, _) => !value.trim().is_empty(),
+        JsonValue::Object(object) => {
+            !object.properties.is_empty()
+                && object
+                    .properties
+                    .iter()
+                    .all(|p| matches!(&p.value, JsonValue::String(v, _) if !v.trim().is_empty()))
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"bin":"./bin/demo.js"}"#,
+        r#"{"bin":{"demo":"./bin/demo.js"}}"#,
+        r#"{"bin":{"demo":"./bin/demo.js","demo-dev":"./bin/dev.js"}}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"bin":""}"#,
+        r#"{"bin":{}}"#,
+        r#"{"bin":{"demo":""}}"#,
+        r#"{"bin":{"demo":1}}"#,
+        r#"{"bin":1}"#,
+    ];
+
+    Tester::new(PackageJsonValidBin::NAME, PackageJsonValidBin::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_description.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_description.rs
@@ -1,0 +1,92 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn invalid_package_json_description_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `description` field in package.json must be a non-empty string.")
+        .with_help("Use a descriptive non-empty package description.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidDescription;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `description` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid descriptions reduce package metadata quality and can break tools
+    /// that expect a human-readable string.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "description": "" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "description": "Fast linter for TypeScript" }
+    /// ```
+    PackageJsonValidDescription,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidDescription {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("description") else {
+            return;
+        };
+
+        let is_valid = match &prop.value {
+            JsonValue::String(value, _) => !value.trim().is_empty(),
+            _ => false,
+        };
+
+        if is_valid {
+            return;
+        }
+
+        ctx.diagnostic(invalid_package_json_description_diagnostic(prop.value.span()));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"description":"Fast linter"}"#,
+        r#"{"description":"CLI for package publishing"}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![r#"{"description":""}"#, r#"{"description":"   "}"#, r#"{"description":1}"#];
+
+    Tester::new(PackageJsonValidDescription::NAME, PackageJsonValidDescription::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_engines.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_engines.rs
@@ -1,0 +1,110 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn invalid_package_json_engines_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `engines` field in package.json is invalid.")
+        .with_help("Use an object with runtime names as keys and semver ranges as values, e.g. `{ \"node\": \">=18\" }`.")
+        .with_label(span)
+}
+
+fn invalid_engine_value_diagnostic(key: &str, span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The `engines.{key}` value in package.json must be a non-empty string."
+    ))
+    .with_help("Use a semver range string like `>=18`, `^20.0.0`, or `*`.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidEngines;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `engines` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid `engines` metadata breaks runtime compatibility checks and
+    /// can confuse package managers that enforce engine constraints.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "engines": "node >= 18" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "engines": { "node": ">=18" } }
+    /// ```
+    PackageJsonValidEngines,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidEngines {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("engines") else {
+            return;
+        };
+
+        let JsonValue::Object(engines) = &prop.value else {
+            ctx.diagnostic(invalid_package_json_engines_diagnostic(prop.value.span()));
+            return;
+        };
+
+        for entry in &engines.properties {
+            match &entry.value {
+                JsonValue::String(value, _) if !value.trim().is_empty() => {}
+                _ => {
+                    ctx.diagnostic(invalid_engine_value_diagnostic(entry.key, entry.value.span()));
+                }
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"engines":{"node":">=18"}}"#,
+        r#"{"engines":{"node":">=18","npm":">=9"}}"#,
+        r#"{"engines":{"node":"*"}}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"engines":"node >= 18"}"#,
+        r#"{"engines":1}"#,
+        r#"{"engines":{"node":""}}"#,
+        r#"{"engines":{"node":1}}"#,
+        r#"{"engines":{"node":">=18","npm":""}}"#,
+    ];
+
+    Tester::new(PackageJsonValidEngines::NAME, PackageJsonValidEngines::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_keywords.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_keywords.rs
@@ -1,0 +1,105 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn invalid_package_json_keywords_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "The `keywords` field in package.json must be an array of non-empty strings.",
+    )
+    .with_help("Use an array of keyword strings for package discoverability.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidKeywords;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `keywords` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid keywords break npm search metadata and reduce package
+    /// discoverability. The field must be an array of non-empty strings.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "keywords": "lint" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "keywords": ["lint", "typescript"] }
+    /// ```
+    PackageJsonValidKeywords,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidKeywords {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("keywords") else {
+            return;
+        };
+
+        match &prop.value {
+            JsonValue::Array(arr) => {
+                for element in &arr.elements {
+                    match element {
+                        JsonValue::String(s, _) if !s.trim().is_empty() => {}
+                        _ => {
+                            ctx.diagnostic(invalid_package_json_keywords_diagnostic(
+                                element.span(),
+                            ));
+                        }
+                    }
+                }
+            }
+            _ => ctx.diagnostic(invalid_package_json_keywords_diagnostic(prop.value.span())),
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"keywords":["lint","typescript"]}"#,
+        r#"{"keywords":["cli"]}"#,
+        r#"{"keywords":[]}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"keywords":"lint"}"#,
+        r#"{"keywords":1}"#,
+        r#"{"keywords":["lint",""]}"#,
+        r#"{"keywords":["lint",1]}"#,
+    ];
+
+    Tester::new(PackageJsonValidKeywords::NAME, PackageJsonValidKeywords::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_license.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_license.rs
@@ -1,0 +1,128 @@
+use super::json_utils::is_json_file;
+
+use lazy_regex::regex_is_match;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use spdx::Expression;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn invalid_package_json_license_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `license` field in package.json must be a valid SPDX expression, `UNLICENSED`, or `SEE LICENSE IN <file>`.")
+        .with_help("Use a valid SPDX identifier or expression such as `MIT` or `(MIT OR Apache-2.0)`, `UNLICENSED`, or `SEE LICENSE IN LICENSE.md`.")
+        .with_label(span)
+}
+
+fn non_string_package_json_license_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `license` field in package.json must be a string.")
+        .with_help("Use a string value such as `MIT`, `(MIT OR Apache-2.0)`, or `UNLICENSED`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidLicense;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `license` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid license metadata breaks npm package metadata expectations and
+    /// makes license auditing less reliable.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "license": "GPL3" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "license": "GPL-3.0-only" }
+    /// ```
+    PackageJsonValidLicense,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidLicense {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("license") else {
+            return;
+        };
+
+        let JsonValue::String(license, _) = &prop.value else {
+            ctx.diagnostic(non_string_package_json_license_diagnostic(prop.value.span()));
+            return;
+        };
+
+        if is_valid_license_value(license) {
+            return;
+        }
+
+        ctx.diagnostic(invalid_package_json_license_diagnostic(prop.value.span()));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn is_valid_license_value(license: &str) -> bool {
+    license == "UNLICENSED"
+        || is_see_license_reference(license)
+        || is_valid_spdx_license_expression(license)
+}
+
+fn is_see_license_reference(license: &str) -> bool {
+    regex_is_match!(r"^SEE LICENSE IN \S(?:.*\S)?$", license)
+}
+
+fn is_valid_spdx_license_expression(license: &str) -> bool {
+    !matches!(license, "NONE" | "NOASSERTION")
+        && !license.contains("LicenseRef-")
+        && !license.contains("DocumentRef-")
+        && Expression::parse(license).is_ok()
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"license":"MIT"}"#,
+        r#"{"license":"(MIT OR Apache-2.0)"}"#,
+        r#"{"license":"GPL-2.0-only WITH Classpath-exception-2.0"}"#,
+        r#"{"license":"UNLICENSED"}"#,
+        r#"{"license":"SEE LICENSE IN LICENSE.md"}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"license":1}"#,
+        r#"{"license":"GPL3"}"#,
+        r#"{"license":"MIT OR NOPE"}"#,
+        r#"{"license":"NOASSERTION"}"#,
+        r#"{"license":"LicenseRef-Custom"}"#,
+        r#"{"license":"SEE LICENSE IN "}"#,
+        r#"{"license":{"type":"MIT"}}"#,
+    ];
+
+    Tester::new(PackageJsonValidLicense::NAME, PackageJsonValidLicense::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_man.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_man.rs
@@ -1,0 +1,117 @@
+use super::json_utils::is_json_file;
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+static MANPAGE_REGEX: Lazy<Regex> = lazy_regex!(r"\.[0-9](?:\.gz)?$");
+
+fn invalid_package_json_man_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `man` field in package.json is invalid.")
+        .with_help(
+            "Use a string or array of strings ending in a manpage section such as `.1` or `.1.gz`.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidMan;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `man` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid manpage metadata can prevent package managers from linking
+    /// command documentation correctly.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "man": ["./man/demo.md"] }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "man": "./man/demo.1" }
+    /// ```
+    PackageJsonValidMan,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidMan {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("man") else {
+            return;
+        };
+
+        if is_valid_man_value(&prop.value) {
+            return;
+        }
+
+        ctx.diagnostic(invalid_package_json_man_diagnostic(prop.value.span()));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn is_valid_man_value(value: &JsonValue<'_>) -> bool {
+    match value {
+        JsonValue::String(value, _) => is_valid_man_path(value),
+        JsonValue::Array(arr) => {
+            !arr.elements.is_empty()
+                && arr.elements.iter().all(
+                    |elem| matches!(elem, JsonValue::String(value, _) if is_valid_man_path(value)),
+                )
+        }
+        _ => false,
+    }
+}
+
+fn is_valid_man_path(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty() && MANPAGE_REGEX.is_match(trimmed)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"man":"./man/demo.1"}"#,
+        r#"{"man":"./man/demo.1.gz"}"#,
+        r#"{"man":["./man/demo.1","./man/demo.2"]}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"man":""}"#,
+        r#"{"man":"./man/demo.md"}"#,
+        r#"{"man":[]}"#,
+        r#"{"man":["./man/demo.1","./man/demo.md"]}"#,
+        r#"{"man":1}"#,
+    ];
+
+    Tester::new(PackageJsonValidMan::NAME, PackageJsonValidMan::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_name.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_name.rs
@@ -1,0 +1,216 @@
+use super::json_utils::is_json_file;
+
+use cow_utils::CowUtils;
+use nodejs_built_in_modules::is_nodejs_builtin_module;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn invalid_package_json_name_diagnostic(complaints: &str, span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Invalid npm package name: {complaints}."))
+        .with_help("Use a valid npm package name, or mark the package as private if it is not meant to be published.")
+        .with_label(span)
+}
+
+fn non_string_package_json_name_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `name` field in package.json must be a string.")
+        .with_help("Use a valid npm package name string.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidName;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `name` field in package.json files as an npm package name.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid package names break npm metadata expectations and publishing
+    /// workflows.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "name": "HTTP" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "name": "@scope/demo-package" }
+    /// ```
+    PackageJsonValidName,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidName {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+
+        if is_private_package(object) {
+            return;
+        }
+
+        let Some(name_prop) = object.get_property("name") else {
+            return;
+        };
+
+        let JsonValue::String(name, _) = &name_prop.value else {
+            ctx.diagnostic(non_string_package_json_name_diagnostic(name_prop.value.span()));
+            return;
+        };
+
+        let complaints = validate_package_name(name);
+        if complaints.is_empty() {
+            return;
+        }
+
+        ctx.diagnostic(invalid_package_json_name_diagnostic(
+            &complaints.join("; "),
+            name_prop.value.span(),
+        ));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn is_private_package(object: &crate::json_parser::JsonObject<'_>) -> bool {
+    matches!(object.get("private"), Some(JsonValue::Boolean(true, _)))
+}
+
+fn validate_package_name(name: &str) -> Vec<String> {
+    let mut complaints = Vec::new();
+
+    if name.is_empty() {
+        complaints.push("name length must be greater than zero".to_string());
+    }
+
+    if name.starts_with('.') {
+        complaints.push("name cannot start with a period".to_string());
+    }
+
+    if name.starts_with('-') {
+        complaints.push("name cannot start with a hyphen".to_string());
+    }
+
+    if name.starts_with('_') {
+        complaints.push("name cannot start with an underscore".to_string());
+    }
+
+    if name.trim() != name {
+        complaints.push("name cannot contain leading or trailing spaces".to_string());
+    }
+
+    let lowercase_name = name.cow_to_ascii_lowercase();
+    if matches!(&*lowercase_name, "node_modules" | "favicon.ico") {
+        complaints.push(format!("{lowercase_name} is not a valid package name"));
+    }
+
+    if is_nodejs_builtin_module(&lowercase_name) {
+        complaints.push(format!("{name} is a core module name"));
+    }
+
+    if name.len() > 214 {
+        complaints.push("name can no longer contain more than 214 characters".to_string());
+    }
+
+    if name.cow_to_ascii_lowercase() != name {
+        complaints.push("name can no longer contain capital letters".to_string());
+    }
+
+    let leaf_name = name.rsplit('/').next().unwrap_or(name);
+    if leaf_name.contains(['~', '\'', '!', '(', ')', '*']) {
+        complaints.push("name can no longer contain special characters (\"~'!()*\")".to_string());
+    }
+
+    if let Some(complaint) = url_friendly_name_complaint(name) {
+        complaints.push(complaint);
+    }
+
+    complaints
+}
+
+fn url_friendly_name_complaint(name: &str) -> Option<String> {
+    if is_url_friendly_segment(name) {
+        return None;
+    }
+
+    let Some(scoped_name) = name.strip_prefix('@') else {
+        return Some("name can only contain URL-friendly characters".to_string());
+    };
+    let Some((scope, package)) = scoped_name.split_once('/') else {
+        return Some("name can only contain URL-friendly characters".to_string());
+    };
+
+    if scope.is_empty() || package.is_empty() || package.contains('/') {
+        return Some("name can only contain URL-friendly characters".to_string());
+    }
+
+    if package.starts_with('.') {
+        return Some("name cannot start with a period".to_string());
+    }
+
+    if is_url_friendly_segment(scope) && is_url_friendly_segment(package) {
+        None
+    } else {
+        Some("name can only contain URL-friendly characters".to_string())
+    }
+}
+
+fn is_url_friendly_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && !segment.contains('/')
+        && segment.chars().all(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '-' | '_' | '.' | '!' | '~' | '*' | '\'' | '(' | ')')
+        })
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"name":"demo"}"#,
+        r#"{"name":"demo-package"}"#,
+        r#"{"name":"demo.package_name"}"#,
+        r#"{"name":"@scope/demo"}"#,
+        r#"{"name":"HTTP","private":true}"#,
+        r#"{"version":"1.0.0"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"name":1}"#,
+        // string "true" is NOT treated as private — only boolean true skips validation
+        r#"{"name":"HTTP","private":"true"}"#,
+        r#"{"name":""}"#,
+        r#"{"name":"HTTP"}"#,
+        r#"{"name":"node_modules"}"#,
+        r#"{"name":" demo"}"#,
+        r#"{"name":"demo!"}"#,
+        r#"{"name":"demo package"}"#,
+        r#"{"name":"_demo"}"#,
+        r#"{"name":"@scope/.demo"}"#,
+    ];
+
+    Tester::new(PackageJsonValidName::NAME, PackageJsonValidName::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_private.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_private.rs
@@ -1,0 +1,107 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+fn invalid_package_json_private_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `private` field in package.json must be a boolean.")
+        .with_help("Use `true` or `false` for the package privacy flag.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidPrivate;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `private` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid `private` values make package publish intent ambiguous and break
+    /// npm metadata expectations.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "private": "true" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "private": true }
+    /// ```
+    PackageJsonValidPrivate,
+    oxc,
+    correctness,
+    fix
+);
+
+impl Rule for PackageJsonValidPrivate {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("private") else {
+            return;
+        };
+
+        if matches!(&prop.value, JsonValue::Boolean(_, _)) {
+            return;
+        }
+
+        // Auto-fix string "true"/"false" to boolean true/false
+        if let JsonValue::String(value, _) = &prop.value
+            && (*value == "true" || *value == "false")
+        {
+            let replacement = if *value == "true" { "true" } else { "false" };
+            ctx.diagnostic_with_fix(
+                invalid_package_json_private_diagnostic(prop.value.span()),
+                |fixer| fixer.replace_full_source_range(prop.value.span(), replacement),
+            );
+            return;
+        }
+
+        ctx.diagnostic(invalid_package_json_private_diagnostic(prop.value.span()));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![r#"{"private":true}"#, r#"{"private":false}"#, r#"{"name":"demo"}"#];
+
+    let fail = vec![
+        r#"{"private":"true"}"#,
+        r#"{"private":"false"}"#,
+        r#"{"private":1}"#,
+        r#"{"private":{}}"#,
+    ];
+
+    let fix = vec![
+        (r#"{"private":"true"}"#, r#"{"private":true}"#, None),
+        (r#"{"private":"false"}"#, r#"{"private":false}"#, None),
+    ];
+
+    Tester::new(PackageJsonValidPrivate::NAME, PackageJsonValidPrivate::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_repository.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_repository.rs
@@ -1,0 +1,138 @@
+use super::json_utils::is_json_file;
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonObject, JsonValue, parse_json},
+    rule::Rule,
+};
+
+static OWNER_REPOSITORY_REGEX: Lazy<Regex> = lazy_regex!(r"^[^/\s]+/[^/\s]+$");
+static PROVIDER_SHORTHAND_REGEX: Lazy<Regex> =
+    lazy_regex!(r"^(?:bitbucket|gist|github|gitlab):\S+$");
+static URL_REPOSITORY_REGEX: Lazy<Regex> =
+    lazy_regex!(r"^(?:git\+)?(?:https?|ssh|git)://[^/\s]+/\S+$");
+static SCP_REPOSITORY_REGEX: Lazy<Regex> = lazy_regex!(r"^git@[^:\s]+:\S+$");
+
+fn invalid_package_json_repository_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `repository` field in package.json is invalid.")
+        .with_help("Use a valid repository shorthand, URL, or `{ type, url }` object.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidRepository;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `repository` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid repository metadata breaks package discoverability and can
+    /// confuse tooling that links a package back to its source.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "repository": "github:" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "repository": "github:npm/cli" }
+    /// ```
+    PackageJsonValidRepository,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidRepository {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("repository") else {
+            return;
+        };
+
+        if is_valid_repository_value(&prop.value) {
+            return;
+        }
+
+        ctx.diagnostic(invalid_package_json_repository_diagnostic(prop.value.span()));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+fn is_valid_repository_value(value: &JsonValue<'_>) -> bool {
+    match value {
+        JsonValue::String(value, _) => is_valid_repository_locator(value),
+        JsonValue::Object(object) => is_valid_repository_object(object),
+        _ => false,
+    }
+}
+
+fn is_valid_repository_object(object: &JsonObject<'_>) -> bool {
+    let type_is_valid =
+        matches!(object.get("type"), Some(JsonValue::String(value, _)) if !value.trim().is_empty());
+    let url_is_valid = matches!(object.get("url"), Some(JsonValue::String(value, _)) if is_valid_repository_locator(value));
+    let directory_is_valid = match object.get("directory") {
+        None => true,
+        Some(JsonValue::String(value, _)) => !value.trim().is_empty(),
+        Some(_) => false,
+    };
+
+    type_is_valid && url_is_valid && directory_is_valid
+}
+
+fn is_valid_repository_locator(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && (OWNER_REPOSITORY_REGEX.is_match(trimmed)
+            || PROVIDER_SHORTHAND_REGEX.is_match(trimmed)
+            || URL_REPOSITORY_REGEX.is_match(trimmed)
+            || SCP_REPOSITORY_REGEX.is_match(trimmed))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"repository":"npm/example"}"#,
+        r#"{"repository":"github:npm/example"}"#,
+        r#"{"repository":"gist:11081aaa281"}"#,
+        r#"{"repository":"git+https://github.com/npm/example.git"}"#,
+        r#"{"repository":"git@github.com:npm/example.git"}"#,
+        r#"{"repository":{"type":"git","url":"https://github.com/npm/example"}}"#,
+        r#"{"repository":{"type":"git","url":"https://github.com/npm/example","directory":"packages/core"}}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"repository":1}"#,
+        r#"{"repository":""}"#,
+        r#"{"repository":"github:"}"#,
+        r#"{"repository":"https://github.com"}"#,
+        r#"{"repository":{"type":"","url":"https://github.com/npm/example"}}"#,
+        r#"{"repository":{"type":"git","url":1}}"#,
+        r#"{"repository":{"type":"git","url":"https://github.com/npm/example","directory":""}}"#,
+    ];
+
+    Tester::new(PackageJsonValidRepository::NAME, PackageJsonValidRepository::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_type.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_type.rs
@@ -1,0 +1,116 @@
+use super::json_utils::{is_json_file, property_deletion_span};
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+fn invalid_package_json_type_diagnostic(actual: &str, span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The `type` field in package.json must be `module` or `commonjs`, not `{actual}`."
+    ))
+    .with_help("Use a valid Node package type or remove the field.")
+    .with_label(span)
+}
+
+fn non_string_package_json_type_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `type` field in package.json must be a string.")
+        .with_help("Use `module` or `commonjs` for the package type.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidType;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `type` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid package types break Node module resolution expectations and make
+    /// package behavior harder to reason about.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "type": "esm" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "type": "module" }
+    /// ```
+    PackageJsonValidType,
+    oxc,
+    correctness,
+    fix
+);
+
+impl Rule for PackageJsonValidType {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some((index, prop)) =
+            object.properties.iter().enumerate().find(|(_, p)| p.key == "type")
+        else {
+            return;
+        };
+
+        match &prop.value {
+            JsonValue::String(kind, _) if *kind == "module" || *kind == "commonjs" => {}
+            JsonValue::String(kind, _) => {
+                ctx.diagnostic(invalid_package_json_type_diagnostic(kind, prop.value.span()));
+            }
+            _ => {
+                let delete_span = property_deletion_span(source_text, object, prop, index);
+                ctx.diagnostic_with_fix(
+                    non_string_package_json_type_diagnostic(prop.value.span()),
+                    |fixer| fixer.delete_range(delete_span),
+                );
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"name":"demo"}"#,
+        r#"{"name":"demo","type":"module"}"#,
+        r#"{"name":"demo","type":"commonjs"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"name":"demo","type":"esm"}"#,
+        r#"{"name":"demo","type":true}"#,
+        r#"{"name":"demo","type":1}"#,
+    ];
+
+    // Non-string types get auto-deleted (restoring Node's default behavior)
+    let fix = vec![
+        (r#"{"name":"demo","type":true}"#, r#"{"name":"demo"}"#, None),
+        (r#"{"name":"demo","type":1}"#, r#"{"name":"demo"}"#, None),
+    ];
+
+    Tester::new(PackageJsonValidType::NAME, PackageJsonValidType::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/package_json_valid_version.rs
+++ b/crates/oxc_linter/src/rules/oxc/package_json_valid_version.rs
@@ -1,0 +1,97 @@
+use super::json_utils::is_json_file;
+
+use lazy_regex::{Lazy, Regex, lazy_regex};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::Rule,
+};
+
+static SEMVER_REGEX: Lazy<Regex> = lazy_regex!(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+);
+
+fn invalid_package_json_version_diagnostic(span: oxc_span::Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `version` field in package.json must be a valid semver string.")
+        .with_help("Use a version like `1.0.0`, `1.2.3-beta.1`, or `1.0.0+build.5`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PackageJsonValidVersion;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates the `version` field in package.json files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Invalid package versions break npm metadata expectations and make
+    /// release automation unreliable.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "version": "1.0" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "version": "1.0.0" }
+    /// ```
+    PackageJsonValidVersion,
+    oxc,
+    correctness
+);
+
+impl Rule for PackageJsonValidVersion {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(JsonValue::Object(object)) = &result.root else {
+            return;
+        };
+        let Some(prop) = object.get_property("version") else {
+            return;
+        };
+
+        match &prop.value {
+            JsonValue::String(version, _) if SEMVER_REGEX.is_match(version) => {}
+            _ => ctx.diagnostic(invalid_package_json_version_diagnostic(prop.value.span())),
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+            && is_json_file(ctx.file_path())
+            && ctx.file_path().file_name().is_some_and(|name| name == "package.json")
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"{"version":"1.0.0"}"#,
+        r#"{"version":"0.1.0-alpha.1"}"#,
+        r#"{"version":"2.3.4+build.5"}"#,
+        r#"{"name":"demo"}"#,
+    ];
+
+    let fail = vec![
+        r#"{"version":"1.0"}"#,
+        r#"{"version":"v1.0.0"}"#,
+        r#"{"version":"01.0.0"}"#,
+        r#"{"version":1}"#,
+    ];
+
+    Tester::new(PackageJsonValidVersion::NAME, PackageJsonValidVersion::PLUGIN, pass, fail)
+        .change_rule_path("package.json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sorted_json_keys.rs
+++ b/crates/oxc_linter/src/rules/oxc/sorted_json_keys.rs
@@ -1,0 +1,221 @@
+use std::{cmp::Ordering, ffi::OsStr};
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use super::json_utils::file_start_span;
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sorted_json_keys_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("JSON object keys should be sorted.")
+        .with_help("Sort object keys consistently to keep locale files easy to diff and review.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum JsonSortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortedJsonKeysConfig {
+    order: JsonSortOrder,
+    indent_spaces: usize,
+}
+
+impl Default for SortedJsonKeysConfig {
+    fn default() -> Self {
+        Self { order: JsonSortOrder::Asc, indent_spaces: 2 }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortedJsonKeys(Box<SortedJsonKeysConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces recursively sorted keys in JSON files.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Locale JSON files are easier to compare, review, and synchronize when
+    /// object keys stay in a deterministic order.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "b": "two", "a": "one" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "a": "one", "b": "two" }
+    /// ```
+    SortedJsonKeys,
+    oxc,
+    style,
+    fix,
+    config = SortedJsonKeysConfig
+);
+
+impl Rule for SortedJsonKeys {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortedJsonKeysConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    #[expect(clippy::cast_possible_truncation)] // Span uses u32 by design
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(root) = &result.root else {
+            return;
+        };
+
+        if is_json_value_sorted(root, self.0.order) {
+            return;
+        }
+
+        // Use serde_json for the fix path (serialization)
+        let Ok(serde_value) = serde_json::from_str::<Value>(source_text) else {
+            return;
+        };
+        let sorted = sort_serde_json_value(&serde_value, self.0.order);
+        let Ok(mut expected) = serialize_json(&sorted, self.0.indent_spaces) else {
+            return;
+        };
+
+        if source_text.ends_with('\n') {
+            expected.push('\n');
+        }
+
+        let file_span = Span::new(0, source_text.len() as u32);
+        ctx.diagnostic_with_fix(
+            sorted_json_keys_diagnostic(file_start_span(source_text)),
+            |fixer| fixer.replace_full_source_range(file_span, expected),
+        );
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && ctx.file_extension().is_some_and(|ext| ext == OsStr::new("json"))
+    }
+}
+
+fn sort_serde_json_value(value: &Value, order: JsonSortOrder) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut entries = object.iter().collect::<Vec<_>>();
+            entries.sort_by(|(left_key, _), (right_key, _)| {
+                let ordering = left_key.cmp(right_key);
+                match order {
+                    JsonSortOrder::Asc => ordering,
+                    JsonSortOrder::Desc => ordering.reverse(),
+                }
+            });
+
+            let mut sorted = Map::with_capacity(object.len());
+            for (key, value) in entries {
+                sorted.insert(key.clone(), sort_serde_json_value(value, order));
+            }
+            Value::Object(sorted)
+        }
+        Value::Array(array) => {
+            Value::Array(array.iter().map(|item| sort_serde_json_value(item, order)).collect())
+        }
+        _ => value.clone(),
+    }
+}
+
+fn is_json_value_sorted(value: &JsonValue<'_>, order: JsonSortOrder) -> bool {
+    match value {
+        JsonValue::Object(object) => {
+            let mut previous_key: Option<&str> = None;
+            for prop in &object.properties {
+                if let Some(previous_key) = previous_key {
+                    let ordering = previous_key.cmp(prop.key);
+                    let in_order = match order {
+                        JsonSortOrder::Asc => ordering != Ordering::Greater,
+                        JsonSortOrder::Desc => ordering != Ordering::Less,
+                    };
+                    if !in_order {
+                        return false;
+                    }
+                }
+
+                if !is_json_value_sorted(&prop.value, order) {
+                    return false;
+                }
+
+                previous_key = Some(prop.key);
+            }
+
+            true
+        }
+        JsonValue::Array(array) => {
+            array.elements.iter().all(|item| is_json_value_sorted(item, order))
+        }
+        _ => true,
+    }
+}
+
+fn serialize_json(value: &Value, indent_spaces: usize) -> Result<String, serde_json::Error> {
+    let indent = vec![b' '; indent_spaces.max(1)];
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(&indent);
+    let mut output = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    value.serialize(&mut serializer)?;
+    Ok(String::from_utf8(output).expect("serde_json emitted invalid UTF-8"))
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"{"a":"one","b":"two"}"#, None),
+        (r#"{"a":{"b":"two","c":"three"},"z":"last"}"#, None),
+        (r#"{"b":"two","a":"one"}"#, Some(json!([{ "order": "desc", "indentSpaces": 2 }]))),
+    ];
+
+    let fail = vec![
+        (r#"{"b":"two","a":"one"}"#, None),
+        (r#"{"z":"last","a":{"c":"three","b":"two"}}"#, None),
+        (r#"{"a":"one","b":"two"}"#, Some(json!([{ "order": "desc", "indentSpaces": 2 }]))),
+    ];
+
+    let fix = vec![
+        (r#"{"b":"two","a":"one"}"#, "{\n  \"a\": \"one\",\n  \"b\": \"two\"\n}", None),
+        (
+            r#"{"z":"last","a":{"c":"three","b":"two"}}"#,
+            "{\n  \"a\": {\n    \"b\": \"two\",\n    \"c\": \"three\"\n  },\n  \"z\": \"last\"\n}",
+            None,
+        ),
+        (
+            r#"{"a":"one","b":"two"}"#,
+            "{\n  \"b\": \"two\",\n  \"a\": \"one\"\n}",
+            Some(json!([{ "order": "desc", "indentSpaces": 2 }])),
+        ),
+    ];
+
+    Tester::new(SortedJsonKeys::NAME, SortedJsonKeys::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/valid_json.rs
+++ b/crates/oxc_linter/src/rules/oxc/valid_json.rs
@@ -1,0 +1,134 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{context::LintContext, json_parser::parse_json, rule::Rule};
+
+fn valid_json_diagnostic(message: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Invalid JSON: {message}"))
+        .with_help("Fix the JSON syntax error.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ValidJsonConfig {
+    allow_comments: bool,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ValidJson(Box<ValidJsonConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Reports invalid JSON documents.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// JSON-backed rule families such as locale catalogs cannot be linted
+    /// reliably if the source file is not valid JSON.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "message": }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "message": "hello" }
+    /// ```
+    ValidJson,
+    oxc,
+    correctness,
+    config = ValidJsonConfig
+);
+
+impl Rule for ValidJson {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        let mut config = ValidJsonConfig::default();
+
+        match value {
+            serde_json::Value::Null => {}
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    match value {
+                        serde_json::Value::String(option) if option == "allowComments" => {
+                            config.allow_comments = true;
+                        }
+                        other => {
+                            config = serde_json::from_value(other)?;
+                        }
+                    }
+                }
+            }
+            serde_json::Value::String(option) if option == "allowComments" => {
+                config.allow_comments = true;
+            }
+            other => {
+                config = serde_json::from_value(other)?;
+            }
+        }
+
+        Ok(Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let owned_stripped;
+        let parse_source = if self.0.allow_comments {
+            let mut stripped = source_text.to_string();
+            if json_strip_comments::strip(&mut stripped).is_ok() {
+                owned_stripped = stripped;
+                owned_stripped.as_str()
+            } else {
+                source_text
+            }
+        } else {
+            source_text
+        };
+
+        let result = parse_json(parse_source);
+        if result.errors.is_empty() && result.root.is_some() {
+            return;
+        }
+
+        for error in &result.errors {
+            ctx.diagnostic(valid_json_diagnostic(&error.message, error.span));
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && is_json_file(ctx.file_path())
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"{"message":"hello"}"#, None),
+        (r#"{"nested":{"message":"hello"}}"#, None),
+        ("{\n  // comment\n  \"message\": \"hello\"\n}", Some(json!(["allowComments"]))),
+        ("{\n  // comment\n  \"message\": \"hello\"\n}", Some(json!([{ "allowComments": true }]))),
+    ];
+
+    let fail = vec![
+        (r#"{"message":}"#, None),
+        (r#"{"message":"hello",}"#, None),
+        ("{\n  // comment\n  \"message\": \"hello\"\n}", None),
+    ];
+
+    Tester::new(ValidJson::NAME, ValidJson::PLUGIN, pass, fail)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/valid_message_syntax.rs
+++ b/crates/oxc_linter/src/rules/oxc/valid_message_syntax.rs
@@ -1,0 +1,142 @@
+use super::json_utils::is_json_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    context::LintContext,
+    json_parser::{JsonValue, parse_json},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn valid_message_syntax_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Translation message must be a non-empty string.")
+        .with_help("Use a non-empty string for locale message leaves.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum MessageSyntaxKind {
+    #[default]
+    NonEmptyString,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ValidMessageSyntaxConfig {
+    syntax: MessageSyntaxKind,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ValidMessageSyntax(Box<ValidMessageSyntaxConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates locale message leaves inside JSON catalogs.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Empty or non-string message values usually indicate broken translations
+    /// or malformed catalog data.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```json
+    /// { "title": "" }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```json
+    /// { "title": "Dashboard" }
+    /// ```
+    ValidMessageSyntax,
+    oxc,
+    correctness,
+    config = ValidMessageSyntaxConfig
+);
+
+impl Rule for ValidMessageSyntax {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<ValidMessageSyntaxConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_json(source_text);
+        let Some(root) = &result.root else {
+            return;
+        };
+
+        let mut invalid_spans = Vec::new();
+        collect_invalid_message_spans(root, self.0.syntax, &mut invalid_spans);
+
+        for span in invalid_spans {
+            ctx.diagnostic(valid_message_syntax_diagnostic(span));
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && is_json_file(ctx.file_path())
+    }
+}
+
+fn collect_invalid_message_spans(
+    value: &JsonValue<'_>,
+    syntax: MessageSyntaxKind,
+    invalid_spans: &mut Vec<Span>,
+) {
+    match value {
+        JsonValue::Object(object) => {
+            for prop in &object.properties {
+                collect_invalid_message_spans(&prop.value, syntax, invalid_spans);
+            }
+        }
+        JsonValue::Array(array) => {
+            for element in &array.elements {
+                collect_invalid_message_spans(element, syntax, invalid_spans);
+            }
+        }
+        JsonValue::String(message, span) => {
+            if matches!(syntax, MessageSyntaxKind::NonEmptyString) && message.trim().is_empty() {
+                invalid_spans.push(*span);
+            }
+        }
+        _ => {
+            if matches!(syntax, MessageSyntaxKind::NonEmptyString) {
+                invalid_spans.push(value.span());
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"{"title":"Dashboard","cta":"Continue"}"#, None),
+        (r#"{"items":["One","Two"],"nested":{"subtitle":"Ready"}}"#, None),
+        (r#"{"title":"Dashboard"}"#, Some(json!([{ "syntax": "non-empty-string" }]))),
+    ];
+
+    let fail = vec![
+        (r#"{"title":""}"#, None),
+        (r#"{"title":"   "}"#, None),
+        (r#"{"title":1}"#, None),
+        (r#"{"items":["One",""]}"#, None),
+    ];
+
+    Tester::new(ValidMessageSyntax::NAME, ValidMessageSyntax::PLUGIN, pass, fail)
+        .change_rule_path_extension("json")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -725,7 +725,7 @@ impl Runtime {
                 None,
                 |me, mut module_to_lint| {
                     module_to_lint.content.with_dependent_mut(
-                    |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
+                    |allocator_guard, ModuleContentDependent { source_text, section_contents }| {
                         assert_eq!(
                             module_to_lint.section_module_records.len(),
                             section_contents.len()
@@ -766,7 +766,13 @@ impl Runtime {
 
                         let (section_messages, disable_directives) = me
                             .linter
-                            .run_with_disable_directives(path, context_sub_hosts, allocator_guard, me.js_allocator_pool());
+                            .run_with_full_source_text_and_disable_directives(
+                                path,
+                                context_sub_hosts,
+                                source_text,
+                                allocator_guard,
+                                me.js_allocator_pool(),
+                            );
 
                         if let Some(disable_directives) = disable_directives {
                             me.disable_directives_map
@@ -804,7 +810,7 @@ impl Runtime {
         rayon::scope(|scope| {
             self.resolve_modules(file_system, &paths_set, scope, check_syntax_errors, Some(tx_error), |me, mut module| {
                 module.content.with_dependent_mut(
-                    |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
+                    |allocator_guard, ModuleContentDependent { source_text, section_contents }| {
                         assert_eq!(module.section_module_records.len(), section_contents.len());
 
                         let context_sub_hosts: Vec<ContextSubHost<'_>> = module
@@ -839,12 +845,15 @@ impl Runtime {
                         }
 
                         messages.lock().unwrap().extend(
-                            me.linter.run(
-                                Path::new(&module.path),
-                                context_sub_hosts,
-                                allocator_guard
-                            )
-                            ,
+                            me.linter
+                                .run_with_full_source_text_and_disable_directives(
+                                    Path::new(&module.path),
+                                    context_sub_hosts,
+                                    source_text,
+                                    allocator_guard,
+                                    None,
+                                )
+                                .0,
                         );
                     },
                 );

--- a/crates/oxc_linter/src/snapshots/oxc_identical_keys.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_identical_keys.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(identical-keys): JSON keys do not match the reference locale file `/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/i18n_catalog/en/common.json`.
+   ╭─[identical_keys.json:1:1]
+ 1 │ {"actions":{"cancel":"Annuler"},"title":"Tableau de bord"}
+   · ─
+   ╰────
+  help: Missing 1 key(s): actions.save
+
+  ⚠ oxc(identical-keys): JSON keys do not match the reference locale file `/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/i18n_catalog/en/common.json`.
+   ╭─[identical_keys.json:1:1]
+ 1 │ {"actions":{"cancel":"Annuler","save":"Enregistrer","submit":"Envoyer"},"title":"Tableau de bord"}
+   · ─
+   ╰────
+  help: Extra 1 key(s): actions.submit
+
+  ⚠ oxc(identical-keys): JSON keys do not match the reference locale file `/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/i18n_catalog/en/common.json`.
+   ╭─[identical_keys.json:1:1]
+ 1 │ {"actions":"Annuler","title":"Tableau de bord"}
+   · ─
+   ╰────
+  help: Type mismatches at 1 path(s): actions

--- a/crates/oxc_linter/src/snapshots/oxc_identical_placeholders.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_identical_placeholders.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(identical-placeholders): Placeholders at `greeting` do not match reference locale `/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/i18n_catalog/en/messages.json`.
+   ╭─[identical_placeholders.json:1:13]
+ 1 │ {"greeting":"Bonjour","count":"{count} éléments","simple":"Tableau de bord"}
+   ·             ─────────
+   ╰────
+  help: missing: {name}
+
+  ⚠ oxc(identical-placeholders): Placeholders at `greeting` do not match reference locale `/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/i18n_catalog/en/messages.json`.
+   ╭─[identical_placeholders.json:1:13]
+ 1 │ {"greeting":"Bonjour {name} {extra}","count":"{count} éléments","simple":"Tableau de bord"}
+   ·             ────────────────────────
+   ╰────
+  help: extra: {extra}

--- a/crates/oxc_linter/src/snapshots/oxc_json_no_comments.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_json_no_comments.snap
@@ -1,0 +1,22 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(json-no-comments): Comments are not allowed in JSON
+   ╭─[json_no_comments.json:2:1]
+ 1 │ {
+ 2 │ // comment
+   · ──────────
+ 3 │ "a": 1
+   ╰────
+  help: Remove the comment. Standard JSON (RFC 8259) does not support comments. Use JSONC if you need comments.
+
+  ⚠ oxc(json-no-comments): Comments are not allowed in JSON
+   ╭─[json_no_comments.json:2:1]
+ 1 │ {
+ 2 │ /* block */
+   · ───────────
+ 3 │ "a": 1
+   ╰────
+  help: Remove the comment. Standard JSON (RFC 8259) does not support comments. Use JSONC if you need comments.

--- a/crates/oxc_linter/src/snapshots/oxc_json_no_duplicate_keys.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_json_no_duplicate_keys.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(json-no-duplicate-keys): Duplicate key "name" in JSON object
+   ╭─[json_no_duplicate_keys.json:1:2]
+ 1 │ {"name": "foo", "name": "bar"}
+   ·  ───┬──         ───┬──
+   ·     │              ╰── duplicate key here
+   ·     ╰── first occurrence
+   ╰────
+  help: Remove one of the duplicate keys. The last value will be used by JSON parsers.
+
+  ⚠ oxc(json-no-duplicate-keys): Duplicate key "a" in JSON object
+   ╭─[json_no_duplicate_keys.json:1:2]
+ 1 │ {"a": 1, "b": 2, "a": 3}
+   ·  ─┬─             ─┬─
+   ·   │               ╰── duplicate key here
+   ·   ╰── first occurrence
+   ╰────
+  help: Remove one of the duplicate keys. The last value will be used by JSON parsers.
+
+  ⚠ oxc(json-no-duplicate-keys): Duplicate key "inner" in JSON object
+   ╭─[json_no_duplicate_keys.json:1:12]
+ 1 │ {"outer": {"inner": 1, "inner": 2}}
+   ·            ───┬───     ───┬───
+   ·               │           ╰── duplicate key here
+   ·               ╰── first occurrence
+   ╰────
+  help: Remove one of the duplicate keys. The last value will be used by JSON parsers.

--- a/crates/oxc_linter/src/snapshots/oxc_json_no_trailing_commas.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_json_no_trailing_commas.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(json-no-trailing-commas): Trailing comma in JSON
+   ╭─[json_no_trailing_commas.json:1:15]
+ 1 │ {"name": "foo",}
+   ·               ─
+   ╰────
+  help: Remove the trailing comma. Trailing commas are not allowed in JSON.
+
+  ⚠ oxc(json-no-trailing-commas): Trailing comma in JSON
+   ╭─[json_no_trailing_commas.json:1:9]
+ 1 │ [1, 2, 3,]
+   ·         ─
+   ╰────
+  help: Remove the trailing comma. Trailing commas are not allowed in JSON.
+
+  ⚠ oxc(json-no-trailing-commas): Trailing comma in JSON
+   ╭─[json_no_trailing_commas.json:1:16]
+ 1 │ {"a": 1, "b": 2,}
+   ·                ─
+   ╰────
+  help: Remove the trailing comma. Trailing commas are not allowed in JSON.

--- a/crates/oxc_linter/src/snapshots/oxc_json_parse_validation.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_json_parse_validation.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(json-parse-validation): Validate `JSON.parse()` results before using them.
+   ╭─[json_parse_validation.ts:1:14]
+ 1 │ const data = JSON.parse(text);
+   ·              ────────────────
+   ╰────
+  help: Wrap `JSON.parse(...)` with `safeParse(...)`/`parse(...)`, or validate the assigned value within the next few statements.
+
+  ⚠ oxc(json-parse-validation): Validate `JSON.parse()` results before using them.
+   ╭─[json_parse_validation.ts:1:8]
+ 1 │ handle(JSON.parse(text));
+   ·        ────────────────
+   ╰────
+  help: Wrap `JSON.parse(...)` with `safeParse(...)`/`parse(...)`, or validate the assigned value within the next few statements.
+
+  ⚠ oxc(json-parse-validation): Validate `JSON.parse()` results before using them.
+   ╭─[json_parse_validation.ts:1:13]
+ 1 │ const raw = JSON.parse(text); doSomething(raw);
+   ·             ────────────────
+   ╰────
+  help: Wrap `JSON.parse(...)` with `safeParse(...)`/`parse(...)`, or validate the assigned value within the next few statements.
+
+  ⚠ oxc(json-parse-validation): Validate `JSON.parse()` results before using them.
+   ╭─[json_parse_validation.ts:1:16]
+ 1 │ let raw; raw = JSON.parse(text); doSomething(raw);
+   ·                ────────────────
+   ╰────
+  help: Wrap `JSON.parse(...)` with `safeParse(...)`/`parse(...)`, or validate the assigned value within the next few statements.
+
+  ⚠ oxc(json-parse-validation): Validate `JSON.parse()` results before using them.
+   ╭─[json_parse_validation.ts:1:13]
+ 1 │ const raw = JSON.parse(text); foo(); bar(); baz(); qux(); v.safeParse(MySchema, raw);
+   ·             ────────────────
+   ╰────
+  help: Wrap `JSON.parse(...)` with `safeParse(...)`/`parse(...)`, or validate the assigned value within the next few statements.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_no_duplicate_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_no_duplicate_dependencies.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-no-duplicate-dependencies): `lodash` is listed in both `dependencies` and `devDependencies`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:57]
+ 1 │ {"dependencies":{"lodash":"^4.17.0"},"devDependencies":{"lodash":"^4.17.0"}}
+   ·                                                         ────────
+   ╰────
+  help: Remove the package from one of the dependency groups.
+
+  ⚠ oxc(package-json-no-duplicate-dependencies): `lodash` is listed in both `dependencies` and `devDependencies`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:75]
+ 1 │ {"dependencies":{"lodash":"^4.17.0","react":"^18.0.0"},"devDependencies":{"lodash":"^4.17.0","vitest":"^1.0.0"}}
+   ·                                                                           ────────
+   ╰────
+  help: Remove the package from one of the dependency groups.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_no_empty_fields.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_no_empty_fields.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ oxc(package-json-no-empty-fields): The `keywords` field in package.json should not be an empty array.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:13]
+ 1 │ {"keywords":[]}
+   ·             ──
+   ╰────
+  help: Remove empty package.json fields that do not carry any information.
+
+  ⚠ oxc(package-json-no-empty-fields): The `publishConfig` field in package.json should not be an empty object.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:18]
+ 1 │ {"publishConfig":{}}
+   ·                  ──
+   ╰────
+  help: Remove empty package.json fields that do not carry any information.
+
+  ⚠ oxc(package-json-no-empty-fields): The `files` field in package.json should not be an empty array.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:10]
+ 1 │ {"files":[],"scripts":{}}
+   ·          ──
+   ╰────
+  help: Remove empty package.json fields that do not carry any information.
+
+  ⚠ oxc(package-json-no-empty-fields): The `scripts` field in package.json should not be an empty object.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:23]
+ 1 │ {"files":[],"scripts":{}}
+   ·                       ──
+   ╰────
+  help: Remove empty package.json fields that do not carry any information.
+
+  ⚠ oxc(package-json-no-empty-fields): The `keywords` field in package.json should not be an empty array.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:27]
+ 1 │ {"name":"demo","keywords":[]}
+   ·                           ──
+   ╰────
+  help: Remove empty package.json fields that do not carry any information.
+
+  ⚠ oxc(package-json-no-empty-fields): The `keywords` field in package.json should not be an empty array.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:13]
+ 1 │ {"keywords":[],"name":"demo"}
+   ·             ──
+   ╰────
+  help: Remove empty package.json fields that do not carry any information.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_no_redundant_publish_config.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_no_redundant_publish_config.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-no-redundant-publish-config): `publishConfig.access` is redundant for unscoped packages because they are always public.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"name":"demo","publishConfig":{"access":"public"}}
+   · ─
+   ╰────
+  help: Remove the redundant `publishConfig.access` field.
+
+  ⚠ oxc(package-json-no-redundant-publish-config): `publishConfig.access` is redundant for unscoped packages because they are always public.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"name":"demo","publishConfig":{"access":"restricted"}}
+   · ─
+   ╰────
+  help: Remove the redundant `publishConfig.access` field.
+
+  ⚠ oxc(package-json-no-redundant-publish-config): `publishConfig.access` is redundant for unscoped packages because they are always public.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"name":"demo","publishConfig":{"access":"public","registry":"https://example.com"}}
+   · ─
+   ╰────
+  help: Remove the redundant `publishConfig.access` field.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_order_properties.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_order_properties.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-order-properties): Top-level property `version` is not ordered in the standard way.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"version":"1.0.0","name":"demo"}
+   · ─
+   ╰────
+  help: Reorder top-level package.json properties consistently.
+
+  ⚠ oxc(package-json-order-properties): Top-level property `description` is not ordered in the standard way.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"description":"x","name":"demo","version":"1.0.0"}
+   · ─
+   ╰────
+  help: Reorder top-level package.json properties consistently.
+
+  ⚠ oxc(package-json-order-properties): Top-level property `foo` is not ordered in the standard way.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"foo":"x","name":"demo","version":"1.0.0"}
+   · ─
+   ╰────
+  help: Reorder top-level package.json properties consistently.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_repository_shorthand.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_repository_shorthand.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-repository-shorthand): Prefer an object locator for a repository.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"repository":"npm/example"}
+   · ─
+   ╰────
+  help: Use `{ "type": "git", "url": "..." }` for the `repository` field.
+
+  ⚠ oxc(package-json-repository-shorthand): Prefer an object locator for a repository.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"repository":"github:npm/example"}
+   · ─
+   ╰────
+  help: Use `{ "type": "git", "url": "..." }` for the `repository` field.
+
+  ⚠ oxc(package-json-repository-shorthand): Prefer a shorthand locator for a supported repository provider.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"repository":{"type":"git","url":"https://github.com/npm/example"}}
+   · ─
+   ╰────
+  help: Use provider shorthand such as `github:user/repo` when the repository URL can be normalized safely.
+
+  ⚠ oxc(package-json-repository-shorthand): Prefer a shorthand locator for a supported repository provider.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"repository":"https://gitlab.com/user/repo.git"}
+   · ─
+   ╰────
+  help: Use provider shorthand such as `github:user/repo` when the repository URL can be normalized safely.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_require_type.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_require_type.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-require-type): package.json should declare a `type` field.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"name":"demo"}
+   · ─
+   ╰────
+  help: Add `"type": "module"` or `"type": "commonjs"` to package.json.
+
+  ⚠ oxc(package-json-require-type): package.json should declare a `type` field.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"version":"1.0.0"}
+   · ─
+   ╰────
+  help: Add `"type": "module"` or `"type": "commonjs"` to package.json.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_require_version.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_require_version.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-require-version): package.json should declare a `version` field.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"name":"demo"}
+   · ─
+   ╰────
+  help: Add a package version such as `"version": "1.0.0"`.
+
+  ⚠ oxc(package-json-require-version): package.json should declare a `version` field.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"type":"module"}
+   · ─
+   ╰────
+  help: Add a package version such as `"version": "1.0.0"`.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_sort_collections.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_sort_collections.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-sort-collections): Entries in `dependencies` are not in lexicographical order.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"dependencies":{"b":"1","a":"1"}}
+   · ─
+   ╰────
+  help: Sort the collection consistently to reduce noisy diffs.
+
+  ⚠ oxc(package-json-sort-collections): Entries in `scripts` are not in lifecycle-aware lexicographical order.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"scripts":{"build":"x","postbuild":"x","prebuild":"x"}}
+   · ─
+   ╰────
+  help: Group `pre<name>`, `<name>`, and `post<name>` scripts together in a stable order.
+
+  ⚠ oxc(package-json-sort-collections): Entries in `pnpm.patchedDependencies` are not in lexicographical order.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:1]
+ 1 │ {"pnpm":{"patchedDependencies":{"b":"patch","a":"patch"}}}
+   · ─
+   ╰────
+  help: Sort the collection consistently to reduce noisy diffs.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_bin.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_bin.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-bin): The `bin` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"bin":""}
+   ·        ──
+   ╰────
+  help: Use a non-empty string or an object whose values are non-empty strings.
+
+  ⚠ oxc(package-json-valid-bin): The `bin` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"bin":{}}
+   ·        ──
+   ╰────
+  help: Use a non-empty string or an object whose values are non-empty strings.
+
+  ⚠ oxc(package-json-valid-bin): The `bin` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"bin":{"demo":""}}
+   ·        ───────────
+   ╰────
+  help: Use a non-empty string or an object whose values are non-empty strings.
+
+  ⚠ oxc(package-json-valid-bin): The `bin` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"bin":{"demo":1}}
+   ·        ──────────
+   ╰────
+  help: Use a non-empty string or an object whose values are non-empty strings.
+
+  ⚠ oxc(package-json-valid-bin): The `bin` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"bin":1}
+   ·        ─
+   ╰────
+  help: Use a non-empty string or an object whose values are non-empty strings.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_description.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_description.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-description): The `description` field in package.json must be a non-empty string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:16]
+ 1 │ {"description":""}
+   ·                ──
+   ╰────
+  help: Use a descriptive non-empty package description.
+
+  ⚠ oxc(package-json-valid-description): The `description` field in package.json must be a non-empty string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:16]
+ 1 │ {"description":"   "}
+   ·                ─────
+   ╰────
+  help: Use a descriptive non-empty package description.
+
+  ⚠ oxc(package-json-valid-description): The `description` field in package.json must be a non-empty string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:16]
+ 1 │ {"description":1}
+   ·                ─
+   ╰────
+  help: Use a descriptive non-empty package description.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_engines.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_engines.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-engines): The `engines` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"engines":"node >= 18"}
+   ·            ────────────
+   ╰────
+  help: Use an object with runtime names as keys and semver ranges as values, e.g. `{ "node": ">=18" }`.
+
+  ⚠ oxc(package-json-valid-engines): The `engines` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"engines":1}
+   ·            ─
+   ╰────
+  help: Use an object with runtime names as keys and semver ranges as values, e.g. `{ "node": ">=18" }`.
+
+  ⚠ oxc(package-json-valid-engines): The `engines.node` value in package.json must be a non-empty string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:20]
+ 1 │ {"engines":{"node":""}}
+   ·                    ──
+   ╰────
+  help: Use a semver range string like `>=18`, `^20.0.0`, or `*`.
+
+  ⚠ oxc(package-json-valid-engines): The `engines.node` value in package.json must be a non-empty string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:20]
+ 1 │ {"engines":{"node":1}}
+   ·                    ─
+   ╰────
+  help: Use a semver range string like `>=18`, `^20.0.0`, or `*`.
+
+  ⚠ oxc(package-json-valid-engines): The `engines.npm` value in package.json must be a non-empty string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:33]
+ 1 │ {"engines":{"node":">=18","npm":""}}
+   ·                                 ──
+   ╰────
+  help: Use a semver range string like `>=18`, `^20.0.0`, or `*`.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_keywords.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_keywords.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-keywords): The `keywords` field in package.json must be an array of non-empty strings.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:13]
+ 1 │ {"keywords":"lint"}
+   ·             ──────
+   ╰────
+  help: Use an array of keyword strings for package discoverability.
+
+  ⚠ oxc(package-json-valid-keywords): The `keywords` field in package.json must be an array of non-empty strings.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:13]
+ 1 │ {"keywords":1}
+   ·             ─
+   ╰────
+  help: Use an array of keyword strings for package discoverability.
+
+  ⚠ oxc(package-json-valid-keywords): The `keywords` field in package.json must be an array of non-empty strings.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:21]
+ 1 │ {"keywords":["lint",""]}
+   ·                     ──
+   ╰────
+  help: Use an array of keyword strings for package discoverability.
+
+  ⚠ oxc(package-json-valid-keywords): The `keywords` field in package.json must be an array of non-empty strings.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:21]
+ 1 │ {"keywords":["lint",1]}
+   ·                     ─
+   ╰────
+  help: Use an array of keyword strings for package discoverability.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_license.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_license.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-license): The `license` field in package.json must be a string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"license":1}
+   ·            ─
+   ╰────
+  help: Use a string value such as `MIT`, `(MIT OR Apache-2.0)`, or `UNLICENSED`.
+
+  ⚠ oxc(package-json-valid-license): The `license` field in package.json must be a valid SPDX expression, `UNLICENSED`, or `SEE LICENSE IN <file>`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"license":"GPL3"}
+   ·            ──────
+   ╰────
+  help: Use a valid SPDX identifier or expression such as `MIT` or `(MIT OR Apache-2.0)`, `UNLICENSED`, or `SEE LICENSE IN LICENSE.md`.
+
+  ⚠ oxc(package-json-valid-license): The `license` field in package.json must be a valid SPDX expression, `UNLICENSED`, or `SEE LICENSE IN <file>`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"license":"MIT OR NOPE"}
+   ·            ─────────────
+   ╰────
+  help: Use a valid SPDX identifier or expression such as `MIT` or `(MIT OR Apache-2.0)`, `UNLICENSED`, or `SEE LICENSE IN LICENSE.md`.
+
+  ⚠ oxc(package-json-valid-license): The `license` field in package.json must be a valid SPDX expression, `UNLICENSED`, or `SEE LICENSE IN <file>`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"license":"NOASSERTION"}
+   ·            ─────────────
+   ╰────
+  help: Use a valid SPDX identifier or expression such as `MIT` or `(MIT OR Apache-2.0)`, `UNLICENSED`, or `SEE LICENSE IN LICENSE.md`.
+
+  ⚠ oxc(package-json-valid-license): The `license` field in package.json must be a valid SPDX expression, `UNLICENSED`, or `SEE LICENSE IN <file>`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"license":"LicenseRef-Custom"}
+   ·            ───────────────────
+   ╰────
+  help: Use a valid SPDX identifier or expression such as `MIT` or `(MIT OR Apache-2.0)`, `UNLICENSED`, or `SEE LICENSE IN LICENSE.md`.
+
+  ⚠ oxc(package-json-valid-license): The `license` field in package.json must be a valid SPDX expression, `UNLICENSED`, or `SEE LICENSE IN <file>`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"license":"SEE LICENSE IN "}
+   ·            ─────────────────
+   ╰────
+  help: Use a valid SPDX identifier or expression such as `MIT` or `(MIT OR Apache-2.0)`, `UNLICENSED`, or `SEE LICENSE IN LICENSE.md`.
+
+  ⚠ oxc(package-json-valid-license): The `license` field in package.json must be a string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"license":{"type":"MIT"}}
+   ·            ──────────────
+   ╰────
+  help: Use a string value such as `MIT`, `(MIT OR Apache-2.0)`, or `UNLICENSED`.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_man.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_man.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-man): The `man` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"man":""}
+   ·        ──
+   ╰────
+  help: Use a string or array of strings ending in a manpage section such as `.1` or `.1.gz`.
+
+  ⚠ oxc(package-json-valid-man): The `man` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"man":"./man/demo.md"}
+   ·        ───────────────
+   ╰────
+  help: Use a string or array of strings ending in a manpage section such as `.1` or `.1.gz`.
+
+  ⚠ oxc(package-json-valid-man): The `man` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"man":[]}
+   ·        ──
+   ╰────
+  help: Use a string or array of strings ending in a manpage section such as `.1` or `.1.gz`.
+
+  ⚠ oxc(package-json-valid-man): The `man` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"man":["./man/demo.1","./man/demo.md"]}
+   ·        ────────────────────────────────
+   ╰────
+  help: Use a string or array of strings ending in a manpage section such as `.1` or `.1.gz`.
+
+  ⚠ oxc(package-json-valid-man): The `man` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:8]
+ 1 │ {"man":1}
+   ·        ─
+   ╰────
+  help: Use a string or array of strings ending in a manpage section such as `.1` or `.1.gz`.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_name.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_name.snap
@@ -1,0 +1,73 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ oxc(package-json-valid-name): The `name` field in package.json must be a string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":1}
+   ·         ─
+   ╰────
+  help: Use a valid npm package name string.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: HTTP is a core module name; name can no longer contain capital letters.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":"HTTP","private":"true"}
+   ·         ──────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: name length must be greater than zero; name can only contain URL-friendly characters.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":""}
+   ·         ──
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: HTTP is a core module name; name can no longer contain capital letters.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":"HTTP"}
+   ·         ──────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: node_modules is not a valid package name.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":"node_modules"}
+   ·         ──────────────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: name cannot contain leading or trailing spaces; name can only contain URL-friendly characters.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":" demo"}
+   ·         ───────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: name can no longer contain special characters ("~'!()*").
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":"demo!"}
+   ·         ───────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: name can only contain URL-friendly characters.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":"demo package"}
+   ·         ──────────────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: name cannot start with an underscore.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":"_demo"}
+   ·         ───────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.
+
+  ⚠ oxc(package-json-valid-name): Invalid npm package name: name cannot start with a period.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:9]
+ 1 │ {"name":"@scope/.demo"}
+   ·         ──────────────
+   ╰────
+  help: Use a valid npm package name, or mark the package as private if it is not meant to be published.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_private.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_private.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ oxc(package-json-valid-private): The `private` field in package.json must be a boolean.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"private":"true"}
+   ·            ──────
+   ╰────
+  help: Use `true` or `false` for the package privacy flag.
+
+  ⚠ oxc(package-json-valid-private): The `private` field in package.json must be a boolean.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"private":"false"}
+   ·            ───────
+   ╰────
+  help: Use `true` or `false` for the package privacy flag.
+
+  ⚠ oxc(package-json-valid-private): The `private` field in package.json must be a boolean.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"private":1}
+   ·            ─
+   ╰────
+  help: Use `true` or `false` for the package privacy flag.
+
+  ⚠ oxc(package-json-valid-private): The `private` field in package.json must be a boolean.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"private":{}}
+   ·            ──
+   ╰────
+  help: Use `true` or `false` for the package privacy flag.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_repository.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_repository.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-repository): The `repository` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:15]
+ 1 │ {"repository":1}
+   ·               ─
+   ╰────
+  help: Use a valid repository shorthand, URL, or `{ type, url }` object.
+
+  ⚠ oxc(package-json-valid-repository): The `repository` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:15]
+ 1 │ {"repository":""}
+   ·               ──
+   ╰────
+  help: Use a valid repository shorthand, URL, or `{ type, url }` object.
+
+  ⚠ oxc(package-json-valid-repository): The `repository` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:15]
+ 1 │ {"repository":"github:"}
+   ·               ─────────
+   ╰────
+  help: Use a valid repository shorthand, URL, or `{ type, url }` object.
+
+  ⚠ oxc(package-json-valid-repository): The `repository` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:15]
+ 1 │ {"repository":"https://github.com"}
+   ·               ────────────────────
+   ╰────
+  help: Use a valid repository shorthand, URL, or `{ type, url }` object.
+
+  ⚠ oxc(package-json-valid-repository): The `repository` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:15]
+ 1 │ {"repository":{"type":"","url":"https://github.com/npm/example"}}
+   ·               ──────────────────────────────────────────────────
+   ╰────
+  help: Use a valid repository shorthand, URL, or `{ type, url }` object.
+
+  ⚠ oxc(package-json-valid-repository): The `repository` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:15]
+ 1 │ {"repository":{"type":"git","url":1}}
+   ·               ──────────────────────
+   ╰────
+  help: Use a valid repository shorthand, URL, or `{ type, url }` object.
+
+  ⚠ oxc(package-json-valid-repository): The `repository` field in package.json is invalid.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:15]
+ 1 │ {"repository":{"type":"git","url":"https://github.com/npm/example","directory":""}}
+   ·               ────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Use a valid repository shorthand, URL, or `{ type, url }` object.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_type.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_type.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-type): The `type` field in package.json must be `module` or `commonjs`, not `esm`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:23]
+ 1 │ {"name":"demo","type":"esm"}
+   ·                       ─────
+   ╰────
+  help: Use a valid Node package type or remove the field.
+
+  ⚠ oxc(package-json-valid-type): The `type` field in package.json must be a string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:23]
+ 1 │ {"name":"demo","type":true}
+   ·                       ────
+   ╰────
+  help: Use `module` or `commonjs` for the package type.
+
+  ⚠ oxc(package-json-valid-type): The `type` field in package.json must be a string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:23]
+ 1 │ {"name":"demo","type":1}
+   ·                       ─
+   ╰────
+  help: Use `module` or `commonjs` for the package type.

--- a/crates/oxc_linter/src/snapshots/oxc_package_json_valid_version.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_package_json_valid_version.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(package-json-valid-version): The `version` field in package.json must be a valid semver string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"version":"1.0"}
+   ·            ─────
+   ╰────
+  help: Use a version like `1.0.0`, `1.2.3-beta.1`, or `1.0.0+build.5`.
+
+  ⚠ oxc(package-json-valid-version): The `version` field in package.json must be a valid semver string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"version":"v1.0.0"}
+   ·            ────────
+   ╰────
+  help: Use a version like `1.0.0`, `1.2.3-beta.1`, or `1.0.0+build.5`.
+
+  ⚠ oxc(package-json-valid-version): The `version` field in package.json must be a valid semver string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"version":"01.0.0"}
+   ·            ────────
+   ╰────
+  help: Use a version like `1.0.0`, `1.2.3-beta.1`, or `1.0.0+build.5`.
+
+  ⚠ oxc(package-json-valid-version): The `version` field in package.json must be a valid semver string.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/package.json:1:12]
+ 1 │ {"version":1}
+   ·            ─
+   ╰────
+  help: Use a version like `1.0.0`, `1.2.3-beta.1`, or `1.0.0+build.5`.

--- a/crates/oxc_linter/src/snapshots/oxc_sorted_json_keys.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sorted_json_keys.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ oxc(sorted-json-keys): JSON object keys should be sorted.
+   ╭─[sorted_json_keys.json:1:1]
+ 1 │ {"b":"two","a":"one"}
+   · ─
+   ╰────
+  help: Sort object keys consistently to keep locale files easy to diff and review.
+
+  ⚠ oxc(sorted-json-keys): JSON object keys should be sorted.
+   ╭─[sorted_json_keys.json:1:1]
+ 1 │ {"z":"last","a":{"c":"three","b":"two"}}
+   · ─
+   ╰────
+  help: Sort object keys consistently to keep locale files easy to diff and review.
+
+  ⚠ oxc(sorted-json-keys): JSON object keys should be sorted.
+   ╭─[sorted_json_keys.json:1:1]
+ 1 │ {"a":"one","b":"two"}
+   · ─
+   ╰────
+  help: Sort object keys consistently to keep locale files easy to diff and review.

--- a/crates/oxc_linter/src/snapshots/oxc_valid_json.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_valid_json.snap
@@ -1,0 +1,27 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(valid-json): Invalid JSON: Unexpected character '}'
+   ╭─[valid_json.json:1:12]
+ 1 │ {"message":}
+   ·            ─
+   ╰────
+  help: Fix the JSON syntax error.
+
+  ⚠ oxc(valid-json): Invalid JSON: Expected string key
+   ╭─[valid_json.json:1:20]
+ 1 │ {"message":"hello",}
+   ·                    ─
+   ╰────
+  help: Fix the JSON syntax error.
+
+  ⚠ oxc(valid-json): Invalid JSON: Expected string key
+   ╭─[valid_json.json:2:3]
+ 1 │ {
+ 2 │   // comment
+   ·   ─
+ 3 │   "message": "hello"
+   ╰────
+  help: Fix the JSON syntax error.

--- a/crates/oxc_linter/src/snapshots/oxc_valid_message_syntax.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_valid_message_syntax.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(valid-message-syntax): Translation message must be a non-empty string.
+   ╭─[valid_message_syntax.json:1:10]
+ 1 │ {"title":""}
+   ·          ──
+   ╰────
+  help: Use a non-empty string for locale message leaves.
+
+  ⚠ oxc(valid-message-syntax): Translation message must be a non-empty string.
+   ╭─[valid_message_syntax.json:1:10]
+ 1 │ {"title":"   "}
+   ·          ─────
+   ╰────
+  help: Use a non-empty string for locale message leaves.
+
+  ⚠ oxc(valid-message-syntax): Translation message must be a non-empty string.
+   ╭─[valid_message_syntax.json:1:10]
+ 1 │ {"title":1}
+   ·          ─
+   ╰────
+  help: Use a non-empty string for locale message leaves.
+
+  ⚠ oxc(valid-message-syntax): Translation message must be a non-empty string.
+   ╭─[valid_message_syntax.json:1:17]
+ 1 │ {"items":["One",""]}
+   ·                 ──
+   ╰────
+  help: Use a non-empty string for locale message leaves.

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -337,6 +337,7 @@ mod test {
             Rc::new(ContextHost::new(
                 path,
                 vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 0)],
+                "",
                 LintOptions::default(),
                 Arc::default(),
             ))


### PR DESCRIPTION
## Summary

> **Merge after**: #21177 (JSON/CSS infrastructure)

Add 28 new rules for JSON, package.json, and i18n file validation:

**JSON rules (6):**
- `json-no-comments`, `json-no-duplicate-keys`, `json-no-trailing-commas`
- `json-parse-validation`, `valid-json`, `sorted-json-keys`

**i18n rules (3):**
- `identical-keys`, `identical-placeholders`, `valid-message-syntax`

**package.json rules (19):**
- `package-json-no-duplicate-dependencies`, `package-json-no-empty-fields`
- `package-json-no-redundant-publish-config`, `package-json-order-properties`
- `package-json-repository-shorthand`, `package-json-require-type`
- `package-json-require-version`, `package-json-sort-collections`
- `package-json-valid-bin`, `package-json-valid-description`
- `package-json-valid-engines`, `package-json-valid-keywords`
- `package-json-valid-license` (SPDX validation), `package-json-valid-man`
- `package-json-valid-name`, `package-json-valid-private`
- `package-json-valid-repository`, `package-json-valid-type`
- `package-json-valid-version`

Includes `json_utils.rs` utility module and i18n test fixtures.

## Test plan

- [x] `cargo test -p oxc_linter` — all 41 rule tests pass
- [x] `cargo lintgen` — generated files up to date
- [x] `just fmt` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)