### PR TITLE
feat(linter): add CSS, sorting, and code organization rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1530,7 +1530,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2072,6 +2072,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "smallvec",
+ "spdx",
  "url",
 ]
 
@@ -2992,7 +2993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3087,7 +3088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3290,6 +3291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,7 +3386,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3856,7 +3866,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ simdutf8 = { version = "0.1.5", features = ["aarch64_neon"] } # SIMD UTF-8 valid
 similar = "2.7.0" # Text diffing
 similar-asserts = "1.7.0" # Test diff assertions
 smallvec = { version = "1.15.1", features = ["union", "serde"] } # Stack-allocated vectors
+spdx = "0.13.4" # SPDX expression and identifier validation
 tempfile = "3.24.0" # Temporary files
 tokio = { version = "1.49.0", default-features = false } # Async runtime
 toml = { version = "1.0.0" }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -73,6 +73,7 @@ serde_json = { workspace = true, features = [
 ] } # preserve_order: print config with ordered keys.
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
+spdx = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/api/admin/users.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/api/admin/users.ts
@@ -1,0 +1,1 @@
+export const adminUsersApi = "admin-users-api";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/api/public/info.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/api/public/info.ts
@@ -1,0 +1,1 @@
+export const publicInfoApi = "public-info-api";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/api/user/profile.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/api/user/profile.ts
@@ -1,0 +1,1 @@
+export const userProfileApi = "user-profile-api";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/components/admin-card.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/components/admin-card.ts
@@ -1,0 +1,1 @@
+export const adminCard = "admin-card";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/components/ui/button.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/components/ui/button.ts
@@ -1,0 +1,1 @@
+export const uiButton = "ui-button";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/components/user-card.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/components/user-card.ts
@@ -1,0 +1,1 @@
+export const userCard = "user-card";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/experimental/scratch.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/experimental/scratch.ts
@@ -1,0 +1,1 @@
+export const scratch = "scratch";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/layouts/main.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/layouts/main.ts
@@ -1,0 +1,1 @@
+export const mainLayout = "main-layout";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/admin/dashboard.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/admin/dashboard.ts
@@ -1,0 +1,1 @@
+export const adminDashboard = "admin-dashboard";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/user/profile.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/user/profile.ts
@@ -1,0 +1,1 @@
+export const userProfile = "user-profile";

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -636,7 +636,7 @@ mod test {
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT | LintPlugins::UNICORN));
         let config: Oxlintrc =
-            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue"] }"#).unwrap();
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue", "json", "css"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::all()));
 
         let config: Oxlintrc =

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -94,6 +94,10 @@ bitflags! {
         const NODE = 1 << 12;
         /// `eslint-plugin-vue`
         const VUE = 1 << 13;
+        /// JSON linting rules
+        const JSON = 1 << 14;
+        /// CSS linting rules
+        const CSS = 1 << 15;
     }
 }
 
@@ -158,6 +162,8 @@ impl TryFrom<&str> for LintPlugins {
             "promise" => Ok(LintPlugins::PROMISE),
             "node" => Ok(LintPlugins::NODE),
             "vue" => Ok(LintPlugins::VUE),
+            "json" => Ok(LintPlugins::JSON),
+            "css" => Ok(LintPlugins::CSS),
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
             "eslint" => Ok(LintPlugins::ESLINT),
@@ -183,6 +189,8 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::PROMISE => "promise",
             LintPlugins::NODE => "node",
             LintPlugins::VUE => "vue",
+            LintPlugins::JSON => "json",
+            LintPlugins::CSS => "css",
             _ => "",
         }
     }
@@ -254,6 +262,8 @@ impl JsonSchema for LintPlugins {
             Promise,
             Node,
             Vue,
+            Json,
+            Css,
         }
 
         let enum_schema = r#gen.subschema_for::<LintPluginOptionsSchema>();

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -150,6 +150,8 @@ pub struct ContextHost<'a> {
     pub(crate) fix: FixKind,
     /// Path to the file being linted.
     pub(super) file_path: Box<Path>,
+    /// Original full source text of the file being linted.
+    pub(super) full_source_text: &'a str,
     /// Extension of the file being linted.
     file_extension: Option<Box<OsStr>>,
     /// Global linter configuration, such as globals to include and the target
@@ -171,6 +173,7 @@ impl<'a> ContextHost<'a> {
     pub fn new<P: AsRef<Path>>(
         file_path: P,
         sub_hosts: Vec<ContextSubHost<'a>>,
+        full_source_text: &'a str,
         options: LintOptions,
         config: Arc<LintConfig>,
     ) -> Self {
@@ -190,6 +193,7 @@ impl<'a> ContextHost<'a> {
             diagnostics: RefCell::new(Vec::with_capacity(DIAGNOSTICS_INITIAL_CAPACITY)),
             fix: options.fix,
             file_path,
+            full_source_text,
             file_extension,
             config,
             frameworks: options.framework_hints,
@@ -252,6 +256,12 @@ impl<'a> ContextHost<'a> {
     #[inline]
     pub fn file_path(&self) -> &Path {
         &self.file_path
+    }
+
+    /// Original full source text of the file being linted.
+    #[inline]
+    pub fn full_source_text(&self) -> &'a str {
+        self.full_source_text
     }
 
     /// Extension of the file currently being linted, without the leading dot.
@@ -506,5 +516,41 @@ impl<'a> ContextHost<'a> {
 impl<'a> From<ContextHost<'a>> for Vec<Message> {
     fn from(ctx_host: ContextHost<'a>) -> Self {
         ctx_host.diagnostics.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{rc::Rc, sync::Arc};
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_semantic::SemanticBuilder;
+    use oxc_span::SourceType;
+
+    use super::{ContextHost, ContextSubHost};
+    use crate::{ModuleRecord, options::LintOptions};
+
+    #[test]
+    fn test_full_source_text_preserves_original_file_text() {
+        let allocator = Allocator::default();
+        let section_source = "const section = 1;";
+        let full_source = "header\nconst section = 1;\nfooter";
+
+        let parser_ret = Parser::new(&allocator, section_source, SourceType::default()).parse();
+        let program = allocator.alloc(parser_ret.program);
+        let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
+
+        let ctx = Rc::new(ContextHost::new(
+            "fixture.vue",
+            vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 7)],
+            full_source,
+            LintOptions::default(),
+            Arc::default(),
+        ))
+        .spawn_for_test();
+
+        assert_eq!(ctx.source_text(), section_source);
+        assert_eq!(ctx.full_source_text(), full_source);
     }
 }

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -133,6 +133,22 @@ impl<'a> LintContext<'a> {
         span.source_text(self.parent.semantic().source_text())
     }
 
+    /// Get a snippet of original file text covered by the given [`Span`].
+    #[inline]
+    pub fn full_source_range(&self, span: Span) -> &'a str {
+        span.source_text(self.parent.full_source_text())
+    }
+
+    /// Original full source text of the file currently being linted.
+    ///
+    /// This differs from the semantic source text for partial-loader files and
+    /// future non-JS file pipelines, where the parsed section may represent only
+    /// one part of the original file.
+    #[inline]
+    pub fn full_source_text(&self) -> &'a str {
+        self.parent.full_source_text()
+    }
+
     /// Finds the next occurrence of the given token in the source code,
     /// starting from the specified position, skipping over comments.
     #[expect(clippy::cast_possible_truncation)]

--- a/crates/oxc_linter/src/css_parser.rs
+++ b/crates/oxc_linter/src/css_parser.rs
@@ -1,0 +1,578 @@
+//! Lightweight span-preserving CSS parser for linting.
+//!
+//! Parses plain CSS into a tree of stylesheet nodes with exact source spans.
+//! Designed for lint rules, not for full CSS spec compliance. Handles:
+//! - Qualified rules (selector + declaration block)
+//! - At-rules (@media, @import, etc.)
+//! - Declarations (property: value)
+//! - Comments (/* ... */)
+
+use oxc_span::Span;
+
+// ── AST ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct CssStylesheet<'a> {
+    pub rules: Vec<CssRule<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum CssRule<'a> {
+    QualifiedRule(CssQualifiedRule<'a>),
+    AtRule(CssAtRule<'a>),
+    Comment(CssComment<'a>),
+}
+
+impl CssRule<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::QualifiedRule(r) => r.span,
+            Self::AtRule(r) => r.span,
+            Self::Comment(c) => c.span,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CssQualifiedRule<'a> {
+    /// The raw selector text (e.g., `.foo > bar`).
+    pub selector: &'a str,
+    pub selector_span: Span,
+    pub block: CssDeclarationBlock<'a>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssAtRule<'a> {
+    /// The at-rule name without `@` (e.g., `media`, `import`).
+    pub name: &'a str,
+    pub name_span: Span,
+    /// The prelude text between the name and `{` or `;`.
+    pub prelude: &'a str,
+    pub prelude_span: Span,
+    /// Body block, if present (at-rules like @import have no block).
+    pub block: Option<CssRuleBlock<'a>>,
+    pub span: Span,
+}
+
+/// A block that can contain nested rules (e.g., @media body).
+#[derive(Debug)]
+pub struct CssRuleBlock<'a> {
+    pub rules: Vec<CssRule<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssDeclarationBlock<'a> {
+    pub declarations: Vec<CssDeclaration<'a>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssDeclaration<'a> {
+    pub property: &'a str,
+    pub property_span: Span,
+    pub value: &'a str,
+    pub value_span: Span,
+    pub important: bool,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct CssComment<'a> {
+    pub text: &'a str,
+    pub span: Span,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct CssParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct CssParseResult<'a> {
+    pub stylesheet: Option<CssStylesheet<'a>>,
+    pub errors: Vec<CssParseError>,
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+pub fn parse_css(source: &str) -> CssParseResult<'_> {
+    let mut parser = Parser::new(source);
+    let rules = parser.parse_rule_list();
+    let span = Span::new(0, source.len() as u32);
+    CssParseResult { stylesheet: Some(CssStylesheet { rules, span }), errors: parser.errors }
+}
+
+struct Parser<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    errors: Vec<CssParseError>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source, bytes: source.as_bytes(), pos: 0, errors: Vec::new() }
+    }
+
+    fn parse_rule_list(&mut self) -> Vec<CssRule<'a>> {
+        let mut rules = Vec::new();
+        loop {
+            self.skip_whitespace();
+            if self.pos >= self.bytes.len() {
+                break;
+            }
+            // Stop if we hit a closing brace (end of containing block)
+            if self.peek() == Some(b'}') {
+                break;
+            }
+            let before = self.pos;
+            if let Some(rule) = self.parse_rule() {
+                rules.push(rule);
+            } else if self.pos == before {
+                // No progress — skip one byte to avoid infinite loop
+                self.pos += 1;
+            }
+        }
+        rules
+    }
+
+    fn parse_rule(&mut self) -> Option<CssRule<'a>> {
+        self.skip_whitespace();
+        if self.pos >= self.bytes.len() {
+            return None;
+        }
+
+        // Comment
+        if self.starts_with(b"/*") {
+            return self.parse_comment().map(CssRule::Comment);
+        }
+
+        // At-rule
+        if self.peek() == Some(b'@') {
+            return self.parse_at_rule().map(CssRule::AtRule);
+        }
+
+        // Closing brace (end of nested block)
+        if self.peek() == Some(b'}') {
+            return None;
+        }
+
+        // Qualified rule
+        self.parse_qualified_rule().map(CssRule::QualifiedRule)
+    }
+
+    fn parse_comment(&mut self) -> Option<CssComment<'a>> {
+        let start = self.pos;
+        self.pos += 2; // skip /*
+        let text_start = self.pos;
+        loop {
+            if self.pos + 1 >= self.bytes.len() {
+                self.errors.push(CssParseError {
+                    message: "Unterminated comment".to_string(),
+                    span: Span::new(start as u32, self.bytes.len() as u32),
+                });
+                let text = &self.source[text_start..self.bytes.len()];
+                self.pos = self.bytes.len();
+                return Some(CssComment {
+                    text,
+                    span: Span::new(start as u32, self.bytes.len() as u32),
+                });
+            }
+            if self.bytes[self.pos] == b'*' && self.bytes[self.pos + 1] == b'/' {
+                let text = &self.source[text_start..self.pos];
+                self.pos += 2; // skip */
+                return Some(CssComment { text, span: Span::new(start as u32, self.pos as u32) });
+            }
+            self.pos += 1;
+        }
+    }
+
+    fn parse_at_rule(&mut self) -> Option<CssAtRule<'a>> {
+        let start = self.pos;
+        self.pos += 1; // skip @
+
+        // Parse name
+        let name_start = self.pos;
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_alphanumeric()
+            || self.pos < self.bytes.len() && self.bytes[self.pos] == b'-'
+        {
+            self.pos += 1;
+        }
+        let name = &self.source[name_start..self.pos];
+        let name_span = Span::new((start) as u32, self.pos as u32); // includes @
+
+        // Parse prelude (everything until { or ;)
+        self.skip_whitespace();
+        let prelude_start = self.pos;
+        let mut depth = 0u32;
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b'{' if depth == 0 => break,
+                b';' if depth == 0 => break,
+                b'(' => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                b')' => {
+                    depth = depth.saturating_sub(1);
+                    self.pos += 1;
+                }
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let prelude_end = self.pos;
+        let prelude = self.source[prelude_start..prelude_end].trim();
+        let prelude_span = Span::new(prelude_start as u32, prelude_end as u32);
+
+        if self.pos >= self.bytes.len() {
+            return Some(CssAtRule {
+                name,
+                name_span,
+                prelude,
+                prelude_span,
+                block: None,
+                span: Span::new(start as u32, self.pos as u32),
+            });
+        }
+
+        // Semicolon-terminated at-rule (e.g., @import)
+        if self.bytes[self.pos] == b';' {
+            self.pos += 1;
+            return Some(CssAtRule {
+                name,
+                name_span,
+                prelude,
+                prelude_span,
+                block: None,
+                span: Span::new(start as u32, self.pos as u32),
+            });
+        }
+
+        // Block at-rule (e.g., @media)
+        let block = self.parse_rule_block();
+        Some(CssAtRule {
+            name,
+            name_span,
+            prelude,
+            prelude_span,
+            block: Some(block),
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn parse_rule_block(&mut self) -> CssRuleBlock<'a> {
+        let block_start = self.pos;
+        self.pos += 1; // skip {
+        let rules = self.parse_rule_list();
+        self.skip_whitespace();
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b'}' {
+            self.pos += 1;
+        }
+        CssRuleBlock { rules, span: Span::new(block_start as u32, self.pos as u32) }
+    }
+
+    fn parse_qualified_rule(&mut self) -> Option<CssQualifiedRule<'a>> {
+        let start = self.pos;
+
+        // Parse selector (everything until {)
+        let selector_start = self.pos;
+        while self.pos < self.bytes.len() && self.bytes[self.pos] != b'{' {
+            match self.bytes[self.pos] {
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let selector_end = self.pos;
+        let selector = self.source[selector_start..selector_end].trim();
+        let selector_span = Span::new(selector_start as u32, selector_end as u32);
+
+        if self.pos >= self.bytes.len() {
+            self.errors.push(CssParseError {
+                message: "Expected '{' after selector".to_string(),
+                span: Span::new(start as u32, self.pos as u32),
+            });
+            return None;
+        }
+
+        let block = self.parse_declaration_block();
+
+        Some(CssQualifiedRule {
+            selector,
+            selector_span,
+            block,
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn parse_declaration_block(&mut self) -> CssDeclarationBlock<'a> {
+        let block_start = self.pos;
+        self.pos += 1; // skip {
+        let mut declarations = Vec::new();
+
+        loop {
+            self.skip_whitespace();
+            if self.pos >= self.bytes.len() || self.bytes[self.pos] == b'}' {
+                break;
+            }
+
+            // Skip comments inside blocks
+            if self.starts_with(b"/*") {
+                self.parse_comment();
+                continue;
+            }
+
+            if let Some(decl) = self.parse_declaration() {
+                declarations.push(decl);
+            }
+        }
+
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b'}' {
+            self.pos += 1;
+        }
+
+        CssDeclarationBlock { declarations, span: Span::new(block_start as u32, self.pos as u32) }
+    }
+
+    fn parse_declaration(&mut self) -> Option<CssDeclaration<'a>> {
+        let start = self.pos;
+
+        // Parse property name
+        let prop_start = self.pos;
+        while self.pos < self.bytes.len()
+            && self.bytes[self.pos] != b':'
+            && self.bytes[self.pos] != b'}'
+            && self.bytes[self.pos] != b';'
+        {
+            self.pos += 1;
+        }
+        let property = self.source[prop_start..self.pos].trim();
+        let property_span = Span::new(prop_start as u32, self.pos as u32);
+
+        if property.is_empty() || self.pos >= self.bytes.len() || self.bytes[self.pos] != b':' {
+            // Not a valid declaration — skip to next ; or }
+            while self.pos < self.bytes.len()
+                && self.bytes[self.pos] != b';'
+                && self.bytes[self.pos] != b'}'
+            {
+                self.pos += 1;
+            }
+            if self.pos < self.bytes.len() && self.bytes[self.pos] == b';' {
+                self.pos += 1;
+            }
+            return None;
+        }
+
+        self.pos += 1; // skip :
+        self.skip_whitespace();
+
+        // Parse value (everything until ; or })
+        let value_start = self.pos;
+        let mut depth = 0u32;
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b';' if depth == 0 => break,
+                b'}' if depth == 0 => break,
+                b'(' => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                b')' => {
+                    depth = depth.saturating_sub(1);
+                    self.pos += 1;
+                }
+                b'\'' | b'"' => self.skip_string(),
+                _ => self.pos += 1,
+            }
+        }
+        let value_end = self.pos;
+        let raw_value = self.source[value_start..value_end].trim();
+        let value_span = Span::new(value_start as u32, value_end as u32);
+
+        let important = raw_value.ends_with("!important") || raw_value.ends_with("! important");
+        let value = if important {
+            raw_value.trim_end_matches("!important").trim_end_matches("! important").trim()
+        } else {
+            raw_value
+        };
+
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b';' {
+            self.pos += 1;
+        }
+
+        Some(CssDeclaration {
+            property,
+            property_span,
+            value,
+            value_span,
+            important,
+            span: Span::new(start as u32, self.pos as u32),
+        })
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn skip_string(&mut self) {
+        let quote = self.bytes[self.pos];
+        self.pos += 1;
+        while self.pos < self.bytes.len() {
+            if self.bytes[self.pos] == b'\\' {
+                self.pos += 2;
+                continue;
+            }
+            if self.bytes[self.pos] == quote {
+                self.pos += 1;
+                return;
+            }
+            self.pos += 1;
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn starts_with(&self, prefix: &[u8]) -> bool {
+        self.bytes[self.pos..].starts_with(prefix)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_rule() {
+        let css = "body { color: red; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        assert_eq!(sheet.rules.len(), 1);
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.selector, "body");
+            assert_eq!(rule.block.declarations.len(), 1);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[0].value, "red");
+            assert!(!rule.block.declarations[0].important);
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_important() {
+        let css = ".x { color: red !important; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations[0].value, "red");
+            assert!(rule.block.declarations[0].important);
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_multiple_declarations() {
+        let css = "h1 { color: blue; font-size: 16px; margin: 0; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations.len(), 3);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[1].property, "font-size");
+            assert_eq!(rule.block.declarations[2].property, "margin");
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_at_rule_import() {
+        let css = "@import url('styles.css');";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::AtRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.name, "import");
+            assert!(rule.prelude.contains("styles.css"));
+            assert!(rule.block.is_none());
+        } else {
+            panic!("Expected at-rule");
+        }
+    }
+
+    #[test]
+    fn parse_at_rule_media() {
+        let css = "@media (max-width: 768px) { body { color: red; } }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::AtRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.name, "media");
+            assert!(rule.block.is_some());
+            let block = rule.block.as_ref().unwrap();
+            assert_eq!(block.rules.len(), 1);
+        } else {
+            panic!("Expected at-rule");
+        }
+    }
+
+    #[test]
+    fn parse_comment() {
+        let css = "/* hello */ body { color: red; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        assert_eq!(sheet.rules.len(), 2);
+        if let CssRule::Comment(c) = &sheet.rules[0] {
+            assert_eq!(c.text, " hello ");
+        } else {
+            panic!("Expected comment");
+        }
+    }
+
+    #[test]
+    fn parse_duplicate_properties() {
+        let css = ".a { color: red; color: blue; }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert_eq!(rule.block.declarations.len(), 2);
+            assert_eq!(rule.block.declarations[0].property, "color");
+            assert_eq!(rule.block.declarations[1].property, "color");
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+
+    #[test]
+    fn parse_empty_block() {
+        let css = ".empty { }";
+        let result = parse_css(css);
+        assert!(result.errors.is_empty());
+        let sheet = result.stylesheet.unwrap();
+        if let CssRule::QualifiedRule(rule) = &sheet.rules[0] {
+            assert!(rule.block.declarations.is_empty());
+        } else {
+            panic!("Expected qualified rule");
+        }
+    }
+}

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -75,6 +75,12 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self.ctx.source_range(span)
     }
 
+    /// Get a snippet of original file text covered by the given [`Span`].
+    #[inline]
+    pub fn full_source_range(&self, span: Span) -> &'a str {
+        self.ctx.full_source_range(span)
+    }
+
     /// Create a [`RuleFix`] that deletes the text covered by the given [`Span`]
     /// or AST node.
     #[inline]
@@ -125,6 +131,30 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
             fixer.new_fix(CompositeFix::Single(fix), message)
         }
+        inner(self, target, replacement.into())
+    }
+
+    /// Replace a span in the original full file text.
+    pub fn replace_full_source_range<S: Into<Cow<'static, str>>>(
+        &self,
+        target: Span,
+        replacement: S,
+    ) -> RuleFix {
+        fn inner(
+            fixer: &RuleFixer<'_, '_>,
+            target: Span,
+            replacement: Cow<'static, str>,
+        ) -> RuleFix {
+            let fix = Fix::new(replacement, target);
+            let target_text = fixer.possibly_truncate_full_source_range(target);
+            let content = fixer.possibly_truncate_snippet(&fix.content);
+            let message = fixer.auto_message.then(|| {
+                Cow::Owned(format_replace_message(target_text.as_ref(), content.as_ref()))
+            });
+
+            fixer.new_fix(CompositeFix::Single(fix), message)
+        }
+
         inner(self, target, replacement.into())
     }
 
@@ -203,6 +233,11 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 
     fn possibly_truncate_range(&self, span: Span) -> Cow<'a, str> {
         let snippet = self.ctx.source_range(span);
+        self.possibly_truncate_snippet(snippet)
+    }
+
+    fn possibly_truncate_full_source_range(&self, span: Span) -> Cow<'a, str> {
+        let snippet = self.ctx.full_source_range(span);
         self.possibly_truncate_snippet(snippet)
     }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3923,6 +3923,108 @@ impl RuleRunner for crate::rules::oxc::uninvoked_array_callback::UninvokedArrayC
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::oxc::avoid_barrel_files::AvoidBarrelFiles {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::avoid_re_export_all::AvoidReExportAll {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExportAllDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::boundaries_dependencies::BoundariesDependencies {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::css_no_duplicate_properties::CssNoDuplicateProperties {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::css_no_empty_blocks::CssNoEmptyBlocks {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::css_no_important::CssNoImportant {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::optimize_regex::OptimizeRegex {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::RegExpLiteral]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_enums::SortEnums {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSEnumDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_imports::SortImports {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_interfaces::SortInterfaces {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSInterfaceDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_intersection_types::SortIntersectionTypes {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSIntersectionType]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_jsx_props::SortJsxProps {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_named_exports::SortNamedExports {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExportNamedDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_named_imports::SortNamedImports {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_object_types::SortObjectTypes {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSTypeLiteral]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_objects::SortObjects {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_switch_case::SortSwitchCase {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::sort_union_types::SortUnionTypes {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSUnionType]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::nextjs::google_font_display::GoogleFontDisplay {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -344,6 +344,8 @@ pub use crate::rules::node::no_new_require::NoNewRequire as NodeNoNewRequire;
 pub use crate::rules::node::no_path_concat::NoPathConcat as NodeNoPathConcat;
 pub use crate::rules::node::no_process_env::NoProcessEnv as NodeNoProcessEnv;
 pub use crate::rules::oxc::approx_constant::ApproxConstant as OxcApproxConstant;
+pub use crate::rules::oxc::avoid_barrel_files::AvoidBarrelFiles as OxcAvoidBarrelFiles;
+pub use crate::rules::oxc::avoid_re_export_all::AvoidReExportAll as OxcAvoidReExportAll;
 pub use crate::rules::oxc::bad_array_method_on_arguments::BadArrayMethodOnArguments as OxcBadArrayMethodOnArguments;
 pub use crate::rules::oxc::bad_bitwise_operator::BadBitwiseOperator as OxcBadBitwiseOperator;
 pub use crate::rules::oxc::bad_char_at_comparison::BadCharAtComparison as OxcBadCharAtComparison;
@@ -351,8 +353,12 @@ pub use crate::rules::oxc::bad_comparison_sequence::BadComparisonSequence as Oxc
 pub use crate::rules::oxc::bad_min_max_func::BadMinMaxFunc as OxcBadMinMaxFunc;
 pub use crate::rules::oxc::bad_object_literal_comparison::BadObjectLiteralComparison as OxcBadObjectLiteralComparison;
 pub use crate::rules::oxc::bad_replace_all_arg::BadReplaceAllArg as OxcBadReplaceAllArg;
+pub use crate::rules::oxc::boundaries_dependencies::BoundariesDependencies as OxcBoundariesDependencies;
 pub use crate::rules::oxc::branches_sharing_code::BranchesSharingCode as OxcBranchesSharingCode;
 pub use crate::rules::oxc::const_comparisons::ConstComparisons as OxcConstComparisons;
+pub use crate::rules::oxc::css_no_duplicate_properties::CssNoDuplicateProperties as OxcCssNoDuplicateProperties;
+pub use crate::rules::oxc::css_no_empty_blocks::CssNoEmptyBlocks as OxcCssNoEmptyBlocks;
+pub use crate::rules::oxc::css_no_important::CssNoImportant as OxcCssNoImportant;
 pub use crate::rules::oxc::double_comparisons::DoubleComparisons as OxcDoubleComparisons;
 pub use crate::rules::oxc::erasing_op::ErasingOp as OxcErasingOp;
 pub use crate::rules::oxc::misrefactored_assign_op::MisrefactoredAssignOp as OxcMisrefactoredAssignOp;
@@ -368,6 +374,18 @@ pub use crate::rules::oxc::no_rest_spread_properties::NoRestSpreadProperties as 
 pub use crate::rules::oxc::no_this_in_exported_function::NoThisInExportedFunction as OxcNoThisInExportedFunction;
 pub use crate::rules::oxc::number_arg_out_of_range::NumberArgOutOfRange as OxcNumberArgOutOfRange;
 pub use crate::rules::oxc::only_used_in_recursion::OnlyUsedInRecursion as OxcOnlyUsedInRecursion;
+pub use crate::rules::oxc::optimize_regex::OptimizeRegex as OxcOptimizeRegex;
+pub use crate::rules::oxc::sort_enums::SortEnums as OxcSortEnums;
+pub use crate::rules::oxc::sort_imports::SortImports as OxcSortImports;
+pub use crate::rules::oxc::sort_interfaces::SortInterfaces as OxcSortInterfaces;
+pub use crate::rules::oxc::sort_intersection_types::SortIntersectionTypes as OxcSortIntersectionTypes;
+pub use crate::rules::oxc::sort_jsx_props::SortJsxProps as OxcSortJsxProps;
+pub use crate::rules::oxc::sort_named_exports::SortNamedExports as OxcSortNamedExports;
+pub use crate::rules::oxc::sort_named_imports::SortNamedImports as OxcSortNamedImports;
+pub use crate::rules::oxc::sort_object_types::SortObjectTypes as OxcSortObjectTypes;
+pub use crate::rules::oxc::sort_objects::SortObjects as OxcSortObjects;
+pub use crate::rules::oxc::sort_switch_case::SortSwitchCase as OxcSortSwitchCase;
+pub use crate::rules::oxc::sort_union_types::SortUnionTypes as OxcSortUnionTypes;
 pub use crate::rules::oxc::uninvoked_array_callback::UninvokedArrayCallback as OxcUninvokedArrayCallback;
 pub use crate::rules::promise::always_return::AlwaysReturn as PromiseAlwaysReturn;
 pub use crate::rules::promise::avoid_new::AvoidNew as PromiseAvoidNew;
@@ -1339,6 +1357,24 @@ pub enum RuleEnum {
     OxcNumberArgOutOfRange(OxcNumberArgOutOfRange),
     OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion),
     OxcUninvokedArrayCallback(OxcUninvokedArrayCallback),
+    OxcAvoidBarrelFiles(OxcAvoidBarrelFiles),
+    OxcAvoidReExportAll(OxcAvoidReExportAll),
+    OxcBoundariesDependencies(OxcBoundariesDependencies),
+    OxcCssNoDuplicateProperties(OxcCssNoDuplicateProperties),
+    OxcCssNoEmptyBlocks(OxcCssNoEmptyBlocks),
+    OxcCssNoImportant(OxcCssNoImportant),
+    OxcOptimizeRegex(OxcOptimizeRegex),
+    OxcSortEnums(OxcSortEnums),
+    OxcSortImports(OxcSortImports),
+    OxcSortInterfaces(OxcSortInterfaces),
+    OxcSortIntersectionTypes(OxcSortIntersectionTypes),
+    OxcSortJsxProps(OxcSortJsxProps),
+    OxcSortNamedExports(OxcSortNamedExports),
+    OxcSortNamedImports(OxcSortNamedImports),
+    OxcSortObjectTypes(OxcSortObjectTypes),
+    OxcSortObjects(OxcSortObjects),
+    OxcSortSwitchCase(OxcSortSwitchCase),
+    OxcSortUnionTypes(OxcSortUnionTypes),
     NextjsGoogleFontDisplay(NextjsGoogleFontDisplay),
     NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect),
     NextjsInlineScriptId(NextjsInlineScriptId),
@@ -2132,7 +2168,25 @@ const OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID: usize = OXC_NO_REST_SPREAD_PROPERTIES
 const OXC_NUMBER_ARG_OUT_OF_RANGE_ID: usize = OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID + 1usize;
 const OXC_ONLY_USED_IN_RECURSION_ID: usize = OXC_NUMBER_ARG_OUT_OF_RANGE_ID + 1usize;
 const OXC_UNINVOKED_ARRAY_CALLBACK_ID: usize = OXC_ONLY_USED_IN_RECURSION_ID + 1usize;
-const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_AVOID_BARREL_FILES_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_AVOID_RE_EXPORT_ALL_ID: usize = OXC_AVOID_BARREL_FILES_ID + 1usize;
+const OXC_BOUNDARIES_DEPENDENCIES_ID: usize = OXC_AVOID_RE_EXPORT_ALL_ID + 1usize;
+const OXC_CSS_NO_DUPLICATE_PROPERTIES_ID: usize = OXC_BOUNDARIES_DEPENDENCIES_ID + 1usize;
+const OXC_CSS_NO_EMPTY_BLOCKS_ID: usize = OXC_CSS_NO_DUPLICATE_PROPERTIES_ID + 1usize;
+const OXC_CSS_NO_IMPORTANT_ID: usize = OXC_CSS_NO_EMPTY_BLOCKS_ID + 1usize;
+const OXC_OPTIMIZE_REGEX_ID: usize = OXC_CSS_NO_IMPORTANT_ID + 1usize;
+const OXC_SORT_ENUMS_ID: usize = OXC_OPTIMIZE_REGEX_ID + 1usize;
+const OXC_SORT_IMPORTS_ID: usize = OXC_SORT_ENUMS_ID + 1usize;
+const OXC_SORT_INTERFACES_ID: usize = OXC_SORT_IMPORTS_ID + 1usize;
+const OXC_SORT_INTERSECTION_TYPES_ID: usize = OXC_SORT_INTERFACES_ID + 1usize;
+const OXC_SORT_JSX_PROPS_ID: usize = OXC_SORT_INTERSECTION_TYPES_ID + 1usize;
+const OXC_SORT_NAMED_EXPORTS_ID: usize = OXC_SORT_JSX_PROPS_ID + 1usize;
+const OXC_SORT_NAMED_IMPORTS_ID: usize = OXC_SORT_NAMED_EXPORTS_ID + 1usize;
+const OXC_SORT_OBJECT_TYPES_ID: usize = OXC_SORT_NAMED_IMPORTS_ID + 1usize;
+const OXC_SORT_OBJECTS_ID: usize = OXC_SORT_OBJECT_TYPES_ID + 1usize;
+const OXC_SORT_SWITCH_CASE_ID: usize = OXC_SORT_OBJECTS_ID + 1usize;
+const OXC_SORT_UNION_TYPES_ID: usize = OXC_SORT_SWITCH_CASE_ID + 1usize;
+const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_SORT_UNION_TYPES_ID + 1usize;
 const NEXTJS_GOOGLE_FONT_PRECONNECT_ID: usize = NEXTJS_GOOGLE_FONT_DISPLAY_ID + 1usize;
 const NEXTJS_INLINE_SCRIPT_ID_ID: usize = NEXTJS_GOOGLE_FONT_PRECONNECT_ID + 1usize;
 const NEXTJS_NEXT_SCRIPT_FOR_GA_ID: usize = NEXTJS_INLINE_SCRIPT_ID_ID + 1usize;
@@ -2954,6 +3008,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OXC_NUMBER_ARG_OUT_OF_RANGE_ID,
             Self::OxcOnlyUsedInRecursion(_) => OXC_ONLY_USED_IN_RECURSION_ID,
             Self::OxcUninvokedArrayCallback(_) => OXC_UNINVOKED_ARRAY_CALLBACK_ID,
+            Self::OxcAvoidBarrelFiles(_) => OXC_AVOID_BARREL_FILES_ID,
+            Self::OxcAvoidReExportAll(_) => OXC_AVOID_RE_EXPORT_ALL_ID,
+            Self::OxcBoundariesDependencies(_) => OXC_BOUNDARIES_DEPENDENCIES_ID,
+            Self::OxcCssNoDuplicateProperties(_) => OXC_CSS_NO_DUPLICATE_PROPERTIES_ID,
+            Self::OxcCssNoEmptyBlocks(_) => OXC_CSS_NO_EMPTY_BLOCKS_ID,
+            Self::OxcCssNoImportant(_) => OXC_CSS_NO_IMPORTANT_ID,
+            Self::OxcOptimizeRegex(_) => OXC_OPTIMIZE_REGEX_ID,
+            Self::OxcSortEnums(_) => OXC_SORT_ENUMS_ID,
+            Self::OxcSortImports(_) => OXC_SORT_IMPORTS_ID,
+            Self::OxcSortInterfaces(_) => OXC_SORT_INTERFACES_ID,
+            Self::OxcSortIntersectionTypes(_) => OXC_SORT_INTERSECTION_TYPES_ID,
+            Self::OxcSortJsxProps(_) => OXC_SORT_JSX_PROPS_ID,
+            Self::OxcSortNamedExports(_) => OXC_SORT_NAMED_EXPORTS_ID,
+            Self::OxcSortNamedImports(_) => OXC_SORT_NAMED_IMPORTS_ID,
+            Self::OxcSortObjectTypes(_) => OXC_SORT_OBJECT_TYPES_ID,
+            Self::OxcSortObjects(_) => OXC_SORT_OBJECTS_ID,
+            Self::OxcSortSwitchCase(_) => OXC_SORT_SWITCH_CASE_ID,
+            Self::OxcSortUnionTypes(_) => OXC_SORT_UNION_TYPES_ID,
             Self::NextjsGoogleFontDisplay(_) => NEXTJS_GOOGLE_FONT_DISPLAY_ID,
             Self::NextjsGoogleFontPreconnect(_) => NEXTJS_GOOGLE_FONT_PRECONNECT_ID,
             Self::NextjsInlineScriptId(_) => NEXTJS_INLINE_SCRIPT_ID_ID,
@@ -3764,6 +3836,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::NAME,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::NAME,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::NAME,
+            Self::OxcAvoidBarrelFiles(_) => OxcAvoidBarrelFiles::NAME,
+            Self::OxcAvoidReExportAll(_) => OxcAvoidReExportAll::NAME,
+            Self::OxcBoundariesDependencies(_) => OxcBoundariesDependencies::NAME,
+            Self::OxcCssNoDuplicateProperties(_) => OxcCssNoDuplicateProperties::NAME,
+            Self::OxcCssNoEmptyBlocks(_) => OxcCssNoEmptyBlocks::NAME,
+            Self::OxcCssNoImportant(_) => OxcCssNoImportant::NAME,
+            Self::OxcOptimizeRegex(_) => OxcOptimizeRegex::NAME,
+            Self::OxcSortEnums(_) => OxcSortEnums::NAME,
+            Self::OxcSortImports(_) => OxcSortImports::NAME,
+            Self::OxcSortInterfaces(_) => OxcSortInterfaces::NAME,
+            Self::OxcSortIntersectionTypes(_) => OxcSortIntersectionTypes::NAME,
+            Self::OxcSortJsxProps(_) => OxcSortJsxProps::NAME,
+            Self::OxcSortNamedExports(_) => OxcSortNamedExports::NAME,
+            Self::OxcSortNamedImports(_) => OxcSortNamedImports::NAME,
+            Self::OxcSortObjectTypes(_) => OxcSortObjectTypes::NAME,
+            Self::OxcSortObjects(_) => OxcSortObjects::NAME,
+            Self::OxcSortSwitchCase(_) => OxcSortSwitchCase::NAME,
+            Self::OxcSortUnionTypes(_) => OxcSortUnionTypes::NAME,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::NAME,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::NAME,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::NAME,
@@ -4616,6 +4706,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::CATEGORY,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::CATEGORY,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::CATEGORY,
+            Self::OxcAvoidBarrelFiles(_) => OxcAvoidBarrelFiles::CATEGORY,
+            Self::OxcAvoidReExportAll(_) => OxcAvoidReExportAll::CATEGORY,
+            Self::OxcBoundariesDependencies(_) => OxcBoundariesDependencies::CATEGORY,
+            Self::OxcCssNoDuplicateProperties(_) => OxcCssNoDuplicateProperties::CATEGORY,
+            Self::OxcCssNoEmptyBlocks(_) => OxcCssNoEmptyBlocks::CATEGORY,
+            Self::OxcCssNoImportant(_) => OxcCssNoImportant::CATEGORY,
+            Self::OxcOptimizeRegex(_) => OxcOptimizeRegex::CATEGORY,
+            Self::OxcSortEnums(_) => OxcSortEnums::CATEGORY,
+            Self::OxcSortImports(_) => OxcSortImports::CATEGORY,
+            Self::OxcSortInterfaces(_) => OxcSortInterfaces::CATEGORY,
+            Self::OxcSortIntersectionTypes(_) => OxcSortIntersectionTypes::CATEGORY,
+            Self::OxcSortJsxProps(_) => OxcSortJsxProps::CATEGORY,
+            Self::OxcSortNamedExports(_) => OxcSortNamedExports::CATEGORY,
+            Self::OxcSortNamedImports(_) => OxcSortNamedImports::CATEGORY,
+            Self::OxcSortObjectTypes(_) => OxcSortObjectTypes::CATEGORY,
+            Self::OxcSortObjects(_) => OxcSortObjects::CATEGORY,
+            Self::OxcSortSwitchCase(_) => OxcSortSwitchCase::CATEGORY,
+            Self::OxcSortUnionTypes(_) => OxcSortUnionTypes::CATEGORY,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::CATEGORY,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::CATEGORY,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::CATEGORY,
@@ -5435,6 +5543,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::FIX,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::FIX,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::FIX,
+            Self::OxcAvoidBarrelFiles(_) => OxcAvoidBarrelFiles::FIX,
+            Self::OxcAvoidReExportAll(_) => OxcAvoidReExportAll::FIX,
+            Self::OxcBoundariesDependencies(_) => OxcBoundariesDependencies::FIX,
+            Self::OxcCssNoDuplicateProperties(_) => OxcCssNoDuplicateProperties::FIX,
+            Self::OxcCssNoEmptyBlocks(_) => OxcCssNoEmptyBlocks::FIX,
+            Self::OxcCssNoImportant(_) => OxcCssNoImportant::FIX,
+            Self::OxcOptimizeRegex(_) => OxcOptimizeRegex::FIX,
+            Self::OxcSortEnums(_) => OxcSortEnums::FIX,
+            Self::OxcSortImports(_) => OxcSortImports::FIX,
+            Self::OxcSortInterfaces(_) => OxcSortInterfaces::FIX,
+            Self::OxcSortIntersectionTypes(_) => OxcSortIntersectionTypes::FIX,
+            Self::OxcSortJsxProps(_) => OxcSortJsxProps::FIX,
+            Self::OxcSortNamedExports(_) => OxcSortNamedExports::FIX,
+            Self::OxcSortNamedImports(_) => OxcSortNamedImports::FIX,
+            Self::OxcSortObjectTypes(_) => OxcSortObjectTypes::FIX,
+            Self::OxcSortObjects(_) => OxcSortObjects::FIX,
+            Self::OxcSortSwitchCase(_) => OxcSortSwitchCase::FIX,
+            Self::OxcSortUnionTypes(_) => OxcSortUnionTypes::FIX,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::FIX,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::FIX,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::FIX,
@@ -6432,6 +6558,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::documentation(),
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::documentation(),
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::documentation(),
+            Self::OxcAvoidBarrelFiles(_) => OxcAvoidBarrelFiles::documentation(),
+            Self::OxcAvoidReExportAll(_) => OxcAvoidReExportAll::documentation(),
+            Self::OxcBoundariesDependencies(_) => OxcBoundariesDependencies::documentation(),
+            Self::OxcCssNoDuplicateProperties(_) => OxcCssNoDuplicateProperties::documentation(),
+            Self::OxcCssNoEmptyBlocks(_) => OxcCssNoEmptyBlocks::documentation(),
+            Self::OxcCssNoImportant(_) => OxcCssNoImportant::documentation(),
+            Self::OxcOptimizeRegex(_) => OxcOptimizeRegex::documentation(),
+            Self::OxcSortEnums(_) => OxcSortEnums::documentation(),
+            Self::OxcSortImports(_) => OxcSortImports::documentation(),
+            Self::OxcSortInterfaces(_) => OxcSortInterfaces::documentation(),
+            Self::OxcSortIntersectionTypes(_) => OxcSortIntersectionTypes::documentation(),
+            Self::OxcSortJsxProps(_) => OxcSortJsxProps::documentation(),
+            Self::OxcSortNamedExports(_) => OxcSortNamedExports::documentation(),
+            Self::OxcSortNamedImports(_) => OxcSortNamedImports::documentation(),
+            Self::OxcSortObjectTypes(_) => OxcSortObjectTypes::documentation(),
+            Self::OxcSortObjects(_) => OxcSortObjects::documentation(),
+            Self::OxcSortSwitchCase(_) => OxcSortSwitchCase::documentation(),
+            Self::OxcSortUnionTypes(_) => OxcSortUnionTypes::documentation(),
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::documentation(),
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::documentation(),
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::documentation(),
@@ -8313,6 +8457,47 @@ impl RuleEnum {
                 OxcUninvokedArrayCallback::config_schema(generator)
                     .or_else(|| OxcUninvokedArrayCallback::schema(generator))
             }
+            Self::OxcAvoidBarrelFiles(_) => OxcAvoidBarrelFiles::config_schema(generator)
+                .or_else(|| OxcAvoidBarrelFiles::schema(generator)),
+            Self::OxcAvoidReExportAll(_) => OxcAvoidReExportAll::config_schema(generator)
+                .or_else(|| OxcAvoidReExportAll::schema(generator)),
+            Self::OxcBoundariesDependencies(_) => {
+                OxcBoundariesDependencies::config_schema(generator)
+                    .or_else(|| OxcBoundariesDependencies::schema(generator))
+            }
+            Self::OxcCssNoDuplicateProperties(_) => {
+                OxcCssNoDuplicateProperties::config_schema(generator)
+                    .or_else(|| OxcCssNoDuplicateProperties::schema(generator))
+            }
+            Self::OxcCssNoEmptyBlocks(_) => OxcCssNoEmptyBlocks::config_schema(generator)
+                .or_else(|| OxcCssNoEmptyBlocks::schema(generator)),
+            Self::OxcCssNoImportant(_) => OxcCssNoImportant::config_schema(generator)
+                .or_else(|| OxcCssNoImportant::schema(generator)),
+            Self::OxcOptimizeRegex(_) => OxcOptimizeRegex::config_schema(generator)
+                .or_else(|| OxcOptimizeRegex::schema(generator)),
+            Self::OxcSortEnums(_) => {
+                OxcSortEnums::config_schema(generator).or_else(|| OxcSortEnums::schema(generator))
+            }
+            Self::OxcSortImports(_) => OxcSortImports::config_schema(generator)
+                .or_else(|| OxcSortImports::schema(generator)),
+            Self::OxcSortInterfaces(_) => OxcSortInterfaces::config_schema(generator)
+                .or_else(|| OxcSortInterfaces::schema(generator)),
+            Self::OxcSortIntersectionTypes(_) => OxcSortIntersectionTypes::config_schema(generator)
+                .or_else(|| OxcSortIntersectionTypes::schema(generator)),
+            Self::OxcSortJsxProps(_) => OxcSortJsxProps::config_schema(generator)
+                .or_else(|| OxcSortJsxProps::schema(generator)),
+            Self::OxcSortNamedExports(_) => OxcSortNamedExports::config_schema(generator)
+                .or_else(|| OxcSortNamedExports::schema(generator)),
+            Self::OxcSortNamedImports(_) => OxcSortNamedImports::config_schema(generator)
+                .or_else(|| OxcSortNamedImports::schema(generator)),
+            Self::OxcSortObjectTypes(_) => OxcSortObjectTypes::config_schema(generator)
+                .or_else(|| OxcSortObjectTypes::schema(generator)),
+            Self::OxcSortObjects(_) => OxcSortObjects::config_schema(generator)
+                .or_else(|| OxcSortObjects::schema(generator)),
+            Self::OxcSortSwitchCase(_) => OxcSortSwitchCase::config_schema(generator)
+                .or_else(|| OxcSortSwitchCase::schema(generator)),
+            Self::OxcSortUnionTypes(_) => OxcSortUnionTypes::config_schema(generator)
+                .or_else(|| OxcSortUnionTypes::schema(generator)),
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::config_schema(generator)
                 .or_else(|| NextjsGoogleFontDisplay::schema(generator)),
             Self::NextjsGoogleFontPreconnect(_) => {
@@ -9197,6 +9382,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => "oxc",
             Self::OxcOnlyUsedInRecursion(_) => "oxc",
             Self::OxcUninvokedArrayCallback(_) => "oxc",
+            Self::OxcAvoidBarrelFiles(_) => "oxc",
+            Self::OxcAvoidReExportAll(_) => "oxc",
+            Self::OxcBoundariesDependencies(_) => "oxc",
+            Self::OxcCssNoDuplicateProperties(_) => "oxc",
+            Self::OxcCssNoEmptyBlocks(_) => "oxc",
+            Self::OxcCssNoImportant(_) => "oxc",
+            Self::OxcOptimizeRegex(_) => "oxc",
+            Self::OxcSortEnums(_) => "oxc",
+            Self::OxcSortImports(_) => "oxc",
+            Self::OxcSortInterfaces(_) => "oxc",
+            Self::OxcSortIntersectionTypes(_) => "oxc",
+            Self::OxcSortJsxProps(_) => "oxc",
+            Self::OxcSortNamedExports(_) => "oxc",
+            Self::OxcSortNamedImports(_) => "oxc",
+            Self::OxcSortObjectTypes(_) => "oxc",
+            Self::OxcSortObjects(_) => "oxc",
+            Self::OxcSortSwitchCase(_) => "oxc",
+            Self::OxcSortUnionTypes(_) => "oxc",
             Self::NextjsGoogleFontDisplay(_) => "nextjs",
             Self::NextjsGoogleFontPreconnect(_) => "nextjs",
             Self::NextjsInlineScriptId(_) => "nextjs",
@@ -11272,6 +11475,60 @@ impl RuleEnum {
             Self::OxcUninvokedArrayCallback(_) => Ok(Self::OxcUninvokedArrayCallback(
                 OxcUninvokedArrayCallback::from_configuration(value)?,
             )),
+            Self::OxcAvoidBarrelFiles(_) => {
+                Ok(Self::OxcAvoidBarrelFiles(OxcAvoidBarrelFiles::from_configuration(value)?))
+            }
+            Self::OxcAvoidReExportAll(_) => {
+                Ok(Self::OxcAvoidReExportAll(OxcAvoidReExportAll::from_configuration(value)?))
+            }
+            Self::OxcBoundariesDependencies(_) => Ok(Self::OxcBoundariesDependencies(
+                OxcBoundariesDependencies::from_configuration(value)?,
+            )),
+            Self::OxcCssNoDuplicateProperties(_) => Ok(Self::OxcCssNoDuplicateProperties(
+                OxcCssNoDuplicateProperties::from_configuration(value)?,
+            )),
+            Self::OxcCssNoEmptyBlocks(_) => {
+                Ok(Self::OxcCssNoEmptyBlocks(OxcCssNoEmptyBlocks::from_configuration(value)?))
+            }
+            Self::OxcCssNoImportant(_) => {
+                Ok(Self::OxcCssNoImportant(OxcCssNoImportant::from_configuration(value)?))
+            }
+            Self::OxcOptimizeRegex(_) => {
+                Ok(Self::OxcOptimizeRegex(OxcOptimizeRegex::from_configuration(value)?))
+            }
+            Self::OxcSortEnums(_) => {
+                Ok(Self::OxcSortEnums(OxcSortEnums::from_configuration(value)?))
+            }
+            Self::OxcSortImports(_) => {
+                Ok(Self::OxcSortImports(OxcSortImports::from_configuration(value)?))
+            }
+            Self::OxcSortInterfaces(_) => {
+                Ok(Self::OxcSortInterfaces(OxcSortInterfaces::from_configuration(value)?))
+            }
+            Self::OxcSortIntersectionTypes(_) => Ok(Self::OxcSortIntersectionTypes(
+                OxcSortIntersectionTypes::from_configuration(value)?,
+            )),
+            Self::OxcSortJsxProps(_) => {
+                Ok(Self::OxcSortJsxProps(OxcSortJsxProps::from_configuration(value)?))
+            }
+            Self::OxcSortNamedExports(_) => {
+                Ok(Self::OxcSortNamedExports(OxcSortNamedExports::from_configuration(value)?))
+            }
+            Self::OxcSortNamedImports(_) => {
+                Ok(Self::OxcSortNamedImports(OxcSortNamedImports::from_configuration(value)?))
+            }
+            Self::OxcSortObjectTypes(_) => {
+                Ok(Self::OxcSortObjectTypes(OxcSortObjectTypes::from_configuration(value)?))
+            }
+            Self::OxcSortObjects(_) => {
+                Ok(Self::OxcSortObjects(OxcSortObjects::from_configuration(value)?))
+            }
+            Self::OxcSortSwitchCase(_) => {
+                Ok(Self::OxcSortSwitchCase(OxcSortSwitchCase::from_configuration(value)?))
+            }
+            Self::OxcSortUnionTypes(_) => {
+                Ok(Self::OxcSortUnionTypes(OxcSortUnionTypes::from_configuration(value)?))
+            }
             Self::NextjsGoogleFontDisplay(_) => Ok(Self::NextjsGoogleFontDisplay(
                 NextjsGoogleFontDisplay::from_configuration(value)?,
             )),
@@ -12198,6 +12455,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.to_configuration(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.to_configuration(),
             Self::OxcUninvokedArrayCallback(rule) => rule.to_configuration(),
+            Self::OxcAvoidBarrelFiles(rule) => rule.to_configuration(),
+            Self::OxcAvoidReExportAll(rule) => rule.to_configuration(),
+            Self::OxcBoundariesDependencies(rule) => rule.to_configuration(),
+            Self::OxcCssNoDuplicateProperties(rule) => rule.to_configuration(),
+            Self::OxcCssNoEmptyBlocks(rule) => rule.to_configuration(),
+            Self::OxcCssNoImportant(rule) => rule.to_configuration(),
+            Self::OxcOptimizeRegex(rule) => rule.to_configuration(),
+            Self::OxcSortEnums(rule) => rule.to_configuration(),
+            Self::OxcSortImports(rule) => rule.to_configuration(),
+            Self::OxcSortInterfaces(rule) => rule.to_configuration(),
+            Self::OxcSortIntersectionTypes(rule) => rule.to_configuration(),
+            Self::OxcSortJsxProps(rule) => rule.to_configuration(),
+            Self::OxcSortNamedExports(rule) => rule.to_configuration(),
+            Self::OxcSortNamedImports(rule) => rule.to_configuration(),
+            Self::OxcSortObjectTypes(rule) => rule.to_configuration(),
+            Self::OxcSortObjects(rule) => rule.to_configuration(),
+            Self::OxcSortSwitchCase(rule) => rule.to_configuration(),
+            Self::OxcSortUnionTypes(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontDisplay(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.to_configuration(),
             Self::NextjsInlineScriptId(rule) => rule.to_configuration(),
@@ -12914,6 +13189,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run(node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run(node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run(node, ctx),
+            Self::OxcAvoidBarrelFiles(rule) => rule.run(node, ctx),
+            Self::OxcAvoidReExportAll(rule) => rule.run(node, ctx),
+            Self::OxcBoundariesDependencies(rule) => rule.run(node, ctx),
+            Self::OxcCssNoDuplicateProperties(rule) => rule.run(node, ctx),
+            Self::OxcCssNoEmptyBlocks(rule) => rule.run(node, ctx),
+            Self::OxcCssNoImportant(rule) => rule.run(node, ctx),
+            Self::OxcOptimizeRegex(rule) => rule.run(node, ctx),
+            Self::OxcSortEnums(rule) => rule.run(node, ctx),
+            Self::OxcSortImports(rule) => rule.run(node, ctx),
+            Self::OxcSortInterfaces(rule) => rule.run(node, ctx),
+            Self::OxcSortIntersectionTypes(rule) => rule.run(node, ctx),
+            Self::OxcSortJsxProps(rule) => rule.run(node, ctx),
+            Self::OxcSortNamedExports(rule) => rule.run(node, ctx),
+            Self::OxcSortNamedImports(rule) => rule.run(node, ctx),
+            Self::OxcSortObjectTypes(rule) => rule.run(node, ctx),
+            Self::OxcSortObjects(rule) => rule.run(node, ctx),
+            Self::OxcSortSwitchCase(rule) => rule.run(node, ctx),
+            Self::OxcSortUnionTypes(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run(node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run(node, ctx),
@@ -13628,6 +13921,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_once(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_once(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_once(ctx),
+            Self::OxcAvoidBarrelFiles(rule) => rule.run_once(ctx),
+            Self::OxcAvoidReExportAll(rule) => rule.run_once(ctx),
+            Self::OxcBoundariesDependencies(rule) => rule.run_once(ctx),
+            Self::OxcCssNoDuplicateProperties(rule) => rule.run_once(ctx),
+            Self::OxcCssNoEmptyBlocks(rule) => rule.run_once(ctx),
+            Self::OxcCssNoImportant(rule) => rule.run_once(ctx),
+            Self::OxcOptimizeRegex(rule) => rule.run_once(ctx),
+            Self::OxcSortEnums(rule) => rule.run_once(ctx),
+            Self::OxcSortImports(rule) => rule.run_once(ctx),
+            Self::OxcSortInterfaces(rule) => rule.run_once(ctx),
+            Self::OxcSortIntersectionTypes(rule) => rule.run_once(ctx),
+            Self::OxcSortJsxProps(rule) => rule.run_once(ctx),
+            Self::OxcSortNamedExports(rule) => rule.run_once(ctx),
+            Self::OxcSortNamedImports(rule) => rule.run_once(ctx),
+            Self::OxcSortObjectTypes(rule) => rule.run_once(ctx),
+            Self::OxcSortObjects(rule) => rule.run_once(ctx),
+            Self::OxcSortSwitchCase(rule) => rule.run_once(ctx),
+            Self::OxcSortUnionTypes(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_once(ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_once(ctx),
@@ -14438,6 +14749,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcAvoidBarrelFiles(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcAvoidReExportAll(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcBoundariesDependencies(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcCssNoDuplicateProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcCssNoEmptyBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcCssNoImportant(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcOptimizeRegex(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortEnums(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortImports(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortInterfaces(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortIntersectionTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortJsxProps(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortNamedExports(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortNamedImports(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortObjectTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortObjects(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortSwitchCase(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcSortUnionTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15156,6 +15485,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.should_run(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.should_run(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.should_run(ctx),
+            Self::OxcAvoidBarrelFiles(rule) => rule.should_run(ctx),
+            Self::OxcAvoidReExportAll(rule) => rule.should_run(ctx),
+            Self::OxcBoundariesDependencies(rule) => rule.should_run(ctx),
+            Self::OxcCssNoDuplicateProperties(rule) => rule.should_run(ctx),
+            Self::OxcCssNoEmptyBlocks(rule) => rule.should_run(ctx),
+            Self::OxcCssNoImportant(rule) => rule.should_run(ctx),
+            Self::OxcOptimizeRegex(rule) => rule.should_run(ctx),
+            Self::OxcSortEnums(rule) => rule.should_run(ctx),
+            Self::OxcSortImports(rule) => rule.should_run(ctx),
+            Self::OxcSortInterfaces(rule) => rule.should_run(ctx),
+            Self::OxcSortIntersectionTypes(rule) => rule.should_run(ctx),
+            Self::OxcSortJsxProps(rule) => rule.should_run(ctx),
+            Self::OxcSortNamedExports(rule) => rule.should_run(ctx),
+            Self::OxcSortNamedImports(rule) => rule.should_run(ctx),
+            Self::OxcSortObjectTypes(rule) => rule.should_run(ctx),
+            Self::OxcSortObjects(rule) => rule.should_run(ctx),
+            Self::OxcSortSwitchCase(rule) => rule.should_run(ctx),
+            Self::OxcSortUnionTypes(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.should_run(ctx),
             Self::NextjsInlineScriptId(rule) => rule.should_run(ctx),
@@ -16148,6 +16495,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::IS_TSGOLINT_RULE,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::IS_TSGOLINT_RULE,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::IS_TSGOLINT_RULE,
+            Self::OxcAvoidBarrelFiles(_) => OxcAvoidBarrelFiles::IS_TSGOLINT_RULE,
+            Self::OxcAvoidReExportAll(_) => OxcAvoidReExportAll::IS_TSGOLINT_RULE,
+            Self::OxcBoundariesDependencies(_) => OxcBoundariesDependencies::IS_TSGOLINT_RULE,
+            Self::OxcCssNoDuplicateProperties(_) => OxcCssNoDuplicateProperties::IS_TSGOLINT_RULE,
+            Self::OxcCssNoEmptyBlocks(_) => OxcCssNoEmptyBlocks::IS_TSGOLINT_RULE,
+            Self::OxcCssNoImportant(_) => OxcCssNoImportant::IS_TSGOLINT_RULE,
+            Self::OxcOptimizeRegex(_) => OxcOptimizeRegex::IS_TSGOLINT_RULE,
+            Self::OxcSortEnums(_) => OxcSortEnums::IS_TSGOLINT_RULE,
+            Self::OxcSortImports(_) => OxcSortImports::IS_TSGOLINT_RULE,
+            Self::OxcSortInterfaces(_) => OxcSortInterfaces::IS_TSGOLINT_RULE,
+            Self::OxcSortIntersectionTypes(_) => OxcSortIntersectionTypes::IS_TSGOLINT_RULE,
+            Self::OxcSortJsxProps(_) => OxcSortJsxProps::IS_TSGOLINT_RULE,
+            Self::OxcSortNamedExports(_) => OxcSortNamedExports::IS_TSGOLINT_RULE,
+            Self::OxcSortNamedImports(_) => OxcSortNamedImports::IS_TSGOLINT_RULE,
+            Self::OxcSortObjectTypes(_) => OxcSortObjectTypes::IS_TSGOLINT_RULE,
+            Self::OxcSortObjects(_) => OxcSortObjects::IS_TSGOLINT_RULE,
+            Self::OxcSortSwitchCase(_) => OxcSortSwitchCase::IS_TSGOLINT_RULE,
+            Self::OxcSortUnionTypes(_) => OxcSortUnionTypes::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::IS_TSGOLINT_RULE,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::IS_TSGOLINT_RULE,
@@ -17049,6 +17414,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::HAS_CONFIG,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::HAS_CONFIG,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::HAS_CONFIG,
+            Self::OxcAvoidBarrelFiles(_) => OxcAvoidBarrelFiles::HAS_CONFIG,
+            Self::OxcAvoidReExportAll(_) => OxcAvoidReExportAll::HAS_CONFIG,
+            Self::OxcBoundariesDependencies(_) => OxcBoundariesDependencies::HAS_CONFIG,
+            Self::OxcCssNoDuplicateProperties(_) => OxcCssNoDuplicateProperties::HAS_CONFIG,
+            Self::OxcCssNoEmptyBlocks(_) => OxcCssNoEmptyBlocks::HAS_CONFIG,
+            Self::OxcCssNoImportant(_) => OxcCssNoImportant::HAS_CONFIG,
+            Self::OxcOptimizeRegex(_) => OxcOptimizeRegex::HAS_CONFIG,
+            Self::OxcSortEnums(_) => OxcSortEnums::HAS_CONFIG,
+            Self::OxcSortImports(_) => OxcSortImports::HAS_CONFIG,
+            Self::OxcSortInterfaces(_) => OxcSortInterfaces::HAS_CONFIG,
+            Self::OxcSortIntersectionTypes(_) => OxcSortIntersectionTypes::HAS_CONFIG,
+            Self::OxcSortJsxProps(_) => OxcSortJsxProps::HAS_CONFIG,
+            Self::OxcSortNamedExports(_) => OxcSortNamedExports::HAS_CONFIG,
+            Self::OxcSortNamedImports(_) => OxcSortNamedImports::HAS_CONFIG,
+            Self::OxcSortObjectTypes(_) => OxcSortObjectTypes::HAS_CONFIG,
+            Self::OxcSortObjects(_) => OxcSortObjects::HAS_CONFIG,
+            Self::OxcSortSwitchCase(_) => OxcSortSwitchCase::HAS_CONFIG,
+            Self::OxcSortUnionTypes(_) => OxcSortUnionTypes::HAS_CONFIG,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::HAS_CONFIG,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::HAS_CONFIG,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::HAS_CONFIG,
@@ -17775,6 +18158,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.types_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.types_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.types_info(),
+            Self::OxcAvoidBarrelFiles(rule) => rule.types_info(),
+            Self::OxcAvoidReExportAll(rule) => rule.types_info(),
+            Self::OxcBoundariesDependencies(rule) => rule.types_info(),
+            Self::OxcCssNoDuplicateProperties(rule) => rule.types_info(),
+            Self::OxcCssNoEmptyBlocks(rule) => rule.types_info(),
+            Self::OxcCssNoImportant(rule) => rule.types_info(),
+            Self::OxcOptimizeRegex(rule) => rule.types_info(),
+            Self::OxcSortEnums(rule) => rule.types_info(),
+            Self::OxcSortImports(rule) => rule.types_info(),
+            Self::OxcSortInterfaces(rule) => rule.types_info(),
+            Self::OxcSortIntersectionTypes(rule) => rule.types_info(),
+            Self::OxcSortJsxProps(rule) => rule.types_info(),
+            Self::OxcSortNamedExports(rule) => rule.types_info(),
+            Self::OxcSortNamedImports(rule) => rule.types_info(),
+            Self::OxcSortObjectTypes(rule) => rule.types_info(),
+            Self::OxcSortObjects(rule) => rule.types_info(),
+            Self::OxcSortSwitchCase(rule) => rule.types_info(),
+            Self::OxcSortUnionTypes(rule) => rule.types_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.types_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.types_info(),
             Self::NextjsInlineScriptId(rule) => rule.types_info(),
@@ -18489,6 +18890,24 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_info(),
+            Self::OxcAvoidBarrelFiles(rule) => rule.run_info(),
+            Self::OxcAvoidReExportAll(rule) => rule.run_info(),
+            Self::OxcBoundariesDependencies(rule) => rule.run_info(),
+            Self::OxcCssNoDuplicateProperties(rule) => rule.run_info(),
+            Self::OxcCssNoEmptyBlocks(rule) => rule.run_info(),
+            Self::OxcCssNoImportant(rule) => rule.run_info(),
+            Self::OxcOptimizeRegex(rule) => rule.run_info(),
+            Self::OxcSortEnums(rule) => rule.run_info(),
+            Self::OxcSortImports(rule) => rule.run_info(),
+            Self::OxcSortInterfaces(rule) => rule.run_info(),
+            Self::OxcSortIntersectionTypes(rule) => rule.run_info(),
+            Self::OxcSortJsxProps(rule) => rule.run_info(),
+            Self::OxcSortNamedExports(rule) => rule.run_info(),
+            Self::OxcSortNamedImports(rule) => rule.run_info(),
+            Self::OxcSortObjectTypes(rule) => rule.run_info(),
+            Self::OxcSortObjects(rule) => rule.run_info(),
+            Self::OxcSortSwitchCase(rule) => rule.run_info(),
+            Self::OxcSortUnionTypes(rule) => rule.run_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_info(),
             Self::NextjsInlineScriptId(rule) => rule.run_info(),
@@ -19317,6 +19736,24 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::OxcNumberArgOutOfRange(OxcNumberArgOutOfRange::default()),
         RuleEnum::OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion::default()),
         RuleEnum::OxcUninvokedArrayCallback(OxcUninvokedArrayCallback::default()),
+        RuleEnum::OxcAvoidBarrelFiles(OxcAvoidBarrelFiles::default()),
+        RuleEnum::OxcAvoidReExportAll(OxcAvoidReExportAll::default()),
+        RuleEnum::OxcBoundariesDependencies(OxcBoundariesDependencies::default()),
+        RuleEnum::OxcCssNoDuplicateProperties(OxcCssNoDuplicateProperties::default()),
+        RuleEnum::OxcCssNoEmptyBlocks(OxcCssNoEmptyBlocks::default()),
+        RuleEnum::OxcCssNoImportant(OxcCssNoImportant::default()),
+        RuleEnum::OxcOptimizeRegex(OxcOptimizeRegex::default()),
+        RuleEnum::OxcSortEnums(OxcSortEnums::default()),
+        RuleEnum::OxcSortImports(OxcSortImports::default()),
+        RuleEnum::OxcSortInterfaces(OxcSortInterfaces::default()),
+        RuleEnum::OxcSortIntersectionTypes(OxcSortIntersectionTypes::default()),
+        RuleEnum::OxcSortJsxProps(OxcSortJsxProps::default()),
+        RuleEnum::OxcSortNamedExports(OxcSortNamedExports::default()),
+        RuleEnum::OxcSortNamedImports(OxcSortNamedImports::default()),
+        RuleEnum::OxcSortObjectTypes(OxcSortObjectTypes::default()),
+        RuleEnum::OxcSortObjects(OxcSortObjects::default()),
+        RuleEnum::OxcSortSwitchCase(OxcSortSwitchCase::default()),
+        RuleEnum::OxcSortUnionTypes(OxcSortUnionTypes::default()),
         RuleEnum::NextjsGoogleFontDisplay(NextjsGoogleFontDisplay::default()),
         RuleEnum::NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect::default()),
         RuleEnum::NextjsInlineScriptId(NextjsInlineScriptId::default()),

--- a/crates/oxc_linter/src/json_parser.rs
+++ b/crates/oxc_linter/src/json_parser.rs
@@ -1,0 +1,544 @@
+//! Lightweight span-preserving JSON parser for linting.
+//!
+//! Unlike `serde_json`, this parser preserves the exact source spans for every
+//! key, value, property, object, and array in the JSON document. This enables
+//! precise diagnostics and autofixes for JSON lint rules.
+
+use oxc_span::Span;
+
+// ── AST ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum JsonValue<'a> {
+    Object(JsonObject<'a>),
+    Array(JsonArray<'a>),
+    /// (unescaped value, span of the full quoted string including quotes)
+    String(&'a str, Span),
+    /// (raw text, span)
+    Number(&'a str, Span),
+    Boolean(bool, Span),
+    Null(Span),
+}
+
+impl JsonValue<'_> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Object(obj) => obj.span,
+            Self::Array(arr) => arr.span,
+            Self::String(_, span)
+            | Self::Number(_, span)
+            | Self::Boolean(_, span)
+            | Self::Null(span) => *span,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&JsonObject<'_>> {
+        if let Self::Object(obj) = self { Some(obj) } else { None }
+    }
+
+    pub fn as_array(&self) -> Option<&JsonArray<'_>> {
+        if let Self::Array(arr) = self { Some(arr) } else { None }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        if let Self::String(s, _) = self { Some(s) } else { None }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        if let Self::Boolean(b, _) = self { Some(*b) } else { None }
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonProperty<'a> {
+    /// The key string (without quotes).
+    pub key: &'a str,
+    /// Span of the full quoted key including quotes.
+    pub key_span: Span,
+    /// The value.
+    pub value: JsonValue<'a>,
+    /// Full span from key start to value end.
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub struct JsonObject<'a> {
+    pub properties: Vec<JsonProperty<'a>>,
+    pub span: Span,
+}
+
+impl<'a> JsonObject<'a> {
+    pub fn get(&self, key: &str) -> Option<&JsonValue<'a>> {
+        self.properties.iter().find(|p| p.key == key).map(|p| &p.value)
+    }
+
+    pub fn get_property(&self, key: &str) -> Option<&JsonProperty<'a>> {
+        self.properties.iter().find(|p| p.key == key)
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonArray<'a> {
+    pub elements: Vec<JsonValue<'a>>,
+    pub span: Span,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct JsonParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+// ── Result ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct JsonParseResult<'a> {
+    pub root: Option<JsonValue<'a>>,
+    pub errors: Vec<JsonParseError>,
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+pub fn parse_json(source: &str) -> JsonParseResult<'_> {
+    let mut parser = Parser::new(source);
+    let root = parser.parse_value();
+    parser.skip_whitespace();
+    if parser.pos < parser.source.len() && parser.errors.is_empty() {
+        parser.errors.push(JsonParseError {
+            message: "Unexpected content after JSON value".to_string(),
+            span: Span::new(parser.pos as u32, (parser.pos + 1) as u32),
+        });
+    }
+    JsonParseResult { root, errors: parser.errors }
+}
+
+struct Parser<'a> {
+    source: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    errors: Vec<JsonParseError>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source, bytes: source.as_bytes(), pos: 0, errors: Vec::new() }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b' ' | b'\t' | b'\n' | b'\r' => self.pos += 1,
+                _ => break,
+            }
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let b = self.bytes.get(self.pos).copied()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn expect(&mut self, expected: u8) -> bool {
+        if self.peek() == Some(expected) {
+            self.pos += 1;
+            true
+        } else {
+            self.errors.push(JsonParseError {
+                message: format!(
+                    "Expected '{}', found {}",
+                    expected as char,
+                    self.peek().map_or("end of input".to_string(), |b| format!("'{}'", b as char))
+                ),
+                span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+            });
+            false
+        }
+    }
+
+    fn parse_value(&mut self) -> Option<JsonValue<'a>> {
+        self.skip_whitespace();
+        match self.peek()? {
+            b'{' => self.parse_object().map(JsonValue::Object),
+            b'[' => self.parse_array().map(JsonValue::Array),
+            b'"' => self.parse_string().map(|(s, span)| JsonValue::String(s, span)),
+            b't' | b'f' => self.parse_boolean(),
+            b'n' => self.parse_null(),
+            b'-' | b'0'..=b'9' => self.parse_number(),
+            c => {
+                self.errors.push(JsonParseError {
+                    message: format!("Unexpected character '{}'", c as char),
+                    span: Span::new(self.pos as u32, (self.pos + 1) as u32),
+                });
+                None
+            }
+        }
+    }
+
+    fn parse_object(&mut self) -> Option<JsonObject<'a>> {
+        let start = self.pos;
+        self.advance(); // skip '{'
+        self.skip_whitespace();
+
+        let mut properties = Vec::new();
+
+        if self.peek() == Some(b'}') {
+            self.advance();
+            return Some(JsonObject { properties, span: Span::new(start as u32, self.pos as u32) });
+        }
+
+        loop {
+            self.skip_whitespace();
+            let prop_start = self.pos;
+
+            // Parse key
+            if self.peek() != Some(b'"') {
+                self.errors.push(JsonParseError {
+                    message: "Expected string key".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            let (key, key_span) = self.parse_string()?;
+
+            self.skip_whitespace();
+            if !self.expect(b':') {
+                return None;
+            }
+
+            // Parse value
+            let value = self.parse_value()?;
+            let prop_end = self.pos;
+
+            properties.push(JsonProperty {
+                key,
+                key_span,
+                span: Span::new(prop_start as u32, prop_end as u32),
+                value,
+            });
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b'}') => {
+                    self.advance();
+                    break;
+                }
+                _ => {
+                    self.errors.push(JsonParseError {
+                        message: "Expected ',' or '}'".to_string(),
+                        span: Span::new(
+                            self.pos as u32,
+                            (self.pos + 1).min(self.source.len()) as u32,
+                        ),
+                    });
+                    return None;
+                }
+            }
+        }
+
+        Some(JsonObject { properties, span: Span::new(start as u32, self.pos as u32) })
+    }
+
+    fn parse_array(&mut self) -> Option<JsonArray<'a>> {
+        let start = self.pos;
+        self.advance(); // skip '['
+        self.skip_whitespace();
+
+        let mut elements = Vec::new();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Some(JsonArray { elements, span: Span::new(start as u32, self.pos as u32) });
+        }
+
+        loop {
+            let value = self.parse_value()?;
+            elements.push(value);
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b']') => {
+                    self.advance();
+                    break;
+                }
+                _ => {
+                    self.errors.push(JsonParseError {
+                        message: "Expected ',' or ']'".to_string(),
+                        span: Span::new(
+                            self.pos as u32,
+                            (self.pos + 1).min(self.source.len()) as u32,
+                        ),
+                    });
+                    return None;
+                }
+            }
+        }
+
+        Some(JsonArray { elements, span: Span::new(start as u32, self.pos as u32) })
+    }
+
+    fn parse_string(&mut self) -> Option<(&'a str, Span)> {
+        let start = self.pos;
+        self.advance(); // skip opening '"'
+
+        while self.pos < self.bytes.len() {
+            match self.bytes[self.pos] {
+                b'"' => {
+                    let value = &self.source[start + 1..self.pos];
+                    self.pos += 1; // skip closing '"'
+                    let span = Span::new(start as u32, self.pos as u32);
+                    return Some((value, span));
+                }
+                b'\\' => {
+                    self.pos += 1; // skip backslash
+                    if self.pos < self.bytes.len() {
+                        // Skip the escaped character
+                        if self.bytes[self.pos] == b'u' {
+                            // \uXXXX — skip 4 hex digits
+                            self.pos += 1;
+                            for _ in 0..4 {
+                                if self.pos < self.bytes.len() {
+                                    self.pos += 1;
+                                }
+                            }
+                        } else {
+                            self.pos += 1;
+                        }
+                    }
+                }
+                _ => {
+                    self.pos += 1;
+                }
+            }
+        }
+
+        self.errors.push(JsonParseError {
+            message: "Unterminated string".to_string(),
+            span: Span::new(start as u32, self.source.len() as u32),
+        });
+        None
+    }
+
+    fn parse_number(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+
+        if self.peek() == Some(b'-') {
+            self.advance();
+        }
+
+        // Integer part
+        match self.peek() {
+            Some(b'0') => {
+                self.advance();
+            }
+            Some(b'1'..=b'9') => {
+                self.advance();
+                while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                    self.pos += 1;
+                }
+            }
+            _ => {
+                self.errors.push(JsonParseError {
+                    message: "Invalid number".to_string(),
+                    span: Span::new(start as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+        }
+
+        // Fraction
+        if self.peek() == Some(b'.') {
+            self.advance();
+            if !self.peek().is_some_and(|b| b.is_ascii_digit()) {
+                self.errors.push(JsonParseError {
+                    message: "Expected digit after decimal point".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+
+        // Exponent
+        if self.peek().is_some_and(|b| b == b'e' || b == b'E') {
+            self.advance();
+            if self.peek().is_some_and(|b| b == b'+' || b == b'-') {
+                self.advance();
+            }
+            if !self.peek().is_some_and(|b| b.is_ascii_digit()) {
+                self.errors.push(JsonParseError {
+                    message: "Expected digit in exponent".to_string(),
+                    span: Span::new(self.pos as u32, (self.pos + 1).min(self.source.len()) as u32),
+                });
+                return None;
+            }
+            while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+
+        let raw = &self.source[start..self.pos];
+        let span = Span::new(start as u32, self.pos as u32);
+        Some(JsonValue::Number(raw, span))
+    }
+
+    fn parse_boolean(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+        if self.source[self.pos..].starts_with("true") {
+            self.pos += 4;
+            Some(JsonValue::Boolean(true, Span::new(start as u32, self.pos as u32)))
+        } else if self.source[self.pos..].starts_with("false") {
+            self.pos += 5;
+            Some(JsonValue::Boolean(false, Span::new(start as u32, self.pos as u32)))
+        } else {
+            self.errors.push(JsonParseError {
+                message: "Invalid boolean".to_string(),
+                span: Span::new(start as u32, (start + 1) as u32),
+            });
+            None
+        }
+    }
+
+    fn parse_null(&mut self) -> Option<JsonValue<'a>> {
+        let start = self.pos;
+        if self.source[self.pos..].starts_with("null") {
+            self.pos += 4;
+            Some(JsonValue::Null(Span::new(start as u32, self.pos as u32)))
+        } else {
+            self.errors.push(JsonParseError {
+                message: "Invalid null".to_string(),
+                span: Span::new(start as u32, (start + 1) as u32),
+            });
+            None
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_object() {
+        let result = parse_json("{}");
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert!(obj.properties.is_empty());
+        assert_eq!(obj.span, Span::new(0, 2));
+    }
+
+    #[test]
+    fn test_simple_object() {
+        let src = r#"{"name": "test", "version": 1}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.properties.len(), 2);
+        assert_eq!(obj.properties[0].key, "name");
+        assert_eq!(obj.properties[0].key_span, Span::new(1, 7)); // "name"
+        assert_eq!(obj.properties[0].value.as_str(), Some("test"));
+        assert_eq!(obj.properties[1].key, "version");
+    }
+
+    #[test]
+    fn test_nested_object() {
+        let src = r#"{"a": {"b": true}}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let outer = root.as_object().unwrap();
+        let inner = outer.properties[0].value.as_object().unwrap();
+        assert_eq!(inner.properties[0].key, "b");
+        assert_eq!(inner.properties[0].value.as_bool(), Some(true));
+    }
+
+    #[test]
+    fn test_array() {
+        let src = r#"[1, "two", true, null]"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        let root = result.root.unwrap();
+        let arr = root.as_array().unwrap();
+        assert_eq!(arr.elements.len(), 4);
+    }
+
+    #[test]
+    fn test_number_spans() {
+        let src = "42";
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+        if let JsonValue::Number(raw, span) = result.root.unwrap() {
+            assert_eq!(raw, "42");
+            assert_eq!(span, Span::new(0, 2));
+        } else {
+            panic!("expected number");
+        }
+    }
+
+    #[test]
+    fn test_string_with_escapes() {
+        let src = r#""hello \"world\"""#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let result = parse_json("{invalid}");
+        assert!(!result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_keys() {
+        let src = r#"{"a": 1, "a": 2}"#;
+        let result = parse_json(src);
+        assert!(result.errors.is_empty()); // parser allows duplicate keys
+        let root = result.root.unwrap();
+        let obj = root.as_object().unwrap();
+        assert_eq!(obj.properties.len(), 2);
+        assert_eq!(obj.properties[0].key, "a");
+        assert_eq!(obj.properties[1].key, "a");
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let result = parse_json("");
+        assert!(result.root.is_none());
+    }
+
+    #[test]
+    fn test_whitespace_only() {
+        let result = parse_json("  \n\t  ");
+        assert!(result.root.is_none());
+    }
+
+    #[test]
+    fn test_negative_number() {
+        let result = parse_json("-3.14e2");
+        assert!(result.errors.is_empty());
+        if let JsonValue::Number(raw, span) = result.root.unwrap() {
+            assert_eq!(raw, "-3.14e2");
+            assert_eq!(span, Span::new(0, 7));
+        } else {
+            panic!("expected number");
+        }
+    }
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -31,12 +31,14 @@ use oxc_span::Span;
 mod ast_util;
 mod config;
 mod context;
+pub mod css_parser;
 mod disable_directives;
 mod external_linter;
 mod external_plugin_store;
 mod fixer;
 mod frameworks;
 mod globals;
+pub mod json_parser;
 mod module_graph_visitor;
 mod module_record;
 mod options;
@@ -192,9 +194,34 @@ impl Linter {
         allocator: &'a Allocator,
         js_allocator_pool: Option<&AllocatorPool>,
     ) -> (Vec<Message>, Option<DisableDirectives>) {
+        let full_source_text =
+            context_sub_hosts.first().map_or("", |sub_host| sub_host.semantic().source_text());
+        self.run_with_full_source_text_and_disable_directives(
+            path,
+            context_sub_hosts,
+            full_source_text,
+            allocator,
+            js_allocator_pool,
+        )
+    }
+
+    pub(crate) fn run_with_full_source_text_and_disable_directives<'a>(
+        &self,
+        path: &Path,
+        context_sub_hosts: Vec<ContextSubHost<'a>>,
+        full_source_text: &'a str,
+        allocator: &'a Allocator,
+        js_allocator_pool: Option<&AllocatorPool>,
+    ) -> (Vec<Message>, Option<DisableDirectives>) {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
 
-        let mut ctx_host = Rc::new(ContextHost::new(path, context_sub_hosts, self.options, config));
+        let mut ctx_host = Rc::new(ContextHost::new(
+            path,
+            context_sub_hosts,
+            full_source_text,
+            self.options,
+            config,
+        ));
 
         #[cfg(debug_assertions)]
         let mut current_diagnostic_index = 0;
@@ -202,12 +229,18 @@ impl Linter {
         let is_partial_loader_file = ctx_host
             .file_extension()
             .is_some_and(|ext| LINT_PARTIAL_LOADER_EXTENSIONS.iter().any(|e| e == &ext));
+        let is_json_file =
+            ctx_host.file_extension().is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
 
         loop {
             let semantic = ctx_host.semantic();
             let rules = rules
                 .iter()
                 .filter(|(rule, _)| {
+                    if is_json_file && rule.plugin_name() != "oxc" {
+                        return false;
+                    }
+
                     if rule.is_tsgolint_rule() {
                         return false;
                     }
@@ -249,16 +282,35 @@ impl Linter {
                 //
                 // See https://github.com/oxc-project/oxc/pull/6600 for more context.
                 if semantic.nodes().len() > 200_000 {
-                    // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
-                    // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
-                    // compile-time since we know all of the rules and their AST node type information ahead of time.
+                    // Pre-compute the number of rules that map to each AST type so we can
+                    // allocate buckets with the right capacity and avoid reallocs.
                     //
                     // Use boxed array to help compiler see that indexing into it with an `AstType`
                     // cannot go out of bounds, and remove bounds checks.
+                    let mut counts = boxed_array![0usize; AST_TYPE_MAX as usize + 1];
+                    let mut any_count = 0usize;
+                    for (rule, _) in &rules {
+                        let rule = *rule;
+                        let run_info = rule.run_info();
+                        if with_runtime_optimization
+                            && let Some(ast_types) = rule.types_info()
+                            && run_info.is_run_implemented()
+                        {
+                            for ty in ast_types {
+                                counts[ty as usize] += 1;
+                            }
+                        } else {
+                            any_count += 1;
+                        }
+                    }
+
                     let mut rules_by_ast_type = boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
-                    // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
-                    // node types, but it at least guarantees we won't need to realloc.
-                    let mut rules_any_ast_type = Vec::with_capacity(rules.len());
+                    for (i, count) in counts.iter().enumerate() {
+                        if *count > 0 {
+                            rules_by_ast_type[i] = Vec::with_capacity(*count);
+                        }
+                    }
+                    let mut rules_any_ast_type = Vec::with_capacity(any_count);
 
                     for (rule, ctx) in &rules {
                         let rule = *rule;

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -1,5 +1,5 @@
 use memchr::{memmem::Finder, memmem::FinderRev};
-use oxc_span::VALID_EXTENSIONS;
+use oxc_span::{SourceType, VALID_EXTENSIONS};
 
 use crate::loader::JavaScriptSource;
 
@@ -15,9 +15,12 @@ const SCRIPT_END: &str = "</script>";
 const COMMENT_START: &str = "<!--";
 const COMMENT_END: &str = "-->";
 
-/// File extensions that can contain JS/TS code in certain parts, such as in `<script>` tags, and can
-/// be loaded using the [`PartialLoader`].
-pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte"];
+/// File extensions that require special loading beyond direct JS/TS parsing.
+///
+/// Some contain embedded script sections (`.vue`, `.astro`, `.svelte`), while
+/// others use non-JS raw-file rules backed by a placeholder semantic section
+/// (`.json`).
+pub const LINT_PARTIAL_LOADER_EXTENSIONS: &[&str] = &["vue", "astro", "svelte", "json", "css"];
 
 /// All valid JavaScript/TypeScript extensions, plus additional framework files that
 /// contain JavaScript/TypeScript code in them (e.g., Vue, Astro, Svelte, etc.).
@@ -34,6 +37,8 @@ impl PartialLoader {
             "vue" => Some(VuePartialLoader::new(source_text).parse()),
             "astro" => Some(AstroPartialLoader::new(source_text).parse()),
             "svelte" => Some(SveltePartialLoader::new(source_text).parse()),
+            "json" => Some(vec![JavaScriptSource::partial("", SourceType::default(), 0)]),
+            "css" => Some(vec![JavaScriptSource::partial("", SourceType::default(), 0)]),
             _ => None,
         }
     }

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -639,6 +639,27 @@ pub(crate) mod oxc {
     pub mod number_arg_out_of_range;
     pub mod only_used_in_recursion;
     pub mod uninvoked_array_callback;
+
+    pub mod avoid_barrel_files;
+    pub mod avoid_re_export_all;
+    pub mod boundaries_dependencies;
+    mod boundary_utils;
+    pub mod css_no_duplicate_properties;
+    pub mod css_no_empty_blocks;
+    pub mod css_no_important;
+    mod css_utils;
+    pub mod optimize_regex;
+    pub mod sort_enums;
+    pub mod sort_imports;
+    pub mod sort_interfaces;
+    pub mod sort_intersection_types;
+    pub mod sort_jsx_props;
+    pub mod sort_named_exports;
+    pub mod sort_named_imports;
+    pub mod sort_object_types;
+    pub mod sort_objects;
+    pub mod sort_switch_case;
+    pub mod sort_union_types;
 }
 
 pub(crate) mod nextjs {

--- a/crates/oxc_linter/src/rules/oxc/avoid_barrel_files.rs
+++ b/crates/oxc_linter/src/rules/oxc/avoid_barrel_files.rs
@@ -1,0 +1,208 @@
+use oxc_ast::{
+    AstKind,
+    ast::{ExportDefaultDeclarationKind, Statement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn avoid_barrel_files_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.",
+    )
+    .with_help("Prefer importing and re-exporting only the concrete symbols you actually need.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct AvoidBarrelFiles(Box<AvoidBarrelFilesConfig>);
+
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct AvoidBarrelFilesConfig {
+    amount_of_exports_to_consider_module_as_barrel: usize,
+}
+
+impl Default for AvoidBarrelFilesConfig {
+    fn default() -> Self {
+        Self { amount_of_exports_to_consider_module_as_barrel: 3 }
+    }
+}
+
+impl std::ops::Deref for AvoidBarrelFiles {
+    type Target = AvoidBarrelFilesConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects files that mostly exist to re-export other modules.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Barrel files tend to widen module graphs and force runtimes or bundlers
+    /// to load more code than consumers actually need.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// export { foo } from "./foo";
+    /// export { bar } from "./bar";
+    /// export { baz } from "./baz";
+    /// export { qux } from "./qux";
+    /// ```
+    AvoidBarrelFiles,
+    oxc,
+    restriction,
+    none,
+    config = AvoidBarrelFilesConfig
+);
+
+impl Rule for AvoidBarrelFiles {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(program) = ctx.semantic().nodes().iter().find_map(|node| match node.kind() {
+            AstKind::Program(program) => Some(program),
+            _ => None,
+        }) else {
+            return;
+        };
+
+        let mut declarations = 0usize;
+        let mut exports = 0usize;
+
+        for statement in &program.body {
+            count_statement(statement, &mut declarations, &mut exports);
+        }
+
+        let threshold = self.amount_of_exports_to_consider_module_as_barrel;
+        if exports > declarations && exports > threshold {
+            let span = program.span;
+            ctx.diagnostic(avoid_barrel_files_diagnostic(span));
+        }
+    }
+}
+
+fn count_statement(statement: &Statement<'_>, declarations: &mut usize, exports: &mut usize) {
+    match statement {
+        Statement::VariableDeclaration(variable_decl) => {
+            *declarations += variable_decl.declarations.len();
+        }
+        Statement::FunctionDeclaration(_)
+        | Statement::ClassDeclaration(_)
+        | Statement::TSTypeAliasDeclaration(_)
+        | Statement::TSInterfaceDeclaration(_) => {
+            *declarations += 1;
+        }
+        Statement::ExportNamedDeclaration(export_named) => {
+            *exports += export_named.specifiers.len();
+        }
+        Statement::ExportAllDeclaration(export_all) => {
+            if !export_all.is_typescript_syntax() {
+                *exports += 1;
+            }
+        }
+        Statement::ExportDefaultDeclaration(export_default) => match &export_default.declaration {
+            ExportDefaultDeclarationKind::FunctionDeclaration(_)
+            | ExportDefaultDeclarationKind::CallExpression(_) => {
+                *declarations += 1;
+            }
+            ExportDefaultDeclarationKind::ObjectExpression(object_expr) => {
+                *exports += object_expr.properties.len();
+            }
+            _ => {
+                *exports += 1;
+            }
+        },
+        _ => {}
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            r#"
+            let foo;
+            export { foo };
+            "#,
+            None,
+        ),
+        (
+            r#"
+            let foo, bar;
+            export { foo, bar };
+            "#,
+            None,
+        ),
+        (
+            r#"
+            let foo, bar, baz;
+            export { foo, bar, baz };
+            "#,
+            None,
+        ),
+        (
+            r#"
+            export default function Foo() {
+              return "bar";
+            }
+            "#,
+            Some(json!([{ "amountOfExportsToConsiderModuleAsBarrel": 0 }])),
+        ),
+        (
+            r#"
+            export default defineFoo({});
+            "#,
+            Some(json!([{ "amountOfExportsToConsiderModuleAsBarrel": 0 }])),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            r#"
+            import { bar, baz, qux } from "foo";
+            let foo;
+            export { foo, bar, baz, qux };
+            "#,
+            None,
+        ),
+        (
+            r#"
+            export * from "foo";
+            export * from "bar";
+            export * from "baz";
+            export * from "qux";
+            "#,
+            None,
+        ),
+        (
+            r#"export { foo, bar, baz } from "foo";"#,
+            Some(json!([{ "amountOfExportsToConsiderModuleAsBarrel": 2 }])),
+        ),
+        (r#"export default { var1, var2, var3, var4 };"#, None),
+    ];
+
+    Tester::new(AvoidBarrelFiles::NAME, AvoidBarrelFiles::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/avoid_re_export_all.rs
+++ b/crates/oxc_linter/src/rules/oxc/avoid_re_export_all.rs
@@ -1,0 +1,78 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn avoid_re_export_all_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Avoid re-exporting `*` from a module, it leads to unused imports and prevents treeshaking.",
+    )
+    .with_help("Prefer named re-exports so consumers and bundlers only pull the symbols they need.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AvoidReExportAll;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Forbids non-type `export *` re-exports.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Star re-exports make it easier to create barrel files that pull in more
+    /// modules than necessary, which hurts runtime startup and bundling.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// export * from "./foo";
+    /// export * as foo from "./foo";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// export { foo } from "./foo";
+    /// export type * from "./types";
+    /// ```
+    AvoidReExportAll,
+    oxc,
+    restriction,
+    none
+);
+
+impl Rule for AvoidReExportAll {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ExportAllDeclaration(export_all) = node.kind() else {
+            return;
+        };
+
+        if export_all.is_typescript_syntax() {
+            return;
+        }
+
+        ctx.diagnostic(avoid_re_export_all_diagnostic(export_all.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"export { foo } from "./foo";"#,
+        r#"export { foo as bar } from "./foo";"#,
+        r#"export type * from "./types";"#,
+        r#"export type * as types from "./types";"#,
+    ];
+
+    let fail = vec![r#"export * from "./foo";"#, r#"export * as foo from "./foo";"#];
+
+    Tester::new(AvoidReExportAll::NAME, AvoidReExportAll::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/boundaries_dependencies.rs
+++ b/crates/oxc_linter/src/rules/oxc/boundaries_dependencies.rs
@@ -1,0 +1,688 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+use super::boundary_utils::{classify_path, read_boundary_elements, resolve_local_specifier};
+
+fn boundaries_dependencies_diagnostic(
+    span: Span,
+    from_type: &str,
+    to_type: &str,
+    specifier: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Dependency from `{from_type}` to `{to_type}` is not allowed."
+    ))
+    .with_help(format!(
+        "Remove the import of `{specifier}` or move the dependency to an allowed architectural layer."
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct BoundariesDependencies(Box<BoundariesDependenciesConfig>);
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct BoundariesDependenciesConfig {
+    default: BoundaryPolicy,
+    rules: Vec<BoundaryDependencyRule>,
+}
+
+#[derive(Debug, Clone, Copy, Default, JsonSchema, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum BoundaryPolicy {
+    #[default]
+    Allow,
+    Disallow,
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct BoundaryDependencyRule {
+    from: BoundaryTypeSelector,
+    allow: Option<BoundaryDependencyTargetSelector>,
+    disallow: Option<BoundaryDependencyTargetSelector>,
+}
+
+#[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct BoundaryDependencyTargetSelector {
+    to: BoundaryTypeSelector,
+}
+
+#[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct BoundaryTypeSelector {
+    #[serde(rename = "type", default)]
+    element_types: BoundaryStringOrList,
+}
+
+#[derive(Debug, Clone, Default, JsonSchema, Deserialize)]
+#[serde(untagged)]
+enum BoundaryStringOrList {
+    Single(String),
+    Many(Vec<String>),
+    #[default]
+    Empty,
+}
+
+impl BoundaryTypeSelector {
+    fn matches(&self, element_type: &str) -> bool {
+        match &self.element_types {
+            BoundaryStringOrList::Single(single) => single == "*" || single == element_type,
+            BoundaryStringOrList::Many(many) => {
+                many.iter().any(|candidate| candidate == "*" || candidate == element_type)
+            }
+            BoundaryStringOrList::Empty => false,
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces architectural dependency boundaries between configured path-based elements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Large frontends often rely on route, component, API, and shared-layer boundaries
+    /// to avoid cross-layer coupling. Invalid imports make the architecture harder to
+    /// evolve and easier to accidentally break.
+    ///
+    /// ### Examples
+    ///
+    /// Given `public-routes` configured to disallow `admin-routes`:
+    ///
+    /// ```ts
+    /// import { adminDashboard } from "../../admin/dashboard";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// import { uiButton } from "../../components/ui/button";
+    /// ```
+    BoundariesDependencies,
+    oxc,
+    restriction,
+    config = BoundariesDependenciesConfig,
+);
+
+impl Rule for BoundariesDependencies {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(elements) = read_boundary_elements(ctx) else {
+            return;
+        };
+
+        let Some(from_type) = classify_path(ctx.file_path(), &elements) else {
+            return;
+        };
+
+        let module_record = ctx.module_record();
+
+        for import_entry in &module_record.import_entries {
+            let specifier = import_entry.module_request.name();
+            let Some(remote_module) = module_record.get_loaded_module(specifier) else {
+                continue;
+            };
+            let Some(to_type) = classify_path(&remote_module.resolved_absolute_path, &elements)
+            else {
+                continue;
+            };
+
+            if !is_allowed_dependency(&self.0, &from_type, &to_type) {
+                ctx.diagnostic(boundaries_dependencies_diagnostic(
+                    import_entry.module_request.span,
+                    &from_type,
+                    &to_type,
+                    specifier,
+                ));
+            }
+        }
+
+        for export_entry in &module_record.indirect_export_entries {
+            let Some(module_request) = &export_entry.module_request else {
+                continue;
+            };
+            let specifier = module_request.name();
+            let Some(remote_module) = module_record.get_loaded_module(specifier) else {
+                continue;
+            };
+            let Some(to_type) = classify_path(&remote_module.resolved_absolute_path, &elements)
+            else {
+                continue;
+            };
+
+            if !is_allowed_dependency(&self.0, &from_type, &to_type) {
+                ctx.diagnostic(boundaries_dependencies_diagnostic(
+                    module_request.span,
+                    &from_type,
+                    &to_type,
+                    specifier,
+                ));
+            }
+        }
+
+        for export_entry in &module_record.star_export_entries {
+            let Some(module_request) = &export_entry.module_request else {
+                continue;
+            };
+            let specifier = module_request.name();
+            let Some(remote_module) = module_record.get_loaded_module(specifier) else {
+                continue;
+            };
+            let Some(to_type) = classify_path(&remote_module.resolved_absolute_path, &elements)
+            else {
+                continue;
+            };
+
+            if !is_allowed_dependency(&self.0, &from_type, &to_type) {
+                ctx.diagnostic(boundaries_dependencies_diagnostic(
+                    module_request.span,
+                    &from_type,
+                    &to_type,
+                    specifier,
+                ));
+            }
+        }
+
+        for node in ctx.nodes() {
+            match node.kind() {
+                AstKind::ImportExpression(import_expr) => {
+                    let Expression::StringLiteral(string_literal) = &import_expr.source else {
+                        continue;
+                    };
+
+                    check_local_dependency(
+                        &self.0,
+                        ctx,
+                        &elements,
+                        &from_type,
+                        string_literal.value.as_str(),
+                        string_literal.span,
+                    );
+                }
+                AstKind::CallExpression(call_expr) => {
+                    let Expression::Identifier(ident) = &call_expr.callee else {
+                        continue;
+                    };
+
+                    if ident.name != "require" {
+                        continue;
+                    }
+
+                    let Some(Argument::StringLiteral(string_literal)) = call_expr.arguments.first()
+                    else {
+                        continue;
+                    };
+
+                    check_local_dependency(
+                        &self.0,
+                        ctx,
+                        &elements,
+                        &from_type,
+                        string_literal.value.as_str(),
+                        string_literal.span,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn check_local_dependency(
+    config: &BoundariesDependenciesConfig,
+    ctx: &LintContext<'_>,
+    elements: &[super::boundary_utils::BoundaryElementSetting],
+    from_type: &str,
+    specifier: &str,
+    span: Span,
+) {
+    let Some(resolved_path) = resolve_local_specifier(ctx.file_path(), specifier) else {
+        return;
+    };
+    let Some(to_type) = classify_path(&resolved_path, elements) else {
+        return;
+    };
+
+    if !is_allowed_dependency(config, from_type, &to_type) {
+        ctx.diagnostic(boundaries_dependencies_diagnostic(span, from_type, &to_type, specifier));
+    }
+}
+
+fn is_allowed_dependency(
+    config: &BoundariesDependenciesConfig,
+    from_type: &str,
+    to_type: &str,
+) -> bool {
+    let mut decision = match config.default {
+        BoundaryPolicy::Allow => Some(true),
+        BoundaryPolicy::Disallow => Some(false),
+    };
+
+    for rule in &config.rules {
+        if !rule.from.matches(from_type) {
+            continue;
+        }
+
+        if let Some(disallow) = &rule.disallow
+            && disallow.to.matches(to_type)
+        {
+            decision = Some(false);
+            continue;
+        }
+
+        if let Some(allow) = &rule.allow
+            && allow.to.matches(to_type)
+        {
+            decision = Some(true);
+        }
+    }
+
+    decision.unwrap_or(true)
+}
+
+#[test]
+fn test_public_routes_boundaries_dependencies() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn eslint_config() -> serde_json::Value {
+        json!({
+            "settings": {
+                "boundaries/elements": [
+                    { "type": "admin-routes", "pattern": ["src/routes/admin/*"] },
+                    { "type": "user-routes", "pattern": ["src/routes/user/*"] },
+                    { "type": "public-routes", "pattern": ["src/routes/public/*"] },
+                    { "type": "admin-components", "pattern": ["src/components/admin-*", "src/components/admin/*"] },
+                    { "type": "user-components", "pattern": ["src/components/user-*"] },
+                    { "type": "api-admin", "pattern": ["src/api/admin/*"] },
+                    { "type": "api-user", "pattern": ["src/api/user/*"] },
+                    { "type": "api-public", "pattern": ["src/api/public/*"] },
+                    { "type": "shared", "pattern": ["src/components/ui/*", "src/library/*", "src/hooks/*", "src/utils/*"] },
+                    { "type": "layouts", "pattern": ["src/layouts/*"] },
+                    { "type": "locales", "pattern": ["src/locales/**/*"] },
+                    { "type": "styles", "pattern": ["src/styles/**/*"] }
+                ]
+            }
+        })
+    }
+
+    fn rule_config() -> serde_json::Value {
+        json!([{
+            "default": "allow",
+            "rules": [
+                {
+                    "from": { "type": ["user-routes", "user-components"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "api-admin"] } }
+                },
+                {
+                    "from": { "type": ["public-routes"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "api-admin", "user-routes", "user-components", "api-user"] } }
+                },
+                {
+                    "from": { "type": ["api-admin", "api-user", "api-public"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "user-routes", "user-components", "public-routes"] } }
+                }
+            ]
+        }])
+    }
+
+    let pass = vec![(
+        r#"
+            import { uiButton } from "../../components/ui/button.ts";
+            import { publicInfoApi } from "../../api/public/info.ts";
+            import { mainLayout } from "../../layouts/main.ts";
+
+            export const landingPage = [uiButton, publicInfoApi, mainLayout];
+            "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    let fail = vec![(
+        r#"
+            import { adminDashboard } from "../admin/dashboard.ts";
+            import { userProfile } from "../user/profile.ts";
+            import { adminCard } from "../../components/admin-card.ts";
+            import { userCard } from "../../components/user-card.ts";
+            import { userProfileApi } from "../../api/user/profile.ts";
+            import { adminUsersApi } from "../../api/admin/users.ts";
+
+            export const landingPage = [
+              adminDashboard,
+              userProfile,
+              adminCard,
+              userCard,
+              userProfileApi,
+              adminUsersApi,
+            ];
+            "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    Tester::new(BoundariesDependencies::NAME, BoundariesDependencies::PLUGIN, pass, fail)
+        .change_rule_path("boundaries-app/src/routes/public/landing.ts")
+        .with_import_plugin(true)
+        .intentionally_allow_no_fix_tests()
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_dynamic_import_and_require_boundaries_dependencies() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn eslint_config() -> serde_json::Value {
+        json!({
+            "settings": {
+                "boundaries/elements": [
+                    { "type": "admin-routes", "pattern": ["src/routes/admin/*"] },
+                    { "type": "user-routes", "pattern": ["src/routes/user/*"] },
+                    { "type": "public-routes", "pattern": ["src/routes/public/*"] },
+                    { "type": "admin-components", "pattern": ["src/components/admin-*", "src/components/admin/*"] },
+                    { "type": "user-components", "pattern": ["src/components/user-*"] },
+                    { "type": "api-admin", "pattern": ["src/api/admin/*"] },
+                    { "type": "api-user", "pattern": ["src/api/user/*"] },
+                    { "type": "api-public", "pattern": ["src/api/public/*"] },
+                    { "type": "shared", "pattern": ["src/components/ui/*", "src/library/*", "src/hooks/*", "src/utils/*"] },
+                    { "type": "layouts", "pattern": ["src/layouts/*"] },
+                    { "type": "locales", "pattern": ["src/locales/**/*"] },
+                    { "type": "styles", "pattern": ["src/styles/**/*"] }
+                ]
+            }
+        })
+    }
+
+    fn rule_config() -> serde_json::Value {
+        json!([{
+            "default": "allow",
+            "rules": [
+                {
+                    "from": { "type": ["public-routes"] },
+                    "disallow": { "to": { "type": ["admin-routes", "user-routes", "admin-components", "user-components", "api-admin", "api-user"] } }
+                }
+            ]
+        }])
+    }
+
+    let pass = vec![(
+        r#"
+        async function loadPage() {
+          const ui = await import("../../components/ui/button");
+          const api = require("../../api/public/info");
+          return [ui, api];
+        }
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    let fail = vec![(
+        r#"
+        async function loadPage() {
+          const adminRoute = await import("../admin/dashboard");
+          const userRoute = await import("../user/profile");
+          const adminApi = require("../../api/admin/users");
+          return [adminRoute, userRoute, adminApi];
+        }
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    Tester::new(BoundariesDependencies::NAME, BoundariesDependencies::PLUGIN, pass, fail)
+        .change_rule_path("boundaries-app/src/routes/public/lazy.ts")
+        .with_import_plugin(true)
+        .with_snapshot_suffix("dynamic")
+        .intentionally_allow_no_fix_tests()
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_default_disallow_with_allow_override_boundaries_dependencies() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn eslint_config() -> serde_json::Value {
+        json!({
+            "settings": {
+                "boundaries/elements": [
+                    { "type": "admin-routes", "pattern": ["src/routes/admin/*"] },
+                    { "type": "user-routes", "pattern": ["src/routes/user/*"] },
+                    { "type": "public-routes", "pattern": ["src/routes/public/*"] },
+                    { "type": "admin-components", "pattern": ["src/components/admin-*", "src/components/admin/*"] },
+                    { "type": "user-components", "pattern": ["src/components/user-*"] },
+                    { "type": "api-admin", "pattern": ["src/api/admin/*"] },
+                    { "type": "api-user", "pattern": ["src/api/user/*"] },
+                    { "type": "api-public", "pattern": ["src/api/public/*"] },
+                    { "type": "shared", "pattern": ["src/components/ui/*", "src/library/*", "src/hooks/*", "src/utils/*"] },
+                    { "type": "layouts", "pattern": ["src/layouts/*"] },
+                    { "type": "locales", "pattern": ["src/locales/**/*"] },
+                    { "type": "styles", "pattern": ["src/styles/**/*"] }
+                ]
+            }
+        })
+    }
+
+    fn rule_config() -> serde_json::Value {
+        json!([{
+            "default": "disallow",
+            "rules": [
+                {
+                    "from": { "type": ["public-routes"] },
+                    "allow": { "to": { "type": ["shared", "layouts", "api-public"] } }
+                }
+            ]
+        }])
+    }
+
+    let pass = vec![(
+        r#"
+        import { uiButton } from "../../components/ui/button";
+        import { publicInfoApi } from "../../api/public/info";
+        import { mainLayout } from "../../layouts/main";
+
+        export const allowedPage = [uiButton, publicInfoApi, mainLayout];
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    let fail = vec![(
+        r#"
+        import { uiButton } from "../../components/ui/button";
+        import { publicInfoApi } from "../../api/public/info";
+        import { adminDashboard } from "../admin/dashboard";
+
+        export const blockedPage = [uiButton, publicInfoApi, adminDashboard];
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    Tester::new(BoundariesDependencies::NAME, BoundariesDependencies::PLUGIN, pass, fail)
+        .change_rule_path("boundaries-app/src/routes/public/explicit.ts")
+        .with_import_plugin(true)
+        .with_snapshot_suffix("default_disallow")
+        .intentionally_allow_no_fix_tests()
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_user_components_boundaries_dependencies() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn eslint_config() -> serde_json::Value {
+        json!({
+            "settings": {
+                "boundaries/elements": [
+                    { "type": "admin-routes", "pattern": ["src/routes/admin/*"] },
+                    { "type": "user-routes", "pattern": ["src/routes/user/*"] },
+                    { "type": "public-routes", "pattern": ["src/routes/public/*"] },
+                    { "type": "admin-components", "pattern": ["src/components/admin-*", "src/components/admin/*"] },
+                    { "type": "user-components", "pattern": ["src/components/user-*"] },
+                    { "type": "api-admin", "pattern": ["src/api/admin/*"] },
+                    { "type": "api-user", "pattern": ["src/api/user/*"] },
+                    { "type": "api-public", "pattern": ["src/api/public/*"] },
+                    { "type": "shared", "pattern": ["src/components/ui/*", "src/library/*", "src/hooks/*", "src/utils/*"] },
+                    { "type": "layouts", "pattern": ["src/layouts/*"] },
+                    { "type": "locales", "pattern": ["src/locales/**/*"] },
+                    { "type": "styles", "pattern": ["src/styles/**/*"] }
+                ]
+            }
+        })
+    }
+
+    fn rule_config() -> serde_json::Value {
+        json!([{
+            "default": "allow",
+            "rules": [
+                {
+                    "from": { "type": ["user-routes", "user-components"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "api-admin"] } }
+                },
+                {
+                    "from": { "type": ["public-routes"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "api-admin", "user-routes", "user-components", "api-user"] } }
+                },
+                {
+                    "from": { "type": ["api-admin", "api-user", "api-public"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "user-routes", "user-components", "public-routes"] } }
+                }
+            ]
+        }])
+    }
+
+    let pass = vec![(
+        r#"
+        import { uiButton } from "./ui/button.ts";
+        import { userProfileApi } from "../api/user/profile.ts";
+
+        export const userComponent = [uiButton, userProfileApi];
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    let fail = vec![(
+        r#"
+        import { adminDashboard } from "../routes/admin/dashboard.ts";
+        import { adminCard } from "./admin-card.ts";
+        import { adminUsersApi } from "../api/admin/users.ts";
+
+        export const userComponent = [adminDashboard, adminCard, adminUsersApi];
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    Tester::new(BoundariesDependencies::NAME, BoundariesDependencies::PLUGIN, pass, fail)
+        .change_rule_path("boundaries-app/src/components/user-card.ts")
+        .with_import_plugin(true)
+        .with_snapshot_suffix("user_components")
+        .intentionally_allow_no_fix_tests()
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_api_public_boundaries_dependencies() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn eslint_config() -> serde_json::Value {
+        json!({
+            "settings": {
+                "boundaries/elements": [
+                    { "type": "admin-routes", "pattern": ["src/routes/admin/*"] },
+                    { "type": "user-routes", "pattern": ["src/routes/user/*"] },
+                    { "type": "public-routes", "pattern": ["src/routes/public/*"] },
+                    { "type": "admin-components", "pattern": ["src/components/admin-*", "src/components/admin/*"] },
+                    { "type": "user-components", "pattern": ["src/components/user-*"] },
+                    { "type": "api-admin", "pattern": ["src/api/admin/*"] },
+                    { "type": "api-user", "pattern": ["src/api/user/*"] },
+                    { "type": "api-public", "pattern": ["src/api/public/*"] },
+                    { "type": "shared", "pattern": ["src/components/ui/*", "src/library/*", "src/hooks/*", "src/utils/*"] },
+                    { "type": "layouts", "pattern": ["src/layouts/*"] },
+                    { "type": "locales", "pattern": ["src/locales/**/*"] },
+                    { "type": "styles", "pattern": ["src/styles/**/*"] }
+                ]
+            }
+        })
+    }
+
+    fn rule_config() -> serde_json::Value {
+        json!([{
+            "default": "allow",
+            "rules": [
+                {
+                    "from": { "type": ["user-routes", "user-components"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "api-admin"] } }
+                },
+                {
+                    "from": { "type": ["public-routes"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "api-admin", "user-routes", "user-components", "api-user"] } }
+                },
+                {
+                    "from": { "type": ["api-admin", "api-user", "api-public"] },
+                    "disallow": { "to": { "type": ["admin-routes", "admin-components", "user-routes", "user-components", "public-routes"] } }
+                }
+            ]
+        }])
+    }
+
+    let pass = vec![(
+        r#"
+        import { uiButton } from "../../components/ui/button.ts";
+        import { adminUsersApi } from "../admin/users.ts";
+
+        export const apiResult = [uiButton, adminUsersApi];
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    let fail = vec![(
+        r#"
+        import { adminDashboard } from "../../routes/admin/dashboard.ts";
+        import { userProfile } from "../../routes/user/profile.ts";
+        import { mainLayout } from "../../layouts/main.ts";
+        import { userCard } from "../../components/user-card.ts";
+
+        export const apiResult = [adminDashboard, userProfile, mainLayout, userCard];
+        "#,
+        Some(rule_config()),
+        Some(eslint_config()),
+    )];
+
+    Tester::new(BoundariesDependencies::NAME, BoundariesDependencies::PLUGIN, pass, fail)
+        .change_rule_path("boundaries-app/src/api/public/info.ts")
+        .with_import_plugin(true)
+        .with_snapshot_suffix("api_public")
+        .intentionally_allow_no_fix_tests()
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/boundary_utils.rs
+++ b/crates/oxc_linter/src/rules/oxc/boundary_utils.rs
@@ -1,0 +1,126 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::context::LintContext;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub(super) struct BoundaryElementSetting {
+    #[serde(rename = "type")]
+    pub(super) element_type: String,
+    pub(super) pattern: BoundaryPatterns,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(untagged)]
+pub(super) enum BoundaryPatterns {
+    Single(String),
+    Many(Vec<String>),
+    #[default]
+    Empty,
+}
+
+impl BoundaryPatterns {
+    pub(super) fn iter(&self) -> impl Iterator<Item = &str> {
+        let patterns: Vec<&str> = match self {
+            Self::Single(single) => vec![single.as_str()],
+            Self::Many(many) => many.iter().map(String::as_str).collect(),
+            Self::Empty => vec![],
+        };
+        patterns.into_iter()
+    }
+}
+
+pub(super) fn read_boundary_elements(ctx: &LintContext<'_>) -> Option<Vec<BoundaryElementSetting>> {
+    let raw_settings = ctx.settings().json.as_ref()?;
+    let raw_elements = raw_settings.get("boundaries/elements")?.clone();
+    serde_json::from_value(raw_elements).ok()
+}
+
+pub(super) fn classify_path(path: &Path, elements: &[BoundaryElementSetting]) -> Option<String> {
+    let suffixes = normalized_path_suffixes(path);
+    for element in elements {
+        if element
+            .pattern
+            .iter()
+            .any(|pattern| suffixes.iter().any(|suffix| fast_glob::glob_match(pattern, suffix)))
+        {
+            return Some(element.element_type.clone());
+        }
+    }
+    None
+}
+
+pub(super) fn resolve_local_specifier(base_file: &Path, specifier: &str) -> Option<PathBuf> {
+    if !specifier.starts_with('.') && !specifier.starts_with('/') {
+        return None;
+    }
+
+    let candidate = if specifier.starts_with('/') {
+        PathBuf::from(specifier)
+    } else {
+        let parent = base_file.parent()?;
+        parent.join(specifier)
+    };
+
+    let candidate = normalize_path(&candidate);
+
+    resolve_existing_module_path(&candidate)
+}
+
+fn resolve_existing_module_path(candidate: &Path) -> Option<PathBuf> {
+    const EXTENSIONS: [&str; 8] = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
+
+    if candidate.is_file() {
+        return Some(candidate.to_path_buf());
+    }
+
+    if candidate.extension().is_none() {
+        for extension in EXTENSIONS {
+            let with_extension = candidate.with_extension(extension);
+            if with_extension.is_file() {
+                return Some(with_extension);
+            }
+        }
+    }
+
+    if candidate.is_dir() {
+        for extension in EXTENSIONS {
+            let index_path = candidate.join(format!("index.{extension}"));
+            if index_path.is_file() {
+                return Some(index_path);
+            }
+        }
+    }
+
+    None
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
+fn normalized_path_suffixes(path: &Path) -> Vec<String> {
+    let components = path
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    (0..components.len()).map(|index| components[index..].join("/")).collect()
+}

--- a/crates/oxc_linter/src/rules/oxc/css_no_duplicate_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/css_no_duplicate_properties.rs
@@ -1,0 +1,125 @@
+use rustc_hash::FxHashMap;
+
+use super::css_utils::is_css_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    css_parser::{CssDeclarationBlock, CssRule, CssStylesheet, parse_css},
+    rule::Rule,
+};
+
+fn css_no_duplicate_properties_diagnostic(
+    property: &str,
+    span: Span,
+    first_span: Span,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Duplicate property `{property}` in declaration block."))
+        .with_help("Remove one of the duplicate declarations or use a different value strategy.")
+        .with_labels([span.label("duplicate here"), first_span.label("first occurrence")])
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CssNoDuplicateProperties;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects duplicate CSS properties within the same declaration block.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Duplicate properties are usually a mistake. The later declaration
+    /// overrides the earlier one, which can hide intended styles. While
+    /// sometimes used as a fallback strategy, explicit fallbacks should use
+    /// different syntax (e.g., custom properties, `@supports`).
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```css
+    /// .a { color: red; color: blue; }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```css
+    /// .a { color: red; background: blue; }
+    /// ```
+    CssNoDuplicateProperties,
+    oxc,
+    correctness
+);
+
+impl Rule for CssNoDuplicateProperties {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_css(source_text);
+        let Some(stylesheet) = &result.stylesheet else {
+            return;
+        };
+
+        check_stylesheet(stylesheet, ctx);
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && is_css_file(ctx.file_path())
+    }
+}
+
+fn check_stylesheet(stylesheet: &CssStylesheet<'_>, ctx: &LintContext<'_>) {
+    for rule in &stylesheet.rules {
+        check_rule(rule, ctx);
+    }
+}
+
+fn check_rule(rule: &CssRule<'_>, ctx: &LintContext<'_>) {
+    match rule {
+        CssRule::QualifiedRule(qr) => check_block(&qr.block, ctx),
+        CssRule::AtRule(ar) => {
+            if let Some(block) = &ar.block {
+                for nested in &block.rules {
+                    check_rule(nested, ctx);
+                }
+            }
+        }
+        CssRule::Comment(_) => {}
+    }
+}
+
+fn check_block(block: &CssDeclarationBlock<'_>, ctx: &LintContext<'_>) {
+    let mut seen: FxHashMap<&str, Span> = FxHashMap::default();
+    for decl in &block.declarations {
+        if let Some(&first_span) = seen.get(decl.property) {
+            ctx.diagnostic(css_no_duplicate_properties_diagnostic(
+                decl.property,
+                decl.property_span,
+                first_span,
+            ));
+        } else {
+            seen.insert(decl.property, decl.property_span);
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ".a { color: red; background: blue; }",
+        ".a { color: red; } .b { color: blue; }",
+        "@media (max-width: 768px) { .a { color: red; } }",
+    ];
+
+    let fail = vec![
+        ".a { color: red; color: blue; }",
+        "h1 { font-size: 16px; margin: 0; font-size: 20px; }",
+    ];
+
+    Tester::new(CssNoDuplicateProperties::NAME, CssNoDuplicateProperties::PLUGIN, pass, fail)
+        .change_rule_path("test.css")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/css_no_empty_blocks.rs
+++ b/crates/oxc_linter/src/rules/oxc/css_no_empty_blocks.rs
@@ -1,0 +1,99 @@
+use super::css_utils::is_css_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    css_parser::{CssRule, CssStylesheet, parse_css},
+    rule::Rule,
+};
+
+fn css_no_empty_blocks_diagnostic(selector: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Empty declaration block for `{selector}`."))
+        .with_help("Remove the empty rule or add declarations to it.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CssNoEmptyBlocks;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects CSS rules with empty declaration blocks.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Empty rule blocks are dead code that increases file size and makes
+    /// stylesheets harder to maintain.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```css
+    /// .a { }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```css
+    /// .a { color: red; }
+    /// ```
+    CssNoEmptyBlocks,
+    oxc,
+    correctness
+);
+
+impl Rule for CssNoEmptyBlocks {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_css(source_text);
+        let Some(stylesheet) = &result.stylesheet else {
+            return;
+        };
+
+        check_stylesheet(stylesheet, ctx);
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && is_css_file(ctx.file_path())
+    }
+}
+
+fn check_stylesheet(stylesheet: &CssStylesheet<'_>, ctx: &LintContext<'_>) {
+    for rule in &stylesheet.rules {
+        check_rule(rule, ctx);
+    }
+}
+
+fn check_rule(rule: &CssRule<'_>, ctx: &LintContext<'_>) {
+    match rule {
+        CssRule::QualifiedRule(qr) => {
+            if qr.block.declarations.is_empty() {
+                ctx.diagnostic(css_no_empty_blocks_diagnostic(qr.selector, qr.block.span));
+            }
+        }
+        CssRule::AtRule(ar) => {
+            if let Some(block) = &ar.block {
+                for nested in &block.rules {
+                    check_rule(nested, ctx);
+                }
+            }
+        }
+        CssRule::Comment(_) => {}
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![".a { color: red; }", "@media (max-width: 768px) { .a { color: red; } }"];
+
+    let fail = vec![".a { }", "h1 { } h2 { color: red; }"];
+
+    Tester::new(CssNoEmptyBlocks::NAME, CssNoEmptyBlocks::PLUGIN, pass, fail)
+        .change_rule_path("test.css")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/css_no_important.rs
+++ b/crates/oxc_linter/src/rules/oxc/css_no_important.rs
@@ -1,0 +1,112 @@
+use super::css_utils::is_css_file;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    css_parser::{CssDeclarationBlock, CssRule, CssStylesheet, parse_css},
+    rule::Rule,
+};
+
+fn css_no_important_diagnostic(property: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`!important` used on `{property}`."))
+        .with_help(
+            "Avoid `!important` — it makes styles harder to override and maintain. \
+             Use more specific selectors instead.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CssNoImportant;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows use of `!important` in CSS declarations.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `!important` overrides the natural specificity cascade, making styles
+    /// difficult to maintain and debug. It often leads to specificity wars
+    /// where more `!important` declarations are added to override earlier ones.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```css
+    /// .a { color: red !important; }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```css
+    /// .a { color: red; }
+    /// ```
+    CssNoImportant,
+    oxc,
+    style
+);
+
+impl Rule for CssNoImportant {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let source_text = ctx.full_source_text();
+        let result = parse_css(source_text);
+        let Some(stylesheet) = &result.stylesheet else {
+            return;
+        };
+
+        check_stylesheet(stylesheet, ctx);
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host() && is_css_file(ctx.file_path())
+    }
+}
+
+fn check_stylesheet(stylesheet: &CssStylesheet<'_>, ctx: &LintContext<'_>) {
+    for rule in &stylesheet.rules {
+        check_rule(rule, ctx);
+    }
+}
+
+fn check_rule(rule: &CssRule<'_>, ctx: &LintContext<'_>) {
+    match rule {
+        CssRule::QualifiedRule(qr) => check_block(&qr.block, ctx),
+        CssRule::AtRule(ar) => {
+            if let Some(block) = &ar.block {
+                for nested in &block.rules {
+                    check_rule(nested, ctx);
+                }
+            }
+        }
+        CssRule::Comment(_) => {}
+    }
+}
+
+fn check_block(block: &CssDeclarationBlock<'_>, ctx: &LintContext<'_>) {
+    for decl in &block.declarations {
+        if decl.important {
+            ctx.diagnostic(css_no_important_diagnostic(decl.property, decl.value_span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ".a { color: red; }",
+        ".a { color: red; font-size: 16px; }",
+        "@media (max-width: 768px) { .a { color: red; } }",
+    ];
+
+    let fail =
+        vec![".a { color: red !important; }", ".a { color: red; font-size: 16px !important; }"];
+
+    Tester::new(CssNoImportant::NAME, CssNoImportant::PLUGIN, pass, fail)
+        .change_rule_path("test.css")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/css_utils.rs
+++ b/crates/oxc_linter/src/rules/oxc/css_utils.rs
@@ -1,0 +1,5 @@
+use std::{ffi::OsStr, path::Path};
+
+pub(super) fn is_css_file(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| ext == OsStr::new("css"))
+}

--- a/crates/oxc_linter/src/rules/oxc/optimize_regex.rs
+++ b/crates/oxc_linter/src/rules/oxc/optimize_regex.rs
@@ -1,0 +1,317 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_regular_expression::ast::{
+    Alternative, CapturingGroup, CharacterClass, CharacterClassContents,
+    CharacterClassContentsKind, Disjunction, IgnoreGroup, LookAroundAssertion, Pattern, Quantifier,
+    Term,
+};
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn optimize_regex_diagnostic(span: Span, replacement: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("This regular expression can be simplified.")
+        .with_help(format!("Replace this fragment with `{replacement}`."))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct OptimizeRegex;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Simplifies a narrow set of regular-expression fragments that are longer
+    /// than equivalent built-in forms.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Shorter regular expressions are easier to scan and usually make the
+    /// intended character set or repetition clearer to readers.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// const digits = /[0-9]+/;
+    /// const word = /[A-Z_a-z0-9]+/;
+    /// const repeated = /aaaaaa/;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const digits = /\d+/;
+    /// const word = /\w+/;
+    /// const repeated = /a{6}/;
+    /// ```
+    OptimizeRegex,
+    oxc,
+    style,
+    fix
+);
+
+impl Rule for OptimizeRegex {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::RegExpLiteral(regex) = node.kind() else {
+            return;
+        };
+
+        let Some(pattern) = regex.regex.pattern.pattern.as_deref() else {
+            return;
+        };
+
+        let mut replacements = Vec::new();
+        collect_pattern_replacements(pattern, ctx, &mut replacements);
+
+        for replacement in replacements {
+            ctx.diagnostic_with_fix(
+                optimize_regex_diagnostic(replacement.span, &replacement.text),
+                |fixer| fixer.replace(replacement.span, replacement.text.clone()),
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Replacement {
+    span: Span,
+    text: String,
+}
+
+fn collect_pattern_replacements(
+    pattern: &Pattern<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    collect_disjunction_replacements(&pattern.body, ctx, replacements);
+}
+
+fn collect_disjunction_replacements(
+    disjunction: &Disjunction<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    for alternative in &disjunction.body {
+        collect_alternative_replacements(alternative, ctx, replacements);
+    }
+}
+
+fn collect_alternative_replacements(
+    alternative: &Alternative<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    for term in &alternative.body {
+        collect_term_replacements(term, ctx, replacements);
+    }
+
+    let source_text = ctx.source_text();
+    let mut index = 0usize;
+
+    while index < alternative.body.len() {
+        let Some(raw_atom) = repeatable_atom_source(&alternative.body[index], source_text) else {
+            index += 1;
+            continue;
+        };
+
+        let mut end_index = index + 1;
+        while end_index < alternative.body.len()
+            && repeatable_atom_source(&alternative.body[end_index], source_text) == Some(raw_atom)
+        {
+            end_index += 1;
+        }
+
+        let count = end_index - index;
+        if count >= 2 {
+            let replacement = format!("{raw_atom}{{{count}}}");
+            if replacement.len() < raw_atom.len() * count {
+                let span = Span::new(
+                    alternative.body[index].span().start,
+                    alternative.body[end_index - 1].span().end,
+                );
+                replacements.push(Replacement { span, text: replacement });
+                index = end_index;
+                continue;
+            }
+        }
+
+        index += 1;
+    }
+}
+
+fn collect_term_replacements(
+    term: &Term<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    match term {
+        Term::Quantifier(quantifier) => {
+            collect_quantifier_replacements(quantifier, ctx, replacements);
+        }
+        Term::CharacterClass(class) => {
+            if let Some(text) = character_class_replacement(class) {
+                replacements.push(Replacement { span: class.span, text: text.to_string() });
+            }
+        }
+        Term::CapturingGroup(group) => {
+            collect_capturing_group_replacements(group, ctx, replacements);
+        }
+        Term::IgnoreGroup(group) => collect_ignore_group_replacements(group, ctx, replacements),
+        Term::LookAroundAssertion(assertion) => {
+            collect_lookaround_replacements(assertion, ctx, replacements);
+        }
+        _ => {}
+    }
+}
+
+fn collect_quantifier_replacements(
+    quantifier: &Quantifier<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    collect_term_replacements(&quantifier.body, ctx, replacements);
+}
+
+fn collect_capturing_group_replacements(
+    group: &CapturingGroup<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    collect_disjunction_replacements(&group.body, ctx, replacements);
+}
+
+fn collect_ignore_group_replacements(
+    group: &IgnoreGroup<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    collect_disjunction_replacements(&group.body, ctx, replacements);
+}
+
+fn collect_lookaround_replacements(
+    assertion: &LookAroundAssertion<'_>,
+    ctx: &LintContext<'_>,
+    replacements: &mut Vec<Replacement>,
+) {
+    collect_disjunction_replacements(&assertion.body, ctx, replacements);
+}
+
+fn repeatable_atom_source<'a>(term: &Term<'_>, source_text: &'a str) -> Option<&'a str> {
+    match term {
+        Term::Character(character) => Some(character.span.source_text(source_text)),
+        Term::Dot(dot) => Some(dot.span.source_text(source_text)),
+        _ => None,
+    }
+}
+
+fn character_class_replacement(class: &CharacterClass<'_>) -> Option<&'static str> {
+    if class.strings || class.kind != CharacterClassContentsKind::Union {
+        return None;
+    }
+
+    if is_digits_class(class) {
+        return Some(if class.negative { r"\D" } else { r"\d" });
+    }
+
+    if is_word_class(class) {
+        return Some(if class.negative { r"\W" } else { r"\w" });
+    }
+
+    None
+}
+
+fn is_digits_class(class: &CharacterClass<'_>) -> bool {
+    class.body.len() == 1
+        && matches!(class.body[0], CharacterClassContents::CharacterClassRange(ref range) if is_range(range, '0', '9'))
+}
+
+fn is_word_class(class: &CharacterClass<'_>) -> bool {
+    if class.body.len() != 4 {
+        return false;
+    }
+
+    let mut seen_lower = false;
+    let mut seen_upper = false;
+    let mut seen_digits = false;
+    let mut seen_underscore = false;
+
+    for content in &class.body {
+        match content {
+            CharacterClassContents::CharacterClassRange(range) if is_range(range, 'a', 'z') => {
+                if seen_lower {
+                    return false;
+                }
+                seen_lower = true;
+            }
+            CharacterClassContents::CharacterClassRange(range) if is_range(range, 'A', 'Z') => {
+                if seen_upper {
+                    return false;
+                }
+                seen_upper = true;
+            }
+            CharacterClassContents::CharacterClassRange(range) if is_range(range, '0', '9') => {
+                if seen_digits {
+                    return false;
+                }
+                seen_digits = true;
+            }
+            CharacterClassContents::Character(character) if character.value == u32::from(b'_') => {
+                if seen_underscore {
+                    return false;
+                }
+                seen_underscore = true;
+            }
+            _ => return false,
+        }
+    }
+
+    seen_lower && seen_upper && seen_digits && seen_underscore
+}
+
+fn is_range(
+    range: &oxc_regular_expression::ast::CharacterClassRange,
+    min: char,
+    max: char,
+) -> bool {
+    range.min.value == min as u32 && range.max.value == max as u32
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass: Vec<(&str, Option<serde_json::Value>, Option<serde_json::Value>)> = vec![
+        (r"const digits = /\d+/;", None, None),
+        (r"const word = /\w+/;", None, None),
+        (r"const not_word = /\W{2}/;", None, None),
+        (r"const hex = /[0-9a-f]+/;", None, None),
+        (r"const almost = /aaaa/;", None, None),
+        (r"const mixed = /(ab)(ab)/;", None, None),
+    ];
+
+    let fail: Vec<(&str, Option<serde_json::Value>, Option<serde_json::Value>)> = vec![
+        (r"const digits = /[0-9]+/;", None, None),
+        (r"const not_digits = /[^0-9]+/;", None, None),
+        (r"const word = /[A-Z_a-z0-9]+/;", None, None),
+        (r"const not_word = /[^a-zA-Z0-9_]+/;", None, None),
+        (r"const repeated = /aaaaaa/;", None, None),
+        (r"const escaped = /\.\.\./;", None, None),
+        (r"const nested = /(?=[0-9])foo/;", None, None),
+    ];
+
+    let fix = vec![
+        (r"const digits = /[0-9]+/;", r"const digits = /\d+/;", None),
+        (r"const not_digits = /[^0-9]+/;", r"const not_digits = /\D+/;", None),
+        (r"const word = /[A-Z_a-z0-9]+/;", r"const word = /\w+/;", None),
+        (r"const not_word = /[^a-zA-Z0-9_]+/;", r"const not_word = /\W+/;", None),
+        (r"const repeated = /aaaaaa/;", r"const repeated = /a{6}/;", None),
+        (r"const escaped = /\.\.\./;", r"const escaped = /\.{3}/;", None),
+        (r"const nested = /(?=[0-9])foo/;", r"const nested = /(?=\d)foo/;", None),
+    ];
+
+    Tester::new(OptimizeRegex::NAME, OptimizeRegex::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_enums.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_enums.rs
@@ -1,0 +1,165 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_enums_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Enum members should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortEnumsConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortEnumsConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortEnums(Box<SortEnumsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted members in TypeScript enums.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unsorted enum members make enums harder to scan and maintain.
+    /// Consistent ordering reduces merge conflicts and improves readability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// enum Color { Red, Green, Blue }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// enum Color { Blue, Green, Red }
+    /// ```
+    SortEnums,
+    oxc,
+    style,
+    none,
+    config = SortEnumsConfig
+);
+
+impl Rule for SortEnums {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortEnumsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSEnumDeclaration(enum_decl) = node.kind() else {
+            return;
+        };
+
+        if enum_decl.body.members.len() < 2 {
+            return;
+        }
+
+        let members: Vec<(usize, String)> = enum_decl
+            .body
+            .members
+            .iter()
+            .enumerate()
+            .map(|(i, member)| {
+                let key = match &member.id {
+                    oxc_ast::ast::TSEnumMemberName::Identifier(ident) => ident.name.to_string(),
+                    oxc_ast::ast::TSEnumMemberName::String(lit) => lit.value.to_string(),
+                    _ => ctx.source_range(member.id.span()).to_string(),
+                };
+                (i, key)
+            })
+            .collect();
+
+        let sorted = sorted_indices(&members, &self.0);
+        if let Some(first_unsorted) = first_unsorted_position(&sorted) {
+            let (orig_idx, _) = &members[first_unsorted];
+            ctx.diagnostic(sort_enums_diagnostic(enum_decl.body.members[*orig_idx].span()));
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+fn sorted_indices(members: &[(usize, String)], config: &SortEnumsConfig) -> Vec<usize> {
+    let mut entries: Vec<(usize, String)> = members
+        .iter()
+        .enumerate()
+        .map(|(pos, (_, key))| {
+            let k = if config.ignore_case {
+                key.cow_to_ascii_lowercase().into_owned()
+            } else {
+                key.clone()
+            };
+            (pos, k)
+        })
+        .collect();
+
+    entries.sort_by(|(ai, ak), (bi, bk)| {
+        let ord = ak.cmp(bk);
+        let ord = match config.order {
+            SortOrder::Asc => ord,
+            SortOrder::Desc => ord.reverse(),
+        };
+        if ord == Ordering::Equal { ai.cmp(bi) } else { ord }
+    });
+
+    entries.into_iter().map(|(pos, _)| pos).collect()
+}
+
+fn first_unsorted_position(indices: &[usize]) -> Option<usize> {
+    indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, index)| (*index != position).then_some(position))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "enum Color { Blue, Green, Red }",
+        "enum Single { A }",
+        "enum Empty {}",
+        "enum Status { Active = 'active', Inactive = 'inactive', Pending = 'pending' }",
+    ];
+
+    let fail = vec!["enum Color { Red, Green, Blue }", "enum Status { Pending, Active, Inactive }"];
+
+    Tester::new(SortEnums::NAME, SortEnums::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_imports.rs
@@ -1,0 +1,152 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::ast::{ImportDeclaration, Statement};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_imports_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Import statements should be sorted alphabetically by source.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortImportsConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortImportsConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortImports(Box<SortImportsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted import statements by their source path.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unsorted imports make it harder to find specific imports and lead to
+    /// unnecessary merge conflicts. Consistent ordering improves readability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// import z from "z";
+    /// import a from "a";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import a from "a";
+    /// import z from "z";
+    /// ```
+    SortImports,
+    oxc,
+    style,
+    none,
+    config = SortImportsConfig
+);
+
+impl Rule for SortImports {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortImportsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let program = ctx.semantic().nodes().program();
+
+        // Collect contiguous groups of import declarations
+        let mut imports: Vec<&ImportDeclaration<'_>> = Vec::new();
+
+        for stmt in &program.body {
+            if let Statement::ImportDeclaration(import) = stmt {
+                imports.push(import);
+            } else {
+                self.check_group(&imports, ctx);
+                imports.clear();
+            }
+        }
+
+        self.check_group(&imports, ctx);
+    }
+}
+
+impl SortImports {
+    fn check_group(&self, imports: &[&ImportDeclaration<'_>], ctx: &LintContext<'_>) {
+        if imports.len() < 2 {
+            return;
+        }
+
+        for window in imports.windows(2) {
+            let a_key = self.import_key(window[0]);
+            let b_key = self.import_key(window[1]);
+
+            let ord = a_key.cmp(&b_key);
+            let ord = match self.0.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            };
+
+            if ord == Ordering::Greater {
+                ctx.diagnostic(sort_imports_diagnostic(window[1].span()));
+                return;
+            }
+        }
+    }
+
+    fn import_key(&self, import: &ImportDeclaration<'_>) -> String {
+        let source = import.source.value.as_str();
+        if self.0.ignore_case {
+            source.cow_to_ascii_lowercase().into_owned()
+        } else {
+            source.to_string()
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"import a from "a"; import b from "b";"#, None),
+        (r#"import a from "a";"#, None),
+        (r#"import A from "A"; import b from "b";"#, None),
+        // Non-import between groups resets
+        (r#"import b from "b"; const x = 1; import a from "a";"#, None),
+    ];
+
+    let fail = vec![
+        (r#"import z from "z"; import a from "a";"#, None),
+        (r#"import b from "b"; import a from "a"; import c from "c";"#, None),
+    ];
+
+    Tester::new(SortImports::NAME, SortImports::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_interfaces.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_interfaces.rs
@@ -1,0 +1,284 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::{
+    AstKind,
+    ast::{TSInterfaceDeclaration, TSSignature},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_interfaces_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Interface members should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortType {
+    #[default]
+    Alphabetical,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortInterfacesConfig {
+    ignore_case: bool,
+    order: SortOrder,
+    r#type: SortType,
+}
+
+impl Default for SortInterfacesConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc, r#type: SortType::Alphabetical }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortInterfaces(Box<SortInterfacesConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted interface members.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Sorting interface members makes shared contracts easier to scan and
+    /// reduces noisy diffs when members are added over time.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// interface User {
+    ///   name: string;
+    ///   id: string;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// interface User {
+    ///   id: string;
+    ///   name: string;
+    /// }
+    /// ```
+    SortInterfaces,
+    oxc,
+    style,
+    conditional_fix,
+    config = SortInterfacesConfig
+);
+
+impl Rule for SortInterfaces {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortInterfacesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSInterfaceDeclaration(interface_decl) = node.kind() else {
+            return;
+        };
+
+        if interface_decl.body.body.len() < 2 || self.0.r#type != SortType::Alphabetical {
+            return;
+        }
+
+        let Some(indices) = sorted_member_indices(interface_decl, ctx, &self.0) else {
+            return;
+        };
+        let Some(first_unsorted_index) = first_unsorted_position(&indices) else {
+            return;
+        };
+
+        let diagnostic_span = interface_decl.body.body[first_unsorted_index].span();
+        if let Some(replacement) = build_fix(interface_decl, ctx, &indices) {
+            let replace_span = Span::new(
+                interface_decl.body.body[0].span().start,
+                interface_decl.body.body[interface_decl.body.body.len() - 1].span().end,
+            );
+            ctx.diagnostic_with_fix(sort_interfaces_diagnostic(diagnostic_span), |fixer| {
+                fixer.replace(replace_span, replacement)
+            });
+            return;
+        }
+
+        ctx.diagnostic(sort_interfaces_diagnostic(diagnostic_span));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+fn first_unsorted_position(indices: &[usize]) -> Option<usize> {
+    indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, index)| (*index != position).then_some(position))
+}
+
+fn sorted_member_indices(
+    interface_decl: &TSInterfaceDeclaration<'_>,
+    _ctx: &LintContext<'_>,
+    config: &SortInterfacesConfig,
+) -> Option<Vec<usize>> {
+    let mut members = interface_decl
+        .body
+        .body
+        .iter()
+        .enumerate()
+        .map(|(index, member)| {
+            let raw_name = member_sort_name(member)?;
+            let key = if config.ignore_case {
+                raw_name.cow_to_ascii_lowercase().into_owned()
+            } else {
+                raw_name
+            };
+            Some((index, key))
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    members.sort_by(|(left_index, left_key), (right_index, right_key)| {
+        let ordering = left_key.cmp(right_key);
+        let ordering = match config.order {
+            SortOrder::Asc => ordering,
+            SortOrder::Desc => ordering.reverse(),
+        };
+        if ordering == Ordering::Equal { left_index.cmp(right_index) } else { ordering }
+    });
+
+    Some(members.into_iter().map(|(index, _)| index).collect())
+}
+
+fn member_sort_name(member: &TSSignature<'_>) -> Option<String> {
+    match member {
+        TSSignature::TSPropertySignature(signature) => {
+            Some(signature.key.static_name()?.into_owned())
+        }
+        TSSignature::TSMethodSignature(signature) => {
+            Some(signature.key.static_name()?.into_owned())
+        }
+        _ => None,
+    }
+}
+
+fn build_fix(
+    interface_decl: &TSInterfaceDeclaration<'_>,
+    ctx: &LintContext<'_>,
+    indices: &[usize],
+) -> Option<String> {
+    let members = interface_decl.body.body.as_slice();
+    let first = members.first()?;
+    let last = members.last()?;
+    let full_span = Span::new(first.span().start, last.span().end);
+    if ctx.has_comments_between(full_span) {
+        return None;
+    }
+
+    for window in members.windows(2) {
+        let between = Span::new(window[0].span().end, window[1].span().start);
+        if ctx.has_comments_between(between) {
+            return None;
+        }
+    }
+
+    let texts = members
+        .iter()
+        .map(|member| ctx.source_range(member.span()).to_string())
+        .collect::<Vec<_>>();
+    let separators = members
+        .windows(2)
+        .map(|window| {
+            ctx.source_range(Span::new(window[0].span().end, window[1].span().start)).to_string()
+        })
+        .collect::<Vec<_>>();
+
+    let mut replacement = String::new();
+    for (position, index) in indices.iter().enumerate() {
+        replacement.push_str(&texts[*index]);
+        if position < separators.len() {
+            replacement.push_str(&separators[position]);
+        }
+    }
+
+    Some(replacement)
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("interface User {\n  id: string;\n  name: string;\n}", None),
+        ("interface User {\n  Id: string;\n  name: string;\n}", None),
+        (
+            "interface User {\n  Id: string;\n  name: string;\n}",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+        ("interface User {\n  getId(): string;\n  name: string;\n}", None),
+        ("interface User {\n  [key: string]: string;\n  name: string;\n}", None),
+    ];
+
+    let fail = vec![
+        ("interface User {\n  name: string;\n  id: string;\n}", None),
+        ("interface User {\n  name: string;\n  getId(): string;\n}", None),
+        (
+            "interface User {\n  id: string;\n  Id: string;\n}",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+        (
+            "interface User {\n  getId(): string;\n  id: string;\n}",
+            Some(json!([{ "order": "desc" }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "interface User {\n  name: string;\n  id: string;\n}",
+            "interface User {\n  id: string;\n  name: string;\n}",
+            None,
+        ),
+        (
+            "interface User {\n  name: string;\n  getId(): string;\n}",
+            "interface User {\n  getId(): string;\n  name: string;\n}",
+            None,
+        ),
+        (
+            "interface User {\n  id: string;\n  Id: string;\n}",
+            "interface User {\n  Id: string;\n  id: string;\n}",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+        (
+            "interface User {\n  getId(): string;\n  id: string;\n}",
+            "interface User {\n  id: string;\n  getId(): string;\n}",
+            Some(json!([{ "order": "desc" }])),
+        ),
+    ];
+
+    Tester::new(SortInterfaces::NAME, SortInterfaces::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_intersection_types.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_intersection_types.rs
@@ -1,0 +1,182 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::{AstKind, ast::TSIntersectionType};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_intersection_types_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Intersection types should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortIntersectionTypesConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortIntersectionTypesConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortIntersectionTypes(Box<SortIntersectionTypesConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted TypeScript intersection type members.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Keeping intersection type members sorted makes type declarations
+    /// easier to scan, diff, and maintain.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// type Combined = Serializable & Comparable & Addressable;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// type Combined = Addressable & Comparable & Serializable;
+    /// ```
+    SortIntersectionTypes,
+    oxc,
+    style,
+    conditional_fix,
+    config = SortIntersectionTypesConfig
+);
+
+impl Rule for SortIntersectionTypes {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortIntersectionTypesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSIntersectionType(intersection) = node.kind() else {
+            return;
+        };
+
+        if intersection.types.len() < 2 {
+            return;
+        }
+
+        let indices = sorted_type_indices(intersection, ctx, &self.0);
+        let Some(first_unsorted) = first_unsorted_position(&indices) else {
+            return;
+        };
+
+        let diagnostic_span = intersection.types[first_unsorted].span();
+        if let Some(replacement) = build_fix(intersection, ctx, &indices) {
+            ctx.diagnostic_with_fix(sort_intersection_types_diagnostic(diagnostic_span), |fixer| {
+                fixer.replace(intersection.span, replacement)
+            });
+            return;
+        }
+        ctx.diagnostic(sort_intersection_types_diagnostic(diagnostic_span));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+fn first_unsorted_position(indices: &[usize]) -> Option<usize> {
+    indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, index)| (*index != position).then_some(position))
+}
+
+fn sorted_type_indices(
+    intersection: &TSIntersectionType<'_>,
+    ctx: &LintContext<'_>,
+    config: &SortIntersectionTypesConfig,
+) -> Vec<usize> {
+    let mut members: Vec<(usize, String)> = intersection
+        .types
+        .iter()
+        .enumerate()
+        .map(|(index, ty)| {
+            let raw = ctx.source_range(ty.span());
+            let key = if config.ignore_case {
+                raw.split_whitespace().collect::<String>().cow_to_ascii_lowercase().into_owned()
+            } else {
+                raw.split_whitespace().collect::<String>()
+            };
+            (index, key)
+        })
+        .collect();
+
+    members.sort_by(|(ai, ak), (bi, bk)| {
+        let ord = ak.cmp(bk);
+        let ord = match config.order {
+            SortOrder::Asc => ord,
+            SortOrder::Desc => ord.reverse(),
+        };
+        if ord == Ordering::Equal { ai.cmp(bi) } else { ord }
+    });
+
+    members.into_iter().map(|(index, _)| index).collect()
+}
+
+fn build_fix(
+    intersection: &TSIntersectionType<'_>,
+    ctx: &LintContext<'_>,
+    indices: &[usize],
+) -> Option<String> {
+    if ctx.has_comments_between(intersection.span) {
+        return None;
+    }
+
+    let pieces: Vec<&str> = indices
+        .iter()
+        .map(|&index| ctx.source_range(intersection.types[index].span()).trim())
+        .collect();
+
+    Some(pieces.join(" & "))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["type T = A & B & C;", "type T = A;"];
+
+    let fail = vec!["type T = C & A & B;", "type T = Z & A;"];
+
+    let fix = vec![
+        ("type T = C & A & B;", "type T = A & B & C;", None),
+        ("type T = Z & A;", "type T = A & Z;", None),
+    ];
+
+    Tester::new(SortIntersectionTypes::NAME, SortIntersectionTypes::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_jsx_props.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_jsx_props.rs
@@ -1,0 +1,150 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_jsx_props_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("JSX props should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortJsxPropsConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortJsxPropsConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortJsxProps(Box<SortJsxPropsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted JSX attributes (props).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unsorted JSX props make components harder to scan and lead to merge
+    /// conflicts. Consistent ordering improves readability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <Component z="1" a="2" m="3" />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <Component a="2" m="3" z="1" />
+    /// ```
+    SortJsxProps,
+    oxc,
+    style,
+    none,
+    config = SortJsxPropsConfig
+);
+
+impl Rule for SortJsxProps {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortJsxPropsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(element) = node.kind() else {
+            return;
+        };
+
+        if element.attributes.len() < 2 {
+            return;
+        }
+
+        // Collect named attributes (skip spread)
+        let named: Vec<(usize, &str)> = element
+            .attributes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, attr)| {
+                if let oxc_ast::ast::JSXAttributeItem::Attribute(a) = attr {
+                    let name = a.name.as_identifier().map(|ident| ident.name.as_str())?;
+                    Some((i, name))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if named.len() < 2 {
+            return;
+        }
+
+        for window in named.windows(2) {
+            let a_key = if self.0.ignore_case {
+                window[0].1.cow_to_ascii_lowercase().into_owned()
+            } else {
+                window[0].1.to_string()
+            };
+            let b_key = if self.0.ignore_case {
+                window[1].1.cow_to_ascii_lowercase().into_owned()
+            } else {
+                window[1].1.to_string()
+            };
+
+            let ord = a_key.cmp(&b_key);
+            let ord = match self.0.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            };
+
+            if ord == Ordering::Greater {
+                ctx.diagnostic(sort_jsx_props_diagnostic(element.attributes[window[1].0].span()));
+                return;
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"<Component a="1" b="2" c="3" />"#,
+        "<Component />",
+        r#"<Component a="1" />"#,
+        r#"<Component A="1" b="2" />"#,
+    ];
+
+    let fail = vec![r#"<Component z="1" a="2" />"#, r#"<Component c="1" a="2" b="3" />"#];
+
+    Tester::new(SortJsxProps::NAME, SortJsxProps::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_named_exports.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_named_exports.rs
@@ -1,0 +1,189 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_named_exports_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Named export specifiers should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortNamedExportsConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortNamedExportsConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortNamedExports(Box<SortNamedExportsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted named export specifiers.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unsorted named exports are harder to scan and lead to unnecessary merge
+    /// conflicts when multiple developers add exports.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// export { z, a, m };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// export { a, m, z };
+    /// ```
+    SortNamedExports,
+    oxc,
+    style,
+    conditional_fix,
+    config = SortNamedExportsConfig
+);
+
+impl Rule for SortNamedExports {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortNamedExportsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ExportNamedDeclaration(export) = node.kind() else {
+            return;
+        };
+
+        if export.specifiers.len() < 2 {
+            return;
+        }
+
+        let names: Vec<(usize, String)> = export
+            .specifiers
+            .iter()
+            .enumerate()
+            .map(|(i, spec)| {
+                let name = spec.local.name().as_str().to_string();
+                (i, name)
+            })
+            .collect();
+
+        for window in names.windows(2) {
+            let a_key = if self.0.ignore_case {
+                window[0].1.cow_to_ascii_lowercase().into_owned()
+            } else {
+                window[0].1.clone()
+            };
+            let b_key = if self.0.ignore_case {
+                window[1].1.cow_to_ascii_lowercase().into_owned()
+            } else {
+                window[1].1.clone()
+            };
+
+            let ord = a_key.cmp(&b_key);
+            let ord = match self.0.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            };
+
+            if ord == Ordering::Greater {
+                let span = export.specifiers[window[1].0].span();
+                if let Some(fix_text) = self.build_fix(export, &names, ctx) {
+                    ctx.diagnostic_with_fix(sort_named_exports_diagnostic(span), |fixer| {
+                        fixer.replace(export.span, fix_text)
+                    });
+                } else {
+                    ctx.diagnostic(sort_named_exports_diagnostic(span));
+                }
+                return;
+            }
+        }
+    }
+}
+
+impl SortNamedExports {
+    fn build_fix(
+        &self,
+        export: &oxc_ast::ast::ExportNamedDeclaration<'_>,
+        names: &[(usize, String)],
+        ctx: &LintContext<'_>,
+    ) -> Option<String> {
+        if ctx.has_comments_between(export.span) {
+            return None;
+        }
+
+        let mut sorted: Vec<&str> = names.iter().map(|(_, name)| name.as_str()).collect();
+        sorted.sort_by(|a, b| {
+            let ak = if self.0.ignore_case {
+                a.cow_to_ascii_lowercase().into_owned()
+            } else {
+                a.to_string()
+            };
+            let bk = if self.0.ignore_case {
+                b.cow_to_ascii_lowercase().into_owned()
+            } else {
+                b.to_string()
+            };
+            let ord = ak.cmp(&bk);
+            match self.0.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            }
+        });
+
+        let specifier_text = sorted.join(", ");
+        if let Some(source) = &export.source {
+            let source_text = ctx.source_range(source.span());
+            Some(format!("export {{ {specifier_text} }} from {source_text}"))
+        } else {
+            Some(format!("export {{ {specifier_text} }}"))
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass =
+        vec!["export { a, b, c };", "export { a };", "const a = 1; const b = 2; export { a, b };"];
+
+    let fail = vec!["export { z, a, m };", "export { b, a };"];
+
+    let fix = vec![
+        ("export { z, a, m };", "export { a, m, z }", None),
+        ("export { b, a };", "export { a, b }", None),
+    ];
+
+    Tester::new(SortNamedExports::NAME, SortNamedExports::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_named_imports.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_named_imports.rs
@@ -1,0 +1,203 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_named_imports_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Named import specifiers should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortNamedImportsConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortNamedImportsConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortNamedImports(Box<SortNamedImportsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted named import specifiers within import statements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unsorted named imports are harder to scan and lead to unnecessary merge
+    /// conflicts when multiple developers add imports.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// import { z, a, m } from "module";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import { a, m, z } from "module";
+    /// ```
+    SortNamedImports,
+    oxc,
+    style,
+    conditional_fix,
+    config = SortNamedImportsConfig
+);
+
+impl Rule for SortNamedImports {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortNamedImportsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ImportDeclaration(import) = node.kind() else {
+            return;
+        };
+
+        let Some(specifiers) = &import.specifiers else {
+            return;
+        };
+
+        let named: Vec<(usize, &str)> = specifiers
+            .iter()
+            .enumerate()
+            .filter_map(|(i, spec)| {
+                if let oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(s) = spec {
+                    Some((i, s.local.name.as_str()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if named.len() < 2 {
+            return;
+        }
+
+        for window in named.windows(2) {
+            let a_key = if self.0.ignore_case {
+                window[0].1.cow_to_ascii_lowercase().into_owned()
+            } else {
+                window[0].1.to_string()
+            };
+            let b_key = if self.0.ignore_case {
+                window[1].1.cow_to_ascii_lowercase().into_owned()
+            } else {
+                window[1].1.to_string()
+            };
+
+            let ord = a_key.cmp(&b_key);
+            let ord = match self.0.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            };
+
+            if ord == Ordering::Greater {
+                let span = specifiers[window[1].0].span();
+                // Try to autofix by sorting all named specifiers
+                if let Some(fix_text) = self.build_fix(import, &named, ctx) {
+                    ctx.diagnostic_with_fix(sort_named_imports_diagnostic(span), |fixer| {
+                        fixer.replace(import.span(), fix_text)
+                    });
+                } else {
+                    ctx.diagnostic(sort_named_imports_diagnostic(span));
+                }
+                return;
+            }
+        }
+    }
+}
+
+impl SortNamedImports {
+    fn build_fix(
+        &self,
+        import: &oxc_ast::ast::ImportDeclaration<'_>,
+        named: &[(usize, &str)],
+        ctx: &LintContext<'_>,
+    ) -> Option<String> {
+        if ctx.has_comments_between(import.span()) {
+            return None;
+        }
+
+        let specifiers = import.specifiers.as_ref()?;
+
+        // Only fix if all specifiers are named (no default or namespace)
+        if named.len() != specifiers.len() {
+            return None;
+        }
+
+        let mut sorted: Vec<&str> = named.iter().map(|(_, name)| *name).collect();
+        sorted.sort_by(|a, b| {
+            let ak = if self.0.ignore_case {
+                a.cow_to_ascii_lowercase().into_owned()
+            } else {
+                a.to_string()
+            };
+            let bk = if self.0.ignore_case {
+                b.cow_to_ascii_lowercase().into_owned()
+            } else {
+                b.to_string()
+            };
+            let ord = ak.cmp(&bk);
+            match self.0.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            }
+        });
+
+        let specifier_text = sorted.join(", ");
+        let source = ctx.source_range(import.source.span());
+        Some(format!("import {{ {specifier_text} }} from {source}"))
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"import { a, b, c } from "mod";"#,
+        r#"import { a } from "mod";"#,
+        r#"import def from "mod";"#,
+        r#"import { A, b } from "mod";"#,
+    ];
+
+    let fail = vec![r#"import { z, a, m } from "mod";"#, r#"import { b, a } from "mod";"#];
+
+    let fix = vec![
+        (r#"import { z, a, m } from "mod";"#, r#"import { a, m, z } from "mod""#, None),
+        (r#"import { b, a } from "mod";"#, r#"import { a, b } from "mod""#, None),
+    ];
+
+    Tester::new(SortNamedImports::NAME, SortNamedImports::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_object_types.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_object_types.rs
@@ -1,0 +1,182 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_object_types_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("TypeScript object type members should be sorted alphabetically.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortObjectTypesConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortObjectTypesConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortObjectTypes(Box<SortObjectTypesConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted members in TypeScript object type literals.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unsorted type members make type definitions harder to scan and diff.
+    /// Consistent ordering improves readability and reduces merge conflicts.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// type User = { name: string; age: number; email: string };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// type User = { age: number; email: string; name: string };
+    /// ```
+    SortObjectTypes,
+    oxc,
+    style,
+    none,
+    config = SortObjectTypesConfig
+);
+
+fn member_key(member: &oxc_ast::ast::TSSignature<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    match member {
+        oxc_ast::ast::TSSignature::TSPropertySignature(prop) => match &prop.key {
+            oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.to_string()),
+            oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.to_string()),
+            _ => Some(ctx.source_range(prop.key.span()).to_string()),
+        },
+        oxc_ast::ast::TSSignature::TSMethodSignature(method) => match &method.key {
+            oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.to_string()),
+            _ => Some(ctx.source_range(method.key.span()).to_string()),
+        },
+        _ => None,
+    }
+}
+
+impl Rule for SortObjectTypes {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortObjectTypesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSTypeLiteral(type_lit) = node.kind() else {
+            return;
+        };
+
+        if type_lit.members.len() < 2 {
+            return;
+        }
+
+        let keyed: Vec<(usize, String)> = type_lit
+            .members
+            .iter()
+            .enumerate()
+            .filter_map(|(i, member)| {
+                let key = member_key(member, ctx)?;
+                Some((i, key))
+            })
+            .collect();
+
+        if keyed.len() < 2 {
+            return;
+        }
+
+        let sorted = sorted_indices(&keyed, &self.0);
+        if let Some(first_unsorted) = first_unsorted_position(&sorted) {
+            let (orig_idx, _) = &keyed[first_unsorted];
+            ctx.diagnostic(sort_object_types_diagnostic(type_lit.members[*orig_idx].span()));
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+fn sorted_indices(keyed: &[(usize, String)], config: &SortObjectTypesConfig) -> Vec<usize> {
+    let mut entries: Vec<(usize, String)> = keyed
+        .iter()
+        .enumerate()
+        .map(|(pos, (_, key))| {
+            let k = if config.ignore_case {
+                key.cow_to_ascii_lowercase().into_owned()
+            } else {
+                key.clone()
+            };
+            (pos, k)
+        })
+        .collect();
+
+    entries.sort_by(|(ai, ak), (bi, bk)| {
+        let ord = ak.cmp(bk);
+        let ord = match config.order {
+            SortOrder::Asc => ord,
+            SortOrder::Desc => ord.reverse(),
+        };
+        if ord == Ordering::Equal { ai.cmp(bi) } else { ord }
+    });
+
+    entries.into_iter().map(|(pos, _)| pos).collect()
+}
+
+fn first_unsorted_position(indices: &[usize]) -> Option<usize> {
+    indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, index)| (*index != position).then_some(position))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "type User = { age: number; email: string; name: string };",
+        "type Empty = {};",
+        "type Single = { a: number };",
+    ];
+
+    let fail = vec![
+        "type User = { name: string; age: number; email: string };",
+        "type Obj = { z: number; a: string };",
+    ];
+
+    Tester::new(SortObjectTypes::NAME, SortObjectTypes::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_objects.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_objects.rs
@@ -1,0 +1,253 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::{AstKind, ast::ObjectExpression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_objects_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Object keys should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortObjectsConfig {
+    ignore_case: bool,
+    order: SortOrder,
+}
+
+impl Default for SortObjectsConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortObjects(Box<SortObjectsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted keys in object literals.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unsorted object keys make objects harder to scan, diff, and maintain.
+    /// Consistent ordering reduces merge conflicts and improves readability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const obj = { z: 1, a: 2, m: 3 };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const obj = { a: 2, m: 3, z: 1 };
+    /// ```
+    SortObjects,
+    oxc,
+    style,
+    conditional_fix,
+    config = SortObjectsConfig
+);
+
+impl Rule for SortObjects {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortObjectsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ObjectExpression(obj) = node.kind() else {
+            return;
+        };
+
+        if obj.properties.len() < 2 {
+            return;
+        }
+
+        // Collect only keyed properties (skip spread elements)
+        let keyed: Vec<(usize, String)> = obj
+            .properties
+            .iter()
+            .enumerate()
+            .filter_map(|(i, prop)| {
+                let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(p) = prop else {
+                    return None;
+                };
+                let key = property_key_text(&p.key, ctx)?;
+                Some((i, key))
+            })
+            .collect();
+
+        if keyed.len() < 2 {
+            return;
+        }
+
+        let sorted_keys = sorted_indices(&keyed, &self.0);
+        let Some(first_unsorted) = first_unsorted_position(&sorted_keys) else {
+            return;
+        };
+
+        let (orig_idx, _) = &keyed[first_unsorted];
+        let span = obj.properties[*orig_idx].span();
+        if let Some(replacement) = build_fix(obj, ctx, &keyed, &sorted_keys) {
+            ctx.diagnostic_with_fix(sort_objects_diagnostic(span), |fixer| {
+                fixer.replace(obj.span, replacement)
+            });
+            return;
+        }
+        ctx.diagnostic(sort_objects_diagnostic(span));
+    }
+}
+
+fn property_key_text(key: &oxc_ast::ast::PropertyKey<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    match key {
+        oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.to_string()),
+        oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.to_string()),
+        oxc_ast::ast::PropertyKey::NumericLiteral(lit) => lit.raw.as_ref().map(ToString::to_string),
+        _ => {
+            // Computed keys — use source text as fallback
+            Some(ctx.source_range(key.span()).to_string())
+        }
+    }
+}
+
+fn sorted_indices(keyed: &[(usize, String)], config: &SortObjectsConfig) -> Vec<usize> {
+    let mut entries: Vec<(usize, String)> = keyed
+        .iter()
+        .enumerate()
+        .map(|(pos, (_, key))| {
+            let k = if config.ignore_case {
+                key.cow_to_ascii_lowercase().into_owned()
+            } else {
+                key.clone()
+            };
+            (pos, k)
+        })
+        .collect();
+
+    entries.sort_by(|(ai, ak), (bi, bk)| {
+        let ord = ak.cmp(bk);
+        let ord = match config.order {
+            SortOrder::Asc => ord,
+            SortOrder::Desc => ord.reverse(),
+        };
+        if ord == Ordering::Equal { ai.cmp(bi) } else { ord }
+    });
+
+    entries.into_iter().map(|(pos, _)| pos).collect()
+}
+
+fn first_unsorted_position(indices: &[usize]) -> Option<usize> {
+    indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, index)| (*index != position).then_some(position))
+}
+
+fn build_fix(
+    obj: &ObjectExpression<'_>,
+    ctx: &LintContext<'_>,
+    keyed: &[(usize, String)],
+    sorted_keys: &[usize],
+) -> Option<String> {
+    if ctx.has_comments_between(obj.span) {
+        return None;
+    }
+
+    // Only fix if all properties are keyed (no spreads)
+    if keyed.len() != obj.properties.len() {
+        return None;
+    }
+
+    let pieces: Vec<&str> = sorted_keys
+        .iter()
+        .map(|&pos| {
+            let (orig_idx, _) = &keyed[pos];
+            ctx.source_range(obj.properties[*orig_idx].span()).trim()
+        })
+        .collect();
+
+    let obj_text = ctx.source_range(obj.span);
+    let is_multiline = obj_text.contains('\n');
+
+    if is_multiline {
+        // Preserve multiline structure
+        let indent = detect_indent(obj_text);
+        let mut result = String::from("{\n");
+        for (i, piece) in pieces.iter().enumerate() {
+            result.push_str(&indent);
+            result.push_str(piece);
+            if i < pieces.len() - 1 || obj_text.contains(",\n}") || obj_text.contains(",\n }") {
+                result.push(',');
+            }
+            result.push('\n');
+        }
+        result.push('}');
+        Some(result)
+    } else {
+        let inner = pieces.join(", ");
+        Some(format!("{{ {inner} }}"))
+    }
+}
+
+fn detect_indent(text: &str) -> String {
+    for line in text.lines().skip(1) {
+        if let Some(first_non_ws) = line.find(|c: char| !c.is_whitespace())
+            && first_non_ws > 0
+        {
+            return line[..first_non_ws].to_string();
+        }
+    }
+    "  ".to_string()
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("const obj = { a: 1, b: 2, c: 3 };", None),
+        ("const obj = { };", None),
+        ("const obj = { a: 1 };", None),
+        ("const obj = { A: 1, b: 2 };", None),
+    ];
+
+    let fail = vec![
+        ("const obj = { z: 1, a: 2 };", None),
+        ("const obj = { b: 1, a: 2, c: 3 };", None),
+        ("const obj = { a: 1, b: 2 };", Some(json!([{ "order": "desc" }]))),
+    ];
+
+    let fix = vec![
+        ("const obj = { z: 1, a: 2 };", "const obj = { a: 2, z: 1 };", None),
+        ("const obj = { b: 1, a: 2, c: 3 };", "const obj = { a: 2, b: 1, c: 3 };", None),
+    ];
+
+    Tester::new(SortObjects::NAME, SortObjects::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_switch_case.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_switch_case.rs
@@ -1,0 +1,437 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, Statement, SwitchCase, SwitchStatement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_switch_case_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Switch cases should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortType {
+    #[default]
+    Alphabetical,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortSwitchCaseConfig {
+    ignore_case: bool,
+    order: SortOrder,
+    r#type: SortType,
+}
+
+impl Default for SortSwitchCaseConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc, r#type: SortType::Alphabetical }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortSwitchCase(Box<SortSwitchCaseConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted switch cases.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Keeping switch branches in a predictable order makes control flow easier
+    /// to scan and reduces noisy diffs when cases are added.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// switch (status) {
+    ///   case "pending":
+    ///     return 1;
+    ///   case "active":
+    ///     return 2;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// switch (status) {
+    ///   case "active":
+    ///     return 2;
+    ///   case "pending":
+    ///     return 1;
+    /// }
+    /// ```
+    SortSwitchCase,
+    oxc,
+    style,
+    conditional_fix,
+    config = SortSwitchCaseConfig
+);
+
+impl Rule for SortSwitchCase {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortSwitchCaseConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::SwitchStatement(switch_statement) = node.kind() else {
+            return;
+        };
+
+        if switch_statement.cases.len() < 2
+            || self.0.r#type != SortType::Alphabetical
+            || matches!(&switch_statement.discriminant, Expression::BooleanLiteral(lit) if lit.value)
+        {
+            return;
+        }
+
+        let groups = build_groups(switch_statement);
+        if groups.len() < 2 && groups.iter().all(|group| group.len() < 2) {
+            return;
+        }
+
+        let mut has_unsorted_labels = false;
+        for group in &groups {
+            if let Some(span) = first_unsorted_label_span(group, switch_statement, &self.0, ctx) {
+                has_unsorted_labels = true;
+                ctx.diagnostic(sort_switch_case_diagnostic(span));
+            }
+            if let Some(span) = misplaced_default_span(group, switch_statement) {
+                has_unsorted_labels = true;
+                ctx.diagnostic(sort_switch_case_diagnostic(span));
+            }
+        }
+
+        let sorted_group_indices = sorted_group_indices(&groups, switch_statement, &self.0, ctx);
+        let Some(first_unsorted_group_position) = first_unsorted_position(&sorted_group_indices)
+        else {
+            return;
+        };
+
+        let group = &groups[first_unsorted_group_position];
+        let diagnostic_span = switch_statement.cases[group[0]].span;
+        if !has_unsorted_labels
+            && let Some(replacement) =
+                build_group_reorder_fix(switch_statement, &groups, &sorted_group_indices, ctx)
+        {
+            let replace_span = Span::new(
+                switch_statement.cases[groups[0][0]].span.start,
+                switch_statement.cases[*groups.last().and_then(|group| group.last()).unwrap()]
+                    .span
+                    .end,
+            );
+            ctx.diagnostic_with_fix(sort_switch_case_diagnostic(diagnostic_span), |fixer| {
+                fixer.replace(replace_span, replacement)
+            });
+            return;
+        }
+
+        ctx.diagnostic(sort_switch_case_diagnostic(diagnostic_span));
+    }
+}
+
+fn build_groups(switch_statement: &SwitchStatement<'_>) -> Vec<Vec<usize>> {
+    let mut groups = vec![Vec::new()];
+
+    for (index, case) in switch_statement.cases.iter().enumerate() {
+        groups.last_mut().unwrap().push(index);
+        if case_ends_group(case) && index + 1 < switch_statement.cases.len() {
+            groups.push(Vec::new());
+        }
+    }
+
+    groups
+}
+
+fn case_ends_group(case: &SwitchCase<'_>) -> bool {
+    if case.consequent.is_empty() {
+        return false;
+    }
+
+    let statements = match case.consequent.first() {
+        Some(Statement::BlockStatement(block)) => block.body.as_slice(),
+        _ => case.consequent.as_slice(),
+    };
+
+    statements.iter().any(|statement| {
+        matches!(statement, Statement::BreakStatement(_) | Statement::ReturnStatement(_))
+    })
+}
+
+fn first_unsorted_position(indices: &[usize]) -> Option<usize> {
+    indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, index)| (*index != position).then_some(position))
+}
+
+fn misplaced_default_span(group: &[usize], switch_statement: &SwitchStatement<'_>) -> Option<Span> {
+    let last_position = group.len().checked_sub(1)?;
+    for (position, case_index) in group.iter().enumerate() {
+        if switch_statement.cases[*case_index].test.is_none() && position != last_position {
+            return Some(switch_statement.cases[*case_index].span);
+        }
+    }
+    None
+}
+
+fn first_unsorted_label_span(
+    group: &[usize],
+    switch_statement: &SwitchStatement<'_>,
+    config: &SortSwitchCaseConfig,
+    ctx: &LintContext<'_>,
+) -> Option<Span> {
+    let labels = group
+        .iter()
+        .filter_map(|case_index| {
+            let case = &switch_statement.cases[*case_index];
+            let test = case.test.as_ref()?;
+            Some((*case_index, normalized_case_name(case, test, config, ctx)))
+        })
+        .collect::<Vec<_>>();
+
+    let mut sorted = labels.clone();
+    sorted.sort_by(|(left_index, left_name), (right_index, right_name)| {
+        let ordering = left_name.cmp(right_name);
+        let ordering = match config.order {
+            SortOrder::Asc => ordering,
+            SortOrder::Desc => ordering.reverse(),
+        };
+        if ordering == Ordering::Equal { left_index.cmp(right_index) } else { ordering }
+    });
+
+    labels.iter().zip(sorted.iter()).find_map(|((actual_index, _), (expected_index, _))| {
+        (actual_index != expected_index).then_some(switch_statement.cases[*actual_index].span)
+    })
+}
+
+fn sorted_group_indices(
+    groups: &[Vec<usize>],
+    switch_statement: &SwitchStatement<'_>,
+    config: &SortSwitchCaseConfig,
+    ctx: &LintContext<'_>,
+) -> Vec<usize> {
+    let last_group_should_stay = groups
+        .last()
+        .is_some_and(|group| !case_ends_group(&switch_statement.cases[*group.last().unwrap()]));
+
+    let mut sortable = groups
+        .iter()
+        .enumerate()
+        .map(|(index, group)| {
+            let is_default_group =
+                group.iter().all(|case_index| switch_statement.cases[*case_index].test.is_none());
+            let key = first_group_key(group, switch_statement, config, ctx);
+            (index, key, is_default_group)
+        })
+        .collect::<Vec<_>>();
+
+    sortable.sort_by(
+        |(left_index, left_key, left_default), (right_index, right_key, right_default)| {
+            if last_group_should_stay {
+                let last_index = groups.len() - 1;
+                if *left_index == last_index {
+                    return Ordering::Greater;
+                }
+                if *right_index == last_index {
+                    return Ordering::Less;
+                }
+            }
+            if *left_default {
+                return Ordering::Greater;
+            }
+            if *right_default {
+                return Ordering::Less;
+            }
+            let ordering = left_key.cmp(right_key);
+            let ordering = match config.order {
+                SortOrder::Asc => ordering,
+                SortOrder::Desc => ordering.reverse(),
+            };
+            if ordering == Ordering::Equal { left_index.cmp(right_index) } else { ordering }
+        },
+    );
+
+    sortable.into_iter().map(|(index, _, _)| index).collect()
+}
+
+fn first_group_key(
+    group: &[usize],
+    switch_statement: &SwitchStatement<'_>,
+    config: &SortSwitchCaseConfig,
+    ctx: &LintContext<'_>,
+) -> String {
+    group
+        .iter()
+        .find_map(|case_index| {
+            let case = &switch_statement.cases[*case_index];
+            let test = case.test.as_ref()?;
+            Some(normalized_case_name(case, test, config, ctx))
+        })
+        .unwrap_or_else(|| "default".to_string())
+}
+
+fn normalized_case_name(
+    case: &SwitchCase<'_>,
+    test: &Expression<'_>,
+    config: &SortSwitchCaseConfig,
+    ctx: &LintContext<'_>,
+) -> String {
+    let raw = ctx.source_range(test.span()).trim();
+    let raw = if raw.is_empty() { ctx.source_range(case.span()).trim() } else { raw };
+    if config.ignore_case { raw.cow_to_ascii_lowercase().into_owned() } else { raw.to_string() }
+}
+
+fn build_group_reorder_fix(
+    switch_statement: &SwitchStatement<'_>,
+    groups: &[Vec<usize>],
+    sorted_group_indices: &[usize],
+    ctx: &LintContext<'_>,
+) -> Option<String> {
+    let first_case_index = groups.first()?.first()?;
+    let last_case_index = groups.last()?.last()?;
+    let full_span = Span::new(
+        switch_statement.cases[*first_case_index].span.start,
+        switch_statement.cases[*last_case_index].span.end,
+    );
+    if ctx.has_comments_between(full_span) {
+        return None;
+    }
+
+    for window in groups.windows(2) {
+        let left = &switch_statement.cases[*window[0].last().unwrap()];
+        let right = &switch_statement.cases[window[1][0]];
+        if ctx.has_comments_between(Span::new(left.span.end, right.span.start)) {
+            return None;
+        }
+    }
+
+    let group_texts = groups
+        .iter()
+        .map(|group| {
+            let start = switch_statement.cases[group[0]].span.start;
+            let end = switch_statement.cases[*group.last().unwrap()].span.end;
+            ctx.source_range(Span::new(start, end)).to_string()
+        })
+        .collect::<Vec<_>>();
+    let separators = groups
+        .windows(2)
+        .map(|window| {
+            let left = &switch_statement.cases[*window[0].last().unwrap()];
+            let right = &switch_statement.cases[window[1][0]];
+            ctx.source_range(Span::new(left.span.end, right.span.start)).to_string()
+        })
+        .collect::<Vec<_>>();
+
+    let mut replacement = String::new();
+    for (position, group_index) in sorted_group_indices.iter().enumerate() {
+        replacement.push_str(&group_texts[*group_index]);
+        if position < separators.len() {
+            replacement.push_str(&separators[position]);
+        }
+    }
+    Some(replacement)
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("switch (status) { case 'active': return 1; case 'pending': return 2; }", None),
+        ("switch (status) { case 'Active': return 1; case 'pending': return 2; }", None),
+        ("switch (true) { case a: return 1; case b: return 2; }", None),
+        (
+            "switch (status) { case 'archived': case 'pending': return 1; case 'zebra': return 2; }",
+            None,
+        ),
+        ("switch (status) { case 'pending': return 1; default: return 2; }", None),
+        (
+            "switch (status) { case 'pending': return 1; case 'archived': return 2; }",
+            Some(json!([{ "order": "desc" }])),
+        ),
+        (
+            "switch (status) { case 'Active': return 1; case 'pending': return 2; }",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+    ];
+
+    let fail = vec![
+        ("switch (status) { case 'pending': return 1; case 'active': return 2; }", None),
+        (
+            "switch (status) { case 'pending': return 1; case 'archived': return 2; case 'zebra': return 3; }",
+            None,
+        ),
+        (
+            "switch (status) { case 'pending': return 1; default: return 2; case 'zebra': return 3; }",
+            None,
+        ),
+        (
+            "switch (status) { case 'pending': case 'archived': return 1; case 'zebra': return 2; }",
+            None,
+        ),
+        ("switch (status) { case 'b': case 'a': return 1; case 'z': return 2; }", None),
+        (
+            "switch (status) { case 'active': return 1; case 'pending': return 2; }",
+            Some(json!([{ "order": "desc" }])),
+        ),
+        (
+            "switch (status) { case 'pending': return 1; case 'Active': return 2; }",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "switch (status) { case 'pending': return 1; case 'active': return 2; }",
+            "switch (status) { case 'active': return 2; case 'pending': return 1; }",
+            None,
+        ),
+        (
+            "switch (status) { case 'pending': return 1; case 'archived': return 2; case 'zebra': return 3; }",
+            "switch (status) { case 'archived': return 2; case 'pending': return 1; case 'zebra': return 3; }",
+            None,
+        ),
+        (
+            "switch (status) { case 'active': return 1; case 'pending': return 2; }",
+            "switch (status) { case 'pending': return 2; case 'active': return 1; }",
+            Some(json!([{ "order": "desc" }])),
+        ),
+        (
+            "switch (status) { case 'pending': return 1; case 'Active': return 2; }",
+            "switch (status) { case 'Active': return 2; case 'pending': return 1; }",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+    ];
+
+    Tester::new(SortSwitchCase::NAME, SortSwitchCase::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/sort_union_types.rs
+++ b/crates/oxc_linter/src/rules/oxc/sort_union_types.rs
@@ -1,0 +1,277 @@
+use std::cmp::Ordering;
+
+use cow_utils::CowUtils;
+use oxc_ast::{AstKind, ast::TSUnionType};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn sort_union_types_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Union types should be sorted alphabetically.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Desc,
+    #[default]
+    Asc,
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortType {
+    #[default]
+    Alphabetical,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortUnionTypesConfig {
+    ignore_case: bool,
+    order: SortOrder,
+    r#type: SortType,
+}
+
+impl Default for SortUnionTypesConfig {
+    fn default() -> Self {
+        Self { ignore_case: true, order: SortOrder::Asc, r#type: SortType::Alphabetical }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortUnionTypes(Box<SortUnionTypesConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces alphabetically sorted TypeScript union members.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Keeping union members in a predictable order makes type declarations
+    /// easier to scan, diff, and maintain.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// type Status = "pending" | "active" | "archived";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// type Status = "active" | "archived" | "pending";
+    /// ```
+    SortUnionTypes,
+    oxc,
+    style,
+    conditional_fix,
+    config = SortUnionTypesConfig
+);
+
+impl Rule for SortUnionTypes {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<SortUnionTypesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSUnionType(union_type) = node.kind() else {
+            return;
+        };
+
+        if union_type.types.len() < 2 || self.0.r#type != SortType::Alphabetical {
+            return;
+        }
+
+        let indices = sorted_type_indices(union_type, ctx, &self.0);
+        let Some(first_unsorted_index) = first_unsorted_position(&indices) else {
+            return;
+        };
+
+        let diagnostic_span = union_type.types[first_unsorted_index].span();
+        if let Some(replacement) = build_fix(union_type, ctx, &indices) {
+            ctx.diagnostic_with_fix(sort_union_types_diagnostic(diagnostic_span), |fixer| {
+                fixer.replace(union_type.span, replacement)
+            });
+            return;
+        }
+
+        ctx.diagnostic(sort_union_types_diagnostic(diagnostic_span));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+fn first_unsorted_position(indices: &[usize]) -> Option<usize> {
+    indices
+        .iter()
+        .enumerate()
+        .find_map(|(position, index)| (*index != position).then_some(position))
+}
+
+fn sorted_type_indices(
+    union_type: &TSUnionType<'_>,
+    ctx: &LintContext<'_>,
+    config: &SortUnionTypesConfig,
+) -> Vec<usize> {
+    let mut members = union_type
+        .types
+        .iter()
+        .enumerate()
+        .map(|(index, ty)| {
+            let raw = ctx.source_range(ty.span());
+            let key = normalized_sort_key(raw, config.ignore_case);
+            (index, key)
+        })
+        .collect::<Vec<_>>();
+
+    members.sort_by(|(left_index, left_key), (right_index, right_key)| {
+        let ordering = left_key.cmp(right_key);
+        let ordering = match config.order {
+            SortOrder::Asc => ordering,
+            SortOrder::Desc => ordering.reverse(),
+        };
+        if ordering == Ordering::Equal { left_index.cmp(right_index) } else { ordering }
+    });
+
+    members.into_iter().map(|(index, _)| index).collect()
+}
+
+fn normalized_sort_key(raw: &str, ignore_case: bool) -> String {
+    let compact = raw.split_whitespace().collect::<String>();
+    if ignore_case { compact.cow_to_ascii_lowercase().into_owned() } else { compact }
+}
+
+fn build_fix(
+    union_type: &TSUnionType<'_>,
+    ctx: &LintContext<'_>,
+    indices: &[usize],
+) -> Option<String> {
+    if ctx.has_comments_between(union_type.span) {
+        return None;
+    }
+
+    for window in union_type.types.windows(2) {
+        let between = Span::new(window[0].span().end, window[1].span().start);
+        if ctx.has_comments_between(between) {
+            return None;
+        }
+    }
+
+    let pieces = indices
+        .iter()
+        .map(|&index| ctx.source_range(union_type.types[index].span()).trim().to_string())
+        .collect::<Vec<_>>();
+
+    let union_text = ctx.source_range(union_type.span);
+    let replacement = if union_text.contains('\n') && union_text.trim_start().starts_with('|') {
+        build_vertical_union_fix(&pieces, union_text, ctx.source_text(), union_type.span)
+    } else {
+        pieces.join(" | ")
+    };
+
+    Some(replacement)
+}
+
+fn build_vertical_union_fix(
+    pieces: &[String],
+    union_text: &str,
+    source_text: &str,
+    span: Span,
+) -> String {
+    let line_start = source_text[..span.start as usize].rfind('\n').map_or(0, |index| index + 1);
+    let indent = &source_text[line_start..span.start as usize];
+    if !indent.chars().all(char::is_whitespace) {
+        return pieces.join(" | ");
+    }
+
+    let trailing_newline = union_text.ends_with('\n');
+    let mut replacement = String::new();
+    for (index, piece) in pieces.iter().enumerate() {
+        if index > 0 {
+            replacement.push('\n');
+            replacement.push_str(indent);
+        }
+        replacement.push_str("| ");
+        replacement.push_str(piece);
+    }
+    if trailing_newline {
+        replacement.push('\n');
+    }
+    replacement
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("type Status = 'active' | 'archived' | 'pending';", None),
+        ("type Status = 'Active' | 'archived' | 'pending';", None),
+        ("type Result = Error | Promise<string> | string;", None),
+        ("type Status =\n  | 'active'\n  | 'archived'\n  | 'pending';", None),
+        (
+            "type Status = 'Active' | 'archived' | 'pending';",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+    ];
+
+    let fail = vec![
+        ("type Status = 'pending' | 'active' | 'archived';", None),
+        ("type Result = string | Error | Promise<string>;", None),
+        ("type Status =\n  | 'pending'\n  | 'active'\n  | 'archived';", None),
+        ("type Status = 'active' | 'archived' | 'pending';", Some(json!([{ "order": "desc" }]))),
+        (
+            "type Status = 'pending' | 'archived' | 'Active';",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "type Status = 'pending' | 'active' | 'archived';",
+            "type Status = 'active' | 'archived' | 'pending';",
+            None,
+        ),
+        (
+            "type Result = string | Error | Promise<string>;",
+            "type Result = Error | Promise<string> | string;",
+            None,
+        ),
+        (
+            "type Status =\n  | 'pending'\n  | 'active'\n  | 'archived';",
+            "type Status =\n  | 'active'\n  | 'archived'\n  | 'pending';",
+            None,
+        ),
+        (
+            "type Status = 'active' | 'archived' | 'pending';",
+            "type Status = 'pending' | 'archived' | 'active';",
+            Some(json!([{ "order": "desc" }])),
+        ),
+        (
+            "type Status = 'pending' | 'archived' | 'Active';",
+            "type Status = 'Active' | 'archived' | 'pending';",
+            Some(json!([{ "ignoreCase": false }])),
+        ),
+    ];
+
+    Tester::new(SortUnionTypes::NAME, SortUnionTypes::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -725,7 +725,7 @@ impl Runtime {
                 None,
                 |me, mut module_to_lint| {
                     module_to_lint.content.with_dependent_mut(
-                    |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
+                    |allocator_guard, ModuleContentDependent { source_text, section_contents }| {
                         assert_eq!(
                             module_to_lint.section_module_records.len(),
                             section_contents.len()
@@ -766,7 +766,13 @@ impl Runtime {
 
                         let (section_messages, disable_directives) = me
                             .linter
-                            .run_with_disable_directives(path, context_sub_hosts, allocator_guard, me.js_allocator_pool());
+                            .run_with_full_source_text_and_disable_directives(
+                                path,
+                                context_sub_hosts,
+                                source_text,
+                                allocator_guard,
+                                me.js_allocator_pool(),
+                            );
 
                         if let Some(disable_directives) = disable_directives {
                             me.disable_directives_map
@@ -804,7 +810,7 @@ impl Runtime {
         rayon::scope(|scope| {
             self.resolve_modules(file_system, &paths_set, scope, check_syntax_errors, Some(tx_error), |me, mut module| {
                 module.content.with_dependent_mut(
-                    |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
+                    |allocator_guard, ModuleContentDependent { source_text, section_contents }| {
                         assert_eq!(module.section_module_records.len(), section_contents.len());
 
                         let context_sub_hosts: Vec<ContextSubHost<'_>> = module
@@ -839,12 +845,15 @@ impl Runtime {
                         }
 
                         messages.lock().unwrap().extend(
-                            me.linter.run(
-                                Path::new(&module.path),
-                                context_sub_hosts,
-                                allocator_guard
-                            )
-                            ,
+                            me.linter
+                                .run_with_full_source_text_and_disable_directives(
+                                    Path::new(&module.path),
+                                    context_sub_hosts,
+                                    source_text,
+                                    allocator_guard,
+                                    None,
+                                )
+                                .0,
                         );
                     },
                 );

--- a/crates/oxc_linter/src/snapshots/oxc_avoid_barrel_files.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_avoid_barrel_files.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(avoid-barrel-files): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[avoid_barrel_files.ts:1:1]
+ 1 │ ╭─▶ 
+ 2 │ │               import { bar, baz, qux } from "foo";
+ 3 │ │               let foo;
+ 4 │ │               export { foo, bar, baz, qux };
+ 5 │ ╰─▶             
+   ╰────
+  help: Prefer importing and re-exporting only the concrete symbols you actually need.
+
+  ⚠ oxc(avoid-barrel-files): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[avoid_barrel_files.ts:1:1]
+ 1 │ ╭─▶ 
+ 2 │ │               export * from "foo";
+ 3 │ │               export * from "bar";
+ 4 │ │               export * from "baz";
+ 5 │ │               export * from "qux";
+ 6 │ ╰─▶             
+   ╰────
+  help: Prefer importing and re-exporting only the concrete symbols you actually need.
+
+  ⚠ oxc(avoid-barrel-files): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[avoid_barrel_files.ts:1:1]
+ 1 │ export { foo, bar, baz } from "foo";
+   · ────────────────────────────────────
+   ╰────
+  help: Prefer importing and re-exporting only the concrete symbols you actually need.
+
+  ⚠ oxc(avoid-barrel-files): Avoid barrel files, they slow down performance, and cause large module graphs with modules that go unused.
+   ╭─[avoid_barrel_files.ts:1:1]
+ 1 │ export default { var1, var2, var3, var4 };
+   · ──────────────────────────────────────────
+   ╰────
+  help: Prefer importing and re-exporting only the concrete symbols you actually need.

--- a/crates/oxc_linter/src/snapshots/oxc_avoid_re_export_all.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_avoid_re_export_all.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(avoid-re-export-all): Avoid re-exporting `*` from a module, it leads to unused imports and prevents treeshaking.
+   ╭─[avoid_re_export_all.ts:1:1]
+ 1 │ export * from "./foo";
+   · ──────────────────────
+   ╰────
+  help: Prefer named re-exports so consumers and bundlers only pull the symbols they need.
+
+  ⚠ oxc(avoid-re-export-all): Avoid re-exporting `*` from a module, it leads to unused imports and prevents treeshaking.
+   ╭─[avoid_re_export_all.ts:1:1]
+ 1 │ export * as foo from "./foo";
+   · ─────────────────────────────
+   ╰────
+  help: Prefer named re-exports so consumers and bundlers only pull the symbols they need.

--- a/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies.snap
@@ -1,0 +1,58 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `admin-routes` is not allowed.
+   ╭─[boundaries-app/src/routes/public/landing.ts:2:44]
+ 1 │ 
+ 2 │             import { adminDashboard } from "../admin/dashboard.ts";
+   ·                                            ───────────────────────
+ 3 │             import { userProfile } from "../user/profile.ts";
+   ╰────
+  help: Remove the import of `../admin/dashboard.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `user-routes` is not allowed.
+   ╭─[boundaries-app/src/routes/public/landing.ts:3:41]
+ 2 │             import { adminDashboard } from "../admin/dashboard.ts";
+ 3 │             import { userProfile } from "../user/profile.ts";
+   ·                                         ────────────────────
+ 4 │             import { adminCard } from "../../components/admin-card.ts";
+   ╰────
+  help: Remove the import of `../user/profile.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `admin-components` is not allowed.
+   ╭─[boundaries-app/src/routes/public/landing.ts:4:39]
+ 3 │             import { userProfile } from "../user/profile.ts";
+ 4 │             import { adminCard } from "../../components/admin-card.ts";
+   ·                                       ────────────────────────────────
+ 5 │             import { userCard } from "../../components/user-card.ts";
+   ╰────
+  help: Remove the import of `../../components/admin-card.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `user-components` is not allowed.
+   ╭─[boundaries-app/src/routes/public/landing.ts:5:38]
+ 4 │             import { adminCard } from "../../components/admin-card.ts";
+ 5 │             import { userCard } from "../../components/user-card.ts";
+   ·                                      ───────────────────────────────
+ 6 │             import { userProfileApi } from "../../api/user/profile.ts";
+   ╰────
+  help: Remove the import of `../../components/user-card.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `api-user` is not allowed.
+   ╭─[boundaries-app/src/routes/public/landing.ts:6:44]
+ 5 │             import { userCard } from "../../components/user-card.ts";
+ 6 │             import { userProfileApi } from "../../api/user/profile.ts";
+   ·                                            ───────────────────────────
+ 7 │             import { adminUsersApi } from "../../api/admin/users.ts";
+   ╰────
+  help: Remove the import of `../../api/user/profile.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `api-admin` is not allowed.
+   ╭─[boundaries-app/src/routes/public/landing.ts:7:43]
+ 6 │             import { userProfileApi } from "../../api/user/profile.ts";
+ 7 │             import { adminUsersApi } from "../../api/admin/users.ts";
+   ·                                           ──────────────────────────
+ 8 │ 
+   ╰────
+  help: Remove the import of `../../api/admin/users.ts` or move the dependency to an allowed architectural layer.

--- a/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@api_public.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@api_public.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `api-public` to `admin-routes` is not allowed.
+   ╭─[boundaries-app/src/api/public/info.ts:2:40]
+ 1 │ 
+ 2 │         import { adminDashboard } from "../../routes/admin/dashboard.ts";
+   ·                                        ─────────────────────────────────
+ 3 │         import { userProfile } from "../../routes/user/profile.ts";
+   ╰────
+  help: Remove the import of `../../routes/admin/dashboard.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `api-public` to `user-routes` is not allowed.
+   ╭─[boundaries-app/src/api/public/info.ts:3:37]
+ 2 │         import { adminDashboard } from "../../routes/admin/dashboard.ts";
+ 3 │         import { userProfile } from "../../routes/user/profile.ts";
+   ·                                     ──────────────────────────────
+ 4 │         import { mainLayout } from "../../layouts/main.ts";
+   ╰────
+  help: Remove the import of `../../routes/user/profile.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `api-public` to `user-components` is not allowed.
+   ╭─[boundaries-app/src/api/public/info.ts:5:34]
+ 4 │         import { mainLayout } from "../../layouts/main.ts";
+ 5 │         import { userCard } from "../../components/user-card.ts";
+   ·                                  ───────────────────────────────
+ 6 │ 
+   ╰────
+  help: Remove the import of `../../components/user-card.ts` or move the dependency to an allowed architectural layer.

--- a/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@default_disallow.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@default_disallow.snap
@@ -1,0 +1,13 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `admin-routes` is not allowed.
+   ╭─[boundaries-app/src/routes/public/explicit.ts:4:40]
+ 3 │         import { publicInfoApi } from "../../api/public/info";
+ 4 │         import { adminDashboard } from "../admin/dashboard";
+   ·                                        ────────────────────
+ 5 │ 
+   ╰────
+  help: Remove the import of `../admin/dashboard` or move the dependency to an allowed architectural layer.

--- a/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@dynamic.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@dynamic.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `admin-routes` is not allowed.
+   ╭─[boundaries-app/src/routes/public/lazy.ts:3:43]
+ 2 │         async function loadPage() {
+ 3 │           const adminRoute = await import("../admin/dashboard");
+   ·                                           ────────────────────
+ 4 │           const userRoute = await import("../user/profile");
+   ╰────
+  help: Remove the import of `../admin/dashboard` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `user-routes` is not allowed.
+   ╭─[boundaries-app/src/routes/public/lazy.ts:4:42]
+ 3 │           const adminRoute = await import("../admin/dashboard");
+ 4 │           const userRoute = await import("../user/profile");
+   ·                                          ─────────────────
+ 5 │           const adminApi = require("../../api/admin/users");
+   ╰────
+  help: Remove the import of `../user/profile` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `public-routes` to `api-admin` is not allowed.
+   ╭─[boundaries-app/src/routes/public/lazy.ts:5:36]
+ 4 │           const userRoute = await import("../user/profile");
+ 5 │           const adminApi = require("../../api/admin/users");
+   ·                                    ───────────────────────
+ 6 │           return [adminRoute, userRoute, adminApi];
+   ╰────
+  help: Remove the import of `../../api/admin/users` or move the dependency to an allowed architectural layer.

--- a/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@user_components.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_boundaries_dependencies@user_components.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `user-components` to `admin-routes` is not allowed.
+   ╭─[boundaries-app/src/components/user-card.ts:2:40]
+ 1 │ 
+ 2 │         import { adminDashboard } from "../routes/admin/dashboard.ts";
+   ·                                        ──────────────────────────────
+ 3 │         import { adminCard } from "./admin-card.ts";
+   ╰────
+  help: Remove the import of `../routes/admin/dashboard.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `user-components` to `admin-components` is not allowed.
+   ╭─[boundaries-app/src/components/user-card.ts:3:35]
+ 2 │         import { adminDashboard } from "../routes/admin/dashboard.ts";
+ 3 │         import { adminCard } from "./admin-card.ts";
+   ·                                   ─────────────────
+ 4 │         import { adminUsersApi } from "../api/admin/users.ts";
+   ╰────
+  help: Remove the import of `./admin-card.ts` or move the dependency to an allowed architectural layer.
+
+  ⚠ oxc(boundaries-dependencies): Dependency from `user-components` to `api-admin` is not allowed.
+   ╭─[boundaries-app/src/components/user-card.ts:4:39]
+ 3 │         import { adminCard } from "./admin-card.ts";
+ 4 │         import { adminUsersApi } from "../api/admin/users.ts";
+   ·                                       ───────────────────────
+ 5 │ 
+   ╰────
+  help: Remove the import of `../api/admin/users.ts` or move the dependency to an allowed architectural layer.

--- a/crates/oxc_linter/src/snapshots/oxc_css_no_duplicate_properties.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_css_no_duplicate_properties.snap
@@ -1,0 +1,22 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(css-no-duplicate-properties): Duplicate property `color` in declaration block.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/test.css:1:6]
+ 1 │ .a { color: red; color: blue; }
+   ·      ──┬──       ──┬──
+   ·        │           ╰── duplicate here
+   ·        ╰── first occurrence
+   ╰────
+  help: Remove one of the duplicate declarations or use a different value strategy.
+
+  ⚠ oxc(css-no-duplicate-properties): Duplicate property `font-size` in declaration block.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/test.css:1:6]
+ 1 │ h1 { font-size: 16px; margin: 0; font-size: 20px; }
+   ·      ────┬────                   ────┬────
+   ·          │                           ╰── duplicate here
+   ·          ╰── first occurrence
+   ╰────
+  help: Remove one of the duplicate declarations or use a different value strategy.

--- a/crates/oxc_linter/src/snapshots/oxc_css_no_empty_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_css_no_empty_blocks.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(css-no-empty-blocks): Empty declaration block for `.a`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/test.css:1:4]
+ 1 │ .a { }
+   ·    ───
+   ╰────
+  help: Remove the empty rule or add declarations to it.
+
+  ⚠ oxc(css-no-empty-blocks): Empty declaration block for `h1`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/test.css:1:4]
+ 1 │ h1 { } h2 { color: red; }
+   ·    ───
+   ╰────
+  help: Remove the empty rule or add declarations to it.

--- a/crates/oxc_linter/src/snapshots/oxc_css_no_important.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_css_no_important.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(css-no-important): `!important` used on `color`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/test.css:1:13]
+ 1 │ .a { color: red !important; }
+   ·             ──────────────
+   ╰────
+  help: Avoid `!important` — it makes styles harder to override and maintain. Use more specific selectors instead.
+
+  ⚠ oxc(css-no-important): `!important` used on `font-size`.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/test.css:1:29]
+ 1 │ .a { color: red; font-size: 16px !important; }
+   ·                             ───────────────
+   ╰────
+  help: Avoid `!important` — it makes styles harder to override and maintain. Use more specific selectors instead.

--- a/crates/oxc_linter/src/snapshots/oxc_optimize_regex.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_optimize_regex.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(optimize-regex): This regular expression can be simplified.
+   ╭─[optimize_regex.ts:1:17]
+ 1 │ const digits = /[0-9]+/;
+   ·                 ─────
+   ╰────
+  help: Replace this fragment with `\d`.
+
+  ⚠ oxc(optimize-regex): This regular expression can be simplified.
+   ╭─[optimize_regex.ts:1:21]
+ 1 │ const not_digits = /[^0-9]+/;
+   ·                     ──────
+   ╰────
+  help: Replace this fragment with `\D`.
+
+  ⚠ oxc(optimize-regex): This regular expression can be simplified.
+   ╭─[optimize_regex.ts:1:15]
+ 1 │ const word = /[A-Z_a-z0-9]+/;
+   ·               ────────────
+   ╰────
+  help: Replace this fragment with `\w`.
+
+  ⚠ oxc(optimize-regex): This regular expression can be simplified.
+   ╭─[optimize_regex.ts:1:19]
+ 1 │ const not_word = /[^a-zA-Z0-9_]+/;
+   ·                   ─────────────
+   ╰────
+  help: Replace this fragment with `\W`.
+
+  ⚠ oxc(optimize-regex): This regular expression can be simplified.
+   ╭─[optimize_regex.ts:1:19]
+ 1 │ const repeated = /aaaaaa/;
+   ·                   ──────
+   ╰────
+  help: Replace this fragment with `a{6}`.
+
+  ⚠ oxc(optimize-regex): This regular expression can be simplified.
+   ╭─[optimize_regex.ts:1:18]
+ 1 │ const escaped = /\.\.\./;
+   ·                  ──────
+   ╰────
+  help: Replace this fragment with `\.{3}`.
+
+  ⚠ oxc(optimize-regex): This regular expression can be simplified.
+   ╭─[optimize_regex.ts:1:20]
+ 1 │ const nested = /(?=[0-9])foo/;
+   ·                    ─────
+   ╰────
+  help: Replace this fragment with `\d`.

--- a/crates/oxc_linter/src/snapshots/oxc_sort_enums.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_enums.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-enums): Enum members should be sorted alphabetically.
+   ╭─[sort_enums.ts:1:14]
+ 1 │ enum Color { Red, Green, Blue }
+   ·              ───
+   ╰────
+
+  ⚠ oxc(sort-enums): Enum members should be sorted alphabetically.
+   ╭─[sort_enums.ts:1:15]
+ 1 │ enum Status { Pending, Active, Inactive }
+   ·               ───────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/oxc_sort_imports.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_imports.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-imports): Import statements should be sorted alphabetically by source.
+   ╭─[sort_imports.tsx:1:20]
+ 1 │ import z from "z"; import a from "a";
+   ·                    ──────────────────
+   ╰────
+
+  ⚠ oxc(sort-imports): Import statements should be sorted alphabetically by source.
+   ╭─[sort_imports.tsx:1:20]
+ 1 │ import b from "b"; import a from "a"; import c from "c";
+   ·                    ──────────────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/oxc_sort_interfaces.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_interfaces.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-interfaces): Interface members should be sorted alphabetically.
+   ╭─[sort_interfaces.ts:2:3]
+ 1 │ interface User {
+ 2 │   name: string;
+   ·   ─────────────
+ 3 │   id: string;
+   ╰────
+  help: Replace `name: string;
+          id: string;` with `id: string;
+          name: string;`.
+
+  ⚠ oxc(sort-interfaces): Interface members should be sorted alphabetically.
+   ╭─[sort_interfaces.ts:2:3]
+ 1 │ interface User {
+ 2 │   name: string;
+   ·   ─────────────
+ 3 │   getId(): string;
+   ╰────
+  help: Replace `name: string;
+          getId(): string;` with `getId(): string;
+          name: string;`.
+
+  ⚠ oxc(sort-interfaces): Interface members should be sorted alphabetically.
+   ╭─[sort_interfaces.ts:2:3]
+ 1 │ interface User {
+ 2 │   id: string;
+   ·   ───────────
+ 3 │   Id: string;
+   ╰────
+  help: Replace `id: string;
+          Id: string;` with `Id: string;
+          id: string;`.
+
+  ⚠ oxc(sort-interfaces): Interface members should be sorted alphabetically.
+   ╭─[sort_interfaces.ts:2:3]
+ 1 │ interface User {
+ 2 │   getId(): string;
+   ·   ────────────────
+ 3 │   id: string;
+   ╰────
+  help: Replace `getId(): string;
+          id: string;` with `id: string;
+          getId(): string;`.

--- a/crates/oxc_linter/src/snapshots/oxc_sort_intersection_types.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_intersection_types.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-intersection-types): Intersection types should be sorted alphabetically.
+   ╭─[sort_intersection_types.ts:1:10]
+ 1 │ type T = C & A & B;
+   ·          ─
+   ╰────
+  help: Replace `C & A & B` with `A & B & C`.
+
+  ⚠ oxc(sort-intersection-types): Intersection types should be sorted alphabetically.
+   ╭─[sort_intersection_types.ts:1:10]
+ 1 │ type T = Z & A;
+   ·          ─
+   ╰────
+  help: Replace `Z & A` with `A & Z`.

--- a/crates/oxc_linter/src/snapshots/oxc_sort_jsx_props.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_jsx_props.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-jsx-props): JSX props should be sorted alphabetically.
+   ╭─[sort_jsx_props.tsx:1:18]
+ 1 │ <Component z="1" a="2" />
+   ·                  ─────
+   ╰────
+
+  ⚠ oxc(sort-jsx-props): JSX props should be sorted alphabetically.
+   ╭─[sort_jsx_props.tsx:1:18]
+ 1 │ <Component c="1" a="2" b="3" />
+   ·                  ─────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/oxc_sort_named_exports.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_named_exports.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-named-exports): Named export specifiers should be sorted alphabetically.
+   ╭─[sort_named_exports.tsx:1:13]
+ 1 │ export { z, a, m };
+   ·             ─
+   ╰────
+  help: Replace `export { z, a, m };` with `export { a, m, z }`.
+
+  ⚠ oxc(sort-named-exports): Named export specifiers should be sorted alphabetically.
+   ╭─[sort_named_exports.tsx:1:13]
+ 1 │ export { b, a };
+   ·             ─
+   ╰────
+  help: Replace `export { b, a };` with `export { a, b }`.

--- a/crates/oxc_linter/src/snapshots/oxc_sort_named_imports.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_named_imports.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-named-imports): Named import specifiers should be sorted alphabetically.
+   ╭─[sort_named_imports.tsx:1:13]
+ 1 │ import { z, a, m } from "mod";
+   ·             ─
+   ╰────
+  help: Replace `import { z, a, m } from "mod";` with `import { a, m, z } from "mod"`.
+
+  ⚠ oxc(sort-named-imports): Named import specifiers should be sorted alphabetically.
+   ╭─[sort_named_imports.tsx:1:13]
+ 1 │ import { b, a } from "mod";
+   ·             ─
+   ╰────
+  help: Replace `import { b, a } from "mod";` with `import { a, b } from "mod"`.

--- a/crates/oxc_linter/src/snapshots/oxc_sort_object_types.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_object_types.snap
@@ -1,0 +1,16 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-object-types): TypeScript object type members should be sorted alphabetically.
+   ╭─[sort_object_types.ts:1:15]
+ 1 │ type User = { name: string; age: number; email: string };
+   ·               ─────────────
+   ╰────
+
+  ⚠ oxc(sort-object-types): TypeScript object type members should be sorted alphabetically.
+   ╭─[sort_object_types.ts:1:14]
+ 1 │ type Obj = { z: number; a: string };
+   ·              ──────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/oxc_sort_objects.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_objects.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-objects): Object keys should be sorted alphabetically.
+   ╭─[sort_objects.tsx:1:15]
+ 1 │ const obj = { z: 1, a: 2 };
+   ·               ────
+   ╰────
+  help: Replace `{ z: 1, a: 2 }` with `{ a: 2, z: 1 }`.
+
+  ⚠ oxc(sort-objects): Object keys should be sorted alphabetically.
+   ╭─[sort_objects.tsx:1:15]
+ 1 │ const obj = { b: 1, a: 2, c: 3 };
+   ·               ────
+   ╰────
+  help: Replace `{ b: 1, a: 2, c: 3 }` with `{ a: 2, b: 1, c: 3 }`.
+
+  ⚠ oxc(sort-objects): Object keys should be sorted alphabetically.
+   ╭─[sort_objects.tsx:1:15]
+ 1 │ const obj = { a: 1, b: 2 };
+   ·               ────
+   ╰────
+  help: Replace `{ a: 1, b: 2 }` with `{ b: 2, a: 1 }`.

--- a/crates/oxc_linter/src/snapshots/oxc_sort_switch_case.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_switch_case.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-switch-case): Switch cases should be sorted alphabetically.
+   ╭─[sort_switch_case.tsx:1:19]
+ 1 │ switch (status) { case 'pending': return 1; case 'active': return 2; }
+   ·                   ─────────────────────────
+   ╰────
+  help: Replace `case 'pending': return 1; case 'active': return 2;` with `case 'active': return 2; case 'pending': return 1;`.
+
+  ⚠ oxc(sort-switch-case): Switch cases should be sorted alphabetically.
+   ╭─[sort_switch_case.tsx:1:19]
+ 1 │ switch (status) { case 'pending': return 1; case 'archived': return 2; case 'zebra': return 3; }
+   ·                   ─────────────────────────
+   ╰────
+  help: Replace `case 'pending': return 1; case 'archived': return 2; case 'zebra': return 3;` with `case 'archived': return 2; case 'pending': return 1; case 'zebra': return 3;`.
+
+  ⚠ oxc(sort-switch-case): Switch cases should be sorted alphabetically.
+   ╭─[sort_switch_case.tsx:1:45]
+ 1 │ switch (status) { case 'pending': return 1; default: return 2; case 'zebra': return 3; }
+   ·                                             ──────────────────
+   ╰────
+  help: Replace `case 'pending': return 1; default: return 2; case 'zebra': return 3;` with `case 'pending': return 1; case 'zebra': return 3; default: return 2;`.
+
+  ⚠ oxc(sort-switch-case): Switch cases should be sorted alphabetically.
+   ╭─[sort_switch_case.tsx:1:19]
+ 1 │ switch (status) { case 'pending': case 'archived': return 1; case 'zebra': return 2; }
+   ·                   ───────────────
+   ╰────
+
+  ⚠ oxc(sort-switch-case): Switch cases should be sorted alphabetically.
+   ╭─[sort_switch_case.tsx:1:19]
+ 1 │ switch (status) { case 'b': case 'a': return 1; case 'z': return 2; }
+   ·                   ─────────
+   ╰────
+
+  ⚠ oxc(sort-switch-case): Switch cases should be sorted alphabetically.
+   ╭─[sort_switch_case.tsx:1:19]
+ 1 │ switch (status) { case 'active': return 1; case 'pending': return 2; }
+   ·                   ────────────────────────
+   ╰────
+  help: Replace `case 'active': return 1; case 'pending': return 2;` with `case 'pending': return 2; case 'active': return 1;`.
+
+  ⚠ oxc(sort-switch-case): Switch cases should be sorted alphabetically.
+   ╭─[sort_switch_case.tsx:1:19]
+ 1 │ switch (status) { case 'pending': return 1; case 'Active': return 2; }
+   ·                   ─────────────────────────
+   ╰────
+  help: Replace `case 'pending': return 1; case 'Active': return 2;` with `case 'Active': return 2; case 'pending': return 1;`.

--- a/crates/oxc_linter/src/snapshots/oxc_sort_union_types.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_sort_union_types.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(sort-union-types): Union types should be sorted alphabetically.
+   ╭─[sort_union_types.ts:1:15]
+ 1 │ type Status = 'pending' | 'active' | 'archived';
+   ·               ─────────
+   ╰────
+  help: Replace `'pending' | 'active' | 'archived'` with `'active' | 'archived' | 'pending'`.
+
+  ⚠ oxc(sort-union-types): Union types should be sorted alphabetically.
+   ╭─[sort_union_types.ts:1:15]
+ 1 │ type Result = string | Error | Promise<string>;
+   ·               ──────
+   ╰────
+  help: Replace `string | Error | Promise<string>` with `Error | Promise<string> | string`.
+
+  ⚠ oxc(sort-union-types): Union types should be sorted alphabetically.
+   ╭─[sort_union_types.ts:2:5]
+ 1 │ type Status =
+ 2 │   | 'pending'
+   ·     ─────────
+ 3 │   | 'active'
+   ╰────
+  help: Replace `| 'pending'
+          | 'active'
+          | 'archived'` with `| 'active'
+          | 'archived'
+          | 'pending'`.
+
+  ⚠ oxc(sort-union-types): Union types should be sorted alphabetically.
+   ╭─[sort_union_types.ts:1:15]
+ 1 │ type Status = 'active' | 'archived' | 'pending';
+   ·               ────────
+   ╰────
+  help: Replace `'active' | 'archived' | 'pending'` with `'pending' | 'archived' | 'active'`.
+
+  ⚠ oxc(sort-union-types): Union types should be sorted alphabetically.
+   ╭─[sort_union_types.ts:1:15]
+ 1 │ type Status = 'pending' | 'archived' | 'Active';
+   ·               ─────────
+   ╰────
+  help: Replace `'pending' | 'archived' | 'Active'` with `'Active' | 'archived' | 'pending'`.

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -337,6 +337,7 @@ mod test {
             Rc::new(ContextHost::new(
                 path,
                 vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 0)],
+                "",
                 LintOptions::default(),
                 Arc::default(),
             ))


### PR DESCRIPTION
## Summary

> **Merge after**: #21177 (JSON/CSS infrastructure)

Add 18 new rules:

**CSS rules (3):**
- `css-no-duplicate-properties`, `css-no-empty-blocks`, `css-no-important`

**Sorting rules (12):**
- `sort-enums`, `sort-imports`, `sort-interfaces`, `sort-intersection-types`
- `sort-jsx-props`, `sort-named-exports`, `sort-named-imports`
- `sort-object-types`, `sort-objects`, `sort-switch-case`, `sort-union-types`
- `optimize-regex`

**Code organization rules (3):**
- `avoid-barrel-files`, `avoid-re-export-all`, `boundaries-dependencies`

Includes `css_utils.rs`, `boundary_utils.rs` utility modules and boundary test fixtures.

## Test plan

- [x] `cargo test -p oxc_linter` — all 26 rule tests pass
- [x] `cargo lintgen` — generated files up to date
- [x] `just fmt` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)