### PR TITLE
feat(linter): add React, naming, and miscellaneous rules

### DIFF
--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/api/admin/users.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/api/admin/users.ts
@@ -1,0 +1,1 @@
+export const adminUsersApi = "admin-users-api";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/api/public/info.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/api/public/info.ts
@@ -1,0 +1,1 @@
+export const publicInfoApi = "public-info-api";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/api/user/profile.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/api/user/profile.ts
@@ -1,0 +1,1 @@
+export const userProfileApi = "user-profile-api";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/components/admin-card.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/components/admin-card.ts
@@ -1,0 +1,1 @@
+export const adminCard = "admin-card";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/components/ui/button.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/components/ui/button.ts
@@ -1,0 +1,1 @@
+export const uiButton = "ui-button";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/components/user-card.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/components/user-card.ts
@@ -1,0 +1,1 @@
+export const userCard = "user-card";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/experimental/scratch.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/experimental/scratch.ts
@@ -1,0 +1,1 @@
+export const scratch = "scratch";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/layouts/main.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/layouts/main.ts
@@ -1,0 +1,1 @@
+export const mainLayout = "main-layout";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/admin/dashboard.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/admin/dashboard.ts
@@ -1,0 +1,1 @@
+export const adminDashboard = "admin-dashboard";

--- a/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/user/profile.ts
+++ b/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/user/profile.ts
@@ -1,0 +1,1 @@
+export const userProfile = "user-profile";

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3923,6 +3923,96 @@ impl RuleRunner for crate::rules::oxc::uninvoked_array_callback::UninvokedArrayC
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::oxc::filename_naming_convention::FilenameNamingConvention {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::folder_naming_convention::FolderNamingConvention {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::no_block_in_inline::NoBlockInInline {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::no_create_ref::NoCreateRef {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::no_default_props::NoDefaultProps {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::no_inline_type_annotations::NoInlineTypeAnnotations {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSTypeLiteral]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::oxc::no_leaked_conditional_rendering::NoLeakedConditionalRendering
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::LogicalExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::no_literal_string::NoLiteralString {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXText]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::no_nested_components::NoNestedComponents {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Function, AstType::VariableDeclarator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::no_prop_types::NoPropTypes {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::ImportDeclaration,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::no_secrets::NoSecrets {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StringLiteral, AstType::TemplateElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+}
+
+impl RuleRunner for crate::rules::oxc::no_unknown::NoUnknown {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::no_unknown_files::NoUnknownFiles {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::oxc::no_unstable_default_props::NoUnstableDefaultProps {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Function]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::oxc::prefer_shorthand_boolean::PreferShorthandBoolean {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::nextjs::google_font_display::GoogleFontDisplay {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -355,19 +355,34 @@ pub use crate::rules::oxc::branches_sharing_code::BranchesSharingCode as OxcBran
 pub use crate::rules::oxc::const_comparisons::ConstComparisons as OxcConstComparisons;
 pub use crate::rules::oxc::double_comparisons::DoubleComparisons as OxcDoubleComparisons;
 pub use crate::rules::oxc::erasing_op::ErasingOp as OxcErasingOp;
+pub use crate::rules::oxc::filename_naming_convention::FilenameNamingConvention as OxcFilenameNamingConvention;
+pub use crate::rules::oxc::folder_naming_convention::FolderNamingConvention as OxcFolderNamingConvention;
 pub use crate::rules::oxc::misrefactored_assign_op::MisrefactoredAssignOp as OxcMisrefactoredAssignOp;
 pub use crate::rules::oxc::missing_throw::MissingThrow as OxcMissingThrow;
 pub use crate::rules::oxc::no_accumulating_spread::NoAccumulatingSpread as OxcNoAccumulatingSpread;
 pub use crate::rules::oxc::no_async_await::NoAsyncAwait as OxcNoAsyncAwait;
 pub use crate::rules::oxc::no_async_endpoint_handlers::NoAsyncEndpointHandlers as OxcNoAsyncEndpointHandlers;
 pub use crate::rules::oxc::no_barrel_file::NoBarrelFile as OxcNoBarrelFile;
+pub use crate::rules::oxc::no_block_in_inline::NoBlockInInline as OxcNoBlockInInline;
 pub use crate::rules::oxc::no_const_enum::NoConstEnum as OxcNoConstEnum;
+pub use crate::rules::oxc::no_create_ref::NoCreateRef as OxcNoCreateRef;
+pub use crate::rules::oxc::no_default_props::NoDefaultProps as OxcNoDefaultProps;
+pub use crate::rules::oxc::no_inline_type_annotations::NoInlineTypeAnnotations as OxcNoInlineTypeAnnotations;
+pub use crate::rules::oxc::no_leaked_conditional_rendering::NoLeakedConditionalRendering as OxcNoLeakedConditionalRendering;
+pub use crate::rules::oxc::no_literal_string::NoLiteralString as OxcNoLiteralString;
 pub use crate::rules::oxc::no_map_spread::NoMapSpread as OxcNoMapSpread;
+pub use crate::rules::oxc::no_nested_components::NoNestedComponents as OxcNoNestedComponents;
 pub use crate::rules::oxc::no_optional_chaining::NoOptionalChaining as OxcNoOptionalChaining;
+pub use crate::rules::oxc::no_prop_types::NoPropTypes as OxcNoPropTypes;
 pub use crate::rules::oxc::no_rest_spread_properties::NoRestSpreadProperties as OxcNoRestSpreadProperties;
+pub use crate::rules::oxc::no_secrets::NoSecrets as OxcNoSecrets;
 pub use crate::rules::oxc::no_this_in_exported_function::NoThisInExportedFunction as OxcNoThisInExportedFunction;
+pub use crate::rules::oxc::no_unknown::NoUnknown as OxcNoUnknown;
+pub use crate::rules::oxc::no_unknown_files::NoUnknownFiles as OxcNoUnknownFiles;
+pub use crate::rules::oxc::no_unstable_default_props::NoUnstableDefaultProps as OxcNoUnstableDefaultProps;
 pub use crate::rules::oxc::number_arg_out_of_range::NumberArgOutOfRange as OxcNumberArgOutOfRange;
 pub use crate::rules::oxc::only_used_in_recursion::OnlyUsedInRecursion as OxcOnlyUsedInRecursion;
+pub use crate::rules::oxc::prefer_shorthand_boolean::PreferShorthandBoolean as OxcPreferShorthandBoolean;
 pub use crate::rules::oxc::uninvoked_array_callback::UninvokedArrayCallback as OxcUninvokedArrayCallback;
 pub use crate::rules::promise::always_return::AlwaysReturn as PromiseAlwaysReturn;
 pub use crate::rules::promise::avoid_new::AvoidNew as PromiseAvoidNew;
@@ -1339,6 +1354,21 @@ pub enum RuleEnum {
     OxcNumberArgOutOfRange(OxcNumberArgOutOfRange),
     OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion),
     OxcUninvokedArrayCallback(OxcUninvokedArrayCallback),
+    OxcFilenameNamingConvention(OxcFilenameNamingConvention),
+    OxcFolderNamingConvention(OxcFolderNamingConvention),
+    OxcNoBlockInInline(OxcNoBlockInInline),
+    OxcNoCreateRef(OxcNoCreateRef),
+    OxcNoDefaultProps(OxcNoDefaultProps),
+    OxcNoInlineTypeAnnotations(OxcNoInlineTypeAnnotations),
+    OxcNoLeakedConditionalRendering(OxcNoLeakedConditionalRendering),
+    OxcNoLiteralString(OxcNoLiteralString),
+    OxcNoNestedComponents(OxcNoNestedComponents),
+    OxcNoPropTypes(OxcNoPropTypes),
+    OxcNoSecrets(OxcNoSecrets),
+    OxcNoUnknown(OxcNoUnknown),
+    OxcNoUnknownFiles(OxcNoUnknownFiles),
+    OxcNoUnstableDefaultProps(OxcNoUnstableDefaultProps),
+    OxcPreferShorthandBoolean(OxcPreferShorthandBoolean),
     NextjsGoogleFontDisplay(NextjsGoogleFontDisplay),
     NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect),
     NextjsInlineScriptId(NextjsInlineScriptId),
@@ -2132,7 +2162,22 @@ const OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID: usize = OXC_NO_REST_SPREAD_PROPERTIES
 const OXC_NUMBER_ARG_OUT_OF_RANGE_ID: usize = OXC_NO_THIS_IN_EXPORTED_FUNCTION_ID + 1usize;
 const OXC_ONLY_USED_IN_RECURSION_ID: usize = OXC_NUMBER_ARG_OUT_OF_RANGE_ID + 1usize;
 const OXC_UNINVOKED_ARRAY_CALLBACK_ID: usize = OXC_ONLY_USED_IN_RECURSION_ID + 1usize;
-const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_FILENAME_NAMING_CONVENTION_ID: usize = OXC_UNINVOKED_ARRAY_CALLBACK_ID + 1usize;
+const OXC_FOLDER_NAMING_CONVENTION_ID: usize = OXC_FILENAME_NAMING_CONVENTION_ID + 1usize;
+const OXC_NO_BLOCK_IN_INLINE_ID: usize = OXC_FOLDER_NAMING_CONVENTION_ID + 1usize;
+const OXC_NO_CREATE_REF_ID: usize = OXC_NO_BLOCK_IN_INLINE_ID + 1usize;
+const OXC_NO_DEFAULT_PROPS_ID: usize = OXC_NO_CREATE_REF_ID + 1usize;
+const OXC_NO_INLINE_TYPE_ANNOTATIONS_ID: usize = OXC_NO_DEFAULT_PROPS_ID + 1usize;
+const OXC_NO_LEAKED_CONDITIONAL_RENDERING_ID: usize = OXC_NO_INLINE_TYPE_ANNOTATIONS_ID + 1usize;
+const OXC_NO_LITERAL_STRING_ID: usize = OXC_NO_LEAKED_CONDITIONAL_RENDERING_ID + 1usize;
+const OXC_NO_NESTED_COMPONENTS_ID: usize = OXC_NO_LITERAL_STRING_ID + 1usize;
+const OXC_NO_PROP_TYPES_ID: usize = OXC_NO_NESTED_COMPONENTS_ID + 1usize;
+const OXC_NO_SECRETS_ID: usize = OXC_NO_PROP_TYPES_ID + 1usize;
+const OXC_NO_UNKNOWN_ID: usize = OXC_NO_SECRETS_ID + 1usize;
+const OXC_NO_UNKNOWN_FILES_ID: usize = OXC_NO_UNKNOWN_ID + 1usize;
+const OXC_NO_UNSTABLE_DEFAULT_PROPS_ID: usize = OXC_NO_UNKNOWN_FILES_ID + 1usize;
+const OXC_PREFER_SHORTHAND_BOOLEAN_ID: usize = OXC_NO_UNSTABLE_DEFAULT_PROPS_ID + 1usize;
+const NEXTJS_GOOGLE_FONT_DISPLAY_ID: usize = OXC_PREFER_SHORTHAND_BOOLEAN_ID + 1usize;
 const NEXTJS_GOOGLE_FONT_PRECONNECT_ID: usize = NEXTJS_GOOGLE_FONT_DISPLAY_ID + 1usize;
 const NEXTJS_INLINE_SCRIPT_ID_ID: usize = NEXTJS_GOOGLE_FONT_PRECONNECT_ID + 1usize;
 const NEXTJS_NEXT_SCRIPT_FOR_GA_ID: usize = NEXTJS_INLINE_SCRIPT_ID_ID + 1usize;
@@ -2954,6 +2999,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OXC_NUMBER_ARG_OUT_OF_RANGE_ID,
             Self::OxcOnlyUsedInRecursion(_) => OXC_ONLY_USED_IN_RECURSION_ID,
             Self::OxcUninvokedArrayCallback(_) => OXC_UNINVOKED_ARRAY_CALLBACK_ID,
+            Self::OxcFilenameNamingConvention(_) => OXC_FILENAME_NAMING_CONVENTION_ID,
+            Self::OxcFolderNamingConvention(_) => OXC_FOLDER_NAMING_CONVENTION_ID,
+            Self::OxcNoBlockInInline(_) => OXC_NO_BLOCK_IN_INLINE_ID,
+            Self::OxcNoCreateRef(_) => OXC_NO_CREATE_REF_ID,
+            Self::OxcNoDefaultProps(_) => OXC_NO_DEFAULT_PROPS_ID,
+            Self::OxcNoInlineTypeAnnotations(_) => OXC_NO_INLINE_TYPE_ANNOTATIONS_ID,
+            Self::OxcNoLeakedConditionalRendering(_) => OXC_NO_LEAKED_CONDITIONAL_RENDERING_ID,
+            Self::OxcNoLiteralString(_) => OXC_NO_LITERAL_STRING_ID,
+            Self::OxcNoNestedComponents(_) => OXC_NO_NESTED_COMPONENTS_ID,
+            Self::OxcNoPropTypes(_) => OXC_NO_PROP_TYPES_ID,
+            Self::OxcNoSecrets(_) => OXC_NO_SECRETS_ID,
+            Self::OxcNoUnknown(_) => OXC_NO_UNKNOWN_ID,
+            Self::OxcNoUnknownFiles(_) => OXC_NO_UNKNOWN_FILES_ID,
+            Self::OxcNoUnstableDefaultProps(_) => OXC_NO_UNSTABLE_DEFAULT_PROPS_ID,
+            Self::OxcPreferShorthandBoolean(_) => OXC_PREFER_SHORTHAND_BOOLEAN_ID,
             Self::NextjsGoogleFontDisplay(_) => NEXTJS_GOOGLE_FONT_DISPLAY_ID,
             Self::NextjsGoogleFontPreconnect(_) => NEXTJS_GOOGLE_FONT_PRECONNECT_ID,
             Self::NextjsInlineScriptId(_) => NEXTJS_INLINE_SCRIPT_ID_ID,
@@ -3764,6 +3824,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::NAME,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::NAME,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::NAME,
+            Self::OxcFilenameNamingConvention(_) => OxcFilenameNamingConvention::NAME,
+            Self::OxcFolderNamingConvention(_) => OxcFolderNamingConvention::NAME,
+            Self::OxcNoBlockInInline(_) => OxcNoBlockInInline::NAME,
+            Self::OxcNoCreateRef(_) => OxcNoCreateRef::NAME,
+            Self::OxcNoDefaultProps(_) => OxcNoDefaultProps::NAME,
+            Self::OxcNoInlineTypeAnnotations(_) => OxcNoInlineTypeAnnotations::NAME,
+            Self::OxcNoLeakedConditionalRendering(_) => OxcNoLeakedConditionalRendering::NAME,
+            Self::OxcNoLiteralString(_) => OxcNoLiteralString::NAME,
+            Self::OxcNoNestedComponents(_) => OxcNoNestedComponents::NAME,
+            Self::OxcNoPropTypes(_) => OxcNoPropTypes::NAME,
+            Self::OxcNoSecrets(_) => OxcNoSecrets::NAME,
+            Self::OxcNoUnknown(_) => OxcNoUnknown::NAME,
+            Self::OxcNoUnknownFiles(_) => OxcNoUnknownFiles::NAME,
+            Self::OxcNoUnstableDefaultProps(_) => OxcNoUnstableDefaultProps::NAME,
+            Self::OxcPreferShorthandBoolean(_) => OxcPreferShorthandBoolean::NAME,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::NAME,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::NAME,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::NAME,
@@ -4616,6 +4691,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::CATEGORY,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::CATEGORY,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::CATEGORY,
+            Self::OxcFilenameNamingConvention(_) => OxcFilenameNamingConvention::CATEGORY,
+            Self::OxcFolderNamingConvention(_) => OxcFolderNamingConvention::CATEGORY,
+            Self::OxcNoBlockInInline(_) => OxcNoBlockInInline::CATEGORY,
+            Self::OxcNoCreateRef(_) => OxcNoCreateRef::CATEGORY,
+            Self::OxcNoDefaultProps(_) => OxcNoDefaultProps::CATEGORY,
+            Self::OxcNoInlineTypeAnnotations(_) => OxcNoInlineTypeAnnotations::CATEGORY,
+            Self::OxcNoLeakedConditionalRendering(_) => OxcNoLeakedConditionalRendering::CATEGORY,
+            Self::OxcNoLiteralString(_) => OxcNoLiteralString::CATEGORY,
+            Self::OxcNoNestedComponents(_) => OxcNoNestedComponents::CATEGORY,
+            Self::OxcNoPropTypes(_) => OxcNoPropTypes::CATEGORY,
+            Self::OxcNoSecrets(_) => OxcNoSecrets::CATEGORY,
+            Self::OxcNoUnknown(_) => OxcNoUnknown::CATEGORY,
+            Self::OxcNoUnknownFiles(_) => OxcNoUnknownFiles::CATEGORY,
+            Self::OxcNoUnstableDefaultProps(_) => OxcNoUnstableDefaultProps::CATEGORY,
+            Self::OxcPreferShorthandBoolean(_) => OxcPreferShorthandBoolean::CATEGORY,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::CATEGORY,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::CATEGORY,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::CATEGORY,
@@ -5435,6 +5525,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::FIX,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::FIX,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::FIX,
+            Self::OxcFilenameNamingConvention(_) => OxcFilenameNamingConvention::FIX,
+            Self::OxcFolderNamingConvention(_) => OxcFolderNamingConvention::FIX,
+            Self::OxcNoBlockInInline(_) => OxcNoBlockInInline::FIX,
+            Self::OxcNoCreateRef(_) => OxcNoCreateRef::FIX,
+            Self::OxcNoDefaultProps(_) => OxcNoDefaultProps::FIX,
+            Self::OxcNoInlineTypeAnnotations(_) => OxcNoInlineTypeAnnotations::FIX,
+            Self::OxcNoLeakedConditionalRendering(_) => OxcNoLeakedConditionalRendering::FIX,
+            Self::OxcNoLiteralString(_) => OxcNoLiteralString::FIX,
+            Self::OxcNoNestedComponents(_) => OxcNoNestedComponents::FIX,
+            Self::OxcNoPropTypes(_) => OxcNoPropTypes::FIX,
+            Self::OxcNoSecrets(_) => OxcNoSecrets::FIX,
+            Self::OxcNoUnknown(_) => OxcNoUnknown::FIX,
+            Self::OxcNoUnknownFiles(_) => OxcNoUnknownFiles::FIX,
+            Self::OxcNoUnstableDefaultProps(_) => OxcNoUnstableDefaultProps::FIX,
+            Self::OxcPreferShorthandBoolean(_) => OxcPreferShorthandBoolean::FIX,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::FIX,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::FIX,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::FIX,
@@ -6432,6 +6537,23 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::documentation(),
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::documentation(),
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::documentation(),
+            Self::OxcFilenameNamingConvention(_) => OxcFilenameNamingConvention::documentation(),
+            Self::OxcFolderNamingConvention(_) => OxcFolderNamingConvention::documentation(),
+            Self::OxcNoBlockInInline(_) => OxcNoBlockInInline::documentation(),
+            Self::OxcNoCreateRef(_) => OxcNoCreateRef::documentation(),
+            Self::OxcNoDefaultProps(_) => OxcNoDefaultProps::documentation(),
+            Self::OxcNoInlineTypeAnnotations(_) => OxcNoInlineTypeAnnotations::documentation(),
+            Self::OxcNoLeakedConditionalRendering(_) => {
+                OxcNoLeakedConditionalRendering::documentation()
+            }
+            Self::OxcNoLiteralString(_) => OxcNoLiteralString::documentation(),
+            Self::OxcNoNestedComponents(_) => OxcNoNestedComponents::documentation(),
+            Self::OxcNoPropTypes(_) => OxcNoPropTypes::documentation(),
+            Self::OxcNoSecrets(_) => OxcNoSecrets::documentation(),
+            Self::OxcNoUnknown(_) => OxcNoUnknown::documentation(),
+            Self::OxcNoUnknownFiles(_) => OxcNoUnknownFiles::documentation(),
+            Self::OxcNoUnstableDefaultProps(_) => OxcNoUnstableDefaultProps::documentation(),
+            Self::OxcPreferShorthandBoolean(_) => OxcPreferShorthandBoolean::documentation(),
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::documentation(),
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::documentation(),
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::documentation(),
@@ -8313,6 +8435,50 @@ impl RuleEnum {
                 OxcUninvokedArrayCallback::config_schema(generator)
                     .or_else(|| OxcUninvokedArrayCallback::schema(generator))
             }
+            Self::OxcFilenameNamingConvention(_) => {
+                OxcFilenameNamingConvention::config_schema(generator)
+                    .or_else(|| OxcFilenameNamingConvention::schema(generator))
+            }
+            Self::OxcFolderNamingConvention(_) => {
+                OxcFolderNamingConvention::config_schema(generator)
+                    .or_else(|| OxcFolderNamingConvention::schema(generator))
+            }
+            Self::OxcNoBlockInInline(_) => OxcNoBlockInInline::config_schema(generator)
+                .or_else(|| OxcNoBlockInInline::schema(generator)),
+            Self::OxcNoCreateRef(_) => OxcNoCreateRef::config_schema(generator)
+                .or_else(|| OxcNoCreateRef::schema(generator)),
+            Self::OxcNoDefaultProps(_) => OxcNoDefaultProps::config_schema(generator)
+                .or_else(|| OxcNoDefaultProps::schema(generator)),
+            Self::OxcNoInlineTypeAnnotations(_) => {
+                OxcNoInlineTypeAnnotations::config_schema(generator)
+                    .or_else(|| OxcNoInlineTypeAnnotations::schema(generator))
+            }
+            Self::OxcNoLeakedConditionalRendering(_) => {
+                OxcNoLeakedConditionalRendering::config_schema(generator)
+                    .or_else(|| OxcNoLeakedConditionalRendering::schema(generator))
+            }
+            Self::OxcNoLiteralString(_) => OxcNoLiteralString::config_schema(generator)
+                .or_else(|| OxcNoLiteralString::schema(generator)),
+            Self::OxcNoNestedComponents(_) => OxcNoNestedComponents::config_schema(generator)
+                .or_else(|| OxcNoNestedComponents::schema(generator)),
+            Self::OxcNoPropTypes(_) => OxcNoPropTypes::config_schema(generator)
+                .or_else(|| OxcNoPropTypes::schema(generator)),
+            Self::OxcNoSecrets(_) => {
+                OxcNoSecrets::config_schema(generator).or_else(|| OxcNoSecrets::schema(generator))
+            }
+            Self::OxcNoUnknown(_) => {
+                OxcNoUnknown::config_schema(generator).or_else(|| OxcNoUnknown::schema(generator))
+            }
+            Self::OxcNoUnknownFiles(_) => OxcNoUnknownFiles::config_schema(generator)
+                .or_else(|| OxcNoUnknownFiles::schema(generator)),
+            Self::OxcNoUnstableDefaultProps(_) => {
+                OxcNoUnstableDefaultProps::config_schema(generator)
+                    .or_else(|| OxcNoUnstableDefaultProps::schema(generator))
+            }
+            Self::OxcPreferShorthandBoolean(_) => {
+                OxcPreferShorthandBoolean::config_schema(generator)
+                    .or_else(|| OxcPreferShorthandBoolean::schema(generator))
+            }
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::config_schema(generator)
                 .or_else(|| NextjsGoogleFontDisplay::schema(generator)),
             Self::NextjsGoogleFontPreconnect(_) => {
@@ -9197,6 +9363,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => "oxc",
             Self::OxcOnlyUsedInRecursion(_) => "oxc",
             Self::OxcUninvokedArrayCallback(_) => "oxc",
+            Self::OxcFilenameNamingConvention(_) => "oxc",
+            Self::OxcFolderNamingConvention(_) => "oxc",
+            Self::OxcNoBlockInInline(_) => "oxc",
+            Self::OxcNoCreateRef(_) => "oxc",
+            Self::OxcNoDefaultProps(_) => "oxc",
+            Self::OxcNoInlineTypeAnnotations(_) => "oxc",
+            Self::OxcNoLeakedConditionalRendering(_) => "oxc",
+            Self::OxcNoLiteralString(_) => "oxc",
+            Self::OxcNoNestedComponents(_) => "oxc",
+            Self::OxcNoPropTypes(_) => "oxc",
+            Self::OxcNoSecrets(_) => "oxc",
+            Self::OxcNoUnknown(_) => "oxc",
+            Self::OxcNoUnknownFiles(_) => "oxc",
+            Self::OxcNoUnstableDefaultProps(_) => "oxc",
+            Self::OxcPreferShorthandBoolean(_) => "oxc",
             Self::NextjsGoogleFontDisplay(_) => "nextjs",
             Self::NextjsGoogleFontPreconnect(_) => "nextjs",
             Self::NextjsInlineScriptId(_) => "nextjs",
@@ -11272,6 +11453,51 @@ impl RuleEnum {
             Self::OxcUninvokedArrayCallback(_) => Ok(Self::OxcUninvokedArrayCallback(
                 OxcUninvokedArrayCallback::from_configuration(value)?,
             )),
+            Self::OxcFilenameNamingConvention(_) => Ok(Self::OxcFilenameNamingConvention(
+                OxcFilenameNamingConvention::from_configuration(value)?,
+            )),
+            Self::OxcFolderNamingConvention(_) => Ok(Self::OxcFolderNamingConvention(
+                OxcFolderNamingConvention::from_configuration(value)?,
+            )),
+            Self::OxcNoBlockInInline(_) => {
+                Ok(Self::OxcNoBlockInInline(OxcNoBlockInInline::from_configuration(value)?))
+            }
+            Self::OxcNoCreateRef(_) => {
+                Ok(Self::OxcNoCreateRef(OxcNoCreateRef::from_configuration(value)?))
+            }
+            Self::OxcNoDefaultProps(_) => {
+                Ok(Self::OxcNoDefaultProps(OxcNoDefaultProps::from_configuration(value)?))
+            }
+            Self::OxcNoInlineTypeAnnotations(_) => Ok(Self::OxcNoInlineTypeAnnotations(
+                OxcNoInlineTypeAnnotations::from_configuration(value)?,
+            )),
+            Self::OxcNoLeakedConditionalRendering(_) => Ok(Self::OxcNoLeakedConditionalRendering(
+                OxcNoLeakedConditionalRendering::from_configuration(value)?,
+            )),
+            Self::OxcNoLiteralString(_) => {
+                Ok(Self::OxcNoLiteralString(OxcNoLiteralString::from_configuration(value)?))
+            }
+            Self::OxcNoNestedComponents(_) => {
+                Ok(Self::OxcNoNestedComponents(OxcNoNestedComponents::from_configuration(value)?))
+            }
+            Self::OxcNoPropTypes(_) => {
+                Ok(Self::OxcNoPropTypes(OxcNoPropTypes::from_configuration(value)?))
+            }
+            Self::OxcNoSecrets(_) => {
+                Ok(Self::OxcNoSecrets(OxcNoSecrets::from_configuration(value)?))
+            }
+            Self::OxcNoUnknown(_) => {
+                Ok(Self::OxcNoUnknown(OxcNoUnknown::from_configuration(value)?))
+            }
+            Self::OxcNoUnknownFiles(_) => {
+                Ok(Self::OxcNoUnknownFiles(OxcNoUnknownFiles::from_configuration(value)?))
+            }
+            Self::OxcNoUnstableDefaultProps(_) => Ok(Self::OxcNoUnstableDefaultProps(
+                OxcNoUnstableDefaultProps::from_configuration(value)?,
+            )),
+            Self::OxcPreferShorthandBoolean(_) => Ok(Self::OxcPreferShorthandBoolean(
+                OxcPreferShorthandBoolean::from_configuration(value)?,
+            )),
             Self::NextjsGoogleFontDisplay(_) => Ok(Self::NextjsGoogleFontDisplay(
                 NextjsGoogleFontDisplay::from_configuration(value)?,
             )),
@@ -12198,6 +12424,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.to_configuration(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.to_configuration(),
             Self::OxcUninvokedArrayCallback(rule) => rule.to_configuration(),
+            Self::OxcFilenameNamingConvention(rule) => rule.to_configuration(),
+            Self::OxcFolderNamingConvention(rule) => rule.to_configuration(),
+            Self::OxcNoBlockInInline(rule) => rule.to_configuration(),
+            Self::OxcNoCreateRef(rule) => rule.to_configuration(),
+            Self::OxcNoDefaultProps(rule) => rule.to_configuration(),
+            Self::OxcNoInlineTypeAnnotations(rule) => rule.to_configuration(),
+            Self::OxcNoLeakedConditionalRendering(rule) => rule.to_configuration(),
+            Self::OxcNoLiteralString(rule) => rule.to_configuration(),
+            Self::OxcNoNestedComponents(rule) => rule.to_configuration(),
+            Self::OxcNoPropTypes(rule) => rule.to_configuration(),
+            Self::OxcNoSecrets(rule) => rule.to_configuration(),
+            Self::OxcNoUnknown(rule) => rule.to_configuration(),
+            Self::OxcNoUnknownFiles(rule) => rule.to_configuration(),
+            Self::OxcNoUnstableDefaultProps(rule) => rule.to_configuration(),
+            Self::OxcPreferShorthandBoolean(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontDisplay(rule) => rule.to_configuration(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.to_configuration(),
             Self::NextjsInlineScriptId(rule) => rule.to_configuration(),
@@ -12914,6 +13155,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run(node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run(node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run(node, ctx),
+            Self::OxcFilenameNamingConvention(rule) => rule.run(node, ctx),
+            Self::OxcFolderNamingConvention(rule) => rule.run(node, ctx),
+            Self::OxcNoBlockInInline(rule) => rule.run(node, ctx),
+            Self::OxcNoCreateRef(rule) => rule.run(node, ctx),
+            Self::OxcNoDefaultProps(rule) => rule.run(node, ctx),
+            Self::OxcNoInlineTypeAnnotations(rule) => rule.run(node, ctx),
+            Self::OxcNoLeakedConditionalRendering(rule) => rule.run(node, ctx),
+            Self::OxcNoLiteralString(rule) => rule.run(node, ctx),
+            Self::OxcNoNestedComponents(rule) => rule.run(node, ctx),
+            Self::OxcNoPropTypes(rule) => rule.run(node, ctx),
+            Self::OxcNoSecrets(rule) => rule.run(node, ctx),
+            Self::OxcNoUnknown(rule) => rule.run(node, ctx),
+            Self::OxcNoUnknownFiles(rule) => rule.run(node, ctx),
+            Self::OxcNoUnstableDefaultProps(rule) => rule.run(node, ctx),
+            Self::OxcPreferShorthandBoolean(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run(node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run(node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run(node, ctx),
@@ -13628,6 +13884,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_once(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_once(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_once(ctx),
+            Self::OxcFilenameNamingConvention(rule) => rule.run_once(ctx),
+            Self::OxcFolderNamingConvention(rule) => rule.run_once(ctx),
+            Self::OxcNoBlockInInline(rule) => rule.run_once(ctx),
+            Self::OxcNoCreateRef(rule) => rule.run_once(ctx),
+            Self::OxcNoDefaultProps(rule) => rule.run_once(ctx),
+            Self::OxcNoInlineTypeAnnotations(rule) => rule.run_once(ctx),
+            Self::OxcNoLeakedConditionalRendering(rule) => rule.run_once(ctx),
+            Self::OxcNoLiteralString(rule) => rule.run_once(ctx),
+            Self::OxcNoNestedComponents(rule) => rule.run_once(ctx),
+            Self::OxcNoPropTypes(rule) => rule.run_once(ctx),
+            Self::OxcNoSecrets(rule) => rule.run_once(ctx),
+            Self::OxcNoUnknown(rule) => rule.run_once(ctx),
+            Self::OxcNoUnknownFiles(rule) => rule.run_once(ctx),
+            Self::OxcNoUnstableDefaultProps(rule) => rule.run_once(ctx),
+            Self::OxcPreferShorthandBoolean(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_once(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_once(ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_once(ctx),
@@ -14438,6 +14709,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcFilenameNamingConvention(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcFolderNamingConvention(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoBlockInInline(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoCreateRef(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoDefaultProps(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoInlineTypeAnnotations(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoLeakedConditionalRendering(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoLiteralString(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoNestedComponents(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoPropTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoSecrets(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoUnknown(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoUnknownFiles(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoUnstableDefaultProps(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcPreferShorthandBoolean(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NextjsInlineScriptId(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15156,6 +15442,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.should_run(ctx),
             Self::OxcOnlyUsedInRecursion(rule) => rule.should_run(ctx),
             Self::OxcUninvokedArrayCallback(rule) => rule.should_run(ctx),
+            Self::OxcFilenameNamingConvention(rule) => rule.should_run(ctx),
+            Self::OxcFolderNamingConvention(rule) => rule.should_run(ctx),
+            Self::OxcNoBlockInInline(rule) => rule.should_run(ctx),
+            Self::OxcNoCreateRef(rule) => rule.should_run(ctx),
+            Self::OxcNoDefaultProps(rule) => rule.should_run(ctx),
+            Self::OxcNoInlineTypeAnnotations(rule) => rule.should_run(ctx),
+            Self::OxcNoLeakedConditionalRendering(rule) => rule.should_run(ctx),
+            Self::OxcNoLiteralString(rule) => rule.should_run(ctx),
+            Self::OxcNoNestedComponents(rule) => rule.should_run(ctx),
+            Self::OxcNoPropTypes(rule) => rule.should_run(ctx),
+            Self::OxcNoSecrets(rule) => rule.should_run(ctx),
+            Self::OxcNoUnknown(rule) => rule.should_run(ctx),
+            Self::OxcNoUnknownFiles(rule) => rule.should_run(ctx),
+            Self::OxcNoUnstableDefaultProps(rule) => rule.should_run(ctx),
+            Self::OxcPreferShorthandBoolean(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontDisplay(rule) => rule.should_run(ctx),
             Self::NextjsGoogleFontPreconnect(rule) => rule.should_run(ctx),
             Self::NextjsInlineScriptId(rule) => rule.should_run(ctx),
@@ -16148,6 +16449,23 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::IS_TSGOLINT_RULE,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::IS_TSGOLINT_RULE,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::IS_TSGOLINT_RULE,
+            Self::OxcFilenameNamingConvention(_) => OxcFilenameNamingConvention::IS_TSGOLINT_RULE,
+            Self::OxcFolderNamingConvention(_) => OxcFolderNamingConvention::IS_TSGOLINT_RULE,
+            Self::OxcNoBlockInInline(_) => OxcNoBlockInInline::IS_TSGOLINT_RULE,
+            Self::OxcNoCreateRef(_) => OxcNoCreateRef::IS_TSGOLINT_RULE,
+            Self::OxcNoDefaultProps(_) => OxcNoDefaultProps::IS_TSGOLINT_RULE,
+            Self::OxcNoInlineTypeAnnotations(_) => OxcNoInlineTypeAnnotations::IS_TSGOLINT_RULE,
+            Self::OxcNoLeakedConditionalRendering(_) => {
+                OxcNoLeakedConditionalRendering::IS_TSGOLINT_RULE
+            }
+            Self::OxcNoLiteralString(_) => OxcNoLiteralString::IS_TSGOLINT_RULE,
+            Self::OxcNoNestedComponents(_) => OxcNoNestedComponents::IS_TSGOLINT_RULE,
+            Self::OxcNoPropTypes(_) => OxcNoPropTypes::IS_TSGOLINT_RULE,
+            Self::OxcNoSecrets(_) => OxcNoSecrets::IS_TSGOLINT_RULE,
+            Self::OxcNoUnknown(_) => OxcNoUnknown::IS_TSGOLINT_RULE,
+            Self::OxcNoUnknownFiles(_) => OxcNoUnknownFiles::IS_TSGOLINT_RULE,
+            Self::OxcNoUnstableDefaultProps(_) => OxcNoUnstableDefaultProps::IS_TSGOLINT_RULE,
+            Self::OxcPreferShorthandBoolean(_) => OxcPreferShorthandBoolean::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::IS_TSGOLINT_RULE,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::IS_TSGOLINT_RULE,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::IS_TSGOLINT_RULE,
@@ -17049,6 +17367,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(_) => OxcNumberArgOutOfRange::HAS_CONFIG,
             Self::OxcOnlyUsedInRecursion(_) => OxcOnlyUsedInRecursion::HAS_CONFIG,
             Self::OxcUninvokedArrayCallback(_) => OxcUninvokedArrayCallback::HAS_CONFIG,
+            Self::OxcFilenameNamingConvention(_) => OxcFilenameNamingConvention::HAS_CONFIG,
+            Self::OxcFolderNamingConvention(_) => OxcFolderNamingConvention::HAS_CONFIG,
+            Self::OxcNoBlockInInline(_) => OxcNoBlockInInline::HAS_CONFIG,
+            Self::OxcNoCreateRef(_) => OxcNoCreateRef::HAS_CONFIG,
+            Self::OxcNoDefaultProps(_) => OxcNoDefaultProps::HAS_CONFIG,
+            Self::OxcNoInlineTypeAnnotations(_) => OxcNoInlineTypeAnnotations::HAS_CONFIG,
+            Self::OxcNoLeakedConditionalRendering(_) => OxcNoLeakedConditionalRendering::HAS_CONFIG,
+            Self::OxcNoLiteralString(_) => OxcNoLiteralString::HAS_CONFIG,
+            Self::OxcNoNestedComponents(_) => OxcNoNestedComponents::HAS_CONFIG,
+            Self::OxcNoPropTypes(_) => OxcNoPropTypes::HAS_CONFIG,
+            Self::OxcNoSecrets(_) => OxcNoSecrets::HAS_CONFIG,
+            Self::OxcNoUnknown(_) => OxcNoUnknown::HAS_CONFIG,
+            Self::OxcNoUnknownFiles(_) => OxcNoUnknownFiles::HAS_CONFIG,
+            Self::OxcNoUnstableDefaultProps(_) => OxcNoUnstableDefaultProps::HAS_CONFIG,
+            Self::OxcPreferShorthandBoolean(_) => OxcPreferShorthandBoolean::HAS_CONFIG,
             Self::NextjsGoogleFontDisplay(_) => NextjsGoogleFontDisplay::HAS_CONFIG,
             Self::NextjsGoogleFontPreconnect(_) => NextjsGoogleFontPreconnect::HAS_CONFIG,
             Self::NextjsInlineScriptId(_) => NextjsInlineScriptId::HAS_CONFIG,
@@ -17775,6 +18108,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.types_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.types_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.types_info(),
+            Self::OxcFilenameNamingConvention(rule) => rule.types_info(),
+            Self::OxcFolderNamingConvention(rule) => rule.types_info(),
+            Self::OxcNoBlockInInline(rule) => rule.types_info(),
+            Self::OxcNoCreateRef(rule) => rule.types_info(),
+            Self::OxcNoDefaultProps(rule) => rule.types_info(),
+            Self::OxcNoInlineTypeAnnotations(rule) => rule.types_info(),
+            Self::OxcNoLeakedConditionalRendering(rule) => rule.types_info(),
+            Self::OxcNoLiteralString(rule) => rule.types_info(),
+            Self::OxcNoNestedComponents(rule) => rule.types_info(),
+            Self::OxcNoPropTypes(rule) => rule.types_info(),
+            Self::OxcNoSecrets(rule) => rule.types_info(),
+            Self::OxcNoUnknown(rule) => rule.types_info(),
+            Self::OxcNoUnknownFiles(rule) => rule.types_info(),
+            Self::OxcNoUnstableDefaultProps(rule) => rule.types_info(),
+            Self::OxcPreferShorthandBoolean(rule) => rule.types_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.types_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.types_info(),
             Self::NextjsInlineScriptId(rule) => rule.types_info(),
@@ -18489,6 +18837,21 @@ impl RuleEnum {
             Self::OxcNumberArgOutOfRange(rule) => rule.run_info(),
             Self::OxcOnlyUsedInRecursion(rule) => rule.run_info(),
             Self::OxcUninvokedArrayCallback(rule) => rule.run_info(),
+            Self::OxcFilenameNamingConvention(rule) => rule.run_info(),
+            Self::OxcFolderNamingConvention(rule) => rule.run_info(),
+            Self::OxcNoBlockInInline(rule) => rule.run_info(),
+            Self::OxcNoCreateRef(rule) => rule.run_info(),
+            Self::OxcNoDefaultProps(rule) => rule.run_info(),
+            Self::OxcNoInlineTypeAnnotations(rule) => rule.run_info(),
+            Self::OxcNoLeakedConditionalRendering(rule) => rule.run_info(),
+            Self::OxcNoLiteralString(rule) => rule.run_info(),
+            Self::OxcNoNestedComponents(rule) => rule.run_info(),
+            Self::OxcNoPropTypes(rule) => rule.run_info(),
+            Self::OxcNoSecrets(rule) => rule.run_info(),
+            Self::OxcNoUnknown(rule) => rule.run_info(),
+            Self::OxcNoUnknownFiles(rule) => rule.run_info(),
+            Self::OxcNoUnstableDefaultProps(rule) => rule.run_info(),
+            Self::OxcPreferShorthandBoolean(rule) => rule.run_info(),
             Self::NextjsGoogleFontDisplay(rule) => rule.run_info(),
             Self::NextjsGoogleFontPreconnect(rule) => rule.run_info(),
             Self::NextjsInlineScriptId(rule) => rule.run_info(),
@@ -19317,6 +19680,21 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::OxcNumberArgOutOfRange(OxcNumberArgOutOfRange::default()),
         RuleEnum::OxcOnlyUsedInRecursion(OxcOnlyUsedInRecursion::default()),
         RuleEnum::OxcUninvokedArrayCallback(OxcUninvokedArrayCallback::default()),
+        RuleEnum::OxcFilenameNamingConvention(OxcFilenameNamingConvention::default()),
+        RuleEnum::OxcFolderNamingConvention(OxcFolderNamingConvention::default()),
+        RuleEnum::OxcNoBlockInInline(OxcNoBlockInInline::default()),
+        RuleEnum::OxcNoCreateRef(OxcNoCreateRef::default()),
+        RuleEnum::OxcNoDefaultProps(OxcNoDefaultProps::default()),
+        RuleEnum::OxcNoInlineTypeAnnotations(OxcNoInlineTypeAnnotations::default()),
+        RuleEnum::OxcNoLeakedConditionalRendering(OxcNoLeakedConditionalRendering::default()),
+        RuleEnum::OxcNoLiteralString(OxcNoLiteralString::default()),
+        RuleEnum::OxcNoNestedComponents(OxcNoNestedComponents::default()),
+        RuleEnum::OxcNoPropTypes(OxcNoPropTypes::default()),
+        RuleEnum::OxcNoSecrets(OxcNoSecrets::default()),
+        RuleEnum::OxcNoUnknown(OxcNoUnknown::default()),
+        RuleEnum::OxcNoUnknownFiles(OxcNoUnknownFiles::default()),
+        RuleEnum::OxcNoUnstableDefaultProps(OxcNoUnstableDefaultProps::default()),
+        RuleEnum::OxcPreferShorthandBoolean(OxcPreferShorthandBoolean::default()),
         RuleEnum::NextjsGoogleFontDisplay(NextjsGoogleFontDisplay::default()),
         RuleEnum::NextjsGoogleFontPreconnect(NextjsGoogleFontPreconnect::default()),
         RuleEnum::NextjsInlineScriptId(NextjsInlineScriptId::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -639,6 +639,23 @@ pub(crate) mod oxc {
     pub mod number_arg_out_of_range;
     pub mod only_used_in_recursion;
     pub mod uninvoked_array_callback;
+
+    mod boundary_utils;
+    pub mod filename_naming_convention;
+    pub mod folder_naming_convention;
+    pub mod no_block_in_inline;
+    pub mod no_create_ref;
+    pub mod no_default_props;
+    pub mod no_inline_type_annotations;
+    pub mod no_leaked_conditional_rendering;
+    pub mod no_literal_string;
+    pub mod no_nested_components;
+    pub mod no_prop_types;
+    pub mod no_secrets;
+    pub mod no_unknown;
+    pub mod no_unknown_files;
+    pub mod no_unstable_default_props;
+    pub mod prefer_shorthand_boolean;
 }
 
 pub(crate) mod nextjs {

--- a/crates/oxc_linter/src/rules/oxc/boundary_utils.rs
+++ b/crates/oxc_linter/src/rules/oxc/boundary_utils.rs
@@ -1,0 +1,126 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::context::LintContext;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub(super) struct BoundaryElementSetting {
+    #[serde(rename = "type")]
+    pub(super) element_type: String,
+    pub(super) pattern: BoundaryPatterns,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(untagged)]
+pub(super) enum BoundaryPatterns {
+    Single(String),
+    Many(Vec<String>),
+    #[default]
+    Empty,
+}
+
+impl BoundaryPatterns {
+    pub(super) fn iter(&self) -> impl Iterator<Item = &str> {
+        let patterns: Vec<&str> = match self {
+            Self::Single(single) => vec![single.as_str()],
+            Self::Many(many) => many.iter().map(String::as_str).collect(),
+            Self::Empty => vec![],
+        };
+        patterns.into_iter()
+    }
+}
+
+pub(super) fn read_boundary_elements(ctx: &LintContext<'_>) -> Option<Vec<BoundaryElementSetting>> {
+    let raw_settings = ctx.settings().json.as_ref()?;
+    let raw_elements = raw_settings.get("boundaries/elements")?.clone();
+    serde_json::from_value(raw_elements).ok()
+}
+
+pub(super) fn classify_path(path: &Path, elements: &[BoundaryElementSetting]) -> Option<String> {
+    let suffixes = normalized_path_suffixes(path);
+    for element in elements {
+        if element
+            .pattern
+            .iter()
+            .any(|pattern| suffixes.iter().any(|suffix| fast_glob::glob_match(pattern, suffix)))
+        {
+            return Some(element.element_type.clone());
+        }
+    }
+    None
+}
+
+pub(super) fn resolve_local_specifier(base_file: &Path, specifier: &str) -> Option<PathBuf> {
+    if !specifier.starts_with('.') && !specifier.starts_with('/') {
+        return None;
+    }
+
+    let candidate = if specifier.starts_with('/') {
+        PathBuf::from(specifier)
+    } else {
+        let parent = base_file.parent()?;
+        parent.join(specifier)
+    };
+
+    let candidate = normalize_path(&candidate);
+
+    resolve_existing_module_path(&candidate)
+}
+
+fn resolve_existing_module_path(candidate: &Path) -> Option<PathBuf> {
+    const EXTENSIONS: [&str; 8] = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
+
+    if candidate.is_file() {
+        return Some(candidate.to_path_buf());
+    }
+
+    if candidate.extension().is_none() {
+        for extension in EXTENSIONS {
+            let with_extension = candidate.with_extension(extension);
+            if with_extension.is_file() {
+                return Some(with_extension);
+            }
+        }
+    }
+
+    if candidate.is_dir() {
+        for extension in EXTENSIONS {
+            let index_path = candidate.join(format!("index.{extension}"));
+            if index_path.is_file() {
+                return Some(index_path);
+            }
+        }
+    }
+
+    None
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
+fn normalized_path_suffixes(path: &Path) -> Vec<String> {
+    let components = path
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    (0..components.len()).map(|index| components[index..].join("/")).collect()
+}

--- a/crates/oxc_linter/src/rules/oxc/filename_naming_convention.rs
+++ b/crates/oxc_linter/src/rules/oxc/filename_naming_convention.rs
@@ -1,0 +1,260 @@
+use convert_case::{Boundary, Case, Converter};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn filename_naming_convention_diagnostic(
+    _span: Span,
+    filename: &str,
+    pattern: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Filename `{filename}` does not match the configured naming convention."
+    ))
+    .with_help(format!(
+        "Rename the file so its basename matches the case style `{pattern}` for this path."
+    ))
+    .with_label(Span::default())
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct FilenameNamingConvention(Box<FilenameNamingConventionConfig>);
+
+#[derive(Debug, Default, Clone)]
+pub struct FilenameNamingConventionConfig {
+    rules: Vec<(String, NamingConvention)>,
+    ignore_middle_extensions: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[expect(clippy::enum_variant_names)]
+enum NamingConvention {
+    CamelCase,
+    FlatCase,
+    KebabCase,
+    PascalCase,
+    ScreamingSnakeCase,
+    SnakeCase,
+}
+
+impl NamingConvention {
+    fn from_config_value(value: &str) -> Option<Self> {
+        match value {
+            "CAMEL_CASE" => Some(Self::CamelCase),
+            "FLAT_CASE" => Some(Self::FlatCase),
+            "KEBAB_CASE" => Some(Self::KebabCase),
+            "PASCAL_CASE" => Some(Self::PascalCase),
+            "SCREAMING_SNAKE_CASE" => Some(Self::ScreamingSnakeCase),
+            "SNAKE_CASE" => Some(Self::SnakeCase),
+            _ => None,
+        }
+    }
+
+    fn matches(self, value: &str) -> bool {
+        if value.contains('.') {
+            return false;
+        }
+
+        let converter =
+            Converter::new().remove_boundaries(&[Boundary::LowerDigit, Boundary::DigitLower]);
+
+        match self {
+            Self::CamelCase => converter.to_case(Case::Camel).convert(value) == value,
+            Self::FlatCase => value
+                .chars()
+                .all(|character| character.is_ascii_lowercase() || character.is_ascii_digit()),
+            Self::KebabCase => converter.to_case(Case::Kebab).convert(value) == value,
+            Self::PascalCase => converter.to_case(Case::Pascal).convert(value) == value,
+            Self::ScreamingSnakeCase => converter.to_case(Case::UpperSnake).convert(value) == value,
+            Self::SnakeCase => converter.to_case(Case::Snake).convert(value) == value,
+        }
+    }
+
+    fn as_config_value(self) -> &'static str {
+        match self {
+            Self::CamelCase => "CAMEL_CASE",
+            Self::FlatCase => "FLAT_CASE",
+            Self::KebabCase => "KEBAB_CASE",
+            Self::PascalCase => "PASCAL_CASE",
+            Self::ScreamingSnakeCase => "SCREAMING_SNAKE_CASE",
+            Self::SnakeCase => "SNAKE_CASE",
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces path-aware filename naming conventions.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Monorepos often rely on consistent filename casing for discoverability,
+    /// import ergonomics, and cross-platform filesystem safety.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// // path: src/core/fileRead.test.ts
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// // path: src/core/file-read.test.ts
+    /// ```
+    FilenameNamingConvention,
+    oxc,
+    style,
+    none
+);
+
+impl Rule for FilenameNamingConvention {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        let mut config = FilenameNamingConventionConfig::default();
+
+        if let Some(pattern_object) = value.get(0).and_then(serde_json::Value::as_object) {
+            config.rules = pattern_object
+                .iter()
+                .filter_map(|(pattern, convention)| {
+                    convention
+                        .as_str()
+                        .and_then(NamingConvention::from_config_value)
+                        .map(|naming| (pattern.clone(), naming))
+                })
+                .collect();
+        }
+
+        config.ignore_middle_extensions = value
+            .get(1)
+            .and_then(serde_json::Value::as_object)
+            .and_then(|options| options.get("ignoreMiddleExtensions"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+
+        Ok(Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(raw_filename) = ctx.file_path().file_name().and_then(|filename| filename.to_str())
+        else {
+            return;
+        };
+
+        let basename = strip_extension(raw_filename, self.0.ignore_middle_extensions);
+        let suffixes = normalized_path_suffixes(ctx.file_path());
+
+        for (pattern, naming) in &self.0.rules {
+            if suffixes.iter().any(|suffix| fast_glob::glob_match(pattern, suffix))
+                && !naming.matches(basename)
+            {
+                ctx.diagnostic(filename_naming_convention_diagnostic(
+                    Span::default(),
+                    raw_filename,
+                    naming.as_config_value(),
+                ));
+                return;
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+    }
+}
+
+fn strip_extension(filename: &str, ignore_middle_extensions: bool) -> &str {
+    if ignore_middle_extensions {
+        filename.split('.').next().unwrap_or(filename)
+    } else {
+        filename.rsplit_once('.').map_or(filename, |(name, _)| name)
+    }
+}
+
+fn normalized_path_suffixes(path: &std::path::Path) -> Vec<String> {
+    let components = path
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    (0..components.len()).map(|index| components[index..].join("/")).collect()
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use serde_json::Value;
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn test_case(
+        path: &'static str,
+        config: Option<Value>,
+    ) -> (&'static str, Option<Value>, Option<Value>, Option<PathBuf>) {
+        ("", config, None, Some(PathBuf::from(path)))
+    }
+
+    let pass = vec![
+        test_case(
+            "src/core/file-read.ts",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": true }]),
+            ),
+        ),
+        test_case(
+            "src/core/file-read.test.ts",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": true }]),
+            ),
+        ),
+        test_case(
+            "scripts/build.mjs",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": true }]),
+            ),
+        ),
+        test_case(
+            "README.md",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": true }]),
+            ),
+        ),
+    ];
+
+    let fail = vec![
+        test_case(
+            "src/core/fileRead.ts",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": true }]),
+            ),
+        ),
+        test_case(
+            "src/core/FileRead.ts",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": true }]),
+            ),
+        ),
+        test_case(
+            "src/core/fileRead.test.ts",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": true }]),
+            ),
+        ),
+        test_case(
+            "src/core/file-read.test.ts",
+            Some(
+                json!([{ "**/*.{ts,mts,js,mjs}": "KEBAB_CASE" }, { "ignoreMiddleExtensions": false }]),
+            ),
+        ),
+    ];
+
+    Tester::new(FilenameNamingConvention::NAME, FilenameNamingConvention::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/folder_naming_convention.rs
+++ b/crates/oxc_linter/src/rules/oxc/folder_naming_convention.rs
@@ -1,0 +1,257 @@
+use convert_case::{Boundary, Case, Converter};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn folder_naming_convention_diagnostic(_span: Span, folder: &str, pattern: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Folder `{folder}` does not match the configured naming convention."
+    ))
+    .with_help(format!(
+        "Rename the folder so matched path segments follow the case style `{pattern}`."
+    ))
+    .with_label(Span::default())
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct FolderNamingConvention(Box<FolderNamingConventionConfig>);
+
+#[derive(Debug, Default, Clone)]
+pub struct FolderNamingConventionConfig {
+    rules: Vec<(String, NamingConvention)>,
+    ignore_words: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[expect(clippy::enum_variant_names)]
+enum NamingConvention {
+    CamelCase,
+    FlatCase,
+    KebabCase,
+    PascalCase,
+    ScreamingSnakeCase,
+    SnakeCase,
+}
+
+impl NamingConvention {
+    fn from_config_value(value: &str) -> Option<Self> {
+        match value {
+            "CAMEL_CASE" => Some(Self::CamelCase),
+            "FLAT_CASE" => Some(Self::FlatCase),
+            "KEBAB_CASE" => Some(Self::KebabCase),
+            "PASCAL_CASE" => Some(Self::PascalCase),
+            "SCREAMING_SNAKE_CASE" => Some(Self::ScreamingSnakeCase),
+            "SNAKE_CASE" => Some(Self::SnakeCase),
+            _ => None,
+        }
+    }
+
+    fn matches(self, value: &str) -> bool {
+        if value.contains('.') {
+            return false;
+        }
+
+        let converter =
+            Converter::new().remove_boundaries(&[Boundary::LowerDigit, Boundary::DigitLower]);
+
+        match self {
+            Self::CamelCase => converter.to_case(Case::Camel).convert(value) == value,
+            Self::FlatCase => value
+                .chars()
+                .all(|character| character.is_ascii_lowercase() || character.is_ascii_digit()),
+            Self::KebabCase => converter.to_case(Case::Kebab).convert(value) == value,
+            Self::PascalCase => converter.to_case(Case::Pascal).convert(value) == value,
+            Self::ScreamingSnakeCase => converter.to_case(Case::UpperSnake).convert(value) == value,
+            Self::SnakeCase => converter.to_case(Case::Snake).convert(value) == value,
+        }
+    }
+
+    fn as_config_value(self) -> &'static str {
+        match self {
+            Self::CamelCase => "CAMEL_CASE",
+            Self::FlatCase => "FLAT_CASE",
+            Self::KebabCase => "KEBAB_CASE",
+            Self::PascalCase => "PASCAL_CASE",
+            Self::ScreamingSnakeCase => "SCREAMING_SNAKE_CASE",
+            Self::SnakeCase => "SNAKE_CASE",
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces path-aware folder naming conventions.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Consistent directory naming keeps imports, navigation, and repository
+    /// structure predictable across packages.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// // path: src/core_utils/file-read.ts
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// // path: src/core/utils/file-read.ts
+    /// ```
+    FolderNamingConvention,
+    oxc,
+    style,
+    none
+);
+
+impl Rule for FolderNamingConvention {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        let mut config = FolderNamingConventionConfig::default();
+
+        if let Some(pattern_object) = value.get(0).and_then(serde_json::Value::as_object) {
+            config.rules = pattern_object
+                .iter()
+                .filter_map(|(pattern, convention)| {
+                    convention
+                        .as_str()
+                        .and_then(NamingConvention::from_config_value)
+                        .map(|naming| (pattern.clone(), naming))
+                })
+                .collect();
+        }
+
+        config.ignore_words = value
+            .get(1)
+            .and_then(serde_json::Value::as_object)
+            .and_then(|options| options.get("ignoreWords"))
+            .and_then(serde_json::Value::as_array)
+            .map(|words| {
+                words
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        Ok(Self(Box::new(config)))
+    }
+
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(parent) = ctx.file_path().parent() else {
+            return;
+        };
+
+        let components = normalized_components(parent);
+
+        for (index, folder_name) in components.iter().enumerate() {
+            if self.0.ignore_words.iter().any(|word| word == folder_name) {
+                continue;
+            }
+
+            for (pattern, naming) in &self.0.rules {
+                if folder_matches_pattern(&components, index, pattern)
+                    && !naming.matches(folder_name)
+                {
+                    ctx.diagnostic(folder_naming_convention_diagnostic(
+                        Span::default(),
+                        folder_name,
+                        naming.as_config_value(),
+                    ));
+                    return;
+                }
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+    }
+}
+
+fn normalized_components(path: &std::path::Path) -> Vec<String> {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn folder_matches_pattern(components: &[String], end_index: usize, pattern: &str) -> bool {
+    for start_index in 0..=end_index {
+        let candidate = format!("{}/", components[start_index..=end_index].join("/"));
+        if path_matches_pattern(pattern, &candidate) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn path_matches_pattern(pattern: &str, candidate: &str) -> bool {
+    if fast_glob::glob_match(pattern, candidate) {
+        return true;
+    }
+
+    let Some(negation_start) = pattern.find("!(") else {
+        return false;
+    };
+    let Some(relative_end) = pattern[negation_start + 2..].find(')') else {
+        return false;
+    };
+
+    let negation_end = negation_start + 2 + relative_end;
+    let excluded = &pattern[negation_start + 2..negation_end];
+
+    if candidate.trim_end_matches('/').rsplit('/').next().is_some_and(|segment| segment == excluded)
+    {
+        return false;
+    }
+
+    let fallback_pattern =
+        format!("{}*{}", &pattern[..negation_start], &pattern[negation_end + 1..]);
+    fast_glob::glob_match(&fallback_pattern, candidate)
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use serde_json::Value;
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn test_case(
+        path: &'static str,
+        config: Option<Value>,
+    ) -> (&'static str, Option<Value>, Option<Value>, Option<PathBuf>) {
+        ("", config, None, Some(PathBuf::from(path)))
+    }
+
+    let pass = vec![
+        test_case("src/core/file-read.ts", Some(json!([{ "src/**/": "KEBAB_CASE" }]))),
+        test_case("src/core/utils/file-read.ts", Some(json!([{ "src/**/": "KEBAB_CASE" }]))),
+        test_case(
+            "src/features/__tests__/file-read.test.ts",
+            Some(json!([{ "src/**/!(__tests__)/": "KEBAB_CASE" }])),
+        ),
+        test_case("tests/helpers/file-read.ts", Some(json!([{ "src/**/": "KEBAB_CASE" }]))),
+    ];
+
+    let fail = vec![
+        test_case("src/core_utils/file-read.ts", Some(json!([{ "src/**/": "KEBAB_CASE" }]))),
+        test_case("src/core/FeatureFlags/file-read.ts", Some(json!([{ "src/**/": "KEBAB_CASE" }]))),
+        test_case(
+            "src/features/BadFolder/file-read.ts",
+            Some(json!([{ "src/**/!(__tests__)/": "KEBAB_CASE" }])),
+        ),
+    ];
+
+    Tester::new(FolderNamingConvention::NAME, FolderNamingConvention::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_block_in_inline.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_block_in_inline.rs
@@ -1,0 +1,229 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use oxc_ast::{AstKind, ast::JSXOpeningElement};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+const DEFAULT_BLOCK_ELEMENTS: [&str; 39] = [
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "dd",
+    "details",
+    "dialog",
+    "div",
+    "dl",
+    "dt",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "section",
+    "summary",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+];
+
+const DEFAULT_INLINE_ELEMENTS: [&str; 18] = [
+    "a", "abbr", "b", "button", "cite", "code", "em", "i", "label", "mark", "q", "small", "span",
+    "strong", "sub", "sup", "time", "u",
+];
+
+fn no_block_in_inline_diagnostic(span: Span, block: &str, inline: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Block-level element `<{block}>` must not be nested inside inline element `<{inline}>`."
+    ))
+    .with_help(
+        "Use a block parent instead, or replace the nested block element with inline markup.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+#[expect(clippy::struct_field_names)]
+pub struct NoBlockInInlineConfig {
+    block_elements: Option<Vec<String>>,
+    inline_elements: Option<Vec<String>>,
+    additional_block_elements: Vec<String>,
+    additional_inline_elements: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct NoBlockInInline(Box<NoBlockInInlineConfig>);
+
+impl std::ops::Deref for NoBlockInInline {
+    type Target = NoBlockInInlineConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Forbids block-level HTML elements nested inside inline HTML elements in JSX.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Block-level HTML inside inline HTML produces invalid DOM structure and can
+    /// lead to layout and accessibility issues.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```tsx
+    /// <span><div /></span>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```tsx
+    /// <div><span /></div>
+    /// ```
+    NoBlockInInline,
+    oxc,
+    correctness,
+    none,
+    config = NoBlockInInlineConfig
+);
+
+impl Rule for NoBlockInInline {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXElement(element) = node.kind() else {
+            return;
+        };
+
+        let Some(block_name) = get_html_element_name(&element.opening_element) else {
+            return;
+        };
+
+        if !self.is_block_element(block_name) {
+            return;
+        }
+
+        for ancestor in ctx.nodes().ancestors(node.id()) {
+            let AstKind::JSXElement(parent_element) = ancestor.kind() else {
+                continue;
+            };
+
+            let Some(inline_name) = get_html_element_name(&parent_element.opening_element) else {
+                continue;
+            };
+
+            if self.is_inline_element(inline_name) {
+                ctx.diagnostic(no_block_in_inline_diagnostic(
+                    element.opening_element.span,
+                    block_name,
+                    inline_name,
+                ));
+                return;
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+impl NoBlockInInline {
+    fn is_block_element(&self, name: &str) -> bool {
+        self.block_elements.as_ref().map_or_else(
+            || {
+                DEFAULT_BLOCK_ELEMENTS.contains(&name)
+                    || self.additional_block_elements.iter().any(|candidate| candidate == name)
+            },
+            |elements| elements.iter().any(|candidate| candidate == name),
+        )
+    }
+
+    fn is_inline_element(&self, name: &str) -> bool {
+        self.inline_elements.as_ref().map_or_else(
+            || {
+                DEFAULT_INLINE_ELEMENTS.contains(&name)
+                    || self.additional_inline_elements.iter().any(|candidate| candidate == name)
+            },
+            |elements| elements.iter().any(|candidate| candidate == name),
+        )
+    }
+}
+
+fn get_html_element_name<'a>(opening_element: &JSXOpeningElement<'a>) -> Option<&'a str> {
+    let oxc_ast::ast::JSXElementName::Identifier(identifier) = &opening_element.name else {
+        return None;
+    };
+
+    let name = identifier.name.as_str();
+    name.chars().next().is_some_and(|character| character.is_ascii_lowercase()).then_some(name)
+}
+
+#[test]
+fn test() {
+    use serde_json::Value;
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass: Vec<(&str, Option<Value>)> = vec![
+        ("const el = <div><span>Hello</span></div>;", None),
+        ("const el = <span><strong>Hello</strong></span>;", None),
+        ("const el = <div><section><p>Hello</p></section></div>;", None),
+        ("const el = <Inline><div /></Inline>;", None),
+        ("const el = <span><motion.div /></span>;", None),
+        (
+            "const el = <span><div /></span>;",
+            Some(
+                json!([{ "blockElements": ["custom-block"], "inlineElements": ["custom-inline"] }]),
+            ),
+        ),
+    ];
+
+    let fail: Vec<(&str, Option<Value>)> = vec![
+        ("const el = <span><div /></span>;", None),
+        ("const el = <a><p>bad</p></a>;", None),
+        ("const el = <span><em><section /></em></span>;", None),
+        (
+            "const el = <custom-inline><custom-block /></custom-inline>;",
+            Some(
+                json!([{ "additionalBlockElements": ["custom-block"], "additionalInlineElements": ["custom-inline"] }]),
+            ),
+        ),
+    ];
+
+    Tester::new(NoBlockInInline::NAME, NoBlockInInline::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_create_ref.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_create_ref.rs
@@ -1,0 +1,79 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_create_ref_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("React.createRef() should not be used in function components")
+        .with_help("Use useRef() hook instead of React.createRef() in function components. createRef creates a new ref object on every render.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoCreateRef;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects use of `React.createRef()` or `createRef()`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `createRef()` creates a new ref object on every render. In function
+    /// components, use `useRef()` instead, which persists the ref across renders.
+    /// In class components, create refs in the constructor instead of in render.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// const ref = React.createRef();
+    /// const ref = createRef();
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// const ref = useRef(null);
+    /// ```
+    NoCreateRef,
+    oxc,
+    correctness,
+    none
+);
+
+impl Rule for NoCreateRef {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let is_create_ref = match &call_expr.callee {
+            Expression::Identifier(ident) => ident.name == "createRef",
+            Expression::StaticMemberExpression(member) => {
+                member.property.name == "createRef"
+                    && matches!(&member.object, Expression::Identifier(obj) if obj.name == "React")
+            }
+            _ => false,
+        };
+
+        if is_create_ref {
+            ctx.diagnostic(no_create_ref_diagnostic(call_expr.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass =
+        vec!["const ref = useRef(null);", "const ref = React.useRef(null);", "foo.createRef()"];
+
+    let fail = vec!["const ref = React.createRef();", "const ref = createRef();", "createRef();"];
+    Tester::new(NoCreateRef::NAME, NoCreateRef::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_default_props.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_default_props.rs
@@ -1,0 +1,75 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_default_props_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("defaultProps is deprecated")
+        .with_help("Use JavaScript default parameters instead of defaultProps. defaultProps is deprecated since React 18.3.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDefaultProps;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects usage of `Component.defaultProps`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `defaultProps` is deprecated since React 18.3 and will be removed in
+    /// a future major version. Use JavaScript default parameters instead.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// Component.defaultProps = { color: "red" };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// function Component({ color = "red" }) { return <div />; }
+    /// ```
+    NoDefaultProps,
+    oxc,
+    restriction,
+    none
+);
+
+impl Rule for NoDefaultProps {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::AssignmentExpression(assign) = node.kind() else {
+            return;
+        };
+
+        let oxc_ast::ast::AssignmentTarget::StaticMemberExpression(member) = &assign.left else {
+            return;
+        };
+
+        if member.property.name == "defaultProps" {
+            ctx.diagnostic(no_default_props_diagnostic(member.property.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "function Component({ color = 'red' }) { return <div />; }",
+        "Component.displayName = 'Component';",
+        "Component.propTypes = {};",
+    ];
+
+    let fail = vec!["Component.defaultProps = { color: 'red' };", "MyButton.defaultProps = {};"];
+
+    Tester::new(NoDefaultProps::NAME, NoDefaultProps::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_inline_type_annotations.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_inline_type_annotations.rs
@@ -1,0 +1,92 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_inline_type_annotations_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use a named type or interface instead of an inline object type.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoInlineTypeAnnotations;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Forbids inline object type annotations.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inline object type annotations duplicate structure at the usage site and
+    /// make shared contracts harder to reuse and evolve. A named type or
+    /// interface keeps the shape centralized and easier to reference.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// function render(props: { title: string }) {
+    ///   return props.title;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// type Props = { title: string };
+    ///
+    /// function render(props: Props) {
+    ///   return props.title;
+    /// }
+    /// ```
+    NoInlineTypeAnnotations,
+    oxc,
+    restriction,
+    none
+);
+
+impl Rule for NoInlineTypeAnnotations {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSTypeLiteral(type_literal) = node.kind() else {
+            return;
+        };
+
+        if matches!(ctx.nodes().parent_kind(node.id()), AstKind::TSTypeAliasDeclaration(_)) {
+            return;
+        }
+
+        ctx.diagnostic(no_inline_type_annotations_diagnostic(type_literal.span));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::Value;
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass: Vec<(&str, Option<Value>)> = vec![
+        ("type Props = { title: string; count: number };", None),
+        ("interface Props { title: string; count: number }", None),
+        ("function render(props: Props) { return props.title; }", None),
+        ("const title: string = 'hello';", None),
+    ];
+
+    let fail: Vec<(&str, Option<Value>)> = vec![
+        ("const props: { title: string } = { title: 'hello' };", None),
+        ("function render(props: { title: string; count: number }) { return props.title; }", None),
+        ("const render = (): { title: string } => ({ title: 'hello' });", None),
+        ("type Loader = () => Promise<{ title: string }>;", Some(json!([]))),
+    ];
+
+    Tester::new(NoInlineTypeAnnotations::NAME, NoInlineTypeAnnotations::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_leaked_conditional_rendering.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_leaked_conditional_rendering.rs
@@ -1,0 +1,149 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::LogicalOperator;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_leaked_conditional_rendering_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Potential leaked value in JSX conditional rendering")
+        .with_help("When using `&&` for conditional rendering, falsy values like `0` or `NaN` will be rendered as text. Use a ternary expression or `Boolean()` to ensure only boolean values are checked.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoLeakedConditionalRendering;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prevents problematic leaked values in JSX expressions when using `&&`
+    /// for conditional rendering.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In React, when using `{value && <Component />}`, if `value` is a falsy
+    /// number like `0` or `NaN`, it will be rendered as text in the output
+    /// instead of rendering nothing. This is a common bug.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// {count && <Component />}
+    /// {data.length && <List items={data} />}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// {count > 0 && <Component />}
+    /// {Boolean(count) && <Component />}
+    /// {count ? <Component /> : null}
+    /// {!!count && <Component />}
+    /// ```
+    NoLeakedConditionalRendering,
+    oxc,
+    correctness,
+    none
+);
+
+/// Check if an expression could be a non-boolean falsy value (number, string, etc.)
+fn is_potentially_leaky(expr: &Expression<'_>) -> bool {
+    match expr {
+        // These are safe — they produce booleans
+        Expression::BooleanLiteral(_) => false,
+        Expression::UnaryExpression(unary)
+            if unary.operator == oxc_syntax::operator::UnaryOperator::LogicalNot =>
+        {
+            false
+        }
+        Expression::CallExpression(call) => {
+            // Boolean(x) is safe
+            if let Expression::Identifier(callee) = &call.callee
+                && callee.name == "Boolean"
+            {
+                return false;
+            }
+            true
+        }
+        Expression::BinaryExpression(bin) => {
+            // Comparison operators produce booleans
+            matches!(
+                bin.operator,
+                oxc_syntax::operator::BinaryOperator::Equality
+                    | oxc_syntax::operator::BinaryOperator::Inequality
+                    | oxc_syntax::operator::BinaryOperator::StrictEquality
+                    | oxc_syntax::operator::BinaryOperator::StrictInequality
+                    | oxc_syntax::operator::BinaryOperator::LessThan
+                    | oxc_syntax::operator::BinaryOperator::LessEqualThan
+                    | oxc_syntax::operator::BinaryOperator::GreaterThan
+                    | oxc_syntax::operator::BinaryOperator::GreaterEqualThan
+                    | oxc_syntax::operator::BinaryOperator::Instanceof
+                    | oxc_syntax::operator::BinaryOperator::In
+            )
+            .not()
+        }
+        // Everything else (string/number literals, identifiers, member expressions, etc.)
+        // could potentially leak non-boolean values
+        _ => true,
+    }
+}
+
+use std::ops::Not;
+
+impl Rule for NoLeakedConditionalRendering {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::LogicalExpression(logical) = node.kind() else {
+            return;
+        };
+
+        if logical.operator != LogicalOperator::And {
+            return;
+        }
+
+        // Check if we're inside a JSX expression container
+        let parent = ctx.nodes().parent_node(node.id());
+        if !matches!(parent.kind(), AstKind::JSXExpressionContainer(_)) {
+            return;
+        }
+
+        // The right side should be JSX for this to be conditional rendering
+        let is_jsx_right =
+            matches!(&logical.right, Expression::JSXElement(_) | Expression::JSXFragment(_));
+
+        if !is_jsx_right {
+            return;
+        }
+
+        if is_potentially_leaky(&logical.left) {
+            ctx.diagnostic(no_leaked_conditional_rendering_diagnostic(logical.left.span()));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"<div>{count > 0 && <Component />}</div>"#,
+        r#"<div>{Boolean(count) && <Component />}</div>"#,
+        r#"<div>{!!count && <Component />}</div>"#,
+        r#"<div>{count ? <Component /> : null}</div>"#,
+        r#"<div>{true && <Component />}</div>"#,
+    ];
+
+    let fail =
+        vec![r#"<div>{count && <Component />}</div>"#, r#"<div>{data.length && <List />}</div>"#];
+
+    Tester::new(
+        NoLeakedConditionalRendering::NAME,
+        NoLeakedConditionalRendering::PLUGIN,
+        pass,
+        fail,
+    )
+    .change_rule_path_extension("tsx")
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_literal_string.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_literal_string.rs
@@ -1,0 +1,209 @@
+use lazy_regex::Regex;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::get_element_type,
+};
+
+fn no_literal_string_diagnostic(span: Span, text: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Literal JSX text should be translated: `{text}`."))
+        .with_help(
+            "Wrap user-facing text in your translation layer instead of rendering it inline.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct PatternGroup {
+    include: Vec<String>,
+    exclude: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct NoLiteralStringConfig {
+    framework: String,
+    mode: String,
+    #[serde(rename = "jsx-components")]
+    jsx_components: PatternGroup,
+    #[serde(rename = "jsx-attributes")]
+    jsx_attributes: PatternGroup,
+    words: PatternGroup,
+    callees: PatternGroup,
+}
+
+impl Default for NoLiteralStringConfig {
+    fn default() -> Self {
+        Self {
+            framework: "react".to_string(),
+            mode: "jsx-text-only".to_string(),
+            jsx_components: PatternGroup {
+                include: Vec::new(),
+                exclude: vec!["Trans".to_string()],
+            },
+            jsx_attributes: PatternGroup::default(),
+            words: PatternGroup::default(),
+            callees: PatternGroup::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct NoLiteralString(Box<NoLiteralStringConfig>);
+
+impl std::ops::Deref for NoLiteralString {
+    type Target = NoLiteralStringConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Flags user-facing literal JSX text that should come from a translation layer.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inline UI strings are easy to miss during localization work and make
+    /// it harder to keep translated interfaces complete.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```tsx
+    /// <button>Save</button>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```tsx
+    /// <button>{t("actions.save")}</button>
+    /// ```
+    NoLiteralString,
+    oxc,
+    pedantic,
+    none,
+    config = NoLiteralStringConfig
+);
+
+impl Rule for NoLiteralString {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXText(jsx_text) = node.kind() else {
+            return;
+        };
+
+        if self.framework != "react" || self.mode != "jsx-text-only" {
+            return;
+        }
+
+        let trimmed = jsx_text.value.as_str().trim();
+        if trimmed.is_empty() {
+            return;
+        }
+
+        if should_skip(&self.words, trimmed)
+            || is_in_excluded_component(node.id(), ctx, &self.jsx_components)
+        {
+            return;
+        }
+
+        ctx.diagnostic(no_literal_string_diagnostic(jsx_text.span, trimmed));
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+fn is_in_excluded_component(
+    node_id: oxc_syntax::node::NodeId,
+    ctx: &LintContext<'_>,
+    components: &PatternGroup,
+) -> bool {
+    ctx.nodes().ancestors(node_id).any(|ancestor| {
+        let AstKind::JSXElement(element) = ancestor.kind() else {
+            return false;
+        };
+        let name = get_element_type(ctx, &element.opening_element);
+        should_skip(components, name.as_ref())
+    })
+}
+
+fn should_skip(patterns: &PatternGroup, text: &str) -> bool {
+    if patterns.include.is_empty() && patterns.exclude.is_empty() {
+        return false;
+    }
+
+    if !patterns.include.is_empty() && match_patterns(&patterns.include, text) {
+        return false;
+    }
+
+    if !patterns.exclude.is_empty() && !match_patterns(&patterns.exclude, text) {
+        return false;
+    }
+
+    true
+}
+
+fn match_patterns(patterns: &[String], text: &str) -> bool {
+    patterns.iter().any(|pattern| matches_pattern(pattern, text))
+}
+
+fn matches_pattern(pattern: &str, text: &str) -> bool {
+    let regex_source = format!("(^|\\.){pattern}{}", if pattern.ends_with('$') { "" } else { "$" });
+    Regex::new(&regex_source).is_ok_and(|regex| regex.is_match(text))
+}
+
+#[test]
+fn test() {
+    use serde_json::{Value, json};
+
+    use crate::tester::Tester;
+
+    let config = Some(json!([{
+        "framework": "react",
+        "mode": "jsx-text-only",
+        "words": {
+            "exclude": ["\\d+", "[A-Z_-]+", "\\S+\\/\\S+", "\\s+"]
+        },
+        "callees": {
+            "exclude": ["t", "i18n\\.t", "console\\.\\w+", "require", "import"]
+        }
+    }]));
+
+    let pass: Vec<(&str, Option<Value>)> = vec![
+        ("const el = <div>{t(\"actions.save\")}</div>;", config.clone()),
+        ("const el = <div>{\"Save\"}</div>;", config.clone()),
+        ("const el = <div>12345</div>;", config.clone()),
+        ("const el = <div>API_URL</div>;", config.clone()),
+        ("const el = <div>foo/bar</div>;", config.clone()),
+        ("const el = <div>   </div>;", config.clone()),
+        ("const el = <Trans>Hello world</Trans>;", config.clone()),
+        ("const el = <I18n.Trans>Hello world</I18n.Trans>;", config.clone()),
+    ];
+
+    let fail: Vec<(&str, Option<Value>)> = vec![
+        ("const el = <div>Hello world</div>;", config.clone()),
+        ("const el = <><span>Save</span></>;", config.clone()),
+        ("const el = <Button>Submit</Button>;", config.clone()),
+    ];
+
+    Tester::new(NoLiteralString::NAME, NoLiteralString::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_nested_components.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_nested_components.rs
@@ -1,0 +1,154 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_nested_components_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Component definition inside another component")
+        .with_help("Move the component definition outside of the parent component. Nested component definitions cause the component to be recreated on every render, destroying its state.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoNestedComponents;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prevents defining React components inside other React components.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When a component is defined inside another component's render, a new
+    /// component type is created on every render. This causes React to unmount
+    /// and remount the nested component, destroying all its state. It also
+    /// prevents React from optimizing re-renders.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// function ParentComponent() {
+    ///     function ChildComponent() {
+    ///         return <div />;
+    ///     }
+    ///     return <ChildComponent />;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// function ChildComponent() {
+    ///     return <div />;
+    /// }
+    /// function ParentComponent() {
+    ///     return <ChildComponent />;
+    /// }
+    /// ```
+    NoNestedComponents,
+    oxc,
+    correctness,
+    none
+);
+
+impl Rule for NoNestedComponents {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Look for function declarations or arrow functions that return JSX
+        let (fn_name_span, has_jsx) = match node.kind() {
+            AstKind::Function(func) => {
+                let Some(id) = &func.id else {
+                    return;
+                };
+                // Check if name starts with uppercase (React component convention)
+                if !id.name.starts_with(|c: char| c.is_ascii_uppercase()) {
+                    return;
+                }
+                (id.span, true)
+            }
+            AstKind::VariableDeclarator(decl) => {
+                // const MyComponent = () => <div />
+                // const MyComponent = function() { return <div /> }
+                let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &decl.id else {
+                    return;
+                };
+                if !id.name.starts_with(|c: char| c.is_ascii_uppercase()) {
+                    return;
+                }
+                let Some(init) = &decl.init else {
+                    return;
+                };
+                let is_fn = matches!(
+                    init,
+                    oxc_ast::ast::Expression::ArrowFunctionExpression(_)
+                        | oxc_ast::ast::Expression::FunctionExpression(_)
+                );
+                if !is_fn {
+                    return;
+                }
+                (id.span, true)
+            }
+            _ => return,
+        };
+
+        if !has_jsx {
+            return;
+        }
+
+        // Check if we're inside another function component
+        for ancestor_id in ctx.nodes().ancestor_ids(node.id()).skip(1) {
+            let ancestor = ctx.nodes().get_node(ancestor_id);
+            match ancestor.kind() {
+                AstKind::Function(func) => {
+                    if let Some(id) = &func.id
+                        && id.name.starts_with(|c: char| c.is_ascii_uppercase())
+                    {
+                        ctx.diagnostic(no_nested_components_diagnostic(fn_name_span));
+                        return;
+                    }
+                }
+                AstKind::VariableDeclarator(decl) => {
+                    if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &decl.id
+                        && id.name.starts_with(|c: char| c.is_ascii_uppercase())
+                        && decl.init.as_ref().is_some_and(|init| {
+                            matches!(
+                                init,
+                                oxc_ast::ast::Expression::ArrowFunctionExpression(_)
+                                    | oxc_ast::ast::Expression::FunctionExpression(_)
+                            )
+                        })
+                    {
+                        ctx.diagnostic(no_nested_components_diagnostic(fn_name_span));
+                        return;
+                    }
+                }
+                AstKind::Program(_) => return,
+                _ => {}
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Top-level components
+        "function ChildComponent() { return <div />; }\nfunction ParentComponent() { return <ChildComponent />; }",
+        // Non-component functions (lowercase)
+        "function ParentComponent() { function helper() { return 1; } return <div />; }",
+    ];
+
+    let fail = vec![
+        // Nested function component
+        "function ParentComponent() { function ChildComponent() { return <div />; } return <ChildComponent />; }",
+        // Nested arrow component
+        "function ParentComponent() { const ChildComponent = () => <div />; return <ChildComponent />; }",
+    ];
+
+    Tester::new(NoNestedComponents::NAME, NoNestedComponents::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_prop_types.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_prop_types.rs
@@ -1,0 +1,86 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_prop_types_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("PropTypes is deprecated")
+        .with_help("Use TypeScript for type checking instead of PropTypes. PropTypes is deprecated since React 15.5.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoPropTypes;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects usage of `Component.propTypes` or imports of `prop-types`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// PropTypes has been deprecated since React 15.5 and provides only
+    /// runtime type checking. Use TypeScript for static type checking instead.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// import PropTypes from "prop-types";
+    /// Component.propTypes = { name: PropTypes.string };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```tsx
+    /// interface ComponentProps { name: string; }
+    /// function Component({ name }: ComponentProps) { return <div />; }
+    /// ```
+    NoPropTypes,
+    oxc,
+    restriction,
+    none
+);
+
+impl Rule for NoPropTypes {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::AssignmentExpression(assign) => {
+                let oxc_ast::ast::AssignmentTarget::StaticMemberExpression(member) = &assign.left
+                else {
+                    return;
+                };
+                if member.property.name == "propTypes" {
+                    ctx.diagnostic(no_prop_types_diagnostic(member.property.span));
+                }
+            }
+            AstKind::ImportDeclaration(import) => {
+                if import.source.value.as_str() == "prop-types" {
+                    ctx.diagnostic(no_prop_types_diagnostic(import.source.span));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "Component.displayName = 'Component';",
+        "Component.defaultProps = {};",
+        "import React from 'react';",
+    ];
+
+    let fail = vec![
+        "Component.propTypes = { name: PropTypes.string };",
+        "import PropTypes from 'prop-types';",
+    ];
+
+    Tester::new(NoPropTypes::NAME, NoPropTypes::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_secrets.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_secrets.rs
@@ -1,0 +1,268 @@
+use lazy_regex::{Lazy, Regex, lazy_regex};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+const DEFAULT_TOLERANCE: f64 = 4.0;
+const CHARSET: &str =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+=!|*^@~`$%+?\"'_<>"; // keep aligned with eslint-plugin-no-secrets
+
+fn high_entropy_diagnostic(span: Span, token: &str, entropy: f64) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Found a high-entropy string `{token}` ({entropy:.2})."))
+        .with_help("Move the secret out of source code or replace it with a safe test value.")
+        .with_label(span)
+}
+
+fn pattern_match_diagnostic(span: Span, name: &str, matched: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Found a string matching secret pattern `{name}`: `{matched}`."
+    ))
+    .with_help("Remove the embedded secret from source code or replace it with a redacted placeholder.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct NoSecrets(Box<NoSecretsConfig>);
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct NoSecretsConfig {
+    tolerance: f64,
+    ignore_modules: bool,
+}
+
+impl Default for NoSecretsConfig {
+    fn default() -> Self {
+        Self { tolerance: DEFAULT_TOLERANCE, ignore_modules: true }
+    }
+}
+
+impl std::ops::Deref for NoSecrets {
+    type Target = NoSecretsConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects likely hardcoded secrets in string literals, template text, and comments.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Credentials, tokens, and private keys committed to source code are a
+    /// high-risk class of security issue and are difficult to fully remediate
+    /// once leaked.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const awsKey = "AKIA1234567890ABCDEF";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const awsKey = process.env.AWS_ACCESS_KEY_ID;
+    /// ```
+    NoSecrets,
+    oxc,
+    suspicious,
+    none,
+    config = NoSecretsConfig
+);
+
+impl Rule for NoSecrets {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::StringLiteral(string_literal) => {
+                if self.ignore_modules && is_module_path_string(node.id(), string_literal.span, ctx)
+                {
+                    return;
+                }
+                check_text(string_literal.span, string_literal.value.as_str(), self.tolerance, ctx);
+            }
+            AstKind::TemplateElement(template_element) => {
+                if let Some(cooked) = template_element.value.cooked {
+                    check_text(template_element.span, cooked.as_str(), self.tolerance, ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn run_once(&self, ctx: &LintContext) {
+        for comment in ctx.comments() {
+            let span = comment.content_span();
+            check_text(span, ctx.source_range(span), self.tolerance, ctx);
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+    }
+}
+
+fn check_text(span: Span, value: &str, tolerance: f64, ctx: &LintContext<'_>) {
+    if value.is_empty() {
+        return;
+    }
+
+    let mut matched_pattern = false;
+    for (name, regex) in patterns() {
+        if let Some(found) = regex.find(value) {
+            matched_pattern = true;
+            ctx.diagnostic(pattern_match_diagnostic(span, name, found.as_str()));
+        }
+    }
+
+    if matched_pattern {
+        return;
+    }
+
+    for (token, entropy) in high_entropy_tokens(value, tolerance) {
+        ctx.diagnostic(high_entropy_diagnostic(span, token, entropy));
+    }
+}
+
+fn high_entropy_tokens(value: &str, tolerance: f64) -> Vec<(&str, f64)> {
+    value
+        .split_whitespace()
+        .filter(|token| !token.is_empty())
+        .filter_map(|token| {
+            let entropy = shannon_entropy(token);
+            (entropy >= tolerance).then_some((token, entropy))
+        })
+        .collect()
+}
+
+fn shannon_entropy(value: &str) -> f64 {
+    if value.is_empty() {
+        return 0.0;
+    }
+
+    #[expect(clippy::cast_precision_loss)]
+    let length = value.len() as f64;
+    let mut entropy = 0.0;
+
+    for character in CHARSET.chars() {
+        #[expect(clippy::cast_precision_loss)]
+        let count = value.chars().filter(|candidate| *candidate == character).count() as f64;
+        if count > 0.0 {
+            let ratio = count / length;
+            entropy += -(ratio * ratio.log2());
+        }
+    }
+
+    entropy
+}
+
+fn is_module_path_string(
+    node_id: oxc_syntax::node::NodeId,
+    span: Span,
+    ctx: &LintContext<'_>,
+) -> bool {
+    match ctx.nodes().parent_kind(node_id) {
+        AstKind::ImportDeclaration(_) => true,
+        AstKind::ImportExpression(import_expr) => import_expr.source.span() == span,
+        AstKind::CallExpression(call_expr) => {
+            matches!(&call_expr.callee, oxc_ast::ast::Expression::Identifier(ident) if ident.name == "require")
+                && call_expr
+                    .arguments
+                    .first()
+                    .and_then(oxc_ast::ast::Argument::as_expression)
+                    .is_some_and(|expression| expression.span() == span)
+        }
+        _ => false,
+    }
+}
+
+fn patterns() -> &'static [(&'static str, &'static Lazy<Regex>)] {
+    static PATTERNS: [(&str, &Lazy<Regex>); 11] = [
+        ("Slack Token", &SLACK_TOKEN),
+        ("RSA private key", &RSA_PRIVATE_KEY),
+        ("SSH (OPENSSH) private key", &OPENSSH_PRIVATE_KEY),
+        ("SSH (DSA) private key", &DSA_PRIVATE_KEY),
+        ("SSH (EC) private key", &EC_PRIVATE_KEY),
+        ("PGP private key block", &PGP_PRIVATE_KEY),
+        ("AWS API Key", &AWS_API_KEY),
+        ("Slack Webhook", &SLACK_WEBHOOK),
+        ("Google (GCP) Service-account", &GCP_SERVICE_ACCOUNT),
+        ("Twilio API Key", &TWILIO_API_KEY),
+        ("Password in URL", &PASSWORD_IN_URL),
+    ];
+
+    &PATTERNS
+}
+
+static SLACK_TOKEN: Lazy<Regex> =
+    lazy_regex!(r"(xox[p|b|o|a]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})");
+#[expect(clippy::trivial_regex)]
+static RSA_PRIVATE_KEY: Lazy<Regex> = lazy_regex!(r"-----BEGIN RSA PRIVATE KEY-----");
+#[expect(clippy::trivial_regex)]
+static OPENSSH_PRIVATE_KEY: Lazy<Regex> = lazy_regex!(r"-----BEGIN OPENSSH PRIVATE KEY-----");
+#[expect(clippy::trivial_regex)]
+static DSA_PRIVATE_KEY: Lazy<Regex> = lazy_regex!(r"-----BEGIN DSA PRIVATE KEY-----");
+#[expect(clippy::trivial_regex)]
+static EC_PRIVATE_KEY: Lazy<Regex> = lazy_regex!(r"-----BEGIN EC PRIVATE KEY-----");
+#[expect(clippy::trivial_regex)]
+static PGP_PRIVATE_KEY: Lazy<Regex> = lazy_regex!(r"-----BEGIN PGP PRIVATE KEY BLOCK-----");
+static AWS_API_KEY: Lazy<Regex> = lazy_regex!(r"AKIA[0-9A-Z]{16}");
+static SLACK_WEBHOOK: Lazy<Regex> = lazy_regex!(
+    r"https://hooks\.slack\.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}"
+);
+#[expect(clippy::trivial_regex)]
+static GCP_SERVICE_ACCOUNT: Lazy<Regex> = lazy_regex!(r#""type": "service_account""#);
+static TWILIO_API_KEY: Lazy<Regex> = lazy_regex!(r"SK[a-z0-9]{32}");
+static PASSWORD_IN_URL: Lazy<Regex> =
+    lazy_regex!(r#"[a-zA-Z]{3,10}://[^/\s:@]{3,20}:[^/\s:@]{3,20}@.{1,100}["'\s]"#);
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("const greeting = 'hello world';", None),
+        ("const path = require('fs');", None),
+        ("import x from './local-module';", None),
+        ("const module = import('./dynamic-module');", None),
+        ("const tmpl = `hello ${name}`;", None),
+        ("// just a normal comment", None),
+        ("const lowEntropy = 'aaaaaaaaaaaa';", Some(json!([{ "tolerance": 4.5 }]))),
+    ];
+
+    let fail = vec![
+        ("const awsKey = 'AKIA1234567890ABCDEF';", None),
+        (
+            "const token = 'ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva';",
+            Some(json!([{ "tolerance": 4.5 }])),
+        ),
+        (
+            "const key = `https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx`;",
+            None,
+        ),
+        ("// -----BEGIN RSA PRIVATE KEY-----", None),
+    ];
+
+    Tester::new(NoSecrets::NAME, NoSecrets::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_unknown.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_unknown.rs
@@ -1,0 +1,184 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+use super::boundary_utils::{classify_path, read_boundary_elements, resolve_local_specifier};
+
+fn no_unknown_diagnostic(span: Span, specifier: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Dependencies to unknown elements are not allowed.")
+        .with_help(format!(
+            "Classify `{specifier}` with `boundaries/elements` or move the dependency into a known architectural area."
+        ))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUnknown;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Reports local dependencies that resolve to files outside all configured `boundaries/elements`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Imports into unknown areas bypass the declared architecture even when the source file itself
+    /// belongs to a valid element.
+    NoUnknown,
+    oxc,
+    restriction,
+);
+
+impl Rule for NoUnknown {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(elements) = read_boundary_elements(ctx) else {
+            return;
+        };
+
+        let module_record = ctx.module_record();
+
+        for import_entry in &module_record.import_entries {
+            let specifier = import_entry.module_request.name();
+            let Some(remote_module) = module_record.get_loaded_module(specifier) else {
+                continue;
+            };
+
+            if classify_path(&remote_module.resolved_absolute_path, &elements).is_none() {
+                ctx.diagnostic(no_unknown_diagnostic(import_entry.module_request.span, specifier));
+            }
+        }
+
+        for export_entry in &module_record.indirect_export_entries {
+            let Some(module_request) = &export_entry.module_request else {
+                continue;
+            };
+            let specifier = module_request.name();
+            let Some(remote_module) = module_record.get_loaded_module(specifier) else {
+                continue;
+            };
+
+            if classify_path(&remote_module.resolved_absolute_path, &elements).is_none() {
+                ctx.diagnostic(no_unknown_diagnostic(module_request.span, specifier));
+            }
+        }
+
+        for export_entry in &module_record.star_export_entries {
+            let Some(module_request) = &export_entry.module_request else {
+                continue;
+            };
+            let specifier = module_request.name();
+            let Some(remote_module) = module_record.get_loaded_module(specifier) else {
+                continue;
+            };
+
+            if classify_path(&remote_module.resolved_absolute_path, &elements).is_none() {
+                ctx.diagnostic(no_unknown_diagnostic(module_request.span, specifier));
+            }
+        }
+
+        for node in ctx.nodes() {
+            match node.kind() {
+                AstKind::ImportExpression(import_expr) => {
+                    let Expression::StringLiteral(string_literal) = &import_expr.source else {
+                        continue;
+                    };
+                    let specifier = string_literal.value.as_str();
+                    let Some(resolved_path) = resolve_local_specifier(ctx.file_path(), specifier)
+                    else {
+                        continue;
+                    };
+
+                    if classify_path(&resolved_path, &elements).is_none() {
+                        ctx.diagnostic(no_unknown_diagnostic(string_literal.span, specifier));
+                    }
+                }
+                AstKind::CallExpression(call_expr) => {
+                    let Expression::Identifier(ident) = &call_expr.callee else {
+                        continue;
+                    };
+
+                    if ident.name != "require" {
+                        continue;
+                    }
+
+                    let Some(Argument::StringLiteral(string_literal)) = call_expr.arguments.first()
+                    else {
+                        continue;
+                    };
+                    let specifier = string_literal.value.as_str();
+                    let Some(resolved_path) = resolve_local_specifier(ctx.file_path(), specifier)
+                    else {
+                        continue;
+                    };
+
+                    if classify_path(&resolved_path, &elements).is_none() {
+                        ctx.diagnostic(no_unknown_diagnostic(string_literal.span, specifier));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn eslint_config() -> serde_json::Value {
+        json!({
+            "settings": {
+                "boundaries/elements": [
+                    { "type": "admin-routes", "pattern": ["src/routes/admin/*"] },
+                    { "type": "user-routes", "pattern": ["src/routes/user/*"] },
+                    { "type": "public-routes", "pattern": ["src/routes/public/*"] },
+                    { "type": "admin-components", "pattern": ["src/components/admin-*", "src/components/admin/*"] },
+                    { "type": "user-components", "pattern": ["src/components/user-*"] },
+                    { "type": "api-admin", "pattern": ["src/api/admin/*"] },
+                    { "type": "api-user", "pattern": ["src/api/user/*"] },
+                    { "type": "api-public", "pattern": ["src/api/public/*"] },
+                    { "type": "shared", "pattern": ["src/components/ui/*", "src/library/*", "src/hooks/*", "src/utils/*"] },
+                    { "type": "layouts", "pattern": ["src/layouts/*"] },
+                    { "type": "locales", "pattern": ["src/locales/**/*"] },
+                    { "type": "styles", "pattern": ["src/styles/**/*"] }
+                ]
+            }
+        })
+    }
+
+    let pass = vec![(
+        r#"
+            import { uiButton } from "../../components/ui/button.ts";
+            const api = require("../../api/public/info");
+            const lazy = import("../../layouts/main");
+            export const known = [uiButton, api, lazy];
+            "#,
+        None,
+        Some(eslint_config()),
+    )];
+
+    let fail = vec![(
+        r#"
+            import { scratch } from "../../experimental/scratch.ts";
+            const required = require("../../experimental/scratch");
+            const lazy = import("../../experimental/scratch");
+            export const unknown = [scratch, required, lazy];
+            "#,
+        None,
+        Some(eslint_config()),
+    )];
+
+    Tester::new(NoUnknown::NAME, NoUnknown::PLUGIN, pass, fail)
+        .change_rule_path("boundaries-app/src/routes/public/no-unknown.ts")
+        .with_import_plugin(true)
+        .intentionally_allow_no_fix_tests()
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_unknown_files.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_unknown_files.rs
@@ -1,0 +1,97 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+use super::boundary_utils::{classify_path, read_boundary_elements};
+
+fn no_unknown_files_diagnostic() -> OxcDiagnostic {
+    OxcDiagnostic::warn("File does not match any configured element pattern.")
+        .with_help("Move the file into a configured architectural element or extend `boundaries/elements`.")
+        .with_label(Span::default())
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUnknownFiles;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Reports files whose paths do not match any configured `boundaries/elements` pattern.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unclassified files usually mean architecture drift: code exists outside the intended
+    /// route, component, API, or shared boundaries.
+    NoUnknownFiles,
+    oxc,
+    restriction,
+);
+
+impl Rule for NoUnknownFiles {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let Some(elements) = read_boundary_elements(ctx) else {
+            return;
+        };
+
+        if classify_path(ctx.file_path(), &elements).is_none() {
+            ctx.diagnostic(no_unknown_files_diagnostic());
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+        ctx.is_first_sub_host()
+    }
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    fn eslint_config() -> serde_json::Value {
+        json!({
+            "settings": {
+                "boundaries/elements": [
+                    { "type": "admin-routes", "pattern": ["src/routes/admin/*"] },
+                    { "type": "user-routes", "pattern": ["src/routes/user/*"] },
+                    { "type": "public-routes", "pattern": ["src/routes/public/*"] },
+                    { "type": "admin-components", "pattern": ["src/components/admin-*", "src/components/admin/*"] },
+                    { "type": "user-components", "pattern": ["src/components/user-*"] },
+                    { "type": "api-admin", "pattern": ["src/api/admin/*"] },
+                    { "type": "api-user", "pattern": ["src/api/user/*"] },
+                    { "type": "api-public", "pattern": ["src/api/public/*"] },
+                    { "type": "shared", "pattern": ["src/components/ui/*", "src/library/*", "src/hooks/*", "src/utils/*"] },
+                    { "type": "layouts", "pattern": ["src/layouts/*"] },
+                    { "type": "locales", "pattern": ["src/locales/**/*"] },
+                    { "type": "styles", "pattern": ["src/styles/**/*"] }
+                ]
+            }
+        })
+    }
+
+    fn test_case(
+        path: &'static str,
+    ) -> (&'static str, Option<serde_json::Value>, Option<serde_json::Value>, Option<PathBuf>) {
+        ("export const value = 1;", None, Some(eslint_config()), Some(PathBuf::from(path)))
+    }
+
+    let pass = vec![
+        test_case("boundaries-app/src/routes/public/known.ts"),
+        test_case("boundaries-app/src/components/ui/button.ts"),
+    ];
+
+    let fail = vec![
+        test_case("boundaries-app/src/experimental/scratch.ts"),
+        test_case("boundaries-app/src/misc/orphan.ts"),
+    ];
+
+    Tester::new(NoUnknownFiles::NAME, NoUnknownFiles::PLUGIN, pass, fail)
+        .change_rule_path("boundaries-app/src/routes/public/known.ts")
+        .intentionally_allow_no_fix_tests()
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_unstable_default_props.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_unstable_default_props.rs
@@ -1,0 +1,125 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_unstable_default_props_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unstable value used as default prop")
+        .with_help("Object and array literals as default parameter values create a new reference on every render. Extract them to a module-level constant.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUnstableDefaultProps;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects object or array literals used as default values for component
+    /// props in function parameters.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using `{}` or `[]` as a default parameter value creates a new reference
+    /// on every render. This defeats React.memo, causes unnecessary re-renders,
+    /// and can trigger infinite loops in useEffect dependencies.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// function Component({ items = [], config = {} }) {
+    ///     return <div />;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// const DEFAULT_ITEMS = [];
+    /// const DEFAULT_CONFIG = {};
+    /// function Component({ items = DEFAULT_ITEMS, config = DEFAULT_CONFIG }) {
+    ///     return <div />;
+    /// }
+    /// ```
+    NoUnstableDefaultProps,
+    oxc,
+    perf,
+    none
+);
+
+impl Rule for NoUnstableDefaultProps {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Function(func) = node.kind() else {
+            return;
+        };
+
+        // Check if this looks like a React component (PascalCase name or arrow in PascalCase var)
+        let is_component = func
+            .id
+            .as_ref()
+            .is_some_and(|id| id.name.starts_with(|c: char| c.is_ascii_uppercase()));
+
+        if !is_component {
+            // Could be an arrow function assigned to a PascalCase variable,
+            // but we can't check that easily from here. Just check the first param.
+            // Skip non-PascalCase named functions.
+            if func.id.is_some() {
+                return;
+            }
+        }
+
+        // Check first parameter for destructured props with default values
+        let Some(first_param) = func.params.items.first() else {
+            return;
+        };
+
+        let oxc_ast::ast::BindingPattern::ObjectPattern(obj_pattern) = &first_param.pattern else {
+            return;
+        };
+
+        for prop in &obj_pattern.properties {
+            if let oxc_ast::ast::BindingPattern::AssignmentPattern(assign) = &prop.value
+                && is_unstable_value(&assign.right)
+            {
+                ctx.diagnostic(no_unstable_default_props_diagnostic(assign.right.span()));
+            }
+        }
+    }
+}
+
+fn is_unstable_value(expr: &Expression<'_>) -> bool {
+    matches!(
+        expr,
+        Expression::ObjectExpression(_)
+            | Expression::ArrayExpression(_)
+            | Expression::ArrowFunctionExpression(_)
+            | Expression::FunctionExpression(_)
+            | Expression::RegExpLiteral(_)
+    )
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "function Component({ items = DEFAULT_ITEMS }) { return <div />; }",
+        "function Component({ count = 0 }) { return <div />; }",
+        "function Component({ name = 'default' }) { return <div />; }",
+        "function Component({ enabled = true }) { return <div />; }",
+        "function helper({ items = [] }) { return items; }",
+    ];
+
+    let fail = vec![
+        "function Component({ items = [] }) { return <div />; }",
+        "function Component({ config = {} }) { return <div />; }",
+        "function Component({ onClick = () => {} }) { return <div />; }",
+    ];
+
+    Tester::new(NoUnstableDefaultProps::NAME, NoUnstableDefaultProps::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/prefer_shorthand_boolean.rs
+++ b/crates/oxc_linter/src/rules/oxc/prefer_shorthand_boolean.rs
@@ -1,0 +1,112 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::JSXAttributeItem;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn prefer_shorthand_boolean_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use shorthand boolean attribute: `{name}` instead of `{name}={{true}}`"))
+        .with_help("Boolean JSX attributes can use the shorthand form. `<Comp disabled />` is equivalent to `<Comp disabled={true} />`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferShorthandBoolean;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the shorthand form for boolean JSX attributes.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `<Component disabled={true} />` is more verbose than the equivalent
+    /// `<Component disabled />`. The shorthand form is idiomatic React.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <Component disabled={true} />
+    /// <Input readOnly={true} />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <Component disabled />
+    /// <Input readOnly />
+    /// <Component active={false} />
+    /// <Component active={isActive} />
+    /// ```
+    PreferShorthandBoolean,
+    oxc,
+    style,
+    conditional_fix
+);
+
+impl Rule for PreferShorthandBoolean {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(element) = node.kind() else {
+            return;
+        };
+
+        for attr in &element.attributes {
+            let JSXAttributeItem::Attribute(jsx_attr) = attr else {
+                continue;
+            };
+
+            let Some(value) = &jsx_attr.value else {
+                continue;
+            };
+
+            let oxc_ast::ast::JSXAttributeValue::ExpressionContainer(container) = value else {
+                continue;
+            };
+
+            let oxc_ast::ast::JSXExpression::BooleanLiteral(lit) = &container.expression else {
+                continue;
+            };
+
+            if !lit.value {
+                continue;
+            }
+
+            let Some(ident) = jsx_attr.name.as_identifier() else {
+                continue;
+            };
+            let name = ident.name.to_string();
+            let attr_span = jsx_attr.span();
+            ctx.diagnostic_with_fix(
+                prefer_shorthand_boolean_diagnostic(attr_span, &name),
+                |fixer| fixer.replace(attr_span, name),
+            );
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<Component disabled />",
+        "<Input readOnly />",
+        "<Component active={false} />",
+        "<Component active={isActive} />",
+        r#"<Component name="test" />"#,
+    ];
+
+    let fail = vec!["<Component disabled={true} />", "<Input readOnly={true} />"];
+
+    let fix = vec![
+        ("<Component disabled={true} />", "<Component disabled />", None),
+        ("<Input readOnly={true} />", "<Input readOnly />", None),
+    ];
+
+    Tester::new(PreferShorthandBoolean::NAME, PreferShorthandBoolean::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .change_rule_path_extension("tsx")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/oxc_filename_naming_convention.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_filename_naming_convention.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(filename-naming-convention): Filename `fileRead.ts` does not match the configured naming convention.
+   ╭─[filename_naming_convention.tsx:1:1]
+   ╰────
+  help: Rename the file so its basename matches the case style `KEBAB_CASE` for this path.
+
+  ⚠ oxc(filename-naming-convention): Filename `FileRead.ts` does not match the configured naming convention.
+   ╭─[filename_naming_convention.tsx:1:1]
+   ╰────
+  help: Rename the file so its basename matches the case style `KEBAB_CASE` for this path.
+
+  ⚠ oxc(filename-naming-convention): Filename `fileRead.test.ts` does not match the configured naming convention.
+   ╭─[filename_naming_convention.tsx:1:1]
+   ╰────
+  help: Rename the file so its basename matches the case style `KEBAB_CASE` for this path.
+
+  ⚠ oxc(filename-naming-convention): Filename `file-read.test.ts` does not match the configured naming convention.
+   ╭─[filename_naming_convention.tsx:1:1]
+   ╰────
+  help: Rename the file so its basename matches the case style `KEBAB_CASE` for this path.

--- a/crates/oxc_linter/src/snapshots/oxc_folder_naming_convention.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_folder_naming_convention.snap
@@ -1,0 +1,19 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(folder-naming-convention): Folder `core_utils` does not match the configured naming convention.
+   ╭─[folder_naming_convention.tsx:1:1]
+   ╰────
+  help: Rename the folder so matched path segments follow the case style `KEBAB_CASE`.
+
+  ⚠ oxc(folder-naming-convention): Folder `FeatureFlags` does not match the configured naming convention.
+   ╭─[folder_naming_convention.tsx:1:1]
+   ╰────
+  help: Rename the folder so matched path segments follow the case style `KEBAB_CASE`.
+
+  ⚠ oxc(folder-naming-convention): Folder `BadFolder` does not match the configured naming convention.
+   ╭─[folder_naming_convention.tsx:1:1]
+   ╰────
+  help: Rename the folder so matched path segments follow the case style `KEBAB_CASE`.

--- a/crates/oxc_linter/src/snapshots/oxc_no_block_in_inline.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_block_in_inline.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-block-in-inline): Block-level element `<div>` must not be nested inside inline element `<span>`.
+   ╭─[no_block_in_inline.tsx:1:18]
+ 1 │ const el = <span><div /></span>;
+   ·                  ───────
+   ╰────
+  help: Use a block parent instead, or replace the nested block element with inline markup.
+
+  ⚠ oxc(no-block-in-inline): Block-level element `<p>` must not be nested inside inline element `<a>`.
+   ╭─[no_block_in_inline.tsx:1:15]
+ 1 │ const el = <a><p>bad</p></a>;
+   ·               ───
+   ╰────
+  help: Use a block parent instead, or replace the nested block element with inline markup.
+
+  ⚠ oxc(no-block-in-inline): Block-level element `<section>` must not be nested inside inline element `<em>`.
+   ╭─[no_block_in_inline.tsx:1:22]
+ 1 │ const el = <span><em><section /></em></span>;
+   ·                      ───────────
+   ╰────
+  help: Use a block parent instead, or replace the nested block element with inline markup.
+
+  ⚠ oxc(no-block-in-inline): Block-level element `<custom-block>` must not be nested inside inline element `<custom-inline>`.
+   ╭─[no_block_in_inline.tsx:1:27]
+ 1 │ const el = <custom-inline><custom-block /></custom-inline>;
+   ·                           ────────────────
+   ╰────
+  help: Use a block parent instead, or replace the nested block element with inline markup.

--- a/crates/oxc_linter/src/snapshots/oxc_no_create_ref.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_create_ref.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-create-ref): React.createRef() should not be used in function components
+   ╭─[no_create_ref.tsx:1:13]
+ 1 │ const ref = React.createRef();
+   ·             ─────────────────
+   ╰────
+  help: Use useRef() hook instead of React.createRef() in function components. createRef creates a new ref object on every render.
+
+  ⚠ oxc(no-create-ref): React.createRef() should not be used in function components
+   ╭─[no_create_ref.tsx:1:13]
+ 1 │ const ref = createRef();
+   ·             ───────────
+   ╰────
+  help: Use useRef() hook instead of React.createRef() in function components. createRef creates a new ref object on every render.
+
+  ⚠ oxc(no-create-ref): React.createRef() should not be used in function components
+   ╭─[no_create_ref.tsx:1:1]
+ 1 │ createRef();
+   · ───────────
+   ╰────
+  help: Use useRef() hook instead of React.createRef() in function components. createRef creates a new ref object on every render.

--- a/crates/oxc_linter/src/snapshots/oxc_no_default_props.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_default_props.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-default-props): defaultProps is deprecated
+   ╭─[no_default_props.tsx:1:11]
+ 1 │ Component.defaultProps = { color: 'red' };
+   ·           ────────────
+   ╰────
+  help: Use JavaScript default parameters instead of defaultProps. defaultProps is deprecated since React 18.3.
+
+  ⚠ oxc(no-default-props): defaultProps is deprecated
+   ╭─[no_default_props.tsx:1:10]
+ 1 │ MyButton.defaultProps = {};
+   ·          ────────────
+   ╰────
+  help: Use JavaScript default parameters instead of defaultProps. defaultProps is deprecated since React 18.3.

--- a/crates/oxc_linter/src/snapshots/oxc_no_inline_type_annotations.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_inline_type_annotations.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-inline-type-annotations): Use a named type or interface instead of an inline object type.
+   ╭─[no_inline_type_annotations.ts:1:14]
+ 1 │ const props: { title: string } = { title: 'hello' };
+   ·              ─────────────────
+   ╰────
+
+  ⚠ oxc(no-inline-type-annotations): Use a named type or interface instead of an inline object type.
+   ╭─[no_inline_type_annotations.ts:1:24]
+ 1 │ function render(props: { title: string; count: number }) { return props.title; }
+   ·                        ────────────────────────────────
+   ╰────
+
+  ⚠ oxc(no-inline-type-annotations): Use a named type or interface instead of an inline object type.
+   ╭─[no_inline_type_annotations.ts:1:20]
+ 1 │ const render = (): { title: string } => ({ title: 'hello' });
+   ·                    ─────────────────
+   ╰────
+
+  ⚠ oxc(no-inline-type-annotations): Use a named type or interface instead of an inline object type.
+   ╭─[no_inline_type_annotations.ts:1:29]
+ 1 │ type Loader = () => Promise<{ title: string }>;
+   ·                             ─────────────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/oxc_no_leaked_conditional_rendering.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_leaked_conditional_rendering.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-leaked-conditional-rendering): Potential leaked value in JSX conditional rendering
+   ╭─[no_leaked_conditional_rendering.tsx:1:7]
+ 1 │ <div>{count && <Component />}</div>
+   ·       ─────
+   ╰────
+  help: When using `&&` for conditional rendering, falsy values like `0` or `NaN` will be rendered as text. Use a ternary expression or `Boolean()` to ensure only boolean values are checked.
+
+  ⚠ oxc(no-leaked-conditional-rendering): Potential leaked value in JSX conditional rendering
+   ╭─[no_leaked_conditional_rendering.tsx:1:7]
+ 1 │ <div>{data.length && <List />}</div>
+   ·       ───────────
+   ╰────
+  help: When using `&&` for conditional rendering, falsy values like `0` or `NaN` will be rendered as text. Use a ternary expression or `Boolean()` to ensure only boolean values are checked.

--- a/crates/oxc_linter/src/snapshots/oxc_no_literal_string.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_literal_string.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-literal-string): Literal JSX text should be translated: `Hello world`.
+   ╭─[no_literal_string.tsx:1:17]
+ 1 │ const el = <div>Hello world</div>;
+   ·                 ───────────
+   ╰────
+  help: Wrap user-facing text in your translation layer instead of rendering it inline.
+
+  ⚠ oxc(no-literal-string): Literal JSX text should be translated: `Save`.
+   ╭─[no_literal_string.tsx:1:20]
+ 1 │ const el = <><span>Save</span></>;
+   ·                    ────
+   ╰────
+  help: Wrap user-facing text in your translation layer instead of rendering it inline.
+
+  ⚠ oxc(no-literal-string): Literal JSX text should be translated: `Submit`.
+   ╭─[no_literal_string.tsx:1:20]
+ 1 │ const el = <Button>Submit</Button>;
+   ·                    ──────
+   ╰────
+  help: Wrap user-facing text in your translation layer instead of rendering it inline.

--- a/crates/oxc_linter/src/snapshots/oxc_no_nested_components.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_nested_components.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-nested-components): Component definition inside another component
+   ╭─[no_nested_components.tsx:1:39]
+ 1 │ function ParentComponent() { function ChildComponent() { return <div />; } return <ChildComponent />; }
+   ·                                       ──────────────
+   ╰────
+  help: Move the component definition outside of the parent component. Nested component definitions cause the component to be recreated on every render, destroying its state.
+
+  ⚠ oxc(no-nested-components): Component definition inside another component
+   ╭─[no_nested_components.tsx:1:36]
+ 1 │ function ParentComponent() { const ChildComponent = () => <div />; return <ChildComponent />; }
+   ·                                    ──────────────
+   ╰────
+  help: Move the component definition outside of the parent component. Nested component definitions cause the component to be recreated on every render, destroying its state.

--- a/crates/oxc_linter/src/snapshots/oxc_no_prop_types.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_prop_types.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-prop-types): PropTypes is deprecated
+   ╭─[no_prop_types.tsx:1:11]
+ 1 │ Component.propTypes = { name: PropTypes.string };
+   ·           ─────────
+   ╰────
+  help: Use TypeScript for type checking instead of PropTypes. PropTypes is deprecated since React 15.5.
+
+  ⚠ oxc(no-prop-types): PropTypes is deprecated
+   ╭─[no_prop_types.tsx:1:23]
+ 1 │ import PropTypes from 'prop-types';
+   ·                       ────────────
+   ╰────
+  help: Use TypeScript for type checking instead of PropTypes. PropTypes is deprecated since React 15.5.

--- a/crates/oxc_linter/src/snapshots/oxc_no_secrets.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_secrets.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-secrets): Found a string matching secret pattern `AWS API Key`: `AKIA1234567890ABCDEF`.
+   ╭─[no_secrets.ts:1:16]
+ 1 │ const awsKey = 'AKIA1234567890ABCDEF';
+   ·                ──────────────────────
+   ╰────
+  help: Remove the embedded secret from source code or replace it with a redacted placeholder.
+
+  ⚠ oxc(no-secrets): Found a high-entropy string `ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva` (6.02).
+   ╭─[no_secrets.ts:1:15]
+ 1 │ const token = 'ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva';
+   ·               ───────────────────────────────────────────────────────────────────
+   ╰────
+  help: Move the secret out of source code or replace it with a safe test value.
+
+  ⚠ oxc(no-secrets): Found a string matching secret pattern `Slack Webhook`: `https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx`.
+   ╭─[no_secrets.ts:1:14]
+ 1 │ const key = `https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnopqrstuvwx`;
+   ·              ─────────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Remove the embedded secret from source code or replace it with a redacted placeholder.
+
+  ⚠ oxc(no-secrets): Found a string matching secret pattern `RSA private key`: `-----BEGIN RSA PRIVATE KEY-----`.
+   ╭─[no_secrets.ts:1:3]
+ 1 │ // -----BEGIN RSA PRIVATE KEY-----
+   ·   ────────────────────────────────
+   ╰────
+  help: Remove the embedded secret from source code or replace it with a redacted placeholder.

--- a/crates/oxc_linter/src/snapshots/oxc_no_unknown.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_unknown.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-unknown): Dependencies to unknown elements are not allowed.
+   ╭─[boundaries-app/src/routes/public/no-unknown.ts:2:37]
+ 1 │ 
+ 2 │             import { scratch } from "../../experimental/scratch.ts";
+   ·                                     ───────────────────────────────
+ 3 │             const required = require("../../experimental/scratch");
+   ╰────
+  help: Classify `../../experimental/scratch.ts` with `boundaries/elements` or move the dependency into a known architectural area.
+
+  ⚠ oxc(no-unknown): Dependencies to unknown elements are not allowed.
+   ╭─[boundaries-app/src/routes/public/no-unknown.ts:3:38]
+ 2 │             import { scratch } from "../../experimental/scratch.ts";
+ 3 │             const required = require("../../experimental/scratch");
+   ·                                      ────────────────────────────
+ 4 │             const lazy = import("../../experimental/scratch");
+   ╰────
+  help: Classify `../../experimental/scratch` with `boundaries/elements` or move the dependency into a known architectural area.
+
+  ⚠ oxc(no-unknown): Dependencies to unknown elements are not allowed.
+   ╭─[boundaries-app/src/routes/public/no-unknown.ts:4:33]
+ 3 │             const required = require("../../experimental/scratch");
+ 4 │             const lazy = import("../../experimental/scratch");
+   ·                                 ────────────────────────────
+ 5 │             export const unknown = [scratch, required, lazy];
+   ╰────
+  help: Classify `../../experimental/scratch` with `boundaries/elements` or move the dependency into a known architectural area.

--- a/crates/oxc_linter/src/snapshots/oxc_no_unknown_files.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_unknown_files.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-unknown-files): File does not match any configured element pattern.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/public/known.ts:1:1]
+ 1 │ export const value = 1;
+   · ▲
+   ╰────
+  help: Move the file into a configured architectural element or extend `boundaries/elements`.
+
+  ⚠ oxc(no-unknown-files): File does not match any configured element pattern.
+   ╭─[/Users/alexeylyakhov/projects/oxc/crates/oxc_linter/fixtures/import/boundaries-app/src/routes/public/known.ts:1:1]
+ 1 │ export const value = 1;
+   · ▲
+   ╰────
+  help: Move the file into a configured architectural element or extend `boundaries/elements`.

--- a/crates/oxc_linter/src/snapshots/oxc_no_unstable_default_props.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_unstable_default_props.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(no-unstable-default-props): Unstable value used as default prop
+   ╭─[no_unstable_default_props.tsx:1:30]
+ 1 │ function Component({ items = [] }) { return <div />; }
+   ·                              ──
+   ╰────
+  help: Object and array literals as default parameter values create a new reference on every render. Extract them to a module-level constant.
+
+  ⚠ oxc(no-unstable-default-props): Unstable value used as default prop
+   ╭─[no_unstable_default_props.tsx:1:31]
+ 1 │ function Component({ config = {} }) { return <div />; }
+   ·                               ──
+   ╰────
+  help: Object and array literals as default parameter values create a new reference on every render. Extract them to a module-level constant.
+
+  ⚠ oxc(no-unstable-default-props): Unstable value used as default prop
+   ╭─[no_unstable_default_props.tsx:1:32]
+ 1 │ function Component({ onClick = () => {} }) { return <div />; }
+   ·                                ────────
+   ╰────
+  help: Object and array literals as default parameter values create a new reference on every render. Extract them to a module-level constant.

--- a/crates/oxc_linter/src/snapshots/oxc_prefer_shorthand_boolean.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_prefer_shorthand_boolean.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ oxc(prefer-shorthand-boolean): Use shorthand boolean attribute: `disabled` instead of `disabled={true}`
+   ╭─[prefer_shorthand_boolean.tsx:1:12]
+ 1 │ <Component disabled={true} />
+   ·            ───────────────
+   ╰────
+  help: Boolean JSX attributes can use the shorthand form. `<Comp disabled />` is equivalent to `<Comp disabled={true} />`.
+
+  ⚠ oxc(prefer-shorthand-boolean): Use shorthand boolean attribute: `readOnly` instead of `readOnly={true}`
+   ╭─[prefer_shorthand_boolean.tsx:1:8]
+ 1 │ <Input readOnly={true} />
+   ·        ───────────────
+   ╰────
+  help: Boolean JSX attributes can use the shorthand form. `<Comp disabled />` is equivalent to `<Comp disabled={true} />`.


### PR DESCRIPTION
## Summary

Add 15 new rules to the oxc plugin:

**React rules (8):**
- `no-block-in-inline`, `no-create-ref`, `no-default-props`
- `no-leaked-conditional-rendering`, `no-nested-components`
- `no-prop-types`, `no-unstable-default-props`, `prefer-shorthand-boolean`

**Naming rules (4):**
- `filename-naming-convention`, `folder-naming-convention`
- `no-unknown`, `no-unknown-files`

**Miscellaneous (3):**
- `no-inline-type-annotations`, `no-literal-string`, `no-secrets`

## Test plan

- [x] `cargo test -p oxc_linter` — all 15 rule tests pass
- [x] `cargo lintgen` — generated files up to date
- [x] `just fmt` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)