### PR TITLE
fix(formatter): sequence expression in arrow function body collapses onto one line

### DIFF
--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -153,12 +153,10 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                             f,
                             [group(&format_args!(
                                 formatted_signature,
-                                group(&format_args!(
-                                    space(),
-                                    token("("),
-                                    soft_block_indent(&format_body),
-                                    token(")")
-                                ))
+                                space(),
+                                token("("),
+                                format_body,
+                                token(")")
                             ))]
                         );
                     };
@@ -625,14 +623,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                 {
                     write!(f, format_sequence);
                 } else {
-                    write!(
-                        f,
-                        [group(&format_args!(
-                            token("("),
-                            soft_block_indent(&format_tail_body),
-                            token(")")
-                        ))]
-                    );
+                    write!(f, [token("("), format_tail_body, token(")")]);
                 }
             } else {
                 let should_add_parens = tail.expression && should_add_parens(tail_body);

--- a/crates/oxc_formatter/src/print/sequence_expression.rs
+++ b/crates/oxc_formatter/src/print/sequence_expression.rs
@@ -10,6 +10,11 @@ use super::FormatWrite;
 
 impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
+        let is_arrow_body = matches!(
+            self.parent(),
+            AstNodes::ExpressionStatement(statement) if statement.is_arrow_function_body()
+        );
+
         let format_inner = format_with(|f| {
             let mut expressions = self.expressions().iter();
             let separator = format_with(|f| {
@@ -39,6 +44,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
             }
         });
 
-        write!(f, group(&format_inner));
+        // For arrow bodies, own the `soft_block_indent` so the break decision is made
+        // at the opening `(`, not at the already-indented column inside it. The arrow
+        // body handler skips its own indent to defer to this group.
+        if is_arrow_body {
+            write!(f, group(&soft_block_indent(&format_inner)));
+        } else {
+            write!(f, group(&format_inner));
+        }
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/issue-21171.js
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/issue-21171.js
@@ -1,0 +1,47 @@
+// Issue #21171 - sequence expression in arrow function body
+// Short sequence: should collapse to one line
+const result = items.reduce(
+  (acc, item) => (
+    (acc[item.id] = item.value),
+    acc
+  ),
+  {}
+);
+
+// Long sequence: should break to separate lines
+const result2 = items.reduce(
+  (acc, item) => (
+    isLong(item) ? (acc[item.id] = { key: item.id, value: item.value }) : undefined,
+    acc
+  ),
+  {}
+);
+
+// Three-item short sequence: should collapse
+const result3 = (a, b) => (a++, b++, a + b);
+
+// Three-item long sequence: should break
+const result4 = (a, b) => (
+  someVeryLongFunctionName(a),
+  anotherVeryLongFunctionName(b),
+  yetAnotherVeryLongFunctionName(a, b)
+);
+
+// Arrow chain returning a sequence (long): should break inside the tail
+const chained = (a) => (b) => (c) => (
+  isLong(a) ? (state[a] = { x: a, y: b, z: c }) : undefined,
+  state
+);
+
+// Arrow chain returning a short sequence: should collapse
+const chained2 = (a) => (b) => ((state[a] = b), state);
+
+// Sequence as a top-level expression statement (not an arrow body):
+// behavior should be unchanged by this fix.
+a, b, c;
+firstLongIdentifier, secondLongIdentifier, thirdLongIdentifier, fourthLongIdentifier;
+
+// Sequence inside a for-loop update clause: behavior should be unchanged.
+for (let i = 0, j = 10; i < j; i++, j--) {
+  doSomething(i, j);
+}

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/issue-21171.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/issue-21171.js.snap
@@ -1,0 +1,152 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #21171 - sequence expression in arrow function body
+// Short sequence: should collapse to one line
+const result = items.reduce(
+  (acc, item) => (
+    (acc[item.id] = item.value),
+    acc
+  ),
+  {}
+);
+
+// Long sequence: should break to separate lines
+const result2 = items.reduce(
+  (acc, item) => (
+    isLong(item) ? (acc[item.id] = { key: item.id, value: item.value }) : undefined,
+    acc
+  ),
+  {}
+);
+
+// Three-item short sequence: should collapse
+const result3 = (a, b) => (a++, b++, a + b);
+
+// Three-item long sequence: should break
+const result4 = (a, b) => (
+  someVeryLongFunctionName(a),
+  anotherVeryLongFunctionName(b),
+  yetAnotherVeryLongFunctionName(a, b)
+);
+
+// Arrow chain returning a sequence (long): should break inside the tail
+const chained = (a) => (b) => (c) => (
+  isLong(a) ? (state[a] = { x: a, y: b, z: c }) : undefined,
+  state
+);
+
+// Arrow chain returning a short sequence: should collapse
+const chained2 = (a) => (b) => ((state[a] = b), state);
+
+// Sequence as a top-level expression statement (not an arrow body):
+// behavior should be unchanged by this fix.
+a, b, c;
+firstLongIdentifier, secondLongIdentifier, thirdLongIdentifier, fourthLongIdentifier;
+
+// Sequence inside a for-loop update clause: behavior should be unchanged.
+for (let i = 0, j = 10; i < j; i++, j--) {
+  doSomething(i, j);
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #21171 - sequence expression in arrow function body
+// Short sequence: should collapse to one line
+const result = items.reduce(
+  (acc, item) => ((acc[item.id] = item.value), acc),
+  {},
+);
+
+// Long sequence: should break to separate lines
+const result2 = items.reduce(
+  (acc, item) => (
+    isLong(item)
+      ? (acc[item.id] = { key: item.id, value: item.value })
+      : undefined,
+    acc
+  ),
+  {},
+);
+
+// Three-item short sequence: should collapse
+const result3 = (a, b) => (a++, b++, a + b);
+
+// Three-item long sequence: should break
+const result4 = (a, b) => (
+  someVeryLongFunctionName(a),
+  anotherVeryLongFunctionName(b),
+  yetAnotherVeryLongFunctionName(a, b)
+);
+
+// Arrow chain returning a sequence (long): should break inside the tail
+const chained = (a) => (b) => (c) => (
+  isLong(a) ? (state[a] = { x: a, y: b, z: c }) : undefined,
+  state
+);
+
+// Arrow chain returning a short sequence: should collapse
+const chained2 = (a) => (b) => ((state[a] = b), state);
+
+// Sequence as a top-level expression statement (not an arrow body):
+// behavior should be unchanged by this fix.
+(a, b, c);
+(firstLongIdentifier,
+  secondLongIdentifier,
+  thirdLongIdentifier,
+  fourthLongIdentifier);
+
+// Sequence inside a for-loop update clause: behavior should be unchanged.
+for (let i = 0, j = 10; i < j; i++, j--) {
+  doSomething(i, j);
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #21171 - sequence expression in arrow function body
+// Short sequence: should collapse to one line
+const result = items.reduce((acc, item) => ((acc[item.id] = item.value), acc), {});
+
+// Long sequence: should break to separate lines
+const result2 = items.reduce(
+  (acc, item) => (
+    isLong(item) ? (acc[item.id] = { key: item.id, value: item.value }) : undefined,
+    acc
+  ),
+  {},
+);
+
+// Three-item short sequence: should collapse
+const result3 = (a, b) => (a++, b++, a + b);
+
+// Three-item long sequence: should break
+const result4 = (a, b) => (
+  someVeryLongFunctionName(a),
+  anotherVeryLongFunctionName(b),
+  yetAnotherVeryLongFunctionName(a, b)
+);
+
+// Arrow chain returning a sequence (long): should break inside the tail
+const chained = (a) => (b) => (c) => (
+  isLong(a) ? (state[a] = { x: a, y: b, z: c }) : undefined,
+  state
+);
+
+// Arrow chain returning a short sequence: should collapse
+const chained2 = (a) => (b) => ((state[a] = b), state);
+
+// Sequence as a top-level expression statement (not an arrow body):
+// behavior should be unchanged by this fix.
+(a, b, c);
+(firstLongIdentifier, secondLongIdentifier, thirdLongIdentifier, fourthLongIdentifier);
+
+// Sequence inside a for-loop update clause: behavior should be unchanged.
+for (let i = 0, j = 10; i < j; i++, j--) {
+  doSomething(i, j);
+}
+
+===================== End =====================


### PR DESCRIPTION
## Summary

Fixes #21171

When a sequence expression (comma operator) is used as the body of a parenthesized arrow function, the formatter incorrectly collapsed all items onto a single line even when the content was too wide to fit at the arrow function's column.

### Input
```js
const result = items.reduce(
  (acc, item) => (
    isLong(item) ? (acc[item.id] = { key: item.id, value: item.value }) : undefined,
    acc
  ),
  {}
);
```

### Before (incorrect)
```js
const result = items.reduce(
  (acc, item) => (
    isLong(item) ? (acc[item.id] = { key: item.id, value: item.value }) : undefined, acc
  ),
  {},
);
```

### After (matches Prettier)
```js
const result = items.reduce(
  (acc, item) => (
    isLong(item)
      ? (acc[item.id] = { key: item.id, value: item.value })
      : undefined,
    acc
  ),
  {},
);
```

Short sequences that fit on one line are unaffected:

```js
// (acc[item.id] = item.value), acc — fits at the arrow column → stays on one line
const result = items.reduce(
  (acc, item) => ((acc[item.id] = item.value), acc),
  {},
);
```

## Root cause

The formatter wrapped sequence expression items in their own `group` and the arrow body handler wrapped that group in `soft_block_indent`. When the arrow body's `(...)` group broke, `soft_block_indent` indented the sequence group to column 4 (inside the parens). At that indented position, the items fit within the print width — so the sequence group never broke and items stayed on one line.

Prettier avoids this by placing the `(` and `)` *outside* the sequence group, so the group measures fitness starting at the arrow-function column (before `(`). That higher column makes long sequences exceed the print width and break correctly.

## Fix

Two coordinated changes:

1. **`sequence_expression.rs`** — when the parent is an arrow function body, wrap items in `soft_block_indent` *inside* the group. This gives the group the same break/indent semantics as Prettier's `group(ifBreak([indent([softline, parts]), softline], parts))`.

2. **`arrow_function_expression.rs`** — remove the outer `soft_block_indent` from the sequence body handler (both `Single` and `Chain` layouts). The sequence group's own `soft_block_indent` is now the sole source of indentation, and the group's break decision is made at the column of `(` — the correct reference point.

Prettier conformance: **no regressions** (745/753 JS, 590/601 TS — unchanged).

## AI Disclosure

This PR was co-authored with Claude Code (AI assistant), as noted in the commit. The fix was reviewed, tested against the full Prettier conformance suite, and verified to produce no regressions.