### PR TITLE
fix(transformer): use correct property name when converting parameter properties

### DIFF
--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{TakeIn, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_semantic::ScopeFlags;
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::BoundIdentifier;
 
@@ -381,12 +381,20 @@ impl<'a> TypeScript<'a> {
         params: &ArenaVec<'a, FormalParameter<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> impl Iterator<Item = Statement<'a>> {
+        // Save source text before the closure borrows `ctx`.
+        let source_text = ctx.state.source_text;
         params
             .iter()
             .filter(|param| param.has_modifier())
             .filter_map(|param| param.pattern.get_binding_identifier())
             .map(|id| {
-                let target = create_this_property_assignment(id.span, id.name, ctx);
+                // Use the source span to recover the original property name.
+                // `id.name` may have been renamed by the class_properties plugin's clash
+                // detection (e.g. `x` → `_x`) before this runs in `enter_method_definition`,
+                // but `id.span` always points to the original identifier in source.
+                // The property name on `this` must use the original user-written name.
+                let prop_name = Ident::from(id.span.source_text(source_text));
+                let target = create_this_property_assignment(id.span, prop_name, ctx);
                 let value = BoundIdentifier::from_binding_ident(id).create_read_expression(ctx);
                 Self::create_assignment(target, value, ctx)
             })

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-class-properties/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-class-properties/input.ts
@@ -1,0 +1,11 @@
+// When a constructor parameter property name clashes with a name used in a class
+// field initializer, the `this.X` assignment must use the original source name.
+class Foo {
+  double = (x: number) => x * 2;
+  constructor(public x: number) {}
+}
+
+class Bar {
+  fn = (foo: string) => foo.length;
+  constructor(public foo: string, private bar: number) {}
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-class-properties/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-class-properties/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-class-properties",
+    "transform-typescript"
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-class-properties/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-class-properties/output.js
@@ -1,0 +1,13 @@
+class Foo {
+  constructor(x) {
+    this.x = x;
+    babelHelpers.defineProperty(this, "double", (x) => x * 2);
+  }
+}
+class Bar {
+  constructor(foo, bar) {
+    this.foo = foo;
+    this.bar = bar;
+    babelHelpers.defineProperty(this, "fn", (foo) => foo.length);
+  }
+}


### PR DESCRIPTION
…m property name when clashing symbol is renamed