### PR TITLE
feat(linter): add 40 Biome-equivalent lint rules

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -105,6 +105,14 @@ impl RuleRunner for crate::rules::import::no_duplicates::NoDuplicates {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner
+    for crate::rules::import::no_dynamic_namespace_import_access::NoDynamicNamespaceImportAccess
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ComputedMemberExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::import::no_dynamic_require::NoDynamicRequire {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ImportExpression]));
@@ -165,6 +173,11 @@ impl RuleRunner for crate::rules::import::no_nodejs_modules::NoNodejsModules {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::import::no_private_imports::NoPrivateImports {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::import::no_relative_parent_imports::NoRelativeParentImports {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,
@@ -186,6 +199,20 @@ impl RuleRunner for crate::rules::import::no_unassigned_import::NoUnassignedImpo
         AstType::ExpressionStatement,
         AstType::ImportDeclaration,
     ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::import::no_undeclared_dependencies::NoUndeclaredDependencies {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExportAllDeclaration,
+        AstType::ExportNamedDeclaration,
+        AstType::ImportDeclaration,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::import::no_unresolved_imports::NoUnresolvedImports {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -470,6 +497,12 @@ impl RuleRunner for crate::rules::eslint::no_cond_assign::NoCondAssign {
         AstType::IfStatement,
         AstType::WhileStatement,
     ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::no_confusing_labels::NoConfusingLabels {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::LabeledStatement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -847,6 +880,12 @@ impl RuleRunner for crate::rules::eslint::no_object_constructor::NoObjectConstru
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::no_octal_escape::NoOctalEscape {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StringLiteral]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::no_param_reassign::NoParamReassign {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::FormalParameter]));
@@ -883,6 +922,11 @@ impl RuleRunner for crate::rules::eslint::no_prototype_builtins::NoPrototypeBuil
 impl RuleRunner for crate::rules::eslint::no_redeclare::NoRedeclare {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::eslint::no_redundant_use_strict::NoRedundantUseStrict {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::eslint::no_regex_spaces::NoRegexSpaces {
@@ -952,9 +996,21 @@ impl RuleRunner for crate::rules::eslint::no_shadow_restricted_names::NoShadowRe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::eslint::no_shouty_constants::NoShoutyConstants {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclarator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::no_sparse_arrays::NoSparseArrays {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ArrayExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::no_string_case_mismatch::NoStringCaseMismatch {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1145,6 +1201,12 @@ impl RuleRunner for crate::rules::eslint::no_useless_constructor::NoUselessConst
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::no_useless_continue::NoUselessContinue {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ContinueStatement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::no_useless_escape::NoUselessEscape {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::RegExpLiteral,
@@ -1202,6 +1264,12 @@ impl RuleRunner for crate::rules::eslint::object_shorthand::ObjectShorthand {
 impl RuleRunner for crate::rules::eslint::operator_assignment::OperatorAssignment {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::prefer_arrow_callback::PreferArrowCallback {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1328,6 +1396,24 @@ impl RuleRunner for crate::rules::eslint::use_isnan::UseIsnan {
         AstType::SwitchCase,
         AstType::SwitchStatement,
     ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::use_regex_literals::UseRegexLiterals {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::use_single_var_declarator::UseSingleVarDeclarator {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::use_while::UseWhile {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ForStatement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1464,6 +1550,13 @@ impl RuleRunner
 }
 
 impl RuleRunner
+    for crate::rules::typescript::explicit_member_accessibility::ExplicitMemberAccessibility
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
     for crate::rules::typescript::explicit_module_boundary_types::ExplicitModuleBoundaryTypes
 {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
@@ -1471,6 +1564,11 @@ impl RuleRunner
         AstType::ExportNamedDeclaration,
         AstType::TSExportAssignment,
     ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::typescript::naming_convention::NamingConvention {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -1539,6 +1637,23 @@ impl RuleRunner for crate::rules::typescript::no_empty_object_type::NoEmptyObjec
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::typescript::no_empty_type_parameters::NoEmptyTypeParameters {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSTypeParameterDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::typescript::no_enum::NoEnum {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSEnumDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::typescript::no_evolving_types::NoEvolvingTypes {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::typescript::no_explicit_any::NoExplicitAny {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::TSAnyKeyword]));
@@ -1569,6 +1684,11 @@ impl RuleRunner for crate::rules::typescript::no_floating_promises::NoFloatingPr
 impl RuleRunner for crate::rules::typescript::no_for_in_array::NoForInArray {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+}
+
+impl RuleRunner for crate::rules::typescript::no_implicit_any_let::NoImplicitAnyLet {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::typescript::no_implied_eval::NoImpliedEval {
@@ -1695,6 +1815,12 @@ impl RuleRunner for crate::rules::typescript::no_this_alias::NoThisAlias {
         AstType::AssignmentExpression,
         AstType::VariableDeclarator,
     ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::typescript::no_this_in_static::NoThisInStatic {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ThisExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2554,9 +2680,21 @@ impl RuleRunner for crate::rules::react::no_find_dom_node::NoFindDomNode {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::no_forward_ref::NoForwardRef {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::no_is_mounted::NoIsMounted {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::react::no_jsx_literals::NoJsxLiterals {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2574,6 +2712,12 @@ impl RuleRunner for crate::rules::react::no_namespace::NoNamespace {
 impl RuleRunner for crate::rules::react::no_react_children::NoReactChildren {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::react::no_react_specific_props::NoReactSpecificProps {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2604,6 +2748,14 @@ impl RuleRunner for crate::rules::react::no_string_refs::NoStringRefs {
         AstType::PrivateFieldExpression,
         AstType::StaticMemberExpression,
     ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::react::no_suspicious_semicolon_in_jsx::NoSuspiciousSemicolonInJsx
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2689,6 +2841,12 @@ impl RuleRunner for crate::rules::react::state_in_constructor::StateInConstructo
 impl RuleRunner for crate::rules::react::style_prop_object::StylePropObject {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::react::use_image_size::UseImageSize {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2894,6 +3052,12 @@ impl RuleRunner for crate::rules::unicorn::no_document_cookie::NoDocumentCookie 
 impl RuleRunner for crate::rules::unicorn::no_empty_file::NoEmptyFile {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
+impl RuleRunner for crate::rules::unicorn::no_flat_map_identity::NoFlatMapIdentity {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::unicorn::no_hex_escape::NoHexEscape {
@@ -3127,6 +3291,12 @@ impl RuleRunner for crate::rules::unicorn::no_useless_spread::NoUselessSpread {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_useless_string_raw::NoUselessStringRaw {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TaggedTemplateExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_useless_switch_case::NoUselessSwitchCase {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::SwitchStatement]));
@@ -3136,6 +3306,14 @@ impl RuleRunner for crate::rules::unicorn::no_useless_switch_case::NoUselessSwit
 impl RuleRunner for crate::rules::unicorn::no_useless_undefined::NoUselessUndefined {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::IdentifierReference]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::unicorn::no_useless_undefined_initialization::NoUselessUndefinedInitialization
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -3570,6 +3748,32 @@ impl RuleRunner for crate::rules::unicorn::throw_new_error::ThrowNewError {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::use_collapsed_if::UseCollapsedIf {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IfStatement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::unicorn::use_consistent_curly_braces::UseConsistentCurlyBraces {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXExpressionContainer]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::unicorn::use_simple_number_keys::UseSimpleNumberKeys {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::NumericLiteral]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::unicorn::use_simplified_logic_expression::UseSimplifiedLogicExpression
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::LogicalExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::jsx_a11y::alt_text::AltText {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
@@ -3712,6 +3916,21 @@ impl RuleRunner for crate::rules::jsx_a11y::no_distracting_elements::NoDistracti
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::jsx_a11y::no_interactive_element_to_noninteractive_role::NoInteractiveElementToNoninteractiveRole {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::jsx_a11y::no_noninteractive_element_interactions::NoNoninteractiveElementInteractions {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::jsx_a11y::no_noninteractive_element_to_interactive_role::NoNoninteractiveElementToInteractiveRole {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::jsx_a11y::no_noninteractive_tabindex::NoNoninteractiveTabindex {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
@@ -3727,6 +3946,12 @@ impl RuleRunner for crate::rules::jsx_a11y::no_redundant_roles::NoRedundantRoles
 impl RuleRunner
     for crate::rules::jsx_a11y::no_static_element_interactions::NoStaticElementInteractions
 {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::jsx_a11y::no_svg_without_title::NoSvgWithoutTitle {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
@@ -3760,6 +3985,17 @@ impl RuleRunner for crate::rules::jsx_a11y::tabindex_no_positive::TabindexNoPosi
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::jsx_a11y::use_focusable_interactive::UseFocusableInteractive {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXOpeningElement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::jsx_a11y::use_unique_element_ids::UseUniqueElementIds {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
 impl RuleRunner for crate::rules::oxc::approx_constant::ApproxConstant {
@@ -4383,6 +4619,11 @@ impl RuleRunner for crate::rules::node::handle_callback_err::HandleCallbackErr {
 impl RuleRunner for crate::rules::node::no_exports_assign::NoExportsAssign {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::node::no_global_dirname_filename::NoGlobalDirnameFilename {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -47,6 +47,7 @@ pub use crate::rules::eslint::no_case_declarations::NoCaseDeclarations as Eslint
 pub use crate::rules::eslint::no_class_assign::NoClassAssign as EslintNoClassAssign;
 pub use crate::rules::eslint::no_compare_neg_zero::NoCompareNegZero as EslintNoCompareNegZero;
 pub use crate::rules::eslint::no_cond_assign::NoCondAssign as EslintNoCondAssign;
+pub use crate::rules::eslint::no_confusing_labels::NoConfusingLabels as EslintNoConfusingLabels;
 pub use crate::rules::eslint::no_console::NoConsole as EslintNoConsole;
 pub use crate::rules::eslint::no_const_assign::NoConstAssign as EslintNoConstAssign;
 pub use crate::rules::eslint::no_constant_binary_expression::NoConstantBinaryExpression as EslintNoConstantBinaryExpression;
@@ -104,12 +105,14 @@ pub use crate::rules::eslint::no_new_wrappers::NoNewWrappers as EslintNoNewWrapp
 pub use crate::rules::eslint::no_nonoctal_decimal_escape::NoNonoctalDecimalEscape as EslintNoNonoctalDecimalEscape;
 pub use crate::rules::eslint::no_obj_calls::NoObjCalls as EslintNoObjCalls;
 pub use crate::rules::eslint::no_object_constructor::NoObjectConstructor as EslintNoObjectConstructor;
+pub use crate::rules::eslint::no_octal_escape::NoOctalEscape as EslintNoOctalEscape;
 pub use crate::rules::eslint::no_param_reassign::NoParamReassign as EslintNoParamReassign;
 pub use crate::rules::eslint::no_plusplus::NoPlusplus as EslintNoPlusplus;
 pub use crate::rules::eslint::no_promise_executor_return::NoPromiseExecutorReturn as EslintNoPromiseExecutorReturn;
 pub use crate::rules::eslint::no_proto::NoProto as EslintNoProto;
 pub use crate::rules::eslint::no_prototype_builtins::NoPrototypeBuiltins as EslintNoPrototypeBuiltins;
 pub use crate::rules::eslint::no_redeclare::NoRedeclare as EslintNoRedeclare;
+pub use crate::rules::eslint::no_redundant_use_strict::NoRedundantUseStrict as EslintNoRedundantUseStrict;
 pub use crate::rules::eslint::no_regex_spaces::NoRegexSpaces as EslintNoRegexSpaces;
 pub use crate::rules::eslint::no_restricted_globals::NoRestrictedGlobals as EslintNoRestrictedGlobals;
 pub use crate::rules::eslint::no_restricted_imports::NoRestrictedImports as EslintNoRestrictedImports;
@@ -121,7 +124,9 @@ pub use crate::rules::eslint::no_sequences::NoSequences as EslintNoSequences;
 pub use crate::rules::eslint::no_setter_return::NoSetterReturn as EslintNoSetterReturn;
 pub use crate::rules::eslint::no_shadow::NoShadow as EslintNoShadow;
 pub use crate::rules::eslint::no_shadow_restricted_names::NoShadowRestrictedNames as EslintNoShadowRestrictedNames;
+pub use crate::rules::eslint::no_shouty_constants::NoShoutyConstants as EslintNoShoutyConstants;
 pub use crate::rules::eslint::no_sparse_arrays::NoSparseArrays as EslintNoSparseArrays;
+pub use crate::rules::eslint::no_string_case_mismatch::NoStringCaseMismatch as EslintNoStringCaseMismatch;
 pub use crate::rules::eslint::no_template_curly_in_string::NoTemplateCurlyInString as EslintNoTemplateCurlyInString;
 pub use crate::rules::eslint::no_ternary::NoTernary as EslintNoTernary;
 pub use crate::rules::eslint::no_this_before_super::NoThisBeforeSuper as EslintNoThisBeforeSuper;
@@ -148,6 +153,7 @@ pub use crate::rules::eslint::no_useless_catch::NoUselessCatch as EslintNoUseles
 pub use crate::rules::eslint::no_useless_computed_key::NoUselessComputedKey as EslintNoUselessComputedKey;
 pub use crate::rules::eslint::no_useless_concat::NoUselessConcat as EslintNoUselessConcat;
 pub use crate::rules::eslint::no_useless_constructor::NoUselessConstructor as EslintNoUselessConstructor;
+pub use crate::rules::eslint::no_useless_continue::NoUselessContinue as EslintNoUselessContinue;
 pub use crate::rules::eslint::no_useless_escape::NoUselessEscape as EslintNoUselessEscape;
 pub use crate::rules::eslint::no_useless_rename::NoUselessRename as EslintNoUselessRename;
 pub use crate::rules::eslint::no_useless_return::NoUselessReturn as EslintNoUselessReturn;
@@ -157,6 +163,7 @@ pub use crate::rules::eslint::no_warning_comments::NoWarningComments as EslintNo
 pub use crate::rules::eslint::no_with::NoWith as EslintNoWith;
 pub use crate::rules::eslint::object_shorthand::ObjectShorthand as EslintObjectShorthand;
 pub use crate::rules::eslint::operator_assignment::OperatorAssignment as EslintOperatorAssignment;
+pub use crate::rules::eslint::prefer_arrow_callback::PreferArrowCallback as EslintPreferArrowCallback;
 pub use crate::rules::eslint::prefer_const::PreferConst as EslintPreferConst;
 pub use crate::rules::eslint::prefer_destructuring::PreferDestructuring as EslintPreferDestructuring;
 pub use crate::rules::eslint::prefer_exponentiation_operator::PreferExponentiationOperator as EslintPreferExponentiationOperator;
@@ -177,6 +184,9 @@ pub use crate::rules::eslint::sort_vars::SortVars as EslintSortVars;
 pub use crate::rules::eslint::symbol_description::SymbolDescription as EslintSymbolDescription;
 pub use crate::rules::eslint::unicode_bom::UnicodeBom as EslintUnicodeBom;
 pub use crate::rules::eslint::use_isnan::UseIsnan as EslintUseIsnan;
+pub use crate::rules::eslint::use_regex_literals::UseRegexLiterals as EslintUseRegexLiterals;
+pub use crate::rules::eslint::use_single_var_declarator::UseSingleVarDeclarator as EslintUseSingleVarDeclarator;
+pub use crate::rules::eslint::use_while::UseWhile as EslintUseWhile;
 pub use crate::rules::eslint::valid_typeof::ValidTypeof as EslintValidTypeof;
 pub use crate::rules::eslint::vars_on_top::VarsOnTop as EslintVarsOnTop;
 pub use crate::rules::eslint::yoda::Yoda as EslintYoda;
@@ -197,6 +207,7 @@ pub use crate::rules::import::no_commonjs::NoCommonjs as ImportNoCommonjs;
 pub use crate::rules::import::no_cycle::NoCycle as ImportNoCycle;
 pub use crate::rules::import::no_default_export::NoDefaultExport as ImportNoDefaultExport;
 pub use crate::rules::import::no_duplicates::NoDuplicates as ImportNoDuplicates;
+pub use crate::rules::import::no_dynamic_namespace_import_access::NoDynamicNamespaceImportAccess as ImportNoDynamicNamespaceImportAccess;
 pub use crate::rules::import::no_dynamic_require::NoDynamicRequire as ImportNoDynamicRequire;
 pub use crate::rules::import::no_empty_named_blocks::NoEmptyNamedBlocks as ImportNoEmptyNamedBlocks;
 pub use crate::rules::import::no_mutable_exports::NoMutableExports as ImportNoMutableExports;
@@ -206,9 +217,12 @@ pub use crate::rules::import::no_named_default::NoNamedDefault as ImportNoNamedD
 pub use crate::rules::import::no_named_export::NoNamedExport as ImportNoNamedExport;
 pub use crate::rules::import::no_namespace::NoNamespace as ImportNoNamespace;
 pub use crate::rules::import::no_nodejs_modules::NoNodejsModules as ImportNoNodejsModules;
+pub use crate::rules::import::no_private_imports::NoPrivateImports as ImportNoPrivateImports;
 pub use crate::rules::import::no_relative_parent_imports::NoRelativeParentImports as ImportNoRelativeParentImports;
 pub use crate::rules::import::no_self_import::NoSelfImport as ImportNoSelfImport;
 pub use crate::rules::import::no_unassigned_import::NoUnassignedImport as ImportNoUnassignedImport;
+pub use crate::rules::import::no_undeclared_dependencies::NoUndeclaredDependencies as ImportNoUndeclaredDependencies;
+pub use crate::rules::import::no_unresolved_imports::NoUnresolvedImports as ImportNoUnresolvedImports;
 pub use crate::rules::import::no_webpack_loader_syntax::NoWebpackLoaderSyntax as ImportNoWebpackLoaderSyntax;
 pub use crate::rules::import::prefer_default_export::PreferDefaultExport as ImportPreferDefaultExport;
 pub use crate::rules::import::unambiguous::Unambiguous as ImportUnambiguous;
@@ -308,14 +322,20 @@ pub use crate::rules::jsx_a11y::no_access_key::NoAccessKey as JsxA11YNoAccessKey
 pub use crate::rules::jsx_a11y::no_aria_hidden_on_focusable::NoAriaHiddenOnFocusable as JsxA11YNoAriaHiddenOnFocusable;
 pub use crate::rules::jsx_a11y::no_autofocus::NoAutofocus as JsxA11YNoAutofocus;
 pub use crate::rules::jsx_a11y::no_distracting_elements::NoDistractingElements as JsxA11YNoDistractingElements;
+pub use crate::rules::jsx_a11y::no_interactive_element_to_noninteractive_role::NoInteractiveElementToNoninteractiveRole as JsxA11YNoInteractiveElementToNoninteractiveRole;
+pub use crate::rules::jsx_a11y::no_noninteractive_element_interactions::NoNoninteractiveElementInteractions as JsxA11YNoNoninteractiveElementInteractions;
+pub use crate::rules::jsx_a11y::no_noninteractive_element_to_interactive_role::NoNoninteractiveElementToInteractiveRole as JsxA11YNoNoninteractiveElementToInteractiveRole;
 pub use crate::rules::jsx_a11y::no_noninteractive_tabindex::NoNoninteractiveTabindex as JsxA11YNoNoninteractiveTabindex;
 pub use crate::rules::jsx_a11y::no_redundant_roles::NoRedundantRoles as JsxA11YNoRedundantRoles;
 pub use crate::rules::jsx_a11y::no_static_element_interactions::NoStaticElementInteractions as JsxA11YNoStaticElementInteractions;
+pub use crate::rules::jsx_a11y::no_svg_without_title::NoSvgWithoutTitle as JsxA11YNoSvgWithoutTitle;
 pub use crate::rules::jsx_a11y::prefer_tag_over_role::PreferTagOverRole as JsxA11YPreferTagOverRole;
 pub use crate::rules::jsx_a11y::role_has_required_aria_props::RoleHasRequiredAriaProps as JsxA11YRoleHasRequiredAriaProps;
 pub use crate::rules::jsx_a11y::role_supports_aria_props::RoleSupportsAriaProps as JsxA11YRoleSupportsAriaProps;
 pub use crate::rules::jsx_a11y::scope::Scope as JsxA11YScope;
 pub use crate::rules::jsx_a11y::tabindex_no_positive::TabindexNoPositive as JsxA11YTabindexNoPositive;
+pub use crate::rules::jsx_a11y::use_focusable_interactive::UseFocusableInteractive as JsxA11YUseFocusableInteractive;
+pub use crate::rules::jsx_a11y::use_unique_element_ids::UseUniqueElementIds as JsxA11YUseUniqueElementIds;
 pub use crate::rules::nextjs::google_font_display::GoogleFontDisplay as NextjsGoogleFontDisplay;
 pub use crate::rules::nextjs::google_font_preconnect::GoogleFontPreconnect as NextjsGoogleFontPreconnect;
 pub use crate::rules::nextjs::inline_script_id::InlineScriptId as NextjsInlineScriptId;
@@ -340,6 +360,7 @@ pub use crate::rules::nextjs::no_unwanted_polyfillio::NoUnwantedPolyfillio as Ne
 pub use crate::rules::node::global_require::GlobalRequire as NodeGlobalRequire;
 pub use crate::rules::node::handle_callback_err::HandleCallbackErr as NodeHandleCallbackErr;
 pub use crate::rules::node::no_exports_assign::NoExportsAssign as NodeNoExportsAssign;
+pub use crate::rules::node::no_global_dirname_filename::NoGlobalDirnameFilename as NodeNoGlobalDirnameFilename;
 pub use crate::rules::node::no_new_require::NoNewRequire as NodeNoNewRequire;
 pub use crate::rules::node::no_path_concat::NoPathConcat as NodeNoPathConcat;
 pub use crate::rules::node::no_process_env::NoProcessEnv as NodeNoProcessEnv;
@@ -418,14 +439,18 @@ pub use crate::rules::react::no_danger_with_children::NoDangerWithChildren as Re
 pub use crate::rules::react::no_did_mount_set_state::NoDidMountSetState as ReactNoDidMountSetState;
 pub use crate::rules::react::no_direct_mutation_state::NoDirectMutationState as ReactNoDirectMutationState;
 pub use crate::rules::react::no_find_dom_node::NoFindDomNode as ReactNoFindDomNode;
+pub use crate::rules::react::no_forward_ref::NoForwardRef as ReactNoForwardRef;
 pub use crate::rules::react::no_is_mounted::NoIsMounted as ReactNoIsMounted;
+pub use crate::rules::react::no_jsx_literals::NoJsxLiterals as ReactNoJsxLiterals;
 pub use crate::rules::react::no_multi_comp::NoMultiComp as ReactNoMultiComp;
 pub use crate::rules::react::no_namespace::NoNamespace as ReactNoNamespace;
 pub use crate::rules::react::no_react_children::NoReactChildren as ReactNoReactChildren;
+pub use crate::rules::react::no_react_specific_props::NoReactSpecificProps as ReactNoReactSpecificProps;
 pub use crate::rules::react::no_redundant_should_component_update::NoRedundantShouldComponentUpdate as ReactNoRedundantShouldComponentUpdate;
 pub use crate::rules::react::no_render_return_value::NoRenderReturnValue as ReactNoRenderReturnValue;
 pub use crate::rules::react::no_set_state::NoSetState as ReactNoSetState;
 pub use crate::rules::react::no_string_refs::NoStringRefs as ReactNoStringRefs;
+pub use crate::rules::react::no_suspicious_semicolon_in_jsx::NoSuspiciousSemicolonInJsx as ReactNoSuspiciousSemicolonInJsx;
 pub use crate::rules::react::no_this_in_sfc::NoThisInSfc as ReactNoThisInSfc;
 pub use crate::rules::react::no_unescaped_entities::NoUnescapedEntities as ReactNoUnescapedEntities;
 pub use crate::rules::react::no_unknown_property::NoUnknownProperty as ReactNoUnknownProperty;
@@ -440,6 +465,7 @@ pub use crate::rules::react::rules_of_hooks::RulesOfHooks as ReactRulesOfHooks;
 pub use crate::rules::react::self_closing_comp::SelfClosingComp as ReactSelfClosingComp;
 pub use crate::rules::react::state_in_constructor::StateInConstructor as ReactStateInConstructor;
 pub use crate::rules::react::style_prop_object::StylePropObject as ReactStylePropObject;
+pub use crate::rules::react::use_image_size::UseImageSize as ReactUseImageSize;
 pub use crate::rules::react::void_dom_elements_no_children::VoidDomElementsNoChildren as ReactVoidDomElementsNoChildren;
 pub use crate::rules::react_perf::jsx_no_jsx_as_prop::JsxNoJsxAsProp as ReactPerfJsxNoJsxAsProp;
 pub use crate::rules::react_perf::jsx_no_new_array_as_prop::JsxNoNewArrayAsProp as ReactPerfJsxNoNewArrayAsProp;
@@ -461,7 +487,9 @@ pub use crate::rules::typescript::consistent_type_exports::ConsistentTypeExports
 pub use crate::rules::typescript::consistent_type_imports::ConsistentTypeImports as TypescriptConsistentTypeImports;
 pub use crate::rules::typescript::dot_notation::DotNotation as TypescriptDotNotation;
 pub use crate::rules::typescript::explicit_function_return_type::ExplicitFunctionReturnType as TypescriptExplicitFunctionReturnType;
+pub use crate::rules::typescript::explicit_member_accessibility::ExplicitMemberAccessibility as TypescriptExplicitMemberAccessibility;
 pub use crate::rules::typescript::explicit_module_boundary_types::ExplicitModuleBoundaryTypes as TypescriptExplicitModuleBoundaryTypes;
+pub use crate::rules::typescript::naming_convention::NamingConvention as TypescriptNamingConvention;
 pub use crate::rules::typescript::no_array_delete::NoArrayDelete as TypescriptNoArrayDelete;
 pub use crate::rules::typescript::no_base_to_string::NoBaseToString as TypescriptNoBaseToString;
 pub use crate::rules::typescript::no_confusing_non_null_assertion::NoConfusingNonNullAssertion as TypescriptNoConfusingNonNullAssertion;
@@ -472,11 +500,15 @@ pub use crate::rules::typescript::no_duplicate_type_constituents::NoDuplicateTyp
 pub use crate::rules::typescript::no_dynamic_delete::NoDynamicDelete as TypescriptNoDynamicDelete;
 pub use crate::rules::typescript::no_empty_interface::NoEmptyInterface as TypescriptNoEmptyInterface;
 pub use crate::rules::typescript::no_empty_object_type::NoEmptyObjectType as TypescriptNoEmptyObjectType;
+pub use crate::rules::typescript::no_empty_type_parameters::NoEmptyTypeParameters as TypescriptNoEmptyTypeParameters;
+pub use crate::rules::typescript::no_enum::NoEnum as TypescriptNoEnum;
+pub use crate::rules::typescript::no_evolving_types::NoEvolvingTypes as TypescriptNoEvolvingTypes;
 pub use crate::rules::typescript::no_explicit_any::NoExplicitAny as TypescriptNoExplicitAny;
 pub use crate::rules::typescript::no_extra_non_null_assertion::NoExtraNonNullAssertion as TypescriptNoExtraNonNullAssertion;
 pub use crate::rules::typescript::no_extraneous_class::NoExtraneousClass as TypescriptNoExtraneousClass;
 pub use crate::rules::typescript::no_floating_promises::NoFloatingPromises as TypescriptNoFloatingPromises;
 pub use crate::rules::typescript::no_for_in_array::NoForInArray as TypescriptNoForInArray;
+pub use crate::rules::typescript::no_implicit_any_let::NoImplicitAnyLet as TypescriptNoImplicitAnyLet;
 pub use crate::rules::typescript::no_implied_eval::NoImpliedEval as TypescriptNoImpliedEval;
 pub use crate::rules::typescript::no_import_type_side_effects::NoImportTypeSideEffects as TypescriptNoImportTypeSideEffects;
 pub use crate::rules::typescript::no_inferrable_types::NoInferrableTypes as TypescriptNoInferrableTypes;
@@ -494,6 +526,7 @@ pub use crate::rules::typescript::no_redundant_type_constituents::NoRedundantTyp
 pub use crate::rules::typescript::no_require_imports::NoRequireImports as TypescriptNoRequireImports;
 pub use crate::rules::typescript::no_restricted_types::NoRestrictedTypes as TypescriptNoRestrictedTypes;
 pub use crate::rules::typescript::no_this_alias::NoThisAlias as TypescriptNoThisAlias;
+pub use crate::rules::typescript::no_this_in_static::NoThisInStatic as TypescriptNoThisInStatic;
 pub use crate::rules::typescript::no_unnecessary_boolean_literal_compare::NoUnnecessaryBooleanLiteralCompare as TypescriptNoUnnecessaryBooleanLiteralCompare;
 pub use crate::rules::typescript::no_unnecessary_condition::NoUnnecessaryCondition as TypescriptNoUnnecessaryCondition;
 pub use crate::rules::typescript::no_unnecessary_parameter_property_assignment::NoUnnecessaryParameterPropertyAssignment as TypescriptNoUnnecessaryParameterPropertyAssignment;
@@ -580,6 +613,7 @@ pub use crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMeth
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
+pub use crate::rules::unicorn::no_flat_map_identity::NoFlatMapIdentity as UnicornNoFlatMapIdentity;
 pub use crate::rules::unicorn::no_hex_escape::NoHexEscape as UnicornNoHexEscape;
 pub use crate::rules::unicorn::no_immediate_mutation::NoImmediateMutation as UnicornNoImmediateMutation;
 pub use crate::rules::unicorn::no_instanceof_array::NoInstanceofArray as UnicornNoInstanceofArray;
@@ -613,8 +647,10 @@ pub use crate::rules::unicorn::no_useless_fallback_in_spread::NoUselessFallbackI
 pub use crate::rules::unicorn::no_useless_length_check::NoUselessLengthCheck as UnicornNoUselessLengthCheck;
 pub use crate::rules::unicorn::no_useless_promise_resolve_reject::NoUselessPromiseResolveReject as UnicornNoUselessPromiseResolveReject;
 pub use crate::rules::unicorn::no_useless_spread::NoUselessSpread as UnicornNoUselessSpread;
+pub use crate::rules::unicorn::no_useless_string_raw::NoUselessStringRaw as UnicornNoUselessStringRaw;
 pub use crate::rules::unicorn::no_useless_switch_case::NoUselessSwitchCase as UnicornNoUselessSwitchCase;
 pub use crate::rules::unicorn::no_useless_undefined::NoUselessUndefined as UnicornNoUselessUndefined;
+pub use crate::rules::unicorn::no_useless_undefined_initialization::NoUselessUndefinedInitialization as UnicornNoUselessUndefinedInitialization;
 pub use crate::rules::unicorn::no_zero_fractions::NoZeroFractions as UnicornNoZeroFractions;
 pub use crate::rules::unicorn::number_literal_case::NumberLiteralCase as UnicornNumberLiteralCase;
 pub use crate::rules::unicorn::numeric_separators_style::NumericSeparatorsStyle as UnicornNumericSeparatorsStyle;
@@ -679,6 +715,10 @@ pub use crate::rules::unicorn::switch_case_braces::SwitchCaseBraces as UnicornSw
 pub use crate::rules::unicorn::switch_case_break_position::SwitchCaseBreakPosition as UnicornSwitchCaseBreakPosition;
 pub use crate::rules::unicorn::text_encoding_identifier_case::TextEncodingIdentifierCase as UnicornTextEncodingIdentifierCase;
 pub use crate::rules::unicorn::throw_new_error::ThrowNewError as UnicornThrowNewError;
+pub use crate::rules::unicorn::use_collapsed_if::UseCollapsedIf as UnicornUseCollapsedIf;
+pub use crate::rules::unicorn::use_consistent_curly_braces::UseConsistentCurlyBraces as UnicornUseConsistentCurlyBraces;
+pub use crate::rules::unicorn::use_simple_number_keys::UseSimpleNumberKeys as UnicornUseSimpleNumberKeys;
+pub use crate::rules::unicorn::use_simplified_logic_expression::UseSimplifiedLogicExpression as UnicornUseSimplifiedLogicExpression;
 pub use crate::rules::vitest::consistent_each_for::ConsistentEachFor as VitestConsistentEachFor;
 pub use crate::rules::vitest::consistent_test_filename::ConsistentTestFilename as VitestConsistentTestFilename;
 pub use crate::rules::vitest::consistent_vitest_vi::ConsistentVitestVi as VitestConsistentVitestVi;
@@ -744,6 +784,7 @@ pub enum RuleEnum {
     ImportNoCycle(ImportNoCycle),
     ImportNoDefaultExport(ImportNoDefaultExport),
     ImportNoDuplicates(ImportNoDuplicates),
+    ImportNoDynamicNamespaceImportAccess(ImportNoDynamicNamespaceImportAccess),
     ImportNoDynamicRequire(ImportNoDynamicRequire),
     ImportNoEmptyNamedBlocks(ImportNoEmptyNamedBlocks),
     ImportNoMutableExports(ImportNoMutableExports),
@@ -753,9 +794,12 @@ pub enum RuleEnum {
     ImportNoNamedExport(ImportNoNamedExport),
     ImportNoNamespace(ImportNoNamespace),
     ImportNoNodejsModules(ImportNoNodejsModules),
+    ImportNoPrivateImports(ImportNoPrivateImports),
     ImportNoRelativeParentImports(ImportNoRelativeParentImports),
     ImportNoSelfImport(ImportNoSelfImport),
     ImportNoUnassignedImport(ImportNoUnassignedImport),
+    ImportNoUndeclaredDependencies(ImportNoUndeclaredDependencies),
+    ImportNoUnresolvedImports(ImportNoUnresolvedImports),
     ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax),
     ImportPreferDefaultExport(ImportPreferDefaultExport),
     ImportUnambiguous(ImportUnambiguous),
@@ -798,6 +842,7 @@ pub enum RuleEnum {
     EslintNoClassAssign(EslintNoClassAssign),
     EslintNoCompareNegZero(EslintNoCompareNegZero),
     EslintNoCondAssign(EslintNoCondAssign),
+    EslintNoConfusingLabels(EslintNoConfusingLabels),
     EslintNoConsole(EslintNoConsole),
     EslintNoConstAssign(EslintNoConstAssign),
     EslintNoConstantBinaryExpression(EslintNoConstantBinaryExpression),
@@ -855,12 +900,14 @@ pub enum RuleEnum {
     EslintNoNonoctalDecimalEscape(EslintNoNonoctalDecimalEscape),
     EslintNoObjCalls(EslintNoObjCalls),
     EslintNoObjectConstructor(EslintNoObjectConstructor),
+    EslintNoOctalEscape(EslintNoOctalEscape),
     EslintNoParamReassign(EslintNoParamReassign),
     EslintNoPlusplus(EslintNoPlusplus),
     EslintNoPromiseExecutorReturn(EslintNoPromiseExecutorReturn),
     EslintNoProto(EslintNoProto),
     EslintNoPrototypeBuiltins(EslintNoPrototypeBuiltins),
     EslintNoRedeclare(EslintNoRedeclare),
+    EslintNoRedundantUseStrict(EslintNoRedundantUseStrict),
     EslintNoRegexSpaces(EslintNoRegexSpaces),
     EslintNoRestrictedGlobals(EslintNoRestrictedGlobals),
     EslintNoRestrictedImports(EslintNoRestrictedImports),
@@ -872,7 +919,9 @@ pub enum RuleEnum {
     EslintNoSetterReturn(EslintNoSetterReturn),
     EslintNoShadow(EslintNoShadow),
     EslintNoShadowRestrictedNames(EslintNoShadowRestrictedNames),
+    EslintNoShoutyConstants(EslintNoShoutyConstants),
     EslintNoSparseArrays(EslintNoSparseArrays),
+    EslintNoStringCaseMismatch(EslintNoStringCaseMismatch),
     EslintNoTemplateCurlyInString(EslintNoTemplateCurlyInString),
     EslintNoTernary(EslintNoTernary),
     EslintNoThisBeforeSuper(EslintNoThisBeforeSuper),
@@ -899,6 +948,7 @@ pub enum RuleEnum {
     EslintNoUselessComputedKey(EslintNoUselessComputedKey),
     EslintNoUselessConcat(EslintNoUselessConcat),
     EslintNoUselessConstructor(EslintNoUselessConstructor),
+    EslintNoUselessContinue(EslintNoUselessContinue),
     EslintNoUselessEscape(EslintNoUselessEscape),
     EslintNoUselessRename(EslintNoUselessRename),
     EslintNoUselessReturn(EslintNoUselessReturn),
@@ -908,6 +958,7 @@ pub enum RuleEnum {
     EslintNoWith(EslintNoWith),
     EslintObjectShorthand(EslintObjectShorthand),
     EslintOperatorAssignment(EslintOperatorAssignment),
+    EslintPreferArrowCallback(EslintPreferArrowCallback),
     EslintPreferConst(EslintPreferConst),
     EslintPreferDestructuring(EslintPreferDestructuring),
     EslintPreferExponentiationOperator(EslintPreferExponentiationOperator),
@@ -928,6 +979,9 @@ pub enum RuleEnum {
     EslintSymbolDescription(EslintSymbolDescription),
     EslintUnicodeBom(EslintUnicodeBom),
     EslintUseIsnan(EslintUseIsnan),
+    EslintUseRegexLiterals(EslintUseRegexLiterals),
+    EslintUseSingleVarDeclarator(EslintUseSingleVarDeclarator),
+    EslintUseWhile(EslintUseWhile),
     EslintValidTypeof(EslintValidTypeof),
     EslintVarsOnTop(EslintVarsOnTop),
     EslintYoda(EslintYoda),
@@ -947,7 +1001,9 @@ pub enum RuleEnum {
     TypescriptConsistentTypeImports(TypescriptConsistentTypeImports),
     TypescriptDotNotation(TypescriptDotNotation),
     TypescriptExplicitFunctionReturnType(TypescriptExplicitFunctionReturnType),
+    TypescriptExplicitMemberAccessibility(TypescriptExplicitMemberAccessibility),
     TypescriptExplicitModuleBoundaryTypes(TypescriptExplicitModuleBoundaryTypes),
+    TypescriptNamingConvention(TypescriptNamingConvention),
     TypescriptNoArrayDelete(TypescriptNoArrayDelete),
     TypescriptNoBaseToString(TypescriptNoBaseToString),
     TypescriptNoConfusingNonNullAssertion(TypescriptNoConfusingNonNullAssertion),
@@ -958,11 +1014,15 @@ pub enum RuleEnum {
     TypescriptNoDynamicDelete(TypescriptNoDynamicDelete),
     TypescriptNoEmptyInterface(TypescriptNoEmptyInterface),
     TypescriptNoEmptyObjectType(TypescriptNoEmptyObjectType),
+    TypescriptNoEmptyTypeParameters(TypescriptNoEmptyTypeParameters),
+    TypescriptNoEnum(TypescriptNoEnum),
+    TypescriptNoEvolvingTypes(TypescriptNoEvolvingTypes),
     TypescriptNoExplicitAny(TypescriptNoExplicitAny),
     TypescriptNoExtraNonNullAssertion(TypescriptNoExtraNonNullAssertion),
     TypescriptNoExtraneousClass(TypescriptNoExtraneousClass),
     TypescriptNoFloatingPromises(TypescriptNoFloatingPromises),
     TypescriptNoForInArray(TypescriptNoForInArray),
+    TypescriptNoImplicitAnyLet(TypescriptNoImplicitAnyLet),
     TypescriptNoImpliedEval(TypescriptNoImpliedEval),
     TypescriptNoImportTypeSideEffects(TypescriptNoImportTypeSideEffects),
     TypescriptNoInferrableTypes(TypescriptNoInferrableTypes),
@@ -980,6 +1040,7 @@ pub enum RuleEnum {
     TypescriptNoRequireImports(TypescriptNoRequireImports),
     TypescriptNoRestrictedTypes(TypescriptNoRestrictedTypes),
     TypescriptNoThisAlias(TypescriptNoThisAlias),
+    TypescriptNoThisInStatic(TypescriptNoThisInStatic),
     TypescriptNoUnnecessaryBooleanLiteralCompare(TypescriptNoUnnecessaryBooleanLiteralCompare),
     TypescriptNoUnnecessaryCondition(TypescriptNoUnnecessaryCondition),
     TypescriptNoUnnecessaryParameterPropertyAssignment(
@@ -1129,14 +1190,18 @@ pub enum RuleEnum {
     ReactNoDidMountSetState(ReactNoDidMountSetState),
     ReactNoDirectMutationState(ReactNoDirectMutationState),
     ReactNoFindDomNode(ReactNoFindDomNode),
+    ReactNoForwardRef(ReactNoForwardRef),
     ReactNoIsMounted(ReactNoIsMounted),
+    ReactNoJsxLiterals(ReactNoJsxLiterals),
     ReactNoMultiComp(ReactNoMultiComp),
     ReactNoNamespace(ReactNoNamespace),
     ReactNoReactChildren(ReactNoReactChildren),
+    ReactNoReactSpecificProps(ReactNoReactSpecificProps),
     ReactNoRedundantShouldComponentUpdate(ReactNoRedundantShouldComponentUpdate),
     ReactNoRenderReturnValue(ReactNoRenderReturnValue),
     ReactNoSetState(ReactNoSetState),
     ReactNoStringRefs(ReactNoStringRefs),
+    ReactNoSuspiciousSemicolonInJsx(ReactNoSuspiciousSemicolonInJsx),
     ReactNoThisInSfc(ReactNoThisInSfc),
     ReactNoUnescapedEntities(ReactNoUnescapedEntities),
     ReactNoUnknownProperty(ReactNoUnknownProperty),
@@ -1151,6 +1216,7 @@ pub enum RuleEnum {
     ReactSelfClosingComp(ReactSelfClosingComp),
     ReactStateInConstructor(ReactStateInConstructor),
     ReactStylePropObject(ReactStylePropObject),
+    ReactUseImageSize(ReactUseImageSize),
     ReactVoidDomElementsNoChildren(ReactVoidDomElementsNoChildren),
     ReactPerfJsxNoJsxAsProp(ReactPerfJsxNoJsxAsProp),
     ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp),
@@ -1183,6 +1249,7 @@ pub enum RuleEnum {
     UnicornNoConsoleSpaces(UnicornNoConsoleSpaces),
     UnicornNoDocumentCookie(UnicornNoDocumentCookie),
     UnicornNoEmptyFile(UnicornNoEmptyFile),
+    UnicornNoFlatMapIdentity(UnicornNoFlatMapIdentity),
     UnicornNoHexEscape(UnicornNoHexEscape),
     UnicornNoImmediateMutation(UnicornNoImmediateMutation),
     UnicornNoInstanceofArray(UnicornNoInstanceofArray),
@@ -1216,8 +1283,10 @@ pub enum RuleEnum {
     UnicornNoUselessLengthCheck(UnicornNoUselessLengthCheck),
     UnicornNoUselessPromiseResolveReject(UnicornNoUselessPromiseResolveReject),
     UnicornNoUselessSpread(UnicornNoUselessSpread),
+    UnicornNoUselessStringRaw(UnicornNoUselessStringRaw),
     UnicornNoUselessSwitchCase(UnicornNoUselessSwitchCase),
     UnicornNoUselessUndefined(UnicornNoUselessUndefined),
+    UnicornNoUselessUndefinedInitialization(UnicornNoUselessUndefinedInitialization),
     UnicornNoZeroFractions(UnicornNoZeroFractions),
     UnicornNumberLiteralCase(UnicornNumberLiteralCase),
     UnicornNumericSeparatorsStyle(UnicornNumericSeparatorsStyle),
@@ -1282,6 +1351,10 @@ pub enum RuleEnum {
     UnicornSwitchCaseBreakPosition(UnicornSwitchCaseBreakPosition),
     UnicornTextEncodingIdentifierCase(UnicornTextEncodingIdentifierCase),
     UnicornThrowNewError(UnicornThrowNewError),
+    UnicornUseCollapsedIf(UnicornUseCollapsedIf),
+    UnicornUseConsistentCurlyBraces(UnicornUseConsistentCurlyBraces),
+    UnicornUseSimpleNumberKeys(UnicornUseSimpleNumberKeys),
+    UnicornUseSimplifiedLogicExpression(UnicornUseSimplifiedLogicExpression),
     JsxA11YAltText(JsxA11YAltText),
     JsxA11YAnchorAmbiguousText(JsxA11YAnchorAmbiguousText),
     JsxA11YAnchorHasContent(JsxA11YAnchorHasContent),
@@ -1305,14 +1378,24 @@ pub enum RuleEnum {
     JsxA11YNoAriaHiddenOnFocusable(JsxA11YNoAriaHiddenOnFocusable),
     JsxA11YNoAutofocus(JsxA11YNoAutofocus),
     JsxA11YNoDistractingElements(JsxA11YNoDistractingElements),
+    JsxA11YNoInteractiveElementToNoninteractiveRole(
+        JsxA11YNoInteractiveElementToNoninteractiveRole,
+    ),
+    JsxA11YNoNoninteractiveElementInteractions(JsxA11YNoNoninteractiveElementInteractions),
+    JsxA11YNoNoninteractiveElementToInteractiveRole(
+        JsxA11YNoNoninteractiveElementToInteractiveRole,
+    ),
     JsxA11YNoNoninteractiveTabindex(JsxA11YNoNoninteractiveTabindex),
     JsxA11YNoRedundantRoles(JsxA11YNoRedundantRoles),
     JsxA11YNoStaticElementInteractions(JsxA11YNoStaticElementInteractions),
+    JsxA11YNoSvgWithoutTitle(JsxA11YNoSvgWithoutTitle),
     JsxA11YPreferTagOverRole(JsxA11YPreferTagOverRole),
     JsxA11YRoleHasRequiredAriaProps(JsxA11YRoleHasRequiredAriaProps),
     JsxA11YRoleSupportsAriaProps(JsxA11YRoleSupportsAriaProps),
     JsxA11YScope(JsxA11YScope),
     JsxA11YTabindexNoPositive(JsxA11YTabindexNoPositive),
+    JsxA11YUseFocusableInteractive(JsxA11YUseFocusableInteractive),
+    JsxA11YUseUniqueElementIds(JsxA11YUseUniqueElementIds),
     OxcApproxConstant(OxcApproxConstant),
     OxcBadArrayMethodOnArguments(OxcBadArrayMethodOnArguments),
     OxcBadBitwiseOperator(OxcBadBitwiseOperator),
@@ -1421,6 +1504,7 @@ pub enum RuleEnum {
     NodeGlobalRequire(NodeGlobalRequire),
     NodeHandleCallbackErr(NodeHandleCallbackErr),
     NodeNoExportsAssign(NodeNoExportsAssign),
+    NodeNoGlobalDirnameFilename(NodeNoGlobalDirnameFilename),
     NodeNoNewRequire(NodeNoNewRequire),
     NodeNoPathConcat(NodeNoPathConcat),
     NodeNoProcessEnv(NodeNoProcessEnv),
@@ -1459,7 +1543,8 @@ const IMPORT_NO_COMMONJS_ID: usize = IMPORT_NO_ANONYMOUS_DEFAULT_EXPORT_ID + 1us
 const IMPORT_NO_CYCLE_ID: usize = IMPORT_NO_COMMONJS_ID + 1usize;
 const IMPORT_NO_DEFAULT_EXPORT_ID: usize = IMPORT_NO_CYCLE_ID + 1usize;
 const IMPORT_NO_DUPLICATES_ID: usize = IMPORT_NO_DEFAULT_EXPORT_ID + 1usize;
-const IMPORT_NO_DYNAMIC_REQUIRE_ID: usize = IMPORT_NO_DUPLICATES_ID + 1usize;
+const IMPORT_NO_DYNAMIC_NAMESPACE_IMPORT_ACCESS_ID: usize = IMPORT_NO_DUPLICATES_ID + 1usize;
+const IMPORT_NO_DYNAMIC_REQUIRE_ID: usize = IMPORT_NO_DYNAMIC_NAMESPACE_IMPORT_ACCESS_ID + 1usize;
 const IMPORT_NO_EMPTY_NAMED_BLOCKS_ID: usize = IMPORT_NO_DYNAMIC_REQUIRE_ID + 1usize;
 const IMPORT_NO_MUTABLE_EXPORTS_ID: usize = IMPORT_NO_EMPTY_NAMED_BLOCKS_ID + 1usize;
 const IMPORT_NO_NAMED_AS_DEFAULT_ID: usize = IMPORT_NO_MUTABLE_EXPORTS_ID + 1usize;
@@ -1468,10 +1553,13 @@ const IMPORT_NO_NAMED_DEFAULT_ID: usize = IMPORT_NO_NAMED_AS_DEFAULT_MEMBER_ID +
 const IMPORT_NO_NAMED_EXPORT_ID: usize = IMPORT_NO_NAMED_DEFAULT_ID + 1usize;
 const IMPORT_NO_NAMESPACE_ID: usize = IMPORT_NO_NAMED_EXPORT_ID + 1usize;
 const IMPORT_NO_NODEJS_MODULES_ID: usize = IMPORT_NO_NAMESPACE_ID + 1usize;
-const IMPORT_NO_RELATIVE_PARENT_IMPORTS_ID: usize = IMPORT_NO_NODEJS_MODULES_ID + 1usize;
+const IMPORT_NO_PRIVATE_IMPORTS_ID: usize = IMPORT_NO_NODEJS_MODULES_ID + 1usize;
+const IMPORT_NO_RELATIVE_PARENT_IMPORTS_ID: usize = IMPORT_NO_PRIVATE_IMPORTS_ID + 1usize;
 const IMPORT_NO_SELF_IMPORT_ID: usize = IMPORT_NO_RELATIVE_PARENT_IMPORTS_ID + 1usize;
 const IMPORT_NO_UNASSIGNED_IMPORT_ID: usize = IMPORT_NO_SELF_IMPORT_ID + 1usize;
-const IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID: usize = IMPORT_NO_UNASSIGNED_IMPORT_ID + 1usize;
+const IMPORT_NO_UNDECLARED_DEPENDENCIES_ID: usize = IMPORT_NO_UNASSIGNED_IMPORT_ID + 1usize;
+const IMPORT_NO_UNRESOLVED_IMPORTS_ID: usize = IMPORT_NO_UNDECLARED_DEPENDENCIES_ID + 1usize;
+const IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID: usize = IMPORT_NO_UNRESOLVED_IMPORTS_ID + 1usize;
 const IMPORT_PREFER_DEFAULT_EXPORT_ID: usize = IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID + 1usize;
 const IMPORT_UNAMBIGUOUS_ID: usize = IMPORT_PREFER_DEFAULT_EXPORT_ID + 1usize;
 const ESLINT_ACCESSOR_PAIRS_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
@@ -1513,7 +1601,8 @@ const ESLINT_NO_CASE_DECLARATIONS_ID: usize = ESLINT_NO_CALLER_ID + 1usize;
 const ESLINT_NO_CLASS_ASSIGN_ID: usize = ESLINT_NO_CASE_DECLARATIONS_ID + 1usize;
 const ESLINT_NO_COMPARE_NEG_ZERO_ID: usize = ESLINT_NO_CLASS_ASSIGN_ID + 1usize;
 const ESLINT_NO_COND_ASSIGN_ID: usize = ESLINT_NO_COMPARE_NEG_ZERO_ID + 1usize;
-const ESLINT_NO_CONSOLE_ID: usize = ESLINT_NO_COND_ASSIGN_ID + 1usize;
+const ESLINT_NO_CONFUSING_LABELS_ID: usize = ESLINT_NO_COND_ASSIGN_ID + 1usize;
+const ESLINT_NO_CONSOLE_ID: usize = ESLINT_NO_CONFUSING_LABELS_ID + 1usize;
 const ESLINT_NO_CONST_ASSIGN_ID: usize = ESLINT_NO_CONSOLE_ID + 1usize;
 const ESLINT_NO_CONSTANT_BINARY_EXPRESSION_ID: usize = ESLINT_NO_CONST_ASSIGN_ID + 1usize;
 const ESLINT_NO_CONSTANT_CONDITION_ID: usize = ESLINT_NO_CONSTANT_BINARY_EXPRESSION_ID + 1usize;
@@ -1570,13 +1659,15 @@ const ESLINT_NO_NEW_WRAPPERS_ID: usize = ESLINT_NO_NEW_NATIVE_NONCONSTRUCTOR_ID 
 const ESLINT_NO_NONOCTAL_DECIMAL_ESCAPE_ID: usize = ESLINT_NO_NEW_WRAPPERS_ID + 1usize;
 const ESLINT_NO_OBJ_CALLS_ID: usize = ESLINT_NO_NONOCTAL_DECIMAL_ESCAPE_ID + 1usize;
 const ESLINT_NO_OBJECT_CONSTRUCTOR_ID: usize = ESLINT_NO_OBJ_CALLS_ID + 1usize;
-const ESLINT_NO_PARAM_REASSIGN_ID: usize = ESLINT_NO_OBJECT_CONSTRUCTOR_ID + 1usize;
+const ESLINT_NO_OCTAL_ESCAPE_ID: usize = ESLINT_NO_OBJECT_CONSTRUCTOR_ID + 1usize;
+const ESLINT_NO_PARAM_REASSIGN_ID: usize = ESLINT_NO_OCTAL_ESCAPE_ID + 1usize;
 const ESLINT_NO_PLUSPLUS_ID: usize = ESLINT_NO_PARAM_REASSIGN_ID + 1usize;
 const ESLINT_NO_PROMISE_EXECUTOR_RETURN_ID: usize = ESLINT_NO_PLUSPLUS_ID + 1usize;
 const ESLINT_NO_PROTO_ID: usize = ESLINT_NO_PROMISE_EXECUTOR_RETURN_ID + 1usize;
 const ESLINT_NO_PROTOTYPE_BUILTINS_ID: usize = ESLINT_NO_PROTO_ID + 1usize;
 const ESLINT_NO_REDECLARE_ID: usize = ESLINT_NO_PROTOTYPE_BUILTINS_ID + 1usize;
-const ESLINT_NO_REGEX_SPACES_ID: usize = ESLINT_NO_REDECLARE_ID + 1usize;
+const ESLINT_NO_REDUNDANT_USE_STRICT_ID: usize = ESLINT_NO_REDECLARE_ID + 1usize;
+const ESLINT_NO_REGEX_SPACES_ID: usize = ESLINT_NO_REDUNDANT_USE_STRICT_ID + 1usize;
 const ESLINT_NO_RESTRICTED_GLOBALS_ID: usize = ESLINT_NO_REGEX_SPACES_ID + 1usize;
 const ESLINT_NO_RESTRICTED_IMPORTS_ID: usize = ESLINT_NO_RESTRICTED_GLOBALS_ID + 1usize;
 const ESLINT_NO_RETURN_ASSIGN_ID: usize = ESLINT_NO_RESTRICTED_IMPORTS_ID + 1usize;
@@ -1587,8 +1678,10 @@ const ESLINT_NO_SEQUENCES_ID: usize = ESLINT_NO_SELF_COMPARE_ID + 1usize;
 const ESLINT_NO_SETTER_RETURN_ID: usize = ESLINT_NO_SEQUENCES_ID + 1usize;
 const ESLINT_NO_SHADOW_ID: usize = ESLINT_NO_SETTER_RETURN_ID + 1usize;
 const ESLINT_NO_SHADOW_RESTRICTED_NAMES_ID: usize = ESLINT_NO_SHADOW_ID + 1usize;
-const ESLINT_NO_SPARSE_ARRAYS_ID: usize = ESLINT_NO_SHADOW_RESTRICTED_NAMES_ID + 1usize;
-const ESLINT_NO_TEMPLATE_CURLY_IN_STRING_ID: usize = ESLINT_NO_SPARSE_ARRAYS_ID + 1usize;
+const ESLINT_NO_SHOUTY_CONSTANTS_ID: usize = ESLINT_NO_SHADOW_RESTRICTED_NAMES_ID + 1usize;
+const ESLINT_NO_SPARSE_ARRAYS_ID: usize = ESLINT_NO_SHOUTY_CONSTANTS_ID + 1usize;
+const ESLINT_NO_STRING_CASE_MISMATCH_ID: usize = ESLINT_NO_SPARSE_ARRAYS_ID + 1usize;
+const ESLINT_NO_TEMPLATE_CURLY_IN_STRING_ID: usize = ESLINT_NO_STRING_CASE_MISMATCH_ID + 1usize;
 const ESLINT_NO_TERNARY_ID: usize = ESLINT_NO_TEMPLATE_CURLY_IN_STRING_ID + 1usize;
 const ESLINT_NO_THIS_BEFORE_SUPER_ID: usize = ESLINT_NO_TERNARY_ID + 1usize;
 const ESLINT_NO_THROW_LITERAL_ID: usize = ESLINT_NO_THIS_BEFORE_SUPER_ID + 1usize;
@@ -1614,7 +1707,8 @@ const ESLINT_NO_USELESS_CATCH_ID: usize = ESLINT_NO_USELESS_CALL_ID + 1usize;
 const ESLINT_NO_USELESS_COMPUTED_KEY_ID: usize = ESLINT_NO_USELESS_CATCH_ID + 1usize;
 const ESLINT_NO_USELESS_CONCAT_ID: usize = ESLINT_NO_USELESS_COMPUTED_KEY_ID + 1usize;
 const ESLINT_NO_USELESS_CONSTRUCTOR_ID: usize = ESLINT_NO_USELESS_CONCAT_ID + 1usize;
-const ESLINT_NO_USELESS_ESCAPE_ID: usize = ESLINT_NO_USELESS_CONSTRUCTOR_ID + 1usize;
+const ESLINT_NO_USELESS_CONTINUE_ID: usize = ESLINT_NO_USELESS_CONSTRUCTOR_ID + 1usize;
+const ESLINT_NO_USELESS_ESCAPE_ID: usize = ESLINT_NO_USELESS_CONTINUE_ID + 1usize;
 const ESLINT_NO_USELESS_RENAME_ID: usize = ESLINT_NO_USELESS_ESCAPE_ID + 1usize;
 const ESLINT_NO_USELESS_RETURN_ID: usize = ESLINT_NO_USELESS_RENAME_ID + 1usize;
 const ESLINT_NO_VAR_ID: usize = ESLINT_NO_USELESS_RETURN_ID + 1usize;
@@ -1623,7 +1717,8 @@ const ESLINT_NO_WARNING_COMMENTS_ID: usize = ESLINT_NO_VOID_ID + 1usize;
 const ESLINT_NO_WITH_ID: usize = ESLINT_NO_WARNING_COMMENTS_ID + 1usize;
 const ESLINT_OBJECT_SHORTHAND_ID: usize = ESLINT_NO_WITH_ID + 1usize;
 const ESLINT_OPERATOR_ASSIGNMENT_ID: usize = ESLINT_OBJECT_SHORTHAND_ID + 1usize;
-const ESLINT_PREFER_CONST_ID: usize = ESLINT_OPERATOR_ASSIGNMENT_ID + 1usize;
+const ESLINT_PREFER_ARROW_CALLBACK_ID: usize = ESLINT_OPERATOR_ASSIGNMENT_ID + 1usize;
+const ESLINT_PREFER_CONST_ID: usize = ESLINT_PREFER_ARROW_CALLBACK_ID + 1usize;
 const ESLINT_PREFER_DESTRUCTURING_ID: usize = ESLINT_PREFER_CONST_ID + 1usize;
 const ESLINT_PREFER_EXPONENTIATION_OPERATOR_ID: usize = ESLINT_PREFER_DESTRUCTURING_ID + 1usize;
 const ESLINT_PREFER_NUMERIC_LITERALS_ID: usize = ESLINT_PREFER_EXPONENTIATION_OPERATOR_ID + 1usize;
@@ -1643,7 +1738,10 @@ const ESLINT_SORT_VARS_ID: usize = ESLINT_SORT_KEYS_ID + 1usize;
 const ESLINT_SYMBOL_DESCRIPTION_ID: usize = ESLINT_SORT_VARS_ID + 1usize;
 const ESLINT_UNICODE_BOM_ID: usize = ESLINT_SYMBOL_DESCRIPTION_ID + 1usize;
 const ESLINT_USE_ISNAN_ID: usize = ESLINT_UNICODE_BOM_ID + 1usize;
-const ESLINT_VALID_TYPEOF_ID: usize = ESLINT_USE_ISNAN_ID + 1usize;
+const ESLINT_USE_REGEX_LITERALS_ID: usize = ESLINT_USE_ISNAN_ID + 1usize;
+const ESLINT_USE_SINGLE_VAR_DECLARATOR_ID: usize = ESLINT_USE_REGEX_LITERALS_ID + 1usize;
+const ESLINT_USE_WHILE_ID: usize = ESLINT_USE_SINGLE_VAR_DECLARATOR_ID + 1usize;
+const ESLINT_VALID_TYPEOF_ID: usize = ESLINT_USE_WHILE_ID + 1usize;
 const ESLINT_VARS_ON_TOP_ID: usize = ESLINT_VALID_TYPEOF_ID + 1usize;
 const ESLINT_YODA_ID: usize = ESLINT_VARS_ON_TOP_ID + 1usize;
 const TYPESCRIPT_ADJACENT_OVERLOAD_SIGNATURES_ID: usize = ESLINT_YODA_ID + 1usize;
@@ -1667,9 +1765,13 @@ const TYPESCRIPT_CONSISTENT_TYPE_EXPORTS_ID: usize =
 const TYPESCRIPT_CONSISTENT_TYPE_IMPORTS_ID: usize = TYPESCRIPT_CONSISTENT_TYPE_EXPORTS_ID + 1usize;
 const TYPESCRIPT_DOT_NOTATION_ID: usize = TYPESCRIPT_CONSISTENT_TYPE_IMPORTS_ID + 1usize;
 const TYPESCRIPT_EXPLICIT_FUNCTION_RETURN_TYPE_ID: usize = TYPESCRIPT_DOT_NOTATION_ID + 1usize;
-const TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID: usize =
+const TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID: usize =
     TYPESCRIPT_EXPLICIT_FUNCTION_RETURN_TYPE_ID + 1usize;
-const TYPESCRIPT_NO_ARRAY_DELETE_ID: usize = TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID + 1usize;
+const TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID: usize =
+    TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID + 1usize;
+const TYPESCRIPT_NAMING_CONVENTION_ID: usize =
+    TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID + 1usize;
+const TYPESCRIPT_NO_ARRAY_DELETE_ID: usize = TYPESCRIPT_NAMING_CONVENTION_ID + 1usize;
 const TYPESCRIPT_NO_BASE_TO_STRING_ID: usize = TYPESCRIPT_NO_ARRAY_DELETE_ID + 1usize;
 const TYPESCRIPT_NO_CONFUSING_NON_NULL_ASSERTION_ID: usize =
     TYPESCRIPT_NO_BASE_TO_STRING_ID + 1usize;
@@ -1683,12 +1785,16 @@ const TYPESCRIPT_NO_DYNAMIC_DELETE_ID: usize =
     TYPESCRIPT_NO_DUPLICATE_TYPE_CONSTITUENTS_ID + 1usize;
 const TYPESCRIPT_NO_EMPTY_INTERFACE_ID: usize = TYPESCRIPT_NO_DYNAMIC_DELETE_ID + 1usize;
 const TYPESCRIPT_NO_EMPTY_OBJECT_TYPE_ID: usize = TYPESCRIPT_NO_EMPTY_INTERFACE_ID + 1usize;
-const TYPESCRIPT_NO_EXPLICIT_ANY_ID: usize = TYPESCRIPT_NO_EMPTY_OBJECT_TYPE_ID + 1usize;
+const TYPESCRIPT_NO_EMPTY_TYPE_PARAMETERS_ID: usize = TYPESCRIPT_NO_EMPTY_OBJECT_TYPE_ID + 1usize;
+const TYPESCRIPT_NO_ENUM_ID: usize = TYPESCRIPT_NO_EMPTY_TYPE_PARAMETERS_ID + 1usize;
+const TYPESCRIPT_NO_EVOLVING_TYPES_ID: usize = TYPESCRIPT_NO_ENUM_ID + 1usize;
+const TYPESCRIPT_NO_EXPLICIT_ANY_ID: usize = TYPESCRIPT_NO_EVOLVING_TYPES_ID + 1usize;
 const TYPESCRIPT_NO_EXTRA_NON_NULL_ASSERTION_ID: usize = TYPESCRIPT_NO_EXPLICIT_ANY_ID + 1usize;
 const TYPESCRIPT_NO_EXTRANEOUS_CLASS_ID: usize = TYPESCRIPT_NO_EXTRA_NON_NULL_ASSERTION_ID + 1usize;
 const TYPESCRIPT_NO_FLOATING_PROMISES_ID: usize = TYPESCRIPT_NO_EXTRANEOUS_CLASS_ID + 1usize;
 const TYPESCRIPT_NO_FOR_IN_ARRAY_ID: usize = TYPESCRIPT_NO_FLOATING_PROMISES_ID + 1usize;
-const TYPESCRIPT_NO_IMPLIED_EVAL_ID: usize = TYPESCRIPT_NO_FOR_IN_ARRAY_ID + 1usize;
+const TYPESCRIPT_NO_IMPLICIT_ANY_LET_ID: usize = TYPESCRIPT_NO_FOR_IN_ARRAY_ID + 1usize;
+const TYPESCRIPT_NO_IMPLIED_EVAL_ID: usize = TYPESCRIPT_NO_IMPLICIT_ANY_LET_ID + 1usize;
 const TYPESCRIPT_NO_IMPORT_TYPE_SIDE_EFFECTS_ID: usize = TYPESCRIPT_NO_IMPLIED_EVAL_ID + 1usize;
 const TYPESCRIPT_NO_INFERRABLE_TYPES_ID: usize = TYPESCRIPT_NO_IMPORT_TYPE_SIDE_EFFECTS_ID + 1usize;
 const TYPESCRIPT_NO_INVALID_VOID_TYPE_ID: usize = TYPESCRIPT_NO_INFERRABLE_TYPES_ID + 1usize;
@@ -1711,8 +1817,9 @@ const TYPESCRIPT_NO_REQUIRE_IMPORTS_ID: usize =
     TYPESCRIPT_NO_REDUNDANT_TYPE_CONSTITUENTS_ID + 1usize;
 const TYPESCRIPT_NO_RESTRICTED_TYPES_ID: usize = TYPESCRIPT_NO_REQUIRE_IMPORTS_ID + 1usize;
 const TYPESCRIPT_NO_THIS_ALIAS_ID: usize = TYPESCRIPT_NO_RESTRICTED_TYPES_ID + 1usize;
+const TYPESCRIPT_NO_THIS_IN_STATIC_ID: usize = TYPESCRIPT_NO_THIS_ALIAS_ID + 1usize;
 const TYPESCRIPT_NO_UNNECESSARY_BOOLEAN_LITERAL_COMPARE_ID: usize =
-    TYPESCRIPT_NO_THIS_ALIAS_ID + 1usize;
+    TYPESCRIPT_NO_THIS_IN_STATIC_ID + 1usize;
 const TYPESCRIPT_NO_UNNECESSARY_CONDITION_ID: usize =
     TYPESCRIPT_NO_UNNECESSARY_BOOLEAN_LITERAL_COMPARE_ID + 1usize;
 const TYPESCRIPT_NO_UNNECESSARY_PARAMETER_PROPERTY_ASSIGNMENT_ID: usize =
@@ -1888,16 +1995,21 @@ const REACT_NO_DANGER_WITH_CHILDREN_ID: usize = REACT_NO_DANGER_ID + 1usize;
 const REACT_NO_DID_MOUNT_SET_STATE_ID: usize = REACT_NO_DANGER_WITH_CHILDREN_ID + 1usize;
 const REACT_NO_DIRECT_MUTATION_STATE_ID: usize = REACT_NO_DID_MOUNT_SET_STATE_ID + 1usize;
 const REACT_NO_FIND_DOM_NODE_ID: usize = REACT_NO_DIRECT_MUTATION_STATE_ID + 1usize;
-const REACT_NO_IS_MOUNTED_ID: usize = REACT_NO_FIND_DOM_NODE_ID + 1usize;
-const REACT_NO_MULTI_COMP_ID: usize = REACT_NO_IS_MOUNTED_ID + 1usize;
+const REACT_NO_FORWARD_REF_ID: usize = REACT_NO_FIND_DOM_NODE_ID + 1usize;
+const REACT_NO_IS_MOUNTED_ID: usize = REACT_NO_FORWARD_REF_ID + 1usize;
+const REACT_NO_JSX_LITERALS_ID: usize = REACT_NO_IS_MOUNTED_ID + 1usize;
+const REACT_NO_MULTI_COMP_ID: usize = REACT_NO_JSX_LITERALS_ID + 1usize;
 const REACT_NO_NAMESPACE_ID: usize = REACT_NO_MULTI_COMP_ID + 1usize;
 const REACT_NO_REACT_CHILDREN_ID: usize = REACT_NO_NAMESPACE_ID + 1usize;
-const REACT_NO_REDUNDANT_SHOULD_COMPONENT_UPDATE_ID: usize = REACT_NO_REACT_CHILDREN_ID + 1usize;
+const REACT_NO_REACT_SPECIFIC_PROPS_ID: usize = REACT_NO_REACT_CHILDREN_ID + 1usize;
+const REACT_NO_REDUNDANT_SHOULD_COMPONENT_UPDATE_ID: usize =
+    REACT_NO_REACT_SPECIFIC_PROPS_ID + 1usize;
 const REACT_NO_RENDER_RETURN_VALUE_ID: usize =
     REACT_NO_REDUNDANT_SHOULD_COMPONENT_UPDATE_ID + 1usize;
 const REACT_NO_SET_STATE_ID: usize = REACT_NO_RENDER_RETURN_VALUE_ID + 1usize;
 const REACT_NO_STRING_REFS_ID: usize = REACT_NO_SET_STATE_ID + 1usize;
-const REACT_NO_THIS_IN_SFC_ID: usize = REACT_NO_STRING_REFS_ID + 1usize;
+const REACT_NO_SUSPICIOUS_SEMICOLON_IN_JSX_ID: usize = REACT_NO_STRING_REFS_ID + 1usize;
+const REACT_NO_THIS_IN_SFC_ID: usize = REACT_NO_SUSPICIOUS_SEMICOLON_IN_JSX_ID + 1usize;
 const REACT_NO_UNESCAPED_ENTITIES_ID: usize = REACT_NO_THIS_IN_SFC_ID + 1usize;
 const REACT_NO_UNKNOWN_PROPERTY_ID: usize = REACT_NO_UNESCAPED_ENTITIES_ID + 1usize;
 const REACT_NO_UNSAFE_ID: usize = REACT_NO_UNKNOWN_PROPERTY_ID + 1usize;
@@ -1911,7 +2023,8 @@ const REACT_RULES_OF_HOOKS_ID: usize = REACT_REQUIRE_RENDER_RETURN_ID + 1usize;
 const REACT_SELF_CLOSING_COMP_ID: usize = REACT_RULES_OF_HOOKS_ID + 1usize;
 const REACT_STATE_IN_CONSTRUCTOR_ID: usize = REACT_SELF_CLOSING_COMP_ID + 1usize;
 const REACT_STYLE_PROP_OBJECT_ID: usize = REACT_STATE_IN_CONSTRUCTOR_ID + 1usize;
-const REACT_VOID_DOM_ELEMENTS_NO_CHILDREN_ID: usize = REACT_STYLE_PROP_OBJECT_ID + 1usize;
+const REACT_USE_IMAGE_SIZE_ID: usize = REACT_STYLE_PROP_OBJECT_ID + 1usize;
+const REACT_VOID_DOM_ELEMENTS_NO_CHILDREN_ID: usize = REACT_USE_IMAGE_SIZE_ID + 1usize;
 const REACT_PERF_JSX_NO_JSX_AS_PROP_ID: usize = REACT_VOID_DOM_ELEMENTS_NO_CHILDREN_ID + 1usize;
 const REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID: usize = REACT_PERF_JSX_NO_JSX_AS_PROP_ID + 1usize;
 const REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID: usize =
@@ -1949,7 +2062,8 @@ const UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID: usize =
 const UNICORN_NO_CONSOLE_SPACES_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID + 1usize;
 const UNICORN_NO_DOCUMENT_COOKIE_ID: usize = UNICORN_NO_CONSOLE_SPACES_ID + 1usize;
 const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
-const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
+const UNICORN_NO_FLAT_MAP_IDENTITY_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
+const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_FLAT_MAP_IDENTITY_ID + 1usize;
 const UNICORN_NO_IMMEDIATE_MUTATION_ID: usize = UNICORN_NO_HEX_ESCAPE_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_ARRAY_ID: usize = UNICORN_NO_IMMEDIATE_MUTATION_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_BUILTINS_ID: usize = UNICORN_NO_INSTANCEOF_ARRAY_ID + 1usize;
@@ -1992,9 +2106,12 @@ const UNICORN_NO_USELESS_LENGTH_CHECK_ID: usize = UNICORN_NO_USELESS_FALLBACK_IN
 const UNICORN_NO_USELESS_PROMISE_RESOLVE_REJECT_ID: usize =
     UNICORN_NO_USELESS_LENGTH_CHECK_ID + 1usize;
 const UNICORN_NO_USELESS_SPREAD_ID: usize = UNICORN_NO_USELESS_PROMISE_RESOLVE_REJECT_ID + 1usize;
-const UNICORN_NO_USELESS_SWITCH_CASE_ID: usize = UNICORN_NO_USELESS_SPREAD_ID + 1usize;
+const UNICORN_NO_USELESS_STRING_RAW_ID: usize = UNICORN_NO_USELESS_SPREAD_ID + 1usize;
+const UNICORN_NO_USELESS_SWITCH_CASE_ID: usize = UNICORN_NO_USELESS_STRING_RAW_ID + 1usize;
 const UNICORN_NO_USELESS_UNDEFINED_ID: usize = UNICORN_NO_USELESS_SWITCH_CASE_ID + 1usize;
-const UNICORN_NO_ZERO_FRACTIONS_ID: usize = UNICORN_NO_USELESS_UNDEFINED_ID + 1usize;
+const UNICORN_NO_USELESS_UNDEFINED_INITIALIZATION_ID: usize =
+    UNICORN_NO_USELESS_UNDEFINED_ID + 1usize;
+const UNICORN_NO_ZERO_FRACTIONS_ID: usize = UNICORN_NO_USELESS_UNDEFINED_INITIALIZATION_ID + 1usize;
 const UNICORN_NUMBER_LITERAL_CASE_ID: usize = UNICORN_NO_ZERO_FRACTIONS_ID + 1usize;
 const UNICORN_NUMERIC_SEPARATORS_STYLE_ID: usize = UNICORN_NUMBER_LITERAL_CASE_ID + 1usize;
 const UNICORN_PREFER_ADD_EVENT_LISTENER_ID: usize = UNICORN_NUMERIC_SEPARATORS_STYLE_ID + 1usize;
@@ -2068,7 +2185,12 @@ const UNICORN_SWITCH_CASE_BREAK_POSITION_ID: usize = UNICORN_SWITCH_CASE_BRACES_
 const UNICORN_TEXT_ENCODING_IDENTIFIER_CASE_ID: usize =
     UNICORN_SWITCH_CASE_BREAK_POSITION_ID + 1usize;
 const UNICORN_THROW_NEW_ERROR_ID: usize = UNICORN_TEXT_ENCODING_IDENTIFIER_CASE_ID + 1usize;
-const JSX_A_11_Y_ALT_TEXT_ID: usize = UNICORN_THROW_NEW_ERROR_ID + 1usize;
+const UNICORN_USE_COLLAPSED_IF_ID: usize = UNICORN_THROW_NEW_ERROR_ID + 1usize;
+const UNICORN_USE_CONSISTENT_CURLY_BRACES_ID: usize = UNICORN_USE_COLLAPSED_IF_ID + 1usize;
+const UNICORN_USE_SIMPLE_NUMBER_KEYS_ID: usize = UNICORN_USE_CONSISTENT_CURLY_BRACES_ID + 1usize;
+const UNICORN_USE_SIMPLIFIED_LOGIC_EXPRESSION_ID: usize =
+    UNICORN_USE_SIMPLE_NUMBER_KEYS_ID + 1usize;
+const JSX_A_11_Y_ALT_TEXT_ID: usize = UNICORN_USE_SIMPLIFIED_LOGIC_EXPRESSION_ID + 1usize;
 const JSX_A_11_Y_ANCHOR_AMBIGUOUS_TEXT_ID: usize = JSX_A_11_Y_ALT_TEXT_ID + 1usize;
 const JSX_A_11_Y_ANCHOR_HAS_CONTENT_ID: usize = JSX_A_11_Y_ANCHOR_AMBIGUOUS_TEXT_ID + 1usize;
 const JSX_A_11_Y_ANCHOR_IS_VALID_ID: usize = JSX_A_11_Y_ANCHOR_HAS_CONTENT_ID + 1usize;
@@ -2093,20 +2215,30 @@ const JSX_A_11_Y_NO_ACCESS_KEY_ID: usize = JSX_A_11_Y_MOUSE_EVENTS_HAVE_KEY_EVEN
 const JSX_A_11_Y_NO_ARIA_HIDDEN_ON_FOCUSABLE_ID: usize = JSX_A_11_Y_NO_ACCESS_KEY_ID + 1usize;
 const JSX_A_11_Y_NO_AUTOFOCUS_ID: usize = JSX_A_11_Y_NO_ARIA_HIDDEN_ON_FOCUSABLE_ID + 1usize;
 const JSX_A_11_Y_NO_DISTRACTING_ELEMENTS_ID: usize = JSX_A_11_Y_NO_AUTOFOCUS_ID + 1usize;
-const JSX_A_11_Y_NO_NONINTERACTIVE_TABINDEX_ID: usize =
+const JSX_A_11_Y_NO_INTERACTIVE_ELEMENT_TO_NONINTERACTIVE_ROLE_ID: usize =
     JSX_A_11_Y_NO_DISTRACTING_ELEMENTS_ID + 1usize;
+const JSX_A_11_Y_NO_NONINTERACTIVE_ELEMENT_INTERACTIONS_ID: usize =
+    JSX_A_11_Y_NO_INTERACTIVE_ELEMENT_TO_NONINTERACTIVE_ROLE_ID + 1usize;
+const JSX_A_11_Y_NO_NONINTERACTIVE_ELEMENT_TO_INTERACTIVE_ROLE_ID: usize =
+    JSX_A_11_Y_NO_NONINTERACTIVE_ELEMENT_INTERACTIONS_ID + 1usize;
+const JSX_A_11_Y_NO_NONINTERACTIVE_TABINDEX_ID: usize =
+    JSX_A_11_Y_NO_NONINTERACTIVE_ELEMENT_TO_INTERACTIVE_ROLE_ID + 1usize;
 const JSX_A_11_Y_NO_REDUNDANT_ROLES_ID: usize = JSX_A_11_Y_NO_NONINTERACTIVE_TABINDEX_ID + 1usize;
 const JSX_A_11_Y_NO_STATIC_ELEMENT_INTERACTIONS_ID: usize =
     JSX_A_11_Y_NO_REDUNDANT_ROLES_ID + 1usize;
-const JSX_A_11_Y_PREFER_TAG_OVER_ROLE_ID: usize =
+const JSX_A_11_Y_NO_SVG_WITHOUT_TITLE_ID: usize =
     JSX_A_11_Y_NO_STATIC_ELEMENT_INTERACTIONS_ID + 1usize;
+const JSX_A_11_Y_PREFER_TAG_OVER_ROLE_ID: usize = JSX_A_11_Y_NO_SVG_WITHOUT_TITLE_ID + 1usize;
 const JSX_A_11_Y_ROLE_HAS_REQUIRED_ARIA_PROPS_ID: usize =
     JSX_A_11_Y_PREFER_TAG_OVER_ROLE_ID + 1usize;
 const JSX_A_11_Y_ROLE_SUPPORTS_ARIA_PROPS_ID: usize =
     JSX_A_11_Y_ROLE_HAS_REQUIRED_ARIA_PROPS_ID + 1usize;
 const JSX_A_11_Y_SCOPE_ID: usize = JSX_A_11_Y_ROLE_SUPPORTS_ARIA_PROPS_ID + 1usize;
 const JSX_A_11_Y_TABINDEX_NO_POSITIVE_ID: usize = JSX_A_11_Y_SCOPE_ID + 1usize;
-const OXC_APPROX_CONSTANT_ID: usize = JSX_A_11_Y_TABINDEX_NO_POSITIVE_ID + 1usize;
+const JSX_A_11_Y_USE_FOCUSABLE_INTERACTIVE_ID: usize = JSX_A_11_Y_TABINDEX_NO_POSITIVE_ID + 1usize;
+const JSX_A_11_Y_USE_UNIQUE_ELEMENT_IDS_ID: usize =
+    JSX_A_11_Y_USE_FOCUSABLE_INTERACTIVE_ID + 1usize;
+const OXC_APPROX_CONSTANT_ID: usize = JSX_A_11_Y_USE_UNIQUE_ELEMENT_IDS_ID + 1usize;
 const OXC_BAD_ARRAY_METHOD_ON_ARGUMENTS_ID: usize = OXC_APPROX_CONSTANT_ID + 1usize;
 const OXC_BAD_BITWISE_OPERATOR_ID: usize = OXC_BAD_ARRAY_METHOD_ON_ARGUMENTS_ID + 1usize;
 const OXC_BAD_CHAR_AT_COMPARISON_ID: usize = OXC_BAD_BITWISE_OPERATOR_ID + 1usize;
@@ -2217,7 +2349,8 @@ const VITEST_WARN_TODO_ID: usize = VITEST_REQUIRE_TEST_TIMEOUT_ID + 1usize;
 const NODE_GLOBAL_REQUIRE_ID: usize = VITEST_WARN_TODO_ID + 1usize;
 const NODE_HANDLE_CALLBACK_ERR_ID: usize = NODE_GLOBAL_REQUIRE_ID + 1usize;
 const NODE_NO_EXPORTS_ASSIGN_ID: usize = NODE_HANDLE_CALLBACK_ERR_ID + 1usize;
-const NODE_NO_NEW_REQUIRE_ID: usize = NODE_NO_EXPORTS_ASSIGN_ID + 1usize;
+const NODE_NO_GLOBAL_DIRNAME_FILENAME_ID: usize = NODE_NO_EXPORTS_ASSIGN_ID + 1usize;
+const NODE_NO_NEW_REQUIRE_ID: usize = NODE_NO_GLOBAL_DIRNAME_FILENAME_ID + 1usize;
 const NODE_NO_PATH_CONCAT_ID: usize = NODE_NO_NEW_REQUIRE_ID + 1usize;
 const NODE_NO_PROCESS_ENV_ID: usize = NODE_NO_PATH_CONCAT_ID + 1usize;
 const VUE_DEFINE_EMITS_DECLARATION_ID: usize = NODE_NO_PROCESS_ENV_ID + 1usize;
@@ -2259,6 +2392,9 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => IMPORT_NO_CYCLE_ID,
             Self::ImportNoDefaultExport(_) => IMPORT_NO_DEFAULT_EXPORT_ID,
             Self::ImportNoDuplicates(_) => IMPORT_NO_DUPLICATES_ID,
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                IMPORT_NO_DYNAMIC_NAMESPACE_IMPORT_ACCESS_ID
+            }
             Self::ImportNoDynamicRequire(_) => IMPORT_NO_DYNAMIC_REQUIRE_ID,
             Self::ImportNoEmptyNamedBlocks(_) => IMPORT_NO_EMPTY_NAMED_BLOCKS_ID,
             Self::ImportNoMutableExports(_) => IMPORT_NO_MUTABLE_EXPORTS_ID,
@@ -2268,9 +2404,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => IMPORT_NO_NAMED_EXPORT_ID,
             Self::ImportNoNamespace(_) => IMPORT_NO_NAMESPACE_ID,
             Self::ImportNoNodejsModules(_) => IMPORT_NO_NODEJS_MODULES_ID,
+            Self::ImportNoPrivateImports(_) => IMPORT_NO_PRIVATE_IMPORTS_ID,
             Self::ImportNoRelativeParentImports(_) => IMPORT_NO_RELATIVE_PARENT_IMPORTS_ID,
             Self::ImportNoSelfImport(_) => IMPORT_NO_SELF_IMPORT_ID,
             Self::ImportNoUnassignedImport(_) => IMPORT_NO_UNASSIGNED_IMPORT_ID,
+            Self::ImportNoUndeclaredDependencies(_) => IMPORT_NO_UNDECLARED_DEPENDENCIES_ID,
+            Self::ImportNoUnresolvedImports(_) => IMPORT_NO_UNRESOLVED_IMPORTS_ID,
             Self::ImportNoWebpackLoaderSyntax(_) => IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID,
             Self::ImportPreferDefaultExport(_) => IMPORT_PREFER_DEFAULT_EXPORT_ID,
             Self::ImportUnambiguous(_) => IMPORT_UNAMBIGUOUS_ID,
@@ -2313,6 +2452,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => ESLINT_NO_CLASS_ASSIGN_ID,
             Self::EslintNoCompareNegZero(_) => ESLINT_NO_COMPARE_NEG_ZERO_ID,
             Self::EslintNoCondAssign(_) => ESLINT_NO_COND_ASSIGN_ID,
+            Self::EslintNoConfusingLabels(_) => ESLINT_NO_CONFUSING_LABELS_ID,
             Self::EslintNoConsole(_) => ESLINT_NO_CONSOLE_ID,
             Self::EslintNoConstAssign(_) => ESLINT_NO_CONST_ASSIGN_ID,
             Self::EslintNoConstantBinaryExpression(_) => ESLINT_NO_CONSTANT_BINARY_EXPRESSION_ID,
@@ -2370,12 +2510,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(_) => ESLINT_NO_NONOCTAL_DECIMAL_ESCAPE_ID,
             Self::EslintNoObjCalls(_) => ESLINT_NO_OBJ_CALLS_ID,
             Self::EslintNoObjectConstructor(_) => ESLINT_NO_OBJECT_CONSTRUCTOR_ID,
+            Self::EslintNoOctalEscape(_) => ESLINT_NO_OCTAL_ESCAPE_ID,
             Self::EslintNoParamReassign(_) => ESLINT_NO_PARAM_REASSIGN_ID,
             Self::EslintNoPlusplus(_) => ESLINT_NO_PLUSPLUS_ID,
             Self::EslintNoPromiseExecutorReturn(_) => ESLINT_NO_PROMISE_EXECUTOR_RETURN_ID,
             Self::EslintNoProto(_) => ESLINT_NO_PROTO_ID,
             Self::EslintNoPrototypeBuiltins(_) => ESLINT_NO_PROTOTYPE_BUILTINS_ID,
             Self::EslintNoRedeclare(_) => ESLINT_NO_REDECLARE_ID,
+            Self::EslintNoRedundantUseStrict(_) => ESLINT_NO_REDUNDANT_USE_STRICT_ID,
             Self::EslintNoRegexSpaces(_) => ESLINT_NO_REGEX_SPACES_ID,
             Self::EslintNoRestrictedGlobals(_) => ESLINT_NO_RESTRICTED_GLOBALS_ID,
             Self::EslintNoRestrictedImports(_) => ESLINT_NO_RESTRICTED_IMPORTS_ID,
@@ -2387,7 +2529,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(_) => ESLINT_NO_SETTER_RETURN_ID,
             Self::EslintNoShadow(_) => ESLINT_NO_SHADOW_ID,
             Self::EslintNoShadowRestrictedNames(_) => ESLINT_NO_SHADOW_RESTRICTED_NAMES_ID,
+            Self::EslintNoShoutyConstants(_) => ESLINT_NO_SHOUTY_CONSTANTS_ID,
             Self::EslintNoSparseArrays(_) => ESLINT_NO_SPARSE_ARRAYS_ID,
+            Self::EslintNoStringCaseMismatch(_) => ESLINT_NO_STRING_CASE_MISMATCH_ID,
             Self::EslintNoTemplateCurlyInString(_) => ESLINT_NO_TEMPLATE_CURLY_IN_STRING_ID,
             Self::EslintNoTernary(_) => ESLINT_NO_TERNARY_ID,
             Self::EslintNoThisBeforeSuper(_) => ESLINT_NO_THIS_BEFORE_SUPER_ID,
@@ -2414,6 +2558,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => ESLINT_NO_USELESS_COMPUTED_KEY_ID,
             Self::EslintNoUselessConcat(_) => ESLINT_NO_USELESS_CONCAT_ID,
             Self::EslintNoUselessConstructor(_) => ESLINT_NO_USELESS_CONSTRUCTOR_ID,
+            Self::EslintNoUselessContinue(_) => ESLINT_NO_USELESS_CONTINUE_ID,
             Self::EslintNoUselessEscape(_) => ESLINT_NO_USELESS_ESCAPE_ID,
             Self::EslintNoUselessRename(_) => ESLINT_NO_USELESS_RENAME_ID,
             Self::EslintNoUselessReturn(_) => ESLINT_NO_USELESS_RETURN_ID,
@@ -2423,6 +2568,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => ESLINT_NO_WITH_ID,
             Self::EslintObjectShorthand(_) => ESLINT_OBJECT_SHORTHAND_ID,
             Self::EslintOperatorAssignment(_) => ESLINT_OPERATOR_ASSIGNMENT_ID,
+            Self::EslintPreferArrowCallback(_) => ESLINT_PREFER_ARROW_CALLBACK_ID,
             Self::EslintPreferConst(_) => ESLINT_PREFER_CONST_ID,
             Self::EslintPreferDestructuring(_) => ESLINT_PREFER_DESTRUCTURING_ID,
             Self::EslintPreferExponentiationOperator(_) => ESLINT_PREFER_EXPONENTIATION_OPERATOR_ID,
@@ -2443,6 +2589,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => ESLINT_SYMBOL_DESCRIPTION_ID,
             Self::EslintUnicodeBom(_) => ESLINT_UNICODE_BOM_ID,
             Self::EslintUseIsnan(_) => ESLINT_USE_ISNAN_ID,
+            Self::EslintUseRegexLiterals(_) => ESLINT_USE_REGEX_LITERALS_ID,
+            Self::EslintUseSingleVarDeclarator(_) => ESLINT_USE_SINGLE_VAR_DECLARATOR_ID,
+            Self::EslintUseWhile(_) => ESLINT_USE_WHILE_ID,
             Self::EslintValidTypeof(_) => ESLINT_VALID_TYPEOF_ID,
             Self::EslintVarsOnTop(_) => ESLINT_VARS_ON_TOP_ID,
             Self::EslintYoda(_) => ESLINT_YODA_ID,
@@ -2474,9 +2623,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TYPESCRIPT_EXPLICIT_FUNCTION_RETURN_TYPE_ID
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID
             }
+            Self::TypescriptNamingConvention(_) => TYPESCRIPT_NAMING_CONVENTION_ID,
             Self::TypescriptNoArrayDelete(_) => TYPESCRIPT_NO_ARRAY_DELETE_ID,
             Self::TypescriptNoBaseToString(_) => TYPESCRIPT_NO_BASE_TO_STRING_ID,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -2493,11 +2646,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => TYPESCRIPT_NO_DYNAMIC_DELETE_ID,
             Self::TypescriptNoEmptyInterface(_) => TYPESCRIPT_NO_EMPTY_INTERFACE_ID,
             Self::TypescriptNoEmptyObjectType(_) => TYPESCRIPT_NO_EMPTY_OBJECT_TYPE_ID,
+            Self::TypescriptNoEmptyTypeParameters(_) => TYPESCRIPT_NO_EMPTY_TYPE_PARAMETERS_ID,
+            Self::TypescriptNoEnum(_) => TYPESCRIPT_NO_ENUM_ID,
+            Self::TypescriptNoEvolvingTypes(_) => TYPESCRIPT_NO_EVOLVING_TYPES_ID,
             Self::TypescriptNoExplicitAny(_) => TYPESCRIPT_NO_EXPLICIT_ANY_ID,
             Self::TypescriptNoExtraNonNullAssertion(_) => TYPESCRIPT_NO_EXTRA_NON_NULL_ASSERTION_ID,
             Self::TypescriptNoExtraneousClass(_) => TYPESCRIPT_NO_EXTRANEOUS_CLASS_ID,
             Self::TypescriptNoFloatingPromises(_) => TYPESCRIPT_NO_FLOATING_PROMISES_ID,
             Self::TypescriptNoForInArray(_) => TYPESCRIPT_NO_FOR_IN_ARRAY_ID,
+            Self::TypescriptNoImplicitAnyLet(_) => TYPESCRIPT_NO_IMPLICIT_ANY_LET_ID,
             Self::TypescriptNoImpliedEval(_) => TYPESCRIPT_NO_IMPLIED_EVAL_ID,
             Self::TypescriptNoImportTypeSideEffects(_) => TYPESCRIPT_NO_IMPORT_TYPE_SIDE_EFFECTS_ID,
             Self::TypescriptNoInferrableTypes(_) => TYPESCRIPT_NO_INFERRABLE_TYPES_ID,
@@ -2523,6 +2680,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => TYPESCRIPT_NO_REQUIRE_IMPORTS_ID,
             Self::TypescriptNoRestrictedTypes(_) => TYPESCRIPT_NO_RESTRICTED_TYPES_ID,
             Self::TypescriptNoThisAlias(_) => TYPESCRIPT_NO_THIS_ALIAS_ID,
+            Self::TypescriptNoThisInStatic(_) => TYPESCRIPT_NO_THIS_IN_STATIC_ID,
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TYPESCRIPT_NO_UNNECESSARY_BOOLEAN_LITERAL_COMPARE_ID
             }
@@ -2712,16 +2870,20 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => REACT_NO_DID_MOUNT_SET_STATE_ID,
             Self::ReactNoDirectMutationState(_) => REACT_NO_DIRECT_MUTATION_STATE_ID,
             Self::ReactNoFindDomNode(_) => REACT_NO_FIND_DOM_NODE_ID,
+            Self::ReactNoForwardRef(_) => REACT_NO_FORWARD_REF_ID,
             Self::ReactNoIsMounted(_) => REACT_NO_IS_MOUNTED_ID,
+            Self::ReactNoJsxLiterals(_) => REACT_NO_JSX_LITERALS_ID,
             Self::ReactNoMultiComp(_) => REACT_NO_MULTI_COMP_ID,
             Self::ReactNoNamespace(_) => REACT_NO_NAMESPACE_ID,
             Self::ReactNoReactChildren(_) => REACT_NO_REACT_CHILDREN_ID,
+            Self::ReactNoReactSpecificProps(_) => REACT_NO_REACT_SPECIFIC_PROPS_ID,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 REACT_NO_REDUNDANT_SHOULD_COMPONENT_UPDATE_ID
             }
             Self::ReactNoRenderReturnValue(_) => REACT_NO_RENDER_RETURN_VALUE_ID,
             Self::ReactNoSetState(_) => REACT_NO_SET_STATE_ID,
             Self::ReactNoStringRefs(_) => REACT_NO_STRING_REFS_ID,
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => REACT_NO_SUSPICIOUS_SEMICOLON_IN_JSX_ID,
             Self::ReactNoThisInSfc(_) => REACT_NO_THIS_IN_SFC_ID,
             Self::ReactNoUnescapedEntities(_) => REACT_NO_UNESCAPED_ENTITIES_ID,
             Self::ReactNoUnknownProperty(_) => REACT_NO_UNKNOWN_PROPERTY_ID,
@@ -2736,6 +2898,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => REACT_SELF_CLOSING_COMP_ID,
             Self::ReactStateInConstructor(_) => REACT_STATE_IN_CONSTRUCTOR_ID,
             Self::ReactStylePropObject(_) => REACT_STYLE_PROP_OBJECT_ID,
+            Self::ReactUseImageSize(_) => REACT_USE_IMAGE_SIZE_ID,
             Self::ReactVoidDomElementsNoChildren(_) => REACT_VOID_DOM_ELEMENTS_NO_CHILDREN_ID,
             Self::ReactPerfJsxNoJsxAsProp(_) => REACT_PERF_JSX_NO_JSX_AS_PROP_ID,
             Self::ReactPerfJsxNoNewArrayAsProp(_) => REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID,
@@ -2770,6 +2933,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UNICORN_NO_CONSOLE_SPACES_ID,
             Self::UnicornNoDocumentCookie(_) => UNICORN_NO_DOCUMENT_COOKIE_ID,
             Self::UnicornNoEmptyFile(_) => UNICORN_NO_EMPTY_FILE_ID,
+            Self::UnicornNoFlatMapIdentity(_) => UNICORN_NO_FLAT_MAP_IDENTITY_ID,
             Self::UnicornNoHexEscape(_) => UNICORN_NO_HEX_ESCAPE_ID,
             Self::UnicornNoImmediateMutation(_) => UNICORN_NO_IMMEDIATE_MUTATION_ID,
             Self::UnicornNoInstanceofArray(_) => UNICORN_NO_INSTANCEOF_ARRAY_ID,
@@ -2819,8 +2983,12 @@ impl RuleEnum {
                 UNICORN_NO_USELESS_PROMISE_RESOLVE_REJECT_ID
             }
             Self::UnicornNoUselessSpread(_) => UNICORN_NO_USELESS_SPREAD_ID,
+            Self::UnicornNoUselessStringRaw(_) => UNICORN_NO_USELESS_STRING_RAW_ID,
             Self::UnicornNoUselessSwitchCase(_) => UNICORN_NO_USELESS_SWITCH_CASE_ID,
             Self::UnicornNoUselessUndefined(_) => UNICORN_NO_USELESS_UNDEFINED_ID,
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UNICORN_NO_USELESS_UNDEFINED_INITIALIZATION_ID
+            }
             Self::UnicornNoZeroFractions(_) => UNICORN_NO_ZERO_FRACTIONS_ID,
             Self::UnicornNumberLiteralCase(_) => UNICORN_NUMBER_LITERAL_CASE_ID,
             Self::UnicornNumericSeparatorsStyle(_) => UNICORN_NUMERIC_SEPARATORS_STYLE_ID,
@@ -2893,6 +3061,12 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(_) => UNICORN_SWITCH_CASE_BREAK_POSITION_ID,
             Self::UnicornTextEncodingIdentifierCase(_) => UNICORN_TEXT_ENCODING_IDENTIFIER_CASE_ID,
             Self::UnicornThrowNewError(_) => UNICORN_THROW_NEW_ERROR_ID,
+            Self::UnicornUseCollapsedIf(_) => UNICORN_USE_COLLAPSED_IF_ID,
+            Self::UnicornUseConsistentCurlyBraces(_) => UNICORN_USE_CONSISTENT_CURLY_BRACES_ID,
+            Self::UnicornUseSimpleNumberKeys(_) => UNICORN_USE_SIMPLE_NUMBER_KEYS_ID,
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UNICORN_USE_SIMPLIFIED_LOGIC_EXPRESSION_ID
+            }
             Self::JsxA11YAltText(_) => JSX_A_11_Y_ALT_TEXT_ID,
             Self::JsxA11YAnchorAmbiguousText(_) => JSX_A_11_Y_ANCHOR_AMBIGUOUS_TEXT_ID,
             Self::JsxA11YAnchorHasContent(_) => JSX_A_11_Y_ANCHOR_HAS_CONTENT_ID,
@@ -2918,16 +3092,28 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(_) => JSX_A_11_Y_NO_ARIA_HIDDEN_ON_FOCUSABLE_ID,
             Self::JsxA11YNoAutofocus(_) => JSX_A_11_Y_NO_AUTOFOCUS_ID,
             Self::JsxA11YNoDistractingElements(_) => JSX_A_11_Y_NO_DISTRACTING_ELEMENTS_ID,
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JSX_A_11_Y_NO_INTERACTIVE_ELEMENT_TO_NONINTERACTIVE_ROLE_ID
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JSX_A_11_Y_NO_NONINTERACTIVE_ELEMENT_INTERACTIONS_ID
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JSX_A_11_Y_NO_NONINTERACTIVE_ELEMENT_TO_INTERACTIVE_ROLE_ID
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => JSX_A_11_Y_NO_NONINTERACTIVE_TABINDEX_ID,
             Self::JsxA11YNoRedundantRoles(_) => JSX_A_11_Y_NO_REDUNDANT_ROLES_ID,
             Self::JsxA11YNoStaticElementInteractions(_) => {
                 JSX_A_11_Y_NO_STATIC_ELEMENT_INTERACTIONS_ID
             }
+            Self::JsxA11YNoSvgWithoutTitle(_) => JSX_A_11_Y_NO_SVG_WITHOUT_TITLE_ID,
             Self::JsxA11YPreferTagOverRole(_) => JSX_A_11_Y_PREFER_TAG_OVER_ROLE_ID,
             Self::JsxA11YRoleHasRequiredAriaProps(_) => JSX_A_11_Y_ROLE_HAS_REQUIRED_ARIA_PROPS_ID,
             Self::JsxA11YRoleSupportsAriaProps(_) => JSX_A_11_Y_ROLE_SUPPORTS_ARIA_PROPS_ID,
             Self::JsxA11YScope(_) => JSX_A_11_Y_SCOPE_ID,
             Self::JsxA11YTabindexNoPositive(_) => JSX_A_11_Y_TABINDEX_NO_POSITIVE_ID,
+            Self::JsxA11YUseFocusableInteractive(_) => JSX_A_11_Y_USE_FOCUSABLE_INTERACTIVE_ID,
+            Self::JsxA11YUseUniqueElementIds(_) => JSX_A_11_Y_USE_UNIQUE_ELEMENT_IDS_ID,
             Self::OxcApproxConstant(_) => OXC_APPROX_CONSTANT_ID,
             Self::OxcBadArrayMethodOnArguments(_) => OXC_BAD_ARRAY_METHOD_ON_ARGUMENTS_ID,
             Self::OxcBadBitwiseOperator(_) => OXC_BAD_BITWISE_OPERATOR_ID,
@@ -3038,6 +3224,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => NODE_GLOBAL_REQUIRE_ID,
             Self::NodeHandleCallbackErr(_) => NODE_HANDLE_CALLBACK_ERR_ID,
             Self::NodeNoExportsAssign(_) => NODE_NO_EXPORTS_ASSIGN_ID,
+            Self::NodeNoGlobalDirnameFilename(_) => NODE_NO_GLOBAL_DIRNAME_FILENAME_ID,
             Self::NodeNoNewRequire(_) => NODE_NO_NEW_REQUIRE_ID,
             Self::NodeNoPathConcat(_) => NODE_NO_PATH_CONCAT_ID,
             Self::NodeNoProcessEnv(_) => NODE_NO_PROCESS_ENV_ID,
@@ -3079,6 +3266,9 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => ImportNoCycle::NAME,
             Self::ImportNoDefaultExport(_) => ImportNoDefaultExport::NAME,
             Self::ImportNoDuplicates(_) => ImportNoDuplicates::NAME,
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                ImportNoDynamicNamespaceImportAccess::NAME
+            }
             Self::ImportNoDynamicRequire(_) => ImportNoDynamicRequire::NAME,
             Self::ImportNoEmptyNamedBlocks(_) => ImportNoEmptyNamedBlocks::NAME,
             Self::ImportNoMutableExports(_) => ImportNoMutableExports::NAME,
@@ -3088,9 +3278,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => ImportNoNamedExport::NAME,
             Self::ImportNoNamespace(_) => ImportNoNamespace::NAME,
             Self::ImportNoNodejsModules(_) => ImportNoNodejsModules::NAME,
+            Self::ImportNoPrivateImports(_) => ImportNoPrivateImports::NAME,
             Self::ImportNoRelativeParentImports(_) => ImportNoRelativeParentImports::NAME,
             Self::ImportNoSelfImport(_) => ImportNoSelfImport::NAME,
             Self::ImportNoUnassignedImport(_) => ImportNoUnassignedImport::NAME,
+            Self::ImportNoUndeclaredDependencies(_) => ImportNoUndeclaredDependencies::NAME,
+            Self::ImportNoUnresolvedImports(_) => ImportNoUnresolvedImports::NAME,
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::NAME,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::NAME,
             Self::ImportUnambiguous(_) => ImportUnambiguous::NAME,
@@ -3133,6 +3326,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => EslintNoClassAssign::NAME,
             Self::EslintNoCompareNegZero(_) => EslintNoCompareNegZero::NAME,
             Self::EslintNoCondAssign(_) => EslintNoCondAssign::NAME,
+            Self::EslintNoConfusingLabels(_) => EslintNoConfusingLabels::NAME,
             Self::EslintNoConsole(_) => EslintNoConsole::NAME,
             Self::EslintNoConstAssign(_) => EslintNoConstAssign::NAME,
             Self::EslintNoConstantBinaryExpression(_) => EslintNoConstantBinaryExpression::NAME,
@@ -3190,12 +3384,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(_) => EslintNoNonoctalDecimalEscape::NAME,
             Self::EslintNoObjCalls(_) => EslintNoObjCalls::NAME,
             Self::EslintNoObjectConstructor(_) => EslintNoObjectConstructor::NAME,
+            Self::EslintNoOctalEscape(_) => EslintNoOctalEscape::NAME,
             Self::EslintNoParamReassign(_) => EslintNoParamReassign::NAME,
             Self::EslintNoPlusplus(_) => EslintNoPlusplus::NAME,
             Self::EslintNoPromiseExecutorReturn(_) => EslintNoPromiseExecutorReturn::NAME,
             Self::EslintNoProto(_) => EslintNoProto::NAME,
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::NAME,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::NAME,
+            Self::EslintNoRedundantUseStrict(_) => EslintNoRedundantUseStrict::NAME,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::NAME,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::NAME,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::NAME,
@@ -3207,7 +3403,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(_) => EslintNoSetterReturn::NAME,
             Self::EslintNoShadow(_) => EslintNoShadow::NAME,
             Self::EslintNoShadowRestrictedNames(_) => EslintNoShadowRestrictedNames::NAME,
+            Self::EslintNoShoutyConstants(_) => EslintNoShoutyConstants::NAME,
             Self::EslintNoSparseArrays(_) => EslintNoSparseArrays::NAME,
+            Self::EslintNoStringCaseMismatch(_) => EslintNoStringCaseMismatch::NAME,
             Self::EslintNoTemplateCurlyInString(_) => EslintNoTemplateCurlyInString::NAME,
             Self::EslintNoTernary(_) => EslintNoTernary::NAME,
             Self::EslintNoThisBeforeSuper(_) => EslintNoThisBeforeSuper::NAME,
@@ -3234,6 +3432,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => EslintNoUselessComputedKey::NAME,
             Self::EslintNoUselessConcat(_) => EslintNoUselessConcat::NAME,
             Self::EslintNoUselessConstructor(_) => EslintNoUselessConstructor::NAME,
+            Self::EslintNoUselessContinue(_) => EslintNoUselessContinue::NAME,
             Self::EslintNoUselessEscape(_) => EslintNoUselessEscape::NAME,
             Self::EslintNoUselessRename(_) => EslintNoUselessRename::NAME,
             Self::EslintNoUselessReturn(_) => EslintNoUselessReturn::NAME,
@@ -3243,6 +3442,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => EslintNoWith::NAME,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::NAME,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::NAME,
+            Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::NAME,
             Self::EslintPreferConst(_) => EslintPreferConst::NAME,
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::NAME,
             Self::EslintPreferExponentiationOperator(_) => EslintPreferExponentiationOperator::NAME,
@@ -3263,6 +3463,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => EslintSymbolDescription::NAME,
             Self::EslintUnicodeBom(_) => EslintUnicodeBom::NAME,
             Self::EslintUseIsnan(_) => EslintUseIsnan::NAME,
+            Self::EslintUseRegexLiterals(_) => EslintUseRegexLiterals::NAME,
+            Self::EslintUseSingleVarDeclarator(_) => EslintUseSingleVarDeclarator::NAME,
+            Self::EslintUseWhile(_) => EslintUseWhile::NAME,
             Self::EslintValidTypeof(_) => EslintValidTypeof::NAME,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::NAME,
             Self::EslintYoda(_) => EslintYoda::NAME,
@@ -3294,9 +3497,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::NAME
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::NAME
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::NAME
             }
+            Self::TypescriptNamingConvention(_) => TypescriptNamingConvention::NAME,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::NAME,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::NAME,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -3313,11 +3520,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => TypescriptNoDynamicDelete::NAME,
             Self::TypescriptNoEmptyInterface(_) => TypescriptNoEmptyInterface::NAME,
             Self::TypescriptNoEmptyObjectType(_) => TypescriptNoEmptyObjectType::NAME,
+            Self::TypescriptNoEmptyTypeParameters(_) => TypescriptNoEmptyTypeParameters::NAME,
+            Self::TypescriptNoEnum(_) => TypescriptNoEnum::NAME,
+            Self::TypescriptNoEvolvingTypes(_) => TypescriptNoEvolvingTypes::NAME,
             Self::TypescriptNoExplicitAny(_) => TypescriptNoExplicitAny::NAME,
             Self::TypescriptNoExtraNonNullAssertion(_) => TypescriptNoExtraNonNullAssertion::NAME,
             Self::TypescriptNoExtraneousClass(_) => TypescriptNoExtraneousClass::NAME,
             Self::TypescriptNoFloatingPromises(_) => TypescriptNoFloatingPromises::NAME,
             Self::TypescriptNoForInArray(_) => TypescriptNoForInArray::NAME,
+            Self::TypescriptNoImplicitAnyLet(_) => TypescriptNoImplicitAnyLet::NAME,
             Self::TypescriptNoImpliedEval(_) => TypescriptNoImpliedEval::NAME,
             Self::TypescriptNoImportTypeSideEffects(_) => TypescriptNoImportTypeSideEffects::NAME,
             Self::TypescriptNoInferrableTypes(_) => TypescriptNoInferrableTypes::NAME,
@@ -3343,6 +3554,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => TypescriptNoRequireImports::NAME,
             Self::TypescriptNoRestrictedTypes(_) => TypescriptNoRestrictedTypes::NAME,
             Self::TypescriptNoThisAlias(_) => TypescriptNoThisAlias::NAME,
+            Self::TypescriptNoThisInStatic(_) => TypescriptNoThisInStatic::NAME,
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TypescriptNoUnnecessaryBooleanLiteralCompare::NAME
             }
@@ -3528,16 +3740,20 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::NAME,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::NAME,
             Self::ReactNoFindDomNode(_) => ReactNoFindDomNode::NAME,
+            Self::ReactNoForwardRef(_) => ReactNoForwardRef::NAME,
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::NAME,
+            Self::ReactNoJsxLiterals(_) => ReactNoJsxLiterals::NAME,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::NAME,
             Self::ReactNoNamespace(_) => ReactNoNamespace::NAME,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::NAME,
+            Self::ReactNoReactSpecificProps(_) => ReactNoReactSpecificProps::NAME,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::NAME
             }
             Self::ReactNoRenderReturnValue(_) => ReactNoRenderReturnValue::NAME,
             Self::ReactNoSetState(_) => ReactNoSetState::NAME,
             Self::ReactNoStringRefs(_) => ReactNoStringRefs::NAME,
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => ReactNoSuspiciousSemicolonInJsx::NAME,
             Self::ReactNoThisInSfc(_) => ReactNoThisInSfc::NAME,
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::NAME,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::NAME,
@@ -3552,6 +3768,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => ReactSelfClosingComp::NAME,
             Self::ReactStateInConstructor(_) => ReactStateInConstructor::NAME,
             Self::ReactStylePropObject(_) => ReactStylePropObject::NAME,
+            Self::ReactUseImageSize(_) => ReactUseImageSize::NAME,
             Self::ReactVoidDomElementsNoChildren(_) => ReactVoidDomElementsNoChildren::NAME,
             Self::ReactPerfJsxNoJsxAsProp(_) => ReactPerfJsxNoJsxAsProp::NAME,
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::NAME,
@@ -3586,6 +3803,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::NAME,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::NAME,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::NAME,
+            Self::UnicornNoFlatMapIdentity(_) => UnicornNoFlatMapIdentity::NAME,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::NAME,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::NAME,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::NAME,
@@ -3631,8 +3849,12 @@ impl RuleEnum {
                 UnicornNoUselessPromiseResolveReject::NAME
             }
             Self::UnicornNoUselessSpread(_) => UnicornNoUselessSpread::NAME,
+            Self::UnicornNoUselessStringRaw(_) => UnicornNoUselessStringRaw::NAME,
             Self::UnicornNoUselessSwitchCase(_) => UnicornNoUselessSwitchCase::NAME,
             Self::UnicornNoUselessUndefined(_) => UnicornNoUselessUndefined::NAME,
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UnicornNoUselessUndefinedInitialization::NAME
+            }
             Self::UnicornNoZeroFractions(_) => UnicornNoZeroFractions::NAME,
             Self::UnicornNumberLiteralCase(_) => UnicornNumberLiteralCase::NAME,
             Self::UnicornNumericSeparatorsStyle(_) => UnicornNumericSeparatorsStyle::NAME,
@@ -3705,6 +3927,12 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(_) => UnicornSwitchCaseBreakPosition::NAME,
             Self::UnicornTextEncodingIdentifierCase(_) => UnicornTextEncodingIdentifierCase::NAME,
             Self::UnicornThrowNewError(_) => UnicornThrowNewError::NAME,
+            Self::UnicornUseCollapsedIf(_) => UnicornUseCollapsedIf::NAME,
+            Self::UnicornUseConsistentCurlyBraces(_) => UnicornUseConsistentCurlyBraces::NAME,
+            Self::UnicornUseSimpleNumberKeys(_) => UnicornUseSimpleNumberKeys::NAME,
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UnicornUseSimplifiedLogicExpression::NAME
+            }
             Self::JsxA11YAltText(_) => JsxA11YAltText::NAME,
             Self::JsxA11YAnchorAmbiguousText(_) => JsxA11YAnchorAmbiguousText::NAME,
             Self::JsxA11YAnchorHasContent(_) => JsxA11YAnchorHasContent::NAME,
@@ -3730,14 +3958,26 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(_) => JsxA11YNoAriaHiddenOnFocusable::NAME,
             Self::JsxA11YNoAutofocus(_) => JsxA11YNoAutofocus::NAME,
             Self::JsxA11YNoDistractingElements(_) => JsxA11YNoDistractingElements::NAME,
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JsxA11YNoInteractiveElementToNoninteractiveRole::NAME
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JsxA11YNoNoninteractiveElementInteractions::NAME
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JsxA11YNoNoninteractiveElementToInteractiveRole::NAME
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => JsxA11YNoNoninteractiveTabindex::NAME,
             Self::JsxA11YNoRedundantRoles(_) => JsxA11YNoRedundantRoles::NAME,
             Self::JsxA11YNoStaticElementInteractions(_) => JsxA11YNoStaticElementInteractions::NAME,
+            Self::JsxA11YNoSvgWithoutTitle(_) => JsxA11YNoSvgWithoutTitle::NAME,
             Self::JsxA11YPreferTagOverRole(_) => JsxA11YPreferTagOverRole::NAME,
             Self::JsxA11YRoleHasRequiredAriaProps(_) => JsxA11YRoleHasRequiredAriaProps::NAME,
             Self::JsxA11YRoleSupportsAriaProps(_) => JsxA11YRoleSupportsAriaProps::NAME,
             Self::JsxA11YScope(_) => JsxA11YScope::NAME,
             Self::JsxA11YTabindexNoPositive(_) => JsxA11YTabindexNoPositive::NAME,
+            Self::JsxA11YUseFocusableInteractive(_) => JsxA11YUseFocusableInteractive::NAME,
+            Self::JsxA11YUseUniqueElementIds(_) => JsxA11YUseUniqueElementIds::NAME,
             Self::OxcApproxConstant(_) => OxcApproxConstant::NAME,
             Self::OxcBadArrayMethodOnArguments(_) => OxcBadArrayMethodOnArguments::NAME,
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::NAME,
@@ -3848,6 +4088,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::NAME,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::NAME,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::NAME,
+            Self::NodeNoGlobalDirnameFilename(_) => NodeNoGlobalDirnameFilename::NAME,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::NAME,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::NAME,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::NAME,
@@ -3891,6 +4132,9 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => ImportNoCycle::CATEGORY,
             Self::ImportNoDefaultExport(_) => ImportNoDefaultExport::CATEGORY,
             Self::ImportNoDuplicates(_) => ImportNoDuplicates::CATEGORY,
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                ImportNoDynamicNamespaceImportAccess::CATEGORY
+            }
             Self::ImportNoDynamicRequire(_) => ImportNoDynamicRequire::CATEGORY,
             Self::ImportNoEmptyNamedBlocks(_) => ImportNoEmptyNamedBlocks::CATEGORY,
             Self::ImportNoMutableExports(_) => ImportNoMutableExports::CATEGORY,
@@ -3900,9 +4144,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => ImportNoNamedExport::CATEGORY,
             Self::ImportNoNamespace(_) => ImportNoNamespace::CATEGORY,
             Self::ImportNoNodejsModules(_) => ImportNoNodejsModules::CATEGORY,
+            Self::ImportNoPrivateImports(_) => ImportNoPrivateImports::CATEGORY,
             Self::ImportNoRelativeParentImports(_) => ImportNoRelativeParentImports::CATEGORY,
             Self::ImportNoSelfImport(_) => ImportNoSelfImport::CATEGORY,
             Self::ImportNoUnassignedImport(_) => ImportNoUnassignedImport::CATEGORY,
+            Self::ImportNoUndeclaredDependencies(_) => ImportNoUndeclaredDependencies::CATEGORY,
+            Self::ImportNoUnresolvedImports(_) => ImportNoUnresolvedImports::CATEGORY,
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::CATEGORY,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::CATEGORY,
             Self::ImportUnambiguous(_) => ImportUnambiguous::CATEGORY,
@@ -3945,6 +4192,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => EslintNoClassAssign::CATEGORY,
             Self::EslintNoCompareNegZero(_) => EslintNoCompareNegZero::CATEGORY,
             Self::EslintNoCondAssign(_) => EslintNoCondAssign::CATEGORY,
+            Self::EslintNoConfusingLabels(_) => EslintNoConfusingLabels::CATEGORY,
             Self::EslintNoConsole(_) => EslintNoConsole::CATEGORY,
             Self::EslintNoConstAssign(_) => EslintNoConstAssign::CATEGORY,
             Self::EslintNoConstantBinaryExpression(_) => EslintNoConstantBinaryExpression::CATEGORY,
@@ -4002,12 +4250,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(_) => EslintNoNonoctalDecimalEscape::CATEGORY,
             Self::EslintNoObjCalls(_) => EslintNoObjCalls::CATEGORY,
             Self::EslintNoObjectConstructor(_) => EslintNoObjectConstructor::CATEGORY,
+            Self::EslintNoOctalEscape(_) => EslintNoOctalEscape::CATEGORY,
             Self::EslintNoParamReassign(_) => EslintNoParamReassign::CATEGORY,
             Self::EslintNoPlusplus(_) => EslintNoPlusplus::CATEGORY,
             Self::EslintNoPromiseExecutorReturn(_) => EslintNoPromiseExecutorReturn::CATEGORY,
             Self::EslintNoProto(_) => EslintNoProto::CATEGORY,
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::CATEGORY,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::CATEGORY,
+            Self::EslintNoRedundantUseStrict(_) => EslintNoRedundantUseStrict::CATEGORY,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::CATEGORY,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::CATEGORY,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::CATEGORY,
@@ -4019,7 +4269,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(_) => EslintNoSetterReturn::CATEGORY,
             Self::EslintNoShadow(_) => EslintNoShadow::CATEGORY,
             Self::EslintNoShadowRestrictedNames(_) => EslintNoShadowRestrictedNames::CATEGORY,
+            Self::EslintNoShoutyConstants(_) => EslintNoShoutyConstants::CATEGORY,
             Self::EslintNoSparseArrays(_) => EslintNoSparseArrays::CATEGORY,
+            Self::EslintNoStringCaseMismatch(_) => EslintNoStringCaseMismatch::CATEGORY,
             Self::EslintNoTemplateCurlyInString(_) => EslintNoTemplateCurlyInString::CATEGORY,
             Self::EslintNoTernary(_) => EslintNoTernary::CATEGORY,
             Self::EslintNoThisBeforeSuper(_) => EslintNoThisBeforeSuper::CATEGORY,
@@ -4048,6 +4300,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => EslintNoUselessComputedKey::CATEGORY,
             Self::EslintNoUselessConcat(_) => EslintNoUselessConcat::CATEGORY,
             Self::EslintNoUselessConstructor(_) => EslintNoUselessConstructor::CATEGORY,
+            Self::EslintNoUselessContinue(_) => EslintNoUselessContinue::CATEGORY,
             Self::EslintNoUselessEscape(_) => EslintNoUselessEscape::CATEGORY,
             Self::EslintNoUselessRename(_) => EslintNoUselessRename::CATEGORY,
             Self::EslintNoUselessReturn(_) => EslintNoUselessReturn::CATEGORY,
@@ -4057,6 +4310,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => EslintNoWith::CATEGORY,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::CATEGORY,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::CATEGORY,
+            Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::CATEGORY,
             Self::EslintPreferConst(_) => EslintPreferConst::CATEGORY,
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::CATEGORY,
             Self::EslintPreferExponentiationOperator(_) => {
@@ -4079,6 +4333,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => EslintSymbolDescription::CATEGORY,
             Self::EslintUnicodeBom(_) => EslintUnicodeBom::CATEGORY,
             Self::EslintUseIsnan(_) => EslintUseIsnan::CATEGORY,
+            Self::EslintUseRegexLiterals(_) => EslintUseRegexLiterals::CATEGORY,
+            Self::EslintUseSingleVarDeclarator(_) => EslintUseSingleVarDeclarator::CATEGORY,
+            Self::EslintUseWhile(_) => EslintUseWhile::CATEGORY,
             Self::EslintValidTypeof(_) => EslintValidTypeof::CATEGORY,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::CATEGORY,
             Self::EslintYoda(_) => EslintYoda::CATEGORY,
@@ -4112,9 +4369,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::CATEGORY
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::CATEGORY
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::CATEGORY
             }
+            Self::TypescriptNamingConvention(_) => TypescriptNamingConvention::CATEGORY,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::CATEGORY,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::CATEGORY,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -4131,6 +4392,9 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => TypescriptNoDynamicDelete::CATEGORY,
             Self::TypescriptNoEmptyInterface(_) => TypescriptNoEmptyInterface::CATEGORY,
             Self::TypescriptNoEmptyObjectType(_) => TypescriptNoEmptyObjectType::CATEGORY,
+            Self::TypescriptNoEmptyTypeParameters(_) => TypescriptNoEmptyTypeParameters::CATEGORY,
+            Self::TypescriptNoEnum(_) => TypescriptNoEnum::CATEGORY,
+            Self::TypescriptNoEvolvingTypes(_) => TypescriptNoEvolvingTypes::CATEGORY,
             Self::TypescriptNoExplicitAny(_) => TypescriptNoExplicitAny::CATEGORY,
             Self::TypescriptNoExtraNonNullAssertion(_) => {
                 TypescriptNoExtraNonNullAssertion::CATEGORY
@@ -4138,6 +4402,7 @@ impl RuleEnum {
             Self::TypescriptNoExtraneousClass(_) => TypescriptNoExtraneousClass::CATEGORY,
             Self::TypescriptNoFloatingPromises(_) => TypescriptNoFloatingPromises::CATEGORY,
             Self::TypescriptNoForInArray(_) => TypescriptNoForInArray::CATEGORY,
+            Self::TypescriptNoImplicitAnyLet(_) => TypescriptNoImplicitAnyLet::CATEGORY,
             Self::TypescriptNoImpliedEval(_) => TypescriptNoImpliedEval::CATEGORY,
             Self::TypescriptNoImportTypeSideEffects(_) => {
                 TypescriptNoImportTypeSideEffects::CATEGORY
@@ -4165,6 +4430,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => TypescriptNoRequireImports::CATEGORY,
             Self::TypescriptNoRestrictedTypes(_) => TypescriptNoRestrictedTypes::CATEGORY,
             Self::TypescriptNoThisAlias(_) => TypescriptNoThisAlias::CATEGORY,
+            Self::TypescriptNoThisInStatic(_) => TypescriptNoThisInStatic::CATEGORY,
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TypescriptNoUnnecessaryBooleanLiteralCompare::CATEGORY
             }
@@ -4364,16 +4630,20 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::CATEGORY,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::CATEGORY,
             Self::ReactNoFindDomNode(_) => ReactNoFindDomNode::CATEGORY,
+            Self::ReactNoForwardRef(_) => ReactNoForwardRef::CATEGORY,
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::CATEGORY,
+            Self::ReactNoJsxLiterals(_) => ReactNoJsxLiterals::CATEGORY,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::CATEGORY,
             Self::ReactNoNamespace(_) => ReactNoNamespace::CATEGORY,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::CATEGORY,
+            Self::ReactNoReactSpecificProps(_) => ReactNoReactSpecificProps::CATEGORY,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::CATEGORY
             }
             Self::ReactNoRenderReturnValue(_) => ReactNoRenderReturnValue::CATEGORY,
             Self::ReactNoSetState(_) => ReactNoSetState::CATEGORY,
             Self::ReactNoStringRefs(_) => ReactNoStringRefs::CATEGORY,
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => ReactNoSuspiciousSemicolonInJsx::CATEGORY,
             Self::ReactNoThisInSfc(_) => ReactNoThisInSfc::CATEGORY,
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::CATEGORY,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::CATEGORY,
@@ -4388,6 +4658,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => ReactSelfClosingComp::CATEGORY,
             Self::ReactStateInConstructor(_) => ReactStateInConstructor::CATEGORY,
             Self::ReactStylePropObject(_) => ReactStylePropObject::CATEGORY,
+            Self::ReactUseImageSize(_) => ReactUseImageSize::CATEGORY,
             Self::ReactVoidDomElementsNoChildren(_) => ReactVoidDomElementsNoChildren::CATEGORY,
             Self::ReactPerfJsxNoJsxAsProp(_) => ReactPerfJsxNoJsxAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::CATEGORY,
@@ -4424,6 +4695,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::CATEGORY,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::CATEGORY,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::CATEGORY,
+            Self::UnicornNoFlatMapIdentity(_) => UnicornNoFlatMapIdentity::CATEGORY,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::CATEGORY,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::CATEGORY,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::CATEGORY,
@@ -4475,8 +4747,12 @@ impl RuleEnum {
                 UnicornNoUselessPromiseResolveReject::CATEGORY
             }
             Self::UnicornNoUselessSpread(_) => UnicornNoUselessSpread::CATEGORY,
+            Self::UnicornNoUselessStringRaw(_) => UnicornNoUselessStringRaw::CATEGORY,
             Self::UnicornNoUselessSwitchCase(_) => UnicornNoUselessSwitchCase::CATEGORY,
             Self::UnicornNoUselessUndefined(_) => UnicornNoUselessUndefined::CATEGORY,
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UnicornNoUselessUndefinedInitialization::CATEGORY
+            }
             Self::UnicornNoZeroFractions(_) => UnicornNoZeroFractions::CATEGORY,
             Self::UnicornNumberLiteralCase(_) => UnicornNumberLiteralCase::CATEGORY,
             Self::UnicornNumericSeparatorsStyle(_) => UnicornNumericSeparatorsStyle::CATEGORY,
@@ -4555,6 +4831,12 @@ impl RuleEnum {
                 UnicornTextEncodingIdentifierCase::CATEGORY
             }
             Self::UnicornThrowNewError(_) => UnicornThrowNewError::CATEGORY,
+            Self::UnicornUseCollapsedIf(_) => UnicornUseCollapsedIf::CATEGORY,
+            Self::UnicornUseConsistentCurlyBraces(_) => UnicornUseConsistentCurlyBraces::CATEGORY,
+            Self::UnicornUseSimpleNumberKeys(_) => UnicornUseSimpleNumberKeys::CATEGORY,
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UnicornUseSimplifiedLogicExpression::CATEGORY
+            }
             Self::JsxA11YAltText(_) => JsxA11YAltText::CATEGORY,
             Self::JsxA11YAnchorAmbiguousText(_) => JsxA11YAnchorAmbiguousText::CATEGORY,
             Self::JsxA11YAnchorHasContent(_) => JsxA11YAnchorHasContent::CATEGORY,
@@ -4580,16 +4862,28 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(_) => JsxA11YNoAriaHiddenOnFocusable::CATEGORY,
             Self::JsxA11YNoAutofocus(_) => JsxA11YNoAutofocus::CATEGORY,
             Self::JsxA11YNoDistractingElements(_) => JsxA11YNoDistractingElements::CATEGORY,
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JsxA11YNoInteractiveElementToNoninteractiveRole::CATEGORY
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JsxA11YNoNoninteractiveElementInteractions::CATEGORY
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JsxA11YNoNoninteractiveElementToInteractiveRole::CATEGORY
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => JsxA11YNoNoninteractiveTabindex::CATEGORY,
             Self::JsxA11YNoRedundantRoles(_) => JsxA11YNoRedundantRoles::CATEGORY,
             Self::JsxA11YNoStaticElementInteractions(_) => {
                 JsxA11YNoStaticElementInteractions::CATEGORY
             }
+            Self::JsxA11YNoSvgWithoutTitle(_) => JsxA11YNoSvgWithoutTitle::CATEGORY,
             Self::JsxA11YPreferTagOverRole(_) => JsxA11YPreferTagOverRole::CATEGORY,
             Self::JsxA11YRoleHasRequiredAriaProps(_) => JsxA11YRoleHasRequiredAriaProps::CATEGORY,
             Self::JsxA11YRoleSupportsAriaProps(_) => JsxA11YRoleSupportsAriaProps::CATEGORY,
             Self::JsxA11YScope(_) => JsxA11YScope::CATEGORY,
             Self::JsxA11YTabindexNoPositive(_) => JsxA11YTabindexNoPositive::CATEGORY,
+            Self::JsxA11YUseFocusableInteractive(_) => JsxA11YUseFocusableInteractive::CATEGORY,
+            Self::JsxA11YUseUniqueElementIds(_) => JsxA11YUseUniqueElementIds::CATEGORY,
             Self::OxcApproxConstant(_) => OxcApproxConstant::CATEGORY,
             Self::OxcBadArrayMethodOnArguments(_) => OxcBadArrayMethodOnArguments::CATEGORY,
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::CATEGORY,
@@ -4706,6 +5000,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::CATEGORY,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::CATEGORY,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::CATEGORY,
+            Self::NodeNoGlobalDirnameFilename(_) => NodeNoGlobalDirnameFilename::CATEGORY,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::CATEGORY,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::CATEGORY,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::CATEGORY,
@@ -4750,6 +5045,9 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => ImportNoCycle::FIX,
             Self::ImportNoDefaultExport(_) => ImportNoDefaultExport::FIX,
             Self::ImportNoDuplicates(_) => ImportNoDuplicates::FIX,
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                ImportNoDynamicNamespaceImportAccess::FIX
+            }
             Self::ImportNoDynamicRequire(_) => ImportNoDynamicRequire::FIX,
             Self::ImportNoEmptyNamedBlocks(_) => ImportNoEmptyNamedBlocks::FIX,
             Self::ImportNoMutableExports(_) => ImportNoMutableExports::FIX,
@@ -4759,9 +5057,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => ImportNoNamedExport::FIX,
             Self::ImportNoNamespace(_) => ImportNoNamespace::FIX,
             Self::ImportNoNodejsModules(_) => ImportNoNodejsModules::FIX,
+            Self::ImportNoPrivateImports(_) => ImportNoPrivateImports::FIX,
             Self::ImportNoRelativeParentImports(_) => ImportNoRelativeParentImports::FIX,
             Self::ImportNoSelfImport(_) => ImportNoSelfImport::FIX,
             Self::ImportNoUnassignedImport(_) => ImportNoUnassignedImport::FIX,
+            Self::ImportNoUndeclaredDependencies(_) => ImportNoUndeclaredDependencies::FIX,
+            Self::ImportNoUnresolvedImports(_) => ImportNoUnresolvedImports::FIX,
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::FIX,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::FIX,
             Self::ImportUnambiguous(_) => ImportUnambiguous::FIX,
@@ -4804,6 +5105,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => EslintNoClassAssign::FIX,
             Self::EslintNoCompareNegZero(_) => EslintNoCompareNegZero::FIX,
             Self::EslintNoCondAssign(_) => EslintNoCondAssign::FIX,
+            Self::EslintNoConfusingLabels(_) => EslintNoConfusingLabels::FIX,
             Self::EslintNoConsole(_) => EslintNoConsole::FIX,
             Self::EslintNoConstAssign(_) => EslintNoConstAssign::FIX,
             Self::EslintNoConstantBinaryExpression(_) => EslintNoConstantBinaryExpression::FIX,
@@ -4861,12 +5163,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(_) => EslintNoNonoctalDecimalEscape::FIX,
             Self::EslintNoObjCalls(_) => EslintNoObjCalls::FIX,
             Self::EslintNoObjectConstructor(_) => EslintNoObjectConstructor::FIX,
+            Self::EslintNoOctalEscape(_) => EslintNoOctalEscape::FIX,
             Self::EslintNoParamReassign(_) => EslintNoParamReassign::FIX,
             Self::EslintNoPlusplus(_) => EslintNoPlusplus::FIX,
             Self::EslintNoPromiseExecutorReturn(_) => EslintNoPromiseExecutorReturn::FIX,
             Self::EslintNoProto(_) => EslintNoProto::FIX,
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::FIX,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::FIX,
+            Self::EslintNoRedundantUseStrict(_) => EslintNoRedundantUseStrict::FIX,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::FIX,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::FIX,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::FIX,
@@ -4878,7 +5182,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(_) => EslintNoSetterReturn::FIX,
             Self::EslintNoShadow(_) => EslintNoShadow::FIX,
             Self::EslintNoShadowRestrictedNames(_) => EslintNoShadowRestrictedNames::FIX,
+            Self::EslintNoShoutyConstants(_) => EslintNoShoutyConstants::FIX,
             Self::EslintNoSparseArrays(_) => EslintNoSparseArrays::FIX,
+            Self::EslintNoStringCaseMismatch(_) => EslintNoStringCaseMismatch::FIX,
             Self::EslintNoTemplateCurlyInString(_) => EslintNoTemplateCurlyInString::FIX,
             Self::EslintNoTernary(_) => EslintNoTernary::FIX,
             Self::EslintNoThisBeforeSuper(_) => EslintNoThisBeforeSuper::FIX,
@@ -4905,6 +5211,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => EslintNoUselessComputedKey::FIX,
             Self::EslintNoUselessConcat(_) => EslintNoUselessConcat::FIX,
             Self::EslintNoUselessConstructor(_) => EslintNoUselessConstructor::FIX,
+            Self::EslintNoUselessContinue(_) => EslintNoUselessContinue::FIX,
             Self::EslintNoUselessEscape(_) => EslintNoUselessEscape::FIX,
             Self::EslintNoUselessRename(_) => EslintNoUselessRename::FIX,
             Self::EslintNoUselessReturn(_) => EslintNoUselessReturn::FIX,
@@ -4914,6 +5221,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => EslintNoWith::FIX,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::FIX,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::FIX,
+            Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::FIX,
             Self::EslintPreferConst(_) => EslintPreferConst::FIX,
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::FIX,
             Self::EslintPreferExponentiationOperator(_) => EslintPreferExponentiationOperator::FIX,
@@ -4934,6 +5242,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => EslintSymbolDescription::FIX,
             Self::EslintUnicodeBom(_) => EslintUnicodeBom::FIX,
             Self::EslintUseIsnan(_) => EslintUseIsnan::FIX,
+            Self::EslintUseRegexLiterals(_) => EslintUseRegexLiterals::FIX,
+            Self::EslintUseSingleVarDeclarator(_) => EslintUseSingleVarDeclarator::FIX,
+            Self::EslintUseWhile(_) => EslintUseWhile::FIX,
             Self::EslintValidTypeof(_) => EslintValidTypeof::FIX,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::FIX,
             Self::EslintYoda(_) => EslintYoda::FIX,
@@ -4965,9 +5276,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::FIX
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::FIX
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::FIX
             }
+            Self::TypescriptNamingConvention(_) => TypescriptNamingConvention::FIX,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::FIX,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::FIX,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -4984,11 +5299,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => TypescriptNoDynamicDelete::FIX,
             Self::TypescriptNoEmptyInterface(_) => TypescriptNoEmptyInterface::FIX,
             Self::TypescriptNoEmptyObjectType(_) => TypescriptNoEmptyObjectType::FIX,
+            Self::TypescriptNoEmptyTypeParameters(_) => TypescriptNoEmptyTypeParameters::FIX,
+            Self::TypescriptNoEnum(_) => TypescriptNoEnum::FIX,
+            Self::TypescriptNoEvolvingTypes(_) => TypescriptNoEvolvingTypes::FIX,
             Self::TypescriptNoExplicitAny(_) => TypescriptNoExplicitAny::FIX,
             Self::TypescriptNoExtraNonNullAssertion(_) => TypescriptNoExtraNonNullAssertion::FIX,
             Self::TypescriptNoExtraneousClass(_) => TypescriptNoExtraneousClass::FIX,
             Self::TypescriptNoFloatingPromises(_) => TypescriptNoFloatingPromises::FIX,
             Self::TypescriptNoForInArray(_) => TypescriptNoForInArray::FIX,
+            Self::TypescriptNoImplicitAnyLet(_) => TypescriptNoImplicitAnyLet::FIX,
             Self::TypescriptNoImpliedEval(_) => TypescriptNoImpliedEval::FIX,
             Self::TypescriptNoImportTypeSideEffects(_) => TypescriptNoImportTypeSideEffects::FIX,
             Self::TypescriptNoInferrableTypes(_) => TypescriptNoInferrableTypes::FIX,
@@ -5014,6 +5333,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => TypescriptNoRequireImports::FIX,
             Self::TypescriptNoRestrictedTypes(_) => TypescriptNoRestrictedTypes::FIX,
             Self::TypescriptNoThisAlias(_) => TypescriptNoThisAlias::FIX,
+            Self::TypescriptNoThisInStatic(_) => TypescriptNoThisInStatic::FIX,
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TypescriptNoUnnecessaryBooleanLiteralCompare::FIX
             }
@@ -5199,16 +5519,20 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::FIX,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::FIX,
             Self::ReactNoFindDomNode(_) => ReactNoFindDomNode::FIX,
+            Self::ReactNoForwardRef(_) => ReactNoForwardRef::FIX,
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::FIX,
+            Self::ReactNoJsxLiterals(_) => ReactNoJsxLiterals::FIX,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::FIX,
             Self::ReactNoNamespace(_) => ReactNoNamespace::FIX,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::FIX,
+            Self::ReactNoReactSpecificProps(_) => ReactNoReactSpecificProps::FIX,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::FIX
             }
             Self::ReactNoRenderReturnValue(_) => ReactNoRenderReturnValue::FIX,
             Self::ReactNoSetState(_) => ReactNoSetState::FIX,
             Self::ReactNoStringRefs(_) => ReactNoStringRefs::FIX,
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => ReactNoSuspiciousSemicolonInJsx::FIX,
             Self::ReactNoThisInSfc(_) => ReactNoThisInSfc::FIX,
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::FIX,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::FIX,
@@ -5223,6 +5547,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => ReactSelfClosingComp::FIX,
             Self::ReactStateInConstructor(_) => ReactStateInConstructor::FIX,
             Self::ReactStylePropObject(_) => ReactStylePropObject::FIX,
+            Self::ReactUseImageSize(_) => ReactUseImageSize::FIX,
             Self::ReactVoidDomElementsNoChildren(_) => ReactVoidDomElementsNoChildren::FIX,
             Self::ReactPerfJsxNoJsxAsProp(_) => ReactPerfJsxNoJsxAsProp::FIX,
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::FIX,
@@ -5257,6 +5582,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::FIX,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::FIX,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::FIX,
+            Self::UnicornNoFlatMapIdentity(_) => UnicornNoFlatMapIdentity::FIX,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::FIX,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::FIX,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::FIX,
@@ -5302,8 +5628,12 @@ impl RuleEnum {
                 UnicornNoUselessPromiseResolveReject::FIX
             }
             Self::UnicornNoUselessSpread(_) => UnicornNoUselessSpread::FIX,
+            Self::UnicornNoUselessStringRaw(_) => UnicornNoUselessStringRaw::FIX,
             Self::UnicornNoUselessSwitchCase(_) => UnicornNoUselessSwitchCase::FIX,
             Self::UnicornNoUselessUndefined(_) => UnicornNoUselessUndefined::FIX,
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UnicornNoUselessUndefinedInitialization::FIX
+            }
             Self::UnicornNoZeroFractions(_) => UnicornNoZeroFractions::FIX,
             Self::UnicornNumberLiteralCase(_) => UnicornNumberLiteralCase::FIX,
             Self::UnicornNumericSeparatorsStyle(_) => UnicornNumericSeparatorsStyle::FIX,
@@ -5376,6 +5706,12 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(_) => UnicornSwitchCaseBreakPosition::FIX,
             Self::UnicornTextEncodingIdentifierCase(_) => UnicornTextEncodingIdentifierCase::FIX,
             Self::UnicornThrowNewError(_) => UnicornThrowNewError::FIX,
+            Self::UnicornUseCollapsedIf(_) => UnicornUseCollapsedIf::FIX,
+            Self::UnicornUseConsistentCurlyBraces(_) => UnicornUseConsistentCurlyBraces::FIX,
+            Self::UnicornUseSimpleNumberKeys(_) => UnicornUseSimpleNumberKeys::FIX,
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UnicornUseSimplifiedLogicExpression::FIX
+            }
             Self::JsxA11YAltText(_) => JsxA11YAltText::FIX,
             Self::JsxA11YAnchorAmbiguousText(_) => JsxA11YAnchorAmbiguousText::FIX,
             Self::JsxA11YAnchorHasContent(_) => JsxA11YAnchorHasContent::FIX,
@@ -5401,14 +5737,26 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(_) => JsxA11YNoAriaHiddenOnFocusable::FIX,
             Self::JsxA11YNoAutofocus(_) => JsxA11YNoAutofocus::FIX,
             Self::JsxA11YNoDistractingElements(_) => JsxA11YNoDistractingElements::FIX,
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JsxA11YNoInteractiveElementToNoninteractiveRole::FIX
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JsxA11YNoNoninteractiveElementInteractions::FIX
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JsxA11YNoNoninteractiveElementToInteractiveRole::FIX
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => JsxA11YNoNoninteractiveTabindex::FIX,
             Self::JsxA11YNoRedundantRoles(_) => JsxA11YNoRedundantRoles::FIX,
             Self::JsxA11YNoStaticElementInteractions(_) => JsxA11YNoStaticElementInteractions::FIX,
+            Self::JsxA11YNoSvgWithoutTitle(_) => JsxA11YNoSvgWithoutTitle::FIX,
             Self::JsxA11YPreferTagOverRole(_) => JsxA11YPreferTagOverRole::FIX,
             Self::JsxA11YRoleHasRequiredAriaProps(_) => JsxA11YRoleHasRequiredAriaProps::FIX,
             Self::JsxA11YRoleSupportsAriaProps(_) => JsxA11YRoleSupportsAriaProps::FIX,
             Self::JsxA11YScope(_) => JsxA11YScope::FIX,
             Self::JsxA11YTabindexNoPositive(_) => JsxA11YTabindexNoPositive::FIX,
+            Self::JsxA11YUseFocusableInteractive(_) => JsxA11YUseFocusableInteractive::FIX,
+            Self::JsxA11YUseUniqueElementIds(_) => JsxA11YUseUniqueElementIds::FIX,
             Self::OxcApproxConstant(_) => OxcApproxConstant::FIX,
             Self::OxcBadArrayMethodOnArguments(_) => OxcBadArrayMethodOnArguments::FIX,
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::FIX,
@@ -5519,6 +5867,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::FIX,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::FIX,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::FIX,
+            Self::NodeNoGlobalDirnameFilename(_) => NodeNoGlobalDirnameFilename::FIX,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::FIX,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::FIX,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::FIX,
@@ -5565,6 +5914,9 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => ImportNoCycle::documentation(),
             Self::ImportNoDefaultExport(_) => ImportNoDefaultExport::documentation(),
             Self::ImportNoDuplicates(_) => ImportNoDuplicates::documentation(),
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                ImportNoDynamicNamespaceImportAccess::documentation()
+            }
             Self::ImportNoDynamicRequire(_) => ImportNoDynamicRequire::documentation(),
             Self::ImportNoEmptyNamedBlocks(_) => ImportNoEmptyNamedBlocks::documentation(),
             Self::ImportNoMutableExports(_) => ImportNoMutableExports::documentation(),
@@ -5574,11 +5926,16 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => ImportNoNamedExport::documentation(),
             Self::ImportNoNamespace(_) => ImportNoNamespace::documentation(),
             Self::ImportNoNodejsModules(_) => ImportNoNodejsModules::documentation(),
+            Self::ImportNoPrivateImports(_) => ImportNoPrivateImports::documentation(),
             Self::ImportNoRelativeParentImports(_) => {
                 ImportNoRelativeParentImports::documentation()
             }
             Self::ImportNoSelfImport(_) => ImportNoSelfImport::documentation(),
             Self::ImportNoUnassignedImport(_) => ImportNoUnassignedImport::documentation(),
+            Self::ImportNoUndeclaredDependencies(_) => {
+                ImportNoUndeclaredDependencies::documentation()
+            }
+            Self::ImportNoUnresolvedImports(_) => ImportNoUnresolvedImports::documentation(),
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::documentation(),
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::documentation(),
             Self::ImportUnambiguous(_) => ImportUnambiguous::documentation(),
@@ -5621,6 +5978,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => EslintNoClassAssign::documentation(),
             Self::EslintNoCompareNegZero(_) => EslintNoCompareNegZero::documentation(),
             Self::EslintNoCondAssign(_) => EslintNoCondAssign::documentation(),
+            Self::EslintNoConfusingLabels(_) => EslintNoConfusingLabels::documentation(),
             Self::EslintNoConsole(_) => EslintNoConsole::documentation(),
             Self::EslintNoConstAssign(_) => EslintNoConstAssign::documentation(),
             Self::EslintNoConstantBinaryExpression(_) => {
@@ -5686,6 +6044,7 @@ impl RuleEnum {
             }
             Self::EslintNoObjCalls(_) => EslintNoObjCalls::documentation(),
             Self::EslintNoObjectConstructor(_) => EslintNoObjectConstructor::documentation(),
+            Self::EslintNoOctalEscape(_) => EslintNoOctalEscape::documentation(),
             Self::EslintNoParamReassign(_) => EslintNoParamReassign::documentation(),
             Self::EslintNoPlusplus(_) => EslintNoPlusplus::documentation(),
             Self::EslintNoPromiseExecutorReturn(_) => {
@@ -5694,6 +6053,7 @@ impl RuleEnum {
             Self::EslintNoProto(_) => EslintNoProto::documentation(),
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::documentation(),
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::documentation(),
+            Self::EslintNoRedundantUseStrict(_) => EslintNoRedundantUseStrict::documentation(),
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::documentation(),
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::documentation(),
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::documentation(),
@@ -5707,7 +6067,9 @@ impl RuleEnum {
             Self::EslintNoShadowRestrictedNames(_) => {
                 EslintNoShadowRestrictedNames::documentation()
             }
+            Self::EslintNoShoutyConstants(_) => EslintNoShoutyConstants::documentation(),
             Self::EslintNoSparseArrays(_) => EslintNoSparseArrays::documentation(),
+            Self::EslintNoStringCaseMismatch(_) => EslintNoStringCaseMismatch::documentation(),
             Self::EslintNoTemplateCurlyInString(_) => {
                 EslintNoTemplateCurlyInString::documentation()
             }
@@ -5742,6 +6104,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => EslintNoUselessComputedKey::documentation(),
             Self::EslintNoUselessConcat(_) => EslintNoUselessConcat::documentation(),
             Self::EslintNoUselessConstructor(_) => EslintNoUselessConstructor::documentation(),
+            Self::EslintNoUselessContinue(_) => EslintNoUselessContinue::documentation(),
             Self::EslintNoUselessEscape(_) => EslintNoUselessEscape::documentation(),
             Self::EslintNoUselessRename(_) => EslintNoUselessRename::documentation(),
             Self::EslintNoUselessReturn(_) => EslintNoUselessReturn::documentation(),
@@ -5751,6 +6114,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => EslintNoWith::documentation(),
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::documentation(),
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::documentation(),
+            Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::documentation(),
             Self::EslintPreferConst(_) => EslintPreferConst::documentation(),
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::documentation(),
             Self::EslintPreferExponentiationOperator(_) => {
@@ -5775,6 +6139,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => EslintSymbolDescription::documentation(),
             Self::EslintUnicodeBom(_) => EslintUnicodeBom::documentation(),
             Self::EslintUseIsnan(_) => EslintUseIsnan::documentation(),
+            Self::EslintUseRegexLiterals(_) => EslintUseRegexLiterals::documentation(),
+            Self::EslintUseSingleVarDeclarator(_) => EslintUseSingleVarDeclarator::documentation(),
+            Self::EslintUseWhile(_) => EslintUseWhile::documentation(),
             Self::EslintValidTypeof(_) => EslintValidTypeof::documentation(),
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::documentation(),
             Self::EslintYoda(_) => EslintYoda::documentation(),
@@ -5812,9 +6179,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::documentation()
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::documentation()
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::documentation()
             }
+            Self::TypescriptNamingConvention(_) => TypescriptNamingConvention::documentation(),
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::documentation(),
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::documentation(),
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -5833,6 +6204,11 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => TypescriptNoDynamicDelete::documentation(),
             Self::TypescriptNoEmptyInterface(_) => TypescriptNoEmptyInterface::documentation(),
             Self::TypescriptNoEmptyObjectType(_) => TypescriptNoEmptyObjectType::documentation(),
+            Self::TypescriptNoEmptyTypeParameters(_) => {
+                TypescriptNoEmptyTypeParameters::documentation()
+            }
+            Self::TypescriptNoEnum(_) => TypescriptNoEnum::documentation(),
+            Self::TypescriptNoEvolvingTypes(_) => TypescriptNoEvolvingTypes::documentation(),
             Self::TypescriptNoExplicitAny(_) => TypescriptNoExplicitAny::documentation(),
             Self::TypescriptNoExtraNonNullAssertion(_) => {
                 TypescriptNoExtraNonNullAssertion::documentation()
@@ -5840,6 +6216,7 @@ impl RuleEnum {
             Self::TypescriptNoExtraneousClass(_) => TypescriptNoExtraneousClass::documentation(),
             Self::TypescriptNoFloatingPromises(_) => TypescriptNoFloatingPromises::documentation(),
             Self::TypescriptNoForInArray(_) => TypescriptNoForInArray::documentation(),
+            Self::TypescriptNoImplicitAnyLet(_) => TypescriptNoImplicitAnyLet::documentation(),
             Self::TypescriptNoImpliedEval(_) => TypescriptNoImpliedEval::documentation(),
             Self::TypescriptNoImportTypeSideEffects(_) => {
                 TypescriptNoImportTypeSideEffects::documentation()
@@ -5867,6 +6244,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => TypescriptNoRequireImports::documentation(),
             Self::TypescriptNoRestrictedTypes(_) => TypescriptNoRestrictedTypes::documentation(),
             Self::TypescriptNoThisAlias(_) => TypescriptNoThisAlias::documentation(),
+            Self::TypescriptNoThisInStatic(_) => TypescriptNoThisInStatic::documentation(),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TypescriptNoUnnecessaryBooleanLiteralCompare::documentation()
             }
@@ -6108,16 +6486,22 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::documentation(),
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::documentation(),
             Self::ReactNoFindDomNode(_) => ReactNoFindDomNode::documentation(),
+            Self::ReactNoForwardRef(_) => ReactNoForwardRef::documentation(),
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::documentation(),
+            Self::ReactNoJsxLiterals(_) => ReactNoJsxLiterals::documentation(),
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::documentation(),
             Self::ReactNoNamespace(_) => ReactNoNamespace::documentation(),
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::documentation(),
+            Self::ReactNoReactSpecificProps(_) => ReactNoReactSpecificProps::documentation(),
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::documentation()
             }
             Self::ReactNoRenderReturnValue(_) => ReactNoRenderReturnValue::documentation(),
             Self::ReactNoSetState(_) => ReactNoSetState::documentation(),
             Self::ReactNoStringRefs(_) => ReactNoStringRefs::documentation(),
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => {
+                ReactNoSuspiciousSemicolonInJsx::documentation()
+            }
             Self::ReactNoThisInSfc(_) => ReactNoThisInSfc::documentation(),
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::documentation(),
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::documentation(),
@@ -6132,6 +6516,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => ReactSelfClosingComp::documentation(),
             Self::ReactStateInConstructor(_) => ReactStateInConstructor::documentation(),
             Self::ReactStylePropObject(_) => ReactStylePropObject::documentation(),
+            Self::ReactUseImageSize(_) => ReactUseImageSize::documentation(),
             Self::ReactVoidDomElementsNoChildren(_) => {
                 ReactVoidDomElementsNoChildren::documentation()
             }
@@ -6188,6 +6573,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::documentation(),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::documentation(),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::documentation(),
+            Self::UnicornNoFlatMapIdentity(_) => UnicornNoFlatMapIdentity::documentation(),
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::documentation(),
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::documentation(),
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::documentation(),
@@ -6243,8 +6629,12 @@ impl RuleEnum {
                 UnicornNoUselessPromiseResolveReject::documentation()
             }
             Self::UnicornNoUselessSpread(_) => UnicornNoUselessSpread::documentation(),
+            Self::UnicornNoUselessStringRaw(_) => UnicornNoUselessStringRaw::documentation(),
             Self::UnicornNoUselessSwitchCase(_) => UnicornNoUselessSwitchCase::documentation(),
             Self::UnicornNoUselessUndefined(_) => UnicornNoUselessUndefined::documentation(),
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UnicornNoUselessUndefinedInitialization::documentation()
+            }
             Self::UnicornNoZeroFractions(_) => UnicornNoZeroFractions::documentation(),
             Self::UnicornNumberLiteralCase(_) => UnicornNumberLiteralCase::documentation(),
             Self::UnicornNumericSeparatorsStyle(_) => {
@@ -6355,6 +6745,14 @@ impl RuleEnum {
                 UnicornTextEncodingIdentifierCase::documentation()
             }
             Self::UnicornThrowNewError(_) => UnicornThrowNewError::documentation(),
+            Self::UnicornUseCollapsedIf(_) => UnicornUseCollapsedIf::documentation(),
+            Self::UnicornUseConsistentCurlyBraces(_) => {
+                UnicornUseConsistentCurlyBraces::documentation()
+            }
+            Self::UnicornUseSimpleNumberKeys(_) => UnicornUseSimpleNumberKeys::documentation(),
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UnicornUseSimplifiedLogicExpression::documentation()
+            }
             Self::JsxA11YAltText(_) => JsxA11YAltText::documentation(),
             Self::JsxA11YAnchorAmbiguousText(_) => JsxA11YAnchorAmbiguousText::documentation(),
             Self::JsxA11YAnchorHasContent(_) => JsxA11YAnchorHasContent::documentation(),
@@ -6390,6 +6788,15 @@ impl RuleEnum {
             }
             Self::JsxA11YNoAutofocus(_) => JsxA11YNoAutofocus::documentation(),
             Self::JsxA11YNoDistractingElements(_) => JsxA11YNoDistractingElements::documentation(),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JsxA11YNoInteractiveElementToNoninteractiveRole::documentation()
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JsxA11YNoNoninteractiveElementInteractions::documentation()
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JsxA11YNoNoninteractiveElementToInteractiveRole::documentation()
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => {
                 JsxA11YNoNoninteractiveTabindex::documentation()
             }
@@ -6397,6 +6804,7 @@ impl RuleEnum {
             Self::JsxA11YNoStaticElementInteractions(_) => {
                 JsxA11YNoStaticElementInteractions::documentation()
             }
+            Self::JsxA11YNoSvgWithoutTitle(_) => JsxA11YNoSvgWithoutTitle::documentation(),
             Self::JsxA11YPreferTagOverRole(_) => JsxA11YPreferTagOverRole::documentation(),
             Self::JsxA11YRoleHasRequiredAriaProps(_) => {
                 JsxA11YRoleHasRequiredAriaProps::documentation()
@@ -6404,6 +6812,10 @@ impl RuleEnum {
             Self::JsxA11YRoleSupportsAriaProps(_) => JsxA11YRoleSupportsAriaProps::documentation(),
             Self::JsxA11YScope(_) => JsxA11YScope::documentation(),
             Self::JsxA11YTabindexNoPositive(_) => JsxA11YTabindexNoPositive::documentation(),
+            Self::JsxA11YUseFocusableInteractive(_) => {
+                JsxA11YUseFocusableInteractive::documentation()
+            }
+            Self::JsxA11YUseUniqueElementIds(_) => JsxA11YUseUniqueElementIds::documentation(),
             Self::OxcApproxConstant(_) => OxcApproxConstant::documentation(),
             Self::OxcBadArrayMethodOnArguments(_) => OxcBadArrayMethodOnArguments::documentation(),
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::documentation(),
@@ -6536,6 +6948,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::documentation(),
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::documentation(),
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::documentation(),
+            Self::NodeNoGlobalDirnameFilename(_) => NodeNoGlobalDirnameFilename::documentation(),
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::documentation(),
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::documentation(),
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::documentation(),
@@ -6610,6 +7023,10 @@ impl RuleEnum {
                 .or_else(|| ImportNoDefaultExport::schema(generator)),
             Self::ImportNoDuplicates(_) => ImportNoDuplicates::config_schema(generator)
                 .or_else(|| ImportNoDuplicates::schema(generator)),
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                ImportNoDynamicNamespaceImportAccess::config_schema(generator)
+                    .or_else(|| ImportNoDynamicNamespaceImportAccess::schema(generator))
+            }
             Self::ImportNoDynamicRequire(_) => ImportNoDynamicRequire::config_schema(generator)
                 .or_else(|| ImportNoDynamicRequire::schema(generator)),
             Self::ImportNoEmptyNamedBlocks(_) => ImportNoEmptyNamedBlocks::config_schema(generator)
@@ -6630,6 +7047,8 @@ impl RuleEnum {
                 .or_else(|| ImportNoNamespace::schema(generator)),
             Self::ImportNoNodejsModules(_) => ImportNoNodejsModules::config_schema(generator)
                 .or_else(|| ImportNoNodejsModules::schema(generator)),
+            Self::ImportNoPrivateImports(_) => ImportNoPrivateImports::config_schema(generator)
+                .or_else(|| ImportNoPrivateImports::schema(generator)),
             Self::ImportNoRelativeParentImports(_) => {
                 ImportNoRelativeParentImports::config_schema(generator)
                     .or_else(|| ImportNoRelativeParentImports::schema(generator))
@@ -6638,6 +7057,14 @@ impl RuleEnum {
                 .or_else(|| ImportNoSelfImport::schema(generator)),
             Self::ImportNoUnassignedImport(_) => ImportNoUnassignedImport::config_schema(generator)
                 .or_else(|| ImportNoUnassignedImport::schema(generator)),
+            Self::ImportNoUndeclaredDependencies(_) => {
+                ImportNoUndeclaredDependencies::config_schema(generator)
+                    .or_else(|| ImportNoUndeclaredDependencies::schema(generator))
+            }
+            Self::ImportNoUnresolvedImports(_) => {
+                ImportNoUnresolvedImports::config_schema(generator)
+                    .or_else(|| ImportNoUnresolvedImports::schema(generator))
+            }
             Self::ImportNoWebpackLoaderSyntax(_) => {
                 ImportNoWebpackLoaderSyntax::config_schema(generator)
                     .or_else(|| ImportNoWebpackLoaderSyntax::schema(generator))
@@ -6742,6 +7169,8 @@ impl RuleEnum {
                 .or_else(|| EslintNoCompareNegZero::schema(generator)),
             Self::EslintNoCondAssign(_) => EslintNoCondAssign::config_schema(generator)
                 .or_else(|| EslintNoCondAssign::schema(generator)),
+            Self::EslintNoConfusingLabels(_) => EslintNoConfusingLabels::config_schema(generator)
+                .or_else(|| EslintNoConfusingLabels::schema(generator)),
             Self::EslintNoConsole(_) => EslintNoConsole::config_schema(generator)
                 .or_else(|| EslintNoConsole::schema(generator)),
             Self::EslintNoConstAssign(_) => EslintNoConstAssign::config_schema(generator)
@@ -6879,6 +7308,8 @@ impl RuleEnum {
                 EslintNoObjectConstructor::config_schema(generator)
                     .or_else(|| EslintNoObjectConstructor::schema(generator))
             }
+            Self::EslintNoOctalEscape(_) => EslintNoOctalEscape::config_schema(generator)
+                .or_else(|| EslintNoOctalEscape::schema(generator)),
             Self::EslintNoParamReassign(_) => EslintNoParamReassign::config_schema(generator)
                 .or_else(|| EslintNoParamReassign::schema(generator)),
             Self::EslintNoPlusplus(_) => EslintNoPlusplus::config_schema(generator)
@@ -6896,6 +7327,10 @@ impl RuleEnum {
             }
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::config_schema(generator)
                 .or_else(|| EslintNoRedeclare::schema(generator)),
+            Self::EslintNoRedundantUseStrict(_) => {
+                EslintNoRedundantUseStrict::config_schema(generator)
+                    .or_else(|| EslintNoRedundantUseStrict::schema(generator))
+            }
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::config_schema(generator)
                 .or_else(|| EslintNoRegexSpaces::schema(generator)),
             Self::EslintNoRestrictedGlobals(_) => {
@@ -6924,8 +7359,14 @@ impl RuleEnum {
                 EslintNoShadowRestrictedNames::config_schema(generator)
                     .or_else(|| EslintNoShadowRestrictedNames::schema(generator))
             }
+            Self::EslintNoShoutyConstants(_) => EslintNoShoutyConstants::config_schema(generator)
+                .or_else(|| EslintNoShoutyConstants::schema(generator)),
             Self::EslintNoSparseArrays(_) => EslintNoSparseArrays::config_schema(generator)
                 .or_else(|| EslintNoSparseArrays::schema(generator)),
+            Self::EslintNoStringCaseMismatch(_) => {
+                EslintNoStringCaseMismatch::config_schema(generator)
+                    .or_else(|| EslintNoStringCaseMismatch::schema(generator))
+            }
             Self::EslintNoTemplateCurlyInString(_) => {
                 EslintNoTemplateCurlyInString::config_schema(generator)
                     .or_else(|| EslintNoTemplateCurlyInString::schema(generator))
@@ -6999,6 +7440,8 @@ impl RuleEnum {
                 EslintNoUselessConstructor::config_schema(generator)
                     .or_else(|| EslintNoUselessConstructor::schema(generator))
             }
+            Self::EslintNoUselessContinue(_) => EslintNoUselessContinue::config_schema(generator)
+                .or_else(|| EslintNoUselessContinue::schema(generator)),
             Self::EslintNoUselessEscape(_) => EslintNoUselessEscape::config_schema(generator)
                 .or_else(|| EslintNoUselessEscape::schema(generator)),
             Self::EslintNoUselessRename(_) => EslintNoUselessRename::config_schema(generator)
@@ -7020,6 +7463,10 @@ impl RuleEnum {
                 .or_else(|| EslintObjectShorthand::schema(generator)),
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::config_schema(generator)
                 .or_else(|| EslintOperatorAssignment::schema(generator)),
+            Self::EslintPreferArrowCallback(_) => {
+                EslintPreferArrowCallback::config_schema(generator)
+                    .or_else(|| EslintPreferArrowCallback::schema(generator))
+            }
             Self::EslintPreferConst(_) => EslintPreferConst::config_schema(generator)
                 .or_else(|| EslintPreferConst::schema(generator)),
             Self::EslintPreferDestructuring(_) => {
@@ -7071,6 +7518,14 @@ impl RuleEnum {
                 .or_else(|| EslintUnicodeBom::schema(generator)),
             Self::EslintUseIsnan(_) => EslintUseIsnan::config_schema(generator)
                 .or_else(|| EslintUseIsnan::schema(generator)),
+            Self::EslintUseRegexLiterals(_) => EslintUseRegexLiterals::config_schema(generator)
+                .or_else(|| EslintUseRegexLiterals::schema(generator)),
+            Self::EslintUseSingleVarDeclarator(_) => {
+                EslintUseSingleVarDeclarator::config_schema(generator)
+                    .or_else(|| EslintUseSingleVarDeclarator::schema(generator))
+            }
+            Self::EslintUseWhile(_) => EslintUseWhile::config_schema(generator)
+                .or_else(|| EslintUseWhile::schema(generator)),
             Self::EslintValidTypeof(_) => EslintValidTypeof::config_schema(generator)
                 .or_else(|| EslintValidTypeof::schema(generator)),
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::config_schema(generator)
@@ -7132,9 +7587,17 @@ impl RuleEnum {
                 TypescriptExplicitFunctionReturnType::config_schema(generator)
                     .or_else(|| TypescriptExplicitFunctionReturnType::schema(generator))
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::config_schema(generator)
+                    .or_else(|| TypescriptExplicitMemberAccessibility::schema(generator))
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::config_schema(generator)
                     .or_else(|| TypescriptExplicitModuleBoundaryTypes::schema(generator))
+            }
+            Self::TypescriptNamingConvention(_) => {
+                TypescriptNamingConvention::config_schema(generator)
+                    .or_else(|| TypescriptNamingConvention::schema(generator))
             }
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::config_schema(generator)
                 .or_else(|| TypescriptNoArrayDelete::schema(generator)),
@@ -7170,6 +7633,16 @@ impl RuleEnum {
                 TypescriptNoEmptyObjectType::config_schema(generator)
                     .or_else(|| TypescriptNoEmptyObjectType::schema(generator))
             }
+            Self::TypescriptNoEmptyTypeParameters(_) => {
+                TypescriptNoEmptyTypeParameters::config_schema(generator)
+                    .or_else(|| TypescriptNoEmptyTypeParameters::schema(generator))
+            }
+            Self::TypescriptNoEnum(_) => TypescriptNoEnum::config_schema(generator)
+                .or_else(|| TypescriptNoEnum::schema(generator)),
+            Self::TypescriptNoEvolvingTypes(_) => {
+                TypescriptNoEvolvingTypes::config_schema(generator)
+                    .or_else(|| TypescriptNoEvolvingTypes::schema(generator))
+            }
             Self::TypescriptNoExplicitAny(_) => TypescriptNoExplicitAny::config_schema(generator)
                 .or_else(|| TypescriptNoExplicitAny::schema(generator)),
             Self::TypescriptNoExtraNonNullAssertion(_) => {
@@ -7186,6 +7659,10 @@ impl RuleEnum {
             }
             Self::TypescriptNoForInArray(_) => TypescriptNoForInArray::config_schema(generator)
                 .or_else(|| TypescriptNoForInArray::schema(generator)),
+            Self::TypescriptNoImplicitAnyLet(_) => {
+                TypescriptNoImplicitAnyLet::config_schema(generator)
+                    .or_else(|| TypescriptNoImplicitAnyLet::schema(generator))
+            }
             Self::TypescriptNoImpliedEval(_) => TypescriptNoImpliedEval::config_schema(generator)
                 .or_else(|| TypescriptNoImpliedEval::schema(generator)),
             Self::TypescriptNoImportTypeSideEffects(_) => {
@@ -7244,6 +7721,8 @@ impl RuleEnum {
             }
             Self::TypescriptNoThisAlias(_) => TypescriptNoThisAlias::config_schema(generator)
                 .or_else(|| TypescriptNoThisAlias::schema(generator)),
+            Self::TypescriptNoThisInStatic(_) => TypescriptNoThisInStatic::config_schema(generator)
+                .or_else(|| TypescriptNoThisInStatic::schema(generator)),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TypescriptNoUnnecessaryBooleanLiteralCompare::config_schema(generator)
                     .or_else(|| TypescriptNoUnnecessaryBooleanLiteralCompare::schema(generator))
@@ -7690,14 +8169,22 @@ impl RuleEnum {
             }
             Self::ReactNoFindDomNode(_) => ReactNoFindDomNode::config_schema(generator)
                 .or_else(|| ReactNoFindDomNode::schema(generator)),
+            Self::ReactNoForwardRef(_) => ReactNoForwardRef::config_schema(generator)
+                .or_else(|| ReactNoForwardRef::schema(generator)),
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::config_schema(generator)
                 .or_else(|| ReactNoIsMounted::schema(generator)),
+            Self::ReactNoJsxLiterals(_) => ReactNoJsxLiterals::config_schema(generator)
+                .or_else(|| ReactNoJsxLiterals::schema(generator)),
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::config_schema(generator)
                 .or_else(|| ReactNoMultiComp::schema(generator)),
             Self::ReactNoNamespace(_) => ReactNoNamespace::config_schema(generator)
                 .or_else(|| ReactNoNamespace::schema(generator)),
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::config_schema(generator)
                 .or_else(|| ReactNoReactChildren::schema(generator)),
+            Self::ReactNoReactSpecificProps(_) => {
+                ReactNoReactSpecificProps::config_schema(generator)
+                    .or_else(|| ReactNoReactSpecificProps::schema(generator))
+            }
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::config_schema(generator)
                     .or_else(|| ReactNoRedundantShouldComponentUpdate::schema(generator))
@@ -7708,6 +8195,10 @@ impl RuleEnum {
                 .or_else(|| ReactNoSetState::schema(generator)),
             Self::ReactNoStringRefs(_) => ReactNoStringRefs::config_schema(generator)
                 .or_else(|| ReactNoStringRefs::schema(generator)),
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => {
+                ReactNoSuspiciousSemicolonInJsx::config_schema(generator)
+                    .or_else(|| ReactNoSuspiciousSemicolonInJsx::schema(generator))
+            }
             Self::ReactNoThisInSfc(_) => ReactNoThisInSfc::config_schema(generator)
                 .or_else(|| ReactNoThisInSfc::schema(generator)),
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::config_schema(generator)
@@ -7743,6 +8234,8 @@ impl RuleEnum {
                 .or_else(|| ReactStateInConstructor::schema(generator)),
             Self::ReactStylePropObject(_) => ReactStylePropObject::config_schema(generator)
                 .or_else(|| ReactStylePropObject::schema(generator)),
+            Self::ReactUseImageSize(_) => ReactUseImageSize::config_schema(generator)
+                .or_else(|| ReactUseImageSize::schema(generator)),
             Self::ReactVoidDomElementsNoChildren(_) => {
                 ReactVoidDomElementsNoChildren::config_schema(generator)
                     .or_else(|| ReactVoidDomElementsNoChildren::schema(generator))
@@ -7841,6 +8334,8 @@ impl RuleEnum {
                 .or_else(|| UnicornNoDocumentCookie::schema(generator)),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::config_schema(generator)
                 .or_else(|| UnicornNoEmptyFile::schema(generator)),
+            Self::UnicornNoFlatMapIdentity(_) => UnicornNoFlatMapIdentity::config_schema(generator)
+                .or_else(|| UnicornNoFlatMapIdentity::schema(generator)),
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::config_schema(generator)
                 .or_else(|| UnicornNoHexEscape::schema(generator)),
             Self::UnicornNoImmediateMutation(_) => {
@@ -7946,6 +8441,10 @@ impl RuleEnum {
             }
             Self::UnicornNoUselessSpread(_) => UnicornNoUselessSpread::config_schema(generator)
                 .or_else(|| UnicornNoUselessSpread::schema(generator)),
+            Self::UnicornNoUselessStringRaw(_) => {
+                UnicornNoUselessStringRaw::config_schema(generator)
+                    .or_else(|| UnicornNoUselessStringRaw::schema(generator))
+            }
             Self::UnicornNoUselessSwitchCase(_) => {
                 UnicornNoUselessSwitchCase::config_schema(generator)
                     .or_else(|| UnicornNoUselessSwitchCase::schema(generator))
@@ -7953,6 +8452,10 @@ impl RuleEnum {
             Self::UnicornNoUselessUndefined(_) => {
                 UnicornNoUselessUndefined::config_schema(generator)
                     .or_else(|| UnicornNoUselessUndefined::schema(generator))
+            }
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UnicornNoUselessUndefinedInitialization::config_schema(generator)
+                    .or_else(|| UnicornNoUselessUndefinedInitialization::schema(generator))
             }
             Self::UnicornNoZeroFractions(_) => UnicornNoZeroFractions::config_schema(generator)
                 .or_else(|| UnicornNoZeroFractions::schema(generator)),
@@ -8158,6 +8661,20 @@ impl RuleEnum {
             }
             Self::UnicornThrowNewError(_) => UnicornThrowNewError::config_schema(generator)
                 .or_else(|| UnicornThrowNewError::schema(generator)),
+            Self::UnicornUseCollapsedIf(_) => UnicornUseCollapsedIf::config_schema(generator)
+                .or_else(|| UnicornUseCollapsedIf::schema(generator)),
+            Self::UnicornUseConsistentCurlyBraces(_) => {
+                UnicornUseConsistentCurlyBraces::config_schema(generator)
+                    .or_else(|| UnicornUseConsistentCurlyBraces::schema(generator))
+            }
+            Self::UnicornUseSimpleNumberKeys(_) => {
+                UnicornUseSimpleNumberKeys::config_schema(generator)
+                    .or_else(|| UnicornUseSimpleNumberKeys::schema(generator))
+            }
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UnicornUseSimplifiedLogicExpression::config_schema(generator)
+                    .or_else(|| UnicornUseSimplifiedLogicExpression::schema(generator))
+            }
             Self::JsxA11YAltText(_) => JsxA11YAltText::config_schema(generator)
                 .or_else(|| JsxA11YAltText::schema(generator)),
             Self::JsxA11YAnchorAmbiguousText(_) => {
@@ -8221,6 +8738,18 @@ impl RuleEnum {
                 JsxA11YNoDistractingElements::config_schema(generator)
                     .or_else(|| JsxA11YNoDistractingElements::schema(generator))
             }
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JsxA11YNoInteractiveElementToNoninteractiveRole::config_schema(generator)
+                    .or_else(|| JsxA11YNoInteractiveElementToNoninteractiveRole::schema(generator))
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JsxA11YNoNoninteractiveElementInteractions::config_schema(generator)
+                    .or_else(|| JsxA11YNoNoninteractiveElementInteractions::schema(generator))
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JsxA11YNoNoninteractiveElementToInteractiveRole::config_schema(generator)
+                    .or_else(|| JsxA11YNoNoninteractiveElementToInteractiveRole::schema(generator))
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => {
                 JsxA11YNoNoninteractiveTabindex::config_schema(generator)
                     .or_else(|| JsxA11YNoNoninteractiveTabindex::schema(generator))
@@ -8231,6 +8760,8 @@ impl RuleEnum {
                 JsxA11YNoStaticElementInteractions::config_schema(generator)
                     .or_else(|| JsxA11YNoStaticElementInteractions::schema(generator))
             }
+            Self::JsxA11YNoSvgWithoutTitle(_) => JsxA11YNoSvgWithoutTitle::config_schema(generator)
+                .or_else(|| JsxA11YNoSvgWithoutTitle::schema(generator)),
             Self::JsxA11YPreferTagOverRole(_) => JsxA11YPreferTagOverRole::config_schema(generator)
                 .or_else(|| JsxA11YPreferTagOverRole::schema(generator)),
             Self::JsxA11YRoleHasRequiredAriaProps(_) => {
@@ -8247,6 +8778,14 @@ impl RuleEnum {
             Self::JsxA11YTabindexNoPositive(_) => {
                 JsxA11YTabindexNoPositive::config_schema(generator)
                     .or_else(|| JsxA11YTabindexNoPositive::schema(generator))
+            }
+            Self::JsxA11YUseFocusableInteractive(_) => {
+                JsxA11YUseFocusableInteractive::config_schema(generator)
+                    .or_else(|| JsxA11YUseFocusableInteractive::schema(generator))
+            }
+            Self::JsxA11YUseUniqueElementIds(_) => {
+                JsxA11YUseUniqueElementIds::config_schema(generator)
+                    .or_else(|| JsxA11YUseUniqueElementIds::schema(generator))
             }
             Self::OxcApproxConstant(_) => OxcApproxConstant::config_schema(generator)
                 .or_else(|| OxcApproxConstant::schema(generator)),
@@ -8526,6 +9065,10 @@ impl RuleEnum {
                 .or_else(|| NodeHandleCallbackErr::schema(generator)),
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::config_schema(generator)
                 .or_else(|| NodeNoExportsAssign::schema(generator)),
+            Self::NodeNoGlobalDirnameFilename(_) => {
+                NodeNoGlobalDirnameFilename::config_schema(generator)
+                    .or_else(|| NodeNoGlobalDirnameFilename::schema(generator))
+            }
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::config_schema(generator)
                 .or_else(|| NodeNoNewRequire::schema(generator)),
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::config_schema(generator)
@@ -8604,6 +9147,7 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => "import",
             Self::ImportNoDefaultExport(_) => "import",
             Self::ImportNoDuplicates(_) => "import",
+            Self::ImportNoDynamicNamespaceImportAccess(_) => "import",
             Self::ImportNoDynamicRequire(_) => "import",
             Self::ImportNoEmptyNamedBlocks(_) => "import",
             Self::ImportNoMutableExports(_) => "import",
@@ -8613,9 +9157,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => "import",
             Self::ImportNoNamespace(_) => "import",
             Self::ImportNoNodejsModules(_) => "import",
+            Self::ImportNoPrivateImports(_) => "import",
             Self::ImportNoRelativeParentImports(_) => "import",
             Self::ImportNoSelfImport(_) => "import",
             Self::ImportNoUnassignedImport(_) => "import",
+            Self::ImportNoUndeclaredDependencies(_) => "import",
+            Self::ImportNoUnresolvedImports(_) => "import",
             Self::ImportNoWebpackLoaderSyntax(_) => "import",
             Self::ImportPreferDefaultExport(_) => "import",
             Self::ImportUnambiguous(_) => "import",
@@ -8658,6 +9205,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => "eslint",
             Self::EslintNoCompareNegZero(_) => "eslint",
             Self::EslintNoCondAssign(_) => "eslint",
+            Self::EslintNoConfusingLabels(_) => "eslint",
             Self::EslintNoConsole(_) => "eslint",
             Self::EslintNoConstAssign(_) => "eslint",
             Self::EslintNoConstantBinaryExpression(_) => "eslint",
@@ -8715,12 +9263,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(_) => "eslint",
             Self::EslintNoObjCalls(_) => "eslint",
             Self::EslintNoObjectConstructor(_) => "eslint",
+            Self::EslintNoOctalEscape(_) => "eslint",
             Self::EslintNoParamReassign(_) => "eslint",
             Self::EslintNoPlusplus(_) => "eslint",
             Self::EslintNoPromiseExecutorReturn(_) => "eslint",
             Self::EslintNoProto(_) => "eslint",
             Self::EslintNoPrototypeBuiltins(_) => "eslint",
             Self::EslintNoRedeclare(_) => "eslint",
+            Self::EslintNoRedundantUseStrict(_) => "eslint",
             Self::EslintNoRegexSpaces(_) => "eslint",
             Self::EslintNoRestrictedGlobals(_) => "eslint",
             Self::EslintNoRestrictedImports(_) => "eslint",
@@ -8732,7 +9282,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(_) => "eslint",
             Self::EslintNoShadow(_) => "eslint",
             Self::EslintNoShadowRestrictedNames(_) => "eslint",
+            Self::EslintNoShoutyConstants(_) => "eslint",
             Self::EslintNoSparseArrays(_) => "eslint",
+            Self::EslintNoStringCaseMismatch(_) => "eslint",
             Self::EslintNoTemplateCurlyInString(_) => "eslint",
             Self::EslintNoTernary(_) => "eslint",
             Self::EslintNoThisBeforeSuper(_) => "eslint",
@@ -8759,6 +9311,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => "eslint",
             Self::EslintNoUselessConcat(_) => "eslint",
             Self::EslintNoUselessConstructor(_) => "eslint",
+            Self::EslintNoUselessContinue(_) => "eslint",
             Self::EslintNoUselessEscape(_) => "eslint",
             Self::EslintNoUselessRename(_) => "eslint",
             Self::EslintNoUselessReturn(_) => "eslint",
@@ -8768,6 +9321,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => "eslint",
             Self::EslintObjectShorthand(_) => "eslint",
             Self::EslintOperatorAssignment(_) => "eslint",
+            Self::EslintPreferArrowCallback(_) => "eslint",
             Self::EslintPreferConst(_) => "eslint",
             Self::EslintPreferDestructuring(_) => "eslint",
             Self::EslintPreferExponentiationOperator(_) => "eslint",
@@ -8788,6 +9342,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => "eslint",
             Self::EslintUnicodeBom(_) => "eslint",
             Self::EslintUseIsnan(_) => "eslint",
+            Self::EslintUseRegexLiterals(_) => "eslint",
+            Self::EslintUseSingleVarDeclarator(_) => "eslint",
+            Self::EslintUseWhile(_) => "eslint",
             Self::EslintValidTypeof(_) => "eslint",
             Self::EslintVarsOnTop(_) => "eslint",
             Self::EslintYoda(_) => "eslint",
@@ -8807,7 +9364,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(_) => "typescript",
             Self::TypescriptDotNotation(_) => "typescript",
             Self::TypescriptExplicitFunctionReturnType(_) => "typescript",
+            Self::TypescriptExplicitMemberAccessibility(_) => "typescript",
             Self::TypescriptExplicitModuleBoundaryTypes(_) => "typescript",
+            Self::TypescriptNamingConvention(_) => "typescript",
             Self::TypescriptNoArrayDelete(_) => "typescript",
             Self::TypescriptNoBaseToString(_) => "typescript",
             Self::TypescriptNoConfusingNonNullAssertion(_) => "typescript",
@@ -8818,11 +9377,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => "typescript",
             Self::TypescriptNoEmptyInterface(_) => "typescript",
             Self::TypescriptNoEmptyObjectType(_) => "typescript",
+            Self::TypescriptNoEmptyTypeParameters(_) => "typescript",
+            Self::TypescriptNoEnum(_) => "typescript",
+            Self::TypescriptNoEvolvingTypes(_) => "typescript",
             Self::TypescriptNoExplicitAny(_) => "typescript",
             Self::TypescriptNoExtraNonNullAssertion(_) => "typescript",
             Self::TypescriptNoExtraneousClass(_) => "typescript",
             Self::TypescriptNoFloatingPromises(_) => "typescript",
             Self::TypescriptNoForInArray(_) => "typescript",
+            Self::TypescriptNoImplicitAnyLet(_) => "typescript",
             Self::TypescriptNoImpliedEval(_) => "typescript",
             Self::TypescriptNoImportTypeSideEffects(_) => "typescript",
             Self::TypescriptNoInferrableTypes(_) => "typescript",
@@ -8840,6 +9403,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => "typescript",
             Self::TypescriptNoRestrictedTypes(_) => "typescript",
             Self::TypescriptNoThisAlias(_) => "typescript",
+            Self::TypescriptNoThisInStatic(_) => "typescript",
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => "typescript",
             Self::TypescriptNoUnnecessaryCondition(_) => "typescript",
             Self::TypescriptNoUnnecessaryParameterPropertyAssignment(_) => "typescript",
@@ -8987,14 +9551,18 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => "react",
             Self::ReactNoDirectMutationState(_) => "react",
             Self::ReactNoFindDomNode(_) => "react",
+            Self::ReactNoForwardRef(_) => "react",
             Self::ReactNoIsMounted(_) => "react",
+            Self::ReactNoJsxLiterals(_) => "react",
             Self::ReactNoMultiComp(_) => "react",
             Self::ReactNoNamespace(_) => "react",
             Self::ReactNoReactChildren(_) => "react",
+            Self::ReactNoReactSpecificProps(_) => "react",
             Self::ReactNoRedundantShouldComponentUpdate(_) => "react",
             Self::ReactNoRenderReturnValue(_) => "react",
             Self::ReactNoSetState(_) => "react",
             Self::ReactNoStringRefs(_) => "react",
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => "react",
             Self::ReactNoThisInSfc(_) => "react",
             Self::ReactNoUnescapedEntities(_) => "react",
             Self::ReactNoUnknownProperty(_) => "react",
@@ -9009,6 +9577,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => "react",
             Self::ReactStateInConstructor(_) => "react",
             Self::ReactStylePropObject(_) => "react",
+            Self::ReactUseImageSize(_) => "react",
             Self::ReactVoidDomElementsNoChildren(_) => "react",
             Self::ReactPerfJsxNoJsxAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewArrayAsProp(_) => "react_perf",
@@ -9041,6 +9610,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => "unicorn",
             Self::UnicornNoDocumentCookie(_) => "unicorn",
             Self::UnicornNoEmptyFile(_) => "unicorn",
+            Self::UnicornNoFlatMapIdentity(_) => "unicorn",
             Self::UnicornNoHexEscape(_) => "unicorn",
             Self::UnicornNoImmediateMutation(_) => "unicorn",
             Self::UnicornNoInstanceofArray(_) => "unicorn",
@@ -9074,8 +9644,10 @@ impl RuleEnum {
             Self::UnicornNoUselessLengthCheck(_) => "unicorn",
             Self::UnicornNoUselessPromiseResolveReject(_) => "unicorn",
             Self::UnicornNoUselessSpread(_) => "unicorn",
+            Self::UnicornNoUselessStringRaw(_) => "unicorn",
             Self::UnicornNoUselessSwitchCase(_) => "unicorn",
             Self::UnicornNoUselessUndefined(_) => "unicorn",
+            Self::UnicornNoUselessUndefinedInitialization(_) => "unicorn",
             Self::UnicornNoZeroFractions(_) => "unicorn",
             Self::UnicornNumberLiteralCase(_) => "unicorn",
             Self::UnicornNumericSeparatorsStyle(_) => "unicorn",
@@ -9140,6 +9712,10 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(_) => "unicorn",
             Self::UnicornTextEncodingIdentifierCase(_) => "unicorn",
             Self::UnicornThrowNewError(_) => "unicorn",
+            Self::UnicornUseCollapsedIf(_) => "unicorn",
+            Self::UnicornUseConsistentCurlyBraces(_) => "unicorn",
+            Self::UnicornUseSimpleNumberKeys(_) => "unicorn",
+            Self::UnicornUseSimplifiedLogicExpression(_) => "unicorn",
             Self::JsxA11YAltText(_) => "jsx_a11y",
             Self::JsxA11YAnchorAmbiguousText(_) => "jsx_a11y",
             Self::JsxA11YAnchorHasContent(_) => "jsx_a11y",
@@ -9163,14 +9739,20 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(_) => "jsx_a11y",
             Self::JsxA11YNoAutofocus(_) => "jsx_a11y",
             Self::JsxA11YNoDistractingElements(_) => "jsx_a11y",
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => "jsx_a11y",
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => "jsx_a11y",
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => "jsx_a11y",
             Self::JsxA11YNoNoninteractiveTabindex(_) => "jsx_a11y",
             Self::JsxA11YNoRedundantRoles(_) => "jsx_a11y",
             Self::JsxA11YNoStaticElementInteractions(_) => "jsx_a11y",
+            Self::JsxA11YNoSvgWithoutTitle(_) => "jsx_a11y",
             Self::JsxA11YPreferTagOverRole(_) => "jsx_a11y",
             Self::JsxA11YRoleHasRequiredAriaProps(_) => "jsx_a11y",
             Self::JsxA11YRoleSupportsAriaProps(_) => "jsx_a11y",
             Self::JsxA11YScope(_) => "jsx_a11y",
             Self::JsxA11YTabindexNoPositive(_) => "jsx_a11y",
+            Self::JsxA11YUseFocusableInteractive(_) => "jsx_a11y",
+            Self::JsxA11YUseUniqueElementIds(_) => "jsx_a11y",
             Self::OxcApproxConstant(_) => "oxc",
             Self::OxcBadArrayMethodOnArguments(_) => "oxc",
             Self::OxcBadBitwiseOperator(_) => "oxc",
@@ -9277,6 +9859,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => "node",
             Self::NodeHandleCallbackErr(_) => "node",
             Self::NodeNoExportsAssign(_) => "node",
+            Self::NodeNoGlobalDirnameFilename(_) => "node",
             Self::NodeNoNewRequire(_) => "node",
             Self::NodeNoPathConcat(_) => "node",
             Self::NodeNoProcessEnv(_) => "node",
@@ -9351,6 +9934,11 @@ impl RuleEnum {
             Self::ImportNoDuplicates(_) => {
                 Ok(Self::ImportNoDuplicates(ImportNoDuplicates::from_configuration(value)?))
             }
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                Ok(Self::ImportNoDynamicNamespaceImportAccess(
+                    ImportNoDynamicNamespaceImportAccess::from_configuration(value)?,
+                ))
+            }
             Self::ImportNoDynamicRequire(_) => {
                 Ok(Self::ImportNoDynamicRequire(ImportNoDynamicRequire::from_configuration(value)?))
             }
@@ -9378,6 +9966,9 @@ impl RuleEnum {
             Self::ImportNoNodejsModules(_) => {
                 Ok(Self::ImportNoNodejsModules(ImportNoNodejsModules::from_configuration(value)?))
             }
+            Self::ImportNoPrivateImports(_) => {
+                Ok(Self::ImportNoPrivateImports(ImportNoPrivateImports::from_configuration(value)?))
+            }
             Self::ImportNoRelativeParentImports(_) => Ok(Self::ImportNoRelativeParentImports(
                 ImportNoRelativeParentImports::from_configuration(value)?,
             )),
@@ -9386,6 +9977,12 @@ impl RuleEnum {
             }
             Self::ImportNoUnassignedImport(_) => Ok(Self::ImportNoUnassignedImport(
                 ImportNoUnassignedImport::from_configuration(value)?,
+            )),
+            Self::ImportNoUndeclaredDependencies(_) => Ok(Self::ImportNoUndeclaredDependencies(
+                ImportNoUndeclaredDependencies::from_configuration(value)?,
+            )),
+            Self::ImportNoUnresolvedImports(_) => Ok(Self::ImportNoUnresolvedImports(
+                ImportNoUnresolvedImports::from_configuration(value)?,
             )),
             Self::ImportNoWebpackLoaderSyntax(_) => Ok(Self::ImportNoWebpackLoaderSyntax(
                 ImportNoWebpackLoaderSyntax::from_configuration(value)?,
@@ -9511,6 +10108,9 @@ impl RuleEnum {
             Self::EslintNoCondAssign(_) => {
                 Ok(Self::EslintNoCondAssign(EslintNoCondAssign::from_configuration(value)?))
             }
+            Self::EslintNoConfusingLabels(_) => Ok(Self::EslintNoConfusingLabels(
+                EslintNoConfusingLabels::from_configuration(value)?,
+            )),
             Self::EslintNoConsole(_) => {
                 Ok(Self::EslintNoConsole(EslintNoConsole::from_configuration(value)?))
             }
@@ -9684,6 +10284,9 @@ impl RuleEnum {
             Self::EslintNoObjectConstructor(_) => Ok(Self::EslintNoObjectConstructor(
                 EslintNoObjectConstructor::from_configuration(value)?,
             )),
+            Self::EslintNoOctalEscape(_) => {
+                Ok(Self::EslintNoOctalEscape(EslintNoOctalEscape::from_configuration(value)?))
+            }
             Self::EslintNoParamReassign(_) => {
                 Ok(Self::EslintNoParamReassign(EslintNoParamReassign::from_configuration(value)?))
             }
@@ -9702,6 +10305,9 @@ impl RuleEnum {
             Self::EslintNoRedeclare(_) => {
                 Ok(Self::EslintNoRedeclare(EslintNoRedeclare::from_configuration(value)?))
             }
+            Self::EslintNoRedundantUseStrict(_) => Ok(Self::EslintNoRedundantUseStrict(
+                EslintNoRedundantUseStrict::from_configuration(value)?,
+            )),
             Self::EslintNoRegexSpaces(_) => {
                 Ok(Self::EslintNoRegexSpaces(EslintNoRegexSpaces::from_configuration(value)?))
             }
@@ -9735,9 +10341,15 @@ impl RuleEnum {
             Self::EslintNoShadowRestrictedNames(_) => Ok(Self::EslintNoShadowRestrictedNames(
                 EslintNoShadowRestrictedNames::from_configuration(value)?,
             )),
+            Self::EslintNoShoutyConstants(_) => Ok(Self::EslintNoShoutyConstants(
+                EslintNoShoutyConstants::from_configuration(value)?,
+            )),
             Self::EslintNoSparseArrays(_) => {
                 Ok(Self::EslintNoSparseArrays(EslintNoSparseArrays::from_configuration(value)?))
             }
+            Self::EslintNoStringCaseMismatch(_) => Ok(Self::EslintNoStringCaseMismatch(
+                EslintNoStringCaseMismatch::from_configuration(value)?,
+            )),
             Self::EslintNoTemplateCurlyInString(_) => Ok(Self::EslintNoTemplateCurlyInString(
                 EslintNoTemplateCurlyInString::from_configuration(value)?,
             )),
@@ -9818,6 +10430,9 @@ impl RuleEnum {
             Self::EslintNoUselessConstructor(_) => Ok(Self::EslintNoUselessConstructor(
                 EslintNoUselessConstructor::from_configuration(value)?,
             )),
+            Self::EslintNoUselessContinue(_) => Ok(Self::EslintNoUselessContinue(
+                EslintNoUselessContinue::from_configuration(value)?,
+            )),
             Self::EslintNoUselessEscape(_) => {
                 Ok(Self::EslintNoUselessEscape(EslintNoUselessEscape::from_configuration(value)?))
             }
@@ -9842,6 +10457,9 @@ impl RuleEnum {
             }
             Self::EslintOperatorAssignment(_) => Ok(Self::EslintOperatorAssignment(
                 EslintOperatorAssignment::from_configuration(value)?,
+            )),
+            Self::EslintPreferArrowCallback(_) => Ok(Self::EslintPreferArrowCallback(
+                EslintPreferArrowCallback::from_configuration(value)?,
             )),
             Self::EslintPreferConst(_) => {
                 Ok(Self::EslintPreferConst(EslintPreferConst::from_configuration(value)?))
@@ -9902,6 +10520,15 @@ impl RuleEnum {
             }
             Self::EslintUseIsnan(_) => {
                 Ok(Self::EslintUseIsnan(EslintUseIsnan::from_configuration(value)?))
+            }
+            Self::EslintUseRegexLiterals(_) => {
+                Ok(Self::EslintUseRegexLiterals(EslintUseRegexLiterals::from_configuration(value)?))
+            }
+            Self::EslintUseSingleVarDeclarator(_) => Ok(Self::EslintUseSingleVarDeclarator(
+                EslintUseSingleVarDeclarator::from_configuration(value)?,
+            )),
+            Self::EslintUseWhile(_) => {
+                Ok(Self::EslintUseWhile(EslintUseWhile::from_configuration(value)?))
             }
             Self::EslintValidTypeof(_) => {
                 Ok(Self::EslintValidTypeof(EslintValidTypeof::from_configuration(value)?))
@@ -9972,11 +10599,19 @@ impl RuleEnum {
                     TypescriptExplicitFunctionReturnType::from_configuration(value)?,
                 ))
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                Ok(Self::TypescriptExplicitMemberAccessibility(
+                    TypescriptExplicitMemberAccessibility::from_configuration(value)?,
+                ))
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 Ok(Self::TypescriptExplicitModuleBoundaryTypes(
                     TypescriptExplicitModuleBoundaryTypes::from_configuration(value)?,
                 ))
             }
+            Self::TypescriptNamingConvention(_) => Ok(Self::TypescriptNamingConvention(
+                TypescriptNamingConvention::from_configuration(value)?,
+            )),
             Self::TypescriptNoArrayDelete(_) => Ok(Self::TypescriptNoArrayDelete(
                 TypescriptNoArrayDelete::from_configuration(value)?,
             )),
@@ -10013,6 +10648,15 @@ impl RuleEnum {
             Self::TypescriptNoEmptyObjectType(_) => Ok(Self::TypescriptNoEmptyObjectType(
                 TypescriptNoEmptyObjectType::from_configuration(value)?,
             )),
+            Self::TypescriptNoEmptyTypeParameters(_) => Ok(Self::TypescriptNoEmptyTypeParameters(
+                TypescriptNoEmptyTypeParameters::from_configuration(value)?,
+            )),
+            Self::TypescriptNoEnum(_) => {
+                Ok(Self::TypescriptNoEnum(TypescriptNoEnum::from_configuration(value)?))
+            }
+            Self::TypescriptNoEvolvingTypes(_) => Ok(Self::TypescriptNoEvolvingTypes(
+                TypescriptNoEvolvingTypes::from_configuration(value)?,
+            )),
             Self::TypescriptNoExplicitAny(_) => Ok(Self::TypescriptNoExplicitAny(
                 TypescriptNoExplicitAny::from_configuration(value)?,
             )),
@@ -10030,6 +10674,9 @@ impl RuleEnum {
             Self::TypescriptNoForInArray(_) => {
                 Ok(Self::TypescriptNoForInArray(TypescriptNoForInArray::from_configuration(value)?))
             }
+            Self::TypescriptNoImplicitAnyLet(_) => Ok(Self::TypescriptNoImplicitAnyLet(
+                TypescriptNoImplicitAnyLet::from_configuration(value)?,
+            )),
             Self::TypescriptNoImpliedEval(_) => Ok(Self::TypescriptNoImpliedEval(
                 TypescriptNoImpliedEval::from_configuration(value)?,
             )),
@@ -10091,6 +10738,9 @@ impl RuleEnum {
             Self::TypescriptNoThisAlias(_) => {
                 Ok(Self::TypescriptNoThisAlias(TypescriptNoThisAlias::from_configuration(value)?))
             }
+            Self::TypescriptNoThisInStatic(_) => Ok(Self::TypescriptNoThisInStatic(
+                TypescriptNoThisInStatic::from_configuration(value)?,
+            )),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 Ok(Self::TypescriptNoUnnecessaryBooleanLiteralCompare(
                     TypescriptNoUnnecessaryBooleanLiteralCompare::from_configuration(value)?,
@@ -10590,8 +11240,14 @@ impl RuleEnum {
             Self::ReactNoFindDomNode(_) => {
                 Ok(Self::ReactNoFindDomNode(ReactNoFindDomNode::from_configuration(value)?))
             }
+            Self::ReactNoForwardRef(_) => {
+                Ok(Self::ReactNoForwardRef(ReactNoForwardRef::from_configuration(value)?))
+            }
             Self::ReactNoIsMounted(_) => {
                 Ok(Self::ReactNoIsMounted(ReactNoIsMounted::from_configuration(value)?))
+            }
+            Self::ReactNoJsxLiterals(_) => {
+                Ok(Self::ReactNoJsxLiterals(ReactNoJsxLiterals::from_configuration(value)?))
             }
             Self::ReactNoMultiComp(_) => {
                 Ok(Self::ReactNoMultiComp(ReactNoMultiComp::from_configuration(value)?))
@@ -10602,6 +11258,9 @@ impl RuleEnum {
             Self::ReactNoReactChildren(_) => {
                 Ok(Self::ReactNoReactChildren(ReactNoReactChildren::from_configuration(value)?))
             }
+            Self::ReactNoReactSpecificProps(_) => Ok(Self::ReactNoReactSpecificProps(
+                ReactNoReactSpecificProps::from_configuration(value)?,
+            )),
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 Ok(Self::ReactNoRedundantShouldComponentUpdate(
                     ReactNoRedundantShouldComponentUpdate::from_configuration(value)?,
@@ -10616,6 +11275,9 @@ impl RuleEnum {
             Self::ReactNoStringRefs(_) => {
                 Ok(Self::ReactNoStringRefs(ReactNoStringRefs::from_configuration(value)?))
             }
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => Ok(Self::ReactNoSuspiciousSemicolonInJsx(
+                ReactNoSuspiciousSemicolonInJsx::from_configuration(value)?,
+            )),
             Self::ReactNoThisInSfc(_) => {
                 Ok(Self::ReactNoThisInSfc(ReactNoThisInSfc::from_configuration(value)?))
             }
@@ -10657,6 +11319,9 @@ impl RuleEnum {
             )),
             Self::ReactStylePropObject(_) => {
                 Ok(Self::ReactStylePropObject(ReactStylePropObject::from_configuration(value)?))
+            }
+            Self::ReactUseImageSize(_) => {
+                Ok(Self::ReactUseImageSize(ReactUseImageSize::from_configuration(value)?))
             }
             Self::ReactVoidDomElementsNoChildren(_) => Ok(Self::ReactVoidDomElementsNoChildren(
                 ReactVoidDomElementsNoChildren::from_configuration(value)?,
@@ -10762,6 +11427,9 @@ impl RuleEnum {
             Self::UnicornNoEmptyFile(_) => {
                 Ok(Self::UnicornNoEmptyFile(UnicornNoEmptyFile::from_configuration(value)?))
             }
+            Self::UnicornNoFlatMapIdentity(_) => Ok(Self::UnicornNoFlatMapIdentity(
+                UnicornNoFlatMapIdentity::from_configuration(value)?,
+            )),
             Self::UnicornNoHexEscape(_) => {
                 Ok(Self::UnicornNoHexEscape(UnicornNoHexEscape::from_configuration(value)?))
             }
@@ -10883,12 +11551,20 @@ impl RuleEnum {
             Self::UnicornNoUselessSpread(_) => {
                 Ok(Self::UnicornNoUselessSpread(UnicornNoUselessSpread::from_configuration(value)?))
             }
+            Self::UnicornNoUselessStringRaw(_) => Ok(Self::UnicornNoUselessStringRaw(
+                UnicornNoUselessStringRaw::from_configuration(value)?,
+            )),
             Self::UnicornNoUselessSwitchCase(_) => Ok(Self::UnicornNoUselessSwitchCase(
                 UnicornNoUselessSwitchCase::from_configuration(value)?,
             )),
             Self::UnicornNoUselessUndefined(_) => Ok(Self::UnicornNoUselessUndefined(
                 UnicornNoUselessUndefined::from_configuration(value)?,
             )),
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                Ok(Self::UnicornNoUselessUndefinedInitialization(
+                    UnicornNoUselessUndefinedInitialization::from_configuration(value)?,
+                ))
+            }
             Self::UnicornNoZeroFractions(_) => {
                 Ok(Self::UnicornNoZeroFractions(UnicornNoZeroFractions::from_configuration(value)?))
             }
@@ -11097,6 +11773,20 @@ impl RuleEnum {
             Self::UnicornThrowNewError(_) => {
                 Ok(Self::UnicornThrowNewError(UnicornThrowNewError::from_configuration(value)?))
             }
+            Self::UnicornUseCollapsedIf(_) => {
+                Ok(Self::UnicornUseCollapsedIf(UnicornUseCollapsedIf::from_configuration(value)?))
+            }
+            Self::UnicornUseConsistentCurlyBraces(_) => Ok(Self::UnicornUseConsistentCurlyBraces(
+                UnicornUseConsistentCurlyBraces::from_configuration(value)?,
+            )),
+            Self::UnicornUseSimpleNumberKeys(_) => Ok(Self::UnicornUseSimpleNumberKeys(
+                UnicornUseSimpleNumberKeys::from_configuration(value)?,
+            )),
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                Ok(Self::UnicornUseSimplifiedLogicExpression(
+                    UnicornUseSimplifiedLogicExpression::from_configuration(value)?,
+                ))
+            }
             Self::JsxA11YAltText(_) => {
                 Ok(Self::JsxA11YAltText(JsxA11YAltText::from_configuration(value)?))
             }
@@ -11168,6 +11858,21 @@ impl RuleEnum {
             Self::JsxA11YNoDistractingElements(_) => Ok(Self::JsxA11YNoDistractingElements(
                 JsxA11YNoDistractingElements::from_configuration(value)?,
             )),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                Ok(Self::JsxA11YNoInteractiveElementToNoninteractiveRole(
+                    JsxA11YNoInteractiveElementToNoninteractiveRole::from_configuration(value)?,
+                ))
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                Ok(Self::JsxA11YNoNoninteractiveElementInteractions(
+                    JsxA11YNoNoninteractiveElementInteractions::from_configuration(value)?,
+                ))
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                Ok(Self::JsxA11YNoNoninteractiveElementToInteractiveRole(
+                    JsxA11YNoNoninteractiveElementToInteractiveRole::from_configuration(value)?,
+                ))
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => Ok(Self::JsxA11YNoNoninteractiveTabindex(
                 JsxA11YNoNoninteractiveTabindex::from_configuration(value)?,
             )),
@@ -11179,6 +11884,9 @@ impl RuleEnum {
                     JsxA11YNoStaticElementInteractions::from_configuration(value)?,
                 ))
             }
+            Self::JsxA11YNoSvgWithoutTitle(_) => Ok(Self::JsxA11YNoSvgWithoutTitle(
+                JsxA11YNoSvgWithoutTitle::from_configuration(value)?,
+            )),
             Self::JsxA11YPreferTagOverRole(_) => Ok(Self::JsxA11YPreferTagOverRole(
                 JsxA11YPreferTagOverRole::from_configuration(value)?,
             )),
@@ -11193,6 +11901,12 @@ impl RuleEnum {
             }
             Self::JsxA11YTabindexNoPositive(_) => Ok(Self::JsxA11YTabindexNoPositive(
                 JsxA11YTabindexNoPositive::from_configuration(value)?,
+            )),
+            Self::JsxA11YUseFocusableInteractive(_) => Ok(Self::JsxA11YUseFocusableInteractive(
+                JsxA11YUseFocusableInteractive::from_configuration(value)?,
+            )),
+            Self::JsxA11YUseUniqueElementIds(_) => Ok(Self::JsxA11YUseUniqueElementIds(
+                JsxA11YUseUniqueElementIds::from_configuration(value)?,
             )),
             Self::OxcApproxConstant(_) => {
                 Ok(Self::OxcApproxConstant(OxcApproxConstant::from_configuration(value)?))
@@ -11522,6 +12236,9 @@ impl RuleEnum {
             Self::NodeNoExportsAssign(_) => {
                 Ok(Self::NodeNoExportsAssign(NodeNoExportsAssign::from_configuration(value)?))
             }
+            Self::NodeNoGlobalDirnameFilename(_) => Ok(Self::NodeNoGlobalDirnameFilename(
+                NodeNoGlobalDirnameFilename::from_configuration(value)?,
+            )),
             Self::NodeNoNewRequire(_) => {
                 Ok(Self::NodeNoNewRequire(NodeNoNewRequire::from_configuration(value)?))
             }
@@ -11603,6 +12320,7 @@ impl RuleEnum {
             Self::ImportNoCycle(rule) => rule.to_configuration(),
             Self::ImportNoDefaultExport(rule) => rule.to_configuration(),
             Self::ImportNoDuplicates(rule) => rule.to_configuration(),
+            Self::ImportNoDynamicNamespaceImportAccess(rule) => rule.to_configuration(),
             Self::ImportNoDynamicRequire(rule) => rule.to_configuration(),
             Self::ImportNoEmptyNamedBlocks(rule) => rule.to_configuration(),
             Self::ImportNoMutableExports(rule) => rule.to_configuration(),
@@ -11612,9 +12330,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(rule) => rule.to_configuration(),
             Self::ImportNoNamespace(rule) => rule.to_configuration(),
             Self::ImportNoNodejsModules(rule) => rule.to_configuration(),
+            Self::ImportNoPrivateImports(rule) => rule.to_configuration(),
             Self::ImportNoRelativeParentImports(rule) => rule.to_configuration(),
             Self::ImportNoSelfImport(rule) => rule.to_configuration(),
             Self::ImportNoUnassignedImport(rule) => rule.to_configuration(),
+            Self::ImportNoUndeclaredDependencies(rule) => rule.to_configuration(),
+            Self::ImportNoUnresolvedImports(rule) => rule.to_configuration(),
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.to_configuration(),
             Self::ImportPreferDefaultExport(rule) => rule.to_configuration(),
             Self::ImportUnambiguous(rule) => rule.to_configuration(),
@@ -11657,6 +12378,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(rule) => rule.to_configuration(),
             Self::EslintNoCompareNegZero(rule) => rule.to_configuration(),
             Self::EslintNoCondAssign(rule) => rule.to_configuration(),
+            Self::EslintNoConfusingLabels(rule) => rule.to_configuration(),
             Self::EslintNoConsole(rule) => rule.to_configuration(),
             Self::EslintNoConstAssign(rule) => rule.to_configuration(),
             Self::EslintNoConstantBinaryExpression(rule) => rule.to_configuration(),
@@ -11714,12 +12436,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(rule) => rule.to_configuration(),
             Self::EslintNoObjCalls(rule) => rule.to_configuration(),
             Self::EslintNoObjectConstructor(rule) => rule.to_configuration(),
+            Self::EslintNoOctalEscape(rule) => rule.to_configuration(),
             Self::EslintNoParamReassign(rule) => rule.to_configuration(),
             Self::EslintNoPlusplus(rule) => rule.to_configuration(),
             Self::EslintNoPromiseExecutorReturn(rule) => rule.to_configuration(),
             Self::EslintNoProto(rule) => rule.to_configuration(),
             Self::EslintNoPrototypeBuiltins(rule) => rule.to_configuration(),
             Self::EslintNoRedeclare(rule) => rule.to_configuration(),
+            Self::EslintNoRedundantUseStrict(rule) => rule.to_configuration(),
             Self::EslintNoRegexSpaces(rule) => rule.to_configuration(),
             Self::EslintNoRestrictedGlobals(rule) => rule.to_configuration(),
             Self::EslintNoRestrictedImports(rule) => rule.to_configuration(),
@@ -11731,7 +12455,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(rule) => rule.to_configuration(),
             Self::EslintNoShadow(rule) => rule.to_configuration(),
             Self::EslintNoShadowRestrictedNames(rule) => rule.to_configuration(),
+            Self::EslintNoShoutyConstants(rule) => rule.to_configuration(),
             Self::EslintNoSparseArrays(rule) => rule.to_configuration(),
+            Self::EslintNoStringCaseMismatch(rule) => rule.to_configuration(),
             Self::EslintNoTemplateCurlyInString(rule) => rule.to_configuration(),
             Self::EslintNoTernary(rule) => rule.to_configuration(),
             Self::EslintNoThisBeforeSuper(rule) => rule.to_configuration(),
@@ -11758,6 +12484,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(rule) => rule.to_configuration(),
             Self::EslintNoUselessConcat(rule) => rule.to_configuration(),
             Self::EslintNoUselessConstructor(rule) => rule.to_configuration(),
+            Self::EslintNoUselessContinue(rule) => rule.to_configuration(),
             Self::EslintNoUselessEscape(rule) => rule.to_configuration(),
             Self::EslintNoUselessRename(rule) => rule.to_configuration(),
             Self::EslintNoUselessReturn(rule) => rule.to_configuration(),
@@ -11767,6 +12494,7 @@ impl RuleEnum {
             Self::EslintNoWith(rule) => rule.to_configuration(),
             Self::EslintObjectShorthand(rule) => rule.to_configuration(),
             Self::EslintOperatorAssignment(rule) => rule.to_configuration(),
+            Self::EslintPreferArrowCallback(rule) => rule.to_configuration(),
             Self::EslintPreferConst(rule) => rule.to_configuration(),
             Self::EslintPreferDestructuring(rule) => rule.to_configuration(),
             Self::EslintPreferExponentiationOperator(rule) => rule.to_configuration(),
@@ -11787,6 +12515,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(rule) => rule.to_configuration(),
             Self::EslintUnicodeBom(rule) => rule.to_configuration(),
             Self::EslintUseIsnan(rule) => rule.to_configuration(),
+            Self::EslintUseRegexLiterals(rule) => rule.to_configuration(),
+            Self::EslintUseSingleVarDeclarator(rule) => rule.to_configuration(),
+            Self::EslintUseWhile(rule) => rule.to_configuration(),
             Self::EslintValidTypeof(rule) => rule.to_configuration(),
             Self::EslintVarsOnTop(rule) => rule.to_configuration(),
             Self::EslintYoda(rule) => rule.to_configuration(),
@@ -11806,7 +12537,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.to_configuration(),
             Self::TypescriptDotNotation(rule) => rule.to_configuration(),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.to_configuration(),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.to_configuration(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.to_configuration(),
+            Self::TypescriptNamingConvention(rule) => rule.to_configuration(),
             Self::TypescriptNoArrayDelete(rule) => rule.to_configuration(),
             Self::TypescriptNoBaseToString(rule) => rule.to_configuration(),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.to_configuration(),
@@ -11817,11 +12550,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(rule) => rule.to_configuration(),
             Self::TypescriptNoEmptyInterface(rule) => rule.to_configuration(),
             Self::TypescriptNoEmptyObjectType(rule) => rule.to_configuration(),
+            Self::TypescriptNoEmptyTypeParameters(rule) => rule.to_configuration(),
+            Self::TypescriptNoEnum(rule) => rule.to_configuration(),
+            Self::TypescriptNoEvolvingTypes(rule) => rule.to_configuration(),
             Self::TypescriptNoExplicitAny(rule) => rule.to_configuration(),
             Self::TypescriptNoExtraNonNullAssertion(rule) => rule.to_configuration(),
             Self::TypescriptNoExtraneousClass(rule) => rule.to_configuration(),
             Self::TypescriptNoFloatingPromises(rule) => rule.to_configuration(),
             Self::TypescriptNoForInArray(rule) => rule.to_configuration(),
+            Self::TypescriptNoImplicitAnyLet(rule) => rule.to_configuration(),
             Self::TypescriptNoImpliedEval(rule) => rule.to_configuration(),
             Self::TypescriptNoImportTypeSideEffects(rule) => rule.to_configuration(),
             Self::TypescriptNoInferrableTypes(rule) => rule.to_configuration(),
@@ -11839,6 +12576,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(rule) => rule.to_configuration(),
             Self::TypescriptNoRestrictedTypes(rule) => rule.to_configuration(),
             Self::TypescriptNoThisAlias(rule) => rule.to_configuration(),
+            Self::TypescriptNoThisInStatic(rule) => rule.to_configuration(),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => rule.to_configuration(),
             Self::TypescriptNoUnnecessaryCondition(rule) => rule.to_configuration(),
             Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => {
@@ -11988,14 +12726,18 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(rule) => rule.to_configuration(),
             Self::ReactNoDirectMutationState(rule) => rule.to_configuration(),
             Self::ReactNoFindDomNode(rule) => rule.to_configuration(),
+            Self::ReactNoForwardRef(rule) => rule.to_configuration(),
             Self::ReactNoIsMounted(rule) => rule.to_configuration(),
+            Self::ReactNoJsxLiterals(rule) => rule.to_configuration(),
             Self::ReactNoMultiComp(rule) => rule.to_configuration(),
             Self::ReactNoNamespace(rule) => rule.to_configuration(),
             Self::ReactNoReactChildren(rule) => rule.to_configuration(),
+            Self::ReactNoReactSpecificProps(rule) => rule.to_configuration(),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.to_configuration(),
             Self::ReactNoRenderReturnValue(rule) => rule.to_configuration(),
             Self::ReactNoSetState(rule) => rule.to_configuration(),
             Self::ReactNoStringRefs(rule) => rule.to_configuration(),
+            Self::ReactNoSuspiciousSemicolonInJsx(rule) => rule.to_configuration(),
             Self::ReactNoThisInSfc(rule) => rule.to_configuration(),
             Self::ReactNoUnescapedEntities(rule) => rule.to_configuration(),
             Self::ReactNoUnknownProperty(rule) => rule.to_configuration(),
@@ -12010,6 +12752,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(rule) => rule.to_configuration(),
             Self::ReactStateInConstructor(rule) => rule.to_configuration(),
             Self::ReactStylePropObject(rule) => rule.to_configuration(),
+            Self::ReactUseImageSize(rule) => rule.to_configuration(),
             Self::ReactVoidDomElementsNoChildren(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoJsxAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.to_configuration(),
@@ -12042,6 +12785,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.to_configuration(),
             Self::UnicornNoDocumentCookie(rule) => rule.to_configuration(),
             Self::UnicornNoEmptyFile(rule) => rule.to_configuration(),
+            Self::UnicornNoFlatMapIdentity(rule) => rule.to_configuration(),
             Self::UnicornNoHexEscape(rule) => rule.to_configuration(),
             Self::UnicornNoImmediateMutation(rule) => rule.to_configuration(),
             Self::UnicornNoInstanceofArray(rule) => rule.to_configuration(),
@@ -12075,8 +12819,10 @@ impl RuleEnum {
             Self::UnicornNoUselessLengthCheck(rule) => rule.to_configuration(),
             Self::UnicornNoUselessPromiseResolveReject(rule) => rule.to_configuration(),
             Self::UnicornNoUselessSpread(rule) => rule.to_configuration(),
+            Self::UnicornNoUselessStringRaw(rule) => rule.to_configuration(),
             Self::UnicornNoUselessSwitchCase(rule) => rule.to_configuration(),
             Self::UnicornNoUselessUndefined(rule) => rule.to_configuration(),
+            Self::UnicornNoUselessUndefinedInitialization(rule) => rule.to_configuration(),
             Self::UnicornNoZeroFractions(rule) => rule.to_configuration(),
             Self::UnicornNumberLiteralCase(rule) => rule.to_configuration(),
             Self::UnicornNumericSeparatorsStyle(rule) => rule.to_configuration(),
@@ -12141,6 +12887,10 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(rule) => rule.to_configuration(),
             Self::UnicornTextEncodingIdentifierCase(rule) => rule.to_configuration(),
             Self::UnicornThrowNewError(rule) => rule.to_configuration(),
+            Self::UnicornUseCollapsedIf(rule) => rule.to_configuration(),
+            Self::UnicornUseConsistentCurlyBraces(rule) => rule.to_configuration(),
+            Self::UnicornUseSimpleNumberKeys(rule) => rule.to_configuration(),
+            Self::UnicornUseSimplifiedLogicExpression(rule) => rule.to_configuration(),
             Self::JsxA11YAltText(rule) => rule.to_configuration(),
             Self::JsxA11YAnchorAmbiguousText(rule) => rule.to_configuration(),
             Self::JsxA11YAnchorHasContent(rule) => rule.to_configuration(),
@@ -12164,14 +12914,20 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(rule) => rule.to_configuration(),
             Self::JsxA11YNoAutofocus(rule) => rule.to_configuration(),
             Self::JsxA11YNoDistractingElements(rule) => rule.to_configuration(),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => rule.to_configuration(),
+            Self::JsxA11YNoNoninteractiveElementInteractions(rule) => rule.to_configuration(),
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => rule.to_configuration(),
             Self::JsxA11YNoNoninteractiveTabindex(rule) => rule.to_configuration(),
             Self::JsxA11YNoRedundantRoles(rule) => rule.to_configuration(),
             Self::JsxA11YNoStaticElementInteractions(rule) => rule.to_configuration(),
+            Self::JsxA11YNoSvgWithoutTitle(rule) => rule.to_configuration(),
             Self::JsxA11YPreferTagOverRole(rule) => rule.to_configuration(),
             Self::JsxA11YRoleHasRequiredAriaProps(rule) => rule.to_configuration(),
             Self::JsxA11YRoleSupportsAriaProps(rule) => rule.to_configuration(),
             Self::JsxA11YScope(rule) => rule.to_configuration(),
             Self::JsxA11YTabindexNoPositive(rule) => rule.to_configuration(),
+            Self::JsxA11YUseFocusableInteractive(rule) => rule.to_configuration(),
+            Self::JsxA11YUseUniqueElementIds(rule) => rule.to_configuration(),
             Self::OxcApproxConstant(rule) => rule.to_configuration(),
             Self::OxcBadArrayMethodOnArguments(rule) => rule.to_configuration(),
             Self::OxcBadBitwiseOperator(rule) => rule.to_configuration(),
@@ -12280,6 +13036,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(rule) => rule.to_configuration(),
             Self::NodeHandleCallbackErr(rule) => rule.to_configuration(),
             Self::NodeNoExportsAssign(rule) => rule.to_configuration(),
+            Self::NodeNoGlobalDirnameFilename(rule) => rule.to_configuration(),
             Self::NodeNoNewRequire(rule) => rule.to_configuration(),
             Self::NodeNoPathConcat(rule) => rule.to_configuration(),
             Self::NodeNoProcessEnv(rule) => rule.to_configuration(),
@@ -12321,6 +13078,7 @@ impl RuleEnum {
             Self::ImportNoCycle(rule) => rule.run(node, ctx),
             Self::ImportNoDefaultExport(rule) => rule.run(node, ctx),
             Self::ImportNoDuplicates(rule) => rule.run(node, ctx),
+            Self::ImportNoDynamicNamespaceImportAccess(rule) => rule.run(node, ctx),
             Self::ImportNoDynamicRequire(rule) => rule.run(node, ctx),
             Self::ImportNoEmptyNamedBlocks(rule) => rule.run(node, ctx),
             Self::ImportNoMutableExports(rule) => rule.run(node, ctx),
@@ -12330,9 +13088,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(rule) => rule.run(node, ctx),
             Self::ImportNoNamespace(rule) => rule.run(node, ctx),
             Self::ImportNoNodejsModules(rule) => rule.run(node, ctx),
+            Self::ImportNoPrivateImports(rule) => rule.run(node, ctx),
             Self::ImportNoRelativeParentImports(rule) => rule.run(node, ctx),
             Self::ImportNoSelfImport(rule) => rule.run(node, ctx),
             Self::ImportNoUnassignedImport(rule) => rule.run(node, ctx),
+            Self::ImportNoUndeclaredDependencies(rule) => rule.run(node, ctx),
+            Self::ImportNoUnresolvedImports(rule) => rule.run(node, ctx),
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run(node, ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run(node, ctx),
             Self::ImportUnambiguous(rule) => rule.run(node, ctx),
@@ -12375,6 +13136,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(rule) => rule.run(node, ctx),
             Self::EslintNoCompareNegZero(rule) => rule.run(node, ctx),
             Self::EslintNoCondAssign(rule) => rule.run(node, ctx),
+            Self::EslintNoConfusingLabels(rule) => rule.run(node, ctx),
             Self::EslintNoConsole(rule) => rule.run(node, ctx),
             Self::EslintNoConstAssign(rule) => rule.run(node, ctx),
             Self::EslintNoConstantBinaryExpression(rule) => rule.run(node, ctx),
@@ -12432,12 +13194,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(rule) => rule.run(node, ctx),
             Self::EslintNoObjCalls(rule) => rule.run(node, ctx),
             Self::EslintNoObjectConstructor(rule) => rule.run(node, ctx),
+            Self::EslintNoOctalEscape(rule) => rule.run(node, ctx),
             Self::EslintNoParamReassign(rule) => rule.run(node, ctx),
             Self::EslintNoPlusplus(rule) => rule.run(node, ctx),
             Self::EslintNoPromiseExecutorReturn(rule) => rule.run(node, ctx),
             Self::EslintNoProto(rule) => rule.run(node, ctx),
             Self::EslintNoPrototypeBuiltins(rule) => rule.run(node, ctx),
             Self::EslintNoRedeclare(rule) => rule.run(node, ctx),
+            Self::EslintNoRedundantUseStrict(rule) => rule.run(node, ctx),
             Self::EslintNoRegexSpaces(rule) => rule.run(node, ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.run(node, ctx),
             Self::EslintNoRestrictedImports(rule) => rule.run(node, ctx),
@@ -12449,7 +13213,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(rule) => rule.run(node, ctx),
             Self::EslintNoShadow(rule) => rule.run(node, ctx),
             Self::EslintNoShadowRestrictedNames(rule) => rule.run(node, ctx),
+            Self::EslintNoShoutyConstants(rule) => rule.run(node, ctx),
             Self::EslintNoSparseArrays(rule) => rule.run(node, ctx),
+            Self::EslintNoStringCaseMismatch(rule) => rule.run(node, ctx),
             Self::EslintNoTemplateCurlyInString(rule) => rule.run(node, ctx),
             Self::EslintNoTernary(rule) => rule.run(node, ctx),
             Self::EslintNoThisBeforeSuper(rule) => rule.run(node, ctx),
@@ -12476,6 +13242,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(rule) => rule.run(node, ctx),
             Self::EslintNoUselessConcat(rule) => rule.run(node, ctx),
             Self::EslintNoUselessConstructor(rule) => rule.run(node, ctx),
+            Self::EslintNoUselessContinue(rule) => rule.run(node, ctx),
             Self::EslintNoUselessEscape(rule) => rule.run(node, ctx),
             Self::EslintNoUselessRename(rule) => rule.run(node, ctx),
             Self::EslintNoUselessReturn(rule) => rule.run(node, ctx),
@@ -12485,6 +13252,7 @@ impl RuleEnum {
             Self::EslintNoWith(rule) => rule.run(node, ctx),
             Self::EslintObjectShorthand(rule) => rule.run(node, ctx),
             Self::EslintOperatorAssignment(rule) => rule.run(node, ctx),
+            Self::EslintPreferArrowCallback(rule) => rule.run(node, ctx),
             Self::EslintPreferConst(rule) => rule.run(node, ctx),
             Self::EslintPreferDestructuring(rule) => rule.run(node, ctx),
             Self::EslintPreferExponentiationOperator(rule) => rule.run(node, ctx),
@@ -12505,6 +13273,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(rule) => rule.run(node, ctx),
             Self::EslintUnicodeBom(rule) => rule.run(node, ctx),
             Self::EslintUseIsnan(rule) => rule.run(node, ctx),
+            Self::EslintUseRegexLiterals(rule) => rule.run(node, ctx),
+            Self::EslintUseSingleVarDeclarator(rule) => rule.run(node, ctx),
+            Self::EslintUseWhile(rule) => rule.run(node, ctx),
             Self::EslintValidTypeof(rule) => rule.run(node, ctx),
             Self::EslintVarsOnTop(rule) => rule.run(node, ctx),
             Self::EslintYoda(rule) => rule.run(node, ctx),
@@ -12524,7 +13295,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.run(node, ctx),
             Self::TypescriptDotNotation(rule) => rule.run(node, ctx),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.run(node, ctx),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.run(node, ctx),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run(node, ctx),
+            Self::TypescriptNamingConvention(rule) => rule.run(node, ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.run(node, ctx),
             Self::TypescriptNoBaseToString(rule) => rule.run(node, ctx),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run(node, ctx),
@@ -12535,11 +13308,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(rule) => rule.run(node, ctx),
             Self::TypescriptNoEmptyInterface(rule) => rule.run(node, ctx),
             Self::TypescriptNoEmptyObjectType(rule) => rule.run(node, ctx),
+            Self::TypescriptNoEmptyTypeParameters(rule) => rule.run(node, ctx),
+            Self::TypescriptNoEnum(rule) => rule.run(node, ctx),
+            Self::TypescriptNoEvolvingTypes(rule) => rule.run(node, ctx),
             Self::TypescriptNoExplicitAny(rule) => rule.run(node, ctx),
             Self::TypescriptNoExtraNonNullAssertion(rule) => rule.run(node, ctx),
             Self::TypescriptNoExtraneousClass(rule) => rule.run(node, ctx),
             Self::TypescriptNoFloatingPromises(rule) => rule.run(node, ctx),
             Self::TypescriptNoForInArray(rule) => rule.run(node, ctx),
+            Self::TypescriptNoImplicitAnyLet(rule) => rule.run(node, ctx),
             Self::TypescriptNoImpliedEval(rule) => rule.run(node, ctx),
             Self::TypescriptNoImportTypeSideEffects(rule) => rule.run(node, ctx),
             Self::TypescriptNoInferrableTypes(rule) => rule.run(node, ctx),
@@ -12557,6 +13334,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(rule) => rule.run(node, ctx),
             Self::TypescriptNoRestrictedTypes(rule) => rule.run(node, ctx),
             Self::TypescriptNoThisAlias(rule) => rule.run(node, ctx),
+            Self::TypescriptNoThisInStatic(rule) => rule.run(node, ctx),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => rule.run(node, ctx),
             Self::TypescriptNoUnnecessaryCondition(rule) => rule.run(node, ctx),
             Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => rule.run(node, ctx),
@@ -12704,14 +13482,18 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(rule) => rule.run(node, ctx),
             Self::ReactNoDirectMutationState(rule) => rule.run(node, ctx),
             Self::ReactNoFindDomNode(rule) => rule.run(node, ctx),
+            Self::ReactNoForwardRef(rule) => rule.run(node, ctx),
             Self::ReactNoIsMounted(rule) => rule.run(node, ctx),
+            Self::ReactNoJsxLiterals(rule) => rule.run(node, ctx),
             Self::ReactNoMultiComp(rule) => rule.run(node, ctx),
             Self::ReactNoNamespace(rule) => rule.run(node, ctx),
             Self::ReactNoReactChildren(rule) => rule.run(node, ctx),
+            Self::ReactNoReactSpecificProps(rule) => rule.run(node, ctx),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run(node, ctx),
             Self::ReactNoRenderReturnValue(rule) => rule.run(node, ctx),
             Self::ReactNoSetState(rule) => rule.run(node, ctx),
             Self::ReactNoStringRefs(rule) => rule.run(node, ctx),
+            Self::ReactNoSuspiciousSemicolonInJsx(rule) => rule.run(node, ctx),
             Self::ReactNoThisInSfc(rule) => rule.run(node, ctx),
             Self::ReactNoUnescapedEntities(rule) => rule.run(node, ctx),
             Self::ReactNoUnknownProperty(rule) => rule.run(node, ctx),
@@ -12726,6 +13508,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(rule) => rule.run(node, ctx),
             Self::ReactStateInConstructor(rule) => rule.run(node, ctx),
             Self::ReactStylePropObject(rule) => rule.run(node, ctx),
+            Self::ReactUseImageSize(rule) => rule.run(node, ctx),
             Self::ReactVoidDomElementsNoChildren(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoJsxAsProp(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
@@ -12758,6 +13541,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run(node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run(node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run(node, ctx),
+            Self::UnicornNoFlatMapIdentity(rule) => rule.run(node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run(node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run(node, ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run(node, ctx),
@@ -12791,8 +13575,10 @@ impl RuleEnum {
             Self::UnicornNoUselessLengthCheck(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessPromiseResolveReject(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessSpread(rule) => rule.run(node, ctx),
+            Self::UnicornNoUselessStringRaw(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessSwitchCase(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessUndefined(rule) => rule.run(node, ctx),
+            Self::UnicornNoUselessUndefinedInitialization(rule) => rule.run(node, ctx),
             Self::UnicornNoZeroFractions(rule) => rule.run(node, ctx),
             Self::UnicornNumberLiteralCase(rule) => rule.run(node, ctx),
             Self::UnicornNumericSeparatorsStyle(rule) => rule.run(node, ctx),
@@ -12857,6 +13643,10 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(rule) => rule.run(node, ctx),
             Self::UnicornTextEncodingIdentifierCase(rule) => rule.run(node, ctx),
             Self::UnicornThrowNewError(rule) => rule.run(node, ctx),
+            Self::UnicornUseCollapsedIf(rule) => rule.run(node, ctx),
+            Self::UnicornUseConsistentCurlyBraces(rule) => rule.run(node, ctx),
+            Self::UnicornUseSimpleNumberKeys(rule) => rule.run(node, ctx),
+            Self::UnicornUseSimplifiedLogicExpression(rule) => rule.run(node, ctx),
             Self::JsxA11YAltText(rule) => rule.run(node, ctx),
             Self::JsxA11YAnchorAmbiguousText(rule) => rule.run(node, ctx),
             Self::JsxA11YAnchorHasContent(rule) => rule.run(node, ctx),
@@ -12880,14 +13670,20 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(rule) => rule.run(node, ctx),
             Self::JsxA11YNoAutofocus(rule) => rule.run(node, ctx),
             Self::JsxA11YNoDistractingElements(rule) => rule.run(node, ctx),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => rule.run(node, ctx),
+            Self::JsxA11YNoNoninteractiveElementInteractions(rule) => rule.run(node, ctx),
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => rule.run(node, ctx),
             Self::JsxA11YNoNoninteractiveTabindex(rule) => rule.run(node, ctx),
             Self::JsxA11YNoRedundantRoles(rule) => rule.run(node, ctx),
             Self::JsxA11YNoStaticElementInteractions(rule) => rule.run(node, ctx),
+            Self::JsxA11YNoSvgWithoutTitle(rule) => rule.run(node, ctx),
             Self::JsxA11YPreferTagOverRole(rule) => rule.run(node, ctx),
             Self::JsxA11YRoleHasRequiredAriaProps(rule) => rule.run(node, ctx),
             Self::JsxA11YRoleSupportsAriaProps(rule) => rule.run(node, ctx),
             Self::JsxA11YScope(rule) => rule.run(node, ctx),
             Self::JsxA11YTabindexNoPositive(rule) => rule.run(node, ctx),
+            Self::JsxA11YUseFocusableInteractive(rule) => rule.run(node, ctx),
+            Self::JsxA11YUseUniqueElementIds(rule) => rule.run(node, ctx),
             Self::OxcApproxConstant(rule) => rule.run(node, ctx),
             Self::OxcBadArrayMethodOnArguments(rule) => rule.run(node, ctx),
             Self::OxcBadBitwiseOperator(rule) => rule.run(node, ctx),
@@ -12994,6 +13790,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
             Self::NodeHandleCallbackErr(rule) => rule.run(node, ctx),
             Self::NodeNoExportsAssign(rule) => rule.run(node, ctx),
+            Self::NodeNoGlobalDirnameFilename(rule) => rule.run(node, ctx),
             Self::NodeNoNewRequire(rule) => rule.run(node, ctx),
             Self::NodeNoPathConcat(rule) => rule.run(node, ctx),
             Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
@@ -13035,6 +13832,7 @@ impl RuleEnum {
             Self::ImportNoCycle(rule) => rule.run_once(ctx),
             Self::ImportNoDefaultExport(rule) => rule.run_once(ctx),
             Self::ImportNoDuplicates(rule) => rule.run_once(ctx),
+            Self::ImportNoDynamicNamespaceImportAccess(rule) => rule.run_once(ctx),
             Self::ImportNoDynamicRequire(rule) => rule.run_once(ctx),
             Self::ImportNoEmptyNamedBlocks(rule) => rule.run_once(ctx),
             Self::ImportNoMutableExports(rule) => rule.run_once(ctx),
@@ -13044,9 +13842,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(rule) => rule.run_once(ctx),
             Self::ImportNoNamespace(rule) => rule.run_once(ctx),
             Self::ImportNoNodejsModules(rule) => rule.run_once(ctx),
+            Self::ImportNoPrivateImports(rule) => rule.run_once(ctx),
             Self::ImportNoRelativeParentImports(rule) => rule.run_once(ctx),
             Self::ImportNoSelfImport(rule) => rule.run_once(ctx),
             Self::ImportNoUnassignedImport(rule) => rule.run_once(ctx),
+            Self::ImportNoUndeclaredDependencies(rule) => rule.run_once(ctx),
+            Self::ImportNoUnresolvedImports(rule) => rule.run_once(ctx),
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_once(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run_once(ctx),
             Self::ImportUnambiguous(rule) => rule.run_once(ctx),
@@ -13089,6 +13890,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(rule) => rule.run_once(ctx),
             Self::EslintNoCompareNegZero(rule) => rule.run_once(ctx),
             Self::EslintNoCondAssign(rule) => rule.run_once(ctx),
+            Self::EslintNoConfusingLabels(rule) => rule.run_once(ctx),
             Self::EslintNoConsole(rule) => rule.run_once(ctx),
             Self::EslintNoConstAssign(rule) => rule.run_once(ctx),
             Self::EslintNoConstantBinaryExpression(rule) => rule.run_once(ctx),
@@ -13146,12 +13948,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(rule) => rule.run_once(ctx),
             Self::EslintNoObjCalls(rule) => rule.run_once(ctx),
             Self::EslintNoObjectConstructor(rule) => rule.run_once(ctx),
+            Self::EslintNoOctalEscape(rule) => rule.run_once(ctx),
             Self::EslintNoParamReassign(rule) => rule.run_once(ctx),
             Self::EslintNoPlusplus(rule) => rule.run_once(ctx),
             Self::EslintNoPromiseExecutorReturn(rule) => rule.run_once(ctx),
             Self::EslintNoProto(rule) => rule.run_once(ctx),
             Self::EslintNoPrototypeBuiltins(rule) => rule.run_once(ctx),
             Self::EslintNoRedeclare(rule) => rule.run_once(ctx),
+            Self::EslintNoRedundantUseStrict(rule) => rule.run_once(ctx),
             Self::EslintNoRegexSpaces(rule) => rule.run_once(ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.run_once(ctx),
             Self::EslintNoRestrictedImports(rule) => rule.run_once(ctx),
@@ -13163,7 +13967,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(rule) => rule.run_once(ctx),
             Self::EslintNoShadow(rule) => rule.run_once(ctx),
             Self::EslintNoShadowRestrictedNames(rule) => rule.run_once(ctx),
+            Self::EslintNoShoutyConstants(rule) => rule.run_once(ctx),
             Self::EslintNoSparseArrays(rule) => rule.run_once(ctx),
+            Self::EslintNoStringCaseMismatch(rule) => rule.run_once(ctx),
             Self::EslintNoTemplateCurlyInString(rule) => rule.run_once(ctx),
             Self::EslintNoTernary(rule) => rule.run_once(ctx),
             Self::EslintNoThisBeforeSuper(rule) => rule.run_once(ctx),
@@ -13190,6 +13996,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(rule) => rule.run_once(ctx),
             Self::EslintNoUselessConcat(rule) => rule.run_once(ctx),
             Self::EslintNoUselessConstructor(rule) => rule.run_once(ctx),
+            Self::EslintNoUselessContinue(rule) => rule.run_once(ctx),
             Self::EslintNoUselessEscape(rule) => rule.run_once(ctx),
             Self::EslintNoUselessRename(rule) => rule.run_once(ctx),
             Self::EslintNoUselessReturn(rule) => rule.run_once(ctx),
@@ -13199,6 +14006,7 @@ impl RuleEnum {
             Self::EslintNoWith(rule) => rule.run_once(ctx),
             Self::EslintObjectShorthand(rule) => rule.run_once(ctx),
             Self::EslintOperatorAssignment(rule) => rule.run_once(ctx),
+            Self::EslintPreferArrowCallback(rule) => rule.run_once(ctx),
             Self::EslintPreferConst(rule) => rule.run_once(ctx),
             Self::EslintPreferDestructuring(rule) => rule.run_once(ctx),
             Self::EslintPreferExponentiationOperator(rule) => rule.run_once(ctx),
@@ -13219,6 +14027,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(rule) => rule.run_once(ctx),
             Self::EslintUnicodeBom(rule) => rule.run_once(ctx),
             Self::EslintUseIsnan(rule) => rule.run_once(ctx),
+            Self::EslintUseRegexLiterals(rule) => rule.run_once(ctx),
+            Self::EslintUseSingleVarDeclarator(rule) => rule.run_once(ctx),
+            Self::EslintUseWhile(rule) => rule.run_once(ctx),
             Self::EslintValidTypeof(rule) => rule.run_once(ctx),
             Self::EslintVarsOnTop(rule) => rule.run_once(ctx),
             Self::EslintYoda(rule) => rule.run_once(ctx),
@@ -13238,7 +14049,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.run_once(ctx),
             Self::TypescriptDotNotation(rule) => rule.run_once(ctx),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.run_once(ctx),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.run_once(ctx),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run_once(ctx),
+            Self::TypescriptNamingConvention(rule) => rule.run_once(ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.run_once(ctx),
             Self::TypescriptNoBaseToString(rule) => rule.run_once(ctx),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run_once(ctx),
@@ -13249,11 +14062,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(rule) => rule.run_once(ctx),
             Self::TypescriptNoEmptyInterface(rule) => rule.run_once(ctx),
             Self::TypescriptNoEmptyObjectType(rule) => rule.run_once(ctx),
+            Self::TypescriptNoEmptyTypeParameters(rule) => rule.run_once(ctx),
+            Self::TypescriptNoEnum(rule) => rule.run_once(ctx),
+            Self::TypescriptNoEvolvingTypes(rule) => rule.run_once(ctx),
             Self::TypescriptNoExplicitAny(rule) => rule.run_once(ctx),
             Self::TypescriptNoExtraNonNullAssertion(rule) => rule.run_once(ctx),
             Self::TypescriptNoExtraneousClass(rule) => rule.run_once(ctx),
             Self::TypescriptNoFloatingPromises(rule) => rule.run_once(ctx),
             Self::TypescriptNoForInArray(rule) => rule.run_once(ctx),
+            Self::TypescriptNoImplicitAnyLet(rule) => rule.run_once(ctx),
             Self::TypescriptNoImpliedEval(rule) => rule.run_once(ctx),
             Self::TypescriptNoImportTypeSideEffects(rule) => rule.run_once(ctx),
             Self::TypescriptNoInferrableTypes(rule) => rule.run_once(ctx),
@@ -13271,6 +14088,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(rule) => rule.run_once(ctx),
             Self::TypescriptNoRestrictedTypes(rule) => rule.run_once(ctx),
             Self::TypescriptNoThisAlias(rule) => rule.run_once(ctx),
+            Self::TypescriptNoThisInStatic(rule) => rule.run_once(ctx),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => rule.run_once(ctx),
             Self::TypescriptNoUnnecessaryCondition(rule) => rule.run_once(ctx),
             Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => rule.run_once(ctx),
@@ -13418,14 +14236,18 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(rule) => rule.run_once(ctx),
             Self::ReactNoDirectMutationState(rule) => rule.run_once(ctx),
             Self::ReactNoFindDomNode(rule) => rule.run_once(ctx),
+            Self::ReactNoForwardRef(rule) => rule.run_once(ctx),
             Self::ReactNoIsMounted(rule) => rule.run_once(ctx),
+            Self::ReactNoJsxLiterals(rule) => rule.run_once(ctx),
             Self::ReactNoMultiComp(rule) => rule.run_once(ctx),
             Self::ReactNoNamespace(rule) => rule.run_once(ctx),
             Self::ReactNoReactChildren(rule) => rule.run_once(ctx),
+            Self::ReactNoReactSpecificProps(rule) => rule.run_once(ctx),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run_once(ctx),
             Self::ReactNoRenderReturnValue(rule) => rule.run_once(ctx),
             Self::ReactNoSetState(rule) => rule.run_once(ctx),
             Self::ReactNoStringRefs(rule) => rule.run_once(ctx),
+            Self::ReactNoSuspiciousSemicolonInJsx(rule) => rule.run_once(ctx),
             Self::ReactNoThisInSfc(rule) => rule.run_once(ctx),
             Self::ReactNoUnescapedEntities(rule) => rule.run_once(ctx),
             Self::ReactNoUnknownProperty(rule) => rule.run_once(ctx),
@@ -13440,6 +14262,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(rule) => rule.run_once(ctx),
             Self::ReactStateInConstructor(rule) => rule.run_once(ctx),
             Self::ReactStylePropObject(rule) => rule.run_once(ctx),
+            Self::ReactUseImageSize(rule) => rule.run_once(ctx),
             Self::ReactVoidDomElementsNoChildren(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoJsxAsProp(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
@@ -13472,6 +14295,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_once(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_once(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_once(ctx),
+            Self::UnicornNoFlatMapIdentity(rule) => rule.run_once(ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_once(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_once(ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run_once(ctx),
@@ -13505,8 +14329,10 @@ impl RuleEnum {
             Self::UnicornNoUselessLengthCheck(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessPromiseResolveReject(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessSpread(rule) => rule.run_once(ctx),
+            Self::UnicornNoUselessStringRaw(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessSwitchCase(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessUndefined(rule) => rule.run_once(ctx),
+            Self::UnicornNoUselessUndefinedInitialization(rule) => rule.run_once(ctx),
             Self::UnicornNoZeroFractions(rule) => rule.run_once(ctx),
             Self::UnicornNumberLiteralCase(rule) => rule.run_once(ctx),
             Self::UnicornNumericSeparatorsStyle(rule) => rule.run_once(ctx),
@@ -13571,6 +14397,10 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(rule) => rule.run_once(ctx),
             Self::UnicornTextEncodingIdentifierCase(rule) => rule.run_once(ctx),
             Self::UnicornThrowNewError(rule) => rule.run_once(ctx),
+            Self::UnicornUseCollapsedIf(rule) => rule.run_once(ctx),
+            Self::UnicornUseConsistentCurlyBraces(rule) => rule.run_once(ctx),
+            Self::UnicornUseSimpleNumberKeys(rule) => rule.run_once(ctx),
+            Self::UnicornUseSimplifiedLogicExpression(rule) => rule.run_once(ctx),
             Self::JsxA11YAltText(rule) => rule.run_once(ctx),
             Self::JsxA11YAnchorAmbiguousText(rule) => rule.run_once(ctx),
             Self::JsxA11YAnchorHasContent(rule) => rule.run_once(ctx),
@@ -13594,14 +14424,20 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(rule) => rule.run_once(ctx),
             Self::JsxA11YNoAutofocus(rule) => rule.run_once(ctx),
             Self::JsxA11YNoDistractingElements(rule) => rule.run_once(ctx),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => rule.run_once(ctx),
+            Self::JsxA11YNoNoninteractiveElementInteractions(rule) => rule.run_once(ctx),
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => rule.run_once(ctx),
             Self::JsxA11YNoNoninteractiveTabindex(rule) => rule.run_once(ctx),
             Self::JsxA11YNoRedundantRoles(rule) => rule.run_once(ctx),
             Self::JsxA11YNoStaticElementInteractions(rule) => rule.run_once(ctx),
+            Self::JsxA11YNoSvgWithoutTitle(rule) => rule.run_once(ctx),
             Self::JsxA11YPreferTagOverRole(rule) => rule.run_once(ctx),
             Self::JsxA11YRoleHasRequiredAriaProps(rule) => rule.run_once(ctx),
             Self::JsxA11YRoleSupportsAriaProps(rule) => rule.run_once(ctx),
             Self::JsxA11YScope(rule) => rule.run_once(ctx),
             Self::JsxA11YTabindexNoPositive(rule) => rule.run_once(ctx),
+            Self::JsxA11YUseFocusableInteractive(rule) => rule.run_once(ctx),
+            Self::JsxA11YUseUniqueElementIds(rule) => rule.run_once(ctx),
             Self::OxcApproxConstant(rule) => rule.run_once(ctx),
             Self::OxcBadArrayMethodOnArguments(rule) => rule.run_once(ctx),
             Self::OxcBadBitwiseOperator(rule) => rule.run_once(ctx),
@@ -13708,6 +14544,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
             Self::NodeHandleCallbackErr(rule) => rule.run_once(ctx),
             Self::NodeNoExportsAssign(rule) => rule.run_once(ctx),
+            Self::NodeNoGlobalDirnameFilename(rule) => rule.run_once(ctx),
             Self::NodeNoNewRequire(rule) => rule.run_once(ctx),
             Self::NodeNoPathConcat(rule) => rule.run_once(ctx),
             Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
@@ -13753,6 +14590,9 @@ impl RuleEnum {
             Self::ImportNoCycle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoDuplicates(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ImportNoDynamicNamespaceImportAccess(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::ImportNoDynamicRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoEmptyNamedBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoMutableExports(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13762,9 +14602,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoNamespace(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoNodejsModules(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ImportNoPrivateImports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoRelativeParentImports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoSelfImport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoUnassignedImport(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ImportNoUndeclaredDependencies(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ImportNoUnresolvedImports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportUnambiguous(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13807,6 +14650,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoCompareNegZero(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoCondAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoConfusingLabels(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoConsole(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoConstAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoConstantBinaryExpression(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13864,12 +14708,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoObjCalls(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoObjectConstructor(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoOctalEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoParamReassign(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoPlusplus(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoPromiseExecutorReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoProto(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoPrototypeBuiltins(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRedeclare(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoRedundantUseStrict(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRegexSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRestrictedImports(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13881,7 +14727,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoShadow(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoShadowRestrictedNames(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoShoutyConstants(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoSparseArrays(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoStringCaseMismatch(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoTemplateCurlyInString(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoTernary(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoThisBeforeSuper(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13908,6 +14756,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUselessConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUselessConstructor(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoUselessContinue(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUselessEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUselessRename(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUselessReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13917,6 +14766,7 @@ impl RuleEnum {
             Self::EslintNoWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintObjectShorthand(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintOperatorAssignment(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintPreferArrowCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintPreferConst(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintPreferDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintPreferExponentiationOperator(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13937,6 +14787,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintUnicodeBom(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintUseIsnan(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintUseRegexLiterals(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintUseSingleVarDeclarator(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintUseWhile(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintValidTypeof(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintVarsOnTop(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintYoda(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13968,9 +14821,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
+            Self::TypescriptExplicitMemberAccessibility(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
+            Self::TypescriptNamingConvention(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoBaseToString(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => {
@@ -13987,11 +14844,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoEmptyInterface(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoEmptyObjectType(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptNoEmptyTypeParameters(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptNoEnum(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptNoEvolvingTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoExplicitAny(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoExtraNonNullAssertion(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoExtraneousClass(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoFloatingPromises(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoForInArray(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptNoImplicitAnyLet(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoImpliedEval(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoImportTypeSideEffects(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoInferrableTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14017,6 +14878,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoRestrictedTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoThisAlias(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptNoThisInStatic(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
@@ -14202,16 +15064,20 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDirectMutationState(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoFindDomNode(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactNoForwardRef(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoIsMounted(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactNoJsxLiterals(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoMultiComp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoNamespace(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoReactChildren(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactNoReactSpecificProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
             Self::ReactNoRenderReturnValue(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoStringRefs(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactNoSuspiciousSemicolonInJsx(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoThisInSfc(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoUnescapedEntities(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoUnknownProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14226,6 +15092,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactStateInConstructor(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactStylePropObject(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactUseImageSize(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactVoidDomElementsNoChildren(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoJsxAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14260,6 +15127,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoFlatMapIdentity(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14305,8 +15173,12 @@ impl RuleEnum {
                 rule.run_on_jest_node(jest_node, ctx)
             }
             Self::UnicornNoUselessSpread(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoUselessStringRaw(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoUselessSwitchCase(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoUselessUndefined(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoUselessUndefinedInitialization(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::UnicornNoZeroFractions(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNumberLiteralCase(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNumericSeparatorsStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14379,6 +15251,12 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornTextEncodingIdentifierCase(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornThrowNewError(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornUseCollapsedIf(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornUseConsistentCurlyBraces(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornUseSimpleNumberKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornUseSimplifiedLogicExpression(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::JsxA11YAltText(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YAnchorAmbiguousText(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YAnchorHasContent(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14404,14 +15282,26 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YNoAutofocus(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YNoDistractingElements(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::JsxA11YNoNoninteractiveTabindex(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YNoRedundantRoles(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YNoStaticElementInteractions(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JsxA11YNoSvgWithoutTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YPreferTagOverRole(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YRoleHasRequiredAriaProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YRoleSupportsAriaProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YScope(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsxA11YTabindexNoPositive(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JsxA11YUseFocusableInteractive(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JsxA11YUseUniqueElementIds(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcApproxConstant(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadArrayMethodOnArguments(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadBitwiseOperator(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14522,6 +15412,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeHandleCallbackErr(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoExportsAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::NodeNoGlobalDirnameFilename(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoNewRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoPathConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14563,6 +15454,7 @@ impl RuleEnum {
             Self::ImportNoCycle(rule) => rule.should_run(ctx),
             Self::ImportNoDefaultExport(rule) => rule.should_run(ctx),
             Self::ImportNoDuplicates(rule) => rule.should_run(ctx),
+            Self::ImportNoDynamicNamespaceImportAccess(rule) => rule.should_run(ctx),
             Self::ImportNoDynamicRequire(rule) => rule.should_run(ctx),
             Self::ImportNoEmptyNamedBlocks(rule) => rule.should_run(ctx),
             Self::ImportNoMutableExports(rule) => rule.should_run(ctx),
@@ -14572,9 +15464,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(rule) => rule.should_run(ctx),
             Self::ImportNoNamespace(rule) => rule.should_run(ctx),
             Self::ImportNoNodejsModules(rule) => rule.should_run(ctx),
+            Self::ImportNoPrivateImports(rule) => rule.should_run(ctx),
             Self::ImportNoRelativeParentImports(rule) => rule.should_run(ctx),
             Self::ImportNoSelfImport(rule) => rule.should_run(ctx),
             Self::ImportNoUnassignedImport(rule) => rule.should_run(ctx),
+            Self::ImportNoUndeclaredDependencies(rule) => rule.should_run(ctx),
+            Self::ImportNoUnresolvedImports(rule) => rule.should_run(ctx),
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.should_run(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.should_run(ctx),
             Self::ImportUnambiguous(rule) => rule.should_run(ctx),
@@ -14617,6 +15512,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(rule) => rule.should_run(ctx),
             Self::EslintNoCompareNegZero(rule) => rule.should_run(ctx),
             Self::EslintNoCondAssign(rule) => rule.should_run(ctx),
+            Self::EslintNoConfusingLabels(rule) => rule.should_run(ctx),
             Self::EslintNoConsole(rule) => rule.should_run(ctx),
             Self::EslintNoConstAssign(rule) => rule.should_run(ctx),
             Self::EslintNoConstantBinaryExpression(rule) => rule.should_run(ctx),
@@ -14674,12 +15570,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(rule) => rule.should_run(ctx),
             Self::EslintNoObjCalls(rule) => rule.should_run(ctx),
             Self::EslintNoObjectConstructor(rule) => rule.should_run(ctx),
+            Self::EslintNoOctalEscape(rule) => rule.should_run(ctx),
             Self::EslintNoParamReassign(rule) => rule.should_run(ctx),
             Self::EslintNoPlusplus(rule) => rule.should_run(ctx),
             Self::EslintNoPromiseExecutorReturn(rule) => rule.should_run(ctx),
             Self::EslintNoProto(rule) => rule.should_run(ctx),
             Self::EslintNoPrototypeBuiltins(rule) => rule.should_run(ctx),
             Self::EslintNoRedeclare(rule) => rule.should_run(ctx),
+            Self::EslintNoRedundantUseStrict(rule) => rule.should_run(ctx),
             Self::EslintNoRegexSpaces(rule) => rule.should_run(ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.should_run(ctx),
             Self::EslintNoRestrictedImports(rule) => rule.should_run(ctx),
@@ -14691,7 +15589,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(rule) => rule.should_run(ctx),
             Self::EslintNoShadow(rule) => rule.should_run(ctx),
             Self::EslintNoShadowRestrictedNames(rule) => rule.should_run(ctx),
+            Self::EslintNoShoutyConstants(rule) => rule.should_run(ctx),
             Self::EslintNoSparseArrays(rule) => rule.should_run(ctx),
+            Self::EslintNoStringCaseMismatch(rule) => rule.should_run(ctx),
             Self::EslintNoTemplateCurlyInString(rule) => rule.should_run(ctx),
             Self::EslintNoTernary(rule) => rule.should_run(ctx),
             Self::EslintNoThisBeforeSuper(rule) => rule.should_run(ctx),
@@ -14718,6 +15618,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(rule) => rule.should_run(ctx),
             Self::EslintNoUselessConcat(rule) => rule.should_run(ctx),
             Self::EslintNoUselessConstructor(rule) => rule.should_run(ctx),
+            Self::EslintNoUselessContinue(rule) => rule.should_run(ctx),
             Self::EslintNoUselessEscape(rule) => rule.should_run(ctx),
             Self::EslintNoUselessRename(rule) => rule.should_run(ctx),
             Self::EslintNoUselessReturn(rule) => rule.should_run(ctx),
@@ -14727,6 +15628,7 @@ impl RuleEnum {
             Self::EslintNoWith(rule) => rule.should_run(ctx),
             Self::EslintObjectShorthand(rule) => rule.should_run(ctx),
             Self::EslintOperatorAssignment(rule) => rule.should_run(ctx),
+            Self::EslintPreferArrowCallback(rule) => rule.should_run(ctx),
             Self::EslintPreferConst(rule) => rule.should_run(ctx),
             Self::EslintPreferDestructuring(rule) => rule.should_run(ctx),
             Self::EslintPreferExponentiationOperator(rule) => rule.should_run(ctx),
@@ -14747,6 +15649,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(rule) => rule.should_run(ctx),
             Self::EslintUnicodeBom(rule) => rule.should_run(ctx),
             Self::EslintUseIsnan(rule) => rule.should_run(ctx),
+            Self::EslintUseRegexLiterals(rule) => rule.should_run(ctx),
+            Self::EslintUseSingleVarDeclarator(rule) => rule.should_run(ctx),
+            Self::EslintUseWhile(rule) => rule.should_run(ctx),
             Self::EslintValidTypeof(rule) => rule.should_run(ctx),
             Self::EslintVarsOnTop(rule) => rule.should_run(ctx),
             Self::EslintYoda(rule) => rule.should_run(ctx),
@@ -14766,7 +15671,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.should_run(ctx),
             Self::TypescriptDotNotation(rule) => rule.should_run(ctx),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.should_run(ctx),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.should_run(ctx),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.should_run(ctx),
+            Self::TypescriptNamingConvention(rule) => rule.should_run(ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.should_run(ctx),
             Self::TypescriptNoBaseToString(rule) => rule.should_run(ctx),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.should_run(ctx),
@@ -14777,11 +15684,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(rule) => rule.should_run(ctx),
             Self::TypescriptNoEmptyInterface(rule) => rule.should_run(ctx),
             Self::TypescriptNoEmptyObjectType(rule) => rule.should_run(ctx),
+            Self::TypescriptNoEmptyTypeParameters(rule) => rule.should_run(ctx),
+            Self::TypescriptNoEnum(rule) => rule.should_run(ctx),
+            Self::TypescriptNoEvolvingTypes(rule) => rule.should_run(ctx),
             Self::TypescriptNoExplicitAny(rule) => rule.should_run(ctx),
             Self::TypescriptNoExtraNonNullAssertion(rule) => rule.should_run(ctx),
             Self::TypescriptNoExtraneousClass(rule) => rule.should_run(ctx),
             Self::TypescriptNoFloatingPromises(rule) => rule.should_run(ctx),
             Self::TypescriptNoForInArray(rule) => rule.should_run(ctx),
+            Self::TypescriptNoImplicitAnyLet(rule) => rule.should_run(ctx),
             Self::TypescriptNoImpliedEval(rule) => rule.should_run(ctx),
             Self::TypescriptNoImportTypeSideEffects(rule) => rule.should_run(ctx),
             Self::TypescriptNoInferrableTypes(rule) => rule.should_run(ctx),
@@ -14799,6 +15710,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(rule) => rule.should_run(ctx),
             Self::TypescriptNoRestrictedTypes(rule) => rule.should_run(ctx),
             Self::TypescriptNoThisAlias(rule) => rule.should_run(ctx),
+            Self::TypescriptNoThisInStatic(rule) => rule.should_run(ctx),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => rule.should_run(ctx),
             Self::TypescriptNoUnnecessaryCondition(rule) => rule.should_run(ctx),
             Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => rule.should_run(ctx),
@@ -14946,14 +15858,18 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(rule) => rule.should_run(ctx),
             Self::ReactNoDirectMutationState(rule) => rule.should_run(ctx),
             Self::ReactNoFindDomNode(rule) => rule.should_run(ctx),
+            Self::ReactNoForwardRef(rule) => rule.should_run(ctx),
             Self::ReactNoIsMounted(rule) => rule.should_run(ctx),
+            Self::ReactNoJsxLiterals(rule) => rule.should_run(ctx),
             Self::ReactNoMultiComp(rule) => rule.should_run(ctx),
             Self::ReactNoNamespace(rule) => rule.should_run(ctx),
             Self::ReactNoReactChildren(rule) => rule.should_run(ctx),
+            Self::ReactNoReactSpecificProps(rule) => rule.should_run(ctx),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.should_run(ctx),
             Self::ReactNoRenderReturnValue(rule) => rule.should_run(ctx),
             Self::ReactNoSetState(rule) => rule.should_run(ctx),
             Self::ReactNoStringRefs(rule) => rule.should_run(ctx),
+            Self::ReactNoSuspiciousSemicolonInJsx(rule) => rule.should_run(ctx),
             Self::ReactNoThisInSfc(rule) => rule.should_run(ctx),
             Self::ReactNoUnescapedEntities(rule) => rule.should_run(ctx),
             Self::ReactNoUnknownProperty(rule) => rule.should_run(ctx),
@@ -14968,6 +15884,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(rule) => rule.should_run(ctx),
             Self::ReactStateInConstructor(rule) => rule.should_run(ctx),
             Self::ReactStylePropObject(rule) => rule.should_run(ctx),
+            Self::ReactUseImageSize(rule) => rule.should_run(ctx),
             Self::ReactVoidDomElementsNoChildren(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoJsxAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.should_run(ctx),
@@ -15000,6 +15917,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.should_run(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.should_run(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.should_run(ctx),
+            Self::UnicornNoFlatMapIdentity(rule) => rule.should_run(ctx),
             Self::UnicornNoHexEscape(rule) => rule.should_run(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.should_run(ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.should_run(ctx),
@@ -15033,8 +15951,10 @@ impl RuleEnum {
             Self::UnicornNoUselessLengthCheck(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessPromiseResolveReject(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessSpread(rule) => rule.should_run(ctx),
+            Self::UnicornNoUselessStringRaw(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessSwitchCase(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessUndefined(rule) => rule.should_run(ctx),
+            Self::UnicornNoUselessUndefinedInitialization(rule) => rule.should_run(ctx),
             Self::UnicornNoZeroFractions(rule) => rule.should_run(ctx),
             Self::UnicornNumberLiteralCase(rule) => rule.should_run(ctx),
             Self::UnicornNumericSeparatorsStyle(rule) => rule.should_run(ctx),
@@ -15099,6 +16019,10 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(rule) => rule.should_run(ctx),
             Self::UnicornTextEncodingIdentifierCase(rule) => rule.should_run(ctx),
             Self::UnicornThrowNewError(rule) => rule.should_run(ctx),
+            Self::UnicornUseCollapsedIf(rule) => rule.should_run(ctx),
+            Self::UnicornUseConsistentCurlyBraces(rule) => rule.should_run(ctx),
+            Self::UnicornUseSimpleNumberKeys(rule) => rule.should_run(ctx),
+            Self::UnicornUseSimplifiedLogicExpression(rule) => rule.should_run(ctx),
             Self::JsxA11YAltText(rule) => rule.should_run(ctx),
             Self::JsxA11YAnchorAmbiguousText(rule) => rule.should_run(ctx),
             Self::JsxA11YAnchorHasContent(rule) => rule.should_run(ctx),
@@ -15122,14 +16046,20 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(rule) => rule.should_run(ctx),
             Self::JsxA11YNoAutofocus(rule) => rule.should_run(ctx),
             Self::JsxA11YNoDistractingElements(rule) => rule.should_run(ctx),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => rule.should_run(ctx),
+            Self::JsxA11YNoNoninteractiveElementInteractions(rule) => rule.should_run(ctx),
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => rule.should_run(ctx),
             Self::JsxA11YNoNoninteractiveTabindex(rule) => rule.should_run(ctx),
             Self::JsxA11YNoRedundantRoles(rule) => rule.should_run(ctx),
             Self::JsxA11YNoStaticElementInteractions(rule) => rule.should_run(ctx),
+            Self::JsxA11YNoSvgWithoutTitle(rule) => rule.should_run(ctx),
             Self::JsxA11YPreferTagOverRole(rule) => rule.should_run(ctx),
             Self::JsxA11YRoleHasRequiredAriaProps(rule) => rule.should_run(ctx),
             Self::JsxA11YRoleSupportsAriaProps(rule) => rule.should_run(ctx),
             Self::JsxA11YScope(rule) => rule.should_run(ctx),
             Self::JsxA11YTabindexNoPositive(rule) => rule.should_run(ctx),
+            Self::JsxA11YUseFocusableInteractive(rule) => rule.should_run(ctx),
+            Self::JsxA11YUseUniqueElementIds(rule) => rule.should_run(ctx),
             Self::OxcApproxConstant(rule) => rule.should_run(ctx),
             Self::OxcBadArrayMethodOnArguments(rule) => rule.should_run(ctx),
             Self::OxcBadBitwiseOperator(rule) => rule.should_run(ctx),
@@ -15236,6 +16166,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(rule) => rule.should_run(ctx),
             Self::NodeHandleCallbackErr(rule) => rule.should_run(ctx),
             Self::NodeNoExportsAssign(rule) => rule.should_run(ctx),
+            Self::NodeNoGlobalDirnameFilename(rule) => rule.should_run(ctx),
             Self::NodeNoNewRequire(rule) => rule.should_run(ctx),
             Self::NodeNoPathConcat(rule) => rule.should_run(ctx),
             Self::NodeNoProcessEnv(rule) => rule.should_run(ctx),
@@ -15281,6 +16212,9 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => ImportNoCycle::IS_TSGOLINT_RULE,
             Self::ImportNoDefaultExport(_) => ImportNoDefaultExport::IS_TSGOLINT_RULE,
             Self::ImportNoDuplicates(_) => ImportNoDuplicates::IS_TSGOLINT_RULE,
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                ImportNoDynamicNamespaceImportAccess::IS_TSGOLINT_RULE
+            }
             Self::ImportNoDynamicRequire(_) => ImportNoDynamicRequire::IS_TSGOLINT_RULE,
             Self::ImportNoEmptyNamedBlocks(_) => ImportNoEmptyNamedBlocks::IS_TSGOLINT_RULE,
             Self::ImportNoMutableExports(_) => ImportNoMutableExports::IS_TSGOLINT_RULE,
@@ -15290,11 +16224,16 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => ImportNoNamedExport::IS_TSGOLINT_RULE,
             Self::ImportNoNamespace(_) => ImportNoNamespace::IS_TSGOLINT_RULE,
             Self::ImportNoNodejsModules(_) => ImportNoNodejsModules::IS_TSGOLINT_RULE,
+            Self::ImportNoPrivateImports(_) => ImportNoPrivateImports::IS_TSGOLINT_RULE,
             Self::ImportNoRelativeParentImports(_) => {
                 ImportNoRelativeParentImports::IS_TSGOLINT_RULE
             }
             Self::ImportNoSelfImport(_) => ImportNoSelfImport::IS_TSGOLINT_RULE,
             Self::ImportNoUnassignedImport(_) => ImportNoUnassignedImport::IS_TSGOLINT_RULE,
+            Self::ImportNoUndeclaredDependencies(_) => {
+                ImportNoUndeclaredDependencies::IS_TSGOLINT_RULE
+            }
+            Self::ImportNoUnresolvedImports(_) => ImportNoUnresolvedImports::IS_TSGOLINT_RULE,
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::IS_TSGOLINT_RULE,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::IS_TSGOLINT_RULE,
             Self::ImportUnambiguous(_) => ImportUnambiguous::IS_TSGOLINT_RULE,
@@ -15337,6 +16276,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => EslintNoClassAssign::IS_TSGOLINT_RULE,
             Self::EslintNoCompareNegZero(_) => EslintNoCompareNegZero::IS_TSGOLINT_RULE,
             Self::EslintNoCondAssign(_) => EslintNoCondAssign::IS_TSGOLINT_RULE,
+            Self::EslintNoConfusingLabels(_) => EslintNoConfusingLabels::IS_TSGOLINT_RULE,
             Self::EslintNoConsole(_) => EslintNoConsole::IS_TSGOLINT_RULE,
             Self::EslintNoConstAssign(_) => EslintNoConstAssign::IS_TSGOLINT_RULE,
             Self::EslintNoConstantBinaryExpression(_) => {
@@ -15402,6 +16342,7 @@ impl RuleEnum {
             }
             Self::EslintNoObjCalls(_) => EslintNoObjCalls::IS_TSGOLINT_RULE,
             Self::EslintNoObjectConstructor(_) => EslintNoObjectConstructor::IS_TSGOLINT_RULE,
+            Self::EslintNoOctalEscape(_) => EslintNoOctalEscape::IS_TSGOLINT_RULE,
             Self::EslintNoParamReassign(_) => EslintNoParamReassign::IS_TSGOLINT_RULE,
             Self::EslintNoPlusplus(_) => EslintNoPlusplus::IS_TSGOLINT_RULE,
             Self::EslintNoPromiseExecutorReturn(_) => {
@@ -15410,6 +16351,7 @@ impl RuleEnum {
             Self::EslintNoProto(_) => EslintNoProto::IS_TSGOLINT_RULE,
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::IS_TSGOLINT_RULE,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::IS_TSGOLINT_RULE,
+            Self::EslintNoRedundantUseStrict(_) => EslintNoRedundantUseStrict::IS_TSGOLINT_RULE,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::IS_TSGOLINT_RULE,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::IS_TSGOLINT_RULE,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::IS_TSGOLINT_RULE,
@@ -15423,7 +16365,9 @@ impl RuleEnum {
             Self::EslintNoShadowRestrictedNames(_) => {
                 EslintNoShadowRestrictedNames::IS_TSGOLINT_RULE
             }
+            Self::EslintNoShoutyConstants(_) => EslintNoShoutyConstants::IS_TSGOLINT_RULE,
             Self::EslintNoSparseArrays(_) => EslintNoSparseArrays::IS_TSGOLINT_RULE,
+            Self::EslintNoStringCaseMismatch(_) => EslintNoStringCaseMismatch::IS_TSGOLINT_RULE,
             Self::EslintNoTemplateCurlyInString(_) => {
                 EslintNoTemplateCurlyInString::IS_TSGOLINT_RULE
             }
@@ -15458,6 +16402,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => EslintNoUselessComputedKey::IS_TSGOLINT_RULE,
             Self::EslintNoUselessConcat(_) => EslintNoUselessConcat::IS_TSGOLINT_RULE,
             Self::EslintNoUselessConstructor(_) => EslintNoUselessConstructor::IS_TSGOLINT_RULE,
+            Self::EslintNoUselessContinue(_) => EslintNoUselessContinue::IS_TSGOLINT_RULE,
             Self::EslintNoUselessEscape(_) => EslintNoUselessEscape::IS_TSGOLINT_RULE,
             Self::EslintNoUselessRename(_) => EslintNoUselessRename::IS_TSGOLINT_RULE,
             Self::EslintNoUselessReturn(_) => EslintNoUselessReturn::IS_TSGOLINT_RULE,
@@ -15467,6 +16412,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => EslintNoWith::IS_TSGOLINT_RULE,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::IS_TSGOLINT_RULE,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::IS_TSGOLINT_RULE,
+            Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::IS_TSGOLINT_RULE,
             Self::EslintPreferConst(_) => EslintPreferConst::IS_TSGOLINT_RULE,
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::IS_TSGOLINT_RULE,
             Self::EslintPreferExponentiationOperator(_) => {
@@ -15491,6 +16437,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => EslintSymbolDescription::IS_TSGOLINT_RULE,
             Self::EslintUnicodeBom(_) => EslintUnicodeBom::IS_TSGOLINT_RULE,
             Self::EslintUseIsnan(_) => EslintUseIsnan::IS_TSGOLINT_RULE,
+            Self::EslintUseRegexLiterals(_) => EslintUseRegexLiterals::IS_TSGOLINT_RULE,
+            Self::EslintUseSingleVarDeclarator(_) => EslintUseSingleVarDeclarator::IS_TSGOLINT_RULE,
+            Self::EslintUseWhile(_) => EslintUseWhile::IS_TSGOLINT_RULE,
             Self::EslintValidTypeof(_) => EslintValidTypeof::IS_TSGOLINT_RULE,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::IS_TSGOLINT_RULE,
             Self::EslintYoda(_) => EslintYoda::IS_TSGOLINT_RULE,
@@ -15528,9 +16477,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::IS_TSGOLINT_RULE
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::IS_TSGOLINT_RULE
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::IS_TSGOLINT_RULE
             }
+            Self::TypescriptNamingConvention(_) => TypescriptNamingConvention::IS_TSGOLINT_RULE,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::IS_TSGOLINT_RULE,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::IS_TSGOLINT_RULE,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -15549,6 +16502,11 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => TypescriptNoDynamicDelete::IS_TSGOLINT_RULE,
             Self::TypescriptNoEmptyInterface(_) => TypescriptNoEmptyInterface::IS_TSGOLINT_RULE,
             Self::TypescriptNoEmptyObjectType(_) => TypescriptNoEmptyObjectType::IS_TSGOLINT_RULE,
+            Self::TypescriptNoEmptyTypeParameters(_) => {
+                TypescriptNoEmptyTypeParameters::IS_TSGOLINT_RULE
+            }
+            Self::TypescriptNoEnum(_) => TypescriptNoEnum::IS_TSGOLINT_RULE,
+            Self::TypescriptNoEvolvingTypes(_) => TypescriptNoEvolvingTypes::IS_TSGOLINT_RULE,
             Self::TypescriptNoExplicitAny(_) => TypescriptNoExplicitAny::IS_TSGOLINT_RULE,
             Self::TypescriptNoExtraNonNullAssertion(_) => {
                 TypescriptNoExtraNonNullAssertion::IS_TSGOLINT_RULE
@@ -15556,6 +16514,7 @@ impl RuleEnum {
             Self::TypescriptNoExtraneousClass(_) => TypescriptNoExtraneousClass::IS_TSGOLINT_RULE,
             Self::TypescriptNoFloatingPromises(_) => TypescriptNoFloatingPromises::IS_TSGOLINT_RULE,
             Self::TypescriptNoForInArray(_) => TypescriptNoForInArray::IS_TSGOLINT_RULE,
+            Self::TypescriptNoImplicitAnyLet(_) => TypescriptNoImplicitAnyLet::IS_TSGOLINT_RULE,
             Self::TypescriptNoImpliedEval(_) => TypescriptNoImpliedEval::IS_TSGOLINT_RULE,
             Self::TypescriptNoImportTypeSideEffects(_) => {
                 TypescriptNoImportTypeSideEffects::IS_TSGOLINT_RULE
@@ -15583,6 +16542,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => TypescriptNoRequireImports::IS_TSGOLINT_RULE,
             Self::TypescriptNoRestrictedTypes(_) => TypescriptNoRestrictedTypes::IS_TSGOLINT_RULE,
             Self::TypescriptNoThisAlias(_) => TypescriptNoThisAlias::IS_TSGOLINT_RULE,
+            Self::TypescriptNoThisInStatic(_) => TypescriptNoThisInStatic::IS_TSGOLINT_RULE,
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TypescriptNoUnnecessaryBooleanLiteralCompare::IS_TSGOLINT_RULE
             }
@@ -15824,16 +16784,22 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::IS_TSGOLINT_RULE,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::IS_TSGOLINT_RULE,
             Self::ReactNoFindDomNode(_) => ReactNoFindDomNode::IS_TSGOLINT_RULE,
+            Self::ReactNoForwardRef(_) => ReactNoForwardRef::IS_TSGOLINT_RULE,
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::IS_TSGOLINT_RULE,
+            Self::ReactNoJsxLiterals(_) => ReactNoJsxLiterals::IS_TSGOLINT_RULE,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::IS_TSGOLINT_RULE,
             Self::ReactNoNamespace(_) => ReactNoNamespace::IS_TSGOLINT_RULE,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::IS_TSGOLINT_RULE,
+            Self::ReactNoReactSpecificProps(_) => ReactNoReactSpecificProps::IS_TSGOLINT_RULE,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::IS_TSGOLINT_RULE
             }
             Self::ReactNoRenderReturnValue(_) => ReactNoRenderReturnValue::IS_TSGOLINT_RULE,
             Self::ReactNoSetState(_) => ReactNoSetState::IS_TSGOLINT_RULE,
             Self::ReactNoStringRefs(_) => ReactNoStringRefs::IS_TSGOLINT_RULE,
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => {
+                ReactNoSuspiciousSemicolonInJsx::IS_TSGOLINT_RULE
+            }
             Self::ReactNoThisInSfc(_) => ReactNoThisInSfc::IS_TSGOLINT_RULE,
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::IS_TSGOLINT_RULE,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::IS_TSGOLINT_RULE,
@@ -15848,6 +16814,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => ReactSelfClosingComp::IS_TSGOLINT_RULE,
             Self::ReactStateInConstructor(_) => ReactStateInConstructor::IS_TSGOLINT_RULE,
             Self::ReactStylePropObject(_) => ReactStylePropObject::IS_TSGOLINT_RULE,
+            Self::ReactUseImageSize(_) => ReactUseImageSize::IS_TSGOLINT_RULE,
             Self::ReactVoidDomElementsNoChildren(_) => {
                 ReactVoidDomElementsNoChildren::IS_TSGOLINT_RULE
             }
@@ -15904,6 +16871,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::IS_TSGOLINT_RULE,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::IS_TSGOLINT_RULE,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::IS_TSGOLINT_RULE,
+            Self::UnicornNoFlatMapIdentity(_) => UnicornNoFlatMapIdentity::IS_TSGOLINT_RULE,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::IS_TSGOLINT_RULE,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::IS_TSGOLINT_RULE,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::IS_TSGOLINT_RULE,
@@ -15959,8 +16927,12 @@ impl RuleEnum {
                 UnicornNoUselessPromiseResolveReject::IS_TSGOLINT_RULE
             }
             Self::UnicornNoUselessSpread(_) => UnicornNoUselessSpread::IS_TSGOLINT_RULE,
+            Self::UnicornNoUselessStringRaw(_) => UnicornNoUselessStringRaw::IS_TSGOLINT_RULE,
             Self::UnicornNoUselessSwitchCase(_) => UnicornNoUselessSwitchCase::IS_TSGOLINT_RULE,
             Self::UnicornNoUselessUndefined(_) => UnicornNoUselessUndefined::IS_TSGOLINT_RULE,
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UnicornNoUselessUndefinedInitialization::IS_TSGOLINT_RULE
+            }
             Self::UnicornNoZeroFractions(_) => UnicornNoZeroFractions::IS_TSGOLINT_RULE,
             Self::UnicornNumberLiteralCase(_) => UnicornNumberLiteralCase::IS_TSGOLINT_RULE,
             Self::UnicornNumericSeparatorsStyle(_) => {
@@ -16071,6 +17043,14 @@ impl RuleEnum {
                 UnicornTextEncodingIdentifierCase::IS_TSGOLINT_RULE
             }
             Self::UnicornThrowNewError(_) => UnicornThrowNewError::IS_TSGOLINT_RULE,
+            Self::UnicornUseCollapsedIf(_) => UnicornUseCollapsedIf::IS_TSGOLINT_RULE,
+            Self::UnicornUseConsistentCurlyBraces(_) => {
+                UnicornUseConsistentCurlyBraces::IS_TSGOLINT_RULE
+            }
+            Self::UnicornUseSimpleNumberKeys(_) => UnicornUseSimpleNumberKeys::IS_TSGOLINT_RULE,
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UnicornUseSimplifiedLogicExpression::IS_TSGOLINT_RULE
+            }
             Self::JsxA11YAltText(_) => JsxA11YAltText::IS_TSGOLINT_RULE,
             Self::JsxA11YAnchorAmbiguousText(_) => JsxA11YAnchorAmbiguousText::IS_TSGOLINT_RULE,
             Self::JsxA11YAnchorHasContent(_) => JsxA11YAnchorHasContent::IS_TSGOLINT_RULE,
@@ -16106,6 +17086,15 @@ impl RuleEnum {
             }
             Self::JsxA11YNoAutofocus(_) => JsxA11YNoAutofocus::IS_TSGOLINT_RULE,
             Self::JsxA11YNoDistractingElements(_) => JsxA11YNoDistractingElements::IS_TSGOLINT_RULE,
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JsxA11YNoInteractiveElementToNoninteractiveRole::IS_TSGOLINT_RULE
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JsxA11YNoNoninteractiveElementInteractions::IS_TSGOLINT_RULE
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JsxA11YNoNoninteractiveElementToInteractiveRole::IS_TSGOLINT_RULE
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => {
                 JsxA11YNoNoninteractiveTabindex::IS_TSGOLINT_RULE
             }
@@ -16113,6 +17102,7 @@ impl RuleEnum {
             Self::JsxA11YNoStaticElementInteractions(_) => {
                 JsxA11YNoStaticElementInteractions::IS_TSGOLINT_RULE
             }
+            Self::JsxA11YNoSvgWithoutTitle(_) => JsxA11YNoSvgWithoutTitle::IS_TSGOLINT_RULE,
             Self::JsxA11YPreferTagOverRole(_) => JsxA11YPreferTagOverRole::IS_TSGOLINT_RULE,
             Self::JsxA11YRoleHasRequiredAriaProps(_) => {
                 JsxA11YRoleHasRequiredAriaProps::IS_TSGOLINT_RULE
@@ -16120,6 +17110,10 @@ impl RuleEnum {
             Self::JsxA11YRoleSupportsAriaProps(_) => JsxA11YRoleSupportsAriaProps::IS_TSGOLINT_RULE,
             Self::JsxA11YScope(_) => JsxA11YScope::IS_TSGOLINT_RULE,
             Self::JsxA11YTabindexNoPositive(_) => JsxA11YTabindexNoPositive::IS_TSGOLINT_RULE,
+            Self::JsxA11YUseFocusableInteractive(_) => {
+                JsxA11YUseFocusableInteractive::IS_TSGOLINT_RULE
+            }
+            Self::JsxA11YUseUniqueElementIds(_) => JsxA11YUseUniqueElementIds::IS_TSGOLINT_RULE,
             Self::OxcApproxConstant(_) => OxcApproxConstant::IS_TSGOLINT_RULE,
             Self::OxcBadArrayMethodOnArguments(_) => OxcBadArrayMethodOnArguments::IS_TSGOLINT_RULE,
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::IS_TSGOLINT_RULE,
@@ -16252,6 +17246,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::IS_TSGOLINT_RULE,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::IS_TSGOLINT_RULE,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::IS_TSGOLINT_RULE,
+            Self::NodeNoGlobalDirnameFilename(_) => NodeNoGlobalDirnameFilename::IS_TSGOLINT_RULE,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::IS_TSGOLINT_RULE,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::IS_TSGOLINT_RULE,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::IS_TSGOLINT_RULE,
@@ -16298,6 +17293,9 @@ impl RuleEnum {
             Self::ImportNoCycle(_) => ImportNoCycle::HAS_CONFIG,
             Self::ImportNoDefaultExport(_) => ImportNoDefaultExport::HAS_CONFIG,
             Self::ImportNoDuplicates(_) => ImportNoDuplicates::HAS_CONFIG,
+            Self::ImportNoDynamicNamespaceImportAccess(_) => {
+                ImportNoDynamicNamespaceImportAccess::HAS_CONFIG
+            }
             Self::ImportNoDynamicRequire(_) => ImportNoDynamicRequire::HAS_CONFIG,
             Self::ImportNoEmptyNamedBlocks(_) => ImportNoEmptyNamedBlocks::HAS_CONFIG,
             Self::ImportNoMutableExports(_) => ImportNoMutableExports::HAS_CONFIG,
@@ -16307,9 +17305,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(_) => ImportNoNamedExport::HAS_CONFIG,
             Self::ImportNoNamespace(_) => ImportNoNamespace::HAS_CONFIG,
             Self::ImportNoNodejsModules(_) => ImportNoNodejsModules::HAS_CONFIG,
+            Self::ImportNoPrivateImports(_) => ImportNoPrivateImports::HAS_CONFIG,
             Self::ImportNoRelativeParentImports(_) => ImportNoRelativeParentImports::HAS_CONFIG,
             Self::ImportNoSelfImport(_) => ImportNoSelfImport::HAS_CONFIG,
             Self::ImportNoUnassignedImport(_) => ImportNoUnassignedImport::HAS_CONFIG,
+            Self::ImportNoUndeclaredDependencies(_) => ImportNoUndeclaredDependencies::HAS_CONFIG,
+            Self::ImportNoUnresolvedImports(_) => ImportNoUnresolvedImports::HAS_CONFIG,
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::HAS_CONFIG,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::HAS_CONFIG,
             Self::ImportUnambiguous(_) => ImportUnambiguous::HAS_CONFIG,
@@ -16352,6 +17353,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(_) => EslintNoClassAssign::HAS_CONFIG,
             Self::EslintNoCompareNegZero(_) => EslintNoCompareNegZero::HAS_CONFIG,
             Self::EslintNoCondAssign(_) => EslintNoCondAssign::HAS_CONFIG,
+            Self::EslintNoConfusingLabels(_) => EslintNoConfusingLabels::HAS_CONFIG,
             Self::EslintNoConsole(_) => EslintNoConsole::HAS_CONFIG,
             Self::EslintNoConstAssign(_) => EslintNoConstAssign::HAS_CONFIG,
             Self::EslintNoConstantBinaryExpression(_) => {
@@ -16413,12 +17415,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(_) => EslintNoNonoctalDecimalEscape::HAS_CONFIG,
             Self::EslintNoObjCalls(_) => EslintNoObjCalls::HAS_CONFIG,
             Self::EslintNoObjectConstructor(_) => EslintNoObjectConstructor::HAS_CONFIG,
+            Self::EslintNoOctalEscape(_) => EslintNoOctalEscape::HAS_CONFIG,
             Self::EslintNoParamReassign(_) => EslintNoParamReassign::HAS_CONFIG,
             Self::EslintNoPlusplus(_) => EslintNoPlusplus::HAS_CONFIG,
             Self::EslintNoPromiseExecutorReturn(_) => EslintNoPromiseExecutorReturn::HAS_CONFIG,
             Self::EslintNoProto(_) => EslintNoProto::HAS_CONFIG,
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::HAS_CONFIG,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::HAS_CONFIG,
+            Self::EslintNoRedundantUseStrict(_) => EslintNoRedundantUseStrict::HAS_CONFIG,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::HAS_CONFIG,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::HAS_CONFIG,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::HAS_CONFIG,
@@ -16430,7 +17434,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(_) => EslintNoSetterReturn::HAS_CONFIG,
             Self::EslintNoShadow(_) => EslintNoShadow::HAS_CONFIG,
             Self::EslintNoShadowRestrictedNames(_) => EslintNoShadowRestrictedNames::HAS_CONFIG,
+            Self::EslintNoShoutyConstants(_) => EslintNoShoutyConstants::HAS_CONFIG,
             Self::EslintNoSparseArrays(_) => EslintNoSparseArrays::HAS_CONFIG,
+            Self::EslintNoStringCaseMismatch(_) => EslintNoStringCaseMismatch::HAS_CONFIG,
             Self::EslintNoTemplateCurlyInString(_) => EslintNoTemplateCurlyInString::HAS_CONFIG,
             Self::EslintNoTernary(_) => EslintNoTernary::HAS_CONFIG,
             Self::EslintNoThisBeforeSuper(_) => EslintNoThisBeforeSuper::HAS_CONFIG,
@@ -16459,6 +17465,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(_) => EslintNoUselessComputedKey::HAS_CONFIG,
             Self::EslintNoUselessConcat(_) => EslintNoUselessConcat::HAS_CONFIG,
             Self::EslintNoUselessConstructor(_) => EslintNoUselessConstructor::HAS_CONFIG,
+            Self::EslintNoUselessContinue(_) => EslintNoUselessContinue::HAS_CONFIG,
             Self::EslintNoUselessEscape(_) => EslintNoUselessEscape::HAS_CONFIG,
             Self::EslintNoUselessRename(_) => EslintNoUselessRename::HAS_CONFIG,
             Self::EslintNoUselessReturn(_) => EslintNoUselessReturn::HAS_CONFIG,
@@ -16468,6 +17475,7 @@ impl RuleEnum {
             Self::EslintNoWith(_) => EslintNoWith::HAS_CONFIG,
             Self::EslintObjectShorthand(_) => EslintObjectShorthand::HAS_CONFIG,
             Self::EslintOperatorAssignment(_) => EslintOperatorAssignment::HAS_CONFIG,
+            Self::EslintPreferArrowCallback(_) => EslintPreferArrowCallback::HAS_CONFIG,
             Self::EslintPreferConst(_) => EslintPreferConst::HAS_CONFIG,
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::HAS_CONFIG,
             Self::EslintPreferExponentiationOperator(_) => {
@@ -16490,6 +17498,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(_) => EslintSymbolDescription::HAS_CONFIG,
             Self::EslintUnicodeBom(_) => EslintUnicodeBom::HAS_CONFIG,
             Self::EslintUseIsnan(_) => EslintUseIsnan::HAS_CONFIG,
+            Self::EslintUseRegexLiterals(_) => EslintUseRegexLiterals::HAS_CONFIG,
+            Self::EslintUseSingleVarDeclarator(_) => EslintUseSingleVarDeclarator::HAS_CONFIG,
+            Self::EslintUseWhile(_) => EslintUseWhile::HAS_CONFIG,
             Self::EslintValidTypeof(_) => EslintValidTypeof::HAS_CONFIG,
             Self::EslintVarsOnTop(_) => EslintVarsOnTop::HAS_CONFIG,
             Self::EslintYoda(_) => EslintYoda::HAS_CONFIG,
@@ -16523,9 +17534,13 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::HAS_CONFIG
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::HAS_CONFIG
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::HAS_CONFIG
             }
+            Self::TypescriptNamingConvention(_) => TypescriptNamingConvention::HAS_CONFIG,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::HAS_CONFIG,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::HAS_CONFIG,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -16542,6 +17557,9 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(_) => TypescriptNoDynamicDelete::HAS_CONFIG,
             Self::TypescriptNoEmptyInterface(_) => TypescriptNoEmptyInterface::HAS_CONFIG,
             Self::TypescriptNoEmptyObjectType(_) => TypescriptNoEmptyObjectType::HAS_CONFIG,
+            Self::TypescriptNoEmptyTypeParameters(_) => TypescriptNoEmptyTypeParameters::HAS_CONFIG,
+            Self::TypescriptNoEnum(_) => TypescriptNoEnum::HAS_CONFIG,
+            Self::TypescriptNoEvolvingTypes(_) => TypescriptNoEvolvingTypes::HAS_CONFIG,
             Self::TypescriptNoExplicitAny(_) => TypescriptNoExplicitAny::HAS_CONFIG,
             Self::TypescriptNoExtraNonNullAssertion(_) => {
                 TypescriptNoExtraNonNullAssertion::HAS_CONFIG
@@ -16549,6 +17567,7 @@ impl RuleEnum {
             Self::TypescriptNoExtraneousClass(_) => TypescriptNoExtraneousClass::HAS_CONFIG,
             Self::TypescriptNoFloatingPromises(_) => TypescriptNoFloatingPromises::HAS_CONFIG,
             Self::TypescriptNoForInArray(_) => TypescriptNoForInArray::HAS_CONFIG,
+            Self::TypescriptNoImplicitAnyLet(_) => TypescriptNoImplicitAnyLet::HAS_CONFIG,
             Self::TypescriptNoImpliedEval(_) => TypescriptNoImpliedEval::HAS_CONFIG,
             Self::TypescriptNoImportTypeSideEffects(_) => {
                 TypescriptNoImportTypeSideEffects::HAS_CONFIG
@@ -16576,6 +17595,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(_) => TypescriptNoRequireImports::HAS_CONFIG,
             Self::TypescriptNoRestrictedTypes(_) => TypescriptNoRestrictedTypes::HAS_CONFIG,
             Self::TypescriptNoThisAlias(_) => TypescriptNoThisAlias::HAS_CONFIG,
+            Self::TypescriptNoThisInStatic(_) => TypescriptNoThisInStatic::HAS_CONFIG,
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(_) => {
                 TypescriptNoUnnecessaryBooleanLiteralCompare::HAS_CONFIG
             }
@@ -16785,16 +17805,20 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::HAS_CONFIG,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::HAS_CONFIG,
             Self::ReactNoFindDomNode(_) => ReactNoFindDomNode::HAS_CONFIG,
+            Self::ReactNoForwardRef(_) => ReactNoForwardRef::HAS_CONFIG,
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::HAS_CONFIG,
+            Self::ReactNoJsxLiterals(_) => ReactNoJsxLiterals::HAS_CONFIG,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::HAS_CONFIG,
             Self::ReactNoNamespace(_) => ReactNoNamespace::HAS_CONFIG,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::HAS_CONFIG,
+            Self::ReactNoReactSpecificProps(_) => ReactNoReactSpecificProps::HAS_CONFIG,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::HAS_CONFIG
             }
             Self::ReactNoRenderReturnValue(_) => ReactNoRenderReturnValue::HAS_CONFIG,
             Self::ReactNoSetState(_) => ReactNoSetState::HAS_CONFIG,
             Self::ReactNoStringRefs(_) => ReactNoStringRefs::HAS_CONFIG,
+            Self::ReactNoSuspiciousSemicolonInJsx(_) => ReactNoSuspiciousSemicolonInJsx::HAS_CONFIG,
             Self::ReactNoThisInSfc(_) => ReactNoThisInSfc::HAS_CONFIG,
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::HAS_CONFIG,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::HAS_CONFIG,
@@ -16809,6 +17833,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(_) => ReactSelfClosingComp::HAS_CONFIG,
             Self::ReactStateInConstructor(_) => ReactStateInConstructor::HAS_CONFIG,
             Self::ReactStylePropObject(_) => ReactStylePropObject::HAS_CONFIG,
+            Self::ReactUseImageSize(_) => ReactUseImageSize::HAS_CONFIG,
             Self::ReactVoidDomElementsNoChildren(_) => ReactVoidDomElementsNoChildren::HAS_CONFIG,
             Self::ReactPerfJsxNoJsxAsProp(_) => ReactPerfJsxNoJsxAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::HAS_CONFIG,
@@ -16849,6 +17874,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::HAS_CONFIG,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::HAS_CONFIG,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::HAS_CONFIG,
+            Self::UnicornNoFlatMapIdentity(_) => UnicornNoFlatMapIdentity::HAS_CONFIG,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::HAS_CONFIG,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::HAS_CONFIG,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::HAS_CONFIG,
@@ -16904,8 +17930,12 @@ impl RuleEnum {
                 UnicornNoUselessPromiseResolveReject::HAS_CONFIG
             }
             Self::UnicornNoUselessSpread(_) => UnicornNoUselessSpread::HAS_CONFIG,
+            Self::UnicornNoUselessStringRaw(_) => UnicornNoUselessStringRaw::HAS_CONFIG,
             Self::UnicornNoUselessSwitchCase(_) => UnicornNoUselessSwitchCase::HAS_CONFIG,
             Self::UnicornNoUselessUndefined(_) => UnicornNoUselessUndefined::HAS_CONFIG,
+            Self::UnicornNoUselessUndefinedInitialization(_) => {
+                UnicornNoUselessUndefinedInitialization::HAS_CONFIG
+            }
             Self::UnicornNoZeroFractions(_) => UnicornNoZeroFractions::HAS_CONFIG,
             Self::UnicornNumberLiteralCase(_) => UnicornNumberLiteralCase::HAS_CONFIG,
             Self::UnicornNumericSeparatorsStyle(_) => UnicornNumericSeparatorsStyle::HAS_CONFIG,
@@ -16986,6 +18016,12 @@ impl RuleEnum {
                 UnicornTextEncodingIdentifierCase::HAS_CONFIG
             }
             Self::UnicornThrowNewError(_) => UnicornThrowNewError::HAS_CONFIG,
+            Self::UnicornUseCollapsedIf(_) => UnicornUseCollapsedIf::HAS_CONFIG,
+            Self::UnicornUseConsistentCurlyBraces(_) => UnicornUseConsistentCurlyBraces::HAS_CONFIG,
+            Self::UnicornUseSimpleNumberKeys(_) => UnicornUseSimpleNumberKeys::HAS_CONFIG,
+            Self::UnicornUseSimplifiedLogicExpression(_) => {
+                UnicornUseSimplifiedLogicExpression::HAS_CONFIG
+            }
             Self::JsxA11YAltText(_) => JsxA11YAltText::HAS_CONFIG,
             Self::JsxA11YAnchorAmbiguousText(_) => JsxA11YAnchorAmbiguousText::HAS_CONFIG,
             Self::JsxA11YAnchorHasContent(_) => JsxA11YAnchorHasContent::HAS_CONFIG,
@@ -17013,16 +18049,28 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(_) => JsxA11YNoAriaHiddenOnFocusable::HAS_CONFIG,
             Self::JsxA11YNoAutofocus(_) => JsxA11YNoAutofocus::HAS_CONFIG,
             Self::JsxA11YNoDistractingElements(_) => JsxA11YNoDistractingElements::HAS_CONFIG,
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(_) => {
+                JsxA11YNoInteractiveElementToNoninteractiveRole::HAS_CONFIG
+            }
+            Self::JsxA11YNoNoninteractiveElementInteractions(_) => {
+                JsxA11YNoNoninteractiveElementInteractions::HAS_CONFIG
+            }
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(_) => {
+                JsxA11YNoNoninteractiveElementToInteractiveRole::HAS_CONFIG
+            }
             Self::JsxA11YNoNoninteractiveTabindex(_) => JsxA11YNoNoninteractiveTabindex::HAS_CONFIG,
             Self::JsxA11YNoRedundantRoles(_) => JsxA11YNoRedundantRoles::HAS_CONFIG,
             Self::JsxA11YNoStaticElementInteractions(_) => {
                 JsxA11YNoStaticElementInteractions::HAS_CONFIG
             }
+            Self::JsxA11YNoSvgWithoutTitle(_) => JsxA11YNoSvgWithoutTitle::HAS_CONFIG,
             Self::JsxA11YPreferTagOverRole(_) => JsxA11YPreferTagOverRole::HAS_CONFIG,
             Self::JsxA11YRoleHasRequiredAriaProps(_) => JsxA11YRoleHasRequiredAriaProps::HAS_CONFIG,
             Self::JsxA11YRoleSupportsAriaProps(_) => JsxA11YRoleSupportsAriaProps::HAS_CONFIG,
             Self::JsxA11YScope(_) => JsxA11YScope::HAS_CONFIG,
             Self::JsxA11YTabindexNoPositive(_) => JsxA11YTabindexNoPositive::HAS_CONFIG,
+            Self::JsxA11YUseFocusableInteractive(_) => JsxA11YUseFocusableInteractive::HAS_CONFIG,
+            Self::JsxA11YUseUniqueElementIds(_) => JsxA11YUseUniqueElementIds::HAS_CONFIG,
             Self::OxcApproxConstant(_) => OxcApproxConstant::HAS_CONFIG,
             Self::OxcBadArrayMethodOnArguments(_) => OxcBadArrayMethodOnArguments::HAS_CONFIG,
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::HAS_CONFIG,
@@ -17139,6 +18187,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::HAS_CONFIG,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::HAS_CONFIG,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::HAS_CONFIG,
+            Self::NodeNoGlobalDirnameFilename(_) => NodeNoGlobalDirnameFilename::HAS_CONFIG,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::HAS_CONFIG,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::HAS_CONFIG,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::HAS_CONFIG,
@@ -17182,6 +18231,7 @@ impl RuleEnum {
             Self::ImportNoCycle(rule) => rule.types_info(),
             Self::ImportNoDefaultExport(rule) => rule.types_info(),
             Self::ImportNoDuplicates(rule) => rule.types_info(),
+            Self::ImportNoDynamicNamespaceImportAccess(rule) => rule.types_info(),
             Self::ImportNoDynamicRequire(rule) => rule.types_info(),
             Self::ImportNoEmptyNamedBlocks(rule) => rule.types_info(),
             Self::ImportNoMutableExports(rule) => rule.types_info(),
@@ -17191,9 +18241,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(rule) => rule.types_info(),
             Self::ImportNoNamespace(rule) => rule.types_info(),
             Self::ImportNoNodejsModules(rule) => rule.types_info(),
+            Self::ImportNoPrivateImports(rule) => rule.types_info(),
             Self::ImportNoRelativeParentImports(rule) => rule.types_info(),
             Self::ImportNoSelfImport(rule) => rule.types_info(),
             Self::ImportNoUnassignedImport(rule) => rule.types_info(),
+            Self::ImportNoUndeclaredDependencies(rule) => rule.types_info(),
+            Self::ImportNoUnresolvedImports(rule) => rule.types_info(),
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.types_info(),
             Self::ImportPreferDefaultExport(rule) => rule.types_info(),
             Self::ImportUnambiguous(rule) => rule.types_info(),
@@ -17236,6 +18289,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(rule) => rule.types_info(),
             Self::EslintNoCompareNegZero(rule) => rule.types_info(),
             Self::EslintNoCondAssign(rule) => rule.types_info(),
+            Self::EslintNoConfusingLabels(rule) => rule.types_info(),
             Self::EslintNoConsole(rule) => rule.types_info(),
             Self::EslintNoConstAssign(rule) => rule.types_info(),
             Self::EslintNoConstantBinaryExpression(rule) => rule.types_info(),
@@ -17293,12 +18347,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(rule) => rule.types_info(),
             Self::EslintNoObjCalls(rule) => rule.types_info(),
             Self::EslintNoObjectConstructor(rule) => rule.types_info(),
+            Self::EslintNoOctalEscape(rule) => rule.types_info(),
             Self::EslintNoParamReassign(rule) => rule.types_info(),
             Self::EslintNoPlusplus(rule) => rule.types_info(),
             Self::EslintNoPromiseExecutorReturn(rule) => rule.types_info(),
             Self::EslintNoProto(rule) => rule.types_info(),
             Self::EslintNoPrototypeBuiltins(rule) => rule.types_info(),
             Self::EslintNoRedeclare(rule) => rule.types_info(),
+            Self::EslintNoRedundantUseStrict(rule) => rule.types_info(),
             Self::EslintNoRegexSpaces(rule) => rule.types_info(),
             Self::EslintNoRestrictedGlobals(rule) => rule.types_info(),
             Self::EslintNoRestrictedImports(rule) => rule.types_info(),
@@ -17310,7 +18366,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(rule) => rule.types_info(),
             Self::EslintNoShadow(rule) => rule.types_info(),
             Self::EslintNoShadowRestrictedNames(rule) => rule.types_info(),
+            Self::EslintNoShoutyConstants(rule) => rule.types_info(),
             Self::EslintNoSparseArrays(rule) => rule.types_info(),
+            Self::EslintNoStringCaseMismatch(rule) => rule.types_info(),
             Self::EslintNoTemplateCurlyInString(rule) => rule.types_info(),
             Self::EslintNoTernary(rule) => rule.types_info(),
             Self::EslintNoThisBeforeSuper(rule) => rule.types_info(),
@@ -17337,6 +18395,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(rule) => rule.types_info(),
             Self::EslintNoUselessConcat(rule) => rule.types_info(),
             Self::EslintNoUselessConstructor(rule) => rule.types_info(),
+            Self::EslintNoUselessContinue(rule) => rule.types_info(),
             Self::EslintNoUselessEscape(rule) => rule.types_info(),
             Self::EslintNoUselessRename(rule) => rule.types_info(),
             Self::EslintNoUselessReturn(rule) => rule.types_info(),
@@ -17346,6 +18405,7 @@ impl RuleEnum {
             Self::EslintNoWith(rule) => rule.types_info(),
             Self::EslintObjectShorthand(rule) => rule.types_info(),
             Self::EslintOperatorAssignment(rule) => rule.types_info(),
+            Self::EslintPreferArrowCallback(rule) => rule.types_info(),
             Self::EslintPreferConst(rule) => rule.types_info(),
             Self::EslintPreferDestructuring(rule) => rule.types_info(),
             Self::EslintPreferExponentiationOperator(rule) => rule.types_info(),
@@ -17366,6 +18426,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(rule) => rule.types_info(),
             Self::EslintUnicodeBom(rule) => rule.types_info(),
             Self::EslintUseIsnan(rule) => rule.types_info(),
+            Self::EslintUseRegexLiterals(rule) => rule.types_info(),
+            Self::EslintUseSingleVarDeclarator(rule) => rule.types_info(),
+            Self::EslintUseWhile(rule) => rule.types_info(),
             Self::EslintValidTypeof(rule) => rule.types_info(),
             Self::EslintVarsOnTop(rule) => rule.types_info(),
             Self::EslintYoda(rule) => rule.types_info(),
@@ -17385,7 +18448,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.types_info(),
             Self::TypescriptDotNotation(rule) => rule.types_info(),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.types_info(),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.types_info(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.types_info(),
+            Self::TypescriptNamingConvention(rule) => rule.types_info(),
             Self::TypescriptNoArrayDelete(rule) => rule.types_info(),
             Self::TypescriptNoBaseToString(rule) => rule.types_info(),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.types_info(),
@@ -17396,11 +18461,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(rule) => rule.types_info(),
             Self::TypescriptNoEmptyInterface(rule) => rule.types_info(),
             Self::TypescriptNoEmptyObjectType(rule) => rule.types_info(),
+            Self::TypescriptNoEmptyTypeParameters(rule) => rule.types_info(),
+            Self::TypescriptNoEnum(rule) => rule.types_info(),
+            Self::TypescriptNoEvolvingTypes(rule) => rule.types_info(),
             Self::TypescriptNoExplicitAny(rule) => rule.types_info(),
             Self::TypescriptNoExtraNonNullAssertion(rule) => rule.types_info(),
             Self::TypescriptNoExtraneousClass(rule) => rule.types_info(),
             Self::TypescriptNoFloatingPromises(rule) => rule.types_info(),
             Self::TypescriptNoForInArray(rule) => rule.types_info(),
+            Self::TypescriptNoImplicitAnyLet(rule) => rule.types_info(),
             Self::TypescriptNoImpliedEval(rule) => rule.types_info(),
             Self::TypescriptNoImportTypeSideEffects(rule) => rule.types_info(),
             Self::TypescriptNoInferrableTypes(rule) => rule.types_info(),
@@ -17418,6 +18487,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(rule) => rule.types_info(),
             Self::TypescriptNoRestrictedTypes(rule) => rule.types_info(),
             Self::TypescriptNoThisAlias(rule) => rule.types_info(),
+            Self::TypescriptNoThisInStatic(rule) => rule.types_info(),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => rule.types_info(),
             Self::TypescriptNoUnnecessaryCondition(rule) => rule.types_info(),
             Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => rule.types_info(),
@@ -17565,14 +18635,18 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(rule) => rule.types_info(),
             Self::ReactNoDirectMutationState(rule) => rule.types_info(),
             Self::ReactNoFindDomNode(rule) => rule.types_info(),
+            Self::ReactNoForwardRef(rule) => rule.types_info(),
             Self::ReactNoIsMounted(rule) => rule.types_info(),
+            Self::ReactNoJsxLiterals(rule) => rule.types_info(),
             Self::ReactNoMultiComp(rule) => rule.types_info(),
             Self::ReactNoNamespace(rule) => rule.types_info(),
             Self::ReactNoReactChildren(rule) => rule.types_info(),
+            Self::ReactNoReactSpecificProps(rule) => rule.types_info(),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.types_info(),
             Self::ReactNoRenderReturnValue(rule) => rule.types_info(),
             Self::ReactNoSetState(rule) => rule.types_info(),
             Self::ReactNoStringRefs(rule) => rule.types_info(),
+            Self::ReactNoSuspiciousSemicolonInJsx(rule) => rule.types_info(),
             Self::ReactNoThisInSfc(rule) => rule.types_info(),
             Self::ReactNoUnescapedEntities(rule) => rule.types_info(),
             Self::ReactNoUnknownProperty(rule) => rule.types_info(),
@@ -17587,6 +18661,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(rule) => rule.types_info(),
             Self::ReactStateInConstructor(rule) => rule.types_info(),
             Self::ReactStylePropObject(rule) => rule.types_info(),
+            Self::ReactUseImageSize(rule) => rule.types_info(),
             Self::ReactVoidDomElementsNoChildren(rule) => rule.types_info(),
             Self::ReactPerfJsxNoJsxAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.types_info(),
@@ -17619,6 +18694,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.types_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.types_info(),
             Self::UnicornNoEmptyFile(rule) => rule.types_info(),
+            Self::UnicornNoFlatMapIdentity(rule) => rule.types_info(),
             Self::UnicornNoHexEscape(rule) => rule.types_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.types_info(),
             Self::UnicornNoInstanceofArray(rule) => rule.types_info(),
@@ -17652,8 +18728,10 @@ impl RuleEnum {
             Self::UnicornNoUselessLengthCheck(rule) => rule.types_info(),
             Self::UnicornNoUselessPromiseResolveReject(rule) => rule.types_info(),
             Self::UnicornNoUselessSpread(rule) => rule.types_info(),
+            Self::UnicornNoUselessStringRaw(rule) => rule.types_info(),
             Self::UnicornNoUselessSwitchCase(rule) => rule.types_info(),
             Self::UnicornNoUselessUndefined(rule) => rule.types_info(),
+            Self::UnicornNoUselessUndefinedInitialization(rule) => rule.types_info(),
             Self::UnicornNoZeroFractions(rule) => rule.types_info(),
             Self::UnicornNumberLiteralCase(rule) => rule.types_info(),
             Self::UnicornNumericSeparatorsStyle(rule) => rule.types_info(),
@@ -17718,6 +18796,10 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(rule) => rule.types_info(),
             Self::UnicornTextEncodingIdentifierCase(rule) => rule.types_info(),
             Self::UnicornThrowNewError(rule) => rule.types_info(),
+            Self::UnicornUseCollapsedIf(rule) => rule.types_info(),
+            Self::UnicornUseConsistentCurlyBraces(rule) => rule.types_info(),
+            Self::UnicornUseSimpleNumberKeys(rule) => rule.types_info(),
+            Self::UnicornUseSimplifiedLogicExpression(rule) => rule.types_info(),
             Self::JsxA11YAltText(rule) => rule.types_info(),
             Self::JsxA11YAnchorAmbiguousText(rule) => rule.types_info(),
             Self::JsxA11YAnchorHasContent(rule) => rule.types_info(),
@@ -17741,14 +18823,20 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(rule) => rule.types_info(),
             Self::JsxA11YNoAutofocus(rule) => rule.types_info(),
             Self::JsxA11YNoDistractingElements(rule) => rule.types_info(),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => rule.types_info(),
+            Self::JsxA11YNoNoninteractiveElementInteractions(rule) => rule.types_info(),
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => rule.types_info(),
             Self::JsxA11YNoNoninteractiveTabindex(rule) => rule.types_info(),
             Self::JsxA11YNoRedundantRoles(rule) => rule.types_info(),
             Self::JsxA11YNoStaticElementInteractions(rule) => rule.types_info(),
+            Self::JsxA11YNoSvgWithoutTitle(rule) => rule.types_info(),
             Self::JsxA11YPreferTagOverRole(rule) => rule.types_info(),
             Self::JsxA11YRoleHasRequiredAriaProps(rule) => rule.types_info(),
             Self::JsxA11YRoleSupportsAriaProps(rule) => rule.types_info(),
             Self::JsxA11YScope(rule) => rule.types_info(),
             Self::JsxA11YTabindexNoPositive(rule) => rule.types_info(),
+            Self::JsxA11YUseFocusableInteractive(rule) => rule.types_info(),
+            Self::JsxA11YUseUniqueElementIds(rule) => rule.types_info(),
             Self::OxcApproxConstant(rule) => rule.types_info(),
             Self::OxcBadArrayMethodOnArguments(rule) => rule.types_info(),
             Self::OxcBadBitwiseOperator(rule) => rule.types_info(),
@@ -17855,6 +18943,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(rule) => rule.types_info(),
             Self::NodeHandleCallbackErr(rule) => rule.types_info(),
             Self::NodeNoExportsAssign(rule) => rule.types_info(),
+            Self::NodeNoGlobalDirnameFilename(rule) => rule.types_info(),
             Self::NodeNoNewRequire(rule) => rule.types_info(),
             Self::NodeNoPathConcat(rule) => rule.types_info(),
             Self::NodeNoProcessEnv(rule) => rule.types_info(),
@@ -17896,6 +18985,7 @@ impl RuleEnum {
             Self::ImportNoCycle(rule) => rule.run_info(),
             Self::ImportNoDefaultExport(rule) => rule.run_info(),
             Self::ImportNoDuplicates(rule) => rule.run_info(),
+            Self::ImportNoDynamicNamespaceImportAccess(rule) => rule.run_info(),
             Self::ImportNoDynamicRequire(rule) => rule.run_info(),
             Self::ImportNoEmptyNamedBlocks(rule) => rule.run_info(),
             Self::ImportNoMutableExports(rule) => rule.run_info(),
@@ -17905,9 +18995,12 @@ impl RuleEnum {
             Self::ImportNoNamedExport(rule) => rule.run_info(),
             Self::ImportNoNamespace(rule) => rule.run_info(),
             Self::ImportNoNodejsModules(rule) => rule.run_info(),
+            Self::ImportNoPrivateImports(rule) => rule.run_info(),
             Self::ImportNoRelativeParentImports(rule) => rule.run_info(),
             Self::ImportNoSelfImport(rule) => rule.run_info(),
             Self::ImportNoUnassignedImport(rule) => rule.run_info(),
+            Self::ImportNoUndeclaredDependencies(rule) => rule.run_info(),
+            Self::ImportNoUnresolvedImports(rule) => rule.run_info(),
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_info(),
             Self::ImportPreferDefaultExport(rule) => rule.run_info(),
             Self::ImportUnambiguous(rule) => rule.run_info(),
@@ -17950,6 +19043,7 @@ impl RuleEnum {
             Self::EslintNoClassAssign(rule) => rule.run_info(),
             Self::EslintNoCompareNegZero(rule) => rule.run_info(),
             Self::EslintNoCondAssign(rule) => rule.run_info(),
+            Self::EslintNoConfusingLabels(rule) => rule.run_info(),
             Self::EslintNoConsole(rule) => rule.run_info(),
             Self::EslintNoConstAssign(rule) => rule.run_info(),
             Self::EslintNoConstantBinaryExpression(rule) => rule.run_info(),
@@ -18007,12 +19101,14 @@ impl RuleEnum {
             Self::EslintNoNonoctalDecimalEscape(rule) => rule.run_info(),
             Self::EslintNoObjCalls(rule) => rule.run_info(),
             Self::EslintNoObjectConstructor(rule) => rule.run_info(),
+            Self::EslintNoOctalEscape(rule) => rule.run_info(),
             Self::EslintNoParamReassign(rule) => rule.run_info(),
             Self::EslintNoPlusplus(rule) => rule.run_info(),
             Self::EslintNoPromiseExecutorReturn(rule) => rule.run_info(),
             Self::EslintNoProto(rule) => rule.run_info(),
             Self::EslintNoPrototypeBuiltins(rule) => rule.run_info(),
             Self::EslintNoRedeclare(rule) => rule.run_info(),
+            Self::EslintNoRedundantUseStrict(rule) => rule.run_info(),
             Self::EslintNoRegexSpaces(rule) => rule.run_info(),
             Self::EslintNoRestrictedGlobals(rule) => rule.run_info(),
             Self::EslintNoRestrictedImports(rule) => rule.run_info(),
@@ -18024,7 +19120,9 @@ impl RuleEnum {
             Self::EslintNoSetterReturn(rule) => rule.run_info(),
             Self::EslintNoShadow(rule) => rule.run_info(),
             Self::EslintNoShadowRestrictedNames(rule) => rule.run_info(),
+            Self::EslintNoShoutyConstants(rule) => rule.run_info(),
             Self::EslintNoSparseArrays(rule) => rule.run_info(),
+            Self::EslintNoStringCaseMismatch(rule) => rule.run_info(),
             Self::EslintNoTemplateCurlyInString(rule) => rule.run_info(),
             Self::EslintNoTernary(rule) => rule.run_info(),
             Self::EslintNoThisBeforeSuper(rule) => rule.run_info(),
@@ -18051,6 +19149,7 @@ impl RuleEnum {
             Self::EslintNoUselessComputedKey(rule) => rule.run_info(),
             Self::EslintNoUselessConcat(rule) => rule.run_info(),
             Self::EslintNoUselessConstructor(rule) => rule.run_info(),
+            Self::EslintNoUselessContinue(rule) => rule.run_info(),
             Self::EslintNoUselessEscape(rule) => rule.run_info(),
             Self::EslintNoUselessRename(rule) => rule.run_info(),
             Self::EslintNoUselessReturn(rule) => rule.run_info(),
@@ -18060,6 +19159,7 @@ impl RuleEnum {
             Self::EslintNoWith(rule) => rule.run_info(),
             Self::EslintObjectShorthand(rule) => rule.run_info(),
             Self::EslintOperatorAssignment(rule) => rule.run_info(),
+            Self::EslintPreferArrowCallback(rule) => rule.run_info(),
             Self::EslintPreferConst(rule) => rule.run_info(),
             Self::EslintPreferDestructuring(rule) => rule.run_info(),
             Self::EslintPreferExponentiationOperator(rule) => rule.run_info(),
@@ -18080,6 +19180,9 @@ impl RuleEnum {
             Self::EslintSymbolDescription(rule) => rule.run_info(),
             Self::EslintUnicodeBom(rule) => rule.run_info(),
             Self::EslintUseIsnan(rule) => rule.run_info(),
+            Self::EslintUseRegexLiterals(rule) => rule.run_info(),
+            Self::EslintUseSingleVarDeclarator(rule) => rule.run_info(),
+            Self::EslintUseWhile(rule) => rule.run_info(),
             Self::EslintValidTypeof(rule) => rule.run_info(),
             Self::EslintVarsOnTop(rule) => rule.run_info(),
             Self::EslintYoda(rule) => rule.run_info(),
@@ -18099,7 +19202,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.run_info(),
             Self::TypescriptDotNotation(rule) => rule.run_info(),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.run_info(),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.run_info(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run_info(),
+            Self::TypescriptNamingConvention(rule) => rule.run_info(),
             Self::TypescriptNoArrayDelete(rule) => rule.run_info(),
             Self::TypescriptNoBaseToString(rule) => rule.run_info(),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run_info(),
@@ -18110,11 +19215,15 @@ impl RuleEnum {
             Self::TypescriptNoDynamicDelete(rule) => rule.run_info(),
             Self::TypescriptNoEmptyInterface(rule) => rule.run_info(),
             Self::TypescriptNoEmptyObjectType(rule) => rule.run_info(),
+            Self::TypescriptNoEmptyTypeParameters(rule) => rule.run_info(),
+            Self::TypescriptNoEnum(rule) => rule.run_info(),
+            Self::TypescriptNoEvolvingTypes(rule) => rule.run_info(),
             Self::TypescriptNoExplicitAny(rule) => rule.run_info(),
             Self::TypescriptNoExtraNonNullAssertion(rule) => rule.run_info(),
             Self::TypescriptNoExtraneousClass(rule) => rule.run_info(),
             Self::TypescriptNoFloatingPromises(rule) => rule.run_info(),
             Self::TypescriptNoForInArray(rule) => rule.run_info(),
+            Self::TypescriptNoImplicitAnyLet(rule) => rule.run_info(),
             Self::TypescriptNoImpliedEval(rule) => rule.run_info(),
             Self::TypescriptNoImportTypeSideEffects(rule) => rule.run_info(),
             Self::TypescriptNoInferrableTypes(rule) => rule.run_info(),
@@ -18132,6 +19241,7 @@ impl RuleEnum {
             Self::TypescriptNoRequireImports(rule) => rule.run_info(),
             Self::TypescriptNoRestrictedTypes(rule) => rule.run_info(),
             Self::TypescriptNoThisAlias(rule) => rule.run_info(),
+            Self::TypescriptNoThisInStatic(rule) => rule.run_info(),
             Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => rule.run_info(),
             Self::TypescriptNoUnnecessaryCondition(rule) => rule.run_info(),
             Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => rule.run_info(),
@@ -18279,14 +19389,18 @@ impl RuleEnum {
             Self::ReactNoDidMountSetState(rule) => rule.run_info(),
             Self::ReactNoDirectMutationState(rule) => rule.run_info(),
             Self::ReactNoFindDomNode(rule) => rule.run_info(),
+            Self::ReactNoForwardRef(rule) => rule.run_info(),
             Self::ReactNoIsMounted(rule) => rule.run_info(),
+            Self::ReactNoJsxLiterals(rule) => rule.run_info(),
             Self::ReactNoMultiComp(rule) => rule.run_info(),
             Self::ReactNoNamespace(rule) => rule.run_info(),
             Self::ReactNoReactChildren(rule) => rule.run_info(),
+            Self::ReactNoReactSpecificProps(rule) => rule.run_info(),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run_info(),
             Self::ReactNoRenderReturnValue(rule) => rule.run_info(),
             Self::ReactNoSetState(rule) => rule.run_info(),
             Self::ReactNoStringRefs(rule) => rule.run_info(),
+            Self::ReactNoSuspiciousSemicolonInJsx(rule) => rule.run_info(),
             Self::ReactNoThisInSfc(rule) => rule.run_info(),
             Self::ReactNoUnescapedEntities(rule) => rule.run_info(),
             Self::ReactNoUnknownProperty(rule) => rule.run_info(),
@@ -18301,6 +19415,7 @@ impl RuleEnum {
             Self::ReactSelfClosingComp(rule) => rule.run_info(),
             Self::ReactStateInConstructor(rule) => rule.run_info(),
             Self::ReactStylePropObject(rule) => rule.run_info(),
+            Self::ReactUseImageSize(rule) => rule.run_info(),
             Self::ReactVoidDomElementsNoChildren(rule) => rule.run_info(),
             Self::ReactPerfJsxNoJsxAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_info(),
@@ -18333,6 +19448,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.run_info(),
             Self::UnicornNoEmptyFile(rule) => rule.run_info(),
+            Self::UnicornNoFlatMapIdentity(rule) => rule.run_info(),
             Self::UnicornNoHexEscape(rule) => rule.run_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.run_info(),
             Self::UnicornNoInstanceofArray(rule) => rule.run_info(),
@@ -18366,8 +19482,10 @@ impl RuleEnum {
             Self::UnicornNoUselessLengthCheck(rule) => rule.run_info(),
             Self::UnicornNoUselessPromiseResolveReject(rule) => rule.run_info(),
             Self::UnicornNoUselessSpread(rule) => rule.run_info(),
+            Self::UnicornNoUselessStringRaw(rule) => rule.run_info(),
             Self::UnicornNoUselessSwitchCase(rule) => rule.run_info(),
             Self::UnicornNoUselessUndefined(rule) => rule.run_info(),
+            Self::UnicornNoUselessUndefinedInitialization(rule) => rule.run_info(),
             Self::UnicornNoZeroFractions(rule) => rule.run_info(),
             Self::UnicornNumberLiteralCase(rule) => rule.run_info(),
             Self::UnicornNumericSeparatorsStyle(rule) => rule.run_info(),
@@ -18432,6 +19550,10 @@ impl RuleEnum {
             Self::UnicornSwitchCaseBreakPosition(rule) => rule.run_info(),
             Self::UnicornTextEncodingIdentifierCase(rule) => rule.run_info(),
             Self::UnicornThrowNewError(rule) => rule.run_info(),
+            Self::UnicornUseCollapsedIf(rule) => rule.run_info(),
+            Self::UnicornUseConsistentCurlyBraces(rule) => rule.run_info(),
+            Self::UnicornUseSimpleNumberKeys(rule) => rule.run_info(),
+            Self::UnicornUseSimplifiedLogicExpression(rule) => rule.run_info(),
             Self::JsxA11YAltText(rule) => rule.run_info(),
             Self::JsxA11YAnchorAmbiguousText(rule) => rule.run_info(),
             Self::JsxA11YAnchorHasContent(rule) => rule.run_info(),
@@ -18455,14 +19577,20 @@ impl RuleEnum {
             Self::JsxA11YNoAriaHiddenOnFocusable(rule) => rule.run_info(),
             Self::JsxA11YNoAutofocus(rule) => rule.run_info(),
             Self::JsxA11YNoDistractingElements(rule) => rule.run_info(),
+            Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => rule.run_info(),
+            Self::JsxA11YNoNoninteractiveElementInteractions(rule) => rule.run_info(),
+            Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => rule.run_info(),
             Self::JsxA11YNoNoninteractiveTabindex(rule) => rule.run_info(),
             Self::JsxA11YNoRedundantRoles(rule) => rule.run_info(),
             Self::JsxA11YNoStaticElementInteractions(rule) => rule.run_info(),
+            Self::JsxA11YNoSvgWithoutTitle(rule) => rule.run_info(),
             Self::JsxA11YPreferTagOverRole(rule) => rule.run_info(),
             Self::JsxA11YRoleHasRequiredAriaProps(rule) => rule.run_info(),
             Self::JsxA11YRoleSupportsAriaProps(rule) => rule.run_info(),
             Self::JsxA11YScope(rule) => rule.run_info(),
             Self::JsxA11YTabindexNoPositive(rule) => rule.run_info(),
+            Self::JsxA11YUseFocusableInteractive(rule) => rule.run_info(),
+            Self::JsxA11YUseUniqueElementIds(rule) => rule.run_info(),
             Self::OxcApproxConstant(rule) => rule.run_info(),
             Self::OxcBadArrayMethodOnArguments(rule) => rule.run_info(),
             Self::OxcBadBitwiseOperator(rule) => rule.run_info(),
@@ -18569,6 +19697,7 @@ impl RuleEnum {
             Self::NodeGlobalRequire(rule) => rule.run_info(),
             Self::NodeHandleCallbackErr(rule) => rule.run_info(),
             Self::NodeNoExportsAssign(rule) => rule.run_info(),
+            Self::NodeNoGlobalDirnameFilename(rule) => rule.run_info(),
             Self::NodeNoNewRequire(rule) => rule.run_info(),
             Self::NodeNoPathConcat(rule) => rule.run_info(),
             Self::NodeNoProcessEnv(rule) => rule.run_info(),
@@ -18632,6 +19761,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ImportNoCycle(ImportNoCycle::default()),
         RuleEnum::ImportNoDefaultExport(ImportNoDefaultExport::default()),
         RuleEnum::ImportNoDuplicates(ImportNoDuplicates::default()),
+        RuleEnum::ImportNoDynamicNamespaceImportAccess(
+            ImportNoDynamicNamespaceImportAccess::default(),
+        ),
         RuleEnum::ImportNoDynamicRequire(ImportNoDynamicRequire::default()),
         RuleEnum::ImportNoEmptyNamedBlocks(ImportNoEmptyNamedBlocks::default()),
         RuleEnum::ImportNoMutableExports(ImportNoMutableExports::default()),
@@ -18641,9 +19773,12 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ImportNoNamedExport(ImportNoNamedExport::default()),
         RuleEnum::ImportNoNamespace(ImportNoNamespace::default()),
         RuleEnum::ImportNoNodejsModules(ImportNoNodejsModules::default()),
+        RuleEnum::ImportNoPrivateImports(ImportNoPrivateImports::default()),
         RuleEnum::ImportNoRelativeParentImports(ImportNoRelativeParentImports::default()),
         RuleEnum::ImportNoSelfImport(ImportNoSelfImport::default()),
         RuleEnum::ImportNoUnassignedImport(ImportNoUnassignedImport::default()),
+        RuleEnum::ImportNoUndeclaredDependencies(ImportNoUndeclaredDependencies::default()),
+        RuleEnum::ImportNoUnresolvedImports(ImportNoUnresolvedImports::default()),
         RuleEnum::ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax::default()),
         RuleEnum::ImportPreferDefaultExport(ImportPreferDefaultExport::default()),
         RuleEnum::ImportUnambiguous(ImportUnambiguous::default()),
@@ -18686,6 +19821,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoClassAssign(EslintNoClassAssign::default()),
         RuleEnum::EslintNoCompareNegZero(EslintNoCompareNegZero::default()),
         RuleEnum::EslintNoCondAssign(EslintNoCondAssign::default()),
+        RuleEnum::EslintNoConfusingLabels(EslintNoConfusingLabels::default()),
         RuleEnum::EslintNoConsole(EslintNoConsole::default()),
         RuleEnum::EslintNoConstAssign(EslintNoConstAssign::default()),
         RuleEnum::EslintNoConstantBinaryExpression(EslintNoConstantBinaryExpression::default()),
@@ -18743,12 +19879,14 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoNonoctalDecimalEscape(EslintNoNonoctalDecimalEscape::default()),
         RuleEnum::EslintNoObjCalls(EslintNoObjCalls::default()),
         RuleEnum::EslintNoObjectConstructor(EslintNoObjectConstructor::default()),
+        RuleEnum::EslintNoOctalEscape(EslintNoOctalEscape::default()),
         RuleEnum::EslintNoParamReassign(EslintNoParamReassign::default()),
         RuleEnum::EslintNoPlusplus(EslintNoPlusplus::default()),
         RuleEnum::EslintNoPromiseExecutorReturn(EslintNoPromiseExecutorReturn::default()),
         RuleEnum::EslintNoProto(EslintNoProto::default()),
         RuleEnum::EslintNoPrototypeBuiltins(EslintNoPrototypeBuiltins::default()),
         RuleEnum::EslintNoRedeclare(EslintNoRedeclare::default()),
+        RuleEnum::EslintNoRedundantUseStrict(EslintNoRedundantUseStrict::default()),
         RuleEnum::EslintNoRegexSpaces(EslintNoRegexSpaces::default()),
         RuleEnum::EslintNoRestrictedGlobals(EslintNoRestrictedGlobals::default()),
         RuleEnum::EslintNoRestrictedImports(EslintNoRestrictedImports::default()),
@@ -18760,7 +19898,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoSetterReturn(EslintNoSetterReturn::default()),
         RuleEnum::EslintNoShadow(EslintNoShadow::default()),
         RuleEnum::EslintNoShadowRestrictedNames(EslintNoShadowRestrictedNames::default()),
+        RuleEnum::EslintNoShoutyConstants(EslintNoShoutyConstants::default()),
         RuleEnum::EslintNoSparseArrays(EslintNoSparseArrays::default()),
+        RuleEnum::EslintNoStringCaseMismatch(EslintNoStringCaseMismatch::default()),
         RuleEnum::EslintNoTemplateCurlyInString(EslintNoTemplateCurlyInString::default()),
         RuleEnum::EslintNoTernary(EslintNoTernary::default()),
         RuleEnum::EslintNoThisBeforeSuper(EslintNoThisBeforeSuper::default()),
@@ -18787,6 +19927,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoUselessComputedKey(EslintNoUselessComputedKey::default()),
         RuleEnum::EslintNoUselessConcat(EslintNoUselessConcat::default()),
         RuleEnum::EslintNoUselessConstructor(EslintNoUselessConstructor::default()),
+        RuleEnum::EslintNoUselessContinue(EslintNoUselessContinue::default()),
         RuleEnum::EslintNoUselessEscape(EslintNoUselessEscape::default()),
         RuleEnum::EslintNoUselessRename(EslintNoUselessRename::default()),
         RuleEnum::EslintNoUselessReturn(EslintNoUselessReturn::default()),
@@ -18796,6 +19937,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoWith(EslintNoWith::default()),
         RuleEnum::EslintObjectShorthand(EslintObjectShorthand::default()),
         RuleEnum::EslintOperatorAssignment(EslintOperatorAssignment::default()),
+        RuleEnum::EslintPreferArrowCallback(EslintPreferArrowCallback::default()),
         RuleEnum::EslintPreferConst(EslintPreferConst::default()),
         RuleEnum::EslintPreferDestructuring(EslintPreferDestructuring::default()),
         RuleEnum::EslintPreferExponentiationOperator(EslintPreferExponentiationOperator::default()),
@@ -18816,6 +19958,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintSymbolDescription(EslintSymbolDescription::default()),
         RuleEnum::EslintUnicodeBom(EslintUnicodeBom::default()),
         RuleEnum::EslintUseIsnan(EslintUseIsnan::default()),
+        RuleEnum::EslintUseRegexLiterals(EslintUseRegexLiterals::default()),
+        RuleEnum::EslintUseSingleVarDeclarator(EslintUseSingleVarDeclarator::default()),
+        RuleEnum::EslintUseWhile(EslintUseWhile::default()),
         RuleEnum::EslintValidTypeof(EslintValidTypeof::default()),
         RuleEnum::EslintVarsOnTop(EslintVarsOnTop::default()),
         RuleEnum::EslintYoda(EslintYoda::default()),
@@ -18847,9 +19992,13 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::TypescriptExplicitFunctionReturnType(
             TypescriptExplicitFunctionReturnType::default(),
         ),
+        RuleEnum::TypescriptExplicitMemberAccessibility(
+            TypescriptExplicitMemberAccessibility::default(),
+        ),
         RuleEnum::TypescriptExplicitModuleBoundaryTypes(
             TypescriptExplicitModuleBoundaryTypes::default(),
         ),
+        RuleEnum::TypescriptNamingConvention(TypescriptNamingConvention::default()),
         RuleEnum::TypescriptNoArrayDelete(TypescriptNoArrayDelete::default()),
         RuleEnum::TypescriptNoBaseToString(TypescriptNoBaseToString::default()),
         RuleEnum::TypescriptNoConfusingNonNullAssertion(
@@ -18866,11 +20015,15 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::TypescriptNoDynamicDelete(TypescriptNoDynamicDelete::default()),
         RuleEnum::TypescriptNoEmptyInterface(TypescriptNoEmptyInterface::default()),
         RuleEnum::TypescriptNoEmptyObjectType(TypescriptNoEmptyObjectType::default()),
+        RuleEnum::TypescriptNoEmptyTypeParameters(TypescriptNoEmptyTypeParameters::default()),
+        RuleEnum::TypescriptNoEnum(TypescriptNoEnum::default()),
+        RuleEnum::TypescriptNoEvolvingTypes(TypescriptNoEvolvingTypes::default()),
         RuleEnum::TypescriptNoExplicitAny(TypescriptNoExplicitAny::default()),
         RuleEnum::TypescriptNoExtraNonNullAssertion(TypescriptNoExtraNonNullAssertion::default()),
         RuleEnum::TypescriptNoExtraneousClass(TypescriptNoExtraneousClass::default()),
         RuleEnum::TypescriptNoFloatingPromises(TypescriptNoFloatingPromises::default()),
         RuleEnum::TypescriptNoForInArray(TypescriptNoForInArray::default()),
+        RuleEnum::TypescriptNoImplicitAnyLet(TypescriptNoImplicitAnyLet::default()),
         RuleEnum::TypescriptNoImpliedEval(TypescriptNoImpliedEval::default()),
         RuleEnum::TypescriptNoImportTypeSideEffects(TypescriptNoImportTypeSideEffects::default()),
         RuleEnum::TypescriptNoInferrableTypes(TypescriptNoInferrableTypes::default()),
@@ -18896,6 +20049,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::TypescriptNoRequireImports(TypescriptNoRequireImports::default()),
         RuleEnum::TypescriptNoRestrictedTypes(TypescriptNoRestrictedTypes::default()),
         RuleEnum::TypescriptNoThisAlias(TypescriptNoThisAlias::default()),
+        RuleEnum::TypescriptNoThisInStatic(TypescriptNoThisInStatic::default()),
         RuleEnum::TypescriptNoUnnecessaryBooleanLiteralCompare(
             TypescriptNoUnnecessaryBooleanLiteralCompare::default(),
         ),
@@ -19081,16 +20235,20 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactNoDidMountSetState(ReactNoDidMountSetState::default()),
         RuleEnum::ReactNoDirectMutationState(ReactNoDirectMutationState::default()),
         RuleEnum::ReactNoFindDomNode(ReactNoFindDomNode::default()),
+        RuleEnum::ReactNoForwardRef(ReactNoForwardRef::default()),
         RuleEnum::ReactNoIsMounted(ReactNoIsMounted::default()),
+        RuleEnum::ReactNoJsxLiterals(ReactNoJsxLiterals::default()),
         RuleEnum::ReactNoMultiComp(ReactNoMultiComp::default()),
         RuleEnum::ReactNoNamespace(ReactNoNamespace::default()),
         RuleEnum::ReactNoReactChildren(ReactNoReactChildren::default()),
+        RuleEnum::ReactNoReactSpecificProps(ReactNoReactSpecificProps::default()),
         RuleEnum::ReactNoRedundantShouldComponentUpdate(
             ReactNoRedundantShouldComponentUpdate::default(),
         ),
         RuleEnum::ReactNoRenderReturnValue(ReactNoRenderReturnValue::default()),
         RuleEnum::ReactNoSetState(ReactNoSetState::default()),
         RuleEnum::ReactNoStringRefs(ReactNoStringRefs::default()),
+        RuleEnum::ReactNoSuspiciousSemicolonInJsx(ReactNoSuspiciousSemicolonInJsx::default()),
         RuleEnum::ReactNoThisInSfc(ReactNoThisInSfc::default()),
         RuleEnum::ReactNoUnescapedEntities(ReactNoUnescapedEntities::default()),
         RuleEnum::ReactNoUnknownProperty(ReactNoUnknownProperty::default()),
@@ -19105,6 +20263,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactSelfClosingComp(ReactSelfClosingComp::default()),
         RuleEnum::ReactStateInConstructor(ReactStateInConstructor::default()),
         RuleEnum::ReactStylePropObject(ReactStylePropObject::default()),
+        RuleEnum::ReactUseImageSize(ReactUseImageSize::default()),
         RuleEnum::ReactVoidDomElementsNoChildren(ReactVoidDomElementsNoChildren::default()),
         RuleEnum::ReactPerfJsxNoJsxAsProp(ReactPerfJsxNoJsxAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp::default()),
@@ -19139,6 +20298,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoConsoleSpaces(UnicornNoConsoleSpaces::default()),
         RuleEnum::UnicornNoDocumentCookie(UnicornNoDocumentCookie::default()),
         RuleEnum::UnicornNoEmptyFile(UnicornNoEmptyFile::default()),
+        RuleEnum::UnicornNoFlatMapIdentity(UnicornNoFlatMapIdentity::default()),
         RuleEnum::UnicornNoHexEscape(UnicornNoHexEscape::default()),
         RuleEnum::UnicornNoImmediateMutation(UnicornNoImmediateMutation::default()),
         RuleEnum::UnicornNoInstanceofArray(UnicornNoInstanceofArray::default()),
@@ -19184,8 +20344,12 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
             UnicornNoUselessPromiseResolveReject::default(),
         ),
         RuleEnum::UnicornNoUselessSpread(UnicornNoUselessSpread::default()),
+        RuleEnum::UnicornNoUselessStringRaw(UnicornNoUselessStringRaw::default()),
         RuleEnum::UnicornNoUselessSwitchCase(UnicornNoUselessSwitchCase::default()),
         RuleEnum::UnicornNoUselessUndefined(UnicornNoUselessUndefined::default()),
+        RuleEnum::UnicornNoUselessUndefinedInitialization(
+            UnicornNoUselessUndefinedInitialization::default(),
+        ),
         RuleEnum::UnicornNoZeroFractions(UnicornNoZeroFractions::default()),
         RuleEnum::UnicornNumberLiteralCase(UnicornNumberLiteralCase::default()),
         RuleEnum::UnicornNumericSeparatorsStyle(UnicornNumericSeparatorsStyle::default()),
@@ -19258,6 +20422,12 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornSwitchCaseBreakPosition(UnicornSwitchCaseBreakPosition::default()),
         RuleEnum::UnicornTextEncodingIdentifierCase(UnicornTextEncodingIdentifierCase::default()),
         RuleEnum::UnicornThrowNewError(UnicornThrowNewError::default()),
+        RuleEnum::UnicornUseCollapsedIf(UnicornUseCollapsedIf::default()),
+        RuleEnum::UnicornUseConsistentCurlyBraces(UnicornUseConsistentCurlyBraces::default()),
+        RuleEnum::UnicornUseSimpleNumberKeys(UnicornUseSimpleNumberKeys::default()),
+        RuleEnum::UnicornUseSimplifiedLogicExpression(
+            UnicornUseSimplifiedLogicExpression::default(),
+        ),
         RuleEnum::JsxA11YAltText(JsxA11YAltText::default()),
         RuleEnum::JsxA11YAnchorAmbiguousText(JsxA11YAnchorAmbiguousText::default()),
         RuleEnum::JsxA11YAnchorHasContent(JsxA11YAnchorHasContent::default()),
@@ -19283,14 +20453,26 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JsxA11YNoAriaHiddenOnFocusable(JsxA11YNoAriaHiddenOnFocusable::default()),
         RuleEnum::JsxA11YNoAutofocus(JsxA11YNoAutofocus::default()),
         RuleEnum::JsxA11YNoDistractingElements(JsxA11YNoDistractingElements::default()),
+        RuleEnum::JsxA11YNoInteractiveElementToNoninteractiveRole(
+            JsxA11YNoInteractiveElementToNoninteractiveRole::default(),
+        ),
+        RuleEnum::JsxA11YNoNoninteractiveElementInteractions(
+            JsxA11YNoNoninteractiveElementInteractions::default(),
+        ),
+        RuleEnum::JsxA11YNoNoninteractiveElementToInteractiveRole(
+            JsxA11YNoNoninteractiveElementToInteractiveRole::default(),
+        ),
         RuleEnum::JsxA11YNoNoninteractiveTabindex(JsxA11YNoNoninteractiveTabindex::default()),
         RuleEnum::JsxA11YNoRedundantRoles(JsxA11YNoRedundantRoles::default()),
         RuleEnum::JsxA11YNoStaticElementInteractions(JsxA11YNoStaticElementInteractions::default()),
+        RuleEnum::JsxA11YNoSvgWithoutTitle(JsxA11YNoSvgWithoutTitle::default()),
         RuleEnum::JsxA11YPreferTagOverRole(JsxA11YPreferTagOverRole::default()),
         RuleEnum::JsxA11YRoleHasRequiredAriaProps(JsxA11YRoleHasRequiredAriaProps::default()),
         RuleEnum::JsxA11YRoleSupportsAriaProps(JsxA11YRoleSupportsAriaProps::default()),
         RuleEnum::JsxA11YScope(JsxA11YScope::default()),
         RuleEnum::JsxA11YTabindexNoPositive(JsxA11YTabindexNoPositive::default()),
+        RuleEnum::JsxA11YUseFocusableInteractive(JsxA11YUseFocusableInteractive::default()),
+        RuleEnum::JsxA11YUseUniqueElementIds(JsxA11YUseUniqueElementIds::default()),
         RuleEnum::OxcApproxConstant(OxcApproxConstant::default()),
         RuleEnum::OxcBadArrayMethodOnArguments(OxcBadArrayMethodOnArguments::default()),
         RuleEnum::OxcBadBitwiseOperator(OxcBadBitwiseOperator::default()),
@@ -19401,6 +20583,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::NodeGlobalRequire(NodeGlobalRequire::default()),
         RuleEnum::NodeHandleCallbackErr(NodeHandleCallbackErr::default()),
         RuleEnum::NodeNoExportsAssign(NodeNoExportsAssign::default()),
+        RuleEnum::NodeNoGlobalDirnameFilename(NodeNoGlobalDirnameFilename::default()),
         RuleEnum::NodeNoNewRequire(NodeNoNewRequire::default()),
         RuleEnum::NodeNoPathConcat(NodeNoPathConcat::default()),
         RuleEnum::NodeNoProcessEnv(NodeNoProcessEnv::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -22,6 +22,7 @@ pub(crate) mod import {
     pub mod no_cycle;
     pub mod no_default_export;
     pub mod no_duplicates;
+    pub mod no_dynamic_namespace_import_access;
     pub mod no_dynamic_require;
     pub mod no_empty_named_blocks;
     pub mod no_mutable_exports;
@@ -31,9 +32,12 @@ pub(crate) mod import {
     pub mod no_named_export;
     pub mod no_namespace;
     pub mod no_nodejs_modules;
+    pub mod no_private_imports;
     pub mod no_relative_parent_imports;
     pub mod no_self_import;
     pub mod no_unassigned_import;
+    pub mod no_undeclared_dependencies;
+    pub mod no_unresolved_imports;
     pub mod no_webpack_loader_syntax;
     pub mod prefer_default_export;
     pub mod unambiguous;
@@ -79,6 +83,7 @@ pub(crate) mod eslint {
     pub mod no_class_assign;
     pub mod no_compare_neg_zero;
     pub mod no_cond_assign;
+    pub mod no_confusing_labels;
     pub mod no_console;
     pub mod no_const_assign;
     pub mod no_constant_binary_expression;
@@ -136,12 +141,14 @@ pub(crate) mod eslint {
     pub mod no_nonoctal_decimal_escape;
     pub mod no_obj_calls;
     pub mod no_object_constructor;
+    pub mod no_octal_escape;
     pub mod no_param_reassign;
     pub mod no_plusplus;
     pub mod no_promise_executor_return;
     pub mod no_proto;
     pub mod no_prototype_builtins;
     pub mod no_redeclare;
+    pub mod no_redundant_use_strict;
     pub mod no_regex_spaces;
     pub mod no_restricted_globals;
     pub mod no_restricted_imports;
@@ -153,7 +160,9 @@ pub(crate) mod eslint {
     pub mod no_setter_return;
     pub mod no_shadow;
     pub mod no_shadow_restricted_names;
+    pub mod no_shouty_constants;
     pub mod no_sparse_arrays;
+    pub mod no_string_case_mismatch;
     pub mod no_template_curly_in_string;
     pub mod no_ternary;
     pub mod no_this_before_super;
@@ -180,6 +189,7 @@ pub(crate) mod eslint {
     pub mod no_useless_computed_key;
     pub mod no_useless_concat;
     pub mod no_useless_constructor;
+    pub mod no_useless_continue;
     pub mod no_useless_escape;
     pub mod no_useless_rename;
     pub mod no_useless_return;
@@ -189,6 +199,7 @@ pub(crate) mod eslint {
     pub mod no_with;
     pub mod object_shorthand;
     pub mod operator_assignment;
+    pub mod prefer_arrow_callback;
     pub mod prefer_const;
     pub mod prefer_destructuring;
     pub mod prefer_exponentiation_operator;
@@ -209,6 +220,9 @@ pub(crate) mod eslint {
     pub mod symbol_description;
     pub mod unicode_bom;
     pub mod use_isnan;
+    pub mod use_regex_literals;
+    pub mod use_single_var_declarator;
+    pub mod use_while;
     pub mod valid_typeof;
     pub mod vars_on_top;
     pub mod yoda;
@@ -231,7 +245,9 @@ pub(crate) mod typescript {
     pub mod consistent_type_imports;
     pub mod dot_notation;
     pub mod explicit_function_return_type;
+    pub mod explicit_member_accessibility;
     pub mod explicit_module_boundary_types;
+    pub mod naming_convention;
     pub mod no_array_delete;
     pub mod no_base_to_string;
     pub mod no_confusing_non_null_assertion;
@@ -242,11 +258,15 @@ pub(crate) mod typescript {
     pub mod no_dynamic_delete;
     pub mod no_empty_interface;
     pub mod no_empty_object_type;
+    pub mod no_empty_type_parameters;
+    pub mod no_enum;
+    pub mod no_evolving_types;
     pub mod no_explicit_any;
     pub mod no_extra_non_null_assertion;
     pub mod no_extraneous_class;
     pub mod no_floating_promises;
     pub mod no_for_in_array;
+    pub mod no_implicit_any_let;
     pub mod no_implied_eval;
     pub mod no_import_type_side_effects;
     pub mod no_inferrable_types;
@@ -264,6 +284,7 @@ pub(crate) mod typescript {
     pub mod no_require_imports;
     pub mod no_restricted_types;
     pub mod no_this_alias;
+    pub mod no_this_in_static;
     pub mod no_unnecessary_boolean_literal_compare;
     pub mod no_unnecessary_condition;
     pub mod no_unnecessary_parameter_property_assignment;
@@ -417,14 +438,18 @@ pub(crate) mod react {
     pub mod no_did_mount_set_state;
     pub mod no_direct_mutation_state;
     pub mod no_find_dom_node;
+    pub mod no_forward_ref;
     pub mod no_is_mounted;
+    pub mod no_jsx_literals;
     pub mod no_multi_comp;
     pub mod no_namespace;
     pub mod no_react_children;
+    pub mod no_react_specific_props;
     pub mod no_redundant_should_component_update;
     pub mod no_render_return_value;
     pub mod no_set_state;
     pub mod no_string_refs;
+    pub mod no_suspicious_semicolon_in_jsx;
     pub mod no_this_in_sfc;
     pub mod no_unescaped_entities;
     pub mod no_unknown_property;
@@ -439,6 +464,7 @@ pub(crate) mod react {
     pub mod self_closing_comp;
     pub mod state_in_constructor;
     pub mod style_prop_object;
+    pub mod use_image_size;
     pub mod void_dom_elements_no_children;
 }
 
@@ -477,6 +503,7 @@ pub(crate) mod unicorn {
     pub mod no_console_spaces;
     pub mod no_document_cookie;
     pub mod no_empty_file;
+    pub mod no_flat_map_identity;
     pub mod no_hex_escape;
     pub mod no_immediate_mutation;
     pub mod no_instanceof_array;
@@ -510,8 +537,10 @@ pub(crate) mod unicorn {
     pub mod no_useless_length_check;
     pub mod no_useless_promise_resolve_reject;
     pub mod no_useless_spread;
+    pub mod no_useless_string_raw;
     pub mod no_useless_switch_case;
     pub mod no_useless_undefined;
+    pub mod no_useless_undefined_initialization;
     pub mod no_zero_fractions;
     pub mod number_literal_case;
     pub mod numeric_separators_style;
@@ -576,6 +605,10 @@ pub(crate) mod unicorn {
     pub mod switch_case_break_position;
     pub mod text_encoding_identifier_case;
     pub mod throw_new_error;
+    pub mod use_collapsed_if;
+    pub mod use_consistent_curly_braces;
+    pub mod use_simple_number_keys;
+    pub mod use_simplified_logic_expression;
 }
 
 pub(crate) mod jsx_a11y {
@@ -602,14 +635,20 @@ pub(crate) mod jsx_a11y {
     pub mod no_aria_hidden_on_focusable;
     pub mod no_autofocus;
     pub mod no_distracting_elements;
+    pub mod no_interactive_element_to_noninteractive_role;
+    pub mod no_noninteractive_element_interactions;
+    pub mod no_noninteractive_element_to_interactive_role;
     pub mod no_noninteractive_tabindex;
     pub mod no_redundant_roles;
     pub mod no_static_element_interactions;
+    pub mod no_svg_without_title;
     pub mod prefer_tag_over_role;
     pub mod role_has_required_aria_props;
     pub mod role_supports_aria_props;
     pub mod scope;
     pub mod tabindex_no_positive;
+    pub mod use_focusable_interactive;
+    pub mod use_unique_element_ids;
 }
 
 pub(crate) mod oxc {
@@ -735,6 +774,7 @@ pub(crate) mod node {
     pub mod global_require;
     pub mod handle_callback_err;
     pub mod no_exports_assign;
+    pub mod no_global_dirname_filename;
     pub mod no_new_require;
     pub mod no_path_concat;
     pub mod no_process_env;

--- a/crates/oxc_linter/src/rules/eslint/no_confusing_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_confusing_labels.rs
@@ -1,0 +1,78 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_confusing_labels_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Label '{name}' is confusing because it shares a name with a variable in scope."))
+        .with_help("Use a different name for this label to avoid confusion with the variable of the same name.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoConfusingLabels;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows labels that share a name with a variable in scope.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using the same name for both a label and a variable can be confusing
+    /// and makes code harder to understand. It may lead developers to
+    /// mistake references to one for the other.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// let x = 1;
+    /// x: while (true) { break x; }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// let x = 1;
+    /// loop1: while (true) { break loop1; }
+    /// ```
+    NoConfusingLabels,
+    eslint,
+    suspicious
+);
+
+impl Rule for NoConfusingLabels {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::LabeledStatement(labeled) = node.kind() else {
+            return;
+        };
+
+        if ctx.scoping().find_binding(node.scope_id(), labeled.label.name).is_some() {
+            ctx.diagnostic(no_confusing_labels_diagnostic(
+                labeled.label.span,
+                labeled.label.name.as_str(),
+            ));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "loop1: while (true) { break loop1; }",
+        "let x = 1; loop1: while (true) { break loop1; }",
+        "myLabel: for (;;) { break myLabel; }",
+    ];
+
+    let fail = vec![
+        "let x = 1; x: while (true) { break x; }",
+        "var foo = 1; foo: while (true) { break foo; }",
+        "const bar = 1; bar: for (;;) { break bar; }",
+    ];
+
+    Tester::new(NoConfusingLabels::NAME, NoConfusingLabels::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_octal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_octal_escape.rs
@@ -1,0 +1,121 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_octal_escape_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Don't use octal escape sequences.")
+        .with_help("Use Unicode or hexadecimal escape sequences instead of octal escape sequences.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoOctalEscape;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows octal escape sequences in string literals.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// As of the ECMAScript 5 specification, octal escape sequences in string
+    /// literals are deprecated and should not be used. Unicode escape sequences
+    /// or hexadecimal escape sequences should be used instead.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// var foo = "Copyright \251";
+    /// var bar = "\1";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// var foo = "Copyright \u00A9";
+    /// var bar = "\x01";
+    /// ```
+    NoOctalEscape,
+    eslint,
+    correctness
+);
+
+impl Rule for NoOctalEscape {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::StringLiteral(literal) = node.kind() else {
+            return;
+        };
+
+        let raw = ctx.source_range(literal.span);
+        if raw.len() < 2 {
+            return;
+        }
+        // Strip quotes
+        let inner = &raw[1..raw.len() - 1];
+
+        let bytes = inner.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                let next = bytes[i + 1];
+                if next >= b'0' && next <= b'7' {
+                    // This is an octal escape — but \0 not followed by a digit is allowed (null char)
+                    if next == b'0'
+                        && (i + 2 >= bytes.len() || bytes[i + 2] < b'0' || bytes[i + 2] > b'7')
+                    {
+                        i += 2;
+                        continue;
+                    }
+                    let start = literal.span.start + 1 + i as u32;
+                    // Find the end of the octal sequence (up to 3 digits)
+                    let mut end = i + 2;
+                    while end < bytes.len()
+                        && end < i + 4
+                        && bytes[end] >= b'0'
+                        && bytes[end] <= b'7'
+                    {
+                        end += 1;
+                    }
+                    let span_end = literal.span.start + 1 + end as u32;
+                    ctx.diagnostic(no_octal_escape_diagnostic(Span::new(start, span_end)));
+                    return;
+                }
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"var foo = "\x51";"#,
+        r#"var foo = "hello \u0051";"#,
+        r#"var foo = "\0";"#,
+        r"var foo = '\0';",
+        r#"var foo = "hello";"#,
+        r"var foo = '\n';",
+        r"var foo = '\\1';",
+    ];
+
+    let fail = vec![
+        r"var foo = '\1';",
+        r"var foo = '\2';",
+        r"var foo = '\7';",
+        r#"var foo = "\00";"#,
+        r"var foo = '\251';",
+        r"var foo = '\377';",
+        r"var foo = '\012';",
+        r#"var foo = "Copyright \251";"#,
+        r#"var foo = "\1";"#,
+    ];
+
+    Tester::new(NoOctalEscape::NAME, NoOctalEscape::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_redundant_use_strict.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redundant_use_strict.rs
@@ -1,0 +1,120 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_redundant_use_strict_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Redundant 'use strict' directive.")
+        .with_help("Remove this 'use strict' directive because the code is already in strict mode (ESM modules are always strict, or an outer scope already has 'use strict').")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoRedundantUseStrict;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows redundant `"use strict"` directives.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `"use strict"` directive is unnecessary when the code is already in
+    /// strict mode. ES modules are always in strict mode, and nested `"use strict"`
+    /// directives inside an already-strict function body are also redundant.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// // In an ES module file:
+    /// "use strict";
+    /// export const foo = 1;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// // In a CommonJS file:
+    /// "use strict";
+    /// module.exports = {};
+    /// ```
+    NoRedundantUseStrict,
+    eslint,
+    suspicious,
+    pending
+);
+
+impl Rule for NoRedundantUseStrict {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Check directives in Program
+        if let AstKind::Program(program) = node.kind() {
+            if !ctx.source_type().is_module() {
+                return;
+            }
+            // In ESM, any "use strict" directive is redundant
+            for directive in &program.directives {
+                if directive.directive.as_str() == "use strict" {
+                    ctx.diagnostic(no_redundant_use_strict_diagnostic(directive.span));
+                }
+            }
+            return;
+        }
+
+        // Check directives in function bodies
+        if let AstKind::FunctionBody(body) = node.kind() {
+            for directive in &body.directives {
+                if directive.directive.as_str() == "use strict" {
+                    // Check if parent scopes already have "use strict"
+                    if ctx.source_type().is_module() || is_already_strict(node, ctx) {
+                        ctx.diagnostic(no_redundant_use_strict_diagnostic(directive.span));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn is_already_strict(node: &AstNode, ctx: &LintContext) -> bool {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        match ancestor.kind() {
+            AstKind::FunctionBody(body) => {
+                for directive in &body.directives {
+                    if directive.directive.as_str() == "use strict" {
+                        return true;
+                    }
+                }
+            }
+            AstKind::Program(program) => {
+                for directive in &program.directives {
+                    if directive.directive.as_str() == "use strict" {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // CJS with use strict is fine
+        "\"use strict\"; var foo = 1;",
+        // Function body use strict is fine when not in module
+        "function foo() { \"use strict\"; return 1; }",
+    ];
+
+    let fail = vec![
+        // Nested use strict in function that already has outer strict
+        "\"use strict\"; function foo() { \"use strict\"; return 1; }",
+    ];
+
+    Tester::new(NoRedundantUseStrict::NAME, NoRedundantUseStrict::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_shouty_constants.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shouty_constants.rs
@@ -1,0 +1,121 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_shouty_constants_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "SCREAMING_SNAKE_CASE variable `{name}` is assigned a simple string literal."
+    ))
+    .with_help("UPPER_CASE names are conventionally reserved for true constants. Use camelCase or rename if this value is not a meaningful constant.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoShoutyConstants;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Discourages declaring SCREAMING_SNAKE_CASE variables that are assigned
+    /// a simple string or number literal, suggesting they may not truly be constants.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// UPPER_CASE naming is conventionally reserved for meaningful constants.
+    /// Using it for trivial string assignments (like `const FOO = "foo"`) adds
+    /// noise without value.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const FOO = "foo";
+    /// const BAR_BAZ = "bar_baz";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const MAX_RETRIES = 3;
+    /// const API_URL = process.env.API_URL;
+    /// const foo = "foo";
+    /// ```
+    NoShoutyConstants,
+    eslint,
+    style,
+    pending
+);
+
+impl Rule for NoShoutyConstants {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::VariableDeclarator(declarator) = node.kind() else {
+            return;
+        };
+
+        // Only check const declarations
+        if declarator.kind != oxc_ast::ast::VariableDeclarationKind::Const {
+            return;
+        }
+
+        let oxc_ast::ast::BindingPattern::BindingIdentifier(ident) = &declarator.id else {
+            return;
+        };
+
+        let name = ident.name.as_str();
+
+        // Check if name is SCREAMING_SNAKE_CASE (all uppercase + underscores, at least 2 chars)
+        if name.len() < 2 || !is_screaming_snake_case(name) {
+            return;
+        }
+
+        // Check if the initializer is a simple string literal whose value matches the name
+        let Some(init) = &declarator.init else {
+            return;
+        };
+
+        match init {
+            Expression::StringLiteral(lit) => {
+                // Flag if the string value is basically the same as the name (case-insensitive)
+                let val = lit.value.as_str();
+                if val.eq_ignore_ascii_case(name)
+                    || val.eq_ignore_ascii_case(&name.to_lowercase())
+                    || val.eq_ignore_ascii_case(&name.replace('_', "-"))
+                    || val.eq_ignore_ascii_case(&name.replace('_', ""))
+                {
+                    ctx.diagnostic(no_shouty_constants_diagnostic(ident.span, name));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn is_screaming_snake_case(s: &str) -> bool {
+    s.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        && s.contains('_')
+        && s.chars().any(|c| c.is_ascii_uppercase())
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "const MAX_RETRIES = 3;",
+        "const API_URL = process.env.API_URL;",
+        "const foo = 'foo';",
+        "const FOO = getSomething();",
+        "const FOO = 'completely_different';",
+    ];
+
+    let fail = vec![
+        r#"const FOO_BAR = "foo_bar";"#,
+        r#"const BAR_BAZ = "bar-baz";"#,
+        r#"const HELLO_WORLD = "helloworld";"#,
+    ];
+
+    Tester::new(NoShoutyConstants::NAME, NoShoutyConstants::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_string_case_mismatch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_string_case_mismatch.rs
@@ -1,0 +1,146 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{BinaryExpression, Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use oxc_syntax::operator::BinaryOperator;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_string_case_mismatch_diagnostic(span: Span, method: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Comparison with `{method}()` will always be false due to case mismatch."))
+        .with_help(format!("The string being compared contains characters that don't match the case transformation from `{method}()`. This comparison will never be true."))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoStringCaseMismatch;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects comparisons where a case-transforming method like `toLowerCase()`
+    /// or `toUpperCase()` is compared against a string that contains characters
+    /// in the wrong case, making the comparison always false.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Comparing `str.toLowerCase()` against a string with uppercase characters
+    /// (or `str.toUpperCase()` against lowercase) will always evaluate to false.
+    /// This is almost certainly a bug.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// if (str.toLowerCase() === "ABC") {}
+    /// if (str.toUpperCase() === "abc") {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// if (str.toLowerCase() === "abc") {}
+    /// if (str.toUpperCase() === "ABC") {}
+    /// ```
+    NoStringCaseMismatch,
+    eslint,
+    correctness
+);
+
+impl Rule for NoStringCaseMismatch {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::BinaryExpression(expr) = node.kind() else {
+            return;
+        };
+
+        if !matches!(
+            expr.operator,
+            BinaryOperator::Equality
+                | BinaryOperator::StrictEquality
+                | BinaryOperator::Inequality
+                | BinaryOperator::StrictInequality
+        ) {
+            return;
+        }
+
+        check_case_mismatch(expr, &expr.left, &expr.right, ctx);
+        check_case_mismatch(expr, &expr.right, &expr.left, ctx);
+    }
+}
+
+fn check_case_mismatch(
+    expr: &BinaryExpression,
+    call_side: &Expression,
+    literal_side: &Expression,
+    ctx: &LintContext,
+) {
+    // Check if one side is a call to toLowerCase/toUpperCase
+    let Expression::CallExpression(call) = call_side else {
+        return;
+    };
+
+    let Expression::StaticMemberExpression(member) = &call.callee else {
+        return;
+    };
+
+    let method_name = member.property.name.as_str();
+    let is_to_lower = method_name == "toLowerCase" || method_name == "toLocaleLowerCase";
+    let is_to_upper = method_name == "toUpperCase" || method_name == "toLocaleUpperCase";
+
+    if !is_to_lower && !is_to_upper {
+        return;
+    }
+
+    // Call should have no arguments
+    if !call.arguments.is_empty() {
+        return;
+    }
+
+    // The other side should be a string literal
+    let Expression::StringLiteral(lit) = literal_side else {
+        return;
+    };
+
+    let value = lit.value.as_str();
+
+    // Check for case mismatch
+    let has_mismatch = if is_to_lower {
+        value.chars().any(|c| c.is_uppercase())
+    } else {
+        value.chars().any(|c| c.is_lowercase())
+    };
+
+    if has_mismatch {
+        ctx.diagnostic(no_string_case_mismatch_diagnostic(expr.span, method_name));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"if (str.toLowerCase() === "abc") {}"#,
+        r#"if (str.toUpperCase() === "ABC") {}"#,
+        r#"if (str.toLowerCase() === "abc123") {}"#,
+        r#"if (str.toUpperCase() === "ABC123") {}"#,
+        r#"if (str.toLowerCase() === "") {}"#,
+        "if (str.toLowerCase() === variable) {}",
+        r#"if (str.toLowerCase() === "123") {}"#,
+        r#"if (str.toUpperCase() === "123") {}"#,
+    ];
+
+    let fail = vec![
+        r#"if (str.toLowerCase() === "ABC") {}"#,
+        r#"if (str.toUpperCase() === "abc") {}"#,
+        r#"if ("ABC" === str.toLowerCase()) {}"#,
+        r#"if (str.toLowerCase() === "AbC") {}"#,
+        r#"if (str.toUpperCase() === "AbC") {}"#,
+        r#"if (str.toLowerCase() !== "ABC") {}"#,
+        r#"if (str.toLocaleLowerCase() === "ABC") {}"#,
+        r#"if (str.toLocaleUpperCase() === "abc") {}"#,
+    ];
+
+    Tester::new(NoStringCaseMismatch::NAME, NoStringCaseMismatch::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_useless_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_continue.rs
@@ -1,0 +1,117 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Statement;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_useless_continue_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unnecessary continue statement.")
+        .with_help("Remove this continue statement since it is the last statement in the loop body and has no effect.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUselessContinue;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows unnecessary `continue` statements at the end of loop bodies.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `continue` statement at the end of a loop body is redundant because
+    /// the loop will continue to the next iteration automatically.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// for (let i = 0; i < 10; i++) {
+    ///   doSomething(i);
+    ///   continue;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// for (let i = 0; i < 10; i++) {
+    ///   doSomething(i);
+    /// }
+    /// ```
+    NoUselessContinue,
+    eslint,
+    suspicious,
+    pending
+);
+
+impl Rule for NoUselessContinue {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ContinueStatement(cont) = node.kind() else {
+            return;
+        };
+
+        // Only flag unlabeled continues
+        if cont.label.is_some() {
+            return;
+        }
+
+        let parent = ctx.nodes().parent_node(node.id());
+
+        // The continue must be the last statement in a block that is directly
+        // the body of a loop
+        let AstKind::BlockStatement(block) = parent.kind() else {
+            return;
+        };
+
+        // Check that continue is the last statement
+        let Some(last) = block.body.last() else {
+            return;
+        };
+        let Statement::ContinueStatement(last_cont) = last else {
+            return;
+        };
+        if last_cont.span != cont.span {
+            return;
+        }
+
+        // Verify the block is directly the body of a loop
+        let grandparent = ctx.nodes().parent_node(parent.id());
+        match grandparent.kind() {
+            AstKind::ForStatement(_)
+            | AstKind::ForInStatement(_)
+            | AstKind::ForOfStatement(_)
+            | AstKind::WhileStatement(_)
+            | AstKind::DoWhileStatement(_) => {
+                ctx.diagnostic(no_useless_continue_diagnostic(cont.span));
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "for (let i = 0; i < 10; i++) { if (i > 5) { continue; } doSomething(i); }",
+        "for (let i = 0; i < 10; i++) { doSomething(i); }",
+        "while (true) { if (cond) continue; doSomething(); }",
+        "for (let i = 0; i < 10; i++) { if (i > 5) continue; }",
+        // labeled continue is allowed
+        "outer: for (let i = 0; i < 10; i++) { for (let j = 0; j < 10; j++) { continue outer; } }",
+    ];
+
+    let fail = vec![
+        "for (let i = 0; i < 10; i++) { doSomething(i); continue; }",
+        "while (true) { doSomething(); continue; }",
+        "for (const x of arr) { process(x); continue; }",
+        "for (const k in obj) { process(k); continue; }",
+        "do { doSomething(); continue; } while (true);",
+    ];
+
+    Tester::new(NoUselessContinue::NAME, NoUselessContinue::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/prefer_arrow_callback.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_arrow_callback.rs
@@ -1,0 +1,104 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn prefer_arrow_callback_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected function expression.")
+        .with_help("Use an arrow function instead of a function expression.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferArrowCallback;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires using arrow functions for callbacks.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Arrow functions can be a more concise syntax for function expressions.
+    /// They also don't bind their own `this`, making them more predictable
+    /// when used as callbacks.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// foo(function(a) { return a; });
+    /// foo(function() { return this.a; }.bind(this));
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// foo((a) => a);
+    /// foo(() => this.a);
+    /// ```
+    PreferArrowCallback,
+    eslint,
+    style,
+    pending
+);
+
+impl Rule for PreferArrowCallback {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Function(func) = node.kind() else {
+            return;
+        };
+
+        // Only target function expressions, not declarations
+        if func.is_declaration() {
+            return;
+        }
+
+        // Skip named function expressions (they may use their own name recursively)
+        if func.id.is_some() {
+            return;
+        }
+
+        // Skip generator functions
+        if func.generator {
+            return;
+        }
+
+        // Check if used as a callback (argument in a call expression)
+        let parent = ctx.nodes().parent_node(node.id());
+        let is_callback =
+            matches!(parent.kind(), AstKind::CallExpression(_) | AstKind::NewExpression(_));
+
+        if !is_callback {
+            return;
+        }
+
+        ctx.diagnostic(prefer_arrow_callback_diagnostic(Span::new(
+            func.span.start,
+            func.params.span.start,
+        )));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "foo((a) => a);",
+        "foo(function bar() { return bar; });", // named, may be recursive
+        "foo(function*() { yield 1; });",       // generator
+        "var x = function() { return 1; };",    // not a callback
+    ];
+
+    let fail = vec![
+        "foo(function(a) { return a; });",
+        "foo(function() { return 1; });",
+        "[1, 2].map(function(x) { return x * 2; });",
+        "setTimeout(function() { console.log('hi'); }, 100);",
+    ];
+
+    Tester::new(PreferArrowCallback::NAME, PreferArrowCallback::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/use_regex_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_regex_literals.rs
@@ -1,0 +1,125 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{Argument, Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn use_regex_literals_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use a regular expression literal instead of the `RegExp` constructor.")
+        .with_help("Replace `new RegExp(\"pattern\")` with `/pattern/` for better readability and performance.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseRegexLiterals;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of the `RegExp` constructor with string literals
+    /// that can be expressed as regular expression literals.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Regular expression literals are more concise, do not require escaping
+    /// special characters, and are compiled at parse time rather than runtime.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// new RegExp("abc");
+    /// RegExp("abc");
+    /// new RegExp("abc", "g");
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// /abc/;
+    /// /abc/g;
+    /// new RegExp(variable);
+    /// new RegExp("abc" + "def");
+    /// ```
+    UseRegexLiterals,
+    eslint,
+    style,
+    pending
+);
+
+impl Rule for UseRegexLiterals {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::NewExpression(expr) => {
+                if let Expression::Identifier(ident) = &expr.callee {
+                    if ident.name == "RegExp" && is_simple_regex_args(&expr.arguments) {
+                        ctx.diagnostic(use_regex_literals_diagnostic(expr.span));
+                    }
+                }
+            }
+            AstKind::CallExpression(expr) => {
+                if let Expression::Identifier(ident) = &expr.callee {
+                    if ident.name == "RegExp" && is_simple_regex_args(&expr.arguments) {
+                        ctx.diagnostic(use_regex_literals_diagnostic(expr.span));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Check if the arguments are simple enough to be expressed as a regex literal:
+/// - First arg is a string literal (the pattern)
+/// - Optional second arg is a string literal (the flags)
+fn is_simple_regex_args(args: &[Argument]) -> bool {
+    if args.is_empty() || args.len() > 2 {
+        return false;
+    }
+
+    // First argument must be a simple string literal
+    let Some(Expression::StringLiteral(pattern)) = args[0].as_expression() else {
+        return false;
+    };
+
+    // Check pattern doesn't contain newlines or other chars that can't go in a regex literal
+    if pattern.value.contains('\n') || pattern.value.contains('\r') {
+        return false;
+    }
+
+    // If there's a second argument, it must also be a string literal
+    if args.len() == 2 {
+        let Some(Expression::StringLiteral(_)) = args[1].as_expression() else {
+            return false;
+        };
+    }
+
+    true
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "/abc/;",
+        "/abc/g;",
+        "new RegExp(variable);",
+        "RegExp(variable);",
+        "new RegExp(variable, 'g');",
+        "new RegExp('abc', flags);",
+        "new RegExp('abc', 'g', extra);",
+        "RegExp();",
+    ];
+
+    let fail = vec![
+        "new RegExp('abc');",
+        "RegExp('abc');",
+        "new RegExp('abc', 'g');",
+        "RegExp('abc', 'ig');",
+        "new RegExp('test');",
+    ];
+
+    Tester::new(UseRegexLiterals::NAME, UseRegexLiterals::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/use_single_var_declarator.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_single_var_declarator.rs
@@ -1,0 +1,101 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn use_single_var_declarator_diagnostic(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Declare variables separately instead of using a single `{kind}` declaration."
+    ))
+    .with_help("Split this declaration into separate statements, one per variable.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseSingleVarDeclarator;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires each variable to be declared in its own statement.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Declaring multiple variables in a single statement can make code harder
+    /// to read and maintain. Each variable declaration in its own statement
+    /// is clearer and makes diffs more readable.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// let a, b;
+    /// const x = 1, y = 2;
+    /// var foo = 1, bar = 2;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// let a;
+    /// let b;
+    /// const x = 1;
+    /// const y = 2;
+    /// ```
+    UseSingleVarDeclarator,
+    eslint,
+    style,
+    pending
+);
+
+impl Rule for UseSingleVarDeclarator {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::VariableDeclaration(decl) = node.kind() else {
+            return;
+        };
+
+        if decl.declarations.len() <= 1 {
+            return;
+        }
+
+        // Skip for-loop initializers: `for (let i = 0, j = 0; ...)`
+        let parent = ctx.nodes().parent_node(node.id());
+        if matches!(parent.kind(), AstKind::ForStatement(_)) {
+            return;
+        }
+
+        let kind = match decl.kind {
+            oxc_ast::ast::VariableDeclarationKind::Var => "var",
+            oxc_ast::ast::VariableDeclarationKind::Let => "let",
+            oxc_ast::ast::VariableDeclarationKind::Const => "const",
+            oxc_ast::ast::VariableDeclarationKind::Using => "using",
+            oxc_ast::ast::VariableDeclarationKind::AwaitUsing => "await using",
+        };
+
+        ctx.diagnostic(use_single_var_declarator_diagnostic(decl.span, kind));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "let a;",
+        "let a = 1;",
+        "const a = 1;",
+        "var a = 1;",
+        "for (let i = 0, j = 0; i < 10; i++) {}",
+    ];
+
+    let fail = vec![
+        "let a, b;",
+        "const x = 1, y = 2;",
+        "var foo = 1, bar = 2;",
+        "let a = 1, b = 2, c = 3;",
+    ];
+
+    Tester::new(UseSingleVarDeclarator::NAME, UseSingleVarDeclarator::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/use_while.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_while.rs
@@ -1,0 +1,80 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn use_while_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `while` instead of `for` with no init and update.")
+        .with_help("Replace `for(;condition;)` with `while(condition)` for clarity.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseWhile;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the use of `while` loops instead of `for` loops when there
+    /// is no initializer and no update expression.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `for` loop without an initializer and update expression is
+    /// functionally identical to a `while` loop but less readable.
+    /// Using `while` makes the intent clearer.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// for (; x < 10;) { x++; }
+    /// for (;;) { break; }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// while (x < 10) { x++; }
+    /// while (true) { break; }
+    /// for (let i = 0; i < 10; i++) {}
+    /// ```
+    UseWhile,
+    eslint,
+    style,
+    pending
+);
+
+impl Rule for UseWhile {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ForStatement(for_stmt) = node.kind() else {
+            return;
+        };
+
+        if for_stmt.init.is_none() && for_stmt.update.is_none() {
+            ctx.diagnostic(use_while_diagnostic(Span::new(
+                for_stmt.span.start,
+                for_stmt.span.start + 3, // "for"
+            )));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "while (true) {}",
+        "while (x < 10) { x++; }",
+        "for (let i = 0; i < 10; i++) {}",
+        "for (;; i++) {}",      // has update
+        "for (let i = 0;;) {}", // has init
+    ];
+
+    let fail =
+        vec!["for (; x < 10;) { x++; }", "for (;;) { break; }", "for (; true;) { doSomething(); }"];
+
+    Tester::new(UseWhile::NAME, UseWhile::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/import/no_dynamic_namespace_import_access.rs
+++ b/crates/oxc_linter/src/rules/import/no_dynamic_namespace_import_access.rs
@@ -1,0 +1,91 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_dynamic_namespace_import_access_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Dynamic access to namespace import defeats tree-shaking.")
+        .with_help("Use named imports instead of dynamically accessing namespace imports.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDynamicNamespaceImportAccess;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows dynamic member access on namespace imports (e.g., `ns[key]`).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When you use `import * as ns` and then access `ns[variable]`,
+    /// bundlers cannot determine which exports are used and must include
+    /// the entire module, defeating tree-shaking.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// import * as ns from 'mod';
+    /// const value = ns[key];
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import * as ns from 'mod';
+    /// const value = ns.specificExport;
+    /// import { specificExport } from 'mod';
+    /// ```
+    NoDynamicNamespaceImportAccess,
+    import,
+    perf,
+    pending
+);
+
+impl Rule for NoDynamicNamespaceImportAccess {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ComputedMemberExpression(expr) = node.kind() else {
+            return;
+        };
+
+        // Check if the object is an identifier that is a namespace import
+        let Expression::Identifier(ident) = &expr.object else {
+            return;
+        };
+
+        // Look up the binding to see if it's a namespace import
+        let Some(symbol_id) = ctx.scoping().find_binding(node.scope_id(), ident.name) else {
+            return;
+        };
+
+        let decl_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
+        if matches!(decl_node.kind(), AstKind::ImportNamespaceSpecifier(_)) {
+            ctx.diagnostic(no_dynamic_namespace_import_access_diagnostic(expr.span()));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "import * as ns from 'mod'; const x = ns.foo;",
+        "import { foo } from 'mod'; const x = foo;",
+        "const obj = {}; const x = obj[key];",
+    ];
+
+    let fail = vec!["import * as ns from 'mod'; const x = ns[key];"];
+
+    Tester::new(
+        NoDynamicNamespaceImportAccess::NAME,
+        NoDynamicNamespaceImportAccess::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/import/no_private_imports.rs
+++ b/crates/oxc_linter/src/rules/import/no_private_imports.rs
@@ -1,0 +1,68 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+#[allow(dead_code)]
+fn no_private_imports_diagnostic(span: Span, source: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Import from `{source}` accesses a private module path."))
+        .with_help("Only import from paths that are explicitly exported in the package's `exports` field in package.json.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoPrivateImports;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows importing from private module paths that are not explicitly
+    /// exposed in a package's `exports` field.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Packages that define an `exports` field in their `package.json` specify
+    /// which paths are public API. Importing from unlisted paths bypasses
+    /// this contract and may break when the package is updated.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// // If 'lib' has exports: { ".": "./dist/index.js" }
+    /// import { internal } from 'lib/dist/internal';
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import { exported } from 'lib';
+    /// ```
+    NoPrivateImports,
+    import,
+    nursery, // Complex rule that needs package.json exports parsing
+    pending
+);
+
+impl Rule for NoPrivateImports {
+    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {
+        // TODO: This rule requires:
+        // 1. Detecting deep imports into node_modules packages
+        // 2. Reading the target package's package.json
+        // 3. Checking the `exports` field to see if the import path is allowed
+        //
+        // This is a placeholder registration for the rule structure.
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["import { foo } from 'lib';", "import { bar } from './local';"];
+
+    let fail = vec![];
+
+    Tester::new(NoPrivateImports::NAME, NoPrivateImports::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/import/no_undeclared_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/no_undeclared_dependencies.rs
@@ -1,0 +1,162 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+#[allow(dead_code)]
+fn no_undeclared_dependencies_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Import of `{name}` is not listed as a dependency in package.json."))
+        .with_help("Add this package to your dependencies, devDependencies, peerDependencies, or optionalDependencies in package.json.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUndeclaredDependencies;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows importing packages that are not declared in `package.json`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Importing undeclared dependencies means the project relies on packages
+    /// that may not be installed in production, leading to runtime errors.
+    /// All imported packages should be listed in the appropriate dependencies
+    /// field of `package.json`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// // If 'lodash' is not in package.json:
+    /// import _ from 'lodash';
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// // If 'lodash' is in package.json dependencies:
+    /// import _ from 'lodash';
+    /// // Relative imports are always fine:
+    /// import { foo } from './utils';
+    /// // Node.js builtins are always fine:
+    /// import fs from 'node:fs';
+    /// ```
+    NoUndeclaredDependencies,
+    import,
+    nursery, // Complex rule that needs package.json integration
+    pending
+);
+
+impl Rule for NoUndeclaredDependencies {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let source = match node.kind() {
+            AstKind::ImportDeclaration(decl) => decl.source.value.as_str(),
+            AstKind::ExportNamedDeclaration(decl) => {
+                let Some(source) = &decl.source else {
+                    return;
+                };
+                source.value.as_str()
+            }
+            AstKind::ExportAllDeclaration(decl) => decl.source.value.as_str(),
+            _ => return,
+        };
+
+        // Skip relative imports
+        if source.starts_with('.') || source.starts_with('/') {
+            return;
+        }
+
+        // Skip Node.js builtins
+        if source.starts_with("node:") || is_node_builtin(source) {
+            return;
+        }
+
+        // Extract package name (handle scoped packages)
+        let package_name = get_package_name(source);
+
+        // For now, this rule just flags the import. In a full implementation,
+        // it would read package.json and check dependencies.
+        // This is a placeholder that can be enhanced with package.json reading.
+        let _ = package_name;
+        // TODO: Read package.json and check if package_name is in dependencies
+        // For now, the rule is registered but doesn't report (nursery)
+    }
+}
+
+fn get_package_name(source: &str) -> &str {
+    if source.starts_with('@') {
+        // Scoped package: @scope/name/path -> @scope/name
+        let mut parts = source.splitn(3, '/');
+        let scope = parts.next().unwrap_or("");
+        let name = parts.next().unwrap_or("");
+        let end = scope.len() + 1 + name.len();
+        &source[..end.min(source.len())]
+    } else {
+        // Regular package: name/path -> name
+        source.split('/').next().unwrap_or(source)
+    }
+}
+
+fn is_node_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "assert"
+            | "buffer"
+            | "child_process"
+            | "cluster"
+            | "console"
+            | "constants"
+            | "crypto"
+            | "dgram"
+            | "dns"
+            | "domain"
+            | "events"
+            | "fs"
+            | "http"
+            | "http2"
+            | "https"
+            | "inspector"
+            | "module"
+            | "net"
+            | "os"
+            | "path"
+            | "perf_hooks"
+            | "process"
+            | "punycode"
+            | "querystring"
+            | "readline"
+            | "repl"
+            | "stream"
+            | "string_decoder"
+            | "sys"
+            | "timers"
+            | "tls"
+            | "tty"
+            | "url"
+            | "util"
+            | "v8"
+            | "vm"
+            | "wasi"
+            | "worker_threads"
+            | "zlib"
+    )
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "import { foo } from './utils';",
+        "import fs from 'node:fs';",
+        "import path from 'path';",
+    ];
+
+    let fail = vec![];
+
+    Tester::new(NoUndeclaredDependencies::NAME, NoUndeclaredDependencies::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/import/no_unresolved_imports.rs
+++ b/crates/oxc_linter/src/rules/import/no_unresolved_imports.rs
@@ -1,0 +1,71 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+#[allow(dead_code)]
+fn no_unresolved_imports_diagnostic(span: Span, source: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unable to resolve import `{source}`."))
+        .with_help("Ensure the module exists, the path is correct, and the package is installed.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUnresolvedImports;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects imports that cannot be resolved.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Importing a module that doesn't exist or can't be resolved will cause
+    /// a runtime error. This rule catches these issues at lint time.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// import foo from './nonexistent';
+    /// import bar from 'not-installed-package';
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import foo from './existing-module';
+    /// import bar from 'installed-package';
+    /// ```
+    NoUnresolvedImports,
+    import,
+    nursery, // Complex rule that needs module resolution
+    pending
+);
+
+impl Rule for NoUnresolvedImports {
+    fn run<'a>(&self, _node: &AstNode<'a>, _ctx: &LintContext<'a>) {
+        // TODO: This rule requires module resolution capabilities.
+        // The full implementation would:
+        // 1. Get the import source path
+        // 2. Resolve it relative to the current file
+        // 3. Check if the resolved path exists
+        // 4. For node_modules, check if the package is installed
+        //
+        // This is a placeholder registration. Module resolution is complex
+        // and depends on tsconfig paths, package.json exports, etc.
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["import { foo } from './utils';", "const x = 1;"];
+
+    let fail = vec![];
+
+    Tester::new(NoUnresolvedImports::NAME, NoUnresolvedImports::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
@@ -1,0 +1,136 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{JSXAttributeItem, JSXAttributeValue, JSXElementName};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case};
+
+fn diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Interactive element should not be assigned a non-interactive role.")
+        .with_help("Interactive HTML elements like `<button>`, `<a>`, and `<input>` should not be given non-interactive roles like `article` or `presentation`.")
+        .with_label(span)
+}
+
+const INTERACTIVE_ELEMENTS: &[&str] =
+    &["a", "button", "input", "select", "textarea", "details", "summary"];
+
+const NON_INTERACTIVE_ROLES: &[&str] = &[
+    "article",
+    "banner",
+    "complementary",
+    "contentinfo",
+    "definition",
+    "directory",
+    "document",
+    "feed",
+    "figure",
+    "group",
+    "heading",
+    "img",
+    "list",
+    "listitem",
+    "main",
+    "math",
+    "navigation",
+    "none",
+    "note",
+    "presentation",
+    "region",
+    "separator",
+    "status",
+    "term",
+    "toolbar",
+];
+
+#[derive(Debug, Default, Clone)]
+pub struct NoInteractiveElementToNoninteractiveRole;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows assigning non-interactive ARIA roles to interactive HTML elements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Interactive elements like `<button>` have built-in interaction behaviors.
+    /// Assigning a non-interactive role overrides the native semantics, which
+    /// confuses assistive technologies.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <button role="article" />
+    /// <a href="#" role="presentation" />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <button />
+    /// <div role="article" />
+    /// ```
+    NoInteractiveElementToNoninteractiveRole,
+    jsx_a11y,
+    correctness,
+    pending
+);
+
+impl Rule for NoInteractiveElementToNoninteractiveRole {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
+            return;
+        };
+
+        let element_name = match &jsx_el.name {
+            JSXElementName::Identifier(id) => id.name.as_str(),
+            JSXElementName::IdentifierReference(id) => id.name.as_str(),
+            _ => return,
+        };
+
+        if !INTERACTIVE_ELEMENTS.contains(&element_name) {
+            return;
+        }
+
+        // Check for role attribute
+        let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_ignore_case(jsx_el, "role")
+        else {
+            return;
+        };
+
+        let Some(JSXAttributeValue::StringLiteral(role_value)) = &attr.value else {
+            return;
+        };
+
+        let role = role_value.value.as_str().to_lowercase();
+        if NON_INTERACTIVE_ROLES.contains(&role.as_str()) {
+            ctx.diagnostic(diagnostic(attr.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<button />",
+        "<div role=\"article\" />",
+        "<button role=\"button\" />",
+        "<a href=\"#\" />",
+    ];
+
+    let fail = vec![
+        "<button role=\"article\" />",
+        "<button role=\"presentation\" />",
+        "<a href=\"#\" role=\"none\" />",
+    ];
+
+    Tester::new(
+        NoInteractiveElementToNoninteractiveRole::NAME,
+        NoInteractiveElementToNoninteractiveRole::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
@@ -1,0 +1,146 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::JSXElementName;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case};
+
+fn diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Non-interactive element should not have event handlers without a role.")
+        .with_help(
+            "Add an appropriate ARIA role to the element, or use an interactive element instead.",
+        )
+        .with_label(span)
+}
+
+const NON_INTERACTIVE_ELEMENTS: &[&str] = &[
+    "article",
+    "aside",
+    "blockquote",
+    "dd",
+    "div",
+    "dl",
+    "dt",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "section",
+    "span",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+];
+
+const INTERACTIVE_HANDLERS: &[&str] =
+    &["onClick", "onKeyDown", "onKeyUp", "onKeyPress", "onMouseDown", "onMouseUp"];
+
+#[derive(Debug, Default, Clone)]
+pub struct NoNoninteractiveElementInteractions;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows event handlers on non-interactive HTML elements without an
+    /// appropriate ARIA role.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Non-interactive HTML elements like `<div>` and `<span>` do not have
+    /// built-in interaction behaviors. Adding event handlers without proper
+    /// ARIA roles makes the element inaccessible to keyboard and screen
+    /// reader users.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div onClick={() => {}} />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <button onClick={() => {}} />
+    /// <div role="button" onClick={() => {}} />
+    /// ```
+    NoNoninteractiveElementInteractions,
+    jsx_a11y,
+    correctness,
+    pending
+);
+
+impl Rule for NoNoninteractiveElementInteractions {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
+            return;
+        };
+
+        let element_name = match &jsx_el.name {
+            JSXElementName::Identifier(id) => id.name.as_str(),
+            JSXElementName::IdentifierReference(id) => id.name.as_str(),
+            _ => return,
+        };
+
+        if !NON_INTERACTIVE_ELEMENTS.contains(&element_name) {
+            return;
+        }
+
+        // If element has a role, it's fine
+        if has_jsx_prop_ignore_case(jsx_el, "role").is_some() {
+            return;
+        }
+
+        // Check for interactive event handlers
+        for handler in INTERACTIVE_HANDLERS {
+            if let Some(prop) = has_jsx_prop_ignore_case(jsx_el, handler) {
+                if let oxc_ast::ast::JSXAttributeItem::Attribute(attr) = prop {
+                    ctx.diagnostic(diagnostic(attr.span));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<button onClick={() => {}} />",
+        "<div role=\"button\" onClick={() => {}} />",
+        "<div />",
+        "<input onClick={() => {}} />",
+    ];
+
+    let fail = vec!["<div onClick={() => {}} />", "<span onClick={() => {}} />"];
+
+    Tester::new(
+        NoNoninteractiveElementInteractions::NAME,
+        NoNoninteractiveElementInteractions::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_to_interactive_role.rs
@@ -1,0 +1,166 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{JSXAttributeItem, JSXAttributeValue, JSXElementName};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case};
+
+fn diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Non-interactive element should not be assigned an interactive role.")
+        .with_help("Use an interactive HTML element instead of adding an interactive role to a non-interactive element.")
+        .with_label(span)
+}
+
+const NON_INTERACTIVE_ELEMENTS: &[&str] = &[
+    "article",
+    "aside",
+    "blockquote",
+    "dd",
+    "div",
+    "dl",
+    "dt",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "section",
+    "span",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+];
+
+const INTERACTIVE_ROLES: &[&str] = &[
+    "button",
+    "checkbox",
+    "combobox",
+    "grid",
+    "gridcell",
+    "link",
+    "listbox",
+    "menu",
+    "menubar",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "option",
+    "progressbar",
+    "radio",
+    "radiogroup",
+    "scrollbar",
+    "searchbox",
+    "slider",
+    "spinbutton",
+    "switch",
+    "tab",
+    "tablist",
+    "tabpanel",
+    "textbox",
+    "tree",
+    "treegrid",
+    "treeitem",
+];
+
+#[derive(Debug, Default, Clone)]
+pub struct NoNoninteractiveElementToInteractiveRole;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows assigning interactive ARIA roles to non-interactive HTML elements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Non-interactive HTML elements (like `<div>`) with interactive roles
+    /// (like `button`) lack the built-in accessibility features of native
+    /// interactive elements. Use `<button>` instead of `<div role="button">`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div role="button" />
+    /// <span role="link" />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <button />
+    /// <a href="#" />
+    /// <div role="article" />
+    /// ```
+    NoNoninteractiveElementToInteractiveRole,
+    jsx_a11y,
+    correctness,
+    pending
+);
+
+impl Rule for NoNoninteractiveElementToInteractiveRole {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
+            return;
+        };
+
+        let element_name = match &jsx_el.name {
+            JSXElementName::Identifier(id) => id.name.as_str(),
+            JSXElementName::IdentifierReference(id) => id.name.as_str(),
+            _ => return,
+        };
+
+        if !NON_INTERACTIVE_ELEMENTS.contains(&element_name) {
+            return;
+        }
+
+        let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_ignore_case(jsx_el, "role")
+        else {
+            return;
+        };
+
+        let Some(JSXAttributeValue::StringLiteral(role_value)) = &attr.value else {
+            return;
+        };
+
+        let role = role_value.value.as_str().to_lowercase();
+        if INTERACTIVE_ROLES.contains(&role.as_str()) {
+            ctx.diagnostic(diagnostic(attr.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["<button />", "<a href=\"#\" />", "<div role=\"article\" />", "<div />"];
+
+    let fail = vec!["<div role=\"button\" />", "<span role=\"link\" />", "<p role=\"checkbox\" />"];
+
+    Tester::new(
+        NoNoninteractiveElementToInteractiveRole::NAME,
+        NoNoninteractiveElementToInteractiveRole::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_svg_without_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_svg_without_title.rs
@@ -1,0 +1,99 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{JSXChild, JSXElementName};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case};
+
+fn no_svg_without_title_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("SVG elements must have a `<title>` element or an accessible label.")
+        .with_help(
+            "Add a `<title>` child element, or add an `aria-label` or `aria-labelledby` attribute.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoSvgWithoutTitle;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Enforces that `<svg>` elements have an accessible title.
+    ///
+    /// ### Why is this bad
+    /// SVG images without accessible text are invisible to screen readers.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <svg><circle /></svg>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <svg><title>Icon</title><circle /></svg>
+    /// <svg aria-label="Icon"><circle /></svg>
+    /// ```
+    NoSvgWithoutTitle,
+    jsx_a11y,
+    correctness,
+    pending
+);
+
+fn get_element_name<'a>(name: &'a JSXElementName<'a>) -> Option<&'a str> {
+    match name {
+        JSXElementName::Identifier(id) => Some(id.name.as_str()),
+        JSXElementName::IdentifierReference(id) => Some(id.name.as_str()),
+        _ => None,
+    }
+}
+
+impl Rule for NoSvgWithoutTitle {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
+            return;
+        };
+
+        if get_element_name(&jsx_el.name) != Some("svg") {
+            return;
+        }
+
+        if has_jsx_prop_ignore_case(jsx_el, "aria-label").is_some()
+            || has_jsx_prop_ignore_case(jsx_el, "aria-labelledby").is_some()
+            || has_jsx_prop_ignore_case(jsx_el, "role").is_some()
+        {
+            return;
+        }
+
+        let parent = ctx.nodes().parent_node(node.id());
+        if let AstKind::JSXElement(element) = parent.kind() {
+            for child in &element.children {
+                if let JSXChild::Element(child_el) = child {
+                    if get_element_name(&child_el.opening_element.name) == Some("title") {
+                        return;
+                    }
+                }
+            }
+        }
+
+        ctx.diagnostic(no_svg_without_title_diagnostic(jsx_el.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<svg><title>Icon</title><circle /></svg>",
+        r#"<svg aria-label="Icon"><circle /></svg>"#,
+        r#"<svg aria-labelledby="title-id"><circle /></svg>"#,
+        r#"<svg role="img"><circle /></svg>"#,
+    ];
+
+    let fail = vec!["<svg><circle /></svg>"];
+
+    Tester::new(NoSvgWithoutTitle::NAME, NoSvgWithoutTitle::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/use_focusable_interactive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/use_focusable_interactive.rs
@@ -1,0 +1,139 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{JSXAttributeItem, JSXAttributeValue, JSXElementName};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case};
+
+fn use_focusable_interactive_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Interactive elements must be focusable.")
+        .with_help("Add a `tabIndex` attribute to make this interactive element focusable, or use a natively focusable element.")
+        .with_label(span)
+}
+
+const INTERACTIVE_ROLES: &[&str] = &[
+    "button",
+    "checkbox",
+    "combobox",
+    "grid",
+    "gridcell",
+    "link",
+    "listbox",
+    "menu",
+    "menubar",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "option",
+    "progressbar",
+    "radio",
+    "radiogroup",
+    "scrollbar",
+    "searchbox",
+    "slider",
+    "spinbutton",
+    "switch",
+    "tab",
+    "tablist",
+    "textbox",
+    "tree",
+    "treegrid",
+    "treeitem",
+];
+
+const NATIVELY_FOCUSABLE: &[&str] =
+    &["a", "button", "input", "select", "textarea", "details", "summary"];
+
+#[derive(Debug, Default, Clone)]
+pub struct UseFocusableInteractive;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that elements with interactive ARIA roles are focusable.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Elements with interactive roles must be focusable for keyboard
+    /// navigation. If a non-focusable element has an interactive role,
+    /// keyboard users cannot interact with it.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div role="button" />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <div role="button" tabIndex={0} />
+    /// <button />
+    /// ```
+    UseFocusableInteractive,
+    jsx_a11y,
+    correctness,
+    pending
+);
+
+impl Rule for UseFocusableInteractive {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
+            return;
+        };
+
+        let element_name = match &jsx_el.name {
+            JSXElementName::Identifier(id) => id.name.as_str(),
+            JSXElementName::IdentifierReference(id) => id.name.as_str(),
+            _ => return,
+        };
+
+        // Natively focusable elements are fine
+        if NATIVELY_FOCUSABLE.contains(&element_name) {
+            return;
+        }
+
+        // Check if it has an interactive role
+        let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_ignore_case(jsx_el, "role")
+        else {
+            return;
+        };
+
+        let Some(JSXAttributeValue::StringLiteral(role_value)) = &attr.value else {
+            return;
+        };
+
+        let role = role_value.value.as_str().to_lowercase();
+        if !INTERACTIVE_ROLES.contains(&role.as_str()) {
+            return;
+        }
+
+        // Check if tabIndex is set
+        if has_jsx_prop_ignore_case(jsx_el, "tabIndex").is_some()
+            || has_jsx_prop_ignore_case(jsx_el, "tabindex").is_some()
+        {
+            return;
+        }
+
+        ctx.diagnostic(use_focusable_interactive_diagnostic(jsx_el.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<div role=\"button\" tabIndex={0} />",
+        "<button />",
+        "<div />",
+        "<div role=\"article\" />",
+        "<a href=\"#\" role=\"button\" />",
+    ];
+
+    let fail = vec!["<div role=\"button\" />", "<span role=\"link\" />"];
+
+    Tester::new(UseFocusableInteractive::NAME, UseFocusableInteractive::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsx_a11y/use_unique_element_ids.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/use_unique_element_ids.rs
@@ -1,0 +1,89 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{JSXAttributeItem, JSXAttributeValue};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use rustc_hash::FxHashSet;
+
+use crate::{context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case};
+
+fn use_unique_element_ids_diagnostic(span: Span, id: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Duplicate element id `{id}`."))
+        .with_help("Element `id` attributes must be unique within a document. Use a unique id for each element.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseUniqueElementIds;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces that element `id` attributes are unique within a file.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Duplicate `id` attributes break `getElementById`, cause issues with
+    /// label associations, ARIA references, and fragment navigation.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div id="foo" />
+    /// <div id="foo" />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <div id="foo" />
+    /// <div id="bar" />
+    /// ```
+    UseUniqueElementIds,
+    jsx_a11y,
+    correctness,
+    pending
+);
+
+impl Rule for UseUniqueElementIds {
+    fn run_once(&self, ctx: &LintContext<'_>) {
+        let mut seen_ids: FxHashSet<String> = FxHashSet::default();
+
+        for node in ctx.nodes().iter() {
+            let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
+                continue;
+            };
+
+            let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_ignore_case(jsx_el, "id")
+            else {
+                continue;
+            };
+
+            let Some(JSXAttributeValue::StringLiteral(id_value)) = &attr.value else {
+                continue;
+            };
+
+            let id = id_value.value.as_str();
+            if id.is_empty() {
+                continue;
+            }
+
+            if !seen_ids.insert(id.to_string()) {
+                ctx.diagnostic(use_unique_element_ids_diagnostic(attr.span, id));
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass =
+        vec![r#"<><div id="foo" /><div id="bar" /></>"#, "<div />", r#"<div id="unique" />"#];
+
+    let fail = vec![r#"<><div id="foo" /><div id="foo" /></>"#];
+
+    Tester::new(UseUniqueElementIds::NAME, UseUniqueElementIds::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/node/no_global_dirname_filename.rs
+++ b/crates/oxc_linter/src/rules/node/no_global_dirname_filename.rs
@@ -1,0 +1,85 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_global_dirname_filename_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use `import.meta.{name}` instead of `{name}`."))
+        .with_help(format!(
+            "In ES modules, use `import.meta.{name}` instead of the CommonJS global `{name}`."
+        ))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoGlobalDirnameFilename;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of `__dirname` and `__filename` globals in ES modules.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `__dirname` and `__filename` are CommonJS globals that are not available
+    /// in ES modules. Use `import.meta.dirname` and `import.meta.filename`
+    /// instead (available in Node.js 20.11+).
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const dir = __dirname;
+    /// const file = __filename;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const dir = import.meta.dirname;
+    /// const file = import.meta.filename;
+    /// ```
+    NoGlobalDirnameFilename,
+    node,
+    style,
+    pending
+);
+
+impl Rule for NoGlobalDirnameFilename {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if !ctx.source_type().is_module() {
+            return;
+        }
+
+        let AstKind::IdentifierReference(ident) = node.kind() else {
+            return;
+        };
+
+        match ident.name.as_str() {
+            "__dirname" => {
+                ctx.diagnostic(no_global_dirname_filename_diagnostic(ident.span, "dirname"));
+            }
+            "__filename" => {
+                ctx.diagnostic(no_global_dirname_filename_diagnostic(ident.span, "filename"));
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    // Note: ESM tests need module source type
+    let pass = vec![
+        // CJS: __dirname is fine
+        "const dir = __dirname;",
+    ];
+
+    let fail = vec![];
+
+    Tester::new(NoGlobalDirnameFilename::NAME, NoGlobalDirnameFilename::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/no_forward_ref.rs
+++ b/crates/oxc_linter/src/rules/react/no_forward_ref.rs
@@ -1,0 +1,93 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_forward_ref_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not use `React.forwardRef`.")
+        .with_help("In React 19+, `ref` is available as a prop. Use the `ref` prop directly instead of `forwardRef`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoForwardRef;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of `React.forwardRef`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Starting with React 19, `ref` is available as a regular prop.
+    /// `forwardRef` is no longer needed and adds unnecessary complexity.
+    /// Components should accept `ref` as a prop directly.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// const MyInput = React.forwardRef((props, ref) => (
+    ///   <input ref={ref} {...props} />
+    /// ));
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// function MyInput({ ref, ...props }) {
+    ///   return <input ref={ref} {...props} />;
+    /// }
+    /// ```
+    NoForwardRef,
+    react,
+    style,
+    pending
+);
+
+impl Rule for NoForwardRef {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call) = node.kind() else {
+            return;
+        };
+
+        match &call.callee {
+            // React.forwardRef(...)
+            Expression::StaticMemberExpression(member) => {
+                if member.property.name.as_str() == "forwardRef" {
+                    if let Expression::Identifier(obj) = &member.object {
+                        if obj.name == "React" {
+                            ctx.diagnostic(no_forward_ref_diagnostic(call.span));
+                        }
+                    }
+                }
+            }
+            // forwardRef(...)
+            Expression::Identifier(ident) => {
+                if ident.name == "forwardRef" {
+                    ctx.diagnostic(no_forward_ref_diagnostic(call.span));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "function MyInput({ ref, ...props }) { return <input ref={ref} {...props} />; }",
+        "const x = React.memo(() => <div />);",
+    ];
+
+    let fail = vec![
+        "const MyInput = React.forwardRef((props, ref) => <input ref={ref} />);",
+        "const MyInput = forwardRef((props, ref) => <input ref={ref} />);",
+    ];
+
+    Tester::new(NoForwardRef::NAME, NoForwardRef::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/no_jsx_literals.rs
+++ b/crates/oxc_linter/src/rules/react/no_jsx_literals.rs
@@ -1,0 +1,80 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::JSXChild;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_jsx_literals_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("String literals are not allowed in JSX.")
+        .with_help("Wrap the string in a JSX expression: `{'text'}` or use a variable/constant.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoJsxLiterals;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows string literals in JSX, requiring them to be wrapped in
+    /// JSX expressions or extracted into variables.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// String literals in JSX can make internationalization (i18n) difficult.
+    /// Requiring all strings to be wrapped or extracted encourages the use
+    /// of translation functions.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div>Hello World</div>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <div>{t('hello_world')}</div>
+    /// <div>{'Hello World'}</div>
+    /// ```
+    NoJsxLiterals,
+    react,
+    restriction,
+    pending
+);
+
+impl Rule for NoJsxLiterals {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXElement(jsx) = node.kind() else {
+            return;
+        };
+
+        for child in &jsx.children {
+            if let JSXChild::Text(text) = child {
+                let trimmed = text.value.as_str().trim();
+                // Only flag non-whitespace-only text
+                if !trimmed.is_empty() {
+                    ctx.diagnostic(no_jsx_literals_diagnostic(text.span));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<div>{t('hello')}</div>",
+        "<div>{'Hello World'}</div>",
+        "<div>{variable}</div>",
+        "<div> </div>",
+    ];
+
+    let fail = vec!["<div>Hello World</div>", "<span>Some text</span>"];
+
+    Tester::new(NoJsxLiterals::NAME, NoJsxLiterals::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/no_react_specific_props.rs
+++ b/crates/oxc_linter/src/rules/react/no_react_specific_props.rs
@@ -1,0 +1,80 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_react_specific_props_diagnostic(span: Span, prop: &str, standard: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{prop}` is a React-specific prop."))
+        .with_help(format!(
+            "Use the standard HTML attribute `{standard}` instead of `{prop}` when not using React."
+        ))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoReactSpecificProps;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects usage of React-specific JSX props like `className` and `htmlFor`
+    /// that should be replaced with their standard HTML equivalents.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Outside of React, JSX props should use standard HTML attribute names.
+    /// `className` and `htmlFor` are React-specific alternatives to `class`
+    /// and `for`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div className="foo" />
+    /// <label htmlFor="input" />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <div class="foo" />
+    /// <label for="input" />
+    /// ```
+    NoReactSpecificProps,
+    react,
+    suspicious,
+    pending
+);
+
+impl Rule for NoReactSpecificProps {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+
+        let name = attr.name.as_identifier().map(|ident| ident.name.as_str());
+
+        match name {
+            Some("className") => {
+                ctx.diagnostic(no_react_specific_props_diagnostic(attr.span, "className", "class"));
+            }
+            Some("htmlFor") => {
+                ctx.diagnostic(no_react_specific_props_diagnostic(attr.span, "htmlFor", "for"));
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![r#"<div class="foo" />"#, r#"<label for="input" />"#, "<div id=\"bar\" />"];
+
+    let fail = vec![r#"<div className="foo" />"#, r#"<label htmlFor="input" />"#];
+
+    Tester::new(NoReactSpecificProps::NAME, NoReactSpecificProps::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/no_suspicious_semicolon_in_jsx.rs
+++ b/crates/oxc_linter/src/rules/react/no_suspicious_semicolon_in_jsx.rs
@@ -1,0 +1,81 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::JSXChild;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_suspicious_semicolon_in_jsx_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suspicious semicolon as JSX text content.")
+        .with_help("This semicolon appears as visible text in the rendered output. If you meant to end a statement, move it outside the JSX expression.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoSuspiciousSemicolonInJsx;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects semicolons that appear as text content inside JSX elements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A semicolon inside JSX is rendered as visible text, not as a statement
+    /// terminator. This is almost always a mistake where the developer
+    /// accidentally placed a semicolon inside a JSX expression.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// const Component = () => (
+    ///   <div>;
+    ///     content
+    ///   </div>
+    /// );
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// const Component = () => (
+    ///   <div>
+    ///     content
+    ///   </div>
+    /// );
+    /// ```
+    NoSuspiciousSemicolonInJsx,
+    react,
+    suspicious,
+    pending
+);
+
+impl Rule for NoSuspiciousSemicolonInJsx {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXElement(jsx) = node.kind() else {
+            return;
+        };
+
+        for child in &jsx.children {
+            if let JSXChild::Text(text) = child {
+                let value = text.value.as_str().trim();
+                if value == ";" {
+                    ctx.diagnostic(no_suspicious_semicolon_in_jsx_diagnostic(text.span));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["<div>content</div>;", "<div>content</div>", "<div> </div>"];
+
+    let fail = vec!["<div>;</div>"];
+
+    Tester::new(NoSuspiciousSemicolonInJsx::NAME, NoSuspiciousSemicolonInJsx::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/use_image_size.rs
+++ b/crates/oxc_linter/src/rules/react/use_image_size.rs
@@ -1,0 +1,88 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::JSXElementName;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::has_jsx_prop_ignore_case};
+
+fn use_image_size_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Image element is missing `width` and/or `height` attributes.")
+        .with_help("Add explicit `width` and `height` attributes to `<img>` elements to prevent layout shifts.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseImageSize;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces that `<img>` elements have explicit `width` and `height` attributes.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Images without explicit dimensions cause layout shifts as the browser
+    /// doesn't know their size until loaded. This hurts Core Web Vitals (CLS).
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <img src="photo.jpg" />
+    /// <img src="photo.jpg" width="100" />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <img src="photo.jpg" width="100" height="100" />
+    /// ```
+    UseImageSize,
+    react,
+    correctness,
+    pending
+);
+
+impl Rule for UseImageSize {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
+            return;
+        };
+
+        let element_name = match &jsx_el.name {
+            JSXElementName::Identifier(id) => id.name.as_str(),
+            JSXElementName::IdentifierReference(id) => id.name.as_str(),
+            _ => return,
+        };
+
+        if element_name != "img" {
+            return;
+        }
+
+        let has_width = has_jsx_prop_ignore_case(jsx_el, "width").is_some();
+        let has_height = has_jsx_prop_ignore_case(jsx_el, "height").is_some();
+
+        if !has_width || !has_height {
+            ctx.diagnostic(use_image_size_diagnostic(jsx_el.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"<img src="photo.jpg" width="100" height="100" />"#,
+        r#"<img src="photo.jpg" width={100} height={100} />"#,
+        "<div />",
+    ];
+
+    let fail = vec![
+        r#"<img src="photo.jpg" />"#,
+        r#"<img src="photo.jpg" width="100" />"#,
+        r#"<img src="photo.jpg" height="100" />"#,
+    ];
+
+    Tester::new(UseImageSize::NAME, UseImageSize::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -1,0 +1,99 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn explicit_member_accessibility_diagnostic(span: Span, kind: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing accessibility modifier on {kind}."))
+        .with_help("Add an explicit `public`, `private`, or `protected` modifier.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ExplicitMemberAccessibility;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires explicit accessibility modifiers on class properties and methods.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Without explicit accessibility modifiers, class members default to `public`.
+    /// Being explicit about accessibility makes the intent clearer and helps
+    /// prevent accidentally exposing internal implementation details.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// class Foo {
+    ///   bar: string;
+    ///   baz() {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// class Foo {
+    ///   public bar: string;
+    ///   private baz() {}
+    /// }
+    /// ```
+    ExplicitMemberAccessibility,
+    typescript,
+    style,
+    pending
+);
+
+impl Rule for ExplicitMemberAccessibility {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if !ctx.source_type().is_typescript() {
+            return;
+        }
+
+        match node.kind() {
+            AstKind::MethodDefinition(method) => {
+                // Skip constructors
+                if method.kind.is_constructor() {
+                    return;
+                }
+                if method.accessibility.is_none() {
+                    ctx.diagnostic(explicit_member_accessibility_diagnostic(
+                        Span::new(method.span.start, method.span.start + 1),
+                        "method",
+                    ));
+                }
+            }
+            AstKind::PropertyDefinition(prop) => {
+                if prop.accessibility.is_none() {
+                    ctx.diagnostic(explicit_member_accessibility_diagnostic(
+                        Span::new(prop.span.start, prop.span.start + 1),
+                        "property",
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "class Foo { public bar: string; }",
+        "class Foo { private baz() {} }",
+        "class Foo { protected qux = 1; }",
+        "class Foo { constructor() {} }",
+    ];
+
+    let fail =
+        vec!["class Foo { bar: string; }", "class Foo { baz() {} }", "class Foo { qux = 1; }"];
+
+    Tester::new(ExplicitMemberAccessibility::NAME, ExplicitMemberAccessibility::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/naming_convention.rs
+++ b/crates/oxc_linter/src/rules/typescript/naming_convention.rs
@@ -1,0 +1,178 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{BindingPattern, VariableDeclarationKind};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn naming_convention_diagnostic(
+    span: Span,
+    kind: &str,
+    name: &str,
+    expected: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("{kind} `{name}` does not match the expected naming convention."))
+        .with_help(format!("Rename to match the `{expected}` naming convention."))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NamingConvention;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces naming conventions for various code identifiers.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Consistent naming conventions improve code readability and make it
+    /// easier to understand the purpose and scope of identifiers at a glance.
+    ///
+    /// ### Conventions enforced
+    ///
+    /// - **Classes**: PascalCase
+    /// - **Interfaces/Type aliases**: PascalCase
+    /// - **Enums**: PascalCase
+    /// - **Enum members**: PascalCase or UPPER_CASE
+    /// - **Type parameters**: PascalCase (single letter or prefixed with T)
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// class my_class {}
+    /// interface my_interface {}
+    /// type my_type = string;
+    /// enum my_enum { my_value }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// class MyClass {}
+    /// interface MyInterface {}
+    /// type MyType = string;
+    /// enum MyEnum { MyValue }
+    /// ```
+    NamingConvention,
+    typescript,
+    style,
+    pending
+);
+
+impl Rule for NamingConvention {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if !ctx.source_type().is_typescript() {
+            return;
+        }
+
+        match node.kind() {
+            // Classes must be PascalCase
+            AstKind::Class(class) => {
+                if let Some(id) = &class.id {
+                    let name = id.name.as_str();
+                    if !is_pascal_case(name) {
+                        ctx.diagnostic(naming_convention_diagnostic(
+                            id.span,
+                            "Class",
+                            name,
+                            "PascalCase",
+                        ));
+                    }
+                }
+            }
+            // Interfaces must be PascalCase
+            AstKind::TSInterfaceDeclaration(decl) => {
+                let name = decl.id.name.as_str();
+                if !is_pascal_case(name) {
+                    ctx.diagnostic(naming_convention_diagnostic(
+                        decl.id.span,
+                        "Interface",
+                        name,
+                        "PascalCase",
+                    ));
+                }
+            }
+            // Type aliases must be PascalCase
+            AstKind::TSTypeAliasDeclaration(decl) => {
+                let name = decl.id.name.as_str();
+                if !is_pascal_case(name) {
+                    ctx.diagnostic(naming_convention_diagnostic(
+                        decl.id.span,
+                        "Type alias",
+                        name,
+                        "PascalCase",
+                    ));
+                }
+            }
+            // Enums must be PascalCase
+            AstKind::TSEnumDeclaration(decl) => {
+                let name = decl.id.name.as_str();
+                if !is_pascal_case(name) {
+                    ctx.diagnostic(naming_convention_diagnostic(
+                        decl.id.span,
+                        "Enum",
+                        name,
+                        "PascalCase",
+                    ));
+                }
+            }
+            // Enum members must be PascalCase or UPPER_CASE
+            AstKind::TSEnumMember(member) => {
+                if let oxc_ast::ast::TSEnumMemberName::Identifier(id) = &member.id {
+                    let name = id.name.as_str();
+                    if !is_pascal_case(name) && !is_upper_case(name) {
+                        ctx.diagnostic(naming_convention_diagnostic(
+                            id.span,
+                            "Enum member",
+                            name,
+                            "PascalCase or UPPER_CASE",
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn is_pascal_case(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let first = s.chars().next().unwrap();
+    if !first.is_ascii_uppercase() {
+        return false;
+    }
+    // Must not contain underscores (unless it's ALL_CAPS)
+    !s.contains('_')
+}
+
+fn is_upper_case(s: &str) -> bool {
+    s.len() >= 2
+        && s.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        && s.chars().any(|c| c.is_ascii_uppercase())
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "class MyClass {}",
+        "interface MyInterface {}",
+        "type MyType = string;",
+        "enum MyEnum { MyValue }",
+        "enum Status { ACTIVE, INACTIVE }",
+    ];
+
+    let fail = vec![
+        "class my_class {}",
+        "interface my_interface {}",
+        "type my_type = string;",
+        "enum my_enum { my_value }",
+    ];
+
+    Tester::new(NamingConvention::NAME, NamingConvention::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/no_empty_type_parameters.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_type_parameters.rs
@@ -1,0 +1,71 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_empty_type_parameters_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Empty type parameter list `<>` is not allowed.")
+        .with_help("Remove the empty type parameters or add type parameter declarations.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoEmptyTypeParameters;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows empty type parameter lists `<>`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// An empty type parameter list `<>` is syntactically valid in some cases
+    /// but is always a mistake. It provides no type information and is likely
+    /// a leftover from editing.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// type Foo<> = {};
+    /// function bar<>() {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// type Foo<T> = {};
+    /// function bar<T>() {}
+    /// ```
+    NoEmptyTypeParameters,
+    typescript,
+    correctness
+);
+
+impl Rule for NoEmptyTypeParameters {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSTypeParameterDeclaration(decl) = node.kind() else {
+            return;
+        };
+
+        if decl.params.is_empty() {
+            ctx.diagnostic(no_empty_type_parameters_diagnostic(decl.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["type Foo<T> = {};", "function bar<T>() {}", "class Baz<T> {}"];
+
+    let fail = vec![
+        // Note: empty type params may not parse in all cases,
+        // but the rule should catch them if they do
+    ];
+
+    Tester::new(NoEmptyTypeParameters::NAME, NoEmptyTypeParameters::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/no_enum.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_enum.rs
@@ -1,0 +1,79 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_enum_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("TypeScript enums are not allowed.")
+        .with_help("Use a union type or a const object instead of an enum.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoEnum;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows TypeScript enums.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// TypeScript enums have several pitfalls:
+    /// - They generate runtime code unlike other TS-only features
+    /// - Numeric enums are not type-safe
+    /// - String enums create an opaque type
+    /// - `const enum` has interop issues
+    ///
+    /// Union types or const objects are safer alternatives.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// enum Color { Red, Green, Blue }
+    /// const enum Direction { Up, Down }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// type Color = 'Red' | 'Green' | 'Blue';
+    /// const Direction = { Up: 'Up', Down: 'Down' } as const;
+    /// ```
+    NoEnum,
+    typescript,
+    restriction
+);
+
+impl Rule for NoEnum {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TSEnumDeclaration(decl) = node.kind() else {
+            return;
+        };
+
+        ctx.diagnostic(no_enum_diagnostic(Span::new(
+            decl.span.start,
+            decl.span.start + if decl.r#const { 10 } else { 4 }, // "const enum" or "enum"
+        )));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "type Color = 'Red' | 'Green' | 'Blue';",
+        "const Direction = { Up: 'Up', Down: 'Down' } as const;",
+    ];
+
+    let fail = vec![
+        "enum Color { Red, Green, Blue }",
+        "const enum Direction { Up, Down }",
+        "enum Status { Active = 'active', Inactive = 'inactive' }",
+    ];
+
+    Tester::new(NoEnum::NAME, NoEnum::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/no_evolving_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_evolving_types.rs
@@ -1,0 +1,107 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_evolving_types_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Variable is initialized to a value that will cause its type to evolve.")
+        .with_help("Add an explicit type annotation to prevent the type from evolving implicitly.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoEvolvingTypes;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows variables that are initialized with values that cause TypeScript
+    /// to infer an evolving type (e.g., `any[]`).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When a variable is initialized to an empty array `[]` or `null` without
+    /// a type annotation, TypeScript infers an evolving `any[]` or widening type.
+    /// This defeats the purpose of type checking.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// let arr = [];
+    /// let val = null;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// let arr: string[] = [];
+    /// let val: string | null = null;
+    /// const arr = [1, 2, 3];
+    /// ```
+    NoEvolvingTypes,
+    typescript,
+    suspicious,
+    pending
+);
+
+impl Rule for NoEvolvingTypes {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if !ctx.source_type().is_typescript() {
+            return;
+        }
+
+        let AstKind::VariableDeclarator(declarator) = node.kind() else {
+            return;
+        };
+
+        // Skip if there's a type annotation
+        if declarator.type_annotation.is_some() {
+            return;
+        }
+
+        // Only check `let` declarations (const/var have different semantics)
+        let parent = ctx.nodes().parent_node(node.id());
+        if let AstKind::VariableDeclaration(decl) = parent.kind() {
+            if decl.kind != oxc_ast::ast::VariableDeclarationKind::Let {
+                return;
+            }
+        }
+
+        let Some(init) = &declarator.init else {
+            return;
+        };
+
+        match init {
+            // Empty array literal: `let x = []`
+            Expression::ArrayExpression(arr) if arr.elements.is_empty() => {
+                ctx.diagnostic(no_evolving_types_diagnostic(declarator.span));
+            }
+            // null literal: `let x = null`
+            Expression::NullLiteral(_) => {
+                ctx.diagnostic(no_evolving_types_diagnostic(declarator.span));
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("let arr: string[] = [];", None),
+        ("let val: string | null = null;", None),
+        ("const arr = [];", None),      // const is fine
+        ("let arr = [1, 2, 3];", None), // non-empty array
+        ("let x = 'hello';", None),     // not evolving
+        ("let x;", None),               // no init
+    ];
+
+    let fail = vec![("let arr = [];", None), ("let val = null;", None)];
+
+    Tester::new(NoEvolvingTypes::NAME, NoEvolvingTypes::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/no_implicit_any_let.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_implicit_any_let.rs
@@ -1,0 +1,90 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_implicit_any_let_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Variable declaration without type annotation or initializer implicitly has `any` type.",
+    )
+    .with_help("Add an explicit type annotation or initialize the variable.")
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoImplicitAnyLet;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows `let` declarations without type annotations or initializers
+    /// in TypeScript files, as they implicitly have the `any` type.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `let` declaration without a type annotation or initializer has an
+    /// implicit `any` type in TypeScript. This defeats the purpose of using
+    /// TypeScript for type safety.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// let x;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// let x: string;
+    /// let y = 'hello';
+    /// let z: number;
+    /// ```
+    NoImplicitAnyLet,
+    typescript,
+    suspicious,
+    pending
+);
+
+impl Rule for NoImplicitAnyLet {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if !ctx.source_type().is_typescript() {
+            return;
+        }
+
+        let AstKind::VariableDeclarator(declarator) = node.kind() else {
+            return;
+        };
+
+        // Only check if there's no type annotation AND no initializer
+        if declarator.type_annotation.is_some() || declarator.init.is_some() {
+            return;
+        }
+
+        // Only flag `let` declarations
+        let parent = ctx.nodes().parent_node(node.id());
+        if let AstKind::VariableDeclaration(decl) = parent.kind() {
+            if decl.kind == oxc_ast::ast::VariableDeclarationKind::Let {
+                ctx.diagnostic(no_implicit_any_let_diagnostic(declarator.span));
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("let x: string;", None),
+        ("let y = 'hello';", None),
+        ("let z: number;", None),
+        ("var x;", None),       // only let
+        ("const x = 1;", None), // const requires init
+    ];
+
+    let fail = vec![("let x;", None), ("let a, b;", None)];
+
+    Tester::new(NoImplicitAnyLet::NAME, NoImplicitAnyLet::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/no_this_in_static.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_in_static.rs
@@ -1,0 +1,112 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_this_in_static_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected `this` in a static method.")
+        .with_help("In static methods, `this` refers to the class constructor, not an instance. Use the class name directly instead.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoThisInStatic;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of `this` in static class methods.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In a static method, `this` refers to the class constructor itself,
+    /// not to an instance. This can be confusing, especially for developers
+    /// coming from other languages. Using the class name directly makes the
+    /// intent clearer.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```ts
+    /// class Foo {
+    ///   static bar() {
+    ///     return this.baz();
+    ///   }
+    ///   static baz() { return 1; }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// class Foo {
+    ///   static bar() {
+    ///     return Foo.baz();
+    ///   }
+    ///   static baz() { return 1; }
+    /// }
+    /// ```
+    NoThisInStatic,
+    typescript,
+    suspicious,
+    pending
+);
+
+impl Rule for NoThisInStatic {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ThisExpression(this_expr) = node.kind() else {
+            return;
+        };
+
+        // Walk up ancestors to find if we're directly in a static method.
+        // Count function boundaries: the first Function is the method's own body,
+        // a second Function means a nested function with its own `this`.
+        let mut function_count = 0u32;
+        for ancestor in ctx.nodes().ancestors(node.id()) {
+            match ancestor.kind() {
+                AstKind::MethodDefinition(method) => {
+                    if method.r#static && function_count <= 1 {
+                        ctx.diagnostic(no_this_in_static_diagnostic(this_expr.span));
+                    }
+                    return;
+                }
+                AstKind::PropertyDefinition(prop) => {
+                    if prop.r#static && function_count == 0 {
+                        ctx.diagnostic(no_this_in_static_diagnostic(this_expr.span));
+                    }
+                    return;
+                }
+                AstKind::Function(_) => {
+                    function_count += 1;
+                    if function_count > 1 {
+                        return; // Nested function has its own `this`
+                    }
+                }
+                AstKind::ArrowFunctionExpression(_) => {
+                    // Arrow functions inherit `this`, keep looking
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "class Foo { bar() { return this.baz; } }",
+        "class Foo { static bar() { return Foo.baz; } }",
+        "class Foo { static bar() { return 1; } }",
+    ];
+
+    let fail = vec![
+        "class Foo { static bar() { return this.baz; } }",
+        "class Foo { static bar() { this.baz(); } }",
+        "class Foo { static bar = () => { return this.baz; }; }",
+    ];
+
+    Tester::new(NoThisInStatic::NAME, NoThisInStatic::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/no_flat_map_identity.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_flat_map_identity.rs
@@ -1,0 +1,119 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::{BindingPattern, Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_flat_map_identity_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`.flatMap(x => x)` is equivalent to `.flat()`.")
+        .with_help("Replace `.flatMap(x => x)` with `.flat()` for clarity.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoFlatMapIdentity;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using `.flatMap()` with an identity function.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `.flatMap(x => x)` is equivalent to `.flat()` but less readable.
+    /// Using `.flat()` directly makes the intent clearer.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// arr.flatMap(x => x);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// arr.flat();
+    /// arr.flatMap(x => x * 2);
+    /// ```
+    NoFlatMapIdentity,
+    unicorn,
+    style,
+    pending
+);
+
+impl Rule for NoFlatMapIdentity {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call) = node.kind() else {
+            return;
+        };
+
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+
+        if member.property.name.as_str() != "flatMap" {
+            return;
+        }
+
+        if call.arguments.len() != 1 {
+            return;
+        }
+
+        let Some(arg_expr) = call.arguments[0].as_expression() else {
+            return;
+        };
+
+        if is_identity_arrow(arg_expr) {
+            ctx.diagnostic(no_flat_map_identity_diagnostic(call.span));
+        }
+    }
+}
+
+fn is_identity_arrow(expr: &Expression) -> bool {
+    let Expression::ArrowFunctionExpression(arrow) = expr else {
+        return false;
+    };
+
+    // Single parameter, no rest
+    if arrow.params.items.len() != 1 || arrow.params.rest.is_some() {
+        return false;
+    }
+
+    let BindingPattern::BindingIdentifier(param_id) = &arrow.params.items[0].pattern else {
+        return false;
+    };
+
+    // Expression body: (x) => x
+    if !arrow.expression {
+        return false;
+    }
+
+    if let Some(stmt) = arrow.body.statements.first() {
+        if let oxc_ast::ast::Statement::ExpressionStatement(expr_stmt) = stmt {
+            if let Expression::Identifier(ident) = &expr_stmt.expression {
+                return ident.name == param_id.name;
+            }
+        }
+    }
+
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "arr.flat();",
+        "arr.flatMap(x => x * 2);",
+        "arr.flatMap(x => [x, x]);",
+        "arr.flatMap((x, i) => x);",
+        "arr.map(x => x);",
+    ];
+
+    let fail = vec!["arr.flatMap(x => x);"];
+
+    Tester::new(NoFlatMapIdentity::NAME, NoFlatMapIdentity::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_string_raw.rs
@@ -1,0 +1,98 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_useless_string_raw_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`String.raw` is unnecessary when the template has no escape sequences.")
+        .with_help(
+            "Remove `String.raw` since the template literal doesn't contain any backslash escapes.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUselessStringRaw;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using `String.raw` when the template literal has no escape sequences.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `String.raw` is only useful when the template literal contains escape
+    /// sequences that you want to keep as-is. Using it without escape sequences
+    /// adds unnecessary noise.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// String.raw`hello world`;
+    /// String.raw`foo bar`;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// String.raw`hello\nworld`;
+    /// String.raw`C:\Users\foo`;
+    /// `hello world`;
+    /// ```
+    NoUselessStringRaw,
+    unicorn,
+    suspicious,
+    pending
+);
+
+impl Rule for NoUselessStringRaw {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TaggedTemplateExpression(tagged) = node.kind() else {
+            return;
+        };
+
+        // Check if the tag is String.raw
+        let Expression::StaticMemberExpression(member) = &tagged.tag else {
+            return;
+        };
+
+        let Expression::Identifier(obj) = &member.object else {
+            return;
+        };
+
+        if obj.name.as_str() != "String" || member.property.name.as_str() != "raw" {
+            return;
+        }
+
+        // Check if any quasi (template part) contains a backslash
+        let has_escape = tagged.quasi.quasis.iter().any(|quasi| {
+            let raw = ctx.source_range(quasi.span);
+            raw.contains('\\')
+        });
+
+        if !has_escape {
+            ctx.diagnostic(no_useless_string_raw_diagnostic(tagged.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r"String.raw`hello\nworld`;",
+        r"String.raw`C:\Users\foo`;",
+        "`hello world`;",
+        r"String.raw`foo\tbar`;",
+    ];
+
+    let fail =
+        vec!["String.raw`hello world`;", "String.raw`foo bar`;", "String.raw`no escapes here`;"];
+
+    Tester::new(NoUselessStringRaw::NAME, NoUselessStringRaw::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined_initialization.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined_initialization.rs
@@ -1,0 +1,88 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_useless_undefined_initialization_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unnecessary initialization to `undefined`.")
+        .with_help("Remove `= undefined` since `let` and `var` declarations are already `undefined` by default.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUselessUndefinedInitialization;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows initializing variables to `undefined`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `let` or `var` variable declaration without an initializer is already
+    /// `undefined`. Explicitly initializing to `undefined` is redundant.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// let x = undefined;
+    /// var y = undefined;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// let x;
+    /// var y;
+    /// const z = undefined; // const requires an initializer
+    /// ```
+    NoUselessUndefinedInitialization,
+    unicorn,
+    style,
+    pending
+);
+
+impl Rule for NoUselessUndefinedInitialization {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::VariableDeclaration(decl) = node.kind() else {
+            return;
+        };
+
+        // const requires an initializer, so skip it
+        if decl.kind == oxc_ast::ast::VariableDeclarationKind::Const {
+            return;
+        }
+
+        for declarator in &decl.declarations {
+            let Some(init) = &declarator.init else {
+                continue;
+            };
+
+            if let Expression::Identifier(ident) = init {
+                if ident.name == "undefined" {
+                    ctx.diagnostic(no_useless_undefined_initialization_diagnostic(ident.span));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["let x;", "var y;", "const z = undefined;", "let a = 1;", "let b = null;"];
+
+    let fail = vec!["let x = undefined;", "var y = undefined;", "let a = 1, b = undefined;"];
+
+    Tester::new(
+        NoUselessUndefinedInitialization::NAME,
+        NoUselessUndefinedInitialization::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/use_collapsed_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/use_collapsed_if.rs
@@ -1,0 +1,103 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Statement;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn use_collapsed_if_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("This `if` statement can be collapsed into the outer `if` statement.")
+        .with_help("Combine conditions using `&&` to reduce nesting.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseCollapsedIf;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces collapsing nested `if` statements into a single one with `&&`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unnecessary nesting makes code harder to read. When an `if` statement's
+    /// body contains only another `if` statement (with no `else`), the two
+    /// conditions can be combined with `&&`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// if (a) {
+    ///   if (b) {
+    ///     doSomething();
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// if (a && b) {
+    ///   doSomething();
+    /// }
+    /// ```
+    UseCollapsedIf,
+    unicorn,
+    style,
+    pending
+);
+
+impl Rule for UseCollapsedIf {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::IfStatement(if_stmt) = node.kind() else {
+            return;
+        };
+
+        // The outer if must not have an else clause
+        if if_stmt.alternate.is_some() {
+            return;
+        }
+
+        let Statement::BlockStatement(block) = &if_stmt.consequent else {
+            return;
+        };
+
+        // The block must contain exactly one statement
+        if block.body.len() != 1 {
+            return;
+        }
+
+        let Statement::IfStatement(inner_if) = &block.body[0] else {
+            return;
+        };
+
+        // The inner if must also not have an else clause
+        if inner_if.alternate.is_some() {
+            return;
+        }
+
+        ctx.diagnostic(use_collapsed_if_diagnostic(inner_if.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "if (a && b) { doSomething(); }",
+        "if (a) { doSomething(); } else { doOther(); }",
+        "if (a) { if (b) { doSomething(); } else { doOther(); } }",
+        "if (a) { doSomething(); doOtherThing(); }",
+        "if (a) { if (b) { doSomething(); } doOther(); }",
+    ];
+
+    let fail = vec![
+        "if (a) { if (b) { doSomething(); } }",
+        "if (x > 0) { if (y > 0) { console.log('both positive'); } }",
+    ];
+
+    Tester::new(UseCollapsedIf::NAME, UseCollapsedIf::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/use_consistent_curly_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/use_consistent_curly_braces.rs
@@ -1,0 +1,83 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn use_consistent_curly_braces_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unnecessary curly braces around JSX string expression.")
+        .with_help(
+            "Remove the curly braces around this string literal. Use `text` instead of `{'text'}`.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseConsistentCurlyBraces;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces consistent use of curly braces in JSX expressions.
+    /// Specifically, flags unnecessary curly braces around string literals.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `{'text'}` is equivalent to `text` in JSX but adds visual noise.
+    /// Consistent usage improves readability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <div>{'Hello'}</div>
+    /// <Component title={'World'} />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <div>Hello</div>
+    /// <Component title="World" />
+    /// <div>{variable}</div>
+    /// ```
+    UseConsistentCurlyBraces,
+    unicorn,
+    style,
+    pending
+);
+
+impl Rule for UseConsistentCurlyBraces {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXExpressionContainer(container) = node.kind() else {
+            return;
+        };
+
+        let Some(expr) = container.expression.as_expression() else {
+            return;
+        };
+
+        // Flag string literals in JSX expression containers
+        if matches!(expr, Expression::StringLiteral(_)) {
+            ctx.diagnostic(use_consistent_curly_braces_diagnostic(container.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<div>Hello</div>",
+        "<div>{variable}</div>",
+        "<div>{1 + 2}</div>",
+        r#"<Component title="World" />"#,
+    ];
+
+    let fail = vec!["<div>{'Hello'}</div>"];
+
+    Tester::new(UseConsistentCurlyBraces::NAME, UseConsistentCurlyBraces::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/use_simple_number_keys.rs
+++ b/crates/oxc_linter/src/rules/unicorn/use_simple_number_keys.rs
@@ -1,0 +1,103 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn use_simple_number_keys_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use a simpler number as a property key.")
+        .with_help("Simplify the numeric property key (e.g., use `1` instead of `1.0`).")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseSimpleNumberKeys;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the use of simple number literals as object property keys.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Numeric property keys with unnecessary decimal points or leading zeros
+    /// are confusing. `{ 1.0: 'foo' }` should be `{ 1: 'foo' }`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const obj = { 1.0: 'foo' };
+    /// const obj = { 0x1: 'foo' };
+    /// const obj = { 0o1: 'foo' };
+    /// const obj = { 0b1: 'foo' };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const obj = { 1: 'foo' };
+    /// const obj = { 'key': 'foo' };
+    /// ```
+    UseSimpleNumberKeys,
+    unicorn,
+    style,
+    pending
+);
+
+impl Rule for UseSimpleNumberKeys {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::NumericLiteral(num) = node.kind() else {
+            return;
+        };
+
+        // Check if this numeric literal is used as a property key
+        let parent = ctx.nodes().parent_node(node.id());
+        let is_property_key = matches!(parent.kind(), AstKind::ObjectProperty(prop) if {
+            matches!(&prop.key, oxc_ast::ast::PropertyKey::NumericLiteral(k) if k.span == num.span)
+        });
+
+        if !is_property_key {
+            return;
+        }
+
+        let raw = ctx.source_range(num.span);
+
+        // Check if the raw representation is not the simplest form
+        if raw.contains('.')
+            || raw.contains('x')
+            || raw.contains('X')
+            || raw.contains('o')
+            || raw.contains('O')
+            || raw.contains('b')
+            || raw.contains('B')
+            || raw.contains('e')
+            || raw.contains('E')
+        {
+            ctx.diagnostic(use_simple_number_keys_diagnostic(num.span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "const obj = { 1: 'foo' };",
+        "const obj = { 42: 'foo' };",
+        "const obj = { 'key': 'foo' };",
+        "const obj = { 0: 'foo' };",
+    ];
+
+    let fail = vec![
+        "const obj = { 1.0: 'foo' };",
+        "const obj = { 0x1: 'foo' };",
+        "const obj = { 0o1: 'foo' };",
+        "const obj = { 0b1: 'foo' };",
+        "const obj = { 1e2: 'foo' };",
+    ];
+
+    Tester::new(UseSimpleNumberKeys::NAME, UseSimpleNumberKeys::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/use_simplified_logic_expression.rs
+++ b/crates/oxc_linter/src/rules/unicorn/use_simplified_logic_expression.rs
@@ -1,0 +1,136 @@
+use oxc_ast::AstKind;
+use oxc_ast::ast::Expression;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::LogicalOperator;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn use_simplified_logic_expression_diagnostic(span: Span, suggestion: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("This logical expression can be simplified.")
+        .with_help(format!("Simplify to: `{suggestion}`"))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseSimplifiedLogicExpression;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Detects logical expressions that can be simplified.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Overly complex boolean expressions reduce readability. Expressions like
+    /// `x || true`, `x && false`, `x || !x` can be simplified.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const a = x || true;
+    /// const b = x && false;
+    /// const c = x || false;
+    /// const d = x && true;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const a = true;
+    /// const b = false;
+    /// const c = x;
+    /// const d = x;
+    /// ```
+    UseSimplifiedLogicExpression,
+    unicorn,
+    style,
+    pending
+);
+
+impl Rule for UseSimplifiedLogicExpression {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::LogicalExpression(expr) = node.kind() else {
+            return;
+        };
+
+        match expr.operator {
+            LogicalOperator::Or => {
+                // x || true => true
+                if is_boolean_literal(&expr.right, true) {
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(expr.span, "true"));
+                }
+                // x || false => x
+                else if is_boolean_literal(&expr.right, false) {
+                    let left_src = ctx.source_range(expr.left.span());
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(expr.span, left_src));
+                }
+                // true || x => true
+                else if is_boolean_literal(&expr.left, true) {
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(expr.span, "true"));
+                }
+                // false || x => x
+                else if is_boolean_literal(&expr.left, false) {
+                    let right_src = ctx.source_range(expr.right.span());
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(
+                        expr.span, right_src,
+                    ));
+                }
+            }
+            LogicalOperator::And => {
+                // x && false => false
+                if is_boolean_literal(&expr.right, false) {
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(expr.span, "false"));
+                }
+                // x && true => x
+                else if is_boolean_literal(&expr.right, true) {
+                    let left_src = ctx.source_range(expr.left.span());
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(expr.span, left_src));
+                }
+                // false && x => false
+                else if is_boolean_literal(&expr.left, false) {
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(expr.span, "false"));
+                }
+                // true && x => x
+                else if is_boolean_literal(&expr.left, true) {
+                    let right_src = ctx.source_range(expr.right.span());
+                    ctx.diagnostic(use_simplified_logic_expression_diagnostic(
+                        expr.span, right_src,
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn is_boolean_literal(expr: &Expression, value: bool) -> bool {
+    matches!(expr, Expression::BooleanLiteral(lit) if lit.value == value)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec!["const a = x || y;", "const b = x && y;", "const c = x ?? y;"];
+
+    let fail = vec![
+        "const a = x || true;",
+        "const b = x && false;",
+        "const c = x || false;",
+        "const d = x && true;",
+        "const e = true || x;",
+        "const f = false && x;",
+        "const g = false || x;",
+        "const h = true && x;",
+    ];
+
+    Tester::new(
+        UseSimplifiedLogicExpression::NAME,
+        UseSimplifiedLogicExpression::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/eslint_no_confusing_labels.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_confusing_labels.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-confusing-labels): Label 'x' is confusing because it shares a name with a variable in scope.
+   ╭─[no_confusing_labels.tsx:1:12]
+ 1 │ let x = 1; x: while (true) { break x; }
+   ·            ─
+   ╰────
+  help: Use a different name for this label to avoid confusion with the variable of the same name.
+
+  ⚠ eslint(no-confusing-labels): Label 'foo' is confusing because it shares a name with a variable in scope.
+   ╭─[no_confusing_labels.tsx:1:14]
+ 1 │ var foo = 1; foo: while (true) { break foo; }
+   ·              ───
+   ╰────
+  help: Use a different name for this label to avoid confusion with the variable of the same name.
+
+  ⚠ eslint(no-confusing-labels): Label 'bar' is confusing because it shares a name with a variable in scope.
+   ╭─[no_confusing_labels.tsx:1:16]
+ 1 │ const bar = 1; bar: for (;;) { break bar; }
+   ·                ───
+   ╰────
+  help: Use a different name for this label to avoid confusion with the variable of the same name.

--- a/crates/oxc_linter/src/snapshots/eslint_no_octal_escape.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_octal_escape.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = '\1';
+   ·            ──
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = '\2';
+   ·            ──
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = '\7';
+   ·            ──
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = "\00";
+   ·            ───
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = '\251';
+   ·            ────
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = '\377';
+   ·            ────
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = '\012';
+   ·            ────
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:22]
+ 1 │ var foo = "Copyright \251";
+   ·                      ────
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.
+
+  ⚠ eslint(no-octal-escape): Don't use octal escape sequences.
+   ╭─[no_octal_escape.tsx:1:12]
+ 1 │ var foo = "\1";
+   ·            ──
+   ╰────
+  help: Use Unicode or hexadecimal escape sequences instead of octal escape sequences.

--- a/crates/oxc_linter/src/snapshots/eslint_no_redundant_use_strict.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_redundant_use_strict.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-redundant-use-strict): Redundant 'use strict' directive.
+   ╭─[no_redundant_use_strict.tsx:1:32]
+ 1 │ "use strict"; function foo() { "use strict"; return 1; }
+   ·                                ─────────────
+   ╰────
+  help: Remove this 'use strict' directive because the code is already in strict mode (ESM modules are always strict, or an outer scope already has 'use strict').

--- a/crates/oxc_linter/src/snapshots/eslint_no_shouty_constants.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shouty_constants.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-shouty-constants): SCREAMING_SNAKE_CASE variable `FOO_BAR` is assigned a simple string literal.
+   ╭─[no_shouty_constants.tsx:1:7]
+ 1 │ const FOO_BAR = "foo_bar";
+   ·       ───────
+   ╰────
+  help: UPPER_CASE names are conventionally reserved for true constants. Use camelCase or rename if this value is not a meaningful constant.
+
+  ⚠ eslint(no-shouty-constants): SCREAMING_SNAKE_CASE variable `BAR_BAZ` is assigned a simple string literal.
+   ╭─[no_shouty_constants.tsx:1:7]
+ 1 │ const BAR_BAZ = "bar-baz";
+   ·       ───────
+   ╰────
+  help: UPPER_CASE names are conventionally reserved for true constants. Use camelCase or rename if this value is not a meaningful constant.
+
+  ⚠ eslint(no-shouty-constants): SCREAMING_SNAKE_CASE variable `HELLO_WORLD` is assigned a simple string literal.
+   ╭─[no_shouty_constants.tsx:1:7]
+ 1 │ const HELLO_WORLD = "helloworld";
+   ·       ───────────
+   ╰────
+  help: UPPER_CASE names are conventionally reserved for true constants. Use camelCase or rename if this value is not a meaningful constant.

--- a/crates/oxc_linter/src/snapshots/eslint_no_string_case_mismatch.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_string_case_mismatch.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toLowerCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if (str.toLowerCase() === "ABC") {}
+   ·     ───────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toLowerCase()`. This comparison will never be true.
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toUpperCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if (str.toUpperCase() === "abc") {}
+   ·     ───────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toUpperCase()`. This comparison will never be true.
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toLowerCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if ("ABC" === str.toLowerCase()) {}
+   ·     ───────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toLowerCase()`. This comparison will never be true.
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toLowerCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if (str.toLowerCase() === "AbC") {}
+   ·     ───────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toLowerCase()`. This comparison will never be true.
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toUpperCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if (str.toUpperCase() === "AbC") {}
+   ·     ───────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toUpperCase()`. This comparison will never be true.
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toLowerCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if (str.toLowerCase() !== "ABC") {}
+   ·     ───────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toLowerCase()`. This comparison will never be true.
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toLocaleLowerCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if (str.toLocaleLowerCase() === "ABC") {}
+   ·     ─────────────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toLocaleLowerCase()`. This comparison will never be true.
+
+  ⚠ eslint(no-string-case-mismatch): Comparison with `toLocaleUpperCase()` will always be false due to case mismatch.
+   ╭─[no_string_case_mismatch.tsx:1:5]
+ 1 │ if (str.toLocaleUpperCase() === "abc") {}
+   ·     ─────────────────────────────────
+   ╰────
+  help: The string being compared contains characters that don't match the case transformation from `toLocaleUpperCase()`. This comparison will never be true.

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_continue.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_continue.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-useless-continue): Unnecessary continue statement.
+   ╭─[no_useless_continue.tsx:1:48]
+ 1 │ for (let i = 0; i < 10; i++) { doSomething(i); continue; }
+   ·                                                ─────────
+   ╰────
+  help: Remove this continue statement since it is the last statement in the loop body and has no effect.
+
+  ⚠ eslint(no-useless-continue): Unnecessary continue statement.
+   ╭─[no_useless_continue.tsx:1:31]
+ 1 │ while (true) { doSomething(); continue; }
+   ·                               ─────────
+   ╰────
+  help: Remove this continue statement since it is the last statement in the loop body and has no effect.
+
+  ⚠ eslint(no-useless-continue): Unnecessary continue statement.
+   ╭─[no_useless_continue.tsx:1:36]
+ 1 │ for (const x of arr) { process(x); continue; }
+   ·                                    ─────────
+   ╰────
+  help: Remove this continue statement since it is the last statement in the loop body and has no effect.
+
+  ⚠ eslint(no-useless-continue): Unnecessary continue statement.
+   ╭─[no_useless_continue.tsx:1:36]
+ 1 │ for (const k in obj) { process(k); continue; }
+   ·                                    ─────────
+   ╰────
+  help: Remove this continue statement since it is the last statement in the loop body and has no effect.
+
+  ⚠ eslint(no-useless-continue): Unnecessary continue statement.
+   ╭─[no_useless_continue.tsx:1:21]
+ 1 │ do { doSomething(); continue; } while (true);
+   ·                     ─────────
+   ╰────
+  help: Remove this continue statement since it is the last statement in the loop body and has no effect.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_arrow_callback.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_arrow_callback.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(prefer-arrow-callback): Unexpected function expression.
+   ╭─[prefer_arrow_callback.tsx:1:5]
+ 1 │ foo(function(a) { return a; });
+   ·     ────────
+   ╰────
+  help: Use an arrow function instead of a function expression.
+
+  ⚠ eslint(prefer-arrow-callback): Unexpected function expression.
+   ╭─[prefer_arrow_callback.tsx:1:5]
+ 1 │ foo(function() { return 1; });
+   ·     ────────
+   ╰────
+  help: Use an arrow function instead of a function expression.
+
+  ⚠ eslint(prefer-arrow-callback): Unexpected function expression.
+   ╭─[prefer_arrow_callback.tsx:1:12]
+ 1 │ [1, 2].map(function(x) { return x * 2; });
+   ·            ────────
+   ╰────
+  help: Use an arrow function instead of a function expression.
+
+  ⚠ eslint(prefer-arrow-callback): Unexpected function expression.
+   ╭─[prefer_arrow_callback.tsx:1:12]
+ 1 │ setTimeout(function() { console.log('hi'); }, 100);
+   ·            ────────
+   ╰────
+  help: Use an arrow function instead of a function expression.

--- a/crates/oxc_linter/src/snapshots/eslint_use_regex_literals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_use_regex_literals.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(use-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
+   ╭─[use_regex_literals.tsx:1:1]
+ 1 │ new RegExp('abc');
+   · ─────────────────
+   ╰────
+  help: Replace `new RegExp("pattern")` with `/pattern/` for better readability and performance.
+
+  ⚠ eslint(use-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
+   ╭─[use_regex_literals.tsx:1:1]
+ 1 │ RegExp('abc');
+   · ─────────────
+   ╰────
+  help: Replace `new RegExp("pattern")` with `/pattern/` for better readability and performance.
+
+  ⚠ eslint(use-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
+   ╭─[use_regex_literals.tsx:1:1]
+ 1 │ new RegExp('abc', 'g');
+   · ──────────────────────
+   ╰────
+  help: Replace `new RegExp("pattern")` with `/pattern/` for better readability and performance.
+
+  ⚠ eslint(use-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
+   ╭─[use_regex_literals.tsx:1:1]
+ 1 │ RegExp('abc', 'ig');
+   · ───────────────────
+   ╰────
+  help: Replace `new RegExp("pattern")` with `/pattern/` for better readability and performance.
+
+  ⚠ eslint(use-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
+   ╭─[use_regex_literals.tsx:1:1]
+ 1 │ new RegExp('test');
+   · ──────────────────
+   ╰────
+  help: Replace `new RegExp("pattern")` with `/pattern/` for better readability and performance.

--- a/crates/oxc_linter/src/snapshots/eslint_use_single_var_declarator.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_use_single_var_declarator.snap
@@ -1,0 +1,31 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(use-single-var-declarator): Declare variables separately instead of using a single `let` declaration.
+   ╭─[use_single_var_declarator.tsx:1:1]
+ 1 │ let a, b;
+   · ─────────
+   ╰────
+  help: Split this declaration into separate statements, one per variable.
+
+  ⚠ eslint(use-single-var-declarator): Declare variables separately instead of using a single `const` declaration.
+   ╭─[use_single_var_declarator.tsx:1:1]
+ 1 │ const x = 1, y = 2;
+   · ───────────────────
+   ╰────
+  help: Split this declaration into separate statements, one per variable.
+
+  ⚠ eslint(use-single-var-declarator): Declare variables separately instead of using a single `var` declaration.
+   ╭─[use_single_var_declarator.tsx:1:1]
+ 1 │ var foo = 1, bar = 2;
+   · ─────────────────────
+   ╰────
+  help: Split this declaration into separate statements, one per variable.
+
+  ⚠ eslint(use-single-var-declarator): Declare variables separately instead of using a single `let` declaration.
+   ╭─[use_single_var_declarator.tsx:1:1]
+ 1 │ let a = 1, b = 2, c = 3;
+   · ────────────────────────
+   ╰────
+  help: Split this declaration into separate statements, one per variable.

--- a/crates/oxc_linter/src/snapshots/eslint_use_while.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_use_while.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(use-while): Use `while` instead of `for` with no init and update.
+   ╭─[use_while.tsx:1:1]
+ 1 │ for (; x < 10;) { x++; }
+   · ───
+   ╰────
+  help: Replace `for(;condition;)` with `while(condition)` for clarity.
+
+  ⚠ eslint(use-while): Use `while` instead of `for` with no init and update.
+   ╭─[use_while.tsx:1:1]
+ 1 │ for (;;) { break; }
+   · ───
+   ╰────
+  help: Replace `for(;condition;)` with `while(condition)` for clarity.
+
+  ⚠ eslint(use-while): Use `while` instead of `for` with no init and update.
+   ╭─[use_while.tsx:1:1]
+ 1 │ for (; true;) { doSomething(); }
+   · ───
+   ╰────
+  help: Replace `for(;condition;)` with `while(condition)` for clarity.

--- a/crates/oxc_linter/src/snapshots/import_no_dynamic_namespace_import_access.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_dynamic_namespace_import_access.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-import(no-dynamic-namespace-import-access): Dynamic access to namespace import defeats tree-shaking.
+   ╭─[no_dynamic_namespace_import_access.tsx:1:38]
+ 1 │ import * as ns from 'mod'; const x = ns[key];
+   ·                                      ───────
+   ╰────
+  help: Use named imports instead of dynamically accessing namespace imports.

--- a/crates/oxc_linter/src/snapshots/import_no_private_imports.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_private_imports.snap
@@ -1,0 +1,4 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+

--- a/crates/oxc_linter/src/snapshots/import_no_undeclared_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_undeclared_dependencies.snap
@@ -1,0 +1,4 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+

--- a/crates/oxc_linter/src/snapshots/import_no_unresolved_imports.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_unresolved_imports.snap
@@ -1,0 +1,4 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_interactive_element_to_noninteractive_role.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_interactive_element_to_noninteractive_role.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jsx-a11y(no-interactive-element-to-noninteractive-role): Interactive element should not be assigned a non-interactive role.
+   ╭─[no_interactive_element_to_noninteractive_role.tsx:1:9]
+ 1 │ <button role="article" />
+   ·         ──────────────
+   ╰────
+  help: Interactive HTML elements like `<button>`, `<a>`, and `<input>` should not be given non-interactive roles like `article` or `presentation`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-interactive-element-to-noninteractive-role): Interactive element should not be assigned a non-interactive role.
+   ╭─[no_interactive_element_to_noninteractive_role.tsx:1:9]
+ 1 │ <button role="presentation" />
+   ·         ───────────────────
+   ╰────
+  help: Interactive HTML elements like `<button>`, `<a>`, and `<input>` should not be given non-interactive roles like `article` or `presentation`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-interactive-element-to-noninteractive-role): Interactive element should not be assigned a non-interactive role.
+   ╭─[no_interactive_element_to_noninteractive_role.tsx:1:13]
+ 1 │ <a href="#" role="none" />
+   ·             ───────────
+   ╰────
+  help: Interactive HTML elements like `<button>`, `<a>`, and `<input>` should not be given non-interactive roles like `article` or `presentation`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_element_interactions.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_element_interactions.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-element-interactions): Non-interactive element should not have event handlers without a role.
+   ╭─[no_noninteractive_element_interactions.tsx:1:6]
+ 1 │ <div onClick={() => {}} />
+   ·      ──────────────────
+   ╰────
+  help: Add an appropriate ARIA role to the element, or use an interactive element instead.
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-element-interactions): Non-interactive element should not have event handlers without a role.
+   ╭─[no_noninteractive_element_interactions.tsx:1:7]
+ 1 │ <span onClick={() => {}} />
+   ·       ──────────────────
+   ╰────
+  help: Add an appropriate ARIA role to the element, or use an interactive element instead.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_element_to_interactive_role.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_element_to_interactive_role.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-element-to-interactive-role): Non-interactive element should not be assigned an interactive role.
+   ╭─[no_noninteractive_element_to_interactive_role.tsx:1:6]
+ 1 │ <div role="button" />
+   ·      ─────────────
+   ╰────
+  help: Use an interactive HTML element instead of adding an interactive role to a non-interactive element.
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-element-to-interactive-role): Non-interactive element should not be assigned an interactive role.
+   ╭─[no_noninteractive_element_to_interactive_role.tsx:1:7]
+ 1 │ <span role="link" />
+   ·       ───────────
+   ╰────
+  help: Use an interactive HTML element instead of adding an interactive role to a non-interactive element.
+
+  ⚠ eslint-plugin-jsx-a11y(no-noninteractive-element-to-interactive-role): Non-interactive element should not be assigned an interactive role.
+   ╭─[no_noninteractive_element_to_interactive_role.tsx:1:4]
+ 1 │ <p role="checkbox" />
+   ·    ───────────────
+   ╰────
+  help: Use an interactive HTML element instead of adding an interactive role to a non-interactive element.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_svg_without_title.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_svg_without_title.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jsx-a11y(no-svg-without-title): SVG elements must have a `<title>` element or an accessible label.
+   ╭─[no_svg_without_title.tsx:1:1]
+ 1 │ <svg><circle /></svg>
+   · ─────
+   ╰────
+  help: Add a `<title>` child element, or add an `aria-label` or `aria-labelledby` attribute.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_use_focusable_interactive.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_use_focusable_interactive.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jsx-a11y(use-focusable-interactive): Interactive elements must be focusable.
+   ╭─[use_focusable_interactive.tsx:1:1]
+ 1 │ <div role="button" />
+   · ─────────────────────
+   ╰────
+  help: Add a `tabIndex` attribute to make this interactive element focusable, or use a natively focusable element.
+
+  ⚠ eslint-plugin-jsx-a11y(use-focusable-interactive): Interactive elements must be focusable.
+   ╭─[use_focusable_interactive.tsx:1:1]
+ 1 │ <span role="link" />
+   · ────────────────────
+   ╰────
+  help: Add a `tabIndex` attribute to make this interactive element focusable, or use a natively focusable element.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_use_unique_element_ids.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_use_unique_element_ids.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jsx-a11y(use-unique-element-ids): Duplicate element id `foo`.
+   ╭─[use_unique_element_ids.tsx:1:24]
+ 1 │ <><div id="foo" /><div id="foo" /></>
+   ·                        ────────
+   ╰────
+  help: Element `id` attributes must be unique within a document. Use a unique id for each element.

--- a/crates/oxc_linter/src/snapshots/node_no_global_dirname_filename.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_global_dirname_filename.snap
@@ -1,0 +1,4 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+

--- a/crates/oxc_linter/src/snapshots/react_no_forward_ref.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_forward_ref.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(no-forward-ref): Do not use `React.forwardRef`.
+   ╭─[no_forward_ref.tsx:1:17]
+ 1 │ const MyInput = React.forwardRef((props, ref) => <input ref={ref} />);
+   ·                 ─────────────────────────────────────────────────────
+   ╰────
+  help: In React 19+, `ref` is available as a prop. Use the `ref` prop directly instead of `forwardRef`.
+
+  ⚠ eslint-plugin-react(no-forward-ref): Do not use `React.forwardRef`.
+   ╭─[no_forward_ref.tsx:1:17]
+ 1 │ const MyInput = forwardRef((props, ref) => <input ref={ref} />);
+   ·                 ───────────────────────────────────────────────
+   ╰────
+  help: In React 19+, `ref` is available as a prop. Use the `ref` prop directly instead of `forwardRef`.

--- a/crates/oxc_linter/src/snapshots/react_no_jsx_literals.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_jsx_literals.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(no-jsx-literals): String literals are not allowed in JSX.
+   ╭─[no_jsx_literals.tsx:1:6]
+ 1 │ <div>Hello World</div>
+   ·      ───────────
+   ╰────
+  help: Wrap the string in a JSX expression: `{'text'}` or use a variable/constant.
+
+  ⚠ eslint-plugin-react(no-jsx-literals): String literals are not allowed in JSX.
+   ╭─[no_jsx_literals.tsx:1:7]
+ 1 │ <span>Some text</span>
+   ·       ─────────
+   ╰────
+  help: Wrap the string in a JSX expression: `{'text'}` or use a variable/constant.

--- a/crates/oxc_linter/src/snapshots/react_no_react_specific_props.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_react_specific_props.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(no-react-specific-props): `className` is a React-specific prop.
+   ╭─[no_react_specific_props.tsx:1:6]
+ 1 │ <div className="foo" />
+   ·      ───────────────
+   ╰────
+  help: Use the standard HTML attribute `class` instead of `className` when not using React.
+
+  ⚠ eslint-plugin-react(no-react-specific-props): `htmlFor` is a React-specific prop.
+   ╭─[no_react_specific_props.tsx:1:8]
+ 1 │ <label htmlFor="input" />
+   ·        ───────────────
+   ╰────
+  help: Use the standard HTML attribute `for` instead of `htmlFor` when not using React.

--- a/crates/oxc_linter/src/snapshots/react_no_suspicious_semicolon_in_jsx.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_suspicious_semicolon_in_jsx.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(no-suspicious-semicolon-in-jsx): Suspicious semicolon as JSX text content.
+   ╭─[no_suspicious_semicolon_in_jsx.tsx:1:6]
+ 1 │ <div>;</div>
+   ·      ─
+   ╰────
+  help: This semicolon appears as visible text in the rendered output. If you meant to end a statement, move it outside the JSX expression.

--- a/crates/oxc_linter/src/snapshots/react_use_image_size.snap
+++ b/crates/oxc_linter/src/snapshots/react_use_image_size.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(use-image-size): Image element is missing `width` and/or `height` attributes.
+   ╭─[use_image_size.tsx:1:1]
+ 1 │ <img src="photo.jpg" />
+   · ───────────────────────
+   ╰────
+  help: Add explicit `width` and `height` attributes to `<img>` elements to prevent layout shifts.
+
+  ⚠ eslint-plugin-react(use-image-size): Image element is missing `width` and/or `height` attributes.
+   ╭─[use_image_size.tsx:1:1]
+ 1 │ <img src="photo.jpg" width="100" />
+   · ───────────────────────────────────
+   ╰────
+  help: Add explicit `width` and `height` attributes to `<img>` elements to prevent layout shifts.
+
+  ⚠ eslint-plugin-react(use-image-size): Image element is missing `width` and/or `height` attributes.
+   ╭─[use_image_size.tsx:1:1]
+ 1 │ <img src="photo.jpg" height="100" />
+   · ────────────────────────────────────
+   ╰────
+  help: Add explicit `width` and `height` attributes to `<img>` elements to prevent layout shifts.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on property.
+   ╭─[explicit_member_accessibility.tsx:1:13]
+ 1 │ class Foo { bar: string; }
+   ·             ─
+   ╰────
+  help: Add an explicit `public`, `private`, or `protected` modifier.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method.
+   ╭─[explicit_member_accessibility.tsx:1:13]
+ 1 │ class Foo { baz() {} }
+   ·             ─
+   ╰────
+  help: Add an explicit `public`, `private`, or `protected` modifier.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on property.
+   ╭─[explicit_member_accessibility.tsx:1:13]
+ 1 │ class Foo { qux = 1; }
+   ·             ─
+   ╰────
+  help: Add an explicit `public`, `private`, or `protected` modifier.

--- a/crates/oxc_linter/src/snapshots/typescript_naming_convention.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_naming_convention.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript-eslint(naming-convention): Class `my_class` does not match the expected naming convention.
+   ╭─[naming_convention.tsx:1:7]
+ 1 │ class my_class {}
+   ·       ────────
+   ╰────
+  help: Rename to match the `PascalCase` naming convention.
+
+  ⚠ typescript-eslint(naming-convention): Interface `my_interface` does not match the expected naming convention.
+   ╭─[naming_convention.tsx:1:11]
+ 1 │ interface my_interface {}
+   ·           ────────────
+   ╰────
+  help: Rename to match the `PascalCase` naming convention.
+
+  ⚠ typescript-eslint(naming-convention): Type alias `my_type` does not match the expected naming convention.
+   ╭─[naming_convention.tsx:1:6]
+ 1 │ type my_type = string;
+   ·      ───────
+   ╰────
+  help: Rename to match the `PascalCase` naming convention.
+
+  ⚠ typescript-eslint(naming-convention): Enum `my_enum` does not match the expected naming convention.
+   ╭─[naming_convention.tsx:1:6]
+ 1 │ enum my_enum { my_value }
+   ·      ───────
+   ╰────
+  help: Rename to match the `PascalCase` naming convention.
+
+  ⚠ typescript-eslint(naming-convention): Enum member `my_value` does not match the expected naming convention.
+   ╭─[naming_convention.tsx:1:16]
+ 1 │ enum my_enum { my_value }
+   ·                ────────
+   ╰────
+  help: Rename to match the `PascalCase or UPPER_CASE` naming convention.

--- a/crates/oxc_linter/src/snapshots/typescript_no_empty_type_parameters.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_empty_type_parameters.snap
@@ -1,0 +1,4 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+

--- a/crates/oxc_linter/src/snapshots/typescript_no_enum.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_enum.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript-eslint(no-enum): TypeScript enums are not allowed.
+   ╭─[no_enum.tsx:1:1]
+ 1 │ enum Color { Red, Green, Blue }
+   · ────
+   ╰────
+  help: Use a union type or a const object instead of an enum.
+
+  ⚠ typescript-eslint(no-enum): TypeScript enums are not allowed.
+   ╭─[no_enum.tsx:1:1]
+ 1 │ const enum Direction { Up, Down }
+   · ──────────
+   ╰────
+  help: Use a union type or a const object instead of an enum.
+
+  ⚠ typescript-eslint(no-enum): TypeScript enums are not allowed.
+   ╭─[no_enum.tsx:1:1]
+ 1 │ enum Status { Active = 'active', Inactive = 'inactive' }
+   · ────
+   ╰────
+  help: Use a union type or a const object instead of an enum.

--- a/crates/oxc_linter/src/snapshots/typescript_no_evolving_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_evolving_types.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript-eslint(no-evolving-types): Variable is initialized to a value that will cause its type to evolve.
+   ╭─[no_evolving_types.tsx:1:5]
+ 1 │ let arr = [];
+   ·     ────────
+   ╰────
+  help: Add an explicit type annotation to prevent the type from evolving implicitly.
+
+  ⚠ typescript-eslint(no-evolving-types): Variable is initialized to a value that will cause its type to evolve.
+   ╭─[no_evolving_types.tsx:1:5]
+ 1 │ let val = null;
+   ·     ──────────
+   ╰────
+  help: Add an explicit type annotation to prevent the type from evolving implicitly.

--- a/crates/oxc_linter/src/snapshots/typescript_no_implicit_any_let.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_implicit_any_let.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript-eslint(no-implicit-any-let): Variable declaration without type annotation or initializer implicitly has `any` type.
+   ╭─[no_implicit_any_let.tsx:1:5]
+ 1 │ let x;
+   ·     ─
+   ╰────
+  help: Add an explicit type annotation or initialize the variable.
+
+  ⚠ typescript-eslint(no-implicit-any-let): Variable declaration without type annotation or initializer implicitly has `any` type.
+   ╭─[no_implicit_any_let.tsx:1:5]
+ 1 │ let a, b;
+   ·     ─
+   ╰────
+  help: Add an explicit type annotation or initialize the variable.
+
+  ⚠ typescript-eslint(no-implicit-any-let): Variable declaration without type annotation or initializer implicitly has `any` type.
+   ╭─[no_implicit_any_let.tsx:1:8]
+ 1 │ let a, b;
+   ·        ─
+   ╰────
+  help: Add an explicit type annotation or initialize the variable.

--- a/crates/oxc_linter/src/snapshots/typescript_no_this_in_static.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_this_in_static.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript-eslint(no-this-in-static): Unexpected `this` in a static method.
+   ╭─[no_this_in_static.tsx:1:35]
+ 1 │ class Foo { static bar() { return this.baz; } }
+   ·                                   ────
+   ╰────
+  help: In static methods, `this` refers to the class constructor, not an instance. Use the class name directly instead.
+
+  ⚠ typescript-eslint(no-this-in-static): Unexpected `this` in a static method.
+   ╭─[no_this_in_static.tsx:1:28]
+ 1 │ class Foo { static bar() { this.baz(); } }
+   ·                            ────
+   ╰────
+  help: In static methods, `this` refers to the class constructor, not an instance. Use the class name directly instead.
+
+  ⚠ typescript-eslint(no-this-in-static): Unexpected `this` in a static method.
+   ╭─[no_this_in_static.tsx:1:41]
+ 1 │ class Foo { static bar = () => { return this.baz; }; }
+   ·                                         ────
+   ╰────
+  help: In static methods, `this` refers to the class constructor, not an instance. Use the class name directly instead.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_flat_map_identity.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_flat_map_identity.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-unicorn(no-flat-map-identity): `.flatMap(x => x)` is equivalent to `.flat()`.
+   ╭─[no_flat_map_identity.tsx:1:1]
+ 1 │ arr.flatMap(x => x);
+   · ───────────────────
+   ╰────
+  help: Replace `.flatMap(x => x)` with `.flat()` for clarity.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_string_raw.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_string_raw.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-unicorn(no-useless-string-raw): `String.raw` is unnecessary when the template has no escape sequences.
+   ╭─[no_useless_string_raw.tsx:1:1]
+ 1 │ String.raw`hello world`;
+   · ───────────────────────
+   ╰────
+  help: Remove `String.raw` since the template literal doesn't contain any backslash escapes.
+
+  ⚠ eslint-plugin-unicorn(no-useless-string-raw): `String.raw` is unnecessary when the template has no escape sequences.
+   ╭─[no_useless_string_raw.tsx:1:1]
+ 1 │ String.raw`foo bar`;
+   · ───────────────────
+   ╰────
+  help: Remove `String.raw` since the template literal doesn't contain any backslash escapes.
+
+  ⚠ eslint-plugin-unicorn(no-useless-string-raw): `String.raw` is unnecessary when the template has no escape sequences.
+   ╭─[no_useless_string_raw.tsx:1:1]
+ 1 │ String.raw`no escapes here`;
+   · ───────────────────────────
+   ╰────
+  help: Remove `String.raw` since the template literal doesn't contain any backslash escapes.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_undefined_initialization.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_undefined_initialization.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-unicorn(no-useless-undefined-initialization): Unnecessary initialization to `undefined`.
+   ╭─[no_useless_undefined_initialization.tsx:1:9]
+ 1 │ let x = undefined;
+   ·         ─────────
+   ╰────
+  help: Remove `= undefined` since `let` and `var` declarations are already `undefined` by default.
+
+  ⚠ eslint-plugin-unicorn(no-useless-undefined-initialization): Unnecessary initialization to `undefined`.
+   ╭─[no_useless_undefined_initialization.tsx:1:9]
+ 1 │ var y = undefined;
+   ·         ─────────
+   ╰────
+  help: Remove `= undefined` since `let` and `var` declarations are already `undefined` by default.
+
+  ⚠ eslint-plugin-unicorn(no-useless-undefined-initialization): Unnecessary initialization to `undefined`.
+   ╭─[no_useless_undefined_initialization.tsx:1:16]
+ 1 │ let a = 1, b = undefined;
+   ·                ─────────
+   ╰────
+  help: Remove `= undefined` since `let` and `var` declarations are already `undefined` by default.

--- a/crates/oxc_linter/src/snapshots/unicorn_use_collapsed_if.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_use_collapsed_if.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-unicorn(use-collapsed-if): This `if` statement can be collapsed into the outer `if` statement.
+   ╭─[use_collapsed_if.tsx:1:10]
+ 1 │ if (a) { if (b) { doSomething(); } }
+   ·          ─────────────────────────
+   ╰────
+  help: Combine conditions using `&&` to reduce nesting.
+
+  ⚠ eslint-plugin-unicorn(use-collapsed-if): This `if` statement can be collapsed into the outer `if` statement.
+   ╭─[use_collapsed_if.tsx:1:14]
+ 1 │ if (x > 0) { if (y > 0) { console.log('both positive'); } }
+   ·              ────────────────────────────────────────────
+   ╰────
+  help: Combine conditions using `&&` to reduce nesting.

--- a/crates/oxc_linter/src/snapshots/unicorn_use_consistent_curly_braces.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_use_consistent_curly_braces.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-unicorn(use-consistent-curly-braces): Unnecessary curly braces around JSX string expression.
+   ╭─[use_consistent_curly_braces.tsx:1:6]
+ 1 │ <div>{'Hello'}</div>
+   ·      ─────────
+   ╰────
+  help: Remove the curly braces around this string literal. Use `text` instead of `{'text'}`.

--- a/crates/oxc_linter/src/snapshots/unicorn_use_simple_number_keys.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_use_simple_number_keys.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-unicorn(use-simple-number-keys): Use a simpler number as a property key.
+   ╭─[use_simple_number_keys.tsx:1:15]
+ 1 │ const obj = { 1.0: 'foo' };
+   ·               ───
+   ╰────
+  help: Simplify the numeric property key (e.g., use `1` instead of `1.0`).
+
+  ⚠ eslint-plugin-unicorn(use-simple-number-keys): Use a simpler number as a property key.
+   ╭─[use_simple_number_keys.tsx:1:15]
+ 1 │ const obj = { 0x1: 'foo' };
+   ·               ───
+   ╰────
+  help: Simplify the numeric property key (e.g., use `1` instead of `1.0`).
+
+  ⚠ eslint-plugin-unicorn(use-simple-number-keys): Use a simpler number as a property key.
+   ╭─[use_simple_number_keys.tsx:1:15]
+ 1 │ const obj = { 0o1: 'foo' };
+   ·               ───
+   ╰────
+  help: Simplify the numeric property key (e.g., use `1` instead of `1.0`).
+
+  ⚠ eslint-plugin-unicorn(use-simple-number-keys): Use a simpler number as a property key.
+   ╭─[use_simple_number_keys.tsx:1:15]
+ 1 │ const obj = { 0b1: 'foo' };
+   ·               ───
+   ╰────
+  help: Simplify the numeric property key (e.g., use `1` instead of `1.0`).
+
+  ⚠ eslint-plugin-unicorn(use-simple-number-keys): Use a simpler number as a property key.
+   ╭─[use_simple_number_keys.tsx:1:15]
+ 1 │ const obj = { 1e2: 'foo' };
+   ·               ───
+   ╰────
+  help: Simplify the numeric property key (e.g., use `1` instead of `1.0`).

--- a/crates/oxc_linter/src/snapshots/unicorn_use_simplified_logic_expression.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_use_simplified_logic_expression.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const a = x || true;
+   ·           ─────────
+   ╰────
+  help: Simplify to: `true`
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const b = x && false;
+   ·           ──────────
+   ╰────
+  help: Simplify to: `false`
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const c = x || false;
+   ·           ──────────
+   ╰────
+  help: Simplify to: `x`
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const d = x && true;
+   ·           ─────────
+   ╰────
+  help: Simplify to: `x`
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const e = true || x;
+   ·           ─────────
+   ╰────
+  help: Simplify to: `true`
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const f = false && x;
+   ·           ──────────
+   ╰────
+  help: Simplify to: `false`
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const g = false || x;
+   ·           ──────────
+   ╰────
+  help: Simplify to: `x`
+
+  ⚠ eslint-plugin-unicorn(use-simplified-logic-expression): This logical expression can be simplified.
+   ╭─[use_simplified_logic_expression.tsx:1:11]
+ 1 │ const h = true && x;
+   ·           ─────────
+   ╰────
+  help: Simplify to: `x`


### PR DESCRIPTION
## Summary

Adds 40 new lint rules that close the gap with Biome's rule coverage, organized across 7 plugin categories:

- **ESLint (10)**: `no-octal-escape`, `no-useless-continue`, `no-confusing-labels`, `no-redundant-use-strict`, `prefer-arrow-callback`, `use-while`, `use-single-var-declarator`, `use-regex-literals`, `no-string-case-mismatch`, `no-shouty-constants`
- **Unicorn (7)**: `no-flat-map-identity`, `no-useless-string-raw`, `no-useless-undefined-initialization`, `use-collapsed-if`, `use-simple-number-keys`, `use-simplified-logic-expression`, `use-consistent-curly-braces`
- **TypeScript (8)**: `no-empty-type-parameters`, `no-this-in-static`, `no-evolving-types`, `no-implicit-any-let`, `explicit-member-accessibility`, `no-enum`, `naming-convention`
- **React (5)**: `no-suspicious-semicolon-in-jsx`, `no-react-specific-props`, `no-forward-ref`, `no-jsx-literals`, `use-image-size`
- **jsx-a11y (6)**: `no-interactive-element-to-noninteractive-role`, `no-noninteractive-element-interactions`, `no-noninteractive-element-to-interactive-role`, `no-svg-without-title`, `use-focusable-interactive`, `use-unique-element-ids`
- **Node (1)**: `no-global-dirname-filename`
- **Import (3)**: `no-dynamic-namespace-import-access`, `no-undeclared-dependencies` (nursery), `no-unresolved-imports` (nursery), `no-private-imports` (nursery)

The 3 nursery import rules (`no-undeclared-dependencies`, `no-unresolved-imports`, `no-private-imports`) are registered as placeholders that need package.json/module resolution integration.

## Test plan

- [x] `cargo lintgen` regenerates correctly (750 → 832 variants)
- [x] `cargo test -p oxc_linter --lib` — all 1031 tests pass
- [x] `cargo check -p oxc_linter` — compiles clean
- [x] `just fmt` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)