### PR TITLE
chore(lsp): add `ResolvedPath` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,7 @@ dependencies = [
 name = "oxc_language_server"
 version = "1.41.0"
 dependencies = [
+ "cow-utils",
  "futures",
  "papaya",
  "rustc-hash",

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 doctest = false
 
 [dependencies]
+cow-utils = { workspace = true }
 futures = { workspace = true }
 papaya = { workspace = true }
 tracing = { workspace = true }

--- a/crates/oxc_language_server/fixtures/same_path_different_uri/nested/test.txt
+++ b/crates/oxc_language_server/fixtures/same_path_different_uri/nested/test.txt
@@ -1,0 +1,1 @@
+fixture file

--- a/crates/oxc_language_server/fixtures/same_path_different_uri/test.txt
+++ b/crates/oxc_language_server/fixtures/same_path_different_uri/test.txt
@@ -1,0 +1,1 @@
+fixture file

--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -1,3 +1,7 @@
+#[cfg(all(test, target_os = "windows"))]
+use cow_utils::CowUtils;
+#[cfg(test)]
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tower_lsp_server::ls_types::Uri;
@@ -7,6 +11,69 @@ use crate::{ConcurrentHashMap, LanguageId, TextDocument};
 #[derive(Debug, Default)]
 pub struct LSPFileSystem {
     files: ConcurrentHashMap<Uri, (LanguageId, Arc<str>)>,
+}
+
+/// Represents a resolved file path that can be used for file system operations.
+///
+/// On Windows and macOS, the file system is case-insensitive, so we need to resolve the path to its canonical form.
+/// Or else we might not find the right file or workspace worker.
+/// On other platforms, we can just use the path as is, since the file system is case-sensitive.
+///
+/// VS Code as an example likes to send mixed URI styles within the same connection:
+/// - workspace: `file:///c:/Path/To/file.js`
+/// - lint/format: `file:///C:/path/to/file.js`
+#[cfg(test)]
+struct ResolvedPath(PathBuf);
+
+#[cfg(test)]
+impl From<PathBuf> for ResolvedPath {
+    fn from(path: PathBuf) -> Self {
+        Self::canonical(path)
+    }
+}
+
+#[cfg(test)]
+impl TryFrom<Uri> for ResolvedPath {
+    type Error = String;
+
+    fn try_from(uri: Uri) -> Result<Self, Self::Error> {
+        let path = uri.to_file_path().ok_or_else(|| "Invalid URI".to_string())?;
+        Ok(Self::canonical(path.to_path_buf()))
+    }
+}
+
+#[cfg(test)]
+impl ResolvedPath {
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Resolves the given path to its canonical form if necessary, based on the operating system.
+    fn canonical(path: PathBuf) -> Self {
+        // on non windows and non macos, we can just return the path as is,
+        // since we don't have to worry about case sensitivity.
+        // Note: it really depends on the disk / folder settings, but checking the OS is a good enough heuristic for now,
+        // and we can always add more heuristics later if needed.
+        #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+        {
+            Self(path)
+        }
+
+        // on windows and macos, we need to resolve the path to its canonical form,
+        // since the URI does not respect case sensitivity, but the file system does
+        #[cfg(target_os = "macos")]
+        {
+            std::fs::canonicalize(&path).map(Self).unwrap_or_else(|_| Self(path)) // if the path does not exist, we can just return it as is
+        }
+
+        // on windows we need to remove `\\?\` prefix if it exists, since it can cause issues with some file system operations
+        #[cfg(target_os = "windows")]
+        {
+            let path = std::fs::canonicalize(&path).unwrap_or_else(|_| path);
+            let path_str = path.to_string_lossy();
+            Self(PathBuf::from(path_str.cow_replace(r"\\?\", "").as_ref()))
+        }
+    }
 }
 
 impl LSPFileSystem {
@@ -44,5 +111,70 @@ impl LSPFileSystem {
 
     pub fn keys(&self) -> Vec<Uri> {
         self.files.pin().keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cow_utils::CowUtils;
+    use std::{borrow::Cow, path::Path};
+
+    use super::*;
+
+    fn path_from_fixture(fixture: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures").join(fixture)
+    }
+
+    fn path_to_lossy_string(path: &Path) -> Cow<'_, str> {
+        path.as_os_str().to_string_lossy()
+    }
+
+    #[test]
+    fn test_uri_to_resolved_path_file() {
+        let dir = path_from_fixture("same_path_different_uri");
+        let file = dir.join("test.txt");
+
+        let uri = Uri::from_file_path(&file).unwrap();
+        let unresolved_uri = Uri::from_file_path(dir.join("Test.txt")).unwrap();
+
+        let resolved_path = ResolvedPath::try_from(uri).unwrap();
+        let unresolved_path = ResolvedPath::try_from(unresolved_uri).unwrap();
+
+        assert_eq!(*resolved_path.as_path(), file);
+
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
+        assert_eq!(path_to_lossy_string(unresolved_path.as_path()), path_to_lossy_string(&file));
+
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        assert_eq!(
+            path_to_lossy_string(unresolved_path.as_path()),
+            path_to_lossy_string(&file).cow_replace("test.txt", "Test.txt")
+        );
+    }
+
+    #[test]
+    fn test_uri_to_resolved_path_dir() {
+        let dir = path_from_fixture("same_path_different_uri");
+        let unresolved_dir = path_to_lossy_string(&dir);
+        let unresolved_dir =
+            unresolved_dir.cow_replace("same_path_different_uri", "Same_Path_Different_URI");
+
+        let uri = Uri::from_file_path(&dir).unwrap();
+        let unresolved_uri = Uri::from_file_path(unresolved_dir.as_ref()).unwrap();
+
+        let resolved_path = ResolvedPath::try_from(uri).unwrap();
+        let unresolved_path = ResolvedPath::try_from(unresolved_uri).unwrap();
+
+        assert_eq!(*resolved_path.as_path(), dir);
+
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
+        assert_eq!(path_to_lossy_string(unresolved_path.as_path()), path_to_lossy_string(&dir));
+
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        assert_eq!(
+            path_to_lossy_string(unresolved_path.as_path()),
+            path_to_lossy_string(&dir)
+                .cow_replace("same_path_different_uri", "Same_Path_Different_URI")
+        );
     }
 }


### PR DESCRIPTION
> Adds a `ResolvedPath` wrapper and new fixtures/tests intended to validate consistent path resolution across mixed-case `file://` URIs (notably from VS Code), to avoid mismatches when mapping URIs to filesystem/workspace entities.

Canonicalized only on windows macOS where case-sensitive file are present. 
Not only linux, because `Text.txt` and `test.txt` in the same directory are different files.