### PR TITLE
fix(lsp): check for real uri path when finding workspace worker

### DIFF
--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -1,8 +1,9 @@
-#[cfg(all(test, target_os = "windows"))]
+#[cfg(target_os = "windows")]
 use cow_utils::CowUtils;
-#[cfg(test)]
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use tower_lsp_server::ls_types::Uri;
 
@@ -22,27 +23,23 @@ pub struct LSPFileSystem {
 /// VS Code as an example likes to send mixed URI styles within the same connection:
 /// - workspace: `file:///c:/Path/To/file.js`
 /// - lint/format: `file:///C:/path/to/file.js`
-#[cfg(test)]
-struct ResolvedPath(PathBuf);
+pub struct ResolvedPath(PathBuf);
 
-#[cfg(test)]
 impl From<PathBuf> for ResolvedPath {
     fn from(path: PathBuf) -> Self {
         Self::canonical(path)
     }
 }
 
-#[cfg(test)]
-impl TryFrom<Uri> for ResolvedPath {
+impl TryFrom<&Uri> for ResolvedPath {
     type Error = String;
 
-    fn try_from(uri: Uri) -> Result<Self, Self::Error> {
+    fn try_from(uri: &Uri) -> Result<Self, Self::Error> {
         let path = uri.to_file_path().ok_or_else(|| "Invalid URI".to_string())?;
         Ok(Self::canonical(path.to_path_buf()))
     }
 }
 
-#[cfg(test)]
 impl ResolvedPath {
     pub fn as_path(&self) -> &Path {
         &self.0
@@ -138,8 +135,8 @@ mod tests {
         let uri = Uri::from_file_path(&file).unwrap();
         let unresolved_uri = Uri::from_file_path(dir.join("Test.txt")).unwrap();
 
-        let resolved_path = ResolvedPath::try_from(uri).unwrap();
-        let unresolved_path = ResolvedPath::try_from(unresolved_uri).unwrap();
+        let resolved_path = ResolvedPath::try_from(&uri).unwrap();
+        let unresolved_path = ResolvedPath::try_from(&unresolved_uri).unwrap();
 
         assert_eq!(*resolved_path.as_path(), file);
 
@@ -163,8 +160,8 @@ mod tests {
         let uri = Uri::from_file_path(&dir).unwrap();
         let unresolved_uri = Uri::from_file_path(unresolved_dir.as_ref()).unwrap();
 
-        let resolved_path = ResolvedPath::try_from(uri).unwrap();
-        let unresolved_path = ResolvedPath::try_from(unresolved_uri).unwrap();
+        let resolved_path = ResolvedPath::try_from(&uri).unwrap();
+        let unresolved_path = ResolvedPath::try_from(&unresolved_uri).unwrap();
 
         assert_eq!(*resolved_path.as_path(), dir);
 

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -11,7 +11,10 @@ use tower_lsp_server::{
 };
 use tracing::debug;
 
-use crate::{capabilities::DiagnosticMode, tool::ToolBuilder, worker::WorkspaceWorker};
+use crate::{
+    capabilities::DiagnosticMode, file_system::ResolvedPath, tool::ToolBuilder,
+    worker::WorkspaceWorker,
+};
 
 /// A RAII guard that holds a shared read lock over the workers list and exposes
 /// a reference to a single [`WorkspaceWorker`] inside it.
@@ -114,14 +117,16 @@ impl WorkerManager {
             return if workers.is_empty() { None } else { Some(0) };
         }
 
-        let file_path = uri.to_file_path()?;
+        let resolved_path = ResolvedPath::try_from(uri).ok()?;
+        let file_path = resolved_path.as_path();
 
         workers
             .iter()
             .enumerate()
             .filter_map(|(i, worker)| {
-                let root_path = worker.get_root_uri().to_file_path()?;
-                if file_path.starts_with(&root_path) {
+                let resolved_path = ResolvedPath::try_from(worker.get_root_uri()).ok()?;
+                let root_path = resolved_path.as_path();
+                if file_path.starts_with(root_path) {
                     Some((i, root_path.as_os_str().len()))
                 } else {
                     None
@@ -332,6 +337,8 @@ impl WorkerManager {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "windows")]
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     use tower_lsp_server::ls_types::Uri;
@@ -343,6 +350,11 @@ mod tests {
 
     fn create_builder() -> Arc<dyn ToolBuilder> {
         Arc::new(FakeToolBuilder::default()) as Arc<dyn ToolBuilder>
+    }
+
+    #[cfg(target_os = "windows")]
+    fn path_from_fixture(fixture: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures").join(fixture)
     }
 
     #[test]
@@ -542,5 +554,29 @@ mod tests {
         let no_path_file: Uri = "file:///".parse().unwrap();
         // Path is "/", so parent() returns None
         assert!(WorkerManager::get_parent_dir_uri(&no_path_file).is_none());
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_get_workspace_folder_case_insensitivity() {
+        let fixture = path_from_fixture("same_path_different_uri");
+        let root_path = PathBuf::from(
+            fixture
+                .to_string_lossy()
+                .replace("same_path_different_uri", "Same_Path_different_uri")
+                .replace("fixtures", "Fixtures"),
+        );
+
+        let workspace = WorkspaceWorker::new(
+            Uri::from_file_path(root_path).unwrap(),
+            create_builder(),
+            DiagnosticMode::None,
+        );
+        let workers = vec![workspace];
+
+        // File with different case should still match on Windows
+        let file: Uri = Uri::from_file_path(fixture.join("text.txt")).unwrap();
+        let worker = WorkerManager::find_worker_for_uri(&workers, &file);
+        assert!(worker.is_some());
     }
 }


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc-vscode/issues/197