### PR TITLE
chore(ci): Add /oxfmt-ecosys trigger for review

### DIFF
--- a/.github/workflows/ecosystem-ci-oxfmt.yml
+++ b/.github/workflows/ecosystem-ci-oxfmt.yml
@@ -1,0 +1,62 @@
+name: Ecosystem CI (oxfmt)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  group: ecosystem-ci-oxfmt-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  trigger:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/oxfmt-ecosys') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        id: prepare
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Triggering Oxfmt Ecosystem CI for \`${pr.head.ref}\`\nhttps://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/oxfmt-ci.yml`,
+            });
+            core.setOutput('ref', pr.head.ref);
+            core.setOutput('comment-id', comment.id);
+
+      - uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          repo: oxc-project/oxc-ecosystem-ci
+          workflow: oxfmt-ci.yml
+          token: ${{ secrets.OXC_BOT_PAT }}
+          ref: main
+          inputs: >-
+            {
+              "issue-number": "${{ github.event.issue.number }}",
+              "comment-id": "${{ steps.prepare.outputs.comment-id }}",
+              "ref": "${{ steps.prepare.outputs.ref }}"
+            }


### PR DESCRIPTION
Since there have been a lot of PR for reviews of `oxc_formatter` lately..., this is a way to help with that.

- If you type `/oxfmt-ecosys`, it will run CI by updating that comment and overwrite the result
- Only the reviewer(org owner+member) can run this
