### PR TITLE
fix(linter): skip `test.extend()` in `expect-expect` and `no-disabled-tests`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -173,6 +173,10 @@ fn run<'a>(
                 if property_name == "skip" && ctx.frameworks().is_vitest() {
                     return;
                 }
+                // test.extend() is a test factory, not a test call itself
+                if property_name == "extend" {
+                    return;
+                }
             }
 
             let assert_function_names = if ctx.frameworks().is_vitest() {
@@ -506,6 +510,8 @@ fn test() {
         ),
         ("it('test', async () => { const array = [1]; for (const element of array) { expect(element).toBe(1); } });", None),
         (r"it('msg', async () => { const r = foo(); return expect(r).rejects.toThrow(); });", None),
+        // test.extend() is a test factory, not a test call
+        ("const myTest = test.extend({});", None),
     ];
 
     let mut fail = vec![
@@ -809,6 +815,28 @@ fn test() {
                 assertType(concat('a', 2))
             ",
             Some(serde_json::json!([{ "assertFunctionNames": ["assertType"] }])),
+        ),
+        // test.extend() is a test factory, not a test call
+        (
+            "
+                import { test } from 'vitest';
+                const myTest = test.extend({
+                    fixture: async ({}, use) => { await use('value'); },
+                });
+            ",
+            None,
+        ),
+        (
+            "
+                import { test, expect } from 'vitest';
+                const myTest = test.extend({
+                    result: async ({}, use) => { await use(42); },
+                });
+                myTest('works', ({ result }) => {
+                    expect(result).toBe(42);
+                });
+            ",
+            None,
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -106,6 +106,12 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
     if let AstKind::CallExpression(call_expr) = node.kind() {
         if let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) {
             let ParsedGeneralJestFnCall { kind, members, name, .. } = jest_fn_call;
+            // test.extend() is a test factory, not a test call itself
+            if let Some(member) = members.first()
+                && member.is_name_equal("extend")
+            {
+                return;
+            }
             // `test('foo')`
             let kind = match kind {
                 JestFnKind::Expect | JestFnKind::ExpectTypeOf | JestFnKind::Unknown => return,
@@ -194,6 +200,8 @@ fn test() {
             None,
         ),
         ("import { test } from './test-utils'; test('something');", None),
+        // test.extend() is a test factory, not a test call
+        ("const myTest = test.extend({});", None),
     ];
 
     let mut fail = vec![
@@ -255,6 +263,13 @@ fn test() {
             import { test } from './test-utils';
 	    test('something');
         ",
+        // test.extend() is a test factory, not a test call
+        r#"
+            import { test } from 'vitest';
+            const myTest = test.extend({
+                fixture: async ({}, use) => { await use('value'); },
+            });
+        "#,
     ];
 
     let fail_vitest = vec![


### PR DESCRIPTION
Currently being reviewed by a human.

## Summary

- Fix false positives for `vitest/expect-expect` and `vitest/no-disabled-tests` when using `test.extend()` to create fixture-based test contexts
- `test.extend()` is a test factory (creates new test functions with fixtures), not a test call itself, so it should not trigger these lint rules
- Follows the same pattern already used in `valid-title` rule and aligns with the upstream fix in [eslint-plugin-vitest#584](https://github.com/vitest-dev/eslint-plugin-vitest/pull/584)

## Reproduction

```ts
import { describe, expect, test } from 'vitest';

describe('example', () => {
  const it = test.extend<{ result: number }>({
    result: async ({}, use) => {
      await use(42);
    },
  });

  it('works', ({ result }) => {
    expect(result).toBe(42);
  });
});
```

Before this fix, `test.extend()` was incorrectly flagged as:
- `expect-expect`: "Test has no assertions"
- `no-disabled-tests`: "Test is missing function argument"

## Changes

### `expect_expect.rs`
Added `extend` to the early-return check alongside `todo` and `skip`:
```rust
if property_name == "extend" {
    return;
}
```

### `no_disabled_tests.rs`
Added an early-return when the first member is `extend` (same pattern as `valid_title.rs`):
```rust
if let Some(member) = members.first()
    && member.is_name_equal("extend")
{
    return;
}
```

## Test plan

- [x] Added pass test cases for `test.extend()` in both Jest and Vitest contexts for `expect-expect`
- [x] Added pass test cases for `test.extend()` in both Jest and Vitest contexts for `no-disabled-tests`
- [x] `cargo test -p oxc_linter -- expect_expect` passes
- [x] `cargo test -p oxc_linter -- no_disabled_tests` passes
- [x] `cargo clippy -p oxc_linter` passes without new warnings

## AI Disclosure

This PR was authored with the assistance of Claude Code (AI).
The contributor has reviewed, tested, and validated all changes.