### PR TITLE
docs(CONTRIBUTING.md): add ban policy for repeated slop PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Oxc is a high-performance JavaScript/TypeScript toolchain written in Rust contai
 
 All AI-generated code must be thoroughly reviewed, tested, and understood by the contributor before submission. Code should meet Oxc's performance and quality standards.
 
+- **Ban policy** - Contributors who submit repeated low-quality ("slop") PRs will be banned without prior warning. Bans may be lifted if you commit to contributing to Oxc in accordance with the policy above. You may request an unban via our Discord.
+
 ## Repository Structure
 
 Rust workspace with key directories:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Thank you for your interest in contributing to Oxc!
 
+> [!IMPORTANT]
+> Please read the complete contributing guide on the [website](https://oxc.rs/docs/contribute/introduction.html).
+
 Please check out our [good first issues](https://github.com/oxc-project/oxc/contribute) or ask for guidance on [Discord](https://discord.gg/9uXCAwqQZW).
 
 We welcome and appreciate any form of contributions.
@@ -17,6 +20,3 @@ When using AI tools (including LLMs like ChatGPT, Claude, Copilot, etc.) to cont
 
 We encourage the use of AI tools to assist with development, but all contributions must be thoroughly reviewed and tested by the contributor before submission. AI-generated code should be understood, validated, and adapted to meet Oxc's standards.
 
----
-
-Please see the complete contributing guide on the [website](https://oxc.rs/docs/contribute/introduction.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ When using AI tools (including LLMs like ChatGPT, Claude, Copilot, etc.) to cont
 - **Please disclose AI usage** to reduce maintainer fatigue
 - **You are responsible** for all AI-generated issues or PRs you submit
 - **Low-quality or unreviewed AI content will be closed immediately**
+- **Contributors who submit repeated low-quality ("slop") PRs will be banned without prior warning.** Bans may be lifted if you commit to contributing to Oxc in accordance with this policy. You may request an unban via our [Discord](https://discord.gg/9uXCAwqQZW).
 
 We encourage the use of AI tools to assist with development, but all contributions must be thoroughly reviewed and tested by the contributor before submission. AI-generated code should be understood, validated, and adapted to meet Oxc's standards.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,3 @@ When using AI tools (including LLMs like ChatGPT, Claude, Copilot, etc.) to cont
 - **Contributors who submit repeated low-quality ("slop") PRs will be banned without prior warning.** Bans may be lifted if you commit to contributing to Oxc in accordance with this policy. You may request an unban via our [Discord](https://discord.gg/9uXCAwqQZW).
 
 We encourage the use of AI tools to assist with development, but all contributions must be thoroughly reviewed and tested by the contributor before submission. AI-generated code should be understood, validated, and adapted to meet Oxc's standards.
-


### PR DESCRIPTION
## Summary
- Document that contributors who repeatedly submit low-quality ("slop") AI PRs will be banned without prior warning
- Note that unbans can be requested via Discord
- Apply to both AGENTS.md and CONTRIBUTING.md