### PR TITLE
refactor(linter): simplify no-param-reassign using MemberWriteTarget flag

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
@@ -2,21 +2,11 @@ use lazy_regex::Regex;
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 
-use oxc_ast::{
-    AstKind,
-    ast::{
-        AssignmentExpression, AssignmentTargetPropertyIdentifier, AssignmentTargetPropertyProperty,
-        CallExpression, ChainExpression, ComputedMemberExpression, ForInStatement, ForOfStatement,
-        ObjectProperty, ParenthesizedExpression, StaticMemberExpression, TSAsExpression,
-        TSNonNullExpression, TSSatisfiesExpression, TSTypeAssertion, UnaryExpression,
-        UpdateExpression,
-    },
-};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, NodeId, Reference};
-use oxc_span::{GetSpan, Span};
-use oxc_syntax::operator::UnaryOperator;
+use oxc_semantic::{AstNode, NodeId};
+use oxc_span::Span;
 use serde_json::Value;
 
 use crate::{context::LintContext, rule::Rule};
@@ -157,110 +147,14 @@ impl Rule for NoParamReassign {
                     continue;
                 }
 
-                if self.0.props && !self.0.is_ignored(name) && is_modifying_property(reference, ctx)
+                if self.0.props
+                    && !self.0.is_ignored(name)
+                    && reference.flags().is_member_write_target()
                 {
                     ctx.diagnostic(assignment_to_param_property_diagnostic(name, span));
                 }
             }
         }
-    }
-}
-
-fn is_modifying_property(reference: &Reference, ctx: &LintContext<'_>) -> bool {
-    let nodes = ctx.nodes();
-    let mut current_id = reference.node_id();
-    let mut current_span = nodes.get_node(current_id).span();
-
-    loop {
-        let parent_id = nodes.parent_id(current_id);
-        if parent_id == NodeId::ROOT {
-            return false;
-        }
-
-        let parent_node = nodes.get_node(parent_id);
-        match parent_node.kind() {
-            AstKind::AssignmentExpression(AssignmentExpression { left, .. }) => {
-                return left.span().contains_inclusive(current_span);
-            }
-            AstKind::UpdateExpression(UpdateExpression { argument, .. }) => {
-                return argument.span().contains_inclusive(current_span);
-            }
-            AstKind::UnaryExpression(UnaryExpression {
-                operator: UnaryOperator::Delete,
-                argument,
-                ..
-            }) => {
-                return argument.span().contains_inclusive(current_span);
-            }
-            AstKind::UnaryExpression(_) => {
-                return false;
-            }
-            AstKind::ForInStatement(ForInStatement { left, .. })
-            | AstKind::ForOfStatement(ForOfStatement { left, .. }) => {
-                return left.span().contains_inclusive(current_span);
-            }
-            AstKind::StaticMemberExpression(StaticMemberExpression { object, .. })
-            | AstKind::ComputedMemberExpression(ComputedMemberExpression { object, .. }) => {
-                if object.span() != current_span {
-                    return false;
-                }
-            }
-            AstKind::ObjectProperty(ObjectProperty { key, .. }) => {
-                if key.span() == current_span {
-                    return false;
-                }
-            }
-            AstKind::AssignmentTargetPropertyIdentifier(AssignmentTargetPropertyIdentifier {
-                binding,
-                ..
-            }) => {
-                if binding.span == current_span {
-                    return false;
-                }
-            }
-            AstKind::AssignmentTargetPropertyProperty(AssignmentTargetPropertyProperty {
-                name,
-                ..
-            }) => {
-                if name.span().contains_inclusive(current_span) {
-                    return false;
-                }
-            }
-            AstKind::ConditionalExpression(conditional) => {
-                if conditional.test.span() == current_span {
-                    return false;
-                }
-            }
-            AstKind::ParenthesizedExpression(ParenthesizedExpression { expression, .. })
-            | AstKind::TSAsExpression(TSAsExpression { expression, .. })
-            | AstKind::TSNonNullExpression(TSNonNullExpression { expression, .. })
-            | AstKind::TSSatisfiesExpression(TSSatisfiesExpression { expression, .. })
-            | AstKind::TSTypeAssertion(TSTypeAssertion { expression, .. }) => {
-                if expression.span() != current_span {
-                    return false;
-                }
-            }
-            AstKind::ChainExpression(ChainExpression { expression, .. }) => {
-                if expression.span() != current_span {
-                    return false;
-                }
-            }
-            AstKind::CallExpression(CallExpression { callee, .. }) => {
-                if callee.span() != current_span {
-                    return false;
-                }
-            }
-            kind if kind.is_statement() || kind.is_declaration() => {
-                return false;
-            }
-            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) | AstKind::Program(_) => {
-                return false;
-            }
-            _ => {}
-        }
-
-        current_id = parent_id;
-        current_span = parent_node.span();
     }
 }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2026,14 +2026,27 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
+    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
+        let kind = AstKind::UnaryExpression(self.alloc(it));
+        self.enter_node(kind);
+        // `delete a.foo` — the argument is in a property-write context.
+        // Set Write so `visit_member_expression` can detect it and mark MemberWriteTarget.
+        // Only for member expressions — `delete x` (bare identifier in sloppy mode)
+        // is not a property modification.
+        if it.operator == UnaryOperator::Delete && it.argument.is_member_expression() {
+            self.current_reference_flags = ReferenceFlags::Write;
+        }
+        self.visit_expression(&it.argument);
+        self.leave_node(kind);
+    }
+
     fn visit_member_expression(&mut self, it: &MemberExpression<'a>) {
         // A.B = 1;
         // ^^^ Can't treat A as a Write reference since it's A's property(B) that changes.
-        // For write-only references (simple `=` assignment), mark as MemberWriteTarget
-        // so the minifier can identify property-write-only references.
-        // Compound assignments (`+=`) and update expressions (`++`) have Read|Write flags,
-        // so `is_write_only()` is false and they correctly skip this branch.
-        if self.current_reference_flags.is_write_only() {
+        // When the member expression is in any write context (simple `=`, compound `+=`,
+        // update `++`, `delete`, for-in/of), mark as MemberWriteTarget so downstream
+        // consumers can identify property-modification-only references.
+        if self.current_reference_flags.is_write() {
             self.current_reference_flags = ReferenceFlags::Read | ReferenceFlags::MemberWriteTarget;
         } else {
             self.current_reference_flags -= ReferenceFlags::Write;

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -1076,7 +1076,12 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         #[cfg(feature = "cfg")]
         self.record_ast_nodes();
+        // The test of a conditional is always a pure read — strip MemberWriteTarget
+        // so that `(a ? x : y).foo = 1` doesn't mark `a` as a property-write target.
+        let saved_flags = self.current_reference_flags;
+        self.current_reference_flags -= ReferenceFlags::MemberWriteTarget;
         self.visit_expression(&expr.test);
+        self.current_reference_flags = saved_flags;
         #[cfg(feature = "cfg")]
         let test_node_id = self.retrieve_recorded_ast_node();
 

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-expression.snap
@@ -52,28 +52,28 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-express
         "node": "VariableDeclarator(obj)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 4,
             "name": "obj",
             "node_id": 27,
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 5,
             "name": "obj",
             "node_id": 32,
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 6,
             "name": "obj",
             "node_id": 37,
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 7,
             "name": "obj",
             "node_id": 42,

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.ts
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 4,
             "name": "Foo",
             "node_id": 34,

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -117,13 +117,14 @@ bitflags! {
         /// a type parameter that might shadow it, since type parameters cannot
         /// have member access.
         const Namespace = 1 << 4;
-        /// The identifier is read as the object of a member expression in an
-        /// assignment target position. For example, `A` in `A.foo = 1`.
+        /// The identifier is read as the object of a member expression in a
+        /// property modification context. For example, `A` in `A.foo = 1`,
+        /// `A.foo += 1`, `++A.foo`, or `delete A.foo`.
         ///
         /// This flag is always combined with [`Read`] (since the identifier is
-        /// read to access the property). It helps the minifier determine if a
-        /// symbol's only reads are property-write targets, enabling dead code
-        /// elimination of patterns like `function A() {} A.foo = 1;`.
+        /// read to access the property). It helps the minifier and linter
+        /// determine if a symbol's only reads are property-modification targets,
+        /// enabling dead code elimination and unused variable detection.
         ///
         /// [`Read`]: ReferenceFlags::Read
         const MemberWriteTarget = 1 << 5;
@@ -183,8 +184,9 @@ impl ReferenceFlags {
         self.contains(Self::Read | Self::Write)
     }
 
-    /// The identifier is read only as the object of a member expression
-    /// in an assignment target position (e.g., `A` in `A.foo = 1`).
+    /// The identifier is read as the object of a member expression
+    /// in a property modification context (e.g., `A` in `A.foo = 1`,
+    /// `A.foo += 1`, `++A.foo`, or `delete A.foo`).
     #[inline]
     pub const fn is_member_write_target(self) -> bool {
         self.intersects(Self::MemberWriteTarget)


### PR DESCRIPTION
## Summary

- Extend `MemberWriteTarget` semantic flag to cover **all** property modification patterns (compound assignments `+=`, update expressions `++/--`, `delete`), not just simple `=`
- Replace the 97-line `is_modifying_property()` ancestor-walking function in `no-param-reassign` with a single `reference.flags().is_member_write_target()` check
- Fix `MemberWriteTarget` leaking into conditional test positions (`(a ? x : y).foo = 1` was incorrectly marking `a`)

## Motivation

PR #20772 added the `MemberWriteTarget` flag but only for simple `=` assignments. This PR extends it to all property modification patterns, which enables:

1. **Linter simplification** — `no-param-reassign` no longer needs a complex ancestor walk to detect property modifications
2. **Minifier** — PR #20773 can use the flag for more patterns
3. **Rolldown** — can consume this directly instead of maintaining its own `MemberExprIsWrite` state

### Semantic builder changes

In `visit_member_expression`, changed `is_write_only()` to `is_write()` so compound assignments and update expressions also set the flag. Added `visit_unary_expression` override to set `Write` for `delete` on member expressions (not bare identifiers).

### no-param-reassign simplification

Before (97 lines of ancestor walking):
```rust
fn is_modifying_property(reference: &Reference, ctx: &LintContext) -> bool {
    let nodes = ctx.nodes();
    let mut current_id = reference.node_id();
    loop {
        match parent_node.kind() {
            AstKind::AssignmentExpression(...) => { ... }
            AstKind::UpdateExpression(...) => { ... }
            AstKind::UnaryExpression(...) => { ... }
            AstKind::ForInStatement(...) => { ... }
            // ... 15+ match arms
        }
    }
}
```

After (1 line):
```rust
reference.flags().is_member_write_target()
```

## Test plan

- [x] All 1003 linter tests pass (including all 74 no-param-reassign cases)
- [x] All semantic tests pass with updated snapshots
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)