### PR TITLE
fix(linter/unicorn): report on optional in `require-number-to-fixed-digits-argument` rule

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -57,7 +57,7 @@ impl Rule for RequireNumberToFixedDigitsArgument {
                 return;
             }
 
-            if member.optional() || member.is_computed() {
+            if member.is_computed() {
                 return;
             }
 
@@ -108,7 +108,7 @@ fn test() {
 
     let fail = vec![
         "const string = number.toFixed();",
-        // r#"const string = number?.toFixed() ?? "";"#,
+        r#"const string = number?.toFixed() ?? "";"#,
         "const string = number.toFixed( /* comment */ );",
         "Number(1).toFixed()",
         "const bigNumber = new BigNumber(1); const string = bigNumber.toFixed();",
@@ -116,6 +116,10 @@ fn test() {
 
     let fix = vec![
         ("const string = number.toFixed();", "const string = number.toFixed(0);"),
+        (
+            r#"const string = number?.toFixed() ?? "";"#,
+            r#"const string = number?.toFixed(0) ?? "";"#,
+        ),
         (
             "const string = number.toFixed( /* comment */ );",
             "const string = number.toFixed( /* comment */ 0);",

--- a/crates/oxc_linter/src/snapshots/unicorn_require_number_to_fixed_digits_argument.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_require_number_to_fixed_digits_argument.snap
@@ -1,11 +1,19 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint-plugin-unicorn(require-number-to-fixed-digits-argument): Number method .toFixed() should have an argument
    ╭─[require_number_to_fixed_digits_argument.tsx:1:30]
  1 │ const string = number.toFixed();
    ·                              ──
+   ╰────
+  help: It's better to make it clear what the value of the digits argument is when calling Number#toFixed(), instead of relying on the default value of 0.
+
+  ⚠ eslint-plugin-unicorn(require-number-to-fixed-digits-argument): Number method .toFixed() should have an argument
+   ╭─[require_number_to_fixed_digits_argument.tsx:1:31]
+ 1 │ const string = number?.toFixed() ?? "";
+   ·                               ──
    ╰────
   help: It's better to make it clear what the value of the digits argument is when calling Number#toFixed(), instead of relying on the default value of 0.
 


### PR DESCRIPTION
fixes commented out test with optional in `unicorn/require-number-to-fixed-digits-argument`