### PR TITLE
feat(linter): add help/notes to diagnostics missing them

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -9,7 +9,9 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct NoUndefined;
 
 fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected use of `undefined`").with_label(span)
+    OxcDiagnostic::warn("Unexpected use of `undefined`")
+        .with_help("Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.")
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -16,6 +16,7 @@ use crate::{
 
 fn prefer_numeric_literals_diagnostic(span: Span, prefix_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use {prefix_name} literals instead of parseInt()."))
+        .with_help("Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -11,7 +11,9 @@ use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule}
 fn prefer_object_has_own_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`."
-    ).with_label(span)
+    )
+    .with_help("Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.")
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -24,17 +24,21 @@ fn unexpected_syntax_order_diagnostic(
     span: Span,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Expected '{curr_kind}' syntax before '{prev_kind}' syntax."))
+        .with_help("Reorder your import statements so that import types appear in the configured order.")
         .with_label(span)
 }
 
 fn sort_imports_alphabetically_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_label(span)
+    OxcDiagnostic::warn("Imports should be sorted alphabetically.")
+        .with_help("Sort the import statements alphabetically by their source module.")
+        .with_label(span)
 }
 
 fn sort_members_alphabetically_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Member '{name}' of the import declaration should be sorted alphabetically."
     ))
+    .with_help("Sort the named import members alphabetically within the import declaration.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -61,7 +61,9 @@ impl Default for SortKeysOptions {
 pub struct SortKeysConfig(SortOrder, SortKeysOptions);
 
 fn sort_properties_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Object keys should be sorted").with_label(span)
+    OxcDiagnostic::warn("Object keys should be sorted")
+        .with_help("Sort the object keys in the configured order (ascending by default).")
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -13,11 +13,15 @@ use crate::{
 };
 
 fn restricted_jest_method(method_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use of `{method_name}` is not allowed")).with_label(span)
+    OxcDiagnostic::warn(format!("Use of `{method_name}` is not allowed"))
+        .with_help(format!("Avoid using `jest.{method_name}()` as it has been restricted by project configuration."))
+        .with_label(span)
 }
 
 fn restricted_jest_method_with_message(message: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(message.to_string()).with_label(span)
+    OxcDiagnostic::warn(message.to_string())
+        .with_note("This Jest method has been restricted by project configuration.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -26,7 +26,9 @@ use crate::{
 };
 
 fn always_return_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Each then() should return a value or throw").with_label(span)
+    OxcDiagnostic::warn("Each then() should return a value or throw")
+        .with_help("Add a `return` statement to the `then()` callback, or use `async/await` instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
+++ b/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
@@ -26,11 +26,13 @@ fn already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise should not be resolved multiple times. Promise is already resolved on line {line}."
     ))
+    .with_help("Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.")
     .with_label(span)
 }
 
 fn potentially_already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}.")).with_label(span)
+    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}.")).with_help("Guard this resolve/reject call with a condition to ensure the promise is only settled once.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -14,6 +14,7 @@ fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise constructor parameters must be named to match `{pattern}`"
     ))
+    .with_help(format!("Rename the parameters to match the pattern `{pattern}` (e.g., `resolve` and `reject`)."))
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -14,6 +14,7 @@ use crate::{
 
 fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Avoid using non-standard `Promise.{prop_name}` method."))
+        .with_help(format!("Use a spec-compliant Promise method instead of `Promise.{prop_name}`."))
         .with_label(member_span)
 }
 

--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -13,6 +13,7 @@ fn zero_or_one_argument_required_diagnostic(
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 0 or 1 arguments, but received {args_len}."
     ))
+    .with_help(format!("Pass 0 or 1 arguments to `Promise.{prop_name}()`."))
     .with_label(span)
 }
 
@@ -24,6 +25,7 @@ fn one_or_two_argument_required_diagnostic(
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 1 or 2 arguments, but received {args_len}."
     ))
+    .with_help(format!("Pass 1 or 2 arguments to `Promise.{prop_name}()`."))
     .with_label(span)
 }
 
@@ -31,6 +33,7 @@ fn one_argument_required_diagnostic(span: Span, prop_name: &str, args_len: usize
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 1 argument, but received {args_len}."
     ))
+    .with_help(format!("Pass exactly 1 argument to `Promise.{prop_name}()`."))
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
@@ -21,6 +21,7 @@ fn jsx_max_depth_diagnostic(depth: usize, max: usize, span: Span) -> OxcDiagnost
     OxcDiagnostic::warn(format!(
         "JSX nesting depth of {depth} exceeds the configured maximum of {max}"
     ))
+    .with_help("Extract nested JSX into separate components to reduce nesting depth.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -11,6 +11,7 @@ use crate::{
 
 fn jsx_no_comment_textnodes_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Comments inside children section of tag should be placed inside braces")
+        .with_help("Wrap the comment in braces: `{/* comment */}`.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 
 fn jsx_no_undef_diagnostic(ident_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{ident_name}' is not defined.")).with_label(span)
+    OxcDiagnostic::warn(format!("'{ident_name}' is not defined."))
+        .with_help(format!("Import or define '{ident_name}' before using it in JSX."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -21,11 +21,15 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 fn needs_more_children(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Fragments should contain more than one child.").with_label(span)
+    OxcDiagnostic::warn("Fragments should contain more than one child.")
+        .with_help("Remove the fragment and render the child directly.")
+        .with_label(span)
 }
 
 fn child_of_html_element(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Passing a fragment to a HTML element is useless.").with_label(span)
+    OxcDiagnostic::warn("Passing a fragment to a HTML element is useless.")
+        .with_help("Remove the fragment and pass the children directly to the HTML element.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -17,7 +17,9 @@ use crate::{
 };
 
 fn jsx_props_no_spreading_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prop spreading is forbidden").with_label(span)
+    OxcDiagnostic::warn("Prop spreading is forbidden")
+        .with_help("Pass each prop individually instead of using the spread operator.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, JsonSchema, Deserialize, Serialize)]

--- a/crates/oxc_linter/src/rules/react/no_redundant_should_component_update.rs
+++ b/crates/oxc_linter/src/rules/react/no_redundant_should_component_update.rs
@@ -15,6 +15,7 @@ fn no_redundant_should_component_update_diagnostic(
     OxcDiagnostic::warn(format!(
         "{component_name} does not need `shouldComponentUpdate` when extending `React.PureComponent`."
     ))
+    .with_help(format!("Remove the `shouldComponentUpdate` method from {component_name}. `React.PureComponent` already implements shallow prop and state comparison."))
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -11,7 +11,9 @@ use crate::{
 };
 
 fn no_set_state_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use `setState`.").with_label(span)
+    OxcDiagnostic::warn("Do not use `setState`.")
+        .with_help("Use React hooks (`useState`) in functional components, or consider using an external state management solution.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -14,7 +14,9 @@ static ESCAPED_SINGLE_QUOTE: &str = "&apos; or &lsquo; or &#39; or &rsquo;";
 
 fn no_unescaped_entities_diagnostic(span: Span, unescaped: char) -> OxcDiagnostic {
     let escaped = if unescaped == '"' { ESCAPED_DOUBLE_QUOTE } else { ESCAPED_SINGLE_QUOTE };
-    OxcDiagnostic::warn(format!("`{unescaped}` can be escaped with {escaped}")).with_label(span)
+    OxcDiagnostic::warn(format!("`{unescaped}` can be escaped with {escaped}"))
+        .with_help(format!("Replace `{unescaped}` with the HTML entity {escaped} to avoid ambiguity in JSX."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/only_export_components.rs
+++ b/crates/oxc_linter/src/rules/react/only_export_components.rs
@@ -14,11 +14,13 @@ use crate::{
 
 fn export_all_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("This rule can't verify that `export *` only exports components.")
+        .with_help("Replace `export *` with explicit named exports to ensure only components are exported.")
         .with_label(span)
 }
 
 fn named_export_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.")
+        .with_help("Move non-component exports (constants, functions, types) to a separate file.")
         .with_label(span)
 }
 
@@ -26,21 +28,25 @@ fn anonymous_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Fast refresh can't handle anonymous components. Add a name to your export.",
     )
+    .with_help("Add a name to the component function or variable before exporting it.")
     .with_label(span)
 }
 
 fn local_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file only exports components. Move your component(s) to a separate file.")
+        .with_help("Move your component(s) to a separate file that only contains component exports.")
         .with_label(span)
 }
 
 fn no_export_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file has exports. Move your component(s) to a separate file.")
+        .with_help("Add an export statement for your component(s), or move them to a separate file.")
         .with_label(span)
 }
 
 fn react_context_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file only exports components. Move your React context(s) to a separate file.")
+        .with_help("Move your React context(s) to a separate file so that components get their own module.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -14,11 +14,13 @@ use crate::{
 
 fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Components should use `createReactClass` instead of an ES2015 class.")
+        .with_help("Replace the ES2015 class with `createReactClass`.")
         .with_label(span)
 }
 
 fn expected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Components should use an ES2015 class instead of `createReactClass`.")
+        .with_help("Replace `createReactClass` with an ES2015 class or a function component.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -20,7 +20,9 @@ use crate::{
 };
 
 fn style_prop_object_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("`style` prop value must be an object.").with_label(span)
+    OxcDiagnostic::warn("`style` prop value must be an object.")
+        .with_help("Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
@@ -7,207 +7,242 @@ source: crates/oxc_linter/src/tester.rs
  1 │ undefined
    · ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined.a
    · ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:3]
  1 │ a[undefined]
    ·   ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined[0]
    · ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:3]
  1 │ f(undefined)
    ·   ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:12]
  1 │ function f(undefined) {}
    ·            ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:20]
  1 │ function f() { var undefined; }
    ·                    ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ function f() { undefined = true; }
    ·                ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined;
    ·     ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:14]
  1 │ try {} catch(undefined) {}
    ·              ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:10]
  1 │ function undefined() {}
    ·          ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:11]
  1 │ (function undefined(){}())
    ·           ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:20]
  1 │ var foo = function undefined() {}
    ·                    ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ foo = function undefined() {}
    ·                ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined = true
    · ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined = true
    ·     ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:4]
  1 │ ({ undefined })
    ·    ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ ({ [undefined]: foo })
    ·     ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:9]
  1 │ ({ bar: undefined })
    ·         ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:9]
  1 │ ({ bar: undefined } = foo)
    ·         ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:7]
  1 │ var { undefined } = foo
    ·       ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:12]
  1 │ var { bar: undefined } = foo
    ·            ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:24]
  1 │ ({ undefined: function undefined() {} })
    ·                        ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:18]
  1 │ ({ foo: function undefined() {} })
    ·                  ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:14]
  1 │ class Foo { [undefined]() {} }
    ·              ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:11]
  1 │ (class { [undefined]() {} })
    ·           ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined = true; undefined = false;
    ·     ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:23]
  1 │ var undefined = true; undefined = false;
    ·                       ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:8]
  1 │ import undefined from 'foo'
    ·        ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:13]
  1 │ import * as undefined from 'foo'
    ·             ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:10]
  1 │ import { undefined } from 'foo'
    ·          ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:15]
  1 │ import { a as undefined } from 'foo'
    ·               ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ let a = [b, ...undefined]
    ·                ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:8]
  1 │ [a, ...undefined] = b
    ·        ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:6]
  1 │ [a = undefined] = b
    ·      ─────────
    ╰────
+  help: Use `void 0` instead of `undefined`, or avoid referencing `undefined` directly.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_numeric_literals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_numeric_literals.snap
@@ -7,6 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt("111110111", 2) === 503;
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt("111110111", 2)` with `0b111110111`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -14,6 +15,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt("767", 8) === 503;
    · ──────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt("767", 8)` with `0o767`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -21,6 +23,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt("1F7", 16) === 255;
    · ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt("1F7", 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -28,6 +31,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt("111110111", 2) === 503;
    · ───────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt("111110111", 2)` with `0b111110111`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -35,6 +39,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt("767", 8) === 503;
    · ─────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt("767", 8)` with `0o767`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -42,6 +47,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt("1F7", 16) === 255;
    · ──────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt("1F7", 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -49,54 +55,63 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('7999', 8);
    · ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt('1234', 2);
    · ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt('1234.5', 8);
    · ─────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt('1️⃣3️⃣3️⃣7️⃣', 16);
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ Number.parseInt('7999', 8);
    · ──────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ Number.parseInt('1234', 2);
    · ──────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ Number.parseInt('1234.5', 8);
    · ────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ Number.parseInt('1️⃣3️⃣3️⃣7️⃣', 16);
    · ───────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt(`111110111`, 2) === 503;
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt(`111110111`, 2)` with `0b111110111`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -104,6 +119,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt(`767`, 8) === 503;
    · ──────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt(`767`, 8)` with `0o767`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -111,6 +127,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt(`1F7`, 16) === 255;
    · ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt(`1F7`, 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -118,36 +135,42 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('', 8);
    · ───────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt(``, 8);
    · ───────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt(`7999`, 8);
    · ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt(`1234`, 2);
    · ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt(`1234.5`, 8);
    · ─────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt('11', 2)
    · ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -155,6 +178,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt('67', 8)
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('67', 8)` with `0o67`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -162,6 +186,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 5+parseInt('A', 16)
    ·   ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('A', 16)` with `0xA`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -169,6 +194,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield(Number).parseInt('11', 2) }
    ·                     ──────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `(Number).parseInt('11', 2)` with ` 0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -176,6 +202,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield(Number.parseInt)('67', 8) }
    ·                     ──────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `(Number.parseInt)('67', 8)` with ` 0o67`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -183,6 +210,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield(parseInt)('A', 16) }
    ·                     ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `(parseInt)('A', 16)` with ` 0xA`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -190,6 +218,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield Number.parseInt('11', 2) }
    ·                      ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -197,6 +226,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield/**/Number.parseInt('67', 8) }
    ·                         ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('67', 8)` with `0o67`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -204,6 +234,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield(parseInt('A', 16)) }
    ·                      ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('A', 16)` with `0xA`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -211,6 +242,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('11', 2)+5
    · ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -218,6 +250,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt('17', 8)+5
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('17', 8)` with `0o17`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -225,6 +258,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('A', 16)+5
    · ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('A', 16)` with `0xA`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -232,6 +266,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('11', 2)in foo
    · ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('11', 2)` with `0b11 `.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -239,6 +274,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt('17', 8)in foo
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('17', 8)` with `0o17 `.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -246,6 +282,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('A', 16)in foo
    · ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('A', 16)` with `0xA `.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -253,6 +290,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('11', 2) in foo
    · ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
@@ -260,6 +298,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt('17', 8)/**/in foo
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('17', 8)` with `0o17`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -267,6 +306,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ (parseInt('A', 16))in foo
    ·  ─────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('A', 16)` with `0xA`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -274,6 +314,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ /* comment */Number.parseInt('11', 2);
    ·              ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -281,6 +322,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number/**/.parseInt('11', 2);
    · ────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number/**/.parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -288,6 +330,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ╭─▶ Number//
  2 │ ╰─▶             .parseInt('11', 2);
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number//
         			.parseInt('11', 2)` with `0b11`.
 
@@ -296,6 +339,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number./**/parseInt('11', 2);
    · ────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number./**/parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -303,6 +347,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt(/**/'11', 2);
    · ────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt(/**/'11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -310,6 +355,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt('11', /**/2);
    · ────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('11', /**/2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -317,6 +363,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt('11', 2)/* comment */;
    · ────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number.parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -324,6 +371,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt/**/('11', 2);
    · ─────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt/**/('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -331,6 +379,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ╭─▶ parseInt(//
  2 │ ╰─▶             '11', 2);
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt(//
         			'11', 2)` with `0b11`.
 
@@ -339,6 +388,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('11'/**/, 2);
    · ─────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('11'/**/, 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -346,6 +396,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt(`11`/**/, 2);
    · ─────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt(`11`/**/, 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -353,6 +404,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('11', 2 /**/);
    · ──────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('11', 2 /**/)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -361,6 +413,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────
  2 │             ;
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt('11', 2)` with `0b11`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -368,6 +421,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt?.("1F7", 16) === 255;
    · ─────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt?.("1F7", 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -375,6 +429,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number?.parseInt("1F7", 16) === 255;
    · ───────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number?.parseInt("1F7", 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -382,6 +437,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number?.parseInt?.("1F7", 16) === 255;
    · ─────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `Number?.parseInt?.("1F7", 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -389,6 +445,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ (Number?.parseInt)("1F7", 16) === 255;
    · ─────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `(Number?.parseInt)("1F7", 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
@@ -396,6 +453,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ (Number?.parseInt)?.("1F7", 16) === 255;
    · ───────────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `(Number?.parseInt)?.("1F7", 16)` with `0x1F7`.
 
   ⚠ eslint(prefer-numeric-literals): Use binary literals instead of parseInt().
@@ -403,24 +461,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt('1_0', 2);
    · ──────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ Number.parseInt('5_000', 8);
    · ───────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ parseInt('0_1', 16);
    · ───────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use hexadecimal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:1:1]
  1 │ Number.parseInt('0_0', 16);
    · ──────────────────────────
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
 
   ⚠ eslint(prefer-numeric-literals): Use octal literals instead of parseInt().
    ╭─[prefer_numeric_literals.tsx:2:13]
@@ -429,4 +491,5 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────
  3 │             function foo() {
    ╰────
+  help: Replace the parseInt() call with the equivalent numeric literal prefix (0b for binary, 0o for octal, 0x for hexadecimal).
   help: Replace `parseInt("767", 8)` with `0o767`.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_object_has_own.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_object_has_own.snap
@@ -7,6 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object.hasOwnProperty.call(obj, 'foo')
    · ──────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -14,6 +15,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object.hasOwnProperty.call(obj, property)
    · ─────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -21,6 +23,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object.prototype.hasOwnProperty.call(obj, 'foo')
    · ────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object.prototype.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -28,6 +31,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ({}).hasOwnProperty.call(obj, 'foo')
    · ────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `({}).hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -35,12 +39,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object/* comment */.prototype.hasOwnProperty.call(a, b);
    · ───────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
    ╭─[prefer_object_has_own.tsx:1:21]
  1 │ const hasProperty = Object.prototype.hasOwnProperty.call(object, property);
    ·                     ──────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object.prototype.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -48,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( Object.prototype.hasOwnProperty.call(object, property) ));
    ·                        ──────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object.prototype.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -55,6 +62,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( Object.prototype.hasOwnProperty.call ))(object, property);
    ·                     ────────────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object.prototype.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -62,6 +70,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( Object.prototype.hasOwnProperty )).call(object, property);
    ·                     ────────────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `(( Object.prototype.hasOwnProperty )).call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -69,6 +78,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( Object.prototype )).hasOwnProperty.call(object, property);
    ·                     ────────────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `(( Object.prototype )).hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -76,6 +86,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( Object )).prototype.hasOwnProperty.call(object, property);
    ·                     ────────────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `(( Object )).prototype.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -83,6 +94,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = {}.hasOwnProperty.call(object, property);
    ·                     ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -90,6 +102,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty={}.hasOwnProperty.call(object, property);
    ·                   ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -97,6 +110,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( {}.hasOwnProperty.call(object, property) ));
    ·                        ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -104,6 +118,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( {}.hasOwnProperty.call ))(object, property);
    ·                     ──────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -111,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( {}.hasOwnProperty )).call(object, property);
    ·                     ──────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `(( {}.hasOwnProperty )).call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -118,6 +134,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const hasProperty = (( {} )).hasOwnProperty.call(object, property);
    ·                     ──────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `(( {} )).hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -125,6 +142,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo(){return {}.hasOwnProperty.call(object, property)}
    ·                       ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -132,6 +150,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo(){return{}.hasOwnProperty.call(object, property)}
    ·                      ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with ` Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -139,6 +158,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo(){return/*comment*/{}.hasOwnProperty.call(object, property)}
    ·                                 ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -146,6 +166,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ async function foo(){return await{}.hasOwnProperty.call(object, property)}
    ·                                  ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with ` Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -153,6 +174,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ async function foo(){return await/*comment*/{}.hasOwnProperty.call(object, property)}
    ·                                             ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -160,6 +182,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ for (const x of{}.hasOwnProperty.call(object, property).toString());
    ·                ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with ` Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -167,6 +190,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ for (const x of/*comment*/{}.hasOwnProperty.call(object, property).toString());
    ·                           ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -174,6 +198,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ for (const x in{}.hasOwnProperty.call(object, property).toString());
    ·                ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with ` Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -181,6 +206,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ for (const x in/*comment*/{}.hasOwnProperty.call(object, property).toString());
    ·                           ────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -188,6 +214,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo(){return({}.hasOwnProperty.call)(object, property)}
    ·                      ──────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `{}.hasOwnProperty.call` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -195,6 +222,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object['prototype']['hasOwnProperty']['call'](object, property);
    · ───────────────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object['prototype']['hasOwnProperty']['call']` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -202,6 +230,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object[`prototype`][`hasOwnProperty`][`call`](object, property);
    · ───────────────────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object[`prototype`][`hasOwnProperty`][`call`]` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -209,6 +238,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object['hasOwnProperty']['call'](object, property);
    · ──────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object['hasOwnProperty']['call']` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -216,6 +246,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object[`hasOwnProperty`][`call`](object, property);
    · ──────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object[`hasOwnProperty`][`call`]` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -223,6 +254,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ({})['hasOwnProperty']['call'](object, property);
    · ────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `({})['hasOwnProperty']['call']` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -230,6 +262,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ({})[`hasOwnProperty`][`call`](object, property);
    · ────────────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `({})[`hasOwnProperty`][`call`]` with `Object.hasOwn`.
 
   ⚠ eslint(prefer-object-has-own): Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
@@ -237,4 +270,5 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object.prototype.hasOwnProperty.call(C,x);
    ·  ─────────────────────────────────────────
    ╰────
+  help: Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.
   help: Replace `Object.prototype.hasOwnProperty.call` with ` Object.hasOwn`.

--- a/crates/oxc_linter/src/snapshots/eslint_sort_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_sort_imports.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import A from 'bar.js';
    ·             ───────────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:13]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import a from 'bar.js';
    ·             ───────────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:13]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import {a, d} from 'bar.js';
    ·             ────────────────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:13]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import * as bar from 'bar.js';
    ·             ──────────────────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Expected 'Multiple' syntax before 'Single' syntax.
    ╭─[sort_imports.tsx:2:13]
@@ -36,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import {b, c} from 'bar.js';
    ·             ────────────────────────────
    ╰────
+  help: Reorder your import statements so that import types appear in the configured order.
 
   ⚠ eslint(sort-imports): Expected 'All' syntax before 'Single' syntax.
    ╭─[sort_imports.tsx:2:13]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import * as b from 'bar.js';
    ·             ────────────────────────────
    ╰────
+  help: Reorder your import statements so that import types appear in the configured order.
 
   ⚠ eslint(sort-imports): Expected 'None' syntax before 'Single' syntax.
    ╭─[sort_imports.tsx:2:13]
@@ -50,6 +56,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import 'bar.js';
    ·             ────────────────
    ╰────
+  help: Reorder your import statements so that import types appear in the configured order.
 
   ⚠ eslint(sort-imports): Expected 'All' syntax before 'Single' syntax.
    ╭─[sort_imports.tsx:2:13]
@@ -57,12 +64,14 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import * as a from 'foo.js';
    ·             ────────────────────────────
    ╰────
+  help: Reorder your import statements so that import types appear in the configured order.
 
   ⚠ eslint(sort-imports): Member 'a' of the import declaration should be sorted alphabetically.
    ╭─[sort_imports.tsx:1:12]
  1 │ import {b, a, d, c} from 'foo.js';
    ·            ─
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
   help: Replace `b, a, d, c` with `a, b, c, d`.
 
   ⚠ eslint(sort-imports): Member 'a' of the import declaration should be sorted alphabetically.
@@ -71,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ─
  2 │             import {e, f, g, h} from 'bar.js';
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
   help: Replace `b, a, d, c` with `a, b, c, d`.
 
   ⚠ eslint(sort-imports): Member 'B' of the import declaration should be sorted alphabetically.
@@ -78,6 +88,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import {a, B, c, D} from 'foo.js';
    ·            ─
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
   help: Replace `a, B, c, D` with `B, D, a, c`.
 
   ⚠ eslint(sort-imports): Member 'aaaaa' of the import declaration should be sorted alphabetically.
@@ -85,24 +96,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import {zzzzz, /* comment */ aaaaa} from 'foo.js';
    ·                              ─────
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
 
   ⚠ eslint(sort-imports): Member 'aaaaa' of the import declaration should be sorted alphabetically.
    ╭─[sort_imports.tsx:1:30]
  1 │ import {zzzzz /* comment */, aaaaa} from 'foo.js';
    ·                              ─────
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
 
   ⚠ eslint(sort-imports): Member 'aaaaa' of the import declaration should be sorted alphabetically.
    ╭─[sort_imports.tsx:1:30]
  1 │ import {/* comment */ zzzzz, aaaaa} from 'foo.js';
    ·                              ─────
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
 
   ⚠ eslint(sort-imports): Member 'aaaaa' of the import declaration should be sorted alphabetically.
    ╭─[sort_imports.tsx:1:16]
  1 │ import {zzzzz, aaaaa /* comment */} from 'foo.js';
    ·                ─────
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
 
   ⚠ eslint(sort-imports): Member 'qux' of the import declaration should be sorted alphabetically.
    ╭─[sort_imports.tsx:6:17]
@@ -111,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────
  7 │                 bar,
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
   help: Replace `boop,
                         foo,
                         zoo,
@@ -129,6 +145,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import a from 'a';
    ·             ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:13]
@@ -136,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import a from 'a';
    ·             ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:13]
@@ -143,18 +161,21 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import a from 'a';
    ·             ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:1:19]
  1 │ import b from 'b';import a from 'a';
    ·                   ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:1:34]
  1 │ import b from 'b'; /* comment */ import a from 'a';
    ·                                  ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:13]
@@ -162,6 +183,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             import a from 'a';
    ·             ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:28]
@@ -169,6 +191,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             /* comment 2 */import a from 'a';
    ·                            ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:35]
@@ -176,6 +199,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                 comment line 2 */ import { a } from 'a';
    ·                                   ──────────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:23]
@@ -183,6 +207,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │ ╭─▶             from 'b'; import a
  3 │ ╰─▶             from 'a';
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:2:32]
@@ -190,6 +215,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │ ╭─▶             'b'; /* comment */ import
  3 │ ╰─▶              { a } from 'a';
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:3:13]
@@ -197,6 +223,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╭─▶             import
  4 │ ╰─▶                 { a } from 'a';
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Imports should be sorted alphabetically.
    ╭─[sort_imports.tsx:4:13]
@@ -204,6 +231,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │             import a from 'a';
    ·             ──────────────────
    ╰────
+  help: Sort the import statements alphabetically by their source module.
 
   ⚠ eslint(sort-imports): Member 'a' of the import declaration should be sorted alphabetically.
    ╭─[sort_imports.tsx:3:25]
@@ -211,4 +239,5 @@ source: crates/oxc_linter/src/tester.rs
  3 │             import { c, a } from 'c';
    ·                         ─
    ╰────
+  help: Sort the named import members alphabetically within the import declaration.
   help: Replace `c, a` with `a, c`.

--- a/crates/oxc_linter/src/snapshots/eslint_sort_keys.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_sort_keys.snap
@@ -7,6 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, '':2} // default
    ·           ───────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, '':2` with `'':2, a:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -14,6 +15,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, [``]:2} // default
    ·           ─────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, [``]:2` with `[``]:2, a:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -21,6 +23,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // default
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -28,6 +31,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `a:1, b:3, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -35,6 +39,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `a:2, b:3, b_:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -42,6 +47,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, c:2, C:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, c:2, C:3` with `C:3, b_:1, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -49,6 +55,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, _:2, A:3, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, _:2, A:3, a:4` with `$:1, A:3, _:2, a:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -56,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, A:3, '11':2}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, A:3, '11':2` with `1:1, '11':2, 2:4, A:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -63,6 +71,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `'#':1, 'Z':2, À:3, è:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -70,6 +79,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = { null: 1, [/(?<zero>0)/]: 2 }
    ·           ──────────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `null: 1, [/(?<zero>0)/]: 2` with `[/(?<zero>0)/]: 2, null: 1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -77,6 +87,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {...z, c:1, b:1}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `c:1, b:1` with `b:1, c:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -84,12 +95,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {...z, ...c, d:4, b:1, ...y, ...f, e:2, a:1}
    ·           ────────────────────────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
    ╭─[sort_keys.tsx:1:11]
  1 │ var obj = {c:1, b:1, ...a}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `c:1, b:1` with `b:1, c:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -97,6 +110,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {...z, ...a, c:1, b:1}
    ·           ──────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `c:1, b:1` with `b:1, c:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -104,6 +118,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {...z, b:1, a:1, ...d, ...c}
    ·           ────────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b:1, a:1` with `a:1, b:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -111,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {...z, a:2, b:0, ...x, ...c}
    ·           ────────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:2, b:0` with `b:0, a:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -118,6 +134,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {...z, a:2, b:0, ...x}
    ·           ──────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:2, b:0` with `b:0, a:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -125,6 +142,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {...z, '':1, a:2}
    ·           ─────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'':1, a:2` with `a:2, '':1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -132,24 +150,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, [b+c]:2, '':3}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
    ╭─[sort_keys.tsx:1:11]
  1 │ var obj = {'':1, [b+c]:2, a:3}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
    ╭─[sort_keys.tsx:1:11]
  1 │ var obj = {b:1, [f()]:2, '':3, a:4}
    ·           ─────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
    ╭─[sort_keys.tsx:1:11]
  1 │ var obj = {a:1, c:{y:1, x:1}, b:1}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:{y:1, x:1}, b:1` with `a:1, b:1, c:{x:1, y:1}`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -157,6 +179,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:{y:1, x:1}, b:1}
    ·                   ──────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `y:1, x:1` with `x:1, y:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -164,6 +187,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // asc
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -171,6 +195,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `a:1, b:3, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -178,6 +203,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `a:2, b:3, b_:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -185,6 +211,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, c:2, C:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, c:2, C:3` with `C:3, b_:1, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -192,6 +219,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, _:2, A:3, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, _:2, A:3, a:4` with `$:1, A:3, _:2, a:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -199,6 +227,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, A:3, '11':2}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, A:3, '11':2` with `1:1, '11':2, 2:4, A:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -206,6 +235,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `'#':1, 'Z':2, À:3, è:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -213,6 +243,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -220,6 +251,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // asc, insensitive
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -227,6 +259,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `a:1, b:3, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -234,6 +267,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `a:2, b:3, b_:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -241,6 +275,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, A:3, _:2, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, A:3, _:2, a:4` with `$:1, _:2, A:3, a:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -248,6 +283,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, A:3, '11':2}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, A:3, '11':2` with `1:1, '11':2, 2:4, A:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -255,6 +291,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `'#':1, 'Z':2, À:3, è:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -262,6 +299,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -269,6 +307,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // asc, natural
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -276,6 +315,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `a:1, b:3, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -283,6 +323,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `a:2, b:3, b_:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -290,6 +331,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, c:2, C:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, c:2, C:3` with `C:3, b_:1, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -297,6 +339,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, A:3, _:2, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, A:3, _:2, a:4` with `$:1, _:2, A:3, a:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -304,6 +347,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, A:3, '11':2}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, A:3, '11':2` with `1:1, 2:4, '11':2, A:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -311,6 +355,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `'#':1, 'Z':2, À:3, è:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -318,6 +363,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -325,6 +371,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // asc, natural, insensitive
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -332,6 +379,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `a:1, b:3, c:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -339,6 +387,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `a:2, b:3, b_:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -346,6 +395,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, A:3, _:2, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, A:3, _:2, a:4` with `$:1, _:2, A:3, a:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -353,6 +403,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, '11':2, 2:4, A:3}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, '11':2, 2:4, A:3` with `1:1, 2:4, '11':2, A:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -360,6 +411,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `'#':1, 'Z':2, À:3, è:4`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -367,6 +419,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `_:2, a:1, b:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -374,6 +427,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'':1, a:'2'} // desc
    ·           ─────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'':1, a:'2'` with `a:'2', '':1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -381,6 +435,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {[``]:1, a:'2'} // desc
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `[``]:1, a:'2'` with `a:'2', [``]:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -388,6 +443,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // desc
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -395,6 +451,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `c:2, b:3, a:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -402,6 +459,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `b_:1, b:3, a:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -409,6 +467,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, c:2, C:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, c:2, C:3` with `c:2, b_:1, C:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -416,6 +475,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, _:2, A:3, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, _:2, A:3, a:4` with `a:4, _:2, A:3, $:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -423,6 +483,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, A:3, '11':2}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, A:3, '11':2` with `A:3, 2:4, '11':2, 1:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -430,6 +491,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `è:4, À:3, 'Z':2, '#':1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -437,6 +499,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -444,6 +507,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // desc, insensitive
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -451,6 +515,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `c:2, b:3, a:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -458,6 +523,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `b_:1, b:3, a:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -465,6 +531,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, c:2, C:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, c:2, C:3` with `c:2, C:3, b_:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -472,6 +539,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, _:2, A:3, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, _:2, A:3, a:4` with `A:3, a:4, _:2, $:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -479,6 +547,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, A:3, '11':2}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, A:3, '11':2` with `A:3, 2:4, '11':2, 1:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -486,6 +555,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `è:4, À:3, 'Z':2, '#':1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -493,6 +563,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -500,6 +571,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // desc, natural
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -507,6 +579,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `c:2, b:3, a:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -514,6 +587,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `b_:1, b:3, a:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -521,6 +595,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, c:2, C:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, c:2, C:3` with `c:2, b_:1, C:3`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -528,6 +603,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, _:2, A:3, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, _:2, A:3, a:4` with `a:4, A:3, _:2, $:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -535,6 +611,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, A:3, '11':2}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, A:3, '11':2` with `A:3, '11':2, 2:4, 1:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -542,6 +619,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `è:4, À:3, 'Z':2, '#':1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -549,6 +627,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -556,6 +635,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3} // desc, natural, insensitive
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -563,6 +643,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, c:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, c:2, b:3` with `c:2, b:3, a:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -570,6 +651,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, a:2, b:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, a:2, b:3` with `b_:1, b:3, a:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -577,6 +659,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {b_:1, c:2, C:3}
    ·           ────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b_:1, c:2, C:3` with `c:2, C:3, b_:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -584,6 +667,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {$:1, _:2, A:3, a:4}
    ·           ────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `$:1, _:2, A:3, a:4` with `A:3, a:4, _:2, $:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -591,6 +675,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {1:1, 2:4, '11':2, A:3}
    ·           ───────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `1:1, 2:4, '11':2, A:3` with `A:3, '11':2, 2:4, 1:1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -598,6 +683,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {'#':1, À:3, 'Z':2, è:4}
    ·           ────────────────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `'#':1, À:3, 'Z':2, è:4` with `è:4, À:3, 'Z':2, '#':1`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -605,6 +691,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var obj = {a:1, _:2, b:3}
    ·           ───────────────
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
@@ -617,6 +704,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                             }
  7 │                             
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b: 1,
                                         c: 2,
                                         a: 3` with `a: 3,
@@ -633,6 +721,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                             }
  7 │                             
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b
         
                                         ,a` with `a
@@ -651,6 +740,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                               }
  9 │                              
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b: 1,
                                         c () {
         
@@ -675,6 +765,7 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶                               }
  11 │                              
     ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
    ╭─[sort_keys.tsx:2:40]
@@ -688,6 +779,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                               }
  9 │                              
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
    ╭─[sort_keys.tsx:2:39]
@@ -699,6 +791,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                             }
  7 │                             
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
     ╭─[sort_keys.tsx:2:39]
@@ -714,6 +807,7 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶                             }
  11 │                             
     ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
     ╭─[sort_keys.tsx:2:39]
@@ -736,6 +830,7 @@ source: crates/oxc_linter/src/tester.rs
  17 │ ╰─▶                             }
  18 │                             
     ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
    ╭─[sort_keys.tsx:2:39]
@@ -746,6 +841,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                             }
  6 │                             
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
   help: Replace `b: "/*",
                                         a: "*/"` with `a: "*/",
                                         b: "/*"`.
@@ -760,6 +856,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                             };
  7 │                             
    ╰────
+  help: Sort the object keys in the configured order (ascending by default).
 
   ⚠ eslint(sort-keys): Object keys should be sorted
     ╭─[sort_keys.tsx:2:39]
@@ -774,3 +871,4 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶                             }
  10 │                             
     ╰────
+  help: Sort the object keys in the configured order (ascending by default).

--- a/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ jest.fn()
    ·      ──
    ╰────
+  help: Avoid using `jest.fn()` as it has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["fn"]()
    ·      ────
    ╰────
+  help: Avoid using `jest.fn()` as it has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest.mock()
    ·      ────
    ╰────
+  note: This Jest method has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["mock"]()
    ·      ──────
    ╰────
+  note: This Jest method has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:22]
@@ -33,18 +37,21 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───────────────────
  4 │             
    ╰────
+  help: Avoid using `jest.advanceTimersByTime()` as it has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.fn()
    ·    ──
    ╰────
+  help: Avoid using `jest.fn()` as it has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.mock()
    ·    ────
    ╰────
+  note: This Jest method has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:12]
@@ -53,9 +60,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────────
  4 │                 
    ╰────
+  help: Avoid using `jest.advanceTimersByTime()` as it has been restricted by project configuration.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi["fn"]()
    ·    ────
    ╰────
+  help: Avoid using `jest.fn()` as it has been restricted by project configuration.

--- a/crates/oxc_linter/src/snapshots/promise_always_return.snap
+++ b/crates/oxc_linter/src/snapshots/promise_always_return.snap
@@ -7,84 +7,98 @@ source: crates/oxc_linter/src/tester.rs
  1 │ hey.then(x => {})
    ·          ───────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { })
    ·          ──────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { }).then(x)
    ·          ──────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { }).then(function() { })
    ·          ──────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:31]
  1 │ hey.then(function() { }).then(function() { })
    ·                               ──────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:39]
  1 │ hey.then(function() { return; }).then(function() { })
    ·                                       ──────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { doSomethingWicked(); })
    ·          ───────────────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { return x; } })
    ·          ───────────────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { return x; } else { }})
    ·          ───────────────────────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { } else { return x; }})
    ·          ───────────────────────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { process.chdir(); } else { return x; }})
    ·          ────────────────────────────────────────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { return you.then(function() { return x; }); } })
    ·          ────────────────────────────────────────────────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:11]
  1 │ hey.then( x => { x ? x.id : null })
    ·           ────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function(x) { x ? x.id : null })
    ·          ───────────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
     ╭─[always_return.tsx:2:21]
@@ -99,6 +113,7 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶     })
  10 │     })()
     ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
@@ -108,6 +123,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       }
  5 │ ╰─▶ })
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
@@ -117,6 +133,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       }
  5 │ ╰─▶ })
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:2:11]
@@ -125,12 +142,14 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────────────────────────────────────────────────────────
  3 │     .then(function(y) { console.log(y) /* no error here */ })
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:22]
  1 │ const foo = hey.then(function(x) {});
    ·                      ──────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:2:21]
@@ -139,6 +158,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────
  3 │ }
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:2:27]
@@ -147,45 +167,53 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ───────────────────────
  3 │ }
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:23]
  1 │ const foo = hey?.then(x => { console.log(x) })
    ·                       ───────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { invalid = x })
    ·          ────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { invalid['x'] = x })
    ·          ─────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { wind[x] = x })
    ·          ────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { wind['x'] = x })
    ·          ──────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { windows['x'] = x })
    ·          ─────────────────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { x() })
    ·          ────────────
    ╰────
+  help: Add a `return` statement to the `then()` callback, or use `async/await` instead.

--- a/crates/oxc_linter/src/snapshots/promise_no_multiple_resolved.snap
+++ b/crates/oxc_linter/src/snapshots/promise_no_multiple_resolved.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  8 │     })
    ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 3.
    ╭─[no_multiple_resolved.tsx:6:5]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  7 │ })
    ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 2.
    ╭─[no_multiple_resolved.tsx:3:5]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  4 │ })
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
     ╭─[no_multiple_resolved.tsx:12:9]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  13 │     })
     ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 5.
     ╭─[no_multiple_resolved.tsx:9:9]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  10 │     })
     ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
     ╭─[no_multiple_resolved.tsx:9:9]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  10 │     })
     ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  9 │     }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 8.
     ╭─[no_multiple_resolved.tsx:11:5]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
     ·     ──────────────
  12 │ })
     ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 3.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  9 │     }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 3.
    ╭─[no_multiple_resolved.tsx:5:5]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  6 │ })
    ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:5]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  8 │ })
    ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:5]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ────────
  8 │ })
    ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 3.
    ╭─[no_multiple_resolved.tsx:5:9]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  6 │     }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:9]
@@ -113,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  8 │     }
    ╰────
+  help: Guard this resolve/reject call with a condition to ensure the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:9]
@@ -121,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  8 │     }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -129,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -137,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -145,6 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:13]
@@ -153,3 +171,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────
  9 │         }
    ╰────
+  help: Remove the duplicate resolve/reject call, or restructure the logic so the promise is only settled once.

--- a/crates/oxc_linter/src/snapshots/promise_param_names.snap
+++ b/crates/oxc_linter/src/snapshots/promise_param_names.snap
@@ -7,45 +7,53 @@ source: crates/oxc_linter/src/tester.rs
  1 │ new Promise(function(reject, resolve) {})
    ·                      ──────
    ╰────
+  help: Rename the parameters to match the pattern `^_?resolve$` (e.g., `resolve` and `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?reject$`
    ╭─[param_names.tsx:1:30]
  1 │ new Promise(function(reject, resolve) {})
    ·                              ───────
    ╰────
+  help: Rename the parameters to match the pattern `^_?reject$` (e.g., `resolve` and `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?reject$`
    ╭─[param_names.tsx:1:31]
  1 │ new Promise(function(resolve, rej) {})
    ·                               ───
    ╰────
+  help: Rename the parameters to match the pattern `^_?reject$` (e.g., `resolve` and `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?resolve$`
    ╭─[param_names.tsx:1:13]
  1 │ new Promise(yes => {})
    ·             ───
    ╰────
+  help: Rename the parameters to match the pattern `^_?resolve$` (e.g., `resolve` and `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?resolve$`
    ╭─[param_names.tsx:1:14]
  1 │ new Promise((yes, no) => {})
    ·              ───
    ╰────
+  help: Rename the parameters to match the pattern `^_?resolve$` (e.g., `resolve` and `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?reject$`
    ╭─[param_names.tsx:1:19]
  1 │ new Promise((yes, no) => {})
    ·                   ──
    ╰────
+  help: Rename the parameters to match the pattern `^_?reject$` (e.g., `resolve` and `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^yes$`
    ╭─[param_names.tsx:1:22]
  1 │ new Promise(function(resolve, reject) { config(); })
    ·                      ───────
    ╰────
+  help: Rename the parameters to match the pattern `^yes$` (e.g., `resolve` and `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^no$`
    ╭─[param_names.tsx:1:31]
  1 │ new Promise(function(resolve, reject) { config(); })
    ·                               ──────
    ╰────
+  help: Rename the parameters to match the pattern `^no$` (e.g., `resolve` and `reject`).

--- a/crates/oxc_linter/src/snapshots/promise_spec_only.snap
+++ b/crates/oxc_linter/src/snapshots/promise_spec_only.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.done()
    · ────────────
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.done`.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.done()
    · ────────────
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.done`.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.something` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.something()
    · ─────────────────
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.something`.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:5]
  1 │ new Promise.done()
    ·     ────────────
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.done`.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:4:22]
@@ -33,6 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────────
  5 │             }
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.done`.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:3:20]
@@ -41,15 +46,18 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ────────────
  4 │             }
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.done`.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.notPermittedMethod` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.notPermittedMethod()
    · ──────────────────────────
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.notPermittedMethod`.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.differingCase` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.differingCase()
    · ─────────────────────
    ╰────
+  help: Use a spec-compliant Promise method instead of `Promise.differingCase`.

--- a/crates/oxc_linter/src/snapshots/promise_valid_params.snap
+++ b/crates/oxc_linter/src/snapshots/promise_valid_params.snap
@@ -7,141 +7,165 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.resolve(1, 2)
    · ─────────────────────
    ╰────
+  help: Pass 0 or 1 arguments to `Promise.resolve()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.resolve()` requires 0 or 1 arguments, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.resolve({}, function() {}, 1, 2, 3)
    · ───────────────────────────────────────────
    ╰────
+  help: Pass 0 or 1 arguments to `Promise.resolve()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject(1, 2, 3)
    · ───────────────────────
    ╰────
+  help: Pass 0 or 1 arguments to `Promise.reject()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject({}, function() {}, 1, 2)
    · ───────────────────────────────────────
    ╰────
+  help: Pass 0 or 1 arguments to `Promise.reject()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race(1, 2)
    · ──────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.race()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race({}, function() {}, 1, 2, 3)
    · ────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.race()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all(1, 2, 3)
    · ────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.all()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.all()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled(1, 2, 3)
    · ───────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.allSettled()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled({}, function() {}, 1, 2)
    · ───────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.allSettled()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any(1, 2, 3)
    · ────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.any()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.any()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then()
    · ────────────────────
    ╰────
+  help: Pass 1 or 2 arguments to `Promise.then()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then(() => {}, () => {}, () => {})
    · ────────────────────────────────────────────────
    ╰────
+  help: Pass 1 or 2 arguments to `Promise.then()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then()
    · ───────────────────────
    ╰────
+  help: Pass 1 or 2 arguments to `Promise.then()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then(() => {}, () => {}, () => {})
    · ───────────────────────────────────────────────────
    ╰────
+  help: Pass 1 or 2 arguments to `Promise.then()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch()
    · ─────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.catch()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch(() => {}, () => {})
    · ───────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.catch()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch()
    · ────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.catch()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch(() => {}, () => {})
    · ──────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.catch()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally()
    · ───────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.finally()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally(() => {}, () => {})
    · ─────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.finally()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally()
    · ──────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.finally()`.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally(() => {}, () => {})
    · ────────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to `Promise.finally()`.

--- a/crates/oxc_linter/src/snapshots/react_jsx_max_depth.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_max_depth.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ───────
  4 │                     </App>
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 1 exceeds the configured maximum of 0
    ╭─[jsx_max_depth.tsx:3:14]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     </App>
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:16]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────
  5 │                       </foo>
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:3:12]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────
  4 │                   
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:12]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────
  5 │                   
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:12]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────────
  5 │                   
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 3 exceeds the configured maximum of 2
    ╭─[jsx_max_depth.tsx:3:23]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ────────
  4 │                     </div>
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 1 exceeds the configured maximum of 0
    ╭─[jsx_max_depth.tsx:3:14]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ───────
  4 │                     </>
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:16]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────
  5 │                       </>
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:12]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ────────────
  5 │                   
    ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
     ╭─[jsx_max_depth.tsx:8:12]
@@ -90,6 +100,7 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶                     </tbody>
  11 │                       
     ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 5 exceeds the configured maximum of 4
     ╭─[jsx_max_depth.tsx:9:22]
@@ -99,3 +110,4 @@ source: crates/oxc_linter/src/tester.rs
  11 │ ╰─▶                               </Button>
  12 │                                 </div>
     ╰────
+  help: Extract nested JSX into separate components to reduce nesting depth.

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_comment_textnodes.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_comment_textnodes.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ──────────
  5 │                       }
    ╰────
+  help: Wrap the comment in braces: `{/* comment */}`.
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:4:26]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ──────────
  5 │                       }
    ╰────
+  help: Wrap the comment in braces: `{/* comment */}`.
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:4:29]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ─────────────
  5 │                       }
    ╰────
+  help: Wrap the comment in braces: `{/* comment */}`.
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:5:23]
@@ -34,6 +37,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                           </div>
  8 │                             );
    ╰────
+  help: Wrap the comment in braces: `{/* comment */}`.
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
     ╭─[jsx_no_comment_textnodes.tsx:5:23]
@@ -45,6 +49,7 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶                           </div>
  10 │                             );
     ╰────
+  help: Wrap the comment in braces: `{/* comment */}`.
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:6:30]
@@ -54,6 +59,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                             {'foo'}
  9 │                               </div>
    ╰────
+  help: Wrap the comment in braces: `{/* comment */}`.
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:3:27]
@@ -62,3 +68,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                    ──
  4 │                     };
    ╰────
+  help: Wrap the comment in braces: `{/* comment */}`.

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_undef.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_undef.snap
@@ -7,45 +7,53 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var React; React.render(<App />);
    ·                          ───
    ╰────
+  help: Import or define 'App' before using it in JSX.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'Appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<Appp.Foo />);
    ·                          ────
    ╰────
+  help: Import or define 'Appp' before using it in JSX.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<appp.Foo />);
    ·                          ────
    ╰────
+  help: Import or define 'appp' before using it in JSX.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<appp.foo.Bar />);
    ·                          ────
    ╰────
+  help: Import or define 'appp' before using it in JSX.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'Foo' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<Foo />);
    ·                          ───
    ╰────
+  help: Import or define 'Foo' before using it in JSX.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'Unknown' is not defined.
    ╭─[jsx_no_undef.tsx:1:35]
  1 │ var React; Unknown; React.render(<Unknown />)
    ·                                   ───────
    ╰────
+  help: Import or define 'Unknown' before using it in JSX.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'App' is not defined.
    ╭─[jsx_no_undef.tsx:1:49]
  1 │ var React; { const App = null; }; React.render(<App />);
    ·                                                 ───
    ╰────
+  help: Import or define 'App' before using it in JSX.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'App' is not defined.
    ╭─[jsx_no_undef.tsx:1:42]
  1 │ var React; enum A { App }; React.render(<App />);
    ·                                          ───
    ╰────
+  help: Import or define 'App' before using it in JSX.

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_useless_fragment.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_useless_fragment.snap
@@ -7,18 +7,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <></>
    · ──
    ╰────
+  help: Remove the fragment and render the child directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:1]
  1 │ <>{}</>
    · ──
    ╰────
+  help: Remove the fragment and render the child directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:7]
  1 │ <p>moo<>foo</></p>
    ·       ──
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Replace `<>foo</>` with `foo`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -26,6 +29,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <p>moo<>foo</></p>
    ·       ──
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>foo</>` with `foo`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
@@ -33,12 +37,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <>{meow}</>
    · ──
    ╰────
+  help: Remove the fragment and render the child directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:4]
  1 │ <p><>{meow}</></p>
    ·    ──
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Replace `<>{meow}</>` with `{meow}`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -46,6 +52,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <p><>{meow}</></p>
    ·    ──
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>{meow}</>` with `{meow}`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
@@ -53,6 +60,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <><div/></>
    · ──
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Replace `<><div/></>` with `<div/>`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
@@ -62,6 +70,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──
  3 │               <div/>
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Replace `<>
                       <div/>
                     </>` with `<div/>`.
@@ -71,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <Fragment />
    · ────────────
    ╰────
+  help: Remove the fragment and render the child directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:2:17]
@@ -79,6 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────
  3 │                   <Foo />
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Replace `<React.Fragment>
                           <Foo />
                         </React.Fragment>` with `<Foo />`.
@@ -88,12 +99,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <Eeee><>foo</></Eeee>
    ·       ──
    ╰────
+  help: Remove the fragment and render the child directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:6]
  1 │ <div><>foo</></div>
    ·      ──
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Replace `<>foo</>` with `foo`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -101,6 +114,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div><>foo</></div>
    ·      ──
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>foo</>` with `foo`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -108,6 +122,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div><>{"a"}{"b"}</></div>
    ·      ──
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>{"a"}{"b"}</>` with `{"a"}{"b"}`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -115,6 +130,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div><>{"a"}{"b"}</></div>
    ·      ──
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>{"a"}{"b"}</>` with `{"a"}{"b"}`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -124,6 +140,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──
  6 │             </section>
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>{"a"}{"b"}</>` with `{"a"}{"b"}`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -131,6 +148,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div><Fragment>{"a"}{"b"}</Fragment></div>
    ·      ──────────
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<Fragment>{"a"}{"b"}</Fragment>` with `{"a"}{"b"}`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -140,6 +158,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ──
  4 │                 <b>hub</b>.
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>
                         <b>hub</b>.
                       </>` with `<b>hub</b>.`.
@@ -151,6 +170,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ──
  8 │             </section>
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<> <b>hub</b></>` with ` <b>hub</b>`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -158,6 +178,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div>a <>{""}{""}</> a</div>
    ·        ──
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Replace `<>{""}{""}</>` with `{""}{""}`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
@@ -167,6 +188,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────
  5 │               </html>
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Remove `<React.Fragment />`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
@@ -176,6 +198,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────
  5 │               </html>
    ╰────
+  help: Remove the fragment and pass the children directly to the HTML element.
   help: Remove `<React.Fragment />`.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
@@ -183,4 +206,5 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <><Foo>{moo}</Foo></>
    · ──
    ╰────
+  help: Remove the fragment and render the child directly.
   help: Replace `<><Foo>{moo}</Foo></>` with `<Foo>{moo}</Foo>`.

--- a/crates/oxc_linter/src/snapshots/react_jsx_props_no_spreading.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_props_no_spreading.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  3 │                   
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:2:26]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  3 │                   
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:2:26]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  3 │                   
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:5:30]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                              ──────────
  6 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:29]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──────────
  7 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:29]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──────────
  7 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:5:31]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ──────────
  6 │                        <img {...props}/>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:29]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──────────
  7 │                        <div {...props}/>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:31]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ──────────
  7 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:28]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ────────────────────────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:28]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ───────────────────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:28]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─────────────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:28]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ───────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:4:42]
@@ -113,3 +126,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                          ──────────
  5 │                        <Nav.Item {...props}/>
    ╰────
+  help: Pass each prop individually instead of using the spread operator.

--- a/crates/oxc_linter/src/snapshots/react_no_redundant_should_component_update.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_redundant_should_component_update.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove the `shouldComponentUpdate` method from Foo. `React.PureComponent` already implements shallow prop and state comparison.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Foo does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:3:14]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove the `shouldComponentUpdate` method from Foo. `React.PureComponent` already implements shallow prop and state comparison.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Foo does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:3:14]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove the `shouldComponentUpdate` method from Foo. `React.PureComponent` already implements shallow prop and state comparison.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Bar does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:4:16]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────────────
  5 │                           return true;
    ╰────
+  help: Remove the `shouldComponentUpdate` method from Bar. `React.PureComponent` already implements shallow prop and state comparison.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Bar does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:4:16]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────────────
  5 │                           return true;
    ╰────
+  help: Remove the `shouldComponentUpdate` method from Bar. `React.PureComponent` already implements shallow prop and state comparison.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Foo does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:3:14]
@@ -49,3 +54,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove the `shouldComponentUpdate` method from Foo. `React.PureComponent` already implements shallow prop and state comparison.

--- a/crates/oxc_linter/src/snapshots/react_no_set_state.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_set_state.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use React hooks (`useState`) in functional components, or consider using an external state management solution.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use React hooks (`useState`) in functional components, or consider using an external state management solution.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use React hooks (`useState`) in functional components, or consider using an external state management solution.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use React hooks (`useState`) in functional components, or consider using an external state management solution.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:48]
@@ -41,3 +45,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                         ─────────────
  5 │                       }
    ╰────
+  help: Use React hooks (`useState`) in functional components, or consider using an external state management solution.

--- a/crates/oxc_linter/src/snapshots/react_no_unescaped_entities.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unescaped_entities.snap
@@ -25,6 +25,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ─
  5 │             }
    ╰────
+  help: Replace `'` with the HTML entity &apos; or &lsquo; or &#39; or &rsquo; to avoid ambiguity in JSX.
 
   × Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
    ╭─[no_unescaped_entities.tsx:4:60]
@@ -39,15 +40,18 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <script>window.foo = "bar"</script>
    ·                      ─
    ╰────
+  help: Replace `"` with the HTML entity &quot; or &ldquo; or &#34; or &rdquo; to avoid ambiguity in JSX.
 
   ⚠ eslint-plugin-react(no-unescaped-entities): `"` can be escaped with &quot; or &ldquo; or &#34; or &rdquo;
    ╭─[no_unescaped_entities.tsx:1:26]
  1 │ <script>window.foo = "bar"</script>
    ·                          ─
    ╰────
+  help: Replace `"` with the HTML entity &quot; or &ldquo; or &#34; or &rdquo; to avoid ambiguity in JSX.
 
   ⚠ eslint-plugin-react(no-unescaped-entities): `"` can be escaped with &quot; or &ldquo; or &#34; or &rdquo;
    ╭─[no_unescaped_entities.tsx:1:16]
  1 │ <script>测试 " 测试</script>
    ·              ─
    ╰────
+  help: Replace `"` with the HTML entity &quot; or &ldquo; or &#34; or &rdquo; to avoid ambiguity in JSX.

--- a/crates/oxc_linter/src/snapshots/react_only_export_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_only_export_components.snap
@@ -7,78 +7,91 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export const foo = () => {}; export const Bar = () => {};
    ·              ───
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:14]
  1 │ export const foo = () => {}; export const Bar = () => {};
    ·              ───
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:14]
  1 │ export const foo = 4; export const Bar = () => {};
    ·              ───
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:46]
  1 │ export function Component() {}; export const Aa = 'a'
    ·                                              ──
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:47]
  1 │ const foo = 4; const Bar = () => {}; export { foo, Bar };
    ·                                               ───
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): This rule can't verify that `export *` only exports components.
    ╭─[only_export_components.tsx:1:1]
  1 │ export * from './foo';
    · ──────────────────────
    ╰────
+  help: Replace `export *` with explicit named exports to ensure only components are exported.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:1]
  1 │ export default () => {};
    · ────────────────────────
    ╰────
+  help: Add a name to the component function or variable before exporting it.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:1]
  1 │ export default memo(() => {});
    · ──────────────────────────────
    ╰────
+  help: Add a name to the component function or variable before exporting it.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:16]
  1 │ export default function () {};
    ·                ──────────────
    ╰────
+  help: Add a name to the component function or variable before exporting it.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:14]
  1 │ export const CONSTANT = 3; export const Foo = () => {};
    ·              ────────
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:13]
  1 │ export enum Tab { Home, Settings }; export const Bar = () => {};
    ·             ───
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const Tab = () => {}; export const tabs = [<Tab />, <Tab />];
    ·       ───
    ╰────
+  help: Move your component(s) to a separate file that only contains component exports.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file has exports. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const App = () => {}; createRoot(document.getElementById('root')).render(<App />);
    ·       ───
    ╰────
+  help: Add an export statement for your component(s), or move them to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:3:22]
@@ -87,45 +100,53 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────
  4 │         
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:1]
  1 │ export default compose()(MainView);
    · ───────────────────────────────────
    ╰────
+  help: Add a name to the component function or variable before exporting it.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:75]
  1 │ export const loader = () => {}; export const Bar = () => {}; export const foo = () => {};
    ·                                                                           ───
    ╰────
+  help: Move non-component exports (constants, functions, types) to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const Foo = () => {}; export { Foo as "🍌"}
    ·       ───
    ╰────
+  help: Move your component(s) to a separate file that only contains component exports.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your React context(s) to a separate file.
    ╭─[only_export_components.tsx:1:51]
  1 │ export const MyComponent = () => {}; export const MyContext = createContext('test');
    ·                                                   ─────────
    ╰────
+  help: Move your React context(s) to a separate file so that components get their own module.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your React context(s) to a separate file.
    ╭─[only_export_components.tsx:1:51]
  1 │ export const MyComponent = () => {}; export const MyContext = React.createContext('test');
    ·                                                   ─────────
    ╰────
+  help: Move your React context(s) to a separate file so that components get their own module.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:31]
  1 │ const MyComponent = () => {}; export default observer(MyComponent);
    ·                               ─────────────────────────────────────
    ╰────
+  help: Add a name to the component function or variable before exporting it.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const MyComponent = () => {}; export default observer(MyComponent);
    ·       ───────────
    ╰────
+  help: Move your component(s) to a separate file that only contains component exports.

--- a/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  3 │               displayName: 'Hello',
    ╰────
+  help: Replace `createReactClass` with an ES2015 class or a function component.
 
   ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of `createReactClass`.
    ╭─[prefer_es6_class.tsx:2:25]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  3 │               render: function() {
    ╰────
+  help: Replace `createReactClass` with an ES2015 class or a function component.
 
   ⚠ eslint-plugin-react(prefer-es6-class): Components should use `createReactClass` instead of an ES2015 class.
    ╭─[prefer_es6_class.tsx:2:19]
@@ -25,3 +27,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────
  3 │               render() {
    ╰────
+  help: Replace the ES2015 class with `createReactClass`.

--- a/crates/oxc_linter/src/snapshots/react_style_prop_object.snap
+++ b/crates/oxc_linter/src/snapshots/react_style_prop_object.snap
@@ -7,18 +7,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div style="color: 'red'" />
    ·            ──────────────
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:14]
  1 │ <Hello style="color: 'green'" />
    ·              ────────────────
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:12]
  1 │ <div style={true} />
    ·            ──────
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
@@ -27,6 +30,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────
  5 │               }
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
@@ -35,6 +39,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────
  5 │               }
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:37]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ────────
  5 │               }
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
@@ -51,18 +57,21 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────
  5 │               }
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:20]
  1 │ <MyComponent style="myStyle" />
    ·                    ─────────
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:44]
  1 │ React.createElement(MyComponent2, { style: "mySpecialStyle" })
    ·                                            ────────────────
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
@@ -71,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────────
  4 │           
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
@@ -79,6 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────────
  4 │           
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
@@ -87,3 +98,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────────
  4 │           
    ╰────
+  help: Pass an object to the `style` prop, e.g., `style={{ color: 'red' }}`.


### PR DESCRIPTION
## Summary

Adds `with_help()` or `with_note()` to diagnostic functions that were only emitting a warning/error message without any actionable guidance. This makes diagnostics more helpful by providing context on how to fix the issue.

**22 rules updated across 4 categories:**

### eslint (5 rules)
- `no_undefined` — suggests using `void 0` or avoiding `undefined`
- `prefer_numeric_literals` — suggests using `0b`/`0o`/`0x` literal prefixes
- `prefer_object_has_own` — suggests `Object.hasOwn()`
- `sort_imports` — context-specific help for syntax order, alphabetical, and member sorting
- `sort_keys` — suggests sorting in configured order

### jest (1 rule)
- `no_restricted_jest_methods` — adds help for generic restrictions and note for custom messages

### promise (5 rules)
- `always_return` — suggests adding `return` or using `async/await`
- `no_multiple_resolved` — context-specific help for definite vs potential duplicates
- `param_names` — suggests renaming to match pattern
- `spec_only` — suggests using spec-compliant methods
- `valid_params` — argument count guidance per method

### react (11 rules)
- `jsx_max_depth` — suggests extracting components
- `jsx_no_comment_textnodes` — shows `{/* comment */}` syntax
- `jsx_no_undef` — suggests importing/defining the component
- `jsx_no_useless_fragment` — context-specific help for single-child and HTML-element cases
- `jsx_props_no_spreading` — suggests passing props individually
- `no_redundant_should_component_update` — explains PureComponent behavior
- `no_set_state` — suggests hooks or external state management
- `no_unescaped_entities` — shows the HTML entity replacement
- `only_export_components` — context-specific help for 6 diagnostic variants
- `prefer_es6_class` — direction-specific help
- `style_prop_object` — shows correct object syntax

Closes #19121 (partial — covers rules that were still missing help/notes at time of writing)