### PR TITLE
feat(oxlint): add --skip-type-aware flag

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -54,6 +54,11 @@ pub struct LintCommand {
     #[bpaf(switch, hide_usage)]
     pub type_aware: bool,
 
+    /// Disable type-aware rules even if enabled in the config file.
+    /// Useful for overriding `typeAware: true` in config (e.g. for fast pre-commit hooks).
+    #[bpaf(switch, hide_usage)]
+    pub skip_type_aware: bool,
+
     /// Enable experimental type checking (includes TypeScript compiler diagnostics)
     #[bpaf(switch, hide_usage)]
     pub type_check: bool,

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -337,11 +337,12 @@ impl CliRunner {
             LintServiceOptions::new(self.cwd.clone()).with_cross_module(use_cross_module);
 
         let config_store = ConfigStore::new(lint_config, nested_configs, external_plugin_store);
+        let skip_type_aware = self.options.skip_type_aware;
         let type_check_only = self.options.type_check_only;
-        let type_aware =
-            type_check_only || self.options.type_aware || config_store.type_aware_enabled();
-        let type_check =
-            type_check_only || self.options.type_check || config_store.type_check_enabled();
+        let type_aware = !skip_type_aware
+            && (type_check_only || self.options.type_aware || config_store.type_aware_enabled());
+        let type_check = !skip_type_aware
+            && (type_check_only || self.options.type_check || config_store.type_check_enabled());
         if type_check && !type_aware {
             print_and_flush_stdout(
                 stdout,
@@ -1443,6 +1444,14 @@ mod test {
     fn test_tsgolint_config_type_aware_false_overridden_by_cli_flag() {
         let args =
             &["--type-aware", "-c", "config-type-aware-false.json", "no-floating-promises.ts"];
+        Tester::new().with_cwd("fixtures/cli/tsgolint".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    #[cfg(not(target_endian = "big"))]
+    fn test_tsgolint_config_type_aware_true_overridden_by_skip_flag() {
+        let args =
+            &["--skip-type-aware", "-c", "config-type-aware.json", "no-floating-promises.ts"];
         Tester::new().with_cwd("fixtures/cli/tsgolint".into()).test_and_snapshot(args);
     }
 

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_--skip-type-aware -c config-type-aware.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_--skip-type-aware -c config-type-aware.json no-floating-promises.ts@oxlint.snap
@@ -1,0 +1,13 @@
+---
+source: apps/oxlint/src/tester.rs
+assertion_line: 134
+---
+########## 
+arguments: --skip-type-aware -c config-type-aware.json no-floating-promises.ts
+working directory: fixtures/cli/tsgolint
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------


### PR DESCRIPTION
Adds a `--skip-type-aware` CLI flag that disables type-aware rules even when `typeAware: true` is set in the config.

**Motivation:** Users who want the VS Code extension to run type-aware rules (requires `options.typeAware: true` in config) currently cannot disable type-aware at the CLI level. This forces them to keep the config flag off and pass `--type-aware` explicitly, which means the VS Code extension never sees it enabled. With `--skip-type-aware`, users can keep the config setting enabled (for the extension) and override it in fast pre-commit hooks.

**Implementation notes:**
- `--skip-type-aware` takes precedence over all other sources (`--type-aware`, `--type-check-only`, config `typeAware`)
- Also suppresses `type_check` when set, since `type_check` implies `type_aware` and would otherwise hit the existing `type_check && !type_aware` validation error