### PR TITLE
refactor(allocator): fix `legacy_numeric_constants` clippy warnings

### DIFF
--- a/crates/oxc_allocator/src/bumpalo_alloc.rs
+++ b/crates/oxc_allocator/src/bumpalo_alloc.rs
@@ -11,7 +11,6 @@
 #![expect(
     clippy::collapsible_if,
     clippy::equatable_if_let,
-    clippy::legacy_numeric_constants,
     clippy::missing_safety_doc,
     clippy::redundant_closure_for_method_calls,
     clippy::undocumented_unsafe_blocks,
@@ -33,7 +32,6 @@ use core::cmp;
 use core::fmt;
 use core::mem;
 use core::ptr::{self, NonNull};
-use core::usize;
 
 pub use core::alloc::{Layout, LayoutErr};
 


### PR DESCRIPTION
Same as stack starting at #21210.

`bumpalo_alloc.rs` was copied directly from `bumpalo`. `bumpalo` supports much older Rust versions than Oxc does, so uses patterns which are flagged by Clippy in more recent versions. #20963 silenced these clippy errors/warnings with a large `#[expect]` block at the top of the file.

This stack of PRs fixes these warnings and removes the `#[expect(clippy:...)]` comments. All PRs in this stack were generated by Claude.  I had him split them into 1 PR per clippy rule so that I could review each in isolation - some of the changes, especially around pointers, are quite subtlle.