### PR TITLE
feat(str)!: remove identity `FromIn` impl for `Ident`

### DIFF
--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -427,14 +427,6 @@ impl<'a> Dummy<'a> for Ident<'a> {
     }
 }
 
-impl<'alloc> FromIn<'alloc, &Ident<'alloc>> for Ident<'alloc> {
-    #[expect(clippy::inline_always)]
-    #[inline(always)] // Because this is a no-op
-    fn from_in(s: &Ident<'alloc>, _: &'alloc Allocator) -> Self {
-        *s
-    }
-}
-
 impl<'alloc> FromIn<'alloc, &str> for Ident<'alloc> {
     #[inline]
     fn from_in(s: &str, allocator: &'alloc Allocator) -> Self {


### PR DESCRIPTION
`Ident` had an identity implementation of `FromIn` trait:

```rust
impl<'a> FromIn<'a, &Ident<'a>> for Ident<'a> {
    fn from_in(s: &Ident<'a>, _: &'a Allocator) -> Self {
        *s
    }
}
```

`FromIn` is intended for conversion from one type to another, not a type to itself, and it's dead code anyway. So remove it.