### PR TITLE
docs(allocator): upper case `SAFETY` in comments

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -2227,7 +2227,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// the most recent allocation being earlier in the slice, and the least
     /// recent allocation being towards the end of the slice.
     ///
-    /// ## Safety
+    /// # SAFETY
     ///
     /// Because this method takes `&mut self`, we know that the bump arena
     /// reference is unique and therefore there aren't any active references to
@@ -2302,7 +2302,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// }
     /// ```
     pub fn iter_allocated_chunks(&mut self) -> ChunkIter<'_, MIN_ALIGN> {
-        // Safety: Ensured by mutable borrow of `self`.
+        // SAFETY: Ensured by mutable borrow of `self`.
         let raw = unsafe { self.iter_allocated_chunks_raw() };
         ChunkIter { raw, bump: PhantomData }
     }
@@ -2315,7 +2315,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// well as ensuring that the iterator is not invalidated by new
     /// allocations.
     ///
-    /// ## Safety
+    /// # SAFETY
     ///
     /// Allocations from this arena must not be performed while the returned
     /// iterator is alive. If reading the chunk data (or casting to a reference)

--- a/crates/oxc_allocator/src/bumpalo_alloc.rs
+++ b/crates/oxc_allocator/src/bumpalo_alloc.rs
@@ -241,7 +241,7 @@ pub unsafe trait Alloc {
     /// behavior, e.g. to ensure initialization to particular sets of
     /// bit patterns.)
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure that `layout` has non-zero size.
@@ -271,7 +271,7 @@ pub unsafe trait Alloc {
 
     /// Deallocate the memory referenced by `ptr`.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure all of the following:
@@ -340,7 +340,7 @@ pub unsafe trait Alloc {
     /// block has not been transferred to this allocator, and the
     /// contents of the memory block are unaltered.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure all of the following:
@@ -415,7 +415,7 @@ pub unsafe trait Alloc {
     /// Behaves like `alloc`, but also ensures that the contents
     /// are set to zero before being returned.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe for the same reasons that `alloc` is.
     ///
@@ -443,7 +443,7 @@ pub unsafe trait Alloc {
     /// the returned block. For some `layout` inputs, like arrays, this
     /// may include extra storage usable for additional data.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe for the same reasons that `alloc` is.
     ///
@@ -467,7 +467,7 @@ pub unsafe trait Alloc {
     /// the returned block. For some `layout` inputs, like arrays, this
     /// may include extra storage usable for additional data.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe for the same reasons that `realloc` is.
     ///
@@ -506,7 +506,7 @@ pub unsafe trait Alloc {
     /// memory block referenced by `ptr` has not been transferred, and
     /// the contents of the memory block are unaltered.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure all of the following:
@@ -558,7 +558,7 @@ pub unsafe trait Alloc {
     /// the memory block has not been transferred, and the contents of
     /// the memory block are unaltered.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure all of the following:
@@ -644,7 +644,7 @@ pub unsafe trait Alloc {
     ///
     /// Captures a common usage pattern for allocators.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure both:
@@ -713,7 +713,7 @@ pub unsafe trait Alloc {
     /// The returned block is suitable for passing to the
     /// `alloc`/`realloc` methods of this allocator.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure all of the following:
@@ -760,7 +760,7 @@ pub unsafe trait Alloc {
     ///
     /// Captures a common usage pattern for allocators.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This function is unsafe because undefined behavior can result
     /// if the caller does not ensure both:

--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -527,10 +527,9 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
 
     /// Creates a `Vec<'a, T>` directly from the raw components of another vector.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
-    /// This is highly unsafe, due to the number of invariants that aren't
-    /// checked:
+    /// This is highly unsafe, due to the number of invariants that aren't checked:
     ///
     /// * `ptr` needs to have been previously allocated via [`String`] / `Vec<'a, T>`
     ///   (at least, it's highly likely to be incorrect if it wasn't).
@@ -653,7 +652,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// This will explicitly set the size of the vector, without actually modifying its buffers,
     /// so it is up to the caller to ensure that the vector is actually the specified size.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// * `new_len` must be less than or equal to `u32::MAX`.
     /// * `new_len` must be less than or equal to [`capacity()`].


### PR DESCRIPTION
Comments-only change. Upper-case `SAFETY` in comments, following the convention we use elsewhere in the repo.