### PR TITLE
refactor(allocator): use `std` instead of `core`

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -7,21 +7,19 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
-#[doc(hidden)]
-pub extern crate alloc as core_alloc;
-
 use crate::bumpalo_alloc;
 
-use core::cell::Cell;
-use core::cmp::Ordering;
-use core::fmt::Display;
-use core::iter;
-use core::marker::PhantomData;
-use core::mem;
-use core::ptr::{self, NonNull};
-use core::slice;
-use core::str;
-use core_alloc::alloc::{Layout, alloc, dealloc};
+use std::{
+    alloc::{Layout, alloc, dealloc},
+    cell::Cell,
+    cmp::Ordering,
+    fmt::Display,
+    iter,
+    marker::PhantomData,
+    mem,
+    ptr::{self, NonNull},
+    slice, str,
+};
 
 use allocator_api2::alloc::{AllocError, Allocator};
 
@@ -45,7 +43,7 @@ impl<E> From<AllocErr> for AllocOrInitError<E> {
     }
 }
 impl<E: Display> Display for AllocOrInitError<E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AllocOrInitError::Alloc(err) => err.fmt(f),
             AllocOrInitError::Init(err) => write!(f, "initialization failed: {err}"),
@@ -432,7 +430,7 @@ pub(crate) unsafe fn round_up_to_unchecked(n: usize, divisor: usize) -> usize {
         x
     } else {
         debug_assert!(false, "round_up_to_unchecked failed");
-        unsafe { core::hint::unreachable_unchecked() }
+        unsafe { std::hint::unreachable_unchecked() }
     }
 }
 
@@ -1468,7 +1466,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         let layout = Layout::for_value(src);
         let dst = self.try_alloc_layout(layout)?.cast::<T>();
         let result = unsafe {
-            core::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_ptr(), src.len());
+            std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_ptr(), src.len());
             slice::from_raw_parts_mut(dst.as_ptr(), src.len())
         };
         Ok(result)
@@ -2350,7 +2348,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// let bump = Bump::new();
     /// let _x = bump.alloc_slice_fill_default::<u32>(5);
     /// let bytes = bump.allocated_bytes();
-    /// assert!(bytes >= core::mem::size_of::<u32>() * 5);
+    /// assert!(bytes >= std::mem::size_of::<u32>() * 5);
     /// ```
     pub fn allocated_bytes(&self) -> usize {
         let footer = self.current_chunk_footer.get();

--- a/crates/oxc_allocator/src/bumpalo_alloc.rs
+++ b/crates/oxc_allocator/src/bumpalo_alloc.rs
@@ -18,12 +18,11 @@
 //! This module was originally copied from `bumpalo` at commit a47f6d6b7b5fee9c99a285f0de80257a0a982ef3
 //! (2 commits after 3.20.2 release). Changes have been made since.
 
-use core::cmp;
-use core::fmt;
-use core::mem;
-use core::ptr::{self, NonNull};
-
-pub use core::alloc::{Layout, LayoutErr};
+use std::{
+    alloc::{Layout, LayoutErr},
+    cmp, fmt, mem,
+    ptr::{self, NonNull},
+};
 
 #[cold]
 fn new_layout_err() -> LayoutErr {


### PR DESCRIPTION
We don't support `no_std`, and import from `std` instead of `core`. Follow that convention here.