### PR TITLE
refactor(allocator): remove `#[deny]` attributes

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -4,8 +4,6 @@
 //! (2 commits after 3.20.2 release). Changes have been made since.
 
 #![expect(clippy::inline_always, clippy::undocumented_unsafe_blocks)]
-#![deny(missing_debug_implementations)]
-#![deny(missing_docs)]
 
 use std::{
     alloc::{Layout, alloc, dealloc},


### PR DESCRIPTION
Small refactor. We don't need these, remove them.