### PR TITLE
fix(parser): add missing error code for optional param diagnostic

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -427,7 +427,7 @@ pub fn invalid_binding_rest_element(span: Span) -> OxcDiagnostic {
 
 #[cold]
 pub fn a_rest_parameter_cannot_be_optional(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A rest parameter cannot be optional")
+    ts_error("1047", "A rest parameter cannot be optional")
         .with_label(span)
         .with_help("Remove this `?`. The default value is an empty array")
 }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12265,7 +12265,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try inserting a semicolon here
 
-  × A rest parameter cannot be optional
+  × TS(1047): A rest parameter cannot be optional
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-rest-optional-parameter/input.ts:1:14]
  1 │ async(...args?: any[]) : any => {}
    ·              ─

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -6481,7 +6481,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ╰────
   help: Try inserting a semicolon here
 
-  × A rest parameter cannot be optional
+  × TS(1047): A rest parameter cannot be optional
    ╭─[typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts:2:8]
  1 │ (arg1?, arg2) => 101;
  2 │ (...arg?) => 102;
@@ -8696,7 +8696,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  19 │ var t4 =
     ╰────
 
-  × A rest parameter cannot be optional
+  × TS(1047): A rest parameter cannot be optional
     ╭─[typescript/tests/cases/compiler/noCrashOnMixin2.ts:11:40]
  10 │ 
  11 │ type Constructor<T = {}> = new (...args?: any[]) => T;
@@ -10517,7 +10517,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                  ─
    ╰────
 
-  × A rest parameter cannot be optional
+  × TS(1047): A rest parameter cannot be optional
    ╭─[typescript/tests/cases/compiler/restParamAsOptional.ts:1:16]
  1 │ function f(...x?) { }
    ·                ─
@@ -17319,7 +17319,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  8 │ a0([1, 2, [["world"]], "string"]);  // Error
    ╰────
 
-  × A rest parameter cannot be optional
+  × TS(1047): A rest parameter cannot be optional
     ╭─[typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts:14:17]
  13 │ function a2(...a: someArray) { }  // Error, rest parameter must be array type
  14 │ function a3(...b?) { }            // Error, can't be optional
@@ -24174,7 +24174,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ }
    ╰────
 
-  × A rest parameter cannot be optional
+  × TS(1047): A rest parameter cannot be optional
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList11.ts:1:8]
  1 │ (...arg?) => 102;
    ·        ─
@@ -24271,7 +24271,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  5 │ }
    ╰────
 
-  × A rest parameter cannot be optional
+  × TS(1047): A rest parameter cannot be optional
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList9.ts:2:14]
  1 │ class C {
  2 │    foo(...bar?) { }


### PR DESCRIPTION
This is a typescript diagnostic error as only TS files are allowed `?: <annotation>` syntax, so it should include the error code