### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS
+.DS_Store
+
 # Rust
 target/
 **/*.rs.bk


### PR DESCRIPTION
## Summary

- Add `.DS_Store` to `.gitignore` to prevent macOS metadata files from being committed

## AI disclosure

This PR was authored with AI assistance (Claude Code). The change was reviewed and validated personally.