### PR TITLE
refactor(allocator): simplify `#[cfg]` attrs

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -12,9 +12,9 @@ use std::{
     ptr::{self, NonNull},
 };
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer as SerdeSerializer};
 
 use crate::Allocator;
@@ -263,14 +263,14 @@ impl<T: ?Sized + Debug> Debug for Box<'_, T> {
 // }
 // }
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 impl<T: Serialize> Serialize for Box<'_, T> {
     fn serialize<S: SerdeSerializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.deref().serialize(serializer)
     }
 }
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 impl<T: ESTree> ESTree for Box<'_, T> {
     fn serialize<S: ESTreeSerializer>(&self, serializer: S) {
         self.deref().serialize(serializer);
@@ -351,6 +351,7 @@ mod test {
         assert_eq!(hash(&a), hash(&b));
     }
 
+    #[cfg(feature = "serialize")]
     #[test]
     fn box_serialize() {
         let allocator = Allocator::default();
@@ -359,6 +360,7 @@ mod test {
         assert_eq!(s, r#""x""#);
     }
 
+    #[cfg(feature = "serialize")]
     #[test]
     fn box_serialize_estree() {
         use oxc_estree::{CompactTSSerializer, ESTree};

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -14,10 +14,10 @@ use std::{
     slice::SliceIndex,
 };
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer as SerdeSerializer};
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 use oxc_estree::{ConcatElement, ESTree, SequenceSerializer, Serializer as ESTreeSerializer};
 
 use crate::{Allocator, Box, bump::Bump, vec2::Vec as InnerVecGeneric};
@@ -308,14 +308,14 @@ impl<'a, T: 'a> From<Vec<'a, T>> for Box<'a, [T]> {
     }
 }
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 impl<T: Serialize> Serialize for Vec<'_, T> {
     fn serialize<S: SerdeSerializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.as_slice().serialize(serializer)
     }
 }
 
-#[cfg(any(feature = "serialize", test))]
+#[cfg(feature = "serialize")]
 impl<T: ESTree> ESTree for Vec<'_, T> {
     fn serialize<S: ESTreeSerializer>(&self, serializer: S) {
         self.as_slice().serialize(serializer);
@@ -375,6 +375,7 @@ mod test {
         assert_eq!(boxed_slice.as_ref(), &["x", "y"]);
     }
 
+    #[cfg(feature = "serialize")]
     #[test]
     fn vec_serialize() {
         let allocator = Allocator::default();
@@ -384,6 +385,7 @@ mod test {
         assert_eq!(s, r#"["x"]"#);
     }
 
+    #[cfg(feature = "serialize")]
     #[test]
     fn vec_serialize_estree() {
         use oxc_estree::{CompactTSSerializer, ESTree};


### PR DESCRIPTION
Tests are run with `--all-features` so `#[cfg(any(feature = "serialize", test))]` is redundant. `#[cfg(feature = "serialize")]` is simpler and does the same.

Add `#[cfg(feature = "serialize")]` to the tests for serialization instead.