### PR TITLE
docs(linter): move docs for `Target` variant onto enum

### DIFF
--- a/crates/oxc_linter/src/rules/import/prefer_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/prefer_default_export.rs
@@ -23,8 +23,10 @@ fn prefer_default_export_diagnostic(span: Span, target: Target) -> OxcDiagnostic
 #[derive(Debug, Default, PartialEq, Clone, Copy, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 enum Target {
+    /// Prefer default export when there is only one export in the module.
     #[default]
     Single,
+    /// Prefer default export in any module that has exports.
     Any,
 }
 
@@ -32,8 +34,6 @@ enum Target {
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferDefaultExport {
     /// Configuration option to specify the target type for preferring default exports.
-    /// - `"single"`: Prefer default export when there is only one export in the module.
-    /// - `"any"`: Prefer default export in any module that has exports.
     target: Target,
 }
 


### PR DESCRIPTION
Just moving where the doc comments live.