### PR TITLE
docs(linter): add missing docs for `class-methods-use-this` config

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/class_methods_use_this.rs
+++ b/crates/oxc_linter/src/rules/eslint/class_methods_use_this.rs
@@ -27,7 +27,9 @@ fn class_methods_use_this_diagnostic(span: Span, name: Option<Cow<'_, str>>) -> 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ClassMethodsUseThisConfig {
-    /// List of method names to exempt from this rule.
+    /// List of method names to exempt from this rule. Names can include the hash for private methods.
+    /// Example: `save`, `#rerender`
+    #[schemars(with = "Vec<String>")]
     except_methods: Vec<MethodException>,
     /// Enforce this rule for class fields that are functions.
     enforce_for_class_fields: bool,
@@ -62,14 +64,19 @@ impl Deref for ClassMethodsUseThis {
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 struct MethodException {
+    /// Name of the method to allow (without the `#` prefix for private methods)
     name: CompactStr,
+    /// Whether this is a private method like `#foo`
     private: bool,
 }
 
-#[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
+#[derive(Debug, Clone, JsonSchema, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 enum IgnoreClassWithImplements {
+    /// Ignores all classes that implement interfaces
+    #[default]
     All,
+    /// Only ignores public fields in classes that implement interfaces
     PublicFields,
 }
 


### PR DESCRIPTION
Ensures that `exceptMethods` is shown in the schema as an array of strings, instead of an array of objects (not accurate). Adds missing doc comments for the `IgnoreClassWithImplements` variants.