### PR TITLE
perf(allocator): use `offset_from_unsigned` in `ChunkFooter::as_raw_parts`

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -357,9 +357,9 @@ impl ChunkFooter {
         let ptr = self.ptr.get().as_ptr();
         debug_assert!(data <= ptr);
         debug_assert!(ptr.cast_const() <= ptr::from_ref::<ChunkFooter>(self).cast::<u8>());
-        #[expect(clippy::cast_sign_loss, reason = "`ptr` is always before or points to footer")]
+        // SAFETY: `ptr` is always before or equal to footer
         let len =
-            unsafe { ptr::from_ref::<ChunkFooter>(self).cast::<u8>().offset_from(ptr) as usize };
+            unsafe { ptr::from_ref::<ChunkFooter>(self).cast::<u8>().offset_from_unsigned(ptr) };
         (ptr, len)
     }
 


### PR DESCRIPTION
By definition, the bump pointer is always at or before the chunk footer, as bump pointer starts at chunk footer, and bumps downwards. Therefore we can use `offset_from_unsigned` to compare the 2 pointers, which can help compiler to optimize. This code is not on a hot path, so it will have no appreciable perf effect in the big picture, but why not?