### PR TITLE
docs(linter): add missing config docs for vitest plugin rules

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
@@ -42,7 +42,9 @@ impl std::ops::Deref for ConsistentEachFor {
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MemberNames {
+    /// Prefer using `.for` to create parameterized tests.
     For,
+    /// Prefer using `.each` to create parameterized tests.
     Each,
 }
 
@@ -90,9 +92,13 @@ pub struct ConsistentEachForConfig {
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct ConsistentEachForJson {
+    /// Preferred method to create parameterized tests for `describe` blocks.
     describe: Option<MemberNames>,
+    /// Preferred method to create parameterized tests for `suite` blocks.
     suite: Option<MemberNames>,
+    /// Preferred method to create parameterized tests for `test` blocks.
     test: Option<MemberNames>,
+    /// Preferred method to create parameterized tests for `it` blocks.
     it: Option<MemberNames>,
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use crate::{
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{PossibleJestNode, parse_general_jest_fn_call},
+    utils::{PossibleJestNode, default_true, parse_general_jest_fn_call},
 };
 
 fn prefer_import_in_mock_diagnostic(span: Span, path: &str) -> OxcDiagnostic {
@@ -32,6 +32,8 @@ impl std::ops::Deref for PreferImportInMock {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
 pub struct PreferImportInMockConfig {
+    /// Whether the rule should generate fixes or not.
+    #[serde(default = "default_true")]
     fixable: bool,
 }
 


### PR DESCRIPTION
Example docs after:

```
## Configuration

This rule accepts a configuration object with the following properties:

### describe

type: `"for" | "each"`


Preferred method to create parameterized tests for `describe` blocks.


### it

type: `"for" | "each"`


Preferred method to create parameterized tests for `it` blocks.


### suite

type: `"for" | "each"`


Preferred method to create parameterized tests for `suite` blocks.


### test

type: `"for" | "each"`


Preferred method to create parameterized tests for `test` blocks.
```

```
## Configuration

This rule accepts a configuration object with the following properties:

### fixable

type: `boolean`

default: `true`

Whether the rule should generate fixes or not.
```

