### PR TITLE
docs(linter): enhance schema docs generation for oneOf

### DIFF
--- a/tasks/website_common/src/schema_markdown.rs
+++ b/tasks/website_common/src/schema_markdown.rs
@@ -239,6 +239,18 @@ impl Renderer {
                         }
                         continue;
                     }
+
+                    // Handle oneOf used by enums with documented variants.
+                    // Schemars generates oneOf with each variant as a separate
+                    // schema object (e.g. {type: "string", enum: ["value"]}).
+                    if let Some(one_of) = &nested_subschemas.one_of {
+                        for nested in one_of {
+                            let nested = Self::get_schema_object(nested);
+                            let nested = self.get_referenced_schema(nested);
+                            flattened_schemas.push(nested);
+                        }
+                        continue;
+                    }
                 }
                 flattened_schemas.push(subschema);
             }

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -373,6 +373,7 @@ Equivalent to passing `--max-warnings` on the CLI.
 
 ### options.reportUnusedDisableDirectives
 
+type: `"allow" | "off" | "warn" | "error" | "deny" | integer`
 
 
 Report unused disable directives (e.g. `// oxlint-disable-line` or `// eslint-disable-line`).


### PR DESCRIPTION
When you have a json schema with a type of `Option<Enum>`, it seemed to not generate the docs correctly. Now, it will properly render all of the possible variants in this case.