### PR TITLE
feat(semantic): extend `MemberWriteTarget` to cover all property modification patterns

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2026,14 +2026,27 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.leave_node(kind);
     }
 
+    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
+        let kind = AstKind::UnaryExpression(self.alloc(it));
+        self.enter_node(kind);
+        // `delete a.foo` — the argument is in a property-write context.
+        // Set Write so `visit_member_expression` can detect it and mark MemberWriteTarget.
+        // Only for member expressions — `delete x` (bare identifier in sloppy mode)
+        // is not a property modification.
+        if it.operator == UnaryOperator::Delete && it.argument.is_member_expression() {
+            self.current_reference_flags = ReferenceFlags::Write;
+        }
+        self.visit_expression(&it.argument);
+        self.leave_node(kind);
+    }
+
     fn visit_member_expression(&mut self, it: &MemberExpression<'a>) {
         // A.B = 1;
         // ^^^ Can't treat A as a Write reference since it's A's property(B) that changes.
-        // For write-only references (simple `=` assignment), mark as MemberWriteTarget
-        // so the minifier can identify property-write-only references.
-        // Compound assignments (`+=`) and update expressions (`++`) have Read|Write flags,
-        // so `is_write_only()` is false and they correctly skip this branch.
-        if self.current_reference_flags.is_write_only() {
+        // When the member expression is in any write context (simple `=`, compound `+=`,
+        // update `++`, `delete`, for-in/of), mark as MemberWriteTarget so downstream
+        // consumers can identify property-modification-only references.
+        if self.current_reference_flags.is_write() {
             self.current_reference_flags = ReferenceFlags::Read | ReferenceFlags::MemberWriteTarget;
         } else {
             self.current_reference_flags -= ReferenceFlags::Write;

--- a/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-expression.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-expression.snap
@@ -52,28 +52,28 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/js/assignments/update-express
         "node": "VariableDeclarator(obj)",
         "references": [
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 4,
             "name": "obj",
             "node_id": 27,
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 5,
             "name": "obj",
             "node_id": 32,
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 6,
             "name": "obj",
             "node_id": 37,
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 7,
             "name": "obj",
             "node_id": 42,

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.snap
@@ -44,7 +44,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/assignments/left-hand.ts
             "scope_id": 0
           },
           {
-            "flags": "ReferenceFlags(Read)",
+            "flags": "ReferenceFlags(Read | MemberWriteTarget)",
             "id": 4,
             "name": "Foo",
             "node_id": 34,

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -117,13 +117,14 @@ bitflags! {
         /// a type parameter that might shadow it, since type parameters cannot
         /// have member access.
         const Namespace = 1 << 4;
-        /// The identifier is read as the object of a member expression in an
-        /// assignment target position. For example, `A` in `A.foo = 1`.
+        /// The identifier is read as the object of a member expression in a
+        /// property modification context. For example, `A` in `A.foo = 1`,
+        /// `A.foo += 1`, `++A.foo`, `delete A.foo`, or `for (A.foo in obj)`.
         ///
         /// This flag is always combined with [`Read`] (since the identifier is
-        /// read to access the property). It helps the minifier determine if a
-        /// symbol's only reads are property-write targets, enabling dead code
-        /// elimination of patterns like `function A() {} A.foo = 1;`.
+        /// read to access the property). It helps the minifier and linter
+        /// determine if a symbol's only reads are property-modification targets,
+        /// enabling dead code elimination and unused variable detection.
         ///
         /// [`Read`]: ReferenceFlags::Read
         const MemberWriteTarget = 1 << 5;
@@ -183,8 +184,9 @@ impl ReferenceFlags {
         self.contains(Self::Read | Self::Write)
     }
 
-    /// The identifier is read only as the object of a member expression
-    /// in an assignment target position (e.g., `A` in `A.foo = 1`).
+    /// The identifier is read as the object of a member expression
+    /// in a property modification context (e.g., `A` in `A.foo = 1`,
+    /// `A.foo += 1`, `++A.foo`, `delete A.foo`, or `for (A.foo in obj)`).
     #[inline]
     pub const fn is_member_write_target(self) -> bool {
         self.intersects(Self::MemberWriteTarget)


### PR DESCRIPTION
## Summary

- Extend `MemberWriteTarget` flag to cover compound assignments (`+=`), update expressions (`++/--`), and `delete` — previously only simple `=` assignments were covered
- Add `visit_unary_expression` override to set `Write` for `delete` on member expressions
- Change `is_write_only()` to `is_write()` in `visit_member_expression` so all write contexts trigger the flag
- Update doc comments to reflect broader scope

## Test plan

- [x] Existing semantic snapshot tests updated
- [x] `just ready` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)