### PR TITLE
feat(linter/n): implement `no-callback-literal` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4441,6 +4441,12 @@ impl RuleRunner for crate::rules::node::handle_callback_err::HandleCallbackErr {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::node::no_callback_literal::NoCallbackLiteral {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::node::no_exports_assign::NoExportsAssign {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -342,6 +342,7 @@ pub use crate::rules::nextjs::no_typos::NoTypos as NextjsNoTypos;
 pub use crate::rules::nextjs::no_unwanted_polyfillio::NoUnwantedPolyfillio as NextjsNoUnwantedPolyfillio;
 pub use crate::rules::node::global_require::GlobalRequire as NodeGlobalRequire;
 pub use crate::rules::node::handle_callback_err::HandleCallbackErr as NodeHandleCallbackErr;
+pub use crate::rules::node::no_callback_literal::NoCallbackLiteral as NodeNoCallbackLiteral;
 pub use crate::rules::node::no_exports_assign::NoExportsAssign as NodeNoExportsAssign;
 pub use crate::rules::node::no_new_require::NoNewRequire as NodeNoNewRequire;
 pub use crate::rules::node::no_path_concat::NoPathConcat as NodeNoPathConcat;
@@ -1436,6 +1437,7 @@ pub enum RuleEnum {
     VitestWarnTodo(VitestWarnTodo),
     NodeGlobalRequire(NodeGlobalRequire),
     NodeHandleCallbackErr(NodeHandleCallbackErr),
+    NodeNoCallbackLiteral(NodeNoCallbackLiteral),
     NodeNoExportsAssign(NodeNoExportsAssign),
     NodeNoNewRequire(NodeNoNewRequire),
     NodeNoPathConcat(NodeNoPathConcat),
@@ -2244,7 +2246,8 @@ const VITEST_REQUIRE_TEST_TIMEOUT_ID: usize = VITEST_REQUIRE_MOCK_TYPE_PARAMETER
 const VITEST_WARN_TODO_ID: usize = VITEST_REQUIRE_TEST_TIMEOUT_ID + 1usize;
 const NODE_GLOBAL_REQUIRE_ID: usize = VITEST_WARN_TODO_ID + 1usize;
 const NODE_HANDLE_CALLBACK_ERR_ID: usize = NODE_GLOBAL_REQUIRE_ID + 1usize;
-const NODE_NO_EXPORTS_ASSIGN_ID: usize = NODE_HANDLE_CALLBACK_ERR_ID + 1usize;
+const NODE_NO_CALLBACK_LITERAL_ID: usize = NODE_HANDLE_CALLBACK_ERR_ID + 1usize;
+const NODE_NO_EXPORTS_ASSIGN_ID: usize = NODE_NO_CALLBACK_LITERAL_ID + 1usize;
 const NODE_NO_NEW_REQUIRE_ID: usize = NODE_NO_EXPORTS_ASSIGN_ID + 1usize;
 const NODE_NO_PATH_CONCAT_ID: usize = NODE_NO_NEW_REQUIRE_ID + 1usize;
 const NODE_NO_PROCESS_ENV_ID: usize = NODE_NO_PATH_CONCAT_ID + 1usize;
@@ -3077,6 +3080,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => VITEST_WARN_TODO_ID,
             Self::NodeGlobalRequire(_) => NODE_GLOBAL_REQUIRE_ID,
             Self::NodeHandleCallbackErr(_) => NODE_HANDLE_CALLBACK_ERR_ID,
+            Self::NodeNoCallbackLiteral(_) => NODE_NO_CALLBACK_LITERAL_ID,
             Self::NodeNoExportsAssign(_) => NODE_NO_EXPORTS_ASSIGN_ID,
             Self::NodeNoNewRequire(_) => NODE_NO_NEW_REQUIRE_ID,
             Self::NodeNoPathConcat(_) => NODE_NO_PATH_CONCAT_ID,
@@ -3897,6 +3901,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => VitestWarnTodo::NAME,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::NAME,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::NAME,
+            Self::NodeNoCallbackLiteral(_) => NodeNoCallbackLiteral::NAME,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::NAME,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::NAME,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::NAME,
@@ -4769,6 +4774,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => VitestWarnTodo::CATEGORY,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::CATEGORY,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::CATEGORY,
+            Self::NodeNoCallbackLiteral(_) => NodeNoCallbackLiteral::CATEGORY,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::CATEGORY,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::CATEGORY,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::CATEGORY,
@@ -5592,6 +5598,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => VitestWarnTodo::FIX,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::FIX,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::FIX,
+            Self::NodeNoCallbackLiteral(_) => NodeNoCallbackLiteral::FIX,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::FIX,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::FIX,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::FIX,
@@ -6627,6 +6634,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => VitestWarnTodo::documentation(),
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::documentation(),
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::documentation(),
+            Self::NodeNoCallbackLiteral(_) => NodeNoCallbackLiteral::documentation(),
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::documentation(),
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::documentation(),
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::documentation(),
@@ -8644,6 +8652,8 @@ impl RuleEnum {
                 .or_else(|| NodeGlobalRequire::schema(generator)),
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::config_schema(generator)
                 .or_else(|| NodeHandleCallbackErr::schema(generator)),
+            Self::NodeNoCallbackLiteral(_) => NodeNoCallbackLiteral::config_schema(generator)
+                .or_else(|| NodeNoCallbackLiteral::schema(generator)),
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::config_schema(generator)
                 .or_else(|| NodeNoExportsAssign::schema(generator)),
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::config_schema(generator)
@@ -9404,6 +9414,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => "vitest",
             Self::NodeGlobalRequire(_) => "node",
             Self::NodeHandleCallbackErr(_) => "node",
+            Self::NodeNoCallbackLiteral(_) => "node",
             Self::NodeNoExportsAssign(_) => "node",
             Self::NodeNoNewRequire(_) => "node",
             Self::NodeNoPathConcat(_) => "node",
@@ -11677,6 +11688,9 @@ impl RuleEnum {
             Self::NodeHandleCallbackErr(_) => {
                 Ok(Self::NodeHandleCallbackErr(NodeHandleCallbackErr::from_configuration(value)?))
             }
+            Self::NodeNoCallbackLiteral(_) => {
+                Ok(Self::NodeNoCallbackLiteral(NodeNoCallbackLiteral::from_configuration(value)?))
+            }
             Self::NodeNoExportsAssign(_) => {
                 Ok(Self::NodeNoExportsAssign(NodeNoExportsAssign::from_configuration(value)?))
             }
@@ -12445,6 +12459,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(rule) => rule.to_configuration(),
             Self::NodeGlobalRequire(rule) => rule.to_configuration(),
             Self::NodeHandleCallbackErr(rule) => rule.to_configuration(),
+            Self::NodeNoCallbackLiteral(rule) => rule.to_configuration(),
             Self::NodeNoExportsAssign(rule) => rule.to_configuration(),
             Self::NodeNoNewRequire(rule) => rule.to_configuration(),
             Self::NodeNoPathConcat(rule) => rule.to_configuration(),
@@ -13167,6 +13182,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(rule) => rule.run(node, ctx),
             Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
             Self::NodeHandleCallbackErr(rule) => rule.run(node, ctx),
+            Self::NodeNoCallbackLiteral(rule) => rule.run(node, ctx),
             Self::NodeNoExportsAssign(rule) => rule.run(node, ctx),
             Self::NodeNoNewRequire(rule) => rule.run(node, ctx),
             Self::NodeNoPathConcat(rule) => rule.run(node, ctx),
@@ -13889,6 +13905,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(rule) => rule.run_once(ctx),
             Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
             Self::NodeHandleCallbackErr(rule) => rule.run_once(ctx),
+            Self::NodeNoCallbackLiteral(rule) => rule.run_once(ctx),
             Self::NodeNoExportsAssign(rule) => rule.run_once(ctx),
             Self::NodeNoNewRequire(rule) => rule.run_once(ctx),
             Self::NodeNoPathConcat(rule) => rule.run_once(ctx),
@@ -14713,6 +14730,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeGlobalRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeHandleCallbackErr(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::NodeNoCallbackLiteral(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoExportsAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoNewRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoPathConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15435,6 +15453,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(rule) => rule.should_run(ctx),
             Self::NodeGlobalRequire(rule) => rule.should_run(ctx),
             Self::NodeHandleCallbackErr(rule) => rule.should_run(ctx),
+            Self::NodeNoCallbackLiteral(rule) => rule.should_run(ctx),
             Self::NodeNoExportsAssign(rule) => rule.should_run(ctx),
             Self::NodeNoNewRequire(rule) => rule.should_run(ctx),
             Self::NodeNoPathConcat(rule) => rule.should_run(ctx),
@@ -16469,6 +16488,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => VitestWarnTodo::IS_TSGOLINT_RULE,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::IS_TSGOLINT_RULE,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::IS_TSGOLINT_RULE,
+            Self::NodeNoCallbackLiteral(_) => NodeNoCallbackLiteral::IS_TSGOLINT_RULE,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::IS_TSGOLINT_RULE,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::IS_TSGOLINT_RULE,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::IS_TSGOLINT_RULE,
@@ -17370,6 +17390,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => VitestWarnTodo::HAS_CONFIG,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::HAS_CONFIG,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::HAS_CONFIG,
+            Self::NodeNoCallbackLiteral(_) => NodeNoCallbackLiteral::HAS_CONFIG,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::HAS_CONFIG,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::HAS_CONFIG,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::HAS_CONFIG,
@@ -18094,6 +18115,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(rule) => rule.types_info(),
             Self::NodeGlobalRequire(rule) => rule.types_info(),
             Self::NodeHandleCallbackErr(rule) => rule.types_info(),
+            Self::NodeNoCallbackLiteral(rule) => rule.types_info(),
             Self::NodeNoExportsAssign(rule) => rule.types_info(),
             Self::NodeNoNewRequire(rule) => rule.types_info(),
             Self::NodeNoPathConcat(rule) => rule.types_info(),
@@ -18816,6 +18838,7 @@ impl RuleEnum {
             Self::VitestWarnTodo(rule) => rule.run_info(),
             Self::NodeGlobalRequire(rule) => rule.run_info(),
             Self::NodeHandleCallbackErr(rule) => rule.run_info(),
+            Self::NodeNoCallbackLiteral(rule) => rule.run_info(),
             Self::NodeNoExportsAssign(rule) => rule.run_info(),
             Self::NodeNoNewRequire(rule) => rule.run_info(),
             Self::NodeNoPathConcat(rule) => rule.run_info(),
@@ -19658,6 +19681,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestWarnTodo(VitestWarnTodo::default()),
         RuleEnum::NodeGlobalRequire(NodeGlobalRequire::default()),
         RuleEnum::NodeHandleCallbackErr(NodeHandleCallbackErr::default()),
+        RuleEnum::NodeNoCallbackLiteral(NodeNoCallbackLiteral::default()),
         RuleEnum::NodeNoExportsAssign(NodeNoExportsAssign::default()),
         RuleEnum::NodeNoNewRequire(NodeNoNewRequire::default()),
         RuleEnum::NodeNoPathConcat(NodeNoPathConcat::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -742,6 +742,7 @@ pub(crate) mod vitest {
 pub(crate) mod node {
     pub mod global_require;
     pub mod handle_callback_err;
+    pub mod no_callback_literal;
     pub mod no_exports_assign;
     pub mod no_new_require;
     pub mod no_path_concat;

--- a/crates/oxc_linter/src/rules/node/no_callback_literal.rs
+++ b/crates/oxc_linter/src/rules/node/no_callback_literal.rs
@@ -29,7 +29,6 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```js
     /// cb('this is an error string');
-    /// cb({ a: 1 });
     /// callback(0);
     /// ```
     ///
@@ -71,7 +70,7 @@ impl Rule for NoCallbackLiteral {
             return;
         }
 
-        ctx.diagnostic(no_callback_literal_diagnostic(node.span()));
+        ctx.diagnostic(no_callback_literal_diagnostic(error_expr.span()));
     }
 }
 
@@ -135,6 +134,8 @@ fn test() {
         r#"cb(null, "super")"#,
         "cb(e as Error)",           // { "parser": tsParser }
         r#"cb("help" as unknown)"#, // { "parser": tsParser }
+        "cb({ a: 1 })",
+        "cb([])",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/node/no_callback_literal.rs
+++ b/crates/oxc_linter/src/rules/node/no_callback_literal.rs
@@ -75,7 +75,7 @@ impl Rule for NoCallbackLiteral {
     }
 }
 
-/// Determine if a node has a possiblity to be an Error object
+/// Determine if a node has a possibility to be an Error object
 fn could_be_error(error_expr: &Expression) -> bool {
     match error_expr.without_parentheses() {
         Expression::BooleanLiteral(_)

--- a/crates/oxc_linter/src/rules/node/no_callback_literal.rs
+++ b/crates/oxc_linter/src/rules/node/no_callback_literal.rs
@@ -1,0 +1,151 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_callback_literal_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected literal in error position of callback.")
+        .with_help("Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoCallbackLiteral;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce Node.js-style error-first callback pattern is followed.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When invoking a callback function which uses the Node.js error-first callback pattern, all of your errors should either use the `Error` class or a subclass of it.
+    /// It is also acceptable to use `undefined` or `null` if there is no error.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// cb('this is an error string');
+    /// cb({ a: 1 });
+    /// callback(0);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// cb(undefined);
+    /// cb(null, 5);
+    /// callback(new Error('some error'));
+    /// callback(someVariable);
+    /// ```
+    NoCallbackLiteral,
+    node,
+    style,
+);
+
+impl Rule for NoCallbackLiteral {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Expression::Identifier(ident) = &call_expr.callee else {
+            return;
+        };
+
+        if ident.name != "callback" && ident.name != "cb" {
+            return;
+        }
+
+        let Some(error_arg) = call_expr.arguments.first() else {
+            return;
+        };
+
+        let Some(error_expr) = error_arg.as_expression() else {
+            return;
+        };
+
+        if could_be_error(error_expr) {
+            return;
+        }
+
+        ctx.diagnostic(no_callback_literal_diagnostic(node.span()));
+    }
+}
+
+/// Determine if a node has a possiblity to be an Error object
+fn could_be_error(error_expr: &Expression) -> bool {
+    match error_expr.without_parentheses() {
+        Expression::BooleanLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_) => false,
+        Expression::AssignmentExpression(assign_expr) => could_be_error(&assign_expr.right),
+        Expression::SequenceExpression(seq_expr) => {
+            let exprs = &seq_expr.expressions;
+
+            let Some(last) = exprs.last() else {
+                return false;
+            };
+
+            could_be_error(last)
+        }
+        Expression::LogicalExpression(logic_expr) => {
+            could_be_error(&logic_expr.left) || could_be_error(&logic_expr.right)
+        }
+        Expression::ConditionalExpression(cond_expr) => {
+            could_be_error(&cond_expr.consequent) || could_be_error(&cond_expr.alternate)
+        }
+        _ => true,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "horse()",
+        "sort(null)",
+        r#"require("zyx")"#,
+        r#"require("zyx", data)"#,
+        "callback()",
+        "callback(undefined)",
+        "callback(null)",
+        "callback(x)",
+        r#"callback(new Error("error"))"#,
+        "callback(friendly, data)",
+        "callback(undefined, data)",
+        "callback(null, data)",
+        "callback(x, data)",
+        r#"callback(new Error("error"), data)"#,
+        "callback(x = obj, data)",
+        "callback((1, a), data)",
+        "callback(a || b, data)",
+        "callback(a ? b : c, data)",
+        "callback(a ? 1 : c, data)",
+        "callback(a ? b : 1, data)",
+        "cb()",
+        "cb(undefined)",
+        "cb(null)",
+        r#"cb(undefined, "super")"#,
+        r#"cb(null, "super")"#,
+        "cb(e as Error)",           // { "parser": tsParser }
+        r#"cb("help" as unknown)"#, // { "parser": tsParser }
+    ];
+
+    let fail = vec![
+        r#"callback(false, "snork")"#,
+        r#"callback("help")"#,
+        r#"callback("help", data)"#,
+        "cb(false)",
+        r#"cb("help")"#,
+        r#"cb("help", data)"#,
+        "callback((a, 1), data)",
+    ];
+
+    Tester::new(NoCallbackLiteral::NAME, NoCallbackLiteral::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/node_no_callback_literal.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_callback_literal.snap
@@ -1,0 +1,52 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
+   ╭─[no_callback_literal.tsx:1:1]
+ 1 │ callback(false, "snork")
+   · ────────────────────────
+   ╰────
+  help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
+
+  ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
+   ╭─[no_callback_literal.tsx:1:1]
+ 1 │ callback("help")
+   · ────────────────
+   ╰────
+  help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
+
+  ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
+   ╭─[no_callback_literal.tsx:1:1]
+ 1 │ callback("help", data)
+   · ──────────────────────
+   ╰────
+  help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
+
+  ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
+   ╭─[no_callback_literal.tsx:1:1]
+ 1 │ cb(false)
+   · ─────────
+   ╰────
+  help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
+
+  ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
+   ╭─[no_callback_literal.tsx:1:1]
+ 1 │ cb("help")
+   · ──────────
+   ╰────
+  help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
+
+  ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
+   ╭─[no_callback_literal.tsx:1:1]
+ 1 │ cb("help", data)
+   · ────────────────
+   ╰────
+  help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
+
+  ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
+   ╭─[no_callback_literal.tsx:1:1]
+ 1 │ callback((a, 1), data)
+   · ──────────────────────
+   ╰────
+  help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.

--- a/crates/oxc_linter/src/snapshots/node_no_callback_literal.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_callback_literal.snap
@@ -3,50 +3,50 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
-   ╭─[no_callback_literal.tsx:1:1]
+   ╭─[no_callback_literal.tsx:1:10]
  1 │ callback(false, "snork")
-   · ────────────────────────
+   ·          ─────
    ╰────
   help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
 
   ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
-   ╭─[no_callback_literal.tsx:1:1]
+   ╭─[no_callback_literal.tsx:1:10]
  1 │ callback("help")
-   · ────────────────
+   ·          ──────
    ╰────
   help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
 
   ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
-   ╭─[no_callback_literal.tsx:1:1]
+   ╭─[no_callback_literal.tsx:1:10]
  1 │ callback("help", data)
-   · ──────────────────────
+   ·          ──────
    ╰────
   help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
 
   ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
-   ╭─[no_callback_literal.tsx:1:1]
+   ╭─[no_callback_literal.tsx:1:4]
  1 │ cb(false)
-   · ─────────
+   ·    ─────
    ╰────
   help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
 
   ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
-   ╭─[no_callback_literal.tsx:1:1]
+   ╭─[no_callback_literal.tsx:1:4]
  1 │ cb("help")
-   · ──────────
+   ·    ──────
    ╰────
   help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
 
   ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
-   ╭─[no_callback_literal.tsx:1:1]
+   ╭─[no_callback_literal.tsx:1:4]
  1 │ cb("help", data)
-   · ────────────────
+   ·    ──────
    ╰────
   help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.
 
   ⚠ eslint-plugin-node(no-callback-literal): Unexpected literal in error position of callback.
-   ╭─[no_callback_literal.tsx:1:1]
+   ╭─[no_callback_literal.tsx:1:10]
  1 │ callback((a, 1), data)
-   · ──────────────────────
+   ·          ──────
    ╰────
   help: Pass an `Error` object (or `null`/`undefined` when there is no error) as the first callback argument.


### PR DESCRIPTION
this PR implements `n/no-callback-literal` rule

issue #493

[Rule source](https://github.com/eslint-community/eslint-plugin-n/blob/472943856633544a744ae5dc8045071457d72c0a/lib/rules/no-callback-literal.js)
[Test source](https://github.com/eslint-community/eslint-plugin-n/blob/472943856633544a744ae5dc8045071457d72c0a/tests/lib/rules/no-callback-literal.js)