### PR TITLE
fix(linter/no-fallthrough): check from start of switch case for empty lines

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -327,7 +327,7 @@ impl Rule for NoFallthrough {
             let is_illegal_fallthrough = {
                 let is_fallthrough = !case.consequent.is_empty()
                     || (!self.0.allow_empty_case
-                        && Self::has_blanks_between(ctx, case.span.start..next_case.span.start));
+                        && Self::has_blanks_between(ctx, case.span.end..next_case.span.start));
                 is_fallthrough
                     && self.maybe_allow_fallthrough_trivia(ctx, case, next_case).is_none()
             };

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -614,6 +614,8 @@ fn test() {
       } });"#,
             None,
         ),
+        // Issue #21320: breaks on multi-line case statements
+        ("switch(foo) {\n  case A\n    .B:\n  case B.A:\n    break;\n}", None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
With `no-fallthrough` enabled this is fine:
```
switch(foo) {
  case A.B:
  case B.A: 
    break;
}
```
but this produces an error:
```
switch(foo) {
  case A
    .B:
  case B.A: // lint error here: Expected a `break` statement before `case`.
    break;
}
```
[Playground link](https://playground.oxc.rs/?t=formatter&formatterPanels=output%2Cprettier&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Atrue%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22ts%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Afalse%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22es2015%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=switch%28foo%29+%7B%0A++case+A.B%3A%0A++case+B.A%3A+%0A++++break%3B%0A%7D%0A%0Aswitch%28foo%29+%7B%0A++case+A%0A++++.B%3A%0A++case+B.A%3A+%0A++++break%3B%0A%7D&lintRules=eslint%2Fno-fallthrough) of the above.  [Eslint playground link](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tZmFsbHRocm91Z2g6IFwiZXJyb3JcIiovXG5cbnN3aXRjaChmb28pIHtcbiAgY2FzZSBBXG4gICAgLkI6XG4gIGNhc2UgQi5BOiBcbiAgICBicmVhaztcbn0iLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=) with no error

This updates `is_illegal_fallthrough` to only consider extra spaces starting from the end of a `case`, so that for example, the newline in `case A\n.B:` isn't counted.  The `no_fallthrough` tests all pass on this branch:
```
cargo test -p oxc_linter --lib -- rules::eslint::no_fallthrough::test
    Finished `test` profile [unoptimized] target(s) in 0.15s
     Running unittests src/lib.rs (target/debug/deps/oxc_linter-13dddf2bce5df143)

running 1 test
test rules::eslint::no_fallthrough::test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1003 filtered out; finished in 0.12s
```

AI disclosure I wrote the failing test case on my own.  I worked with Sonnet to come up with the a fix but I do understand why it works.

closes #21320