### PR TITLE
docs(linter): add explanation for `n/no-callback-literal` in unsupported rules

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -34,6 +34,7 @@
     "n/prefer-node-protocol": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "n/no-process-exit": "No need to implement, already implemented by `unicorn/no-process-exit`.",
     "n/file-extension-in-import": "No need to implement, already implemented by `import/extensions`.",
+    "n/no-callback-literal": "Use `--type-check` and TypeScript callback typing (`err: Error | null | undefined`) to catch non-Error literals in error-first callbacks.",
     "import/enforce-node-protocol-usage": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "import/no-deprecated": "No need to implement, already implemented by `typescript/no-deprecated` via tsgolint.",
     "n/no-restricted-import": "No need to implement, already implemented by `no-restricted-imports` rule.",

--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -34,7 +34,7 @@
     "n/prefer-node-protocol": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "n/no-process-exit": "No need to implement, already implemented by `unicorn/no-process-exit`.",
     "n/file-extension-in-import": "No need to implement, already implemented by `import/extensions`.",
-    "n/no-callback-literal": "Use `--type-check` and TypeScript callback typing (`err: Error | null | undefined`) to catch non-Error literals in error-first callbacks.",
+    "n/no-callback-literal": "Use type-aware linting with `--type-aware --type-check` (or enable `options.typeAware` in config) and TypeScript callback typing (`err: Error | null | undefined`) to catch non-Error literals in error-first callbacks.",
     "import/enforce-node-protocol-usage": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "import/no-deprecated": "No need to implement, already implemented by `typescript/no-deprecated` via tsgolint.",
     "n/no-restricted-import": "No need to implement, already implemented by `no-restricted-imports` rule.",


### PR DESCRIPTION
Add `n/no-callback-literal` to unsupported rules, since it is better handled by type checking. See: https://github.com/oxc-project/oxc/pull/21319#pullrequestreview-4092375785