### PR TITLE
perf(allocator): `Allocator::alloc_concat_strs_array` check for 0 length earlier

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -415,6 +415,11 @@ impl Allocator {
             unsafe { assert_unchecked!(len <= (isize::MAX as usize)) };
             total_len.checked_add(len).unwrap()
         });
+
+        if total_len == 0 {
+            return "";
+        }
+
         assert!(
             isize::try_from(total_len).is_ok(),
             "attempted to create a string longer than `isize::MAX` bytes"
@@ -440,10 +445,6 @@ impl Allocator {
         strings: [&str; N],
         total_len: usize,
     ) -> &'a str {
-        if total_len == 0 {
-            return "";
-        }
-
         // Allocate `total_len` bytes.
         // SAFETY: Caller guarantees `total_len <= isize::MAX`.
         let layout = unsafe { Layout::from_size_align_unchecked(total_len, 1) };


### PR DESCRIPTION
`Allocator::alloc_concat_strs_array` bails out early if `total_len` is 0. Move this check from `alloc_concat_strs_array_with_total_len_in` into `alloc_concat_strs_array` itself. That function is inlined into callers so compiler can likely prove that `total_len` cannot be 0, and remove the check entirely when any of the strings passes in are static (e.g. `allocator.alloc_concat_strs_array(["_", name])`.