### PR TITLE
fix(allocator): `StringBuilder` use `Allocator::alloc_layout`

### DIFF
--- a/crates/oxc_allocator/src/string_builder.rs
+++ b/crates/oxc_allocator/src/string_builder.rs
@@ -100,7 +100,7 @@ impl<'a> StringBuilder<'a> {
         }
 
         let layout = Layout::from_size_align(capacity, 1).expect("`capacity` exceeds `isize::MAX");
-        let start_ptr = allocator.bump().alloc_layout(layout);
+        let start_ptr = allocator.alloc_layout(layout);
         // SAFETY: We just allocated `capacity` bytes, starting at `start_ptr`
         let end_capacity_ptr = unsafe { start_ptr.add(capacity) };
 
@@ -122,7 +122,7 @@ impl<'a> StringBuilder<'a> {
     #[inline]
     pub fn from_str_in(s: &str, allocator: &'a Allocator) -> Self {
         let layout = Layout::for_value(s);
-        let start_ptr = allocator.bump().alloc_layout(layout);
+        let start_ptr = allocator.alloc_layout(layout);
 
         // SAFETY: `s.as_ptr()` is the start of `s` string, so valid for reading `s.len()` bytes.
         // `start_ptr.as_ptr()` is valid for writing `bytes.len()` bytes as we just reserved capacity.
@@ -218,7 +218,7 @@ impl<'a> StringBuilder<'a> {
         // Allocate `total_len` bytes.
         // SAFETY: Caller guarantees `total_len <= isize::MAX`.
         let layout = unsafe { Layout::from_size_align_unchecked(total_len, 1) };
-        let start_ptr = allocator.bump().alloc_layout(layout);
+        let start_ptr = allocator.alloc_layout(layout);
 
         let mut end_ptr = start_ptr;
         for str in strings {
@@ -461,7 +461,7 @@ impl<'a> StringBuilder<'a> {
             let additional = cmp::max(additional, DEFAULT_MIN_CAPACITY);
             let layout = Layout::from_size_align(additional, 1)
                 .expect("attempt to grow `StringBuilder` beyond `isize::MAX` bytes");
-            let start_ptr = self.allocator.bump().alloc_layout(layout);
+            let start_ptr = self.allocator.alloc_layout(layout);
             self.start_ptr = start_ptr;
             self.end_ptr = start_ptr;
             // SAFETY: Just allocated `additional` bytes, starting at `start_ptr`,
@@ -513,7 +513,7 @@ impl<'a> StringBuilder<'a> {
             // Ensure don't allocate less than 8 bytes.
             // SAFETY: `DEFAULT_MIN_CAPACITY` is a valid size for `Layout` with align 1.
             let layout = unsafe { Layout::from_size_align_unchecked(DEFAULT_MIN_CAPACITY, 1) };
-            let start_ptr = self.allocator.bump().alloc_layout(layout);
+            let start_ptr = self.allocator.alloc_layout(layout);
             self.start_ptr = start_ptr;
             self.end_ptr = start_ptr;
             // SAFETY: Just allocated `DEFAULT_MIN_CAPACITY` bytes, starting at `start_ptr`,

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           9672 |             21 ||         267640 |          22847
+checker.ts                 | 2.92 MB        ||           9672 |             21 ||         267647 |          22847
 
-cal.com.tsx                | 1.06 MB        ||           1083 |             49 ||         136127 |          13697
+cal.com.tsx                | 1.06 MB        ||           1083 |             49 ||         136129 |          13697
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            363 |             66
+RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            364 |             66
 
-pdf.mjs                    | 567.30 kB      ||            703 |             75 ||          90547 |           8148
+pdf.mjs                    | 567.30 kB      ||            703 |             75 ||          90578 |           8148
 
-antd.js                    | 6.69 MB        ||           7132 |            235 ||         528505 |          55357
+antd.js                    | 6.69 MB        ||           7132 |            235 ||         528577 |          55357
 
 binder.ts                  | 193.08 kB      ||            530 |              7 ||          16788 |           1467
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -2,9 +2,9 @@ File                       | File size      || Sys allocs     | Sys reallocs   |
 -------------------------------------------------------------------------------------------------------------------------------------------
 checker.ts                 | 2.92 MB        ||             61 |              1 ||           4398 |             64
 
-cal.com.tsx                | 1.06 MB        ||             42 |              3 ||          38172 |           3515
+cal.com.tsx                | 1.06 MB        ||             42 |              3 ||          38201 |           3515
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             22 |              3 ||            257 |             24
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             22 |              3 ||            259 |             24
 
 pdf.mjs                    | 567.30 kB      ||             15 |              0 ||              2 |              0
 


### PR DESCRIPTION
`StringBuilder` methods were allocating using `allocator.bump().alloc_layout(layout)` i.e. allocating directly via `Bump`. Switch to allocating via `Allocator` with `allocator.alloc_layout(layout)`. This shortens the code and also correctly counts the allocations in allocator tracker - previously they were being ignored in the allocation counts.