### PR TITLE
fix(allocator): move allocation tracking into `Bump`

### DIFF
--- a/crates/oxc_allocator/src/alloc.rs
+++ b/crates/oxc_allocator/src/alloc.rs
@@ -96,13 +96,6 @@ impl Alloc for Bump {
     /// Panics if reserving space for `layout` fails.
     #[inline(always)]
     fn alloc(&self, layout: Layout) -> NonNull<u8> {
-        // SAFETY: This is UNSOUND (see comment on `get_stats_ref`). But usage is gated behind
-        // `track_allocations` feature, so should never be compiled in production code.
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        unsafe {
-            crate::tracking::get_stats_ref(self).record_allocation();
-        }
-
         self.alloc_layout(layout)
     }
 
@@ -141,13 +134,6 @@ impl Alloc for Bump {
     /// Panics / aborts if reserving space for `new_layout` fails.
     #[inline(always)]
     unsafe fn grow(&self, ptr: NonNull<u8>, old_layout: Layout, new_layout: Layout) -> NonNull<u8> {
-        // SAFETY: This is UNSOUND (see comment on `get_stats_ref`). But usage is gated behind
-        // `track_allocations` feature, so should never be compiled in production code.
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        unsafe {
-            crate::tracking::get_stats_ref(self).record_reallocation();
-        }
-
         // SAFETY: Safety requirements of `Allocator::grow` are the same as for this method
         let res = unsafe { Allocator::grow(&self, ptr, old_layout, new_layout) };
         match res {

--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -4,15 +4,9 @@ use std::{
     slice, str,
 };
 
-#[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-use std::mem::offset_of;
-
 use crate::bump::Bump;
 
 use oxc_data_structures::assert_unchecked;
-
-#[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-use crate::tracking::AllocationStats;
 
 /// A bump-allocated memory arena.
 ///
@@ -219,19 +213,10 @@ use crate::tracking::AllocationStats;
 /// [`Vec::new_in`]: crate::Vec::new_in
 /// [`HashMap::new_in`]: crate::HashMap::new_in
 #[derive(Default)]
+#[repr(transparent)]
 pub struct Allocator {
     bump: Bump,
-    /// Used to track number of allocations made in this allocator when `track_allocations` feature is enabled
-    #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-    pub(crate) stats: AllocationStats,
 }
-
-/// Offset of `stats` field, relative to `bump` field.
-/// Used in `tracking` module for allocation tracking.
-#[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-#[expect(clippy::cast_possible_wrap)]
-pub const STATS_FIELD_OFFSET: isize =
-    (offset_of!(Allocator, stats) as isize) - (offset_of!(Allocator, bump) as isize);
 
 impl Allocator {
     /// Create a new [`Allocator`] with no initial capacity.
@@ -257,11 +242,7 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn new() -> Self {
-        Self {
-            bump: Bump::new(),
-            #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-            stats: AllocationStats::default(),
-        }
+        Self { bump: Bump::new() }
     }
 
     /// Create a new [`Allocator`] with specified capacity.
@@ -272,11 +253,7 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            bump: Bump::with_capacity(capacity),
-            #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-            stats: AllocationStats::default(),
-        }
+        Self { bump: Bump::with_capacity(capacity) }
     }
 
     /// Allocate an object in this [`Allocator`] and return an exclusive reference to it.
@@ -300,9 +277,6 @@ impl Allocator {
     pub fn alloc<T>(&self, val: T) -> &mut T {
         const { assert!(!std::mem::needs_drop::<T>(), "Cannot allocate Drop type in arena") };
 
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        self.stats.record_allocation();
-
         self.bump.alloc(val)
     }
 
@@ -324,9 +298,6 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc_str<'alloc>(&'alloc self, src: &str) -> &'alloc str {
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        self.stats.record_allocation();
-
         self.bump.alloc_str(src)
     }
 
@@ -347,9 +318,6 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc_slice_copy<T: Copy>(&self, src: &[T]) -> &mut [T] {
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        self.stats.record_allocation();
-
         self.bump.alloc_slice_copy(src)
     }
 
@@ -367,9 +335,6 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc_layout(&self, layout: Layout) -> NonNull<u8> {
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        self.stats.record_allocation();
-
         self.bump.alloc_layout(layout)
     }
 
@@ -513,9 +478,6 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn reset(&mut self) {
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        self.stats.reset();
-
         self.bump.reset();
     }
 
@@ -637,11 +599,7 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub(crate) fn from_bump(bump: Bump) -> Self {
-        Self {
-            bump,
-            #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-            stats: AllocationStats::default(),
-        }
+        Self { bump }
     }
 }
 

--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -23,6 +23,9 @@ use allocator_api2::alloc::{AllocError, Allocator};
 use crate::bumpalo_alloc::Alloc as BumpaloAlloc;
 pub use crate::bumpalo_alloc::AllocErr;
 
+#[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+use crate::tracking::AllocationStats;
+
 /// An error returned from [`Bump::try_alloc_try_with`].
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AllocOrInitError<E> {
@@ -287,6 +290,9 @@ pub struct Bump<const MIN_ALIGN: usize = 1> {
     // The current chunk we are bump allocating within.
     current_chunk_footer: Cell<NonNull<ChunkFooter>>,
     allocation_limit: Cell<Option<usize>>,
+    /// Used to track number of allocations made in this `Bump` when `track_allocations` feature is enabled
+    #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+    pub(crate) stats: AllocationStats,
 }
 
 #[repr(C)]
@@ -773,6 +779,8 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         Self {
             current_chunk_footer: Cell::new(chunk_footer_ptr),
             allocation_limit: Cell::new(allocation_limit),
+            #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+            stats: AllocationStats::default(),
         }
     }
 
@@ -1003,6 +1011,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// }
     ///```
     pub fn reset(&mut self) {
+        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+        self.stats.reset();
+
         // Takes `&mut self` so `self` must be unique and there can't be any
         // borrows active that would get invalidated by resetting.
         unsafe {
@@ -2046,11 +2057,18 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// Errors if reserving space matching `layout` fails.
     #[inline(always)]
     pub fn try_alloc_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        if let Some(p) = self.try_alloc_layout_fast(layout) {
+        let res = if let Some(p) = self.try_alloc_layout_fast(layout) {
             Ok(p)
         } else {
             self.alloc_layout_slow(layout).ok_or(AllocErr)
+        };
+
+        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+        if res.is_ok() {
+            self.stats.record_allocation();
         }
+
+        res
     }
 
     #[inline(always)]
@@ -2427,6 +2445,12 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
             } else {
                 let new_ptr = self.try_alloc_layout(new_layout)?;
 
+                #[cfg(all(
+                    feature = "track_allocations",
+                    not(feature = "disable_track_allocations")
+                ))]
+                self.stats.record_reallocation_after_allocation();
+
                 // We know that these regions are nonoverlapping because
                 // `new_ptr` is a fresh allocation.
                 unsafe {
@@ -2494,6 +2518,12 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
                 // in the `if` condition.
                 ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
 
+                #[cfg(all(
+                    feature = "track_allocations",
+                    not(feature = "disable_track_allocations")
+                ))]
+                self.stats.record_reallocation();
+
                 return Ok(new_ptr);
             }
         }
@@ -2525,6 +2555,13 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
                 self.try_alloc_layout_fast(layout_from_size_align(delta, old_layout.align())?)
             {
                 unsafe { ptr::copy(ptr.as_ptr(), p.as_ptr(), old_size) };
+
+                #[cfg(all(
+                    feature = "track_allocations",
+                    not(feature = "disable_track_allocations")
+                ))]
+                self.stats.record_reallocation();
+
                 return Ok(p);
             }
         }
@@ -2532,6 +2569,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         // Fallback: do a fresh allocation and copy the existing data into it.
         let new_ptr = self.try_alloc_layout(new_layout)?;
         unsafe { ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_size) };
+
+        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+        self.stats.record_reallocation_after_allocation();
+
         Ok(new_ptr)
     }
 }

--- a/crates/oxc_allocator/src/tracking.rs
+++ b/crates/oxc_allocator/src/tracking.rs
@@ -1,26 +1,20 @@
 //! Allocation tracking.
 //!
-//! This module is only loaded when `track_allocations` feature is enabled.
-//! This feature is only used in `tasks/track_memory_allocations`.
+//! Tracking is only used in `tasks/track_memory_allocations`.
 //!
-//! Current implementation is unsound - see comment on [`get_stats_ref`] below.
-//! It's OK to use it in our internal `tasks/track_memory_allocations` tool,
-//! but we must take great care that this is NEVER enabled in any other circumstances.
-//!
-//! Even without the unsoundness, we don't want this enabled outside of `tasks/track_memory_allocations`,
+//! We don't want this enabled outside of `tasks/track_memory_allocations`,
 //! as it imposes a performance cost on making allocations.
 //!
-//! The 2nd cargo feature `disable_track_allocations` is to ensure that compiling with `--all-features`
+//! This module is only loaded when `track_allocations` feature is enabled, and `disable_track_allocations`
+//! feature is *not* enabled. The reason for the 2nd feature is to ensure that compiling with `--all-features`
 //! will not load this module.
-//!
-//! TODO: Remove the hack from `get_stats_ref` and make this sound.
 
-use std::{cell::Cell, ptr};
+use std::cell::Cell;
 
-use crate::{Allocator, allocator::STATS_FIELD_OFFSET, bump::Bump};
+use crate::{Allocator, bump::Bump};
 
 /// Counters of allocations and reallocations made in an [`Allocator`].
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AllocationStats {
     /// Number of allocations
     num_alloc: Cell<usize>,
@@ -43,6 +37,20 @@ impl AllocationStats {
         self.num_realloc.set(self.num_realloc.get().saturating_add(1));
     }
 
+    /// Record that a reallocation was made, after it was initially recorded as an allocation.
+    pub(crate) fn record_reallocation_after_allocation(&self) {
+        // Reduce counter by 1 to "uncount" the allocation which was recorded.
+        // If counter is `usize::MAX`, don't reduce it because it might have saturated.
+        let num_alloc = self.num_alloc.get();
+        if num_alloc != usize::MAX {
+            self.num_alloc.set(num_alloc - 1);
+        }
+
+        // Counter maxes out at `usize::MAX`, but if there's that many allocations,
+        // the exact number is not important
+        self.num_realloc.set(self.num_realloc.get().saturating_add(1));
+    }
+
     /// Reset allocation counters.
     pub(crate) fn reset(&self) {
         self.num_alloc.set(0);
@@ -50,40 +58,19 @@ impl AllocationStats {
     }
 }
 
-impl Allocator {
-    /// Get number of allocations and reallocations made in this [`Allocator`].
-    #[doc(hidden)]
-    pub fn get_allocation_stats(&self) -> (usize, usize) {
+impl Bump {
+    /// Get number of allocations and reallocations made in this [`Bump`].
+    fn get_allocation_stats(&self) -> (usize, usize) {
         let num_alloc = self.stats.num_alloc.get();
         let num_realloc = self.stats.num_realloc.get();
         (num_alloc, num_realloc)
     }
 }
 
-/// Get reference to [`AllocationStats`] for a [`Bump`].
-///
-/// # SAFETY
-///
-/// Caller must guarantee that the `Bump` provided to this function is wrapped in an [`Allocator`].
-///
-/// In Oxc, we never use `Bump` alone, without it being wrapped in an `Allocator`.
-/// However, we have no static guarantee of this relationship between `Bump` and `Allocator`,
-/// so it's usually impossible for callers to proveably satisfy the safety requirements of this method.
-///
-/// Even if the `Bump` *is* wrapped in an `Allocator`, this may still be UB, as we project beyond
-/// the bounds of the `&Bump`. Certainly stacked borrows memory model says this is UB, though it's unclear
-/// to me (@overlookmotel) whether stacked borrows is unnecessarily strict on this point.
-/// <https://github.com/rust-lang/unsafe-code-guidelines/issues/134>
-///
-/// This function (and the `track_allocations` feature in general) must only be used for internal tools,
-/// and must NEVER be compiled in production code.
-pub unsafe fn get_stats_ref(bump: &Bump) -> &AllocationStats {
-    // We assume the `Bump` is wrapped in an `Allocator`. We can therefore get a pointer to the `stats`
-    // field of `Allocator` from the memory location of the `Bump`.
-    // SAFETY: This is UNSOUND. See above.
-    unsafe {
-        let stats_ptr =
-            ptr::from_ref(bump).byte_offset(STATS_FIELD_OFFSET).cast::<AllocationStats>();
-        stats_ptr.as_ref().unwrap_unchecked()
+impl Allocator {
+    /// Get number of allocations and reallocations made in this [`Allocator`].
+    #[doc(hidden)]
+    pub fn get_allocation_stats(&self) -> (usize, usize) {
+        self.bump().get_allocation_stats()
     }
 }

--- a/tasks/track_memory_allocations/allocs_parser.snap
+++ b/tasks/track_memory_allocations/allocs_parser.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           9672 |             21 ||         267647 |          22847
+checker.ts                 | 2.92 MB        ||           9672 |             21 ||         267651 |          22847
 
-cal.com.tsx                | 1.06 MB        ||           1083 |             49 ||         136129 |          13697
+cal.com.tsx                | 1.06 MB        ||           1083 |             49 ||         136145 |          13697
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            364 |             66
+RadixUIAdoptionSection.jsx | 2.52 kB        ||              1 |              0 ||            367 |             66
 
-pdf.mjs                    | 567.30 kB      ||            703 |             75 ||          90578 |           8148
+pdf.mjs                    | 567.30 kB      ||            703 |             75 ||          90583 |           8148
 
 antd.js                    | 6.69 MB        ||           7132 |            235 ||         528577 |          55357
 
-binder.ts                  | 193.08 kB      ||            530 |              7 ||          16788 |           1467
+binder.ts                  | 193.08 kB      ||            530 |              7 ||          16791 |           1467
 


### PR DESCRIPTION
Previously we tracked allocations (`just allocs`) using unsound code in `Allocator`. That was necessary previously because we used `bumpalo` as the underlying allocator. Now we have control of `Bump`, we can remove this unsoundness, and just track allocations directly in `Bump`.

This also fixes some places where allocations failed to be counted. Unclear exactly where that discrepancy comes from, but likely from some route into `Bump` which went via `allocator_api2::Allocator` or `Alloc` traits. Now that tracking is centralized in `Bump` where the allocations actually occur, it's much simpler to ensure they're counted correctly.