### PR TITLE
fix(oxlint, oxfmt): apply `check_for_writer_error` to `.flush()`

### DIFF
--- a/apps/oxfmt/src/core/utils.rs
+++ b/apps/oxfmt/src/core/utils.rs
@@ -71,7 +71,7 @@ pub fn print_and_flush(writer: &mut dyn Write, message: &str) {
     }
 
     writer.write_all(message.as_bytes()).or_else(check_for_writer_error).unwrap();
-    writer.flush().unwrap();
+    writer.flush().or_else(check_for_writer_error).unwrap();
 }
 
 /// Normalize a relative path by:

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -595,7 +595,7 @@ impl CliRunner {
 
 pub fn print_and_flush_stdout(stdout: &mut dyn Write, message: &str) {
     stdout.write_all(message.as_bytes()).or_else(check_for_writer_error).unwrap();
-    stdout.flush().unwrap();
+    stdout.flush().or_else(check_for_writer_error).unwrap();
 }
 
 fn check_for_writer_error(error: std::io::Error) -> Result<(), std::io::Error> {


### PR DESCRIPTION
The print-and-flush helpers in oxlint and oxfmt apply `check_for_writer_error` to `write_all` but not to the following `flush()`. When the flush returns a benign I/O error — BrokenPipe from piping into `head`/`less`, or WouldBlock/EAGAIN on CI runners with non-blocking stdout — the raw `.unwrap()` panics.

This applies the existing helper to both flush calls, matching the pattern already in [service.rs line 234](https://github.com/oxc-project/oxc/blob/main/crates/oxc_diagnostics/src/service.rs#L234) and similar to #20295.

## Reproduction

Minimal reproduction repo: https://github.com/craigmorrison/oxlint-stdio-panic-repro

```bash
# install oxlint@^1.59.0
pnpm install

# Reproduction, panics at lint.rs:544:20 with BrokenPipe
pnpm exec oxlint errors.js | head -1
```

`errors.js` contains 100 `debugger;` statements triggering the default `no-debugger` rule. Without the pipe, oxlint reports all 100 warnings and exits cleanly.

## AI Disclosure

This issue was discovered and reproduced with the assistance of LLMs (via Claude Code). The reproduction, root cause analysis, patch, and test results were verified manually by me.