### PR TITLE
docs(linter): add missing docs for options for `typescript/class-literal-property-style`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/class_literal_property_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/class_literal_property_style.rs
@@ -39,8 +39,42 @@ fn prefer_getter_style_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum ClassLiteralPropertyStyleOption {
+    /// Enforce using readonly fields for literal values.
+    ///
+    /// Examples of **incorrect** code with this option:
+    /// ```ts
+    /// class C {
+    ///   get name() {
+    ///     return "oxc";
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code with this option:
+    /// ```ts
+    /// class C {
+    ///   readonly name = "oxc";
+    /// }
+    /// ```
     #[default]
     Fields,
+    /// Enforce using getters for literal values.
+    ///
+    /// Examples of **incorrect** code with this option:
+    /// ```ts
+    /// class C {
+    ///   readonly name = "oxc";
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code with this option:
+    /// ```ts
+    /// class C {
+    ///   get name() {
+    ///     return "oxc";
+    ///   }
+    /// }
+    /// ```
     Getters,
 }
 

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -1967,7 +1967,52 @@ class C {
 
 This rule accepts one of the following string values:
 
-type: `"fields" | "getters"`
+### `"fields"`
+
+
+
+Enforce using readonly fields for literal values.
+
+Examples of **incorrect** code with this option:
+```ts
+class C {
+get name() {
+return "oxc";
+}
+}
+```
+
+Examples of **correct** code with this option:
+```ts
+class C {
+readonly name = "oxc";
+}
+```
+
+
+### `"getters"`
+
+
+
+Enforce using getters for literal values.
+
+Examples of **incorrect** code with this option:
+```ts
+class C {
+readonly name = "oxc";
+}
+```
+
+Examples of **correct** code with this option:
+```ts
+class C {
+get name() {
+return "oxc";
+}
+}
+```
+
+
 
 
 


### PR DESCRIPTION
These fields had no documentation before.