### PR TITLE
fix(allocator): fix unfulfilled clippy lint expectation

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -566,7 +566,8 @@ impl Bump<1> {
     /// let bump = Bump::try_new();
     /// # let _ = bump.unwrap();
     /// ```
-    #[expect(clippy::missing_errors_doc, reason = "`try_with_capacity(0)` always returns `Ok`")]
+    /// # Errors
+    /// Returns `Err` if the allocator fails to allocate memory.
     pub fn try_new() -> Result<Self, AllocErr> {
         Bump::try_with_capacity(0)
     }


### PR DESCRIPTION
Replace `#[expect(clippy::missing_errors_doc)]` with an actual `# Errors`
doc section, since the lint is no longer triggered on newer Rust toolchains.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>