### PR TITLE
feat(tasks/linter): set rulegen version to next in template

### DIFF
--- a/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
+++ b/tasks/rulegen/src/snapshots/rulegen__template__tests__rulegen_template_render.snap
@@ -61,6 +61,7 @@ declare_oxc_lint!(
              // keep at 'pending' if you think one could be added but don't know how.
              // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
     config = MyRule,
+    version = "next",
 );
 
 impl Rule for MyRule {

--- a/tasks/rulegen/template.txt
+++ b/tasks/rulegen/template.txt
@@ -62,6 +62,7 @@ declare_oxc_lint!(
 {{#if rule_config}}
     config = {{pascal_rule_name}},
 {{/if}}
+    version = "next",
 );
 
 impl Rule for {{pascal_rule_name}} {


### PR DESCRIPTION
- follow up to #21363 by setting `version = "next"` in the rulegen template for newly scaffolded lint rules
- update the rulegen template snapshot to match

