### PR TITLE
feat(linter/jest): implement `prefer-ending-with-an-expect` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2246,6 +2246,11 @@ impl RuleRunner for crate::rules::jest::prefer_each::PreferEach {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::jest::prefer_ending_with_an_expect::PreferEndingWithAnExpect {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::jest::prefer_equality_matcher::PreferEqualityMatcher {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -246,6 +246,7 @@ pub use crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks 
 pub use crate::rules::jest::prefer_called_with::PreferCalledWith as JestPreferCalledWith;
 pub use crate::rules::jest::prefer_comparison_matcher::PreferComparisonMatcher as JestPreferComparisonMatcher;
 pub use crate::rules::jest::prefer_each::PreferEach as JestPreferEach;
+pub use crate::rules::jest::prefer_ending_with_an_expect::PreferEndingWithAnExpect as JestPreferEndingWithAnExpect;
 pub use crate::rules::jest::prefer_equality_matcher::PreferEqualityMatcher as JestPreferEqualityMatcher;
 pub use crate::rules::jest::prefer_expect_resolves::PreferExpectResolves as JestPreferExpectResolves;
 pub use crate::rules::jest::prefer_hooks_in_order::PreferHooksInOrder as JestPreferHooksInOrder;
@@ -1084,6 +1085,7 @@ pub enum RuleEnum {
     JestPreferCalledWith(JestPreferCalledWith),
     JestPreferComparisonMatcher(JestPreferComparisonMatcher),
     JestPreferEach(JestPreferEach),
+    JestPreferEndingWithAnExpect(JestPreferEndingWithAnExpect),
     JestPreferEqualityMatcher(JestPreferEqualityMatcher),
     JestPreferExpectResolves(JestPreferExpectResolves),
     JestPreferHooksInOrder(JestPreferHooksInOrder),
@@ -1851,7 +1853,8 @@ const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_PADDING_AROUND_AFTER_ALL_
 const JEST_PREFER_CALLED_WITH_ID: usize = JEST_PADDING_AROUND_TEST_BLOCKS_ID + 1usize;
 const JEST_PREFER_COMPARISON_MATCHER_ID: usize = JEST_PREFER_CALLED_WITH_ID + 1usize;
 const JEST_PREFER_EACH_ID: usize = JEST_PREFER_COMPARISON_MATCHER_ID + 1usize;
-const JEST_PREFER_EQUALITY_MATCHER_ID: usize = JEST_PREFER_EACH_ID + 1usize;
+const JEST_PREFER_ENDING_WITH_AN_EXPECT_ID: usize = JEST_PREFER_EACH_ID + 1usize;
+const JEST_PREFER_EQUALITY_MATCHER_ID: usize = JEST_PREFER_ENDING_WITH_AN_EXPECT_ID + 1usize;
 const JEST_PREFER_EXPECT_RESOLVES_ID: usize = JEST_PREFER_EQUALITY_MATCHER_ID + 1usize;
 const JEST_PREFER_HOOKS_IN_ORDER_ID: usize = JEST_PREFER_EXPECT_RESOLVES_ID + 1usize;
 const JEST_PREFER_HOOKS_ON_TOP_ID: usize = JEST_PREFER_HOOKS_IN_ORDER_ID + 1usize;
@@ -2685,6 +2688,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => JEST_PREFER_CALLED_WITH_ID,
             Self::JestPreferComparisonMatcher(_) => JEST_PREFER_COMPARISON_MATCHER_ID,
             Self::JestPreferEach(_) => JEST_PREFER_EACH_ID,
+            Self::JestPreferEndingWithAnExpect(_) => JEST_PREFER_ENDING_WITH_AN_EXPECT_ID,
             Self::JestPreferEqualityMatcher(_) => JEST_PREFER_EQUALITY_MATCHER_ID,
             Self::JestPreferExpectResolves(_) => JEST_PREFER_EXPECT_RESOLVES_ID,
             Self::JestPreferHooksInOrder(_) => JEST_PREFER_HOOKS_IN_ORDER_ID,
@@ -3516,6 +3520,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::NAME,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::NAME,
             Self::JestPreferEach(_) => JestPreferEach::NAME,
+            Self::JestPreferEndingWithAnExpect(_) => JestPreferEndingWithAnExpect::NAME,
             Self::JestPreferEqualityMatcher(_) => JestPreferEqualityMatcher::NAME,
             Self::JestPreferExpectResolves(_) => JestPreferExpectResolves::NAME,
             Self::JestPreferHooksInOrder(_) => JestPreferHooksInOrder::NAME,
@@ -4361,6 +4366,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::CATEGORY,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::CATEGORY,
             Self::JestPreferEach(_) => JestPreferEach::CATEGORY,
+            Self::JestPreferEndingWithAnExpect(_) => JestPreferEndingWithAnExpect::CATEGORY,
             Self::JestPreferEqualityMatcher(_) => JestPreferEqualityMatcher::CATEGORY,
             Self::JestPreferExpectResolves(_) => JestPreferExpectResolves::CATEGORY,
             Self::JestPreferHooksInOrder(_) => JestPreferHooksInOrder::CATEGORY,
@@ -5213,6 +5219,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::FIX,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::FIX,
             Self::JestPreferEach(_) => JestPreferEach::FIX,
+            Self::JestPreferEndingWithAnExpect(_) => JestPreferEndingWithAnExpect::FIX,
             Self::JestPreferEqualityMatcher(_) => JestPreferEqualityMatcher::FIX,
             Self::JestPreferExpectResolves(_) => JestPreferExpectResolves::FIX,
             Self::JestPreferHooksInOrder(_) => JestPreferHooksInOrder::FIX,
@@ -6127,6 +6134,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::documentation(),
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::documentation(),
             Self::JestPreferEach(_) => JestPreferEach::documentation(),
+            Self::JestPreferEndingWithAnExpect(_) => JestPreferEndingWithAnExpect::documentation(),
             Self::JestPreferEqualityMatcher(_) => JestPreferEqualityMatcher::documentation(),
             Self::JestPreferExpectResolves(_) => JestPreferExpectResolves::documentation(),
             Self::JestPreferHooksInOrder(_) => JestPreferHooksInOrder::documentation(),
@@ -7650,6 +7658,10 @@ impl RuleEnum {
             }
             Self::JestPreferEach(_) => JestPreferEach::config_schema(generator)
                 .or_else(|| JestPreferEach::schema(generator)),
+            Self::JestPreferEndingWithAnExpect(_) => {
+                JestPreferEndingWithAnExpect::config_schema(generator)
+                    .or_else(|| JestPreferEndingWithAnExpect::schema(generator))
+            }
             Self::JestPreferEqualityMatcher(_) => {
                 JestPreferEqualityMatcher::config_schema(generator)
                     .or_else(|| JestPreferEqualityMatcher::schema(generator))
@@ -9067,6 +9079,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => "jest",
             Self::JestPreferComparisonMatcher(_) => "jest",
             Self::JestPreferEach(_) => "jest",
+            Self::JestPreferEndingWithAnExpect(_) => "jest",
             Self::JestPreferEqualityMatcher(_) => "jest",
             Self::JestPreferExpectResolves(_) => "jest",
             Self::JestPreferHooksInOrder(_) => "jest",
@@ -10569,6 +10582,9 @@ impl RuleEnum {
             Self::JestPreferEach(_) => {
                 Ok(Self::JestPreferEach(JestPreferEach::from_configuration(value)?))
             }
+            Self::JestPreferEndingWithAnExpect(_) => Ok(Self::JestPreferEndingWithAnExpect(
+                JestPreferEndingWithAnExpect::from_configuration(value)?,
+            )),
             Self::JestPreferEqualityMatcher(_) => Ok(Self::JestPreferEqualityMatcher(
                 JestPreferEqualityMatcher::from_configuration(value)?,
             )),
@@ -12110,6 +12126,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(rule) => rule.to_configuration(),
             Self::JestPreferComparisonMatcher(rule) => rule.to_configuration(),
             Self::JestPreferEach(rule) => rule.to_configuration(),
+            Self::JestPreferEndingWithAnExpect(rule) => rule.to_configuration(),
             Self::JestPreferEqualityMatcher(rule) => rule.to_configuration(),
             Self::JestPreferExpectResolves(rule) => rule.to_configuration(),
             Self::JestPreferHooksInOrder(rule) => rule.to_configuration(),
@@ -12835,6 +12852,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(rule) => rule.run(node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run(node, ctx),
             Self::JestPreferEach(rule) => rule.run(node, ctx),
+            Self::JestPreferEndingWithAnExpect(rule) => rule.run(node, ctx),
             Self::JestPreferEqualityMatcher(rule) => rule.run(node, ctx),
             Self::JestPreferExpectResolves(rule) => rule.run(node, ctx),
             Self::JestPreferHooksInOrder(rule) => rule.run(node, ctx),
@@ -13558,6 +13576,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(rule) => rule.run_once(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_once(ctx),
             Self::JestPreferEach(rule) => rule.run_once(ctx),
+            Self::JestPreferEndingWithAnExpect(rule) => rule.run_once(ctx),
             Self::JestPreferEqualityMatcher(rule) => rule.run_once(ctx),
             Self::JestPreferExpectResolves(rule) => rule.run_once(ctx),
             Self::JestPreferHooksInOrder(rule) => rule.run_once(ctx),
@@ -14349,6 +14368,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferEach(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JestPreferEndingWithAnExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferEqualityMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferExpectResolves(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferHooksInOrder(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15106,6 +15126,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(rule) => rule.should_run(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.should_run(ctx),
             Self::JestPreferEach(rule) => rule.should_run(ctx),
+            Self::JestPreferEndingWithAnExpect(rule) => rule.should_run(ctx),
             Self::JestPreferEqualityMatcher(rule) => rule.should_run(ctx),
             Self::JestPreferExpectResolves(rule) => rule.should_run(ctx),
             Self::JestPreferHooksInOrder(rule) => rule.should_run(ctx),
@@ -15985,6 +16006,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::IS_TSGOLINT_RULE,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::IS_TSGOLINT_RULE,
             Self::JestPreferEach(_) => JestPreferEach::IS_TSGOLINT_RULE,
+            Self::JestPreferEndingWithAnExpect(_) => JestPreferEndingWithAnExpect::IS_TSGOLINT_RULE,
             Self::JestPreferEqualityMatcher(_) => JestPreferEqualityMatcher::IS_TSGOLINT_RULE,
             Self::JestPreferExpectResolves(_) => JestPreferExpectResolves::IS_TSGOLINT_RULE,
             Self::JestPreferHooksInOrder(_) => JestPreferHooksInOrder::IS_TSGOLINT_RULE,
@@ -16971,6 +16993,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::HAS_CONFIG,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::HAS_CONFIG,
             Self::JestPreferEach(_) => JestPreferEach::HAS_CONFIG,
+            Self::JestPreferEndingWithAnExpect(_) => JestPreferEndingWithAnExpect::HAS_CONFIG,
             Self::JestPreferEqualityMatcher(_) => JestPreferEqualityMatcher::HAS_CONFIG,
             Self::JestPreferExpectResolves(_) => JestPreferExpectResolves::HAS_CONFIG,
             Self::JestPreferHooksInOrder(_) => JestPreferHooksInOrder::HAS_CONFIG,
@@ -17770,6 +17793,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(rule) => rule.types_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.types_info(),
             Self::JestPreferEach(rule) => rule.types_info(),
+            Self::JestPreferEndingWithAnExpect(rule) => rule.types_info(),
             Self::JestPreferEqualityMatcher(rule) => rule.types_info(),
             Self::JestPreferExpectResolves(rule) => rule.types_info(),
             Self::JestPreferHooksInOrder(rule) => rule.types_info(),
@@ -18493,6 +18517,7 @@ impl RuleEnum {
             Self::JestPreferCalledWith(rule) => rule.run_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.run_info(),
             Self::JestPreferEach(rule) => rule.run_info(),
+            Self::JestPreferEndingWithAnExpect(rule) => rule.run_info(),
             Self::JestPreferEqualityMatcher(rule) => rule.run_info(),
             Self::JestPreferExpectResolves(rule) => rule.run_info(),
             Self::JestPreferHooksInOrder(rule) => rule.run_info(),
@@ -19302,6 +19327,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestPreferCalledWith(JestPreferCalledWith::default()),
         RuleEnum::JestPreferComparisonMatcher(JestPreferComparisonMatcher::default()),
         RuleEnum::JestPreferEach(JestPreferEach::default()),
+        RuleEnum::JestPreferEndingWithAnExpect(JestPreferEndingWithAnExpect::default()),
         RuleEnum::JestPreferEqualityMatcher(JestPreferEqualityMatcher::default()),
         RuleEnum::JestPreferExpectResolves(JestPreferExpectResolves::default()),
         RuleEnum::JestPreferHooksInOrder(JestPreferHooksInOrder::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -360,6 +360,7 @@ pub(crate) mod jest {
     pub mod prefer_called_with;
     pub mod prefer_comparison_matcher;
     pub mod prefer_each;
+    pub mod prefer_ending_with_an_expect;
     pub mod prefer_equality_matcher;
     pub mod prefer_expect_resolves;
     pub mod prefer_hooks_in_order;

--- a/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
@@ -1,0 +1,585 @@
+use cow_utils::CowUtils;
+use lazy_regex::Regex;
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression, FunctionBody, Statement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_str::CompactStr;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    rules::PossibleJestNode,
+    utils::{
+        JestGeneralFnKind, get_node_name, parse_expect_jest_fn_call, parse_general_jest_fn_call,
+    },
+};
+
+fn prefer_ending_with_an_expect_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Test must end with an assertion")
+        .with_help("Add an `expect` or assertion call as the last statement in the test block.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct PreferEndingWithAnExpect(Box<PreferEndingWithAnExpectConfig>);
+
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct PreferEndingWithAnExpectConfig {
+    /// An array of function names that should also be treated as test blocks.
+    additional_test_block_functions: Vec<CompactStr>,
+    /// A list of function names that should be treated as assertion functions.
+    assert_function_names: Vec<CompactStr>,
+}
+
+impl std::ops::Deref for PreferEndingWithAnExpect {
+    type Target = PreferEndingWithAnExpectConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Default for PreferEndingWithAnExpectConfig {
+    fn default() -> Self {
+        Self {
+            assert_function_names: vec!["expect".into()],
+            additional_test_block_functions: vec![],
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces that test blocks end with an assertion (`expect` or a configured
+    /// assertion function).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A test that doesn't end with an assertion may be performing side effects
+    /// or setup after its last check, which makes the test harder to understand
+    /// and can hide failures. Ending with an assertion ensures the test's final
+    /// action is verifying behavior.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule with default values:
+    /// ```js
+    /// it('lets me change the selected option', () => {
+    ///   const container = render(MySelect, {
+    ///     props: { options: [1, 2, 3], selected: 1 },
+    ///   });
+    ///
+    ///   expect(container).toBeDefined();
+    ///   expect(container.toHTML()).toContain('<option value="1" selected>');
+    ///
+    ///   container.setProp('selected', 2);
+    /// });
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with defaults values:
+    /// ```js
+    /// it('lets me change the selected option', () => {
+    ///   const container = render(MySelect, {
+    ///     props: { options: [1, 2, 3], selected: 1 },
+    ///   });
+    ///
+    ///   expect(container).toBeDefined();
+    ///   expect(container.toHTML()).toContain('<option value="1" selected>');
+    ///
+    ///   container.setProp('selected', 2);
+    ///
+    ///   expect(container.toHTML()).not.toContain('<option value="1" selected>');
+    ///   expect(container.toHTML()).toContain('<option value="2" selected>');
+    /// });
+    /// ```
+    ///
+    /// Examples of **incorrect** code for this rule with `{ "assertFunctionNames": ["expect"] }`:
+    /// ```js
+    /// import { expectSaga } from 'redux-saga-test-plan';
+    /// import { addSaga } from '../src/sagas';
+    ///
+    /// test('returns sum', () => {
+    ///   expectSaga(addSaga, 1, 1).returns(2).run();
+    /// });
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with `{ "assertFunctionNames": ["expect"] }`:
+    /// ```js
+    /// import { expectSaga } from 'redux-saga-test-plan';
+    /// import { addSaga } from '../src/sagas';
+    ///
+    /// test('returns sum', () => {
+    ///   expectSaga(addSaga, 1, 1).returns(2).run();
+    /// });
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with `{ "additionalTestBlockFunctions": ["each.test"] }`:
+    /// ```js
+    /// each([
+    ///   [2, 3],
+    ///   [1, 3],
+    /// ]).test(
+    ///   'the selection can change from %d to %d',
+    ///   (firstSelection, secondSelection) => {
+    ///     const container = render(MySelect, {
+    ///       props: { options: [1, 2, 3], selected: firstSelection },
+    ///     });
+    ///
+    ///     expect(container).toBeDefined();
+    ///     expect(container.toHTML()).toContain(
+    ///       `<option value="${firstSelection}" selected>`,
+    ///     );
+    ///
+    ///     container.setProp('selected', secondSelection);
+    ///
+    ///     expect(container.toHTML()).not.toContain(
+    ///       `<option value="${firstSelection}" selected>`,
+    ///     );
+    ///     expect(container.toHTML()).toContain(
+    ///       `<option value="${secondSelection}" selected>`,
+    ///     );
+    ///   },
+    /// );
+    /// ```
+    PreferEndingWithAnExpect,
+    jest,
+    style,
+    config = PreferEndingWithAnExpectConfig,
+);
+
+impl Rule for PreferEndingWithAnExpect {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let config = value.get(0);
+
+        let assert_function_names = config
+            .and_then(|config| config.get("assertFunctionNames"))
+            .and_then(serde_json::Value::as_array)
+            .map(|v| {
+                v.iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(convert_pattern)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or(vec!["expect".into()]);
+
+        let additional_test_block_functions = config
+            .and_then(|config| config.get("additionalTestBlockFunctions"))
+            .and_then(serde_json::Value::as_array)
+            .map(|v| v.iter().filter_map(serde_json::Value::as_str).map(CompactStr::from).collect())
+            .unwrap_or_default();
+
+        Ok(Self(Box::new(PreferEndingWithAnExpectConfig {
+            additional_test_block_functions,
+            assert_function_names,
+        })))
+    }
+
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        possible_jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        let node = possible_jest_node.node;
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let name = get_node_name(&call_expr.callee);
+
+        let Some(test_fn_argument) = call_expr.arguments.get(1) else {
+            return;
+        };
+
+        let Some(function_body) = function_argument(test_fn_argument) else {
+            return;
+        };
+
+        let Some(parsed_jest_fn) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
+            return;
+        };
+
+        let contains_test_name = if self.additional_test_block_functions.is_empty() {
+            true
+        } else {
+            self.additional_test_block_functions.contains(&name)
+        };
+
+        if parsed_jest_fn
+            .kind
+            .to_general()
+            .is_some_and(|test_kind| matches!(test_kind, JestGeneralFnKind::Describe))
+            || !contains_test_name
+        {
+            return;
+        }
+
+        if self.is_valid_last_statement(function_body, ctx) {
+            return;
+        }
+
+        ctx.diagnostic(prefer_ending_with_an_expect_diagnostic(call_expr.callee.span()));
+    }
+}
+
+impl PreferEndingWithAnExpect {
+    fn is_valid_last_statement<'a>(
+        &self,
+        function_body: &'a FunctionBody<'a>,
+        ctx: &LintContext<'a>,
+    ) -> bool {
+        let Some(statement) = function_body.statements.last() else {
+            return false;
+        };
+
+        let statement_expression = match statement {
+            Statement::ExpressionStatement(expression_statement) => {
+                &expression_statement.expression
+            }
+            _ => {
+                return false;
+            }
+        };
+
+        let call_expression = match &statement_expression {
+            Expression::AwaitExpression(awaited) => {
+                let Expression::CallExpression(ref call_expression_awaited) = awaited.argument
+                else {
+                    return false;
+                };
+
+                call_expression_awaited
+            }
+            Expression::CallExpression(last_call_expression) => last_call_expression,
+            _ => {
+                return false;
+            }
+        };
+
+        let possible_jest_node = PossibleJestNode {
+            node: ctx.nodes().get_node(call_expression.node_id()),
+            original: None,
+        };
+
+        if parse_expect_jest_fn_call(call_expression, &possible_jest_node, ctx).is_some() {
+            return true;
+        }
+
+        let node_name = get_node_name(&call_expression.callee);
+
+        matches_assert_function_name(&node_name, &self.assert_function_names)
+    }
+}
+
+fn function_argument<'a>(argument: &'a Argument<'a>) -> Option<&'a FunctionBody<'a>> {
+    match argument {
+        Argument::ArrowFunctionExpression(array_fn) => Some(&array_fn.body),
+        Argument::FunctionExpression(function) => function.body.as_ref().map(AsRef::as_ref),
+        _ => None,
+    }
+}
+
+/// Checks if node names returned by getNodeName matches any of the given star patterns
+fn matches_assert_function_name(name: &str, patterns: &[CompactStr]) -> bool {
+    patterns.iter().any(|pattern| Regex::new(pattern).unwrap().is_match(name))
+}
+
+fn convert_pattern(pattern: &str) -> CompactStr {
+    // Pre-process pattern, e.g.
+    // request.*.expect -> request.[a-z\\d]*.expect
+    // request.**.expect -> request.[a-z\\d\\.]*.expect
+    // request.**.expect* -> request.[a-z\\d\\.]*.expect[a-z\\d]*
+    let pattern = pattern
+        .split('.')
+        .map(|p| {
+            if p == "**" {
+                CompactStr::from("[a-z\\d\\.]*")
+            } else {
+                p.cow_replace('*', "[a-z\\d]*").into()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\\.");
+
+    // 'a.b.c' -> /^a\.b\.c(\.|$)/iu
+    format!("(?ui)^{pattern}(\\.|$)").into()
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"it.todo("will test something eventually")"#, None),
+        (r#"test.todo("will test something eventually")"#, None),
+        ("['x']();", None),
+        (r#"it("is weird", "because this should be a function")"#, None),
+        (r#"it("is weird", "because this should be a function", () => {})"#, None),
+        (r#"it("should pass", () => expect(true).toBeDefined())"#, None),
+        (r#"test("should pass", () => expect(true).toBeDefined())"#, None),
+        (r#"it("should pass", myTest); function myTest() { expect(true).toBeDefined() }"#, None),
+        (
+            "test('should pass', () => {
+              expect(true).toBeDefined();
+              foo(true).toBe(true);
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect", "foo"] }])),
+        ),
+        (
+            r#"it("should return undefined",() => expectSaga(mySaga).returns());"#,
+            Some(serde_json::json!([{ "assertFunctionNames": ["expectSaga"] }])),
+        ),
+        (
+            "test('verifies expect method call', () => expect$(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect\\$"] }])),
+        ),
+        (
+            "test('verifies expect method call', () => new Foo().expect(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["Foo.expect"] }])),
+        ),
+        (
+            "test('verifies deep expect method call', () => {
+              tester.foo().expect(123);
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["tester.foo.expect"] }])),
+        ),
+        (
+            "test('verifies chained expect method call', () => {
+              doSomething();
+              tester
+                .foo()
+                .bar()
+                .expect(456);
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["tester.foo.bar.expect"] }])),
+        ),
+        (
+            r#"test("verifies the function call", () => {
+              td.verify(someFunctionCall())
+            })"#,
+            Some(serde_json::json!([{ "assertFunctionNames": ["td.verify"] }])),
+        ),
+        (r#"it("should pass", async () => expect(true).toBeDefined())"#, None),
+        (
+            r#"it("should pass", () => expect(true).toBeDefined())"#,
+            Some(
+                serde_json::json!([ { "assertFunctionNames": "undefined", "additionalTestBlockFunctions": "undefined", }, ]),
+            ),
+        ),
+        (r#"it("should pass", () => { expect(true).toBeDefined() })"#, None),
+        (r#"it("should pass", function () { expect(true).toBeDefined() })"#, None),
+        (
+            "it('is a complete test', () => {
+              const container = render(Greeter);
+              expect(container).toBeDefined();
+              container.setProp('name', 'Bob');
+              expect(container.toHTML()).toContain('Hello Bob!');
+            });",
+            None,
+        ),
+        (
+            "it('is a complete test', async () => {
+              const container = render(Greeter);
+              expect(container).toBeDefined();
+              container.setProp('name', 'Bob');
+              await expect(container.toHTML()).resolve.toContain('Hello Bob!');
+            });",
+            None,
+        ),
+        (
+            "it('is a complete test', async function () {
+              const container = render(Greeter);
+              expect(container).toBeDefined();
+              container.setProp('name', 'Bob');
+              await expect(container.toHTML()).resolve.toContain('Hello Bob!');
+            });",
+            None,
+        ),
+        (
+            "describe('GET /user', function () {
+              it('responds with json', function (done) {
+                doSomething();
+                request(app).get('/user').expect('Content-Type', /json/).expect(200, done);
+              });
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect", "request.**.expect"] }])),
+        ),
+        (
+            r#"each([
+              [2, 3],
+              [1, 3],
+            ]).test(
+              'the selection can change from %d to %d',
+              (firstSelection, secondSelection) => {
+                const container = render(MySelect, {
+                  props: { options: [1, 2, 3], selected: firstSelection },
+                });
+                expect(container).toBeDefined();
+                expect(container.toHTML()).toContain(
+                  `<option value="${firstSelection}" selected>`
+                );
+                container.setProp('selected', secondSelection);
+                expect(container.toHTML()).not.toContain(
+                  `<option value="${firstSelection}" selected>`
+                );
+                expect(container.toHTML()).toContain(
+                  `<option value="${secondSelection}" selected>`
+                );
+              }
+            );"#,
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["each.test"] }])),
+        ),
+        (
+            "test('should pass *', () => expect404ToBeLoaded());",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect*"] }])),
+        ),
+        (
+            "test('should pass *', () => expect.toHaveStatus404());",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect.**"] }])),
+        ),
+        (
+            "test('should pass', () => tester.foo().expect(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["tester.*.expect"] }])),
+        ),
+        (
+            "test('should pass **', () => tester.foo().expect(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["**"] }])),
+        ),
+        (
+            "test('should pass *', () => tester.foo().expect(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["*"] }])),
+        ),
+        (
+            "test('should pass', () => tester.foo().expect(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["tester.**"] }])),
+        ),
+        (
+            "test('should pass', () => tester.foo().expect(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["tester.*"] }])),
+        ),
+        (
+            "test('should pass', () => tester.foo().bar().expectIt(456));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["tester.**.expect*"] }])),
+        ),
+        (
+            "test('should pass', () => request.get().foo().expect(456));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["request.**.expect"] }])),
+        ),
+        (
+            "test('should pass', () => request.get().foo().expect(456));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["request.**.e*e*t"] }])),
+        ),
+        (
+            "import { test } from '@jest/globals';
+            test('should pass', () => {
+              expect(true).toBeDefined();
+              foo(true).toBe(true);
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect", "foo"] }])),
+        ),
+        (
+            "import { test as checkThat } from '@jest/globals';
+            checkThat('this passes', () => {
+              expect(true).toBeDefined();
+              foo(true).toBe(true);
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect", "foo"] }])),
+        ),
+        (
+            "const { test } = require('@jest/globals');
+            test('verifies chained expect method call', () => {
+              tester
+                .foo()
+                .bar()
+                .expect(456);
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["tester.foo.bar.expect"] }])),
+        ),
+    ];
+
+    let fail = vec![
+        (r#"it("should fail", () => {});"#, None),
+        (r#"test("should fail", () => {});"#, None),
+        (r#"test.skip("should fail", () => {});"#, None),
+        (r#"it("should fail", () => { somePromise.then(() => {}); });"#, None),
+        (
+            r#"test("should fail", () => { foo(true).toBe(true); })"#,
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect"] }])),
+        ),
+        (
+            r#"it("should also fail",() => expectSaga(mySaga).returns());"#,
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect"] }])),
+        ),
+        (r#"it("should pass", () => somePromise().then(() => expect(true).toBeDefined()))"#, None),
+        (r#"it("should pass", () => render(Greeter))"#, None),
+        (r#"it("should pass", () => { render(Greeter) })"#, None),
+        (r#"it("should pass", function () { render(Greeter) })"#, None),
+        (r#"it("should not pass", () => class {})"#, None),
+        (r#"it("should not pass", () => ([]))"#, None),
+        (r#"it("should not pass", () => { const x = []; })"#, None),
+        (r#"it("should not pass", function () { class Mx {} })"#, None),
+        (
+            "it('is a complete test', () => {
+              const container = render(Greeter);
+              expect(container).toBeDefined();
+              container.setProp('name', 'Bob');
+            });",
+            None,
+        ),
+        (
+            "it('is a complete test', async () => {
+              const container = render(Greeter);
+              await expect(container).toBeDefined();
+              await container.setProp('name', 'Bob');
+            });",
+            None,
+        ),
+        (
+            "test('should fail', () => request.get().foo().expect(456));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["request.*.expect"] }])),
+        ),
+        (
+            "test('should fail', () => request.get().foo().bar().expect(456));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["request.foo**.expect"] }])),
+        ),
+        (
+            "test('should fail', () => tester.request(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["request.*"] }])),
+        ),
+        (
+            "test('should fail', () => request(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["request.*"] }])),
+        ),
+        (
+            "test('should fail', () => request(123));",
+            Some(serde_json::json!([{ "assertFunctionNames": ["request.**"] }])),
+        ),
+        (
+            "import { test as checkThat } from '@jest/globals';
+            checkThat('this passes', () => {
+              // ...
+            });",
+            Some(serde_json::json!([{ "assertFunctionNames": ["expect", "foo"] }])),
+        ),
+        (
+            "import { test as checkThat } from '@jest/globals';
+            checkThat.skip('this passes', () => {
+              // ...
+            });",
+            None,
+        ),
+    ];
+
+    Tester::new(PreferEndingWithAnExpect::NAME, PreferEndingWithAnExpect::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jest_prefer_ending_with_an_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_ending_with_an_expect.snap
@@ -1,0 +1,170 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should fail", () => {});
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test("should fail", () => {});
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test.skip("should fail", () => {});
+   · ─────────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should fail", () => { somePromise.then(() => {}); });
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test("should fail", () => { foo(true).toBe(true); })
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should also fail",() => expectSaga(mySaga).returns());
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should pass", () => somePromise().then(() => expect(true).toBeDefined()))
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should pass", () => render(Greeter))
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should pass", () => { render(Greeter) })
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should pass", function () { render(Greeter) })
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should not pass", () => class {})
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should not pass", () => ([]))
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should not pass", () => { const x = []; })
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it("should not pass", function () { class Mx {} })
+   · ──
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it('is a complete test', () => {
+   · ──
+ 2 │               const container = render(Greeter);
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ it('is a complete test', async () => {
+   · ──
+ 2 │               const container = render(Greeter);
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test('should fail', () => request.get().foo().expect(456));
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test('should fail', () => request.get().foo().bar().expect(456));
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test('should fail', () => tester.request(123));
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test('should fail', () => request(123));
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test('should fail', () => request(123));
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:2:13]
+ 1 │ import { test as checkThat } from '@jest/globals';
+ 2 │             checkThat('this passes', () => {
+   ·             ─────────
+ 3 │               // ...
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ eslint-plugin-jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:2:13]
+ 1 │ import { test as checkThat } from '@jest/globals';
+ 2 │             checkThat.skip('this passes', () => {
+   ·             ──────────────
+ 3 │               // ...
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/492

# AI Disclosure

Only used AI to generate the diagnostic messages and doc. The code has been made from zero.

# Summary

Implements `prefer-ending-with-an-expect`. The pattern logic has been copy from the rule `expect-expect`

# Info

- [Docs](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/docs/rules/prefer-ending-with-an-expect.md)
- [Source Code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/prefer-ending-with-an-expect.ts)
- [Test](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.1/src/rules/__tests__/prefer-ending-with-an-expect.test.ts)