### PR TITLE
feat(linter/jest): mark `valid-expect-with-promise` as unsupported due to type information requirement

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -48,6 +48,7 @@
     "jest/no-unnecessary-assertion": "Requires type information. Not currently possible to implement in oxlint.",
     "jest/unbound-method": "Requires type information. Not currently possible to implement in oxlint.",
     "jest/no-error-equal": "Requires type information. Not currently possible to implement in oxlint.",
+    "jest/valid-expect-with-promise": "Requires type information. Not currently possible to implement in oxlint.",
     "vitest/unbound-method": "Requires type information. Not currently possible to implement in oxlint.",
     "vitest/prefer-vi-mocked": "Requires type information. Not currently possible to implement in oxlint.",
 


### PR DESCRIPTION
[The rule needs Typescript information to know what diagnostic to report](https://github.com/jest-community/eslint-plugin-jest/blob/v29.15.2/src/rules/valid-expect-with-promise.ts). The rule reports:
- Using promises methods in a non promise variable.
- Non using the methods when expecting a promise.

The second diagnostic it’s possible to make an effort to detect it, but we can’t say the same for detecting non promises variables.