### PR TITLE
feat(napi/transform): expose `optimizeConstEnums` and `optimizeEnums` options

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -617,6 +617,24 @@ export interface TypeScriptOptions {
    */
   removeClassFieldsWithoutInitializer?: boolean
   /**
+   * When true, optimize const enums by inlining their values at usage sites
+   * and removing the enum declaration.
+   *
+   * @default false
+   */
+  optimizeConstEnums?: boolean
+  /**
+   * When true, optimize regular (non-const) enums by inlining their member
+   * accesses at usage sites when the member value is statically known.
+   *
+   * Non-exported enum declarations are also removed when all members are
+   * evaluable and no references to the enum as a runtime value exist
+   * (e.g., `console.log(Foo)`, `typeof Foo`, or passing the enum as an argument).
+   *
+   * @default false
+   */
+  optimizeEnums?: boolean
+  /**
    * Also generate a `.d.ts` declaration file for TypeScript files.
    *
    * The source file must be compliant with all

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -314,6 +314,20 @@ pub struct TypeScriptOptions {
     ///
     /// Defaults to `false`.
     pub remove_class_fields_without_initializer: Option<bool>,
+    /// When true, optimize const enums by inlining their values at usage sites
+    /// and removing the enum declaration.
+    ///
+    /// @default false
+    pub optimize_const_enums: Option<bool>,
+    /// When true, optimize regular (non-const) enums by inlining their member
+    /// accesses at usage sites when the member value is statically known.
+    ///
+    /// Non-exported enum declarations are also removed when all members are
+    /// evaluable and no references to the enum as a runtime value exist
+    /// (e.g., `console.log(Foo)`, `typeof Foo`, or passing the enum as an argument).
+    ///
+    /// @default false
+    pub optimize_enums: Option<bool>,
     /// Also generate a `.d.ts` declaration file for TypeScript files.
     ///
     /// The source file must be compliant with all
@@ -345,8 +359,8 @@ impl From<TypeScriptOptions> for oxc::transformer::TypeScriptOptions {
                 .unwrap_or(ops.only_remove_type_imports),
             allow_namespaces: options.allow_namespaces.unwrap_or(ops.allow_namespaces),
             allow_declare_fields: options.allow_declare_fields.unwrap_or(ops.allow_declare_fields),
-            optimize_const_enums: false,
-            optimize_enums: false,
+            optimize_const_enums: options.optimize_const_enums.unwrap_or(ops.optimize_const_enums),
+            optimize_enums: options.optimize_enums.unwrap_or(ops.optimize_enums),
             remove_class_fields_without_initializer: options
                 .remove_class_fields_without_initializer
                 .unwrap_or(ops.remove_class_fields_without_initializer),

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -409,6 +409,32 @@ describe("typescript", () => {
       `);
     });
 
+    test("optimizeConstEnums", () => {
+      const code = `
+        const enum Color { Red = 1, Green, Blue }
+        console.log(Color.Red, Color.Green, Color.Blue);
+      `;
+      const ret = transformSync("test.ts", code, {
+        typescript: {
+          optimizeConstEnums: true,
+        },
+      });
+      expect(ret.code).toEqual("console.log(1, 2, 3);\n");
+    });
+
+    test("optimizeEnums", () => {
+      const code = `
+        enum Status { Active = 1, Inactive = 2 }
+        console.log(Status.Active, Status.Inactive);
+      `;
+      const ret = transformSync("test.ts", code, {
+        typescript: {
+          optimizeEnums: true,
+        },
+      });
+      expect(ret.code).toEqual("console.log(1, 2);\n");
+    });
+
     test("align `useDefineForClassFields: false`", () => {
       const code = `
         class Foo {


### PR DESCRIPTION
Surface the TypeScript transformer's `optimize_const_enums` and
`optimize_enums` options through the napi bindings so JavaScript
consumers can opt into const enum inlining and regular (non-const)
enum inlining. Previously both were hardcoded to `false` in the
`From<TypeScriptOptions>` conversion, making them unreachable from JS.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>