### PR TITLE
fix(linter/prefer-ending-with-an-expect): add missing `version` docs

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
@@ -152,7 +152,7 @@ declare_oxc_lint!(
     jest,
     style,
     config = PreferEndingWithAnExpectConfig,
-    version = "next"
+    version = "1.60.0"
 );
 
 impl Rule for PreferEndingWithAnExpect {

--- a/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
@@ -152,6 +152,7 @@ declare_oxc_lint!(
     jest,
     style,
     config = PreferEndingWithAnExpectConfig,
+    version = "next"
 );
 
 impl Rule for PreferEndingWithAnExpect {


### PR DESCRIPTION
Follow up PR #21372, Added the version docs property.

Related to https://github.com/oxc-project/oxc/pull/21362
