### PR TITLE
refactor(allocator): rename `Bump` to `Arena`

### DIFF
--- a/crates/oxc_allocator/src/alloc.rs
+++ b/crates/oxc_allocator/src/alloc.rs
@@ -1,4 +1,4 @@
-// All methods just delegate to `Bump`'s methods
+// All methods just delegate to `Arena`'s methods
 #![expect(clippy::inline_always)]
 
 use std::{
@@ -8,7 +8,7 @@ use std::{
 
 use allocator_api2::alloc::Allocator;
 
-use crate::bump::Bump;
+use crate::bump::Arena;
 
 /// Trait describing an allocator.
 ///
@@ -82,10 +82,10 @@ pub trait Alloc {
     ) -> NonNull<u8>;
 }
 
-/// Implement [`Alloc`] for [`Bump`].
+/// Implement [`Alloc`] for [`Arena`].
 ///
-/// All methods except `alloc` delegate to [`Bump`]'s impl of `allocator_api2`'s [`Allocator`] trait.
-impl Alloc for Bump {
+/// All methods except `alloc` delegate to [`Arena`]'s impl of `allocator_api2`'s [`Allocator`] trait.
+impl Alloc for Arena {
     /// Allocate space for an object with the given [`Layout`].
     ///
     /// The returned pointer points at uninitialized memory, and should be initialized

--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -4,7 +4,7 @@ use std::{
     slice, str,
 };
 
-use crate::bump::Bump;
+use crate::bump::Arena;
 
 use oxc_data_structures::assert_unchecked;
 
@@ -215,7 +215,7 @@ use oxc_data_structures::assert_unchecked;
 #[derive(Default)]
 #[repr(transparent)]
 pub struct Allocator {
-    bump: Bump,
+    arena: Arena,
 }
 
 impl Allocator {
@@ -238,22 +238,22 @@ impl Allocator {
     /// [`Vec::new_in`]: crate::Vec::new_in
     /// [`HashMap::new_in`]: crate::HashMap::new_in
     //
-    // `#[inline(always)]` because just delegates to `Bump` method
+    // `#[inline(always)]` because just delegates to `Arena` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn new() -> Self {
-        Self { bump: Bump::new() }
+        Self { arena: Arena::new() }
     }
 
     /// Create a new [`Allocator`] with specified capacity.
     ///
     /// See [`Allocator`] docs for more information on efficient use of [`Allocator`].
     //
-    // `#[inline(always)]` because just delegates to `Bump` method
+    // `#[inline(always)]` because just delegates to `Arena` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn with_capacity(capacity: usize) -> Self {
-        Self { bump: Bump::with_capacity(capacity) }
+        Self { arena: Arena::with_capacity(capacity) }
     }
 
     /// Allocate an object in this [`Allocator`] and return an exclusive reference to it.
@@ -270,14 +270,14 @@ impl Allocator {
     /// assert_eq!(x, &[1u8; 20]);
     /// ```
     //
-    // `#[inline(always)]` because this is a very hot path and `Bump::alloc` is a very small function.
+    // `#[inline(always)]` because this is a very hot path and `Arena::alloc` is a very small function.
     // We always want it to be inlined.
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc<T>(&self, val: T) -> &mut T {
         const { assert!(!std::mem::needs_drop::<T>(), "Cannot allocate Drop type in arena") };
 
-        self.bump.alloc(val)
+        self.arena.alloc(val)
     }
 
     /// Copy a string slice into this [`Allocator`] and return a reference to it.
@@ -293,15 +293,15 @@ impl Allocator {
     /// assert_eq!(hello, "hello world");
     /// ```
     //
-    // `#[inline(always)]` because this is a hot path and `Bump::alloc_str` is a very small function.
+    // `#[inline(always)]` because this is a hot path and `Arena::alloc_str` is a very small function.
     // We always want it to be inlined.
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc_str<'alloc>(&'alloc self, src: &str) -> &'alloc str {
-        self.bump.alloc_str(src)
+        self.arena.alloc_str(src)
     }
 
-    /// `Copy` a slice into this `Bump` and return an exclusive reference to the copy.
+    /// `Copy` a slice into this [`Allocator`] and return an exclusive reference to the copy.
     ///
     /// # Panics
     /// Panics if reserving space for the slice fails.
@@ -313,12 +313,13 @@ impl Allocator {
     /// let x = allocator.alloc_slice_copy(&[1, 2, 3]);
     /// assert_eq!(x, &[1, 2, 3]);
     /// ```
-    // `#[inline(always)]` because this is a hot path and `Bump::alloc_slice_copy` is a very small function.
+    //
+    // `#[inline(always)]` because this is a hot path and `Arena::alloc_slice_copy` is a very small function.
     // We always want it to be inlined.
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc_slice_copy<T: Copy>(&self, src: &[T]) -> &mut [T] {
-        self.bump.alloc_slice_copy(src)
+        self.arena.alloc_slice_copy(src)
     }
 
     /// Allocate space for an object with the given [`Layout`].
@@ -330,12 +331,12 @@ impl Allocator {
     ///
     /// Panics if reserving space matching `layout` fails.
     //
-    // `#[inline(always)]` because this is a hot path and `Bump::alloc_layout` is a very small function.
+    // `#[inline(always)]` because this is a hot path and `Arena::alloc_layout` is a very small function.
     // We always want it to be inlined.
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc_layout(&self, layout: Layout) -> NonNull<u8> {
-        self.bump.alloc_layout(layout)
+        self.arena.alloc_layout(layout)
     }
 
     /// Create new `&str` from a fixed-size array of `&str`s concatenated together,
@@ -474,11 +475,11 @@ impl Allocator {
     /// }
     /// ```
     //
-    // `#[inline(always)]` because just delegates to `Bump` method
+    // `#[inline(always)]` because just delegates to `Arena` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn reset(&mut self) {
-        self.bump.reset();
+        self.arena.reset();
     }
 
     /// Calculate the total capacity of this [`Allocator`] including all chunks, in bytes.
@@ -501,11 +502,11 @@ impl Allocator {
     ///
     /// [`used_bytes`]: Allocator::used_bytes
     //
-    // `#[inline(always)]` because just delegates to `Bump` method
+    // `#[inline(always)]` because just delegates to `Arena` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn capacity(&self) -> usize {
-        self.bump.allocated_bytes()
+        self.arena.allocated_bytes()
     }
 
     /// Calculate the total size of data used in this [`Allocator`], in bytes.
@@ -571,26 +572,26 @@ impl Allocator {
     pub fn used_bytes(&self) -> usize {
         let mut bytes = 0;
         // SAFETY: No allocations are made while `chunks_iter` is alive. No data is read from the chunks.
-        let chunks_iter = unsafe { self.bump.iter_allocated_chunks_raw() };
+        let chunks_iter = unsafe { self.arena.iter_allocated_chunks_raw() };
         for (_, size) in chunks_iter {
             bytes += size;
         }
         bytes
     }
 
-    /// Get inner [`Bump`].
+    /// Get inner [`Arena`].
     ///
-    /// This method is not public. We don't want to expose `Bump` to user.
-    /// The inner `Bump` is an internal implementation detail.
+    /// This method is not public. We don't want to expose `Arena` to user.
+    /// The inner `Arena` is an internal implementation detail.
     //
     // `#[inline(always)]` because it's a no-op
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub(crate) fn bump(&self) -> &Bump {
-        &self.bump
+    pub(crate) fn arena(&self) -> &Arena {
+        &self.arena
     }
 
-    /// Create [`Allocator`] from a [`Bump`].
+    /// Create [`Allocator`] from an [`Arena`].
     ///
     /// This method is not public. Only used by [`Allocator::from_raw_parts`].
     //
@@ -598,8 +599,8 @@ impl Allocator {
     #[cfg(feature = "from_raw_parts")]
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub(crate) fn from_bump(bump: Bump) -> Self {
-        Self { bump }
+    pub(crate) fn from_arena(arena: Arena) -> Self {
+        Self { arena }
     }
 }
 

--- a/crates/oxc_allocator/src/allocator_api2.rs
+++ b/crates/oxc_allocator/src/allocator_api2.rs
@@ -1,22 +1,22 @@
-// All methods just delegate to `Bump`, so all marked `#[inline(always)]`.
-// All have same safety preconditions of `Bump` methods of the same name.
+// All methods just delegate to `Arena`, so all marked `#[inline(always)]`.
+// All have same safety preconditions of `Arena` methods of the same name.
 #![expect(clippy::inline_always, clippy::undocumented_unsafe_blocks)]
 
 use std::{alloc::Layout, ptr::NonNull};
 
 use allocator_api2::alloc::{AllocError, Allocator};
 
-/// SAFETY: See `bump.rs` for the implementation of `Allocator` for `&Bump`.
+/// SAFETY: See `bump.rs` for the implementation of `Allocator` for `&Arena`.
 unsafe impl Allocator for &crate::Allocator {
     #[inline(always)]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        Allocator::allocate(&self.bump(), layout)
+        Allocator::allocate(&self.arena(), layout)
     }
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         unsafe {
-            Allocator::deallocate(&self.bump(), ptr, layout);
+            Allocator::deallocate(&self.arena(), ptr, layout);
         }
     }
 
@@ -27,7 +27,7 @@ unsafe impl Allocator for &crate::Allocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        unsafe { Allocator::shrink(&self.bump(), ptr, old_layout, new_layout) }
+        unsafe { Allocator::shrink(&self.arena(), ptr, old_layout, new_layout) }
     }
 
     #[inline(always)]
@@ -37,7 +37,7 @@ unsafe impl Allocator for &crate::Allocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        unsafe { Allocator::grow(&self.bump(), ptr, old_layout, new_layout) }
+        unsafe { Allocator::grow(&self.arena(), ptr, old_layout, new_layout) }
     }
 
     #[inline(always)]
@@ -47,6 +47,6 @@ unsafe impl Allocator for &crate::Allocator {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        unsafe { Allocator::grow_zeroed(&self.bump(), ptr, old_layout, new_layout) }
+        unsafe { Allocator::grow_zeroed(&self.arena(), ptr, old_layout, new_layout) }
     }
 }

--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -97,7 +97,7 @@ impl<T> Box<'_, T> {
         // guaranteed to be unique - not just now, but we're guaranteed it's not
         // borrowed from some other reference. This in turn is because we never
         // construct a `Box` with a borrowed reference, only with a fresh
-        // one just allocated from a `Bump`.
+        // one just allocated from an `Arena`.
         unsafe { ptr::read(self.0.as_ptr()) }
     }
 }
@@ -210,7 +210,7 @@ impl<T: ?Sized> Deref for Box<'_, T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        // SAFETY: `self.0` is always a unique reference allocated from a `Bump` in `Box::new_in`,
+        // SAFETY: `self.0` is always a unique reference allocated from an `Arena` in `Box::new_in`,
         // or an empty slice allocated from `Box::new_empty_boxed_slice`
         unsafe { self.0.as_ref() }
     }
@@ -219,7 +219,7 @@ impl<T: ?Sized> Deref for Box<'_, T> {
 impl<T: ?Sized> DerefMut for Box<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: `self.0` is always a unique reference allocated from a `Bump` in `Box::new_in`,
+        // SAFETY: `self.0` is always a unique reference allocated from an `Arena` in `Box::new_in`,
         // or an empty slice allocated from `Box::new_empty_boxed_slice`
         unsafe { self.0.as_mut() }
     }

--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -26,7 +26,7 @@ pub use crate::bumpalo_alloc::AllocErr;
 #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
 use crate::tracking::AllocationStats;
 
-/// An error returned from [`Bump::try_alloc_try_with`].
+/// An error returned from [`Arena::try_alloc_try_with`].
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AllocOrInitError<E> {
     /// Indicates that the initial allocation failed.
@@ -67,12 +67,12 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// * any other resource that must be cleaned up (e.g. an `mmap`)
 ///
 /// and relies on its `Drop` implementation to clean up the internal resource,
-/// then if you allocate that type with a `Bump`, you need to find a new way to
+/// then if you allocate that type with an `Arena`, you need to find a new way to
 /// clean up after it yourself.
 ///
 /// Potential solutions are:
 ///
-/// * Using [`bumpalo::boxed::Box::new_in`] instead of [`Bump::alloc`], that
+/// * Using [`bumpalo::boxed::Box::new_in`] instead of [`Arena::alloc`], that
 ///   will drop wrapped values similarly to [`std::boxed::Box`]. Note that this
 ///   requires enabling the `"boxed"` Cargo feature for this crate. **This is
 ///   often the easiest solution.**
@@ -82,7 +82,7 @@ impl<E: Display> Display for AllocOrInitError<E> {
 ///
 /// * Using [`bumpalo::collections::Vec`] instead of [`std::vec::Vec`].
 ///
-/// * Avoiding allocating these problematic types within a `Bump`.
+/// * Avoiding allocating these problematic types within an `Arena`.
 ///
 /// Note that not calling `Drop` is memory safe! Destructors are never
 /// guaranteed to run in Rust, you can't rely on them for enforcing memory
@@ -101,24 +101,24 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// # Example
 ///
 /// ```
-/// # use oxc_allocator::bump::Bump;
+/// # use oxc_allocator::bump::Arena;
 ///
 /// // Create a new bump arena.
-/// let bump = Bump::new();
+/// let arena = Arena::new();
 ///
 /// // Allocate values into the arena.
-/// let forty_two = bump.alloc(42);
+/// let forty_two = arena.alloc(42);
 /// assert_eq!(*forty_two, 42);
 ///
 /// // Mutable references are returned from allocation.
-/// let mut s = bump.alloc("bumpalo");
+/// let mut s = arena.alloc("bumpalo");
 /// *s = "the bump allocator; and also is a buffalo";
 /// ```
 ///
 /// # Allocation Methods Come in Many Flavors
 ///
-/// There are various allocation methods on `Bump`, the simplest being
-/// [`alloc`][Bump::alloc]. The others exist to satisfy some combination of
+/// There are various allocation methods on `Arena`, the simplest being
+/// [`alloc`][Arena::alloc]. The others exist to satisfy some combination of
 /// fallible allocation and initialization. The allocation methods are
 /// summarized in the following table:
 ///
@@ -155,11 +155,11 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// scenarios, rather than raising a panic on OOM.
 ///
 /// ```
-/// # use oxc_allocator::bump::Bump;
+/// # use oxc_allocator::bump::Arena;
 ///
-/// let bump = Bump::new();
+/// let arena = Arena::new();
 ///
-/// match bump.try_alloc(MyStruct {
+/// match arena.try_alloc(MyStruct {
 ///     // ...
 /// }) {
 ///     Ok(my_struct) => {
@@ -183,13 +183,13 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// space for storing `x` on the heap.
 ///
 /// This can be useful in certain edge-cases related to compiler optimizations.
-/// When evaluating for example `bump.alloc(x)`, semantically `x` is first put
+/// When evaluating for example `arena.alloc(x)`, semantically `x` is first put
 /// on the stack and then moved onto the heap. In some cases, the compiler is
 /// able to optimize this into constructing `x` directly on the heap, however
 /// in many cases it does not.
 ///
 /// The `…alloc_with` functions try to help the compiler be smarter. In most
-/// cases doing for example `bump.try_alloc_with(|| x)` on release mode will be
+/// cases doing for example `arena.try_alloc_with(|| x)` on release mode will be
 /// enough to help the compiler realize that this optimization is valid and
 /// to construct `x` directly onto the heap.
 ///
@@ -223,16 +223,16 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// in <code>self</code>.</summary>
 ///
 /// For example, the following will always leak also space for the [`Result`]
-/// into this `Bump`, even though the inner reference isn't kept and the [`Err`]
+/// into this `Arena`, even though the inner reference isn't kept and the [`Err`]
 /// payload is returned semantically by value:
 ///
 /// ```rust
-/// # use oxc_allocator::bump::Bump;
+/// # use oxc_allocator::bump::Arena;
 ///
-/// let bump = Bump::new();
+/// let arena = Arena::new();
 ///
-/// let r: Result<&mut [u8; 1000], ()> = bump.alloc_try_with(|| {
-///     let _ = bump.alloc(0_u8);
+/// let r: Result<&mut [u8; 1000], ()> = arena.alloc_try_with(|| {
+///     let _ = arena.alloc(0_u8);
 ///     Err(())
 /// });
 ///
@@ -242,42 +242,42 @@ impl<E: Display> Display for AllocOrInitError<E> {
 ///</details></p>
 ///
 /// Since [`Err`] payloads are first placed on the heap and then moved to the
-/// stack, `bump.…alloc_try_with(|| x)?` is likely to execute more slowly than
-/// the matching `bump.…alloc(x?)` in case of initialization failure. If this
+/// stack, `arena.…alloc_try_with(|| x)?` is likely to execute more slowly than
+/// the matching `arena.…alloc(x?)` in case of initialization failure. If this
 /// happens frequently, using the plain un-suffixed method may perform better.
 ///
 /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 /// [`Ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Ok
 /// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
 ///
-/// ## `Bump` Allocation Limits
+/// ## `Arena` Allocation Limits
 ///
 /// `bumpalo` supports setting a limit on the maximum bytes of memory that can
-/// be allocated for use in a particular `Bump` arena. This limit can be set and removed with
-/// [`set_allocation_limit`][Bump::set_allocation_limit].
+/// be allocated for use in a particular `Arena` arena. This limit can be set and removed with
+/// [`set_allocation_limit`][Arena::set_allocation_limit].
 /// The allocation limit is only enforced when allocating new backing chunks for
-/// a `Bump`. Updating the allocation limit will not affect existing allocations
-/// or any future allocations within the `Bump`'s current chunk.
+/// an `Arena`. Updating the allocation limit will not affect existing allocations
+/// or any future allocations within the `Arena`'s current chunk.
 ///
 /// ### Example
 ///
 /// ```
-/// # use oxc_allocator::bump::Bump;
+/// # use oxc_allocator::bump::Arena;
 ///
-/// let bump = Bump::new();
+/// let arena = Arena::new();
 ///
-/// assert_eq!(bump.allocation_limit(), None);
-/// bump.set_allocation_limit(Some(0));
+/// assert_eq!(arena.allocation_limit(), None);
+/// arena.set_allocation_limit(Some(0));
 ///
-/// assert!(bump.try_alloc(5).is_err());
+/// assert!(arena.try_alloc(5).is_err());
 ///
-/// bump.set_allocation_limit(Some(6));
+/// arena.set_allocation_limit(Some(6));
 ///
-/// assert_eq!(bump.allocation_limit(), Some(6));
+/// assert_eq!(arena.allocation_limit(), Some(6));
 ///
-/// bump.set_allocation_limit(None);
+/// arena.set_allocation_limit(None);
 ///
-/// assert_eq!(bump.allocation_limit(), None);
+/// assert_eq!(arena.allocation_limit(), None);
 /// ```
 ///
 /// ### Warning
@@ -286,11 +286,11 @@ impl<E: Display> Display for AllocOrInitError<E> {
 /// due to allocation limits will not present differently than
 /// errors due to resource exhaustion.
 #[derive(Debug)]
-pub struct Bump<const MIN_ALIGN: usize = 1> {
+pub struct Arena<const MIN_ALIGN: usize = 1> {
     // The current chunk we are bump allocating within.
     current_chunk_footer: Cell<NonNull<ChunkFooter>>,
     allocation_limit: Cell<Option<usize>>,
-    /// Used to track number of allocations made in this `Bump` when `track_allocations` feature is enabled
+    /// Used to track number of allocations made in this `Arena` when `track_allocations` feature is enabled
     #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
     pub(crate) stats: AllocationStats,
 }
@@ -375,13 +375,13 @@ impl ChunkFooter {
     }
 }
 
-impl<const MIN_ALIGN: usize> Default for Bump<MIN_ALIGN> {
+impl<const MIN_ALIGN: usize> Default for Arena<MIN_ALIGN> {
     fn default() -> Self {
         Self::with_min_align()
     }
 }
 
-impl<const MIN_ALIGN: usize> Drop for Bump<MIN_ALIGN> {
+impl<const MIN_ALIGN: usize> Drop for Arena<MIN_ALIGN> {
     fn drop(&mut self) {
         unsafe {
             dealloc_chunk_list(self.current_chunk_footer.get());
@@ -400,11 +400,11 @@ unsafe fn dealloc_chunk_list(mut footer: NonNull<ChunkFooter>) {
     }
 }
 
-// `Bump`s are safe to send between threads because nothing aliases its owned
+// `Arena`s are safe to send between threads because nothing aliases its owned
 // chunks until you start allocating from it. But by the time you allocate from
-// it, the returned references to allocations borrow the `Bump` and therefore
-// prevent sending the `Bump` across threads until the borrows end.
-unsafe impl<const MIN_ALIGN: usize> Send for Bump<MIN_ALIGN> {}
+// it, the returned references to allocations borrow the `Arena` and therefore
+// prevent sending the `Arena` across threads until the borrows end.
+unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 
 #[inline]
 fn is_pointer_aligned_to<T>(pointer: *mut T, align: usize) -> bool {
@@ -538,20 +538,20 @@ fn allocation_size_overflow<T>() -> T {
     panic!("requested allocation size overflowed")
 }
 
-// NB: We don't have constructors as methods on `impl<N> Bump<N>` that return
+// NB: We don't have constructors as methods on `impl<N> Arena<N>` that return
 // `Self` because then `rustc` can't infer the `N` if it isn't explicitly
 // provided, even though it has a default value. There doesn't seem to be a good
-// workaround, other than putting constructors on the `Bump<DEFAULT>`; even
+// workaround, other than putting constructors on the `Arena<DEFAULT>`; even
 // `std` does this same thing with `HashMap`, for example.
-impl Bump<1> {
+impl Arena<1> {
     /// Construct a new arena to bump allocate into.
     ///
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
-    /// let bump = Bump::new();
-    /// # let _ = bump;
+    /// # use oxc_allocator::bump::Arena;
+    /// let arena = Arena::new();
+    /// # let _ = arena;
     /// ```
     pub fn new() -> Self {
         Self::with_capacity(0)
@@ -562,13 +562,13 @@ impl Bump<1> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
-    /// let bump = Bump::try_new();
-    /// # let _ = bump.unwrap();
+    /// # use oxc_allocator::bump::Arena;
+    /// let arena = Arena::try_new();
+    /// # let _ = arena.unwrap();
     /// ```
     #[expect(clippy::missing_errors_doc, reason = "`try_with_capacity(0)` always returns `Ok`")]
     pub fn try_new() -> Result<Self, AllocErr> {
-        Bump::try_with_capacity(0)
+        Arena::try_with_capacity(0)
     }
 
     /// Construct a new arena with the specified byte capacity to bump allocate
@@ -577,9 +577,9 @@ impl Bump<1> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
-    /// let bump = Bump::with_capacity(100);
-    /// # let _ = bump;
+    /// # use oxc_allocator::bump::Arena;
+    /// let arena = Arena::with_capacity(100);
+    /// # let _ = arena;
     /// ```
     ///
     /// # Panics
@@ -597,10 +597,10 @@ impl Bump<1> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::{AllocErr, Bump};
+    /// # use oxc_allocator::bump::{AllocErr, Arena};
     /// # fn _foo() -> Result<(), AllocErr> {
-    /// let bump = Bump::try_with_capacity(100)?;
-    /// # let _ = bump;
+    /// let arena = Arena::try_with_capacity(100)?;
+    /// # let _ = arena;
     /// # Ok(())
     /// # }
     /// ```
@@ -620,8 +620,8 @@ impl Bump<1> {
     }
 }
 
-impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
-    /// Create a new `Bump` that enforces a minimum alignment.
+impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
+    /// Create a new `Arena` that enforces a minimum alignment.
     ///
     /// The minimum alignment must be a power of two and no larger than `16`.
     ///
@@ -633,12 +633,12 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// type BumpAlign8 = Bump<8>;
-    /// let bump = BumpAlign8::with_min_align();
+    /// type ArenaAlign8 = Arena<8>;
+    /// let arena = ArenaAlign8::with_min_align();
     /// for x in 0..u8::MAX {
-    ///     let x = bump.alloc(x);
+    ///     let x = arena.alloc(x);
     ///     assert_eq!((x as *mut _ as usize) % 8, 0, "x is aligned to 8");
     /// }
     /// ```
@@ -648,9 +648,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// Panics on invalid minimum alignments.
     //
     // Because of `rustc`'s poor type inference for default type/const
-    // parameters (see the comment above the `impl Bump` block with no const
+    // parameters (see the comment above the `impl Arena` block with no const
     // `MIN_ALIGN` parameter) and because we don't want to force everyone to
-    // specify a minimum alignment with `Bump::new()` et al, we have a separate
+    // specify a minimum alignment with `Arena::new()` et al, we have a separate
     // constructor for specifying the minimum alignment.
     pub fn with_min_align() -> Self {
         assert!(MIN_ALIGN.is_power_of_two(), "MIN_ALIGN must be a power of two; found {MIN_ALIGN}");
@@ -662,7 +662,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         Self::new_impl(EMPTY_CHUNK.get(), None)
     }
 
-    /// Create a new `Bump` that enforces a minimum alignment and starts with
+    /// Create a new `Arena` that enforces a minimum alignment and starts with
     /// room for at least `capacity` bytes.
     ///
     /// The minimum alignment must be a power of two and no larger than `16`.
@@ -675,16 +675,16 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// type BumpAlign8 = Bump<8>;
-    /// let mut bump = BumpAlign8::with_min_align_and_capacity(8 * 100);
+    /// type ArenaAlign8 = Arena<8>;
+    /// let mut arena = ArenaAlign8::with_min_align_and_capacity(8 * 100);
     /// for x in 0..100_u64 {
-    ///     let x = bump.alloc(x);
+    ///     let x = arena.alloc(x);
     ///     assert_eq!((x as *mut _ as usize) % 8, 0, "x is aligned to 8");
     /// }
     /// assert_eq!(
-    ///     bump.iter_allocated_chunks().count(), 1,
+    ///     arena.iter_allocated_chunks().count(), 1,
     ///     "initial chunk had capacity for all allocations",
     /// );
     /// ```
@@ -698,7 +698,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         Self::try_with_min_align_and_capacity(capacity).unwrap_or_else(|_| oom())
     }
 
-    /// Create a new `Bump` that enforces a minimum alignment and starts with
+    /// Create a new `Arena` that enforces a minimum alignment and starts with
     /// room for at least `capacity` bytes.
     ///
     /// The minimum alignment must be a power of two and no larger than `16`.
@@ -711,16 +711,16 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::{AllocErr, Bump};
+    /// # use oxc_allocator::bump::{AllocErr, Arena};
     /// # fn _foo() -> Result<(), AllocErr> {
-    /// type BumpAlign8 = Bump<8>;
-    /// let mut bump = BumpAlign8::try_with_min_align_and_capacity(8 * 100)?;
+    /// type ArenaAlign8 = Arena<8>;
+    /// let mut arena = ArenaAlign8::try_with_min_align_and_capacity(8 * 100)?;
     /// for x in 0..100_u64 {
-    ///     let x = bump.alloc(x);
+    ///     let x = arena.alloc(x);
     ///     assert_eq!((x as *mut _ as usize) % 8, 0, "x is aligned to 8");
     /// }
     /// assert_eq!(
-    ///     bump.iter_allocated_chunks().count(), 1,
+    ///     arena.iter_allocated_chunks().count(), 1,
     ///     "initial chunk had capacity for all allocations",
     /// );
     /// # Ok(())
@@ -760,7 +760,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
             Self::new_chunk(
                 // `new_size_without_footer` here was `None` in original `bumpalo` code.
                 // Changed to `Some(capacity)` when we increased `FIRST_ALLOCATION_GOAL` to 16 KiB,
-                // to avoid `Bump::with_capacity` allocating 16 KiB even when requested `capacity` is much smaller.
+                // to avoid `Arena::with_capacity` allocating 16 KiB even when requested `capacity` is much smaller.
                 Self::new_chunk_memory_details(Some(capacity), layout).ok_or(AllocErr)?,
                 layout,
                 EMPTY_CHUNK.get(),
@@ -771,9 +771,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         Ok(Self::new_impl(chunk_footer, None))
     }
 
-    /// Create a new `Bump` from a chunk footer pointer and an optional allocation limit.
+    /// Create a new `Arena` from a chunk footer pointer and an optional allocation limit.
     ///
-    /// This is a helper function for all code paths which create a `Bump`.
+    /// This is a helper function for all code paths which create an `Arena`.
     #[inline(always)]
     fn new_impl(chunk_footer_ptr: NonNull<ChunkFooter>, allocation_limit: Option<usize>) -> Self {
         Self {
@@ -791,13 +791,13 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump2 = Bump::<2>::with_min_align();
-    /// assert_eq!(bump2.min_align(), 2);
+    /// let arena2 = Arena::<2>::with_min_align();
+    /// assert_eq!(arena2.min_align(), 2);
     ///
-    /// let bump4 = Bump::<4>::with_min_align();
-    /// assert_eq!(bump4.min_align(), 4);
+    /// let arena4 = Arena::<4>::with_min_align();
+    /// assert_eq!(arena4.min_align(), 4);
     /// ```
     #[inline]
     #[expect(clippy::unused_self, reason = "part of public API")]
@@ -810,19 +810,19 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::with_capacity(0);
+    /// let arena = Arena::with_capacity(0);
     ///
-    /// assert_eq!(bump.allocation_limit(), None);
+    /// assert_eq!(arena.allocation_limit(), None);
     ///
-    /// bump.set_allocation_limit(Some(6));
+    /// arena.set_allocation_limit(Some(6));
     ///
-    /// assert_eq!(bump.allocation_limit(), Some(6));
+    /// assert_eq!(arena.allocation_limit(), Some(6));
     ///
-    /// bump.set_allocation_limit(None);
+    /// arena.set_allocation_limit(None);
     ///
-    /// assert_eq!(bump.allocation_limit(), None);
+    /// assert_eq!(arena.allocation_limit(), None);
     /// ```
     pub fn allocation_limit(&self) -> Option<usize> {
         self.allocation_limit.get()
@@ -831,19 +831,19 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// Set the allocation limit in bytes for this arena.
     ///
     /// The allocation limit is only enforced when allocating new backing chunks for
-    /// a `Bump`. Updating the allocation limit will not affect existing allocations
-    /// or any future allocations within the `Bump`'s current chunk.
+    /// an `Arena`. Updating the allocation limit will not affect existing allocations
+    /// or any future allocations within the `Arena`'s current chunk.
     ///
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::with_capacity(0);
+    /// let arena = Arena::with_capacity(0);
     ///
-    /// bump.set_allocation_limit(Some(0));
+    /// arena.set_allocation_limit(Some(0));
     ///
-    /// assert!(bump.try_alloc(5).is_err());
+    /// assert!(arena.try_alloc(5).is_err());
     /// ```
     pub fn set_allocation_limit(&self, limit: Option<usize>) {
         self.allocation_limit.set(limit);
@@ -863,7 +863,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     }
 
     /// Whether a request to allocate a new chunk with a given size for a given
-    /// requested layout will fit under the allocation limit set on a `Bump`.
+    /// requested layout will fit under the allocation limit set on an `Arena`.
     fn chunk_fits_under_limit(
         allocation_limit_remaining: Option<usize>,
         new_chunk_memory_details: NewChunkMemoryDetails,
@@ -982,7 +982,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// Performs mass deallocation on everything allocated in this arena by
     /// resetting the pointer into the underlying chunk of memory to the start
     /// of the chunk. Does not run any `Drop` implementations on deallocated
-    /// objects; see [the top-level documentation](struct.Bump.html) for details.
+    /// objects; see [the top-level documentation](struct.Arena.html) for details.
     ///
     /// If this arena has allocated multiple chunks to bump allocate into, then
     /// the excess chunks are returned to the global allocator.
@@ -990,24 +990,24 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let mut bump = Bump::new();
+    /// let mut arena = Arena::new();
     ///
     /// // Allocate a bunch of things.
     /// {
     ///     for i in 0..100 {
-    ///         bump.alloc(i);
+    ///         arena.alloc(i);
     ///     }
     /// }
     ///
     /// // Reset the arena.
-    /// bump.reset();
+    /// arena.reset();
     ///
     /// // Allocate some new things in the space previously occupied by the
     /// // original things.
     /// for j in 200..400 {
-    ///     bump.alloc(j);
+    ///     arena.alloc(j);
     /// }
     ///```
     pub fn reset(&mut self) {
@@ -1050,7 +1050,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Allocate an object in this `Bump` and return an exclusive reference to
+    /// Allocate an object in this `Arena` and return an exclusive reference to
     /// it.
     ///
     /// # Panics
@@ -1060,10 +1060,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.alloc("hello");
+    /// let arena = Arena::new();
+    /// let x = arena.alloc("hello");
     /// assert_eq!(*x, "hello");
     /// ```
     #[inline(always)]
@@ -1071,7 +1071,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         self.alloc_with(|| val)
     }
 
-    /// Try to allocate an object in this `Bump` and return an exclusive
+    /// Try to allocate an object in this `Arena` and return an exclusive
     /// reference to it.
     ///
     /// # Errors
@@ -1081,10 +1081,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.try_alloc("hello");
+    /// let arena = Arena::new();
+    /// let x = arena.try_alloc("hello");
     /// assert_eq!(x, Ok(&mut "hello"));
     /// ```
     #[inline(always)]
@@ -1092,7 +1092,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         self.try_alloc_with(|| val)
     }
 
-    /// Pre-allocate space for an object in this `Bump`, initializes it using
+    /// Pre-allocate space for an object in this `Arena`, initializes it using
     /// the closure, then returns an exclusive reference to it.
     ///
     /// See [The `_with` Method Suffix](#initializer-functions-the-_with-method-suffix) for a
@@ -1107,10 +1107,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.alloc_with(|| "hello");
+    /// let arena = Arena::new();
+    /// let x = arena.alloc_with(|| "hello");
     /// assert_eq!(*x, "hello");
     /// ```
     #[expect(clippy::mut_from_ref)]
@@ -1147,7 +1147,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Tries to pre-allocate space for an object in this `Bump`, initializes
+    /// Tries to pre-allocate space for an object in this `Arena`, initializes
     /// it using the closure, then returns an exclusive reference to it.
     ///
     /// See [The `_with` Method Suffix](#initializer-functions-the-_with-method-suffix) for a
@@ -1162,10 +1162,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.try_alloc_with(|| "hello");
+    /// let arena = Arena::new();
+    /// let x = arena.try_alloc_with(|| "hello");
     /// assert_eq!(x, Ok(&mut "hello"));
     /// ```
     #[expect(clippy::mut_from_ref)]
@@ -1203,7 +1203,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Pre-allocates space for a [`Result`] in this `Bump`, initializes it using
+    /// Pre-allocates space for a [`Result`] in this `Arena`, initializes it using
     /// the closure, then returns an exclusive reference to its `T` if [`Ok`].
     ///
     /// Iff the allocation fails, the closure is not run.
@@ -1234,10 +1234,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.alloc_try_with(|| Ok("hello"))?;
+    /// let arena = Arena::new();
+    /// let x = arena.alloc_try_with(|| Ok("hello"))?;
     /// assert_eq!(*x, "hello");
     /// # Result::<_, ()>::Ok(())
     /// ```
@@ -1312,7 +1312,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Tries to pre-allocates space for a [`Result`] in this `Bump`,
+    /// Tries to pre-allocates space for a [`Result`] in this `Arena`,
     /// initializes it using the closure, then returns an exclusive reference
     /// to its `T` if all [`Ok`].
     ///
@@ -1345,10 +1345,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::{AllocOrInitError, Bump};
+    /// # use oxc_allocator::bump::{AllocOrInitError, Arena};
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.try_alloc_try_with(|| Ok("hello"))?;
+    /// let arena = Arena::new();
+    /// let x = arena.try_alloc_try_with(|| Ok("hello"))?;
     /// assert_eq!(*x, "hello");
     /// # Result::<_, AllocOrInitError<()>>::Ok(())
     /// ```
@@ -1423,7 +1423,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// `Copy` a slice into this `Bump` and return an exclusive reference to
+    /// `Copy` a slice into this `Arena` and return an exclusive reference to
     /// the copy.
     ///
     /// # Panics
@@ -1433,10 +1433,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.alloc_slice_copy(&[1, 2, 3]);
+    /// let arena = Arena::new();
+    /// let x = arena.alloc_slice_copy(&[1, 2, 3]);
     /// assert_eq!(x, &[1, 2, 3]);
     /// ```
     #[expect(clippy::mut_from_ref)]
@@ -1459,23 +1459,23 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::{AllocErr, Bump};
+    /// # use oxc_allocator::bump::{AllocErr, Arena};
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.try_alloc_slice_copy(&[1, 2, 3]);
+    /// let arena = Arena::new();
+    /// let x = arena.try_alloc_slice_copy(&[1, 2, 3]);
     /// assert_eq!(x, Ok(&mut[1, 2, 3] as &mut [_]));
     ///
     ///
-    /// let bump = Bump::new();
-    /// bump.set_allocation_limit(Some(4));
-    /// let x = bump.try_alloc_slice_copy(&[1, 2, 3, 4, 5, 6]);
+    /// let arena = Arena::new();
+    /// arena.set_allocation_limit(Some(4));
+    /// let x = arena.try_alloc_slice_copy(&[1, 2, 3, 4, 5, 6]);
     /// assert_eq!(x, Err(AllocErr)); // too big
     /// ```
     ///
     /// # Errors
     ///
     /// Returns `Err(AllocErr)` if reserving a fresh `Layout::for_value(src)`
-    /// region via [`Bump::try_alloc_layout`] fails — that is, if the current
+    /// region via [`Arena::try_alloc_layout`] fails — that is, if the current
     /// chunk has no room, a new chunk cannot be obtained from the underlying
     /// allocator, or the configured `allocation_limit` would be exceeded.
     #[expect(clippy::mut_from_ref)]
@@ -1493,7 +1493,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         Ok(result)
     }
 
-    /// `Clone` a slice into this `Bump` and return an exclusive reference to
+    /// `Clone` a slice into this `Arena` and return an exclusive reference to
     /// the clone. Prefer [`alloc_slice_copy`](#method.alloc_slice_copy) if `T` is `Copy`.
     ///
     /// # Panics
@@ -1503,7 +1503,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
     /// #[derive(Clone, Debug, Eq, PartialEq)]
     /// struct Sheep {
@@ -1516,8 +1516,8 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     ///     Sheep { name: "Cathy".into() },
     /// ];
     ///
-    /// let bump = Bump::new();
-    /// let clones = bump.alloc_slice_clone(&originals);
+    /// let arena = Arena::new();
+    /// let clones = arena.alloc_slice_clone(&originals);
     /// assert_eq!(originals, clones);
     /// ```
     #[expect(clippy::mut_from_ref)]
@@ -1543,7 +1543,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Errors
     ///
     /// Returns `Err(AllocErr)` if reserving a fresh `Layout::for_value(src)`
-    /// region via [`Bump::try_alloc_layout`] fails (no room in the current
+    /// region via [`Arena::try_alloc_layout`] fails (no room in the current
     /// chunk, a new chunk cannot be obtained from the underlying allocator,
     /// or the configured `allocation_limit` would be exceeded).
     #[expect(clippy::mut_from_ref)]
@@ -1564,7 +1564,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// `Copy` a string slice into this `Bump` and return an exclusive reference to it.
+    /// `Copy` a string slice into this `Arena` and return an exclusive reference to it.
     ///
     /// # Panics
     ///
@@ -1573,10 +1573,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let hello = bump.alloc_str("hello world");
+    /// let arena = Arena::new();
+    /// let hello = arena.alloc_str("hello world");
     /// assert_eq!("hello world", hello);
     /// ```
     #[expect(clippy::mut_from_ref)]
@@ -1594,24 +1594,24 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::{AllocErr, Bump};
+    /// # use oxc_allocator::bump::{AllocErr, Arena};
     ///
-    /// let bump = Bump::new();
-    /// let hello = bump.try_alloc_str("hello world").unwrap();
+    /// let arena = Arena::new();
+    /// let hello = arena.try_alloc_str("hello world").unwrap();
     /// assert_eq!("hello world", hello);
     ///
     ///
-    /// let bump = Bump::new();
-    /// bump.set_allocation_limit(Some(5));
-    /// let hello = bump.try_alloc_str("hello world");
+    /// let arena = Arena::new();
+    /// arena.set_allocation_limit(Some(5));
+    /// let hello = arena.try_alloc_str("hello world");
     /// assert_eq!(Err(AllocErr), hello);
     /// ```
     ///
     /// # Errors
     ///
-    /// Forwards the error from [`Bump::try_alloc_slice_copy`]: returns
+    /// Forwards the error from [`Arena::try_alloc_slice_copy`]: returns
     /// `Err(AllocErr)` if reserving `src.len()` bytes via
-    /// [`Bump::try_alloc_layout`] fails because the current chunk has no
+    /// [`Arena::try_alloc_layout`] fails because the current chunk has no
     /// room, a new chunk cannot be obtained from the underlying allocator,
     /// or the configured `allocation_limit` would be exceeded.
     #[expect(clippy::mut_from_ref)]
@@ -1624,7 +1624,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// Allocates a new slice of size `len` into this `Arena` and returns an
     /// exclusive reference to the copy.
     ///
     /// The elements of the slice are initialized using the supplied closure.
@@ -1637,10 +1637,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.alloc_slice_fill_with(5, |i| 5 * (i + 1));
+    /// let arena = Arena::new();
+    /// let x = arena.alloc_slice_fill_with(5, |i| 5 * (i + 1));
     /// assert_eq!(x, &[5, 10, 15, 20, 25]);
     /// ```
     #[expect(clippy::mut_from_ref)]
@@ -1663,7 +1663,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// Allocates a new slice of size `len` into this `Arena` and returns an
     /// exclusive reference to the copy, failing if the closure return an Err.
     ///
     /// The elements of the slice are initialized using the supplied closure.
@@ -1676,18 +1676,18 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x: Result<&mut [usize], ()> = bump.alloc_slice_try_fill_with(5, |i| Ok(5 * i));
-    /// assert_eq!(x, Ok(bump.alloc_slice_copy(&[0, 5, 10, 15, 20])));
+    /// let arena = Arena::new();
+    /// let x: Result<&mut [usize], ()> = arena.alloc_slice_try_fill_with(5, |i| Ok(5 * i));
+    /// assert_eq!(x, Ok(arena.alloc_slice_copy(&[0, 5, 10, 15, 20])));
     /// ```
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x: Result<&mut [usize], ()> = bump.alloc_slice_try_fill_with(
+    /// let arena = Arena::new();
+    /// let x: Result<&mut [usize], ()> = arena.alloc_slice_try_fill_with(
     ///    5,
     ///    |n| if n == 2 { Err(()) } else { Ok(n) }
     /// );
@@ -1700,7 +1700,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// soon as it returns `Err` for any element; any elements already written
     /// are abandoned and the just-made backing allocation is deallocated.
     /// Allocation failure is *not* reported via `Err` here — it panics via
-    /// [`Bump::alloc_layout`] instead.
+    /// [`Arena::alloc_layout`] instead.
     #[expect(clippy::mut_from_ref)]
     #[inline(always)]
     pub fn alloc_slice_try_fill_with<T, F, E>(&self, len: usize, mut f: F) -> Result<&mut [T], E>
@@ -1728,7 +1728,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// Allocates a new slice of size `len` into this `Arena` and returns an
     /// exclusive reference to the copy.
     ///
     /// The elements of the slice are initialized using the supplied closure.
@@ -1737,16 +1737,16 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::{AllocErr, Bump};
+    /// # use oxc_allocator::bump::{AllocErr, Arena};
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.try_alloc_slice_fill_with(5, |i| 5 * (i + 1));
+    /// let arena = Arena::new();
+    /// let x = arena.try_alloc_slice_fill_with(5, |i| 5 * (i + 1));
     /// assert_eq!(x, Ok(&mut[5usize, 10, 15, 20, 25] as &mut [_]));
     ///
     ///
-    /// let bump = Bump::new();
-    /// bump.set_allocation_limit(Some(4));
-    /// let x = bump.try_alloc_slice_fill_with(10, |i| 5 * (i + 1));
+    /// let arena = Arena::new();
+    /// arena.set_allocation_limit(Some(4));
+    /// let x = arena.try_alloc_slice_fill_with(10, |i| 5 * (i + 1));
     /// assert_eq!(x, Err(AllocErr));
     /// ```
     ///
@@ -1754,7 +1754,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     ///
     /// Returns `Err(AllocErr)` if [`Layout::array::<T>(len)`](Layout::array)
     /// fails (for example because `len * size_of::<T>()` overflows `isize`),
-    /// or if reserving that layout via [`Bump::try_alloc_layout`] fails
+    /// or if reserving that layout via [`Arena::try_alloc_layout`] fails
     /// because there is no room in the current chunk, a new chunk cannot be
     /// obtained from the underlying allocator, or the configured
     /// `allocation_limit` would be exceeded.
@@ -1782,7 +1782,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         }
     }
 
-    /// Allocates a new slice of size `len` into this `Bump` and returns an
+    /// Allocates a new slice of size `len` into this `Arena` and returns an
     /// exclusive reference to the copy.
     ///
     /// All elements of the slice are initialized to `value`.
@@ -1794,10 +1794,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.alloc_slice_fill_copy(5, 42);
+    /// let arena = Arena::new();
+    /// let x = arena.alloc_slice_fill_copy(5, 42);
     /// assert_eq!(x, &[42, 42, 42, 42, 42]);
     /// ```
     #[inline(always)]
@@ -1809,9 +1809,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     ///
     /// # Errors
     ///
-    /// Forwards the error from [`Bump::try_alloc_slice_fill_with`]: returns
+    /// Forwards the error from [`Arena::try_alloc_slice_fill_with`]: returns
     /// `Err(AllocErr)` if constructing `Layout::array::<T>(len)` fails or the
-    /// underlying [`Bump::try_alloc_layout`] call fails (no room in the
+    /// underlying [`Arena::try_alloc_layout`] call fails (no room in the
     /// current chunk, underlying allocator failure, or `allocation_limit`
     /// exceeded).
     #[inline(always)]
@@ -1823,7 +1823,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         self.try_alloc_slice_fill_with(len, |_| value)
     }
 
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// Allocates a new slice of size `len` slice into this `Arena` and return an
     /// exclusive reference to the copy.
     ///
     /// All elements of the slice are initialized to `value.clone()`.
@@ -1835,11 +1835,11 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let s: String = "Hello Bump!".to_string();
-    /// let x: &[String] = bump.alloc_slice_fill_clone(2, &s);
+    /// let arena = Arena::new();
+    /// let s: String = "Hello Arena!".to_string();
+    /// let x: &[String] = arena.alloc_slice_fill_clone(2, &s);
     /// assert_eq!(x.len(), 2);
     /// assert_eq!(&x[0], &s);
     /// assert_eq!(&x[1], &s);
@@ -1853,9 +1853,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     ///
     /// # Errors
     ///
-    /// Forwards the error from [`Bump::try_alloc_slice_fill_with`]: returns
+    /// Forwards the error from [`Arena::try_alloc_slice_fill_with`]: returns
     /// `Err(AllocErr)` if constructing `Layout::array::<T>(len)` fails or the
-    /// underlying [`Bump::try_alloc_layout`] call fails (no room in the
+    /// underlying [`Arena::try_alloc_layout`] call fails (no room in the
     /// current chunk, underlying allocator failure, or `allocation_limit`
     /// exceeded).
     #[inline(always)]
@@ -1867,7 +1867,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         self.try_alloc_slice_fill_with(len, |_| value.clone())
     }
 
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// Allocates a new slice of size `len` slice into this `Arena` and return an
     /// exclusive reference to the copy.
     ///
     /// The elements are initialized using the supplied iterator.
@@ -1880,10 +1880,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x: &[i32] = bump.alloc_slice_fill_iter([2, 3, 5].iter().cloned().map(|i| i * i));
+    /// let arena = Arena::new();
+    /// let x: &[i32] = arena.alloc_slice_fill_iter([2, 3, 5].iter().cloned().map(|i| i * i));
     /// assert_eq!(x, [4, 9, 25]);
     /// ```
     #[inline(always)]
@@ -1898,7 +1898,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         })
     }
 
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// Allocates a new slice of size `len` slice into this `Arena` and return an
     /// exclusive reference to the copy, failing if the iterator returns an Err.
     ///
     /// The elements are initialized using the supplied iterator.
@@ -1911,20 +1911,20 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Examples
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x: Result<&mut [i32], ()> = bump.alloc_slice_try_fill_iter(
+    /// let arena = Arena::new();
+    /// let x: Result<&mut [i32], ()> = arena.alloc_slice_try_fill_iter(
     ///    [2, 3, 5].iter().cloned().map(|i| Ok(i * i))
     /// );
-    /// assert_eq!(x, Ok(bump.alloc_slice_copy(&[4, 9, 25])));
+    /// assert_eq!(x, Ok(arena.alloc_slice_copy(&[4, 9, 25])));
     /// ```
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x: Result<&mut [i32], ()> = bump.alloc_slice_try_fill_iter(
+    /// let arena = Arena::new();
+    /// let x: Result<&mut [i32], ()> = arena.alloc_slice_try_fill_iter(
     ///    [Ok(2), Err(()), Ok(5)].iter().cloned()
     /// );
     /// assert_eq!(x, Err(()));
@@ -1933,7 +1933,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Errors
     ///
     /// Returns `Err(E)` propagated from the first `Err` item yielded by
-    /// `iter`, forwarded through [`Bump::alloc_slice_try_fill_with`]. As in
+    /// `iter`, forwarded through [`Arena::alloc_slice_try_fill_with`]. As in
     /// that method, allocation failure is reported by panicking rather than
     /// via `Err`.
     #[inline(always)]
@@ -1948,7 +1948,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         })
     }
 
-    /// Allocates a new slice of size `iter.len()` slice into this `Bump` and return an
+    /// Allocates a new slice of size `iter.len()` slice into this `Arena` and return an
     /// exclusive reference to the copy. Does not panic on failure.
     ///
     /// The elements are initialized using the supplied iterator.
@@ -1956,10 +1956,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x: &[i32] = bump.try_alloc_slice_fill_iter([2, 3, 5]
+    /// let arena = Arena::new();
+    /// let x: &[i32] = arena.try_alloc_slice_fill_iter([2, 3, 5]
     ///     .iter().cloned().map(|i| i * i)).unwrap();
     /// assert_eq!(x, [4, 9, 25]);
     /// ```
@@ -1972,9 +1972,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     ///
     /// # Errors
     ///
-    /// Forwards the error from [`Bump::try_alloc_slice_fill_with`]: returns
+    /// Forwards the error from [`Arena::try_alloc_slice_fill_with`]: returns
     /// `Err(AllocErr)` if constructing `Layout::array::<T>(iter.len())`
-    /// fails or the underlying [`Bump::try_alloc_layout`] call fails (no
+    /// fails or the underlying [`Arena::try_alloc_layout`] call fails (no
     /// room in the current chunk, underlying allocator failure, or
     /// `allocation_limit` exceeded).
     #[inline(always)]
@@ -1989,7 +1989,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         })
     }
 
-    /// Allocates a new slice of size `len` slice into this `Bump` and return an
+    /// Allocates a new slice of size `len` slice into this `Arena` and return an
     /// exclusive reference to the copy.
     ///
     /// All elements of the slice are initialized to [`T::default()`].
@@ -2003,10 +2003,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let x = bump.alloc_slice_fill_default::<u32>(5);
+    /// let arena = Arena::new();
+    /// let x = arena.alloc_slice_fill_default::<u32>(5);
     /// assert_eq!(x, &[0, 0, 0, 0, 0]);
     /// ```
     #[inline(always)]
@@ -2018,9 +2018,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     ///
     /// # Errors
     ///
-    /// Forwards the error from [`Bump::try_alloc_slice_fill_with`]: returns
+    /// Forwards the error from [`Arena::try_alloc_slice_fill_with`]: returns
     /// `Err(AllocErr)` if constructing `Layout::array::<T>(len)` fails or the
-    /// underlying [`Bump::try_alloc_layout`] call fails (no room in the
+    /// underlying [`Arena::try_alloc_layout`] call fails (no room in the
     /// current chunk, underlying allocator failure, or `allocation_limit`
     /// exceeded).
     #[inline(always)]
@@ -2170,11 +2170,11 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::with_capacity(100);
+    /// let arena = Arena::with_capacity(100);
     ///
-    /// let capacity = bump.chunk_capacity();
+    /// let capacity = arena.chunk_capacity();
     /// assert!(capacity >= 100);
     /// ```
     pub fn chunk_capacity(&self) -> usize {
@@ -2285,20 +2285,20 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let mut bump = Bump::new();
+    /// let mut arena = Arena::new();
     ///
     /// // Allocate a bunch of `i32`s in this bump arena, potentially causing
     /// // additional memory chunks to be reserved.
     /// for i in 0..10000 {
-    ///     bump.alloc(i);
+    ///     arena.alloc(i);
     /// }
     ///
     /// // Iterate over each chunk we've bump allocated into. This is safe
     /// // because we have only allocated `i32`s in this arena, which fulfills
     /// // the above requirements.
-    /// for ch in bump.iter_allocated_chunks() {
+    /// for ch in arena.iter_allocated_chunks() {
     ///     println!("Used a chunk that is {} bytes long", ch.len());
     ///     println!("The first byte is {:?}", unsafe {
     ///         ch[0].assume_init()
@@ -2310,13 +2310,13 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// // through the chunk's data, we get them in the order 'c', then 'b',
     /// // then 'a'.
     ///
-    /// bump.reset();
-    /// bump.alloc(b'a');
-    /// bump.alloc(b'b');
-    /// bump.alloc(b'c');
+    /// arena.reset();
+    /// arena.alloc(b'a');
+    /// arena.alloc(b'b');
+    /// arena.alloc(b'c');
     ///
-    /// assert_eq!(bump.iter_allocated_chunks().count(), 1);
-    /// let chunk = bump.iter_allocated_chunks().nth(0).unwrap();
+    /// assert_eq!(arena.iter_allocated_chunks().count(), 1);
+    /// let chunk = arena.iter_allocated_chunks().nth(0).unwrap();
     /// assert_eq!(chunk.len(), 3);
     ///
     /// // Safe because we've only allocated `u8`s in this arena, which
@@ -2330,13 +2330,13 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     pub fn iter_allocated_chunks(&mut self) -> ChunkIter<'_, MIN_ALIGN> {
         // SAFETY: Ensured by mutable borrow of `self`.
         let raw = unsafe { self.iter_allocated_chunks_raw() };
-        ChunkIter { raw, bump: PhantomData }
+        ChunkIter { raw, arena: PhantomData }
     }
 
     /// Returns an iterator over raw pointers to chunks of allocated memory that
     /// this arena has bump allocated into.
     ///
-    /// This is an unsafe version of [`iter_allocated_chunks()`](Bump::iter_allocated_chunks),
+    /// This is an unsafe version of [`iter_allocated_chunks()`](Arena::iter_allocated_chunks),
     /// with the caller responsible for safe usage of the returned pointers as
     /// well as ensuring that the iterator is not invalidated by new
     /// allocations.
@@ -2349,9 +2349,9 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// previously allocated data.
     ///
     /// In addition, all of the caveats when reading the chunk data from
-    /// [`iter_allocated_chunks()`](Bump::iter_allocated_chunks) still apply.
+    /// [`iter_allocated_chunks()`](Arena::iter_allocated_chunks) still apply.
     pub unsafe fn iter_allocated_chunks_raw(&self) -> ChunkRawIter<'_, MIN_ALIGN> {
-        ChunkRawIter { footer: self.current_chunk_footer.get(), bump: PhantomData }
+        ChunkRawIter { footer: self.current_chunk_footer.get(), arena: PhantomData }
     }
 
     /// Calculates the number of bytes currently allocated across all chunks in
@@ -2371,11 +2371,11 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// # Example
     ///
     /// ```
-    /// # use oxc_allocator::bump::Bump;
+    /// # use oxc_allocator::bump::Arena;
     ///
-    /// let bump = Bump::new();
-    /// let _x = bump.alloc_slice_fill_default::<u32>(5);
-    /// let bytes = bump.allocated_bytes();
+    /// let arena = Arena::new();
+    /// let _x = arena.alloc_slice_fill_default::<u32>(5);
+    /// let bytes = arena.allocated_bytes();
     /// assert!(bytes >= size_of::<u32>() * 5);
     /// ```
     pub fn allocated_bytes(&self) -> usize {
@@ -2384,7 +2384,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         unsafe { footer.as_ref().allocated_bytes }
     }
 
-    /// Calculates the number of bytes requested from the Rust allocator for this `Bump`.
+    /// Calculates the number of bytes requested from the Rust allocator for this `Arena`.
     ///
     /// This number is equal to the [`allocated_bytes()`](Self::allocated_bytes) plus
     /// the size of the bump metadata.
@@ -2580,14 +2580,14 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
 /// Methods only available when `from_raw_parts` feature is enabled.
 /// These methods are only used by raw transfer.
 #[cfg(feature = "from_raw_parts")]
-impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
-    /// Construct a static-sized [`Bump`] from an existing memory allocation.
+impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
+    /// Construct a static-sized [`Arena`] from an existing memory allocation.
     ///
-    /// The [`Bump`] which is returned takes ownership of the memory allocation,
-    /// and the allocation will be freed if the `Bump` is dropped.
-    /// If caller wishes to prevent that happening, they must wrap the `Bump` in `ManuallyDrop`.
+    /// The [`Arena`] which is returned takes ownership of the memory allocation,
+    /// and the allocation will be freed if the `Arena` is dropped.
+    /// If caller wishes to prevent that happening, they must wrap the `Arena` in `ManuallyDrop`.
     ///
-    /// The [`Bump`] returned by this function cannot grow.
+    /// The [`Arena`] returned by this function cannot grow.
     ///
     /// # SAFETY
     ///
@@ -2596,7 +2596,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
     /// * `size` must be at least [`CHUNK_FOOTER_SIZE`].
     /// * The memory region starting at `ptr` and encompassing `size` bytes must be within a single allocation.
     /// * The memory region starting at `ptr` and encompassing `size` bytes must have been allocated from system
-    ///   allocator with alignment of [`CHUNK_ALIGN`] (or caller must wrap the `Bump` in `ManuallyDrop`
+    ///   allocator with alignment of [`CHUNK_ALIGN`] (or caller must wrap the `Arena` in `ManuallyDrop`
     ///   and ensure the backing memory is freed correctly themselves).
     /// * `ptr` must have permission for writes.
     ///
@@ -2640,25 +2640,25 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         // Therefore `chunk_footer_ptr` is valid for writing a `ChunkFooter`.
         unsafe { chunk_footer_ptr.write(chunk_footer) };
 
-        // Create `Bump` with allocation limit of `size_without_footer`.
+        // Create `Arena` with allocation limit of `size_without_footer`.
         // i.e. it cannot grow because it's already exactly at its limit.
         // This means that the memory chunk we've just created will remain its only chunk.
-        // Therefore it can never be deallocated, until the `Bump` is dropped.
-        // `Bump::reset` would only reset the "cursor" pointer, not deallocate the memory.
+        // Therefore it can never be deallocated, until the `Arena` is dropped.
+        // `Arena::reset` would only reset the "cursor" pointer, not deallocate the memory.
         Self::new_impl(chunk_footer_ptr, Some(size_without_footer))
     }
 
-    /// Set cursor pointer for this [`Bump`]'s current chunk.
+    /// Set cursor pointer for this [`Arena`]'s current chunk.
     ///
     /// This is dangerous, and this method should not ordinarily be used.
-    /// It is only here for manually resetting the `Bump`.
+    /// It is only here for manually resetting the `Arena`.
     ///
     /// # SAFETY
     ///
-    /// * `Bump` must have at least 1 allocated chunk.
-    ///   It is UB to call this method on an `Bump` which has not allocated
-    ///   i.e. fresh from `Bump::new`.
-    /// * `ptr` must point to within the `Bump`'s current chunk.
+    /// * `Arena` must have at least 1 allocated chunk.
+    ///   It is UB to call this method on an `Arena` which has not allocated
+    ///   i.e. fresh from `Arena::new`.
+    /// * `ptr` must point to within the `Arena`'s current chunk.
     /// * `ptr` must be equal to or after data pointer for this chunk.
     /// * `ptr` must be equal to or before the chunk's `ChunkFooter`.
     /// * `ptr` must be aligned to `MIN_ALIGN`.
@@ -2671,24 +2671,24 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
         debug_assert!(ptr.as_ptr().cast_const() <= ptr::from_ref(chunk_footer).cast::<u8>());
         debug_assert!(ptr.addr().get().is_multiple_of(MIN_ALIGN));
 
-        // SAFETY: Caller guarantees `Bump` has at least 1 allocated chunk, and `ptr` is valid.
+        // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `ptr` is valid.
         #[expect(clippy::unnecessary_safety_comment)]
         chunk_footer.ptr.set(ptr);
     }
 
-    /// Get pointer to end of the data region of this [`Bump`]'s current chunk
+    /// Get pointer to end of the data region of this [`Arena`]'s current chunk
     /// i.e to the start of the `ChunkFooter`.
     pub fn data_end_ptr(&self) -> NonNull<u8> {
         self.current_chunk_footer.get().cast::<u8>()
     }
 
-    /// Get pointer to end of this [`Bump`]'s current chunk (after the `ChunkFooter`).
+    /// Get pointer to end of this [`Arena`]'s current chunk (after the `ChunkFooter`).
     pub fn end_ptr(&self) -> NonNull<u8> {
         let chunk_footer_ptr = self.current_chunk_footer.get();
 
         // SAFETY: `chunk_footer_ptr` always points to a valid `ChunkFooter`,
         // so stepping past it cannot be out of bounds of the chunk's allocation.
-        // If `Bump` has not allocated, so `chunk_footer_ptr` returns a pointer to the static empty chunk,
+        // If `Arena` has not allocated, so `chunk_footer_ptr` returns a pointer to the static empty chunk,
         // it's still valid.
         unsafe { chunk_footer_ptr.add(1).cast::<u8>() }
     }
@@ -2704,14 +2704,14 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
 /// recent allocation being earlier in the slice.
 ///
 /// This struct is created by the [`iter_allocated_chunks`] method on
-/// [`Bump`]. See that function for a safety description regarding reading from the returned items.
+/// [`Arena`]. See that function for a safety description regarding reading from the returned items.
 ///
-/// [`Bump`]: struct.Bump.html
-/// [`iter_allocated_chunks`]: struct.Bump.html#method.iter_allocated_chunks
+/// [`Arena`]: struct.Arena.html
+/// [`iter_allocated_chunks`]: struct.Arena.html#method.iter_allocated_chunks
 #[derive(Debug)]
 pub struct ChunkIter<'a, const MIN_ALIGN: usize = 1> {
     raw: ChunkRawIter<'a, MIN_ALIGN>,
-    bump: PhantomData<&'a mut Bump<MIN_ALIGN>>,
+    arena: PhantomData<&'a mut Arena<MIN_ALIGN>>,
 }
 
 impl<'a, const MIN_ALIGN: usize> Iterator for ChunkIter<'a, MIN_ALIGN> {
@@ -2734,15 +2734,15 @@ impl<const MIN_ALIGN: usize> iter::FusedIterator for ChunkIter<'_, MIN_ALIGN> {}
 /// See [`ChunkIter`] for details regarding the returned chunks.
 ///
 /// This struct is created by the [`iter_allocated_chunks_raw`] method on
-/// [`Bump`]. See that function for a safety description regarding reading from
+/// [`Arena`]. See that function for a safety description regarding reading from
 /// the returned items.
 ///
-/// [`Bump`]: struct.Bump.html
-/// [`iter_allocated_chunks_raw`]: struct.Bump.html#method.iter_allocated_chunks_raw
+/// [`Arena`]: struct.Arena.html
+/// [`iter_allocated_chunks_raw`]: struct.Arena.html#method.iter_allocated_chunks_raw
 #[derive(Debug)]
 pub struct ChunkRawIter<'a, const MIN_ALIGN: usize = 1> {
     footer: NonNull<ChunkFooter>,
-    bump: PhantomData<&'a Bump<MIN_ALIGN>>,
+    arena: PhantomData<&'a Arena<MIN_ALIGN>>,
 }
 
 impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
@@ -2768,7 +2768,7 @@ fn oom() -> ! {
     panic!("out of memory")
 }
 
-unsafe impl<const MIN_ALIGN: usize> BumpaloAlloc for &Bump<MIN_ALIGN> {
+unsafe impl<const MIN_ALIGN: usize> BumpaloAlloc for &Arena<MIN_ALIGN> {
     #[inline(always)]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         self.try_alloc_layout(layout)
@@ -2776,7 +2776,7 @@ unsafe impl<const MIN_ALIGN: usize> BumpaloAlloc for &Bump<MIN_ALIGN> {
 
     #[inline]
     unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
-        unsafe { Bump::<MIN_ALIGN>::dealloc(self, ptr, layout) };
+        unsafe { Arena::<MIN_ALIGN>::dealloc(self, ptr, layout) };
     }
 
     #[inline]
@@ -2794,25 +2794,25 @@ unsafe impl<const MIN_ALIGN: usize> BumpaloAlloc for &Bump<MIN_ALIGN> {
 
         let new_layout = layout_from_size_align(new_size, layout.align())?;
         if new_size <= old_size {
-            unsafe { Bump::shrink(self, ptr, layout, new_layout) }
+            unsafe { Arena::shrink(self, ptr, layout, new_layout) }
         } else {
-            unsafe { Bump::grow(self, ptr, layout, new_layout) }
+            unsafe { Arena::grow(self, ptr, layout, new_layout) }
         }
     }
 }
 
-/// This function tests that Bump isn't Sync.
+/// This function tests that Arena isn't Sync.
 /// ```compile_fail
-/// use oxc_allocator::Bump;
+/// use oxc_allocator::Arena;
 /// fn _requires_sync<T: Sync>(_value: T) {}
-/// fn _bump_not_sync(b: Bump) {
+/// fn _arena_not_sync(b: Arena) {
 ///    _requires_sync(b);
 /// }
 /// ```
 #[cfg(doctest)]
 fn _doctest_only() {}
 
-unsafe impl<const MIN_ALIGN: usize> Allocator for &Bump<MIN_ALIGN> {
+unsafe impl<const MIN_ALIGN: usize> Allocator for &Arena<MIN_ALIGN> {
     #[inline]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.try_alloc_layout(layout)
@@ -2824,7 +2824,7 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Bump<MIN_ALIGN> {
 
     #[inline]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        unsafe { Bump::<MIN_ALIGN>::dealloc(self, ptr, layout) };
+        unsafe { Arena::<MIN_ALIGN>::dealloc(self, ptr, layout) };
     }
 
     #[inline]
@@ -2834,7 +2834,7 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Bump<MIN_ALIGN> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        unsafe { Bump::<MIN_ALIGN>::shrink(self, ptr, old_layout, new_layout) }
+        unsafe { Arena::<MIN_ALIGN>::shrink(self, ptr, old_layout, new_layout) }
             .map(|p| unsafe {
                 NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), new_layout.size()))
             })
@@ -2848,7 +2848,7 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Bump<MIN_ALIGN> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        unsafe { Bump::<MIN_ALIGN>::grow(self, ptr, old_layout, new_layout) }
+        unsafe { Arena::<MIN_ALIGN>::grow(self, ptr, old_layout, new_layout) }
             .map(|p| unsafe {
                 NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), new_layout.size()))
             })
@@ -2892,7 +2892,7 @@ mod tests {
     // Uses private `DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER` and `CHUNK_FOOTER_SIZE`.
     #[test]
     fn allocated_bytes() {
-        let mut b = Bump::new();
+        let mut b = Arena::new();
 
         assert_eq!(b.allocated_bytes(), 0);
         assert_eq!(b.allocated_bytes_including_metadata(), 0);
@@ -2919,7 +2919,7 @@ mod tests {
     fn test_realloc() {
         unsafe {
             const CAPACITY: usize = DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER;
-            let mut b = Bump::<1>::with_min_align_and_capacity(CAPACITY);
+            let mut b = Arena::<1>::with_min_align_and_capacity(CAPACITY);
 
             // `realloc` doesn't shrink allocations that aren't "worth it".
             let layout = Layout::from_size_align(100, 1).unwrap();
@@ -2964,7 +2964,7 @@ mod tests {
     // Uses our private `bumpalo_alloc` module.
     #[test]
     fn invalid_read() {
-        let mut b = &Bump::new();
+        let mut b = &Arena::new();
 
         unsafe {
             let l1 = Layout::from_size_align(12000, 4).unwrap();

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -9,7 +9,7 @@ use std::ptr::NonNull;
 
 use crate::{
     Allocator,
-    bump::{Bump, CHUNK_ALIGN, CHUNK_FOOTER_SIZE},
+    bump::{Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE},
 };
 
 impl Allocator {
@@ -41,9 +41,9 @@ impl Allocator {
     /// [`RAW_MIN_ALIGN`]: Self::RAW_MIN_ALIGN
     /// [`RAW_MIN_SIZE`]: Self::RAW_MIN_SIZE
     pub unsafe fn from_raw_parts(ptr: NonNull<u8>, size: usize) -> Self {
-        // SAFETY: Safety requirements of `Bump::from_raw_parts` are the same as for this method
-        let bump = unsafe { Bump::from_raw_parts(ptr, size) };
-        Self::from_bump(bump)
+        // SAFETY: Safety requirements of `Arena::from_raw_parts` are the same as for this method
+        let arena = unsafe { Arena::from_raw_parts(ptr, size) };
+        Self::from_arena(arena)
     }
 
     /// Set cursor pointer for this [`Allocator`]'s current chunk.
@@ -62,18 +62,18 @@ impl Allocator {
     /// * No live references to data in the current chunk before `ptr` can exist.
     pub unsafe fn set_cursor_ptr(&self, ptr: NonNull<u8>) {
         // SAFETY: Caller guarantees `Allocator` has at least 1 allocated chunk, and `ptr` is valid.
-        // The `Bump` contained in `Allocator` has `MIN_ALIGN = 1`, so no alignment requirement for `ptr`.
-        unsafe { self.bump().set_cursor_ptr(ptr) };
+        // The `Arena` contained in `Allocator` has `MIN_ALIGN = 1`, so no alignment requirement for `ptr`.
+        unsafe { self.arena().set_cursor_ptr(ptr) };
     }
 
     /// Get pointer to end of the data region of this [`Allocator`]'s current chunk
     /// i.e to the start of the `ChunkFooter`.
     pub fn data_end_ptr(&self) -> NonNull<u8> {
-        self.bump().data_end_ptr()
+        self.arena().data_end_ptr()
     }
 
     /// Get pointer to end of this [`Allocator`]'s current chunk (after the `ChunkFooter`).
     pub fn end_ptr(&self) -> NonNull<u8> {
-        self.bump().end_ptr()
+        self.arena().end_ptr()
     }
 }

--- a/crates/oxc_allocator/src/hash_map.rs
+++ b/crates/oxc_allocator/src/hash_map.rs
@@ -20,7 +20,7 @@ use std::{
 
 use rustc_hash::FxBuildHasher;
 
-use crate::bump::Bump;
+use crate::bump::Arena;
 
 // Re-export additional types from `hashbrown`
 pub use hashbrown::{
@@ -33,7 +33,7 @@ pub use hashbrown::{
 
 use crate::Allocator;
 
-type InnerHashMap<'alloc, K, V, S> = hashbrown::HashMap<K, V, S, &'alloc Bump>;
+type InnerHashMap<'alloc, K, V, S> = hashbrown::HashMap<K, V, S, &'alloc Arena>;
 
 /// A hash map without `Drop` that stores data in arena allocator.
 ///
@@ -66,27 +66,27 @@ impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for HashMap<'_, K, V, S> {
     }
 }
 
-/// SAFETY: Even though `Bump` is not `Sync`, we can make `HashMap<K, V>` `Sync` if both `K` and `V`
+/// SAFETY: Even though `Arena` is not `Sync`, we can make `HashMap<K, V>` `Sync` if both `K` and `V`
 /// are `Sync` because:
 ///
-/// 1. No public methods allow access to the `&Bump` that `HashMap` contains (in `hashbrown::HashMap`),
-///    so user cannot illegally obtain 2 `&Bump`s on different threads via `HashMap`.
+/// 1. No public methods allow access to the `&Arena` that `HashMap` contains (in `hashbrown::HashMap`),
+///    so user cannot illegally obtain 2 `&Arena`s on different threads via `HashMap`.
 ///
-/// 2. All internal methods which access the `&Bump` take a `&mut self`.
+/// 2. All internal methods which access the `&Arena` take a `&mut self`.
 ///    `&mut HashMap` cannot be transferred across threads, and nor can an owned `HashMap`
 ///    (`HashMap` is not `Send`).
 ///    Therefore these methods taking `&mut self` can be sure they're not operating on a `HashMap`
 ///    which has been moved across threads.
 ///
 /// Note: `HashMap` CANNOT be `Send`, even if `K` and `V` are `Send`, because that would allow 2 `HashMap`s
-/// on different threads to both allocate into same arena simultaneously. `Bump` is not thread-safe,
+/// on different threads to both allocate into same arena simultaneously. `Arena` is not thread-safe,
 /// and this would be undefined behavior.
 ///
 /// ### Soundness holes
 ///
 /// This is not actually fully sound. There are 2 holes I (@overlookmotel) am aware of:
 ///
-/// 1. `allocator` method, which does allow access to the `&Bump` that `HashMap` contains.
+/// 1. `allocator` method, which does allow access to the `&Arena` that `HashMap` contains.
 /// 2. `Clone` impl on `hashbrown::HashMap`, which may perform allocations in the arena, given only a
 ///    `&self` reference.
 ///
@@ -127,7 +127,7 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
     pub fn with_hasher_in(hasher: S, allocator: &'alloc Allocator) -> Self {
         const { Self::ASSERT_K_AND_V_ARE_NOT_DROP };
 
-        let inner = InnerHashMap::with_hasher_in(hasher, allocator.bump());
+        let inner = InnerHashMap::with_hasher_in(hasher, allocator.arena());
         Self(ManuallyDrop::new(inner))
     }
 
@@ -144,7 +144,7 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
     ) -> Self {
         const { Self::ASSERT_K_AND_V_ARE_NOT_DROP };
 
-        let inner = InnerHashMap::with_capacity_and_hasher_in(capacity, hasher, allocator.bump());
+        let inner = InnerHashMap::with_capacity_and_hasher_in(capacity, hasher, allocator.arena());
         Self(ManuallyDrop::new(inner))
     }
 
@@ -152,7 +152,7 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
     ///
     /// The map cannot be used after calling this. The iterator element type is `K`.
     #[inline(always)]
-    pub fn into_keys(self) -> IntoKeys<K, V, &'alloc Bump> {
+    pub fn into_keys(self) -> IntoKeys<K, V, &'alloc Arena> {
         let inner = ManuallyDrop::into_inner(self.0);
         inner.into_keys()
     }
@@ -161,7 +161,7 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
     ///
     /// The map cannot be used after calling this. The iterator element type is `V`.
     #[inline(always)]
-    pub fn into_values(self) -> IntoValues<K, V, &'alloc Bump> {
+    pub fn into_values(self) -> IntoValues<K, V, &'alloc Arena> {
         let inner = ManuallyDrop::into_inner(self.0);
         inner.into_values()
     }
@@ -169,7 +169,7 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
     /// Calling this method produces a compile-time panic.
     ///
     /// This method would be unsound, because [`HashMap`] is `Sync`, and the underlying allocator
-    /// (`Bump`) is not `Sync`.
+    /// (`Arena`) is not `Sync`.
     ///
     /// This method exists only to block access as much as possible to the underlying
     /// `hashbrown::HashMap::allocator` method. That method can still be accessed via explicit `Deref`
@@ -178,7 +178,7 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
     /// We'll prevent access to it completely and remove this method as soon as we can.
     // TODO: Do that!
     #[expect(clippy::unused_self)]
-    pub fn allocator(&self) -> &'alloc Bump {
+    pub fn allocator(&self) -> &'alloc Arena {
         const { panic!("This method cannot be called") };
         unreachable!();
     }
@@ -232,7 +232,7 @@ impl<'alloc, K, V, S: Default> HashMap<'alloc, K, V, S> {
         //   e.g. filter iterators.
         let capacity = iter.size_hint().0;
         let map =
-            InnerHashMap::with_capacity_and_hasher_in(capacity, S::default(), allocator.bump());
+            InnerHashMap::with_capacity_and_hasher_in(capacity, S::default(), allocator.arena());
         // Wrap in `ManuallyDrop` *before* calling `for_each`, so compiler doesn't insert unnecessary code
         // to drop the `FxHashMap` in case of a panic in iterator's `next` method
         let mut map = ManuallyDrop::new(map);
@@ -263,7 +263,7 @@ impl<'alloc, K, V, S> DerefMut for HashMap<'alloc, K, V, S> {
 }
 
 impl<'alloc, K, V, S> IntoIterator for HashMap<'alloc, K, V, S> {
-    type IntoIter = IntoIter<K, V, &'alloc Bump>;
+    type IntoIter = IntoIter<K, V, &'alloc Arena>;
     type Item = (K, V);
 
     /// Creates a consuming iterator, that is, one that moves each key-value pair out of the map

--- a/crates/oxc_allocator/src/hash_set.rs
+++ b/crates/oxc_allocator/src/hash_set.rs
@@ -20,7 +20,7 @@ use std::{
 
 use rustc_hash::FxBuildHasher;
 
-use crate::bump::Bump;
+use crate::bump::Arena;
 
 // Re-export additional types from `hashbrown`
 pub use hashbrown::hash_set::{
@@ -29,7 +29,7 @@ pub use hashbrown::hash_set::{
 
 use crate::{Allocator, HashMap};
 
-type InnerHashSet<'alloc, T, S> = hashbrown::HashSet<T, S, &'alloc Bump>;
+type InnerHashSet<'alloc, T, S> = hashbrown::HashSet<T, S, &'alloc Arena>;
 
 /// A hash set without `Drop` that stores data in arena allocator.
 ///
@@ -81,7 +81,7 @@ impl<'alloc, T, S> HashSet<'alloc, T, S> {
     pub fn with_hasher_in(hasher: S, allocator: &'alloc Allocator) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
-        let inner = InnerHashSet::with_hasher_in(hasher, allocator.bump());
+        let inner = InnerHashSet::with_hasher_in(hasher, allocator.arena());
         Self(ManuallyDrop::new(inner))
     }
 
@@ -98,14 +98,14 @@ impl<'alloc, T, S> HashSet<'alloc, T, S> {
     ) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
-        let inner = InnerHashSet::with_capacity_and_hasher_in(capacity, hasher, allocator.bump());
+        let inner = InnerHashSet::with_capacity_and_hasher_in(capacity, hasher, allocator.arena());
         Self(ManuallyDrop::new(inner))
     }
 
     /// Calling this method produces a compile-time panic.
     ///
     /// This method would be unsound, because [`HashSet`] is `Sync`, and the underlying allocator
-    /// (`Bump`) is not `Sync`.
+    /// (`Arena`) is not `Sync`.
     ///
     /// This method exists only to block access as much as possible to the underlying
     /// `hashbrown::HashSet::allocator` method. That method can still be accessed via explicit `Deref`
@@ -114,7 +114,7 @@ impl<'alloc, T, S> HashSet<'alloc, T, S> {
     /// We'll prevent access to it completely and remove this method as soon as we can.
     // TODO: Do that!
     #[expect(clippy::unused_self)]
-    pub fn allocator(&self) -> &'alloc Bump {
+    pub fn allocator(&self) -> &'alloc Arena {
         const { panic!("This method cannot be called") };
         unreachable!();
     }
@@ -161,7 +161,7 @@ impl<'alloc, T> HashSet<'alloc, T> {
         //   e.g. filter iterators.
         let capacity = iter.size_hint().0;
         let set =
-            InnerHashSet::with_capacity_and_hasher_in(capacity, FxBuildHasher, allocator.bump());
+            InnerHashSet::with_capacity_and_hasher_in(capacity, FxBuildHasher, allocator.arena());
         // Wrap in `ManuallyDrop` *before* calling `for_each`, so compiler doesn't insert unnecessary code
         // to drop the `FxHashSet` in case of a panic in iterator's `next` method
         let mut set = ManuallyDrop::new(set);
@@ -192,7 +192,7 @@ impl<'alloc, T, S> DerefMut for HashSet<'alloc, T, S> {
 }
 
 impl<'alloc, T, S> IntoIterator for HashSet<'alloc, T, S> {
-    type IntoIter = IntoIter<T, &'alloc Bump>;
+    type IntoIter = IntoIter<T, &'alloc Arena>;
     type Item = T;
 
     /// Creates a consuming iterator, that is, one that moves each value out of the set

--- a/crates/oxc_allocator/src/string_builder.rs
+++ b/crates/oxc_allocator/src/string_builder.rs
@@ -488,7 +488,7 @@ impl<'a> StringBuilder<'a> {
             // SAFETY: Previously allocated at `start_ptr` with `old_layout`.
             // `new_layout` is larger than `old_layout`.
             let new_start_ptr =
-                unsafe { self.allocator.bump().grow(self.start_ptr, old_layout, new_layout) };
+                unsafe { self.allocator.arena().grow(self.start_ptr, old_layout, new_layout) };
 
             self.start_ptr = new_start_ptr;
             // SAFETY: `len` is always less than or equal to capacity.
@@ -540,7 +540,7 @@ impl<'a> StringBuilder<'a> {
             // SAFETY: Previously allocated at `start_ptr` with `old_layout`.
             // `new_layout` is larger than `old_layout`.
             let new_start_ptr =
-                unsafe { self.allocator.bump().grow(self.start_ptr, old_layout, new_layout) };
+                unsafe { self.allocator.arena().grow(self.start_ptr, old_layout, new_layout) };
 
             self.start_ptr = new_start_ptr;
             // SAFETY: `len` is always less than or equal to capacity.

--- a/crates/oxc_allocator/src/tracking.rs
+++ b/crates/oxc_allocator/src/tracking.rs
@@ -11,7 +11,7 @@
 
 use std::cell::Cell;
 
-use crate::{Allocator, bump::Bump};
+use crate::{Allocator, bump::Arena};
 
 /// Counters of allocations and reallocations made in an [`Allocator`].
 #[derive(Default, Debug)]
@@ -58,8 +58,8 @@ impl AllocationStats {
     }
 }
 
-impl Bump {
-    /// Get number of allocations and reallocations made in this [`Bump`].
+impl Arena {
+    /// Get number of allocations and reallocations made in this [`Arena`].
     fn get_allocation_stats(&self) -> (usize, usize) {
         let num_alloc = self.stats.num_alloc.get();
         let num_realloc = self.stats.num_realloc.get();
@@ -71,6 +71,6 @@ impl Allocator {
     /// Get number of allocations and reallocations made in this [`Allocator`].
     #[doc(hidden)]
     pub fn get_allocation_stats(&self) -> (usize, usize) {
-        self.bump().get_allocation_stats()
+        self.arena().get_allocation_stats()
     }
 }

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -20,9 +20,9 @@ use serde::{Serialize, Serializer as SerdeSerializer};
 #[cfg(feature = "serialize")]
 use oxc_estree::{ConcatElement, ESTree, SequenceSerializer, Serializer as ESTreeSerializer};
 
-use crate::{Allocator, Box, bump::Bump, vec2::Vec as InnerVecGeneric};
+use crate::{Allocator, Box, bump::Arena, vec2::Vec as InnerVecGeneric};
 
-type InnerVec<'a, T> = InnerVecGeneric<'a, T, Bump>;
+type InnerVec<'a, T> = InnerVecGeneric<'a, T, Arena>;
 
 /// A `Vec` without [`Drop`], which stores its data in the arena allocator.
 ///
@@ -40,18 +40,18 @@ type InnerVec<'a, T> = InnerVecGeneric<'a, T, Bump>;
 #[repr(transparent)]
 pub struct Vec<'alloc, T>(InnerVec<'alloc, T>);
 
-/// SAFETY: Even though `Bump` is not `Sync`, we can make `Vec<T>` `Sync` if `T` is `Sync` because:
+/// SAFETY: Even though `Arena` is not `Sync`, we can make `Vec<T>` `Sync` if `T` is `Sync` because:
 ///
-/// 1. No public methods allow access to the `&Bump` that `Vec` contains (in `RawVec`),
-///    so user cannot illegally obtain 2 `&Bump`s on different threads via `Vec`.
+/// 1. No public methods allow access to the `&Arena` that `Vec` contains (in `RawVec`),
+///    so user cannot illegally obtain 2 `&Arena`s on different threads via `Vec`.
 ///
-/// 2. All internal methods which access the `&Bump` take a `&mut self`.
+/// 2. All internal methods which access the `&Arena` take a `&mut self`.
 ///    `&mut Vec` cannot be transferred across threads, and nor can an owned `Vec` (`Vec` is not `Send`).
 ///    Therefore these methods taking `&mut self` can be sure they're not operating on a `Vec`
 ///    which has been moved across threads.
 ///
 /// Note: `Vec` CANNOT be `Send`, even if `T` is `Send`, because that would allow 2 `Vec`s on different
-/// threads to both allocate into same arena simultaneously. `Bump` is not thread-safe, and this would
+/// threads to both allocate into same arena simultaneously. `Arena` is not thread-safe, and this would
 /// be undefined behavior.
 unsafe impl<T: Sync> Sync for Vec<'_, T> {}
 
@@ -78,7 +78,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     pub fn new_in(allocator: &'alloc Allocator) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
-        Self(InnerVec::new_in(allocator.bump()))
+        Self(InnerVec::new_in(allocator.arena()))
     }
 
     /// Constructs a new, empty `Vec<T>` with at least the specified capacity
@@ -131,7 +131,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     pub fn with_capacity_in(capacity: usize, allocator: &'alloc Allocator) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
-        Self(InnerVec::with_capacity_in(capacity, allocator.bump()))
+        Self(InnerVec::with_capacity_in(capacity, allocator.arena()))
     }
 
     /// Create a new [`Vec`] whose elements are taken from an iterator and
@@ -145,7 +145,7 @@ impl<'alloc, T> Vec<'alloc, T> {
         let iter = iter.into_iter();
         let hint = iter.size_hint();
         let capacity = hint.1.unwrap_or(hint.0);
-        let mut vec = InnerVec::with_capacity_in(capacity, allocator.bump());
+        let mut vec = InnerVec::with_capacity_in(capacity, allocator.arena());
         vec.extend(iter);
         Self(vec)
     }
@@ -175,7 +175,7 @@ impl<'alloc, T> Vec<'alloc, T> {
         // `ptr` was allocated with correct size for `[T; N]`.
         // `len` and `capacity` are both `N`.
         // Allocated size cannot be larger than `isize::MAX`, or `Box::new_in` would have failed.
-        let vec = unsafe { InnerVec::from_raw_parts_in(ptr, N, N, allocator.bump()) };
+        let vec = unsafe { InnerVec::from_raw_parts_in(ptr, N, N, allocator.arena()) };
         Self(vec)
     }
 

--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -1774,9 +1774,9 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
 
         let other_len = self.len_usize() - at;
         // SAFETY: This method takes a `&mut self`. It lives for the duration of this method
-        // - longer than we use `bump` for.
-        let bump = unsafe { self.buf.bump() };
-        let mut other = Vec::with_capacity_in(other_len, bump);
+        // - longer than we use `arena` for.
+        let arena = unsafe { self.buf.arena() };
+        let mut other = Vec::with_capacity_in(other_len, arena);
 
         // Unsafely `set_len` and copy items to `other`.
         unsafe {
@@ -2723,10 +2723,10 @@ impl<I: Iterator, A: Alloc> Drop for Splice<'_, '_, I, A> {
             // `Splice` inherits the lifetime of `&mut self` from that method, so the mut borrow
             // of the `Vec` is held for the life of the `Splice`.
             // Therefore we have exclusive access to the `Vec` until end of this method.
-            // That is longer than we use `bump` for.
-            let bump = self.drain.vec.as_ref().buf.bump();
+            // That is longer than we use `arena` for.
+            let arena = self.drain.vec.as_ref().buf.arena();
 
-            let mut collected = Vec::new_in(bump);
+            let mut collected = Vec::new_in(arena);
             collected.extend(self.replace_with.by_ref());
             let mut collected = collected.into_iter();
             // Now we have an exact count.

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -203,13 +203,13 @@ impl<'a, T, A: Alloc> RawVec<'a, T, A> {
     ///
     /// This method is hazardous.
     ///
-    /// `Vec` is `Sync`, but `Bump` is not, because it utilizes interior mutability.
-    /// It is possible to make allocations into the arena while holding only a `&Bump`.
+    /// `Vec` is `Sync`, but `Arena` is not, because it utilizes interior mutability.
+    /// It is possible to make allocations into the arena while holding only a `&Arena`.
     /// Because `Vec` is `Sync`, it's possible for multiple `&Vec` references to the same `Vec`,
-    /// or references to multiple `Vec`s attached to the same `Bump`, to exist simultaneously
+    /// or references to multiple `Vec`s attached to the same `Arena`, to exist simultaneously
     /// on different threads.
     ///
-    /// So this method could be used to obtain 2 `&Bump` references simultaneously on different threads.
+    /// So this method could be used to obtain 2 `&Arena` references simultaneously on different threads.
     /// Utilizing those references to allocate into the arena simultaneously from different threads
     /// would be UB.
     ///
@@ -240,7 +240,7 @@ impl<'a, T, A: Alloc> RawVec<'a, T, A> {
     /// for the duration that the reference returned by this method is held.
     /// See text above for further detail.
     #[inline(always)]
-    pub unsafe fn bump(&self) -> &'a A {
+    pub unsafe fn arena(&self) -> &'a A {
         self.alloc
     }
 
@@ -878,13 +878,13 @@ fn handle_error(error: AllocError) -> ! {
 
 #[cfg(test)]
 mod tests {
-    use crate::bump::Bump;
+    use crate::bump::Arena;
 
     use super::*;
 
     #[test]
     fn reserve_does_not_overallocate() {
-        let arena = Bump::new();
+        let arena = Arena::new();
         {
             let mut v: RawVec<u32, _> = RawVec::new_in(&arena);
             // First `reserve` allocates like `reserve_exact`

--- a/crates/oxc_allocator/tests/bump/alloc_fill.rs
+++ b/crates/oxc_allocator/tests/bump/alloc_fill.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 use std::alloc::Layout;
 use std::cmp;
 use std::iter::repeat;
@@ -6,7 +6,7 @@ use std::mem;
 
 #[test]
 fn alloc_slice_fill_zero() {
-    let b = Bump::new();
+    let b = Arena::new();
     let u8_layout = Layout::new::<u8>();
 
     let ptr1 = b.alloc_layout(u8_layout);
@@ -34,14 +34,14 @@ fn alloc_slice_fill_zero() {
 
 #[test]
 fn alloc_slice_try_fill_with_succeeds() {
-    let b = Bump::new();
+    let b = Arena::new();
     let res: Result<&mut [usize], ()> = b.alloc_slice_try_fill_with(100, |n| Ok(n));
     assert_eq!(res.map(|arr| arr[50]), Ok(50));
 }
 
 #[test]
 fn alloc_slice_try_fill_with_fails() {
-    let b = Bump::new();
+    let b = Arena::new();
     let res: Result<&mut [u16], ()> =
         b.alloc_slice_try_fill_with(1000, |n| if n == 100 { Err(()) } else { Ok(42) });
     assert_eq!(res, Err(()));
@@ -49,7 +49,7 @@ fn alloc_slice_try_fill_with_fails() {
 
 #[test]
 fn alloc_slice_try_fill_iter_succeeds() {
-    let b = Bump::new();
+    let b = Arena::new();
     let elems = repeat(42).take(10).collect::<Vec<_>>();
     let res: Result<&mut [u16], ()> = b.alloc_slice_try_fill_iter(elems.into_iter().map(Ok));
     assert_eq!(res.map(|arr| arr[5]), Ok(42));
@@ -57,7 +57,7 @@ fn alloc_slice_try_fill_iter_succeeds() {
 
 #[test]
 fn alloc_slice_try_fill_iter_fails() {
-    let b = Bump::new();
+    let b = Arena::new();
     let elems = repeat(()).take(10).collect::<Vec<_>>();
     let res: Result<&mut [u16], ()> = b.alloc_slice_try_fill_iter(elems.into_iter().map(Err));
     assert_eq!(res, Err(()));
@@ -66,7 +66,7 @@ fn alloc_slice_try_fill_iter_fails() {
 #[test]
 #[should_panic(expected = "out of memory")]
 fn alloc_slice_overflow() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_slice_fill_default::<u64>(usize::max_value());
 }

--- a/crates/oxc_allocator/tests/bump/alloc_try_with.rs
+++ b/crates/oxc_allocator/tests/bump/alloc_try_with.rs
@@ -6,12 +6,12 @@
 
 use std::iter::repeat;
 
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_array() -> Result<(), ()> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_try_with(|| Ok([4u8; 10_000_000]))?;
 
@@ -21,7 +21,7 @@ fn alloc_try_with_large_array() -> Result<(), ()> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_array_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.alloc_try_with(|| Result::<[u8; 10_000_000], _>::Err(())).is_err());
 }
@@ -37,7 +37,7 @@ struct LargeStruct {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_struct() -> Result<(), ()> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_try_with(|| {
         Ok(LargeStruct {
@@ -54,7 +54,7 @@ fn alloc_try_with_large_struct() -> Result<(), ()> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_struct_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.alloc_try_with(|| Result::<LargeStruct, _>::Err(())).is_err());
 }
@@ -62,7 +62,7 @@ fn alloc_try_with_large_struct_err() {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_tuple() -> Result<(), ()> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_try_with(|| {
         Ok((
@@ -82,7 +82,7 @@ fn alloc_try_with_large_tuple() -> Result<(), ()> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_tuple_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.alloc_try_with(|| { Result::<(u32, LargeStruct), _>::Err(()) }).is_err());
 }
@@ -96,7 +96,7 @@ enum LargeEnum {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_enum() -> Result<(), ()> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_try_with(|| Ok(LargeEnum::Small))?;
 
@@ -106,7 +106,7 @@ fn alloc_try_with_large_enum() -> Result<(), ()> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_try_with_large_enum_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.alloc_try_with(|| Result::<LargeEnum, _>::Err(())).is_err());
 }
@@ -114,7 +114,7 @@ fn alloc_try_with_large_enum_err() {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_slice_try_fill_with_large_length() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.alloc_slice_try_fill_with(10_000_000, |_| Err::<u8, _>(())).is_err());
 }
@@ -122,7 +122,7 @@ fn alloc_slice_try_fill_with_large_length() {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_slice_try_fill_iter_large_length() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     let elems = repeat(Err::<u8, _>(())).take(10_000_000).collect::<Vec<_>>();
     assert!(b.alloc_slice_try_fill_iter(elems).is_err());

--- a/crates/oxc_allocator/tests/bump/alloc_with.rs
+++ b/crates/oxc_allocator/tests/bump/alloc_with.rs
@@ -4,12 +4,12 @@
 // We only run them when debug_assertions are not set, as we expect them to fail outside release
 // mode.
 
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_with_large_array() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_with(|| [4u8; 10_000_000]);
 }
@@ -25,7 +25,7 @@ struct LargeStruct {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_with_large_struct() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_with(|| LargeStruct {
         small: 1,
@@ -38,7 +38,7 @@ fn alloc_with_large_struct() {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_with_large_tuple() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_with(|| {
         (
@@ -62,7 +62,7 @@ enum LargeEnum {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn alloc_with_large_enum() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.alloc_with(|| LargeEnum::Small);
 }

--- a/crates/oxc_allocator/tests/bump/allocation_limit.rs
+++ b/crates/oxc_allocator/tests/bump/allocation_limit.rs
@@ -1,91 +1,91 @@
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 
 #[test]
 fn allocation_limit_trivial() {
-    let bump = Bump::with_capacity(0);
-    bump.set_allocation_limit(Some(0));
+    let arena = Arena::with_capacity(0);
+    arena.set_allocation_limit(Some(0));
 
-    assert!(bump.try_alloc(5).is_err());
-    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+    assert!(arena.try_alloc(5).is_err());
+    assert!(arena.allocation_limit().unwrap() >= arena.allocated_bytes());
 
-    bump.set_allocation_limit(None);
+    arena.set_allocation_limit(None);
 
-    assert!(bump.try_alloc(5).is_ok());
+    assert!(arena.try_alloc(5).is_ok());
 }
 
 #[test]
 fn change_allocation_limit_with_live_allocations() {
-    let bump = Bump::with_capacity(448);
+    let arena = Arena::with_capacity(448);
 
-    bump.set_allocation_limit(Some(512));
+    arena.set_allocation_limit(Some(512));
 
-    bump.alloc(10);
+    arena.alloc(10);
 
-    assert!(bump.try_alloc([0; 2048]).is_err());
+    assert!(arena.try_alloc([0; 2048]).is_err());
 
-    bump.set_allocation_limit(Some(32768));
+    arena.set_allocation_limit(Some(32768));
 
-    assert!(bump.try_alloc([0; 2048]).is_ok());
-    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+    assert!(arena.try_alloc([0; 2048]).is_ok());
+    assert!(arena.allocation_limit().unwrap() >= arena.allocated_bytes());
 }
 
 #[test]
 fn remove_allocation_limit_with_live_allocations() {
-    let bump = Bump::new();
+    let arena = Arena::new();
 
-    bump.set_allocation_limit(Some(512));
+    arena.set_allocation_limit(Some(512));
 
-    bump.alloc(10);
+    arena.alloc(10);
 
-    assert!(bump.try_alloc([0; 2048]).is_err());
-    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+    assert!(arena.try_alloc([0; 2048]).is_err());
+    assert!(arena.allocation_limit().unwrap() >= arena.allocated_bytes());
 
-    bump.set_allocation_limit(None);
+    arena.set_allocation_limit(None);
 
-    assert!(bump.try_alloc([0; 2048]).is_ok());
+    assert!(arena.try_alloc([0; 2048]).is_ok());
 }
 
 #[test]
 fn reset_preserves_allocation_limits() {
-    let mut bump = Bump::new();
+    let mut arena = Arena::new();
 
-    bump.set_allocation_limit(Some(512));
-    bump.reset();
+    arena.set_allocation_limit(Some(512));
+    arena.reset();
 
-    assert!(bump.try_alloc([0; 2048]).is_err());
-    assert!(bump.allocation_limit().unwrap() >= bump.allocated_bytes());
+    assert!(arena.try_alloc([0; 2048]).is_err());
+    assert!(arena.allocation_limit().unwrap() >= arena.allocated_bytes());
 }
 
 #[test]
 fn reset_updates_allocated_bytes() {
-    let mut bump = Bump::with_capacity(512);
+    let mut arena = Arena::with_capacity(512);
 
-    bump.alloc([0; 1 << 9]);
+    arena.alloc([0; 1 << 9]);
 
     // This second allocation should be a big enough one
     // after the first to force a new chunk allocation
-    bump.alloc([0; 1 << 9]);
+    arena.alloc([0; 1 << 9]);
 
-    let allocated_bytes_before_reset = bump.allocated_bytes();
+    let allocated_bytes_before_reset = arena.allocated_bytes();
 
-    bump.reset();
+    arena.reset();
 
-    let allocated_bytes_after_reset = bump.allocated_bytes();
+    let allocated_bytes_after_reset = arena.allocated_bytes();
 
     assert!(allocated_bytes_after_reset < allocated_bytes_before_reset);
 }
 
 #[test]
-fn new_bump_allocated_bytes_is_zero() {
-    let bump = Bump::new();
+fn new_arena_allocated_bytes_is_zero() {
+    let arena = Arena::new();
 
-    assert_eq!(bump.allocated_bytes(), 0);
+    assert_eq!(arena.allocated_bytes(), 0);
 }
 
 #[test]
 fn small_allocation_limit() {
-    let bump = Bump::new();
+    let arena = Arena::new();
 
-    bump.set_allocation_limit(Some(64));
-    assert!(bump.try_alloc([0; 1]).is_ok());
+    arena.set_allocation_limit(Some(64));
+    assert!(arena.try_alloc([0; 1]).is_ok());
 }

--- a/crates/oxc_allocator/tests/bump/capacity.rs
+++ b/crates/oxc_allocator/tests/bump/capacity.rs
@@ -1,7 +1,7 @@
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 
 #[test]
 fn try_with_capacity_too_large() {
     // Shouldn't panic even though the capacity is too large for a `Layout`.
-    let _ = Bump::try_with_capacity(isize::MAX as usize + 1);
+    let _ = Arena::try_with_capacity(isize::MAX as usize + 1);
 }

--- a/crates/oxc_allocator/tests/bump/quickchecks.rs
+++ b/crates/oxc_allocator/tests/bump/quickchecks.rs
@@ -1,6 +1,6 @@
 use crate::quickcheck;
 use ::quickcheck::{Arbitrary, Gen};
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 use std::mem;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -110,11 +110,11 @@ fn range<T>(t: &T) -> (usize, usize) {
 
 quickcheck! {
     fn can_allocate_big_values(values: Vec<BigValue>) -> () {
-        let bump = Bump::new();
+        let arena = Arena::new();
         let mut alloced = vec![];
 
         for vals in values.iter().cloned() {
-            alloced.push(bump.alloc(vals));
+            alloced.push(arena.alloc(vals));
         }
 
         for (vals, alloc) in values.iter().zip(alloced.into_iter()) {
@@ -123,11 +123,11 @@ quickcheck! {
     }
 
     fn big_allocations_never_overlap(values: Vec<BigValue>) -> () {
-        let bump = Bump::new();
+        let arena = Arena::new();
         let mut alloced = vec![];
 
         for v in values {
-            let a = bump.alloc(v);
+            let a = arena.alloc(v);
             let start = a as *const _ as usize;
             let end = unsafe { (a as *const BigValue).offset(1) as usize };
             let range = (start, end);
@@ -141,28 +141,28 @@ quickcheck! {
     }
 
     fn can_allocate_heterogeneous_things_and_they_dont_overlap(things: Vec<Elems<u8, u64>>) -> () {
-        let bump = Bump::new();
+        let arena = Arena::new();
         let mut ranges = vec![];
 
         for t in things {
             let r = match t {
                 Elems::OneT(a) => {
-                    range(bump.alloc(a))
+                    range(arena.alloc(a))
                 },
                 Elems::TwoT(a, b) => {
-                    range(bump.alloc([a, b]))
+                    range(arena.alloc([a, b]))
                 },
                 Elems::FourT(a, b, c, d) => {
-                    range(bump.alloc([a, b, c, d]))
+                    range(arena.alloc([a, b, c, d]))
                 },
                 Elems::OneU(a) => {
-                    range(bump.alloc(a))
+                    range(arena.alloc(a))
                 },
                 Elems::TwoU(a, b) => {
-                    range(bump.alloc([a, b]))
+                    range(arena.alloc([a, b]))
                 },
                 Elems::FourU(a, b, c, d) => {
-                    range(bump.alloc([a, b, c, d]))
+                    range(arena.alloc([a, b, c, d]))
                 },
             };
 
@@ -178,7 +178,7 @@ quickcheck! {
     fn test_alignment_chunks(sizes: Vec<usize>) -> () {
         const SUPPORTED_ALIGNMENTS: &[usize] = &[1, 2, 4, 8, 16];
         for &alignment in SUPPORTED_ALIGNMENTS {
-            let mut b = Bump::<1>::with_min_align_and_capacity(513);
+            let mut b = Arena::<1>::with_min_align_and_capacity(513);
             let mut sizes = sizes.iter().map(|&size| (size % 10) * alignment).collect::<Vec<_>>();
 
             for &size in &sizes {
@@ -200,7 +200,7 @@ quickcheck! {
     }
 
     fn alloc_slices(allocs: Vec<(u8, usize)>) -> () {
-        let b = Bump::new();
+        let b = Arena::new();
         let mut allocated: Vec<(usize, usize)> = vec![];
         for (val, len) in allocs {
             let len = len % 100;
@@ -219,7 +219,7 @@ quickcheck! {
     }
 
     fn alloc_strs(allocs: Vec<String>) -> () {
-        let b = Bump::new();
+        let b = Arena::new();
         let allocated: Vec<&str> = allocs.iter().map(|s| b.alloc_str(s) as &_).collect();
         for (val, alloc) in allocs.into_iter().zip(allocated) {
             assert_eq!(val, alloc);
@@ -227,7 +227,7 @@ quickcheck! {
     }
 
     fn all_allocations_in_a_chunk(values: Vec<BigValue>) -> () {
-        let b = Bump::new();
+        let b = Arena::new();
         let allocated: Vec<&BigValue> = values.into_iter().map(|val| b.alloc(val) as &_).collect();
         let chunks: Vec<(*mut u8, usize)> = unsafe { b.iter_allocated_chunks_raw() }.collect();
         for alloc in allocated.into_iter() {
@@ -240,7 +240,7 @@ quickcheck! {
     }
 
     fn chunks_and_raw_chunks_are_same(values: Vec<BigValue>) -> () {
-        let mut b = Bump::new();
+        let mut b = Arena::new();
         for val in values {
             b.alloc(val);
         }
@@ -258,9 +258,9 @@ quickcheck! {
     // function. This test runs afoul of that bug.
     #[cfg(not(miri))]
     fn limit_is_never_exceeded(limit: usize) -> bool {
-        let bump = Bump::new();
+        let arena = Arena::new();
 
-        bump.set_allocation_limit(Some(limit));
+        arena.set_allocation_limit(Some(limit));
 
         // The exact numbers here on how much to allocate are a bit murky but we
         // have two main goals.
@@ -269,14 +269,14 @@ quickcheck! {
         // - Allocate in increments small enough that at least a few allocations succeed
         let layout = std::alloc::Layout::array::<u8>(limit / 16).unwrap();
         for _ in 0..32 {
-            let _ = bump.try_alloc_layout(layout);
+            let _ = arena.try_alloc_layout(layout);
         }
 
-        bump.allocated_bytes() <= limit
+        arena.allocated_bytes() <= limit
     }
 
     fn allocated_bytes_including_metadata(allocs: Vec<usize>) -> () {
-        let b = Bump::new();
+        let b = Arena::new();
         let mut slice_bytes = 0;
         let allocs_len = allocs.len();
         for len in allocs {

--- a/crates/oxc_allocator/tests/bump/tests.rs
+++ b/crates/oxc_allocator/tests/bump/tests.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 use std::alloc::Layout;
 use std::fmt::Debug;
 use std::mem;
@@ -6,7 +6,7 @@ use std::usize;
 
 #[test]
 fn can_iterate_over_allocated_things() {
-    let mut bump = Bump::new();
+    let mut arena = Arena::new();
 
     #[cfg(not(miri))]
     const MAX: u64 = 131_072;
@@ -18,7 +18,7 @@ fn can_iterate_over_allocated_things() {
     let mut last = None;
 
     for i in 0..MAX {
-        let this = bump.alloc(i);
+        let this = arena.alloc(i);
         assert_eq!(*this, i);
         let this = this as *const _ as usize;
 
@@ -42,7 +42,7 @@ fn can_iterate_over_allocated_things() {
 
     // Safe because we always allocated objects of the same type in this arena,
     // and their size >= their align.
-    for ch in bump.iter_allocated_chunks() {
+    for ch in arena.iter_allocated_chunks() {
         let chunk_end = ch.as_ptr() as usize + ch.len();
         println!("iter chunk ending @ {:#x}", chunk_end);
         assert_eq!(
@@ -68,8 +68,8 @@ fn can_iterate_over_allocated_things() {
 #[test]
 #[should_panic(expected = "out of memory")]
 fn oom_instead_of_bump_pointer_overflow() {
-    let bump = Bump::new();
-    let x = bump.alloc(0_u8);
+    let arena = Arena::new();
+    let x = arena.alloc(0_u8);
     let p = x as *mut u8 as usize;
 
     // A size guaranteed to overflow the bump pointer.
@@ -85,12 +85,12 @@ fn oom_instead_of_bump_pointer_overflow() {
     };
 
     // This should panic.
-    bump.alloc_layout(layout);
+    arena.alloc_layout(layout);
 }
 
 #[test]
 fn force_new_chunk_fits_well() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     // Use the first chunk for something
     b.alloc_layout(Layout::from_size_align(1, 1).unwrap());
@@ -102,7 +102,7 @@ fn force_new_chunk_fits_well() {
 
 #[test]
 fn alloc_with_strong_alignment() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     // 64 is probably the strongest alignment we'll see in practice
     // e.g. AVX-512 types, or cache line padding optimizations
@@ -111,7 +111,7 @@ fn alloc_with_strong_alignment() {
 
 #[test]
 fn alloc_slice_copy() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     let src: &[u16] = &[0xFEED, 0xFACE, 0xA7, 0xCAFE];
     let dst = b.alloc_slice_copy(src);
@@ -121,7 +121,7 @@ fn alloc_slice_copy() {
 
 #[test]
 fn alloc_slice_clone() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     // Original bumpalo test uses `Vec<Vec<i32>>`, but bump allocators don't run
     // destructors, so the inner Vecs' heap buffers would leak. Use a non-Copy
@@ -138,7 +138,7 @@ fn alloc_slice_clone() {
 
 #[test]
 fn small_size_and_large_align() {
-    let b = Bump::new();
+    let b = Arena::new();
     let layout = std::alloc::Layout::from_size_align(1, 0x1000).unwrap();
     b.alloc_layout(layout);
 }
@@ -149,7 +149,7 @@ where
     I: Clone + Iterator<Item = T> + DoubleEndedIterator,
 {
     for &initial_size in &[0, 1, 8, 11, 0x1000, 0x12345] {
-        let mut b = Bump::<1>::with_min_align_and_capacity(initial_size);
+        let mut b = Arena::<1>::with_min_align_and_capacity(initial_size);
 
         for v in iter.clone() {
             b.alloc(v);
@@ -186,7 +186,7 @@ fn with_capacity_test() {
 
 #[test]
 fn test_reset() {
-    let mut b = Bump::new();
+    let mut b = Arena::new();
 
     for i in 0u64..10_000 {
         b.alloc(i);
@@ -205,7 +205,7 @@ fn test_reset() {
 #[test]
 fn test_alignment() {
     for &alignment in &[2, 4, 8, 16, 32, 64] {
-        let b = Bump::with_capacity(513);
+        let b = Arena::with_capacity(513);
         let layout = std::alloc::Layout::from_size_align(alignment, alignment).unwrap();
 
         for _ in 0..1024 {
@@ -217,27 +217,27 @@ fn test_alignment() {
 
 #[test]
 fn test_chunk_capacity() {
-    let b = Bump::with_capacity(512);
+    let b = Arena::with_capacity(512);
     let orig_capacity = b.chunk_capacity();
     b.alloc(true);
     assert!(b.chunk_capacity() < orig_capacity);
 }
 
 #[test]
-fn bump_is_send() {
+fn arena_is_send() {
     fn assert_send(_: impl Send) {}
-    assert_send(Bump::new());
+    assert_send(Arena::new());
 }
 
 #[test]
 fn test_debug_assert_data_le_bump_ptr_pr_313() {
-    let bump = Bump::new();
-    bump.set_allocation_limit(Some(1));
-    bump.alloc_layout(Layout::from_size_align(0, 16).unwrap());
+    let arena = Arena::new();
+    arena.set_allocation_limit(Some(1));
+    arena.alloc_layout(Layout::from_size_align(0, 16).unwrap());
 }
 
 #[test]
 fn test_debug_assert_ptr_align_pr_313() {
-    let bump = Bump::<16>::with_min_align();
-    bump.alloc(0u8);
+    let arena = Arena::<16>::with_min_align();
+    arena.alloc(0u8);
 }

--- a/crates/oxc_allocator/tests/bump/try_alloc_try_with.rs
+++ b/crates/oxc_allocator/tests/bump/try_alloc_try_with.rs
@@ -4,12 +4,12 @@
 // We only run them when debug_assertions are not set, as we expect them to fail outside release
 // mode.
 
-use oxc_allocator::bump::{AllocOrInitError, Bump};
+use oxc_allocator::bump::{AllocOrInitError, Arena};
 
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_array() -> Result<(), AllocOrInitError<()>> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_try_with(|| Ok([4u8; 10_000_000]))?;
 
@@ -19,7 +19,7 @@ fn try_alloc_try_with_large_array() -> Result<(), AllocOrInitError<()>> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_array_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.try_alloc_try_with(|| Result::<[u8; 10_000_000], _>::Err(())).is_err());
 }
@@ -35,7 +35,7 @@ struct LargeStruct {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_struct() -> Result<(), AllocOrInitError<()>> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_try_with(|| {
         Ok(LargeStruct {
@@ -52,7 +52,7 @@ fn try_alloc_try_with_large_struct() -> Result<(), AllocOrInitError<()>> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_struct_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.try_alloc_try_with(|| Result::<LargeStruct, _>::Err(())).is_err());
 }
@@ -60,7 +60,7 @@ fn try_alloc_try_with_large_struct_err() {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_tuple() -> Result<(), AllocOrInitError<()>> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_try_with(|| {
         Ok((
@@ -80,7 +80,7 @@ fn try_alloc_try_with_large_tuple() -> Result<(), AllocOrInitError<()>> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_tuple_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.try_alloc_try_with(|| { Result::<(u32, LargeStruct), _>::Err(()) }).is_err());
 }
@@ -94,7 +94,7 @@ enum LargeEnum {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_enum() -> Result<(), AllocOrInitError<()>> {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_try_with(|| Ok(LargeEnum::Small))?;
 
@@ -104,7 +104,7 @@ fn try_alloc_try_with_large_enum() -> Result<(), AllocOrInitError<()>> {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_try_with_large_enum_err() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     assert!(b.try_alloc_try_with(|| Result::<LargeEnum, _>::Err(())).is_err());
 }

--- a/crates/oxc_allocator/tests/bump/try_alloc_with.rs
+++ b/crates/oxc_allocator/tests/bump/try_alloc_with.rs
@@ -4,12 +4,12 @@
 // We only run them when debug_assertions are not set, as we expect them to fail outside release
 // mode.
 
-use oxc_allocator::bump::Bump;
+use oxc_allocator::bump::Arena;
 
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_with_large_array() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_with(|| [4u8; 10_000_000]).unwrap();
 }
@@ -25,7 +25,7 @@ struct LargeStruct {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_with_large_struct() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_with(|| LargeStruct {
         small: 1,
@@ -39,7 +39,7 @@ fn try_alloc_with_large_struct() {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_with_large_tuple() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_with(|| {
         (
@@ -64,7 +64,7 @@ enum LargeEnum {
 #[test]
 #[cfg_attr(debug_assertions, ignore)]
 fn try_alloc_with_large_enum() {
-    let b = Bump::new();
+    let b = Arena::new();
 
     b.try_alloc_with(|| LargeEnum::Small).unwrap();
 }

--- a/crates/oxc_allocator/tests/bump_try_alloc.rs
+++ b/crates/oxc_allocator/tests/bump_try_alloc.rs
@@ -8,7 +8,7 @@
     clippy::uninlined_format_args
 )]
 
-use oxc_allocator::bump::{AllocOrInitError, Bump};
+use oxc_allocator::bump::{AllocOrInitError, Arena};
 use rand::RngExt as _;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -97,53 +97,56 @@ fn main() {
         };
     }
 
-    fn test_static_size_alloc(assert_alloc_ok: fn(bump: &Bump), assert_alloc_err: fn(bump: &Bump)) {
+    fn test_static_size_alloc(
+        assert_alloc_ok: fn(arena: &Arena),
+        assert_alloc_err: fn(arena: &Arena),
+    ) {
         // Unlike with `try_alloc_layout`, it's not that easy to test a variety
         // of size/capacity combinations here.
-        // Since nothing in Bump is really random, and we have to start fresh
+        // Since nothing in Arena is really random, and we have to start fresh
         // each time, just checking each case once is enough.
         for &fail_alloc in &[false, true] {
-            let bump = GLOBAL_ALLOCATOR.with_successful_allocs(|| {
+            let arena = GLOBAL_ALLOCATOR.with_successful_allocs(|| {
                 // We can't query the remaining free space in the current chunk,
-                // so we have to create a new Bump for each test and fill it to
+                // so we have to create a new Arena for each test and fill it to
                 // the brink of a new allocation.
-                let bump = Bump::try_new().unwrap();
+                let arena = Arena::try_new().unwrap();
 
-                // Bump preallocates space in the initial chunk, so we need to
+                // Arena preallocates space in the initial chunk, so we need to
                 // use up this block prior to the actual test
-                let layout = Layout::from_size_align(bump.chunk_capacity(), 1).unwrap();
-                assert!(bump.try_alloc_layout(layout).is_ok());
+                let layout = Layout::from_size_align(arena.chunk_capacity(), 1).unwrap();
+                assert!(arena.try_alloc_layout(layout).is_ok());
 
-                bump
+                arena
             });
 
             GLOBAL_ALLOCATOR.set_returning_null(fail_alloc);
 
             if fail_alloc {
-                assert_alloc_err(&bump);
+                assert_alloc_err(&arena);
             } else {
-                assert_alloc_ok(&bump);
+                assert_alloc_ok(&arena);
             }
         }
     }
 
     let tests = [
-        test!("Bump::try_new fails when global allocator fails", || {
+        test!("Arena::try_new fails when global allocator fails", || {
             GLOBAL_ALLOCATOR.with_alloc_failures(|| {
-                assert!(Bump::try_with_capacity(1).is_err());
+                assert!(Arena::try_with_capacity(1).is_err());
             });
         }),
         test!("test try_alloc_layout with and without global allocation failures", || {
             const NUM_TESTS: usize = 5000;
             const MAX_BYTES_ALLOCATED: usize = 65536;
 
-            let mut bump = Bump::try_new().unwrap();
-            let mut bytes_allocated = bump.chunk_capacity();
+            let mut arena = Arena::try_new().unwrap();
+            let mut bytes_allocated = arena.chunk_capacity();
 
-            // Bump preallocates space in the initial chunk, so we need to
+            // Arena preallocates space in the initial chunk, so we need to
             // use up this block prior to the actual test
-            let layout = Layout::from_size_align(bump.chunk_capacity(), 1).unwrap();
-            assert!(bump.try_alloc_layout(layout).is_ok());
+            let layout = Layout::from_size_align(arena.chunk_capacity(), 1).unwrap();
+            assert!(arena.try_alloc_layout(layout).is_ok());
 
             let mut rng = rand::rng();
 
@@ -152,49 +155,49 @@ fn main() {
                     GLOBAL_ALLOCATOR.toggle_returning_null();
                 }
 
-                let layout = Layout::from_size_align(bump.chunk_capacity() + 1, 1).unwrap();
+                let layout = Layout::from_size_align(arena.chunk_capacity() + 1, 1).unwrap();
                 if GLOBAL_ALLOCATOR.is_returning_null() {
-                    assert!(bump.try_alloc_layout(layout).is_err());
+                    assert!(arena.try_alloc_layout(layout).is_err());
                 } else {
-                    assert!(bump.try_alloc_layout(layout).is_ok());
-                    bytes_allocated += bump.chunk_capacity();
+                    assert!(arena.try_alloc_layout(layout).is_ok());
+                    bytes_allocated += arena.chunk_capacity();
                 }
 
                 if bytes_allocated >= MAX_BYTES_ALLOCATED {
-                    bump = GLOBAL_ALLOCATOR.with_successful_allocs(|| Bump::try_new().unwrap());
-                    bytes_allocated = bump.chunk_capacity();
+                    arena = GLOBAL_ALLOCATOR.with_successful_allocs(|| Arena::try_new().unwrap());
+                    bytes_allocated = arena.chunk_capacity();
                 }
             }
         },),
         test!("test try_alloc with and without global allocation failures", || {
             test_static_size_alloc(
-                |bump| assert!(bump.try_alloc(1u8).is_ok()),
-                |bump| assert!(bump.try_alloc(1u8).is_err()),
+                |arena| assert!(arena.try_alloc(1u8).is_ok()),
+                |arena| assert!(arena.try_alloc(1u8).is_err()),
             );
         },),
         test!("test try_alloc_with with and without global allocation failures", || {
             test_static_size_alloc(
-                |bump| assert!(bump.try_alloc_with(|| 1u8).is_ok()),
-                |bump| assert!(bump.try_alloc_with(|| 1u8).is_err()),
+                |arena| assert!(arena.try_alloc_with(|| 1u8).is_ok()),
+                |arena| assert!(arena.try_alloc_with(|| 1u8).is_err()),
             );
         },),
         test!("test try_alloc_try_with (Ok) with and without global allocation failures", || {
             test_static_size_alloc(
-                |bump| assert!(bump.try_alloc_try_with::<_, _, ()>(|| Ok(1u8)).is_ok()),
-                |bump| assert!(bump.try_alloc_try_with::<_, _, ()>(|| Ok(1u8)).is_err()),
+                |arena| assert!(arena.try_alloc_try_with::<_, _, ()>(|| Ok(1u8)).is_ok()),
+                |arena| assert!(arena.try_alloc_try_with::<_, _, ()>(|| Ok(1u8)).is_err()),
             );
         },),
         test!("test try_alloc_try_with (Err) with and without global allocation failures", || {
             test_static_size_alloc(
-                |bump| {
+                |arena| {
                     assert!(matches!(
-                        bump.try_alloc_try_with::<_, u8, _>(|| Err(())),
+                        arena.try_alloc_try_with::<_, u8, _>(|| Err(())),
                         Err(AllocOrInitError::Init(_))
                     ));
                 },
-                |bump| {
+                |arena| {
                     assert!(matches!(
-                        bump.try_alloc_try_with::<_, u8, _>(|| Err(())),
+                        arena.try_alloc_try_with::<_, u8, _>(|| Err(())),
                         Err(AllocOrInitError::Alloc(_))
                     ));
                 },


### PR DESCRIPTION
Pure refactor. Rename `Bump` to `Arena`. The name "Bump" was a legacy from `bumpalo`, `Arena` is a more appropriate name.

No substantive changes, only renaming.