### PR TITLE
feat(allocator)!: rename `Box` and `Vec` methods

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -179,7 +179,7 @@ impl<'a, T> Box<'a, [T]> {
     // `#[inline(always)]` because this is a no-op. `Box<[T]>` and `&[T]` have the same layout.
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub fn into_bump_slice(self) -> &'a [T] {
+    pub fn into_arena_slice(self) -> &'a [T] {
         let r = self.as_ref();
         // Extend lifetime of reference to lifetime of the allocator.
         // SAFETY: `self` is consumed by this method, so there cannot be any mutable references to it.
@@ -195,7 +195,7 @@ impl<'a, T> Box<'a, [T]> {
     // `#[inline(always)]` because this is a no-op. `Box<[T]>` and `&mut [T]` have the same layout.
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub fn into_bump_slice_mut(mut self) -> &'a mut [T] {
+    pub fn into_arena_slice_mut(mut self) -> &'a mut [T] {
         let r = self.as_mut();
         // Extend lifetime of reference to lifetime of the allocator.
         // SAFETY: `self` is consumed by this method, so there cannot be any other references to it.
@@ -310,20 +310,20 @@ mod test {
     }
 
     #[test]
-    fn boxed_slice_into_bump_slice() {
+    fn boxed_slice_into_arena_slice() {
         let allocator = Allocator::default();
         let v = Vec::from_iter_in([1, 2, 3], &allocator);
         let b = v.into_boxed_slice();
-        let slice = b.into_bump_slice();
+        let slice = b.into_arena_slice();
         assert_eq!(slice, &[1, 2, 3]);
     }
 
     #[test]
-    fn boxed_slice_into_bump_slice_mut() {
+    fn boxed_slice_into_arena_slice_mut() {
         let allocator = Allocator::default();
         let v = Vec::from_iter_in([10, 20, 30], &allocator);
         let b = v.into_boxed_slice();
-        let slice = b.into_bump_slice_mut();
+        let slice = b.into_arena_slice_mut();
         slice[1] = 99;
         assert_eq!(slice, &[10, 99, 30]);
     }

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -186,7 +186,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// [`Box<[T]>`]: Box
     #[inline]
     pub fn into_boxed_slice(self) -> Box<'alloc, [T]> {
-        let slice = self.0.into_bump_slice_mut();
+        let slice = self.0.into_arena_slice_mut();
         let ptr = NonNull::from(slice);
         // SAFETY: `ptr` points to a valid `[T]`.
         // Contents of the `Vec` are in an arena.
@@ -205,12 +205,12 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// let allocator = Allocator::default();
     ///
     /// let mut vec = Vec::from_iter_in([1, 2, 3], &allocator);
-    /// let slice = vec.into_bump_slice();
+    /// let slice = vec.into_arena_slice();
     /// assert_eq!(slice, [1, 2, 3]);
     /// ```
     #[inline]
-    pub fn into_bump_slice(self) -> &'alloc [T] {
-        self.0.into_bump_slice()
+    pub fn into_arena_slice(self) -> &'alloc [T] {
+        self.0.into_arena_slice()
     }
 
     /// Converts [`Vec<T>`] into [`&'alloc mut [T]`].
@@ -223,13 +223,13 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// let allocator = Allocator::default();
     ///
     /// let vec = Vec::from_iter_in([1, 2, 3], &allocator);
-    /// let slice = vec.into_bump_slice_mut();
+    /// let slice = vec.into_arena_slice_mut();
     /// slice[0] = 4;
     /// assert_eq!(slice, [4, 2, 3]);
     /// ```
     #[inline]
-    pub fn into_bump_slice_mut(self) -> &'alloc mut [T] {
-        self.0.into_bump_slice_mut()
+    pub fn into_arena_slice_mut(self) -> &'alloc mut [T] {
+        self.0.into_arena_slice_mut()
     }
 }
 

--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -861,10 +861,10 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// let b = Bump::new();
     /// let v = Vec::from_iter_in([1, 2, 3], &b);
     ///
-    /// let slice = v.into_bump_slice();
+    /// let slice = v.into_arena_slice();
     /// assert_eq!(slice, [1, 2, 3]);
     /// ```
-    pub fn into_bump_slice(self) -> &'a [T] {
+    pub fn into_arena_slice(self) -> &'a [T] {
         unsafe {
             let ptr = self.as_ptr();
             let len = self.len_usize();
@@ -883,14 +883,14 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// let b = Bump::new();
     /// let v = Vec::from_iter_in([1, 2, 3], &b);
     ///
-    /// let mut slice = v.into_bump_slice_mut();
+    /// let mut slice = v.into_arena_slice_mut();
     ///
     /// slice[0] = 3;
     /// slice[2] = 1;
     ///
     /// assert_eq!(slice, [3, 2, 1]);
     /// ```
-    pub fn into_bump_slice_mut(mut self) -> &'a mut [T] {
+    pub fn into_arena_slice_mut(mut self) -> &'a mut [T] {
         let ptr = self.as_mut_ptr();
         let len = self.len_usize();
         // Don't need `mem::forget(self)` here, because `Vec` does not implement `Drop`.

--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -2368,7 +2368,7 @@ impl<'ast> Format<'ast> for BestFitting<'_, 'ast> {
             buffer.write_fmt(Arguments::from(variant));
             buffer.write_element(FormatElement::Tag(EndEntry));
 
-            formatted_variants.push(buffer.take_vec().into_bump_slice());
+            formatted_variants.push(buffer.take_vec().into_arena_slice());
         }
 
         let formatted_variants =

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -25,7 +25,7 @@ impl<'a> Document<'a> {
         elements: ArenaVec<'a, FormatElement<'a>>,
         sorted_tailwind_classes: Vec<String>,
     ) -> Self {
-        Self { elements: elements.into_bump_slice(), sorted_tailwind_classes }
+        Self { elements: elements.into_arena_slice(), sorted_tailwind_classes }
     }
 
     /// Consumes the document and returns its elements and sorted Tailwind CSS classes.
@@ -38,7 +38,7 @@ impl<'a> Document<'a> {
     /// If you have modified the elements and want to update the document,
     /// use this method to set the new elements.
     pub fn replace_elements(&mut self, elements: ArenaVec<'a, FormatElement<'a>>) {
-        self.elements = elements.into_bump_slice();
+        self.elements = elements.into_arena_slice();
     }
 }
 

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -162,7 +162,7 @@ pub struct Interned<'a>(&'a [FormatElement<'a>]);
 
 impl<'a> Interned<'a> {
     pub(super) fn new(content: ArenaVec<'a, FormatElement<'a>>) -> Self {
-        Self(content.into_bump_slice())
+        Self(content.into_arena_slice())
     }
 }
 
@@ -336,7 +336,7 @@ impl<'a> BestFittingElement<'a> {
             "Requires at least the least expanded and most expanded variants"
         );
 
-        Self { variants: variants.into_bump_slice() }
+        Self { variants: variants.into_arena_slice() }
     }
 
     /// Returns the most expanded variant

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -742,7 +742,7 @@ fn write_grouped_arguments<'a>(
 
         buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
-        buffer.into_vec().into_bump_slice()
+        buffer.into_vec().into_arena_slice()
     };
 
     // Now reformat the first or last argument if they happen to be a function or arrow function expression.
@@ -861,7 +861,7 @@ fn write_grouped_arguments<'a>(
 
         buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
-        buffer.into_vec().into_bump_slice()
+        buffer.into_vec().into_arena_slice()
     };
 
     // If the grouped content breaks, then we can skip the most_flat variant,
@@ -896,7 +896,7 @@ fn write_grouped_arguments<'a>(
 
             buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
-            buffer.into_vec().into_bump_slice()
+            buffer.into_vec().into_arena_slice()
         };
 
         ArenaVec::from_array_in([most_flat, middle_variant, most_expanded], f.context().allocator())

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -478,7 +478,7 @@ impl Linter {
         }
 
         // `allocator` is a fixed-size allocator, so no need to clone AST into a new one
-        let tokens = ctx_host.parser_tokens_mut().take_in(allocator).into_bump_slice_mut();
+        let tokens = ctx_host.parser_tokens_mut().take_in(allocator).into_arena_slice_mut();
 
         // If file has a hashbang, add it to comments.
         // It will be converted to a `Shebang` comment on JS side.


### PR DESCRIPTION
Rename `Box` and `Vec` methods which contained the word "bump", in line with renaming `Bump` to `Arena` (#21394).

No substantive changes, only renaming.