### PR TITLE
test(allocator): fix compile fail doctest

### DIFF
--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -2802,7 +2802,7 @@ unsafe impl<const MIN_ALIGN: usize> BumpaloAlloc for &Arena<MIN_ALIGN> {
 
 /// This function tests that Arena isn't Sync.
 /// ```compile_fail
-/// use oxc_allocator::Arena;
+/// use oxc_allocator::arena::Arena;
 /// fn _requires_sync<T: Sync>(_value: T) {}
 /// fn _arena_not_sync(b: Arena) {
 ///    _requires_sync(b);


### PR DESCRIPTION
Fix doctest that checks that `Arena` is not `Sync`. This was previously failing to compile as expected, but not for the right reasons! The import path was wrong.