### PR TITLE
fix(formatter): preserve parens around `intrinsic` in type alias annotation

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -1306,7 +1306,46 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSBigIntKeyword> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeReference<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        write!(f, [self.type_name(), self.type_arguments()]);
+        let wrap = is_leftmost_intrinsic_in_type_alias(self);
+        write!(
+            f,
+            [wrap.then_some("("), self.type_name(), self.type_arguments(), wrap.then_some(")")]
+        );
+    }
+}
+
+/// The parser treats a leading `intrinsic` identifier in a type alias annotation
+/// as `TSIntrinsicKeyword` (e.g. `type t = intrinsic`). Source like `type t = (intrinsic);`
+/// loses its parens (`preserve_parens: false`), so without re-emitting them the output
+/// re-parses as `TSIntrinsicKeyword` (or fails to parse when followed by `|`/`&`).
+///
+/// See: <https://github.com/oxc-project/oxc/issues/20205>
+fn is_leftmost_intrinsic_in_type_alias(reference: &AstNode<'_, TSTypeReference<'_>>) -> bool {
+    let TSTypeName::IdentifierReference(ident) = &reference.type_name else {
+        return false;
+    };
+    if ident.name != "intrinsic" || reference.type_arguments.is_some() {
+        return false;
+    }
+    let span_start = reference.span().start;
+    let mut parent = reference.parent();
+    loop {
+        match parent {
+            AstNodes::TSTypeAliasDeclaration(_) => return true,
+            AstNodes::TSUnionType(union) => {
+                if union.types.first().is_none_or(|t| t.span().start != span_start) {
+                    return false;
+                }
+                parent = union.parent();
+            }
+            AstNodes::TSIntersectionType(intersection) => {
+                if intersection.types.first().is_none_or(|t| t.span().start != span_start) {
+                    return false;
+                }
+                parent = intersection.parent();
+            }
+            _ => return false,
+        }
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts
@@ -1,0 +1,8 @@
+type t1 = (intrinsic);
+type t2<T> = (intrinsic);
+type t3 = (intrinsic) | string;
+type t4 = (intrinsic) & string;
+type t5 = string | (intrinsic);
+type t6 = [intrinsic];
+type t7 = { x: intrinsic };
+type t8 = Array<intrinsic>;

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+type t1 = (intrinsic);
+type t2<T> = (intrinsic);
+type t3 = (intrinsic) | string;
+type t4 = (intrinsic) & string;
+type t5 = string | (intrinsic);
+type t6 = [intrinsic];
+type t7 = { x: intrinsic };
+type t8 = Array<intrinsic>;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+type t1 = (intrinsic);
+type t2<T> = (intrinsic);
+type t3 = (intrinsic) | string;
+type t4 = (intrinsic) & string;
+type t5 = string | intrinsic;
+type t6 = [intrinsic];
+type t7 = { x: intrinsic };
+type t8 = Array<intrinsic>;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+type t1 = (intrinsic);
+type t2<T> = (intrinsic);
+type t3 = (intrinsic) | string;
+type t4 = (intrinsic) & string;
+type t5 = string | intrinsic;
+type t6 = [intrinsic];
+type t7 = { x: intrinsic };
+type t8 = Array<intrinsic>;
+
+===================== End =====================


### PR DESCRIPTION
## Summary

Fixes #20205 — `type t = (intrinsic);` was losing its parentheses during formatting, changing the AST on re-parse or producing unparseable TypeScript.

## Why this happens

The parser treats a leading `intrinsic` identifier in a type alias annotation as `TSIntrinsicKeyword`:

- `type t = intrinsic;` → `TSIntrinsicKeyword`
- `type t = (intrinsic);` → `TSParenthesizedType(TSTypeReference(IdentifierReference))`

`oxc_formatter` runs the parser with `preserve_parens: false`, which drops the `TSParenthesizedType` wrapper. Without re-emitting the parens:

| Input | Naive output | Re-parses as |
|-------|-------------|--------------|
| `type t = (intrinsic);` | `type t = intrinsic;` | `TSIntrinsicKeyword` (different AST) |
| `type t = (intrinsic) \| string;` | `type t = intrinsic \| string;` | **Syntax error** — oxc and TypeScript both reject it |
| `type t = (intrinsic) & string;` | `type t = intrinsic & string;` | **Syntax error** |

Prettier has the same bug and emits the broken outputs; we intentionally diverge to produce correct, round-trippable TypeScript.

## Fix

In `FormatWrite<TSTypeReference>::write`, detect when the reference is a bare `intrinsic` identifier AND is the leftmost descendant of a `TSTypeAliasDeclaration` (directly, or through leftmost members of union/intersection types). When so, wrap the output in parens. Any other `intrinsic` position (right arm of union, array element, object property, type arguments, etc.) is unambiguous and is left alone.

Fast-pathed on the name check so non-`intrinsic` references pay only a hash-prefixed string compare.

## Test plan

- [x] New fixture `crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts` covers direct, leftmost-union, leftmost-intersection, right-arm, tuple, object property, and type-argument positions
- [x] Output round-trips through `oxc_parser`
- [x] `cargo test -p oxc_formatter` — 269/269 passing
- [x] `cargo run -p oxc_prettier_conformance` — js 746/753, ts 591/601 (no delta)
