### PR TITLE
fix(linter/no-unused-vars): allow segments of dotted namespace declarations

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -120,7 +120,16 @@ impl NoUnusedVars {
         symbol: &Symbol<'_, 'a>,
         namespace: &TSModuleDeclaration<'a>,
     ) -> bool {
-        namespace.declare || symbol.is_in_declared_module()
+        if namespace.declare || symbol.is_in_declared_module() {
+            return true;
+        }
+        // Segments of a dotted namespace declaration (`namespace A.B.C {}`) are
+        // parsed as nested `TSModuleDeclaration`s. Don't flag any segment as unused.
+        matches!(&namespace.body, Some(TSModuleDeclarationBody::TSModuleDeclaration(_)))
+            || matches!(
+                symbol.nodes().parent_kind(symbol.declaration().id()),
+                AstKind::TSModuleDeclaration(_)
+            )
     }
 
     /// Returns `true` if this unused variable declaration should be allowed

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1290,6 +1290,14 @@ fn test_namespaces() {
             }
         }
         ",
+        "
+        export namespace editor.multiplayer {
+          export type AwarenessPayload = { d: any; };
+        }
+        export namespace editor.internal.export_settings {
+          export type Format = 'png' | 'svg';
+        }
+        ",
     ];
 
     let fail = vec![
@@ -1304,6 +1312,7 @@ fn test_namespaces() {
         ",
         "declare module 'bun:test' { type Matchers2<T> = {} }",
         "declare module 'bun:test' { class MyClass<T> {} }",
+        "export namespace N { namespace Inner {} }",
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -935,16 +935,29 @@ fn test() {
             ",
             None,
         ),
-        // (
-        //     "
-        // namespace foo.bar {
-        //   export interface User {
-        //     name: string;
-        //   }
-        // }
-        //     ",
-        //     None,
-        // ),
+        (
+            "
+        namespace foo.bar {
+          export interface User {
+            name: string;
+          }
+        }
+            ",
+            None,
+        ),
+        (
+            "
+        export namespace editor.multiplayer {
+          export type AwarenessPayload = {
+            cursor: { x: number; y: number } | null;
+          };
+        }
+        export namespace editor.internal.export_settings {
+          export type Format = 'png' | 'svg';
+        }
+            ",
+            None,
+        ),
         // exported self-referencing types
         (
             "

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -945,19 +945,6 @@ fn test() {
             ",
             None,
         ),
-        (
-            "
-        export namespace editor.multiplayer {
-          export type AwarenessPayload = {
-            cursor: { x: number; y: number } | null;
-          };
-        }
-        export namespace editor.internal.export_settings {
-          export type Format = 'png' | 'svg';
-        }
-            ",
-            None,
-        ),
         // exported self-referencing types
         (
             "

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
@@ -51,3 +51,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                                           ╰── 'T' is declared here
    ╰────
   help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable 'Inner' is declared but never used.
+   ╭─[no_unused_vars.tsx:1:32]
+ 1 │ export namespace N { namespace Inner {} }
+   ·                                ──┬──
+   ·                                  ╰── 'Inner' is declared here
+   ╰────
+  help: Consider removing this declaration.


### PR DESCRIPTION
closes #21405