### PR TITLE
fix(minifier): avoid illegal `var;` when folding unused arguments copy loop

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -886,46 +886,49 @@ impl<'a> PeepholeOptimizations {
                 .then(|| r_id.take_in(ctx.ast))
         };
 
-        let base_arr = ctx.ast.expression_array(
-            SPAN,
-            ctx.ast.vec1(ctx.ast.array_expression_element_spread_element(
+        if let Some(r_id_pat) = r_id_pat {
+            let base_arr = ctx.ast.expression_array(
                 SPAN,
-                Expression::Identifier(arguments_id.take_in_box(ctx.ast)),
-            )),
-        );
-        // wrap with `.slice(offset)`
-        let arr = if offset > 0.0 {
-            let obj = base_arr;
-            let callee =
-                Expression::StaticMemberExpression(ctx.ast.alloc_static_member_expression(
+                ctx.ast.vec1(ctx.ast.array_expression_element_spread_element(
                     SPAN,
-                    obj,
-                    ctx.ast.identifier_name(SPAN, "slice"),
+                    Expression::Identifier(arguments_id.take_in_box(ctx.ast)),
+                )),
+            );
+            // wrap with `.slice(offset)`
+            let arr = if offset > 0.0 {
+                let obj = base_arr;
+                let callee =
+                    Expression::StaticMemberExpression(ctx.ast.alloc_static_member_expression(
+                        SPAN,
+                        obj,
+                        ctx.ast.identifier_name(SPAN, "slice"),
+                        false,
+                    ));
+                ctx.ast.expression_call(
+                    SPAN,
+                    callee,
+                    NONE,
+                    ctx.ast.vec1(Argument::from(ctx.ast.expression_numeric_literal(
+                        SPAN,
+                        offset,
+                        None,
+                        NumberBase::Decimal,
+                    ))),
                     false,
-                ));
-            ctx.ast.expression_call(
-                SPAN,
-                callee,
-                NONE,
-                ctx.ast.vec1(Argument::from(ctx.ast.expression_numeric_literal(
-                    SPAN,
-                    offset,
-                    None,
-                    NumberBase::Decimal,
-                ))),
-                false,
-            )
-        } else {
-            base_arr
-        };
+                )
+            } else {
+                base_arr
+            };
 
-        var_init.declarations = if let Some(r_id_pat) = r_id_pat {
             let new_decl =
                 ctx.ast.variable_declarator(SPAN, var_init.kind, r_id_pat, NONE, Some(arr), false);
-            ctx.ast.vec1(new_decl)
+            var_init.declarations = ctx.ast.vec1(new_decl);
         } else {
-            ctx.ast.vec()
-        };
+            // `for (var; 0;)` with an empty `VariableDeclaration` is invalid JS when printed and
+            // makes `try_fold_for` hoist a bogus `var;`. Use `for (; 0;)` instead so dead-code
+            // folding becomes an empty statement.
+            for_stmt.init = None;
+        }
         for_stmt.test =
             Some(ctx.ast.expression_numeric_literal(for_stmt.span, 0.0, None, NumberBase::Decimal));
         for_stmt.update = None;

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -842,6 +842,11 @@ fn test_rewrite_arguments_copy_loop() {
         "function _() { for (var e = arguments.length, r = Array(e), a = 0; a < e; a++) r[a] = arguments[a]; }",
         "function _() {}",
     );
+    // Unused copy result + consequent must not become illegal `var;` (see `for_stmt.init = None`).
+    test(
+        "function _(){if(window.__x)for(var n=arguments.length,a=[],i=0;i<n;i++)a[i]=arguments[i]}",
+        "function _(){window.__x}",
+    );
     test(
         "function _() { for (var e = arguments.length, r = Array(e > 1 ? e - 1 : 0), a = 1; a < e; a++) r[a - 1] = arguments[a] }",
         "function _() {}",


### PR DESCRIPTION
## Summary

When peephole-folding the classic `arguments` copy loop, we could end up with an empty `VariableDeclaration` initializer (`for (var; …)`), which prints as invalid `var;` and can confuse downstream folding (e.g. `try_fold_for` hoisting).

## Changes

- Only build the `[...arguments]` / `.slice(offset)` array initializer when there is a binding pattern for the copy result (`r_id_pat`).
- If there is **no** binding pattern, clear `for_stmt.init` instead of emitting an empty `VariableDeclaration`, so the loop becomes `for (; 0;)` and dead-code elimination can remove it cleanly.

## Tests

- Added a regression in `crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs` covering unused copy result + consequent (must not become illegal `var;`).

## AI usage

This change was developed with assistance from Cursor; I reviewed the diff and tests locally before opening this PR.