### PR TITLE
ci(tools): run rustdoc with `--all-features`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,7 +462,7 @@ jobs:
           cache: rust
       - run: rustup toolchain install "${TOOLCHAIN}" --profile minimal --component rust-docs
       # https://github.com/rust-lang/rust/issues/146895
-      - run: RUSTDOCFLAGS='-D warnings' cargo +"${TOOLCHAIN}" doc --no-deps --document-private-items -Zrustdoc-mergeable-info
+      - run: RUSTDOCFLAGS='-D warnings' cargo +"${TOOLCHAIN}" doc --no-deps --document-private-items --all-features -Zrustdoc-mergeable-info
 
   conformance:
     name: Conformance

--- a/justfile
+++ b/justfile
@@ -66,11 +66,11 @@ fmt:
 
 [unix]
 doc:
-  RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items
+  RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items --all-features
 
 [windows]
 doc:
-  $Env:RUSTDOCFLAGS='-D warnings'; cargo doc --no-deps --document-private-items
+  $Env:RUSTDOCFLAGS='-D warnings'; cargo doc --no-deps --document-private-items --all-features
 
 # Fix all auto-fixable format and lint issues
 fix:


### PR DESCRIPTION
`just doc` run rustdoc with `--all-features` flag.

I discovered that `just doc` was not, for example, catching errors in doc comments in #21425, because the code is behind a feature which is not enabled by default.