### PR TITLE
refactor(allocator): remove `Arena::allocated_bytes_including_metadata` method

### DIFF
--- a/crates/oxc_allocator/src/arena.rs
+++ b/crates/oxc_allocator/src/arena.rs
@@ -1594,24 +1594,6 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         total
     }
 
-    /// Calculates the number of bytes requested from the Rust allocator for this `Arena`.
-    ///
-    /// This number is equal to the [`allocated_bytes()`](Self::allocated_bytes) plus
-    /// the size of the metadata.
-    pub fn allocated_bytes_including_metadata(&self) -> usize {
-        let mut total = 0;
-        let mut footer_ptr = self.current_chunk_footer.get();
-        // SAFETY: Walk the chunk list until the empty sentinel chunk.
-        // Every non-empty chunk is a live allocation whose `layout.size()` includes the footer.
-        unsafe {
-            while !footer_ptr.as_ref().is_empty() {
-                total += footer_ptr.as_ref().layout.size();
-                footer_ptr = footer_ptr.as_ref().prev.get();
-            }
-        }
-        total
-    }
-
     #[inline]
     unsafe fn is_last_allocation(&self, ptr: NonNull<u8>) -> bool {
         let footer = self.current_chunk_footer.get();
@@ -2105,29 +2087,20 @@ mod tests {
         assert_eq!(mem::size_of::<ChunkFooter>(), mem::size_of::<usize>() * 8);
     }
 
-    // Uses private `DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER` and `CHUNK_FOOTER_SIZE`.
+    // Uses private `DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER`.
     #[test]
     fn allocated_bytes() {
         let mut b = Arena::new();
 
         assert_eq!(b.allocated_bytes(), 0);
-        assert_eq!(b.allocated_bytes_including_metadata(), 0);
 
         b.alloc(0u8);
 
         assert_eq!(b.allocated_bytes(), DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
-        assert_eq!(
-            b.allocated_bytes_including_metadata(),
-            DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER + CHUNK_FOOTER_SIZE
-        );
 
         b.reset();
 
         assert_eq!(b.allocated_bytes(), DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
-        assert_eq!(
-            b.allocated_bytes_including_metadata(),
-            DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER + CHUNK_FOOTER_SIZE
-        );
     }
 
     // Uses private `bumpalo_alloc` module.

--- a/crates/oxc_allocator/tests/arena/quickchecks.rs
+++ b/crates/oxc_allocator/tests/arena/quickchecks.rs
@@ -253,24 +253,19 @@ quickcheck! {
         }
     }
 
-    fn allocated_bytes_including_metadata(allocs: Vec<usize>) -> () {
+    fn allocated_bytes_tracking(allocs: Vec<usize>) -> () {
         let b = Arena::new();
         let mut slice_bytes = 0;
-        let allocs_len = allocs.len();
         for len in allocs {
             const MAX_LEN: usize = 512;
             let len = len % MAX_LEN;
             b.alloc_slice_fill_copy(len, 0);
             slice_bytes += len;
             let allocated_bytes = b.allocated_bytes();
-            let allocated_bytes_including_metadata = b.allocated_bytes_including_metadata();
             if slice_bytes == 0 {
                 assert_eq!(allocated_bytes, 0);
-                assert_eq!(allocated_bytes_including_metadata, 0);
             } else {
                 assert!(allocated_bytes >= slice_bytes);
-                assert!(allocated_bytes_including_metadata > allocated_bytes);
-                assert!(allocated_bytes_including_metadata < allocated_bytes + allocs_len * 100);
             }
         }
     }


### PR DESCRIPTION
Remove this method. It's not useful.