### PR TITLE
feat(linter/typescript): implement explicit-member-accessibility

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1473,6 +1473,18 @@ impl RuleRunner
 }
 
 impl RuleRunner
+    for crate::rules::typescript::explicit_member_accessibility::ExplicitMemberAccessibility
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AccessorProperty,
+        AstType::FormalParameter,
+        AstType::MethodDefinition,
+        AstType::PropertyDefinition,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
     for crate::rules::typescript::explicit_module_boundary_types::ExplicitModuleBoundaryTypes
 {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -467,6 +467,7 @@ pub use crate::rules::typescript::consistent_type_exports::ConsistentTypeExports
 pub use crate::rules::typescript::consistent_type_imports::ConsistentTypeImports as TypescriptConsistentTypeImports;
 pub use crate::rules::typescript::dot_notation::DotNotation as TypescriptDotNotation;
 pub use crate::rules::typescript::explicit_function_return_type::ExplicitFunctionReturnType as TypescriptExplicitFunctionReturnType;
+pub use crate::rules::typescript::explicit_member_accessibility::ExplicitMemberAccessibility as TypescriptExplicitMemberAccessibility;
 pub use crate::rules::typescript::explicit_module_boundary_types::ExplicitModuleBoundaryTypes as TypescriptExplicitModuleBoundaryTypes;
 pub use crate::rules::typescript::no_array_delete::NoArrayDelete as TypescriptNoArrayDelete;
 pub use crate::rules::typescript::no_base_to_string::NoBaseToString as TypescriptNoBaseToString;
@@ -958,6 +959,7 @@ pub enum RuleEnum {
     TypescriptConsistentTypeImports(TypescriptConsistentTypeImports),
     TypescriptDotNotation(TypescriptDotNotation),
     TypescriptExplicitFunctionReturnType(TypescriptExplicitFunctionReturnType),
+    TypescriptExplicitMemberAccessibility(TypescriptExplicitMemberAccessibility),
     TypescriptExplicitModuleBoundaryTypes(TypescriptExplicitModuleBoundaryTypes),
     TypescriptNoArrayDelete(TypescriptNoArrayDelete),
     TypescriptNoBaseToString(TypescriptNoBaseToString),
@@ -1688,8 +1690,10 @@ const TYPESCRIPT_CONSISTENT_TYPE_EXPORTS_ID: usize =
 const TYPESCRIPT_CONSISTENT_TYPE_IMPORTS_ID: usize = TYPESCRIPT_CONSISTENT_TYPE_EXPORTS_ID + 1usize;
 const TYPESCRIPT_DOT_NOTATION_ID: usize = TYPESCRIPT_CONSISTENT_TYPE_IMPORTS_ID + 1usize;
 const TYPESCRIPT_EXPLICIT_FUNCTION_RETURN_TYPE_ID: usize = TYPESCRIPT_DOT_NOTATION_ID + 1usize;
-const TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID: usize =
+const TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID: usize =
     TYPESCRIPT_EXPLICIT_FUNCTION_RETURN_TYPE_ID + 1usize;
+const TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID: usize =
+    TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID + 1usize;
 const TYPESCRIPT_NO_ARRAY_DELETE_ID: usize = TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID + 1usize;
 const TYPESCRIPT_NO_BASE_TO_STRING_ID: usize = TYPESCRIPT_NO_ARRAY_DELETE_ID + 1usize;
 const TYPESCRIPT_NO_CONFUSING_NON_NULL_ASSERTION_ID: usize =
@@ -2508,6 +2512,9 @@ impl RuleEnum {
             Self::TypescriptDotNotation(_) => TYPESCRIPT_DOT_NOTATION_ID,
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TYPESCRIPT_EXPLICIT_FUNCTION_RETURN_TYPE_ID
+            }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID
@@ -3343,6 +3350,9 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::NAME
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::NAME
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::NAME
             }
@@ -4172,6 +4182,9 @@ impl RuleEnum {
             Self::TypescriptDotNotation(_) => TypescriptDotNotation::CATEGORY,
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::CATEGORY
+            }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::CATEGORY
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::CATEGORY
@@ -5042,6 +5055,9 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::FIX
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::FIX
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::FIX
             }
@@ -5900,6 +5916,9 @@ impl RuleEnum {
             Self::TypescriptDotNotation(_) => TypescriptDotNotation::documentation(),
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::documentation()
+            }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::documentation()
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::documentation()
@@ -7245,6 +7264,10 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::config_schema(generator)
                     .or_else(|| TypescriptExplicitFunctionReturnType::schema(generator))
+            }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::config_schema(generator)
+                    .or_else(|| TypescriptExplicitMemberAccessibility::schema(generator))
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::config_schema(generator)
@@ -8954,6 +8977,7 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(_) => "typescript",
             Self::TypescriptDotNotation(_) => "typescript",
             Self::TypescriptExplicitFunctionReturnType(_) => "typescript",
+            Self::TypescriptExplicitMemberAccessibility(_) => "typescript",
             Self::TypescriptExplicitModuleBoundaryTypes(_) => "typescript",
             Self::TypescriptNoArrayDelete(_) => "typescript",
             Self::TypescriptNoBaseToString(_) => "typescript",
@@ -10129,6 +10153,11 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 Ok(Self::TypescriptExplicitFunctionReturnType(
                     TypescriptExplicitFunctionReturnType::from_configuration(value)?,
+                ))
+            }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                Ok(Self::TypescriptExplicitMemberAccessibility(
+                    TypescriptExplicitMemberAccessibility::from_configuration(value)?,
                 ))
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
@@ -11999,6 +12028,7 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.to_configuration(),
             Self::TypescriptDotNotation(rule) => rule.to_configuration(),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.to_configuration(),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.to_configuration(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.to_configuration(),
             Self::TypescriptNoArrayDelete(rule) => rule.to_configuration(),
             Self::TypescriptNoBaseToString(rule) => rule.to_configuration(),
@@ -12727,6 +12757,7 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.run(node, ctx),
             Self::TypescriptDotNotation(rule) => rule.run(node, ctx),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.run(node, ctx),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.run(node, ctx),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run(node, ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.run(node, ctx),
             Self::TypescriptNoBaseToString(rule) => rule.run(node, ctx),
@@ -13451,6 +13482,7 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.run_once(ctx),
             Self::TypescriptDotNotation(rule) => rule.run_once(ctx),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.run_once(ctx),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.run_once(ctx),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run_once(ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.run_once(ctx),
             Self::TypescriptNoBaseToString(rule) => rule.run_once(ctx),
@@ -14189,6 +14221,9 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptDotNotation(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptExplicitFunctionReturnType(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::TypescriptExplicitMemberAccessibility(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => {
@@ -15001,6 +15036,7 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.should_run(ctx),
             Self::TypescriptDotNotation(rule) => rule.should_run(ctx),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.should_run(ctx),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.should_run(ctx),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.should_run(ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.should_run(ctx),
             Self::TypescriptNoBaseToString(rule) => rule.should_run(ctx),
@@ -15772,6 +15808,9 @@ impl RuleEnum {
             Self::TypescriptDotNotation(_) => TypescriptDotNotation::IS_TSGOLINT_RULE,
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::IS_TSGOLINT_RULE
+            }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::IS_TSGOLINT_RULE
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::IS_TSGOLINT_RULE
@@ -16790,6 +16829,9 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => {
                 TypescriptExplicitFunctionReturnType::HAS_CONFIG
             }
+            Self::TypescriptExplicitMemberAccessibility(_) => {
+                TypescriptExplicitMemberAccessibility::HAS_CONFIG
+            }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::HAS_CONFIG
             }
@@ -17668,6 +17710,7 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.types_info(),
             Self::TypescriptDotNotation(rule) => rule.types_info(),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.types_info(),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.types_info(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.types_info(),
             Self::TypescriptNoArrayDelete(rule) => rule.types_info(),
             Self::TypescriptNoBaseToString(rule) => rule.types_info(),
@@ -18392,6 +18435,7 @@ impl RuleEnum {
             Self::TypescriptConsistentTypeImports(rule) => rule.run_info(),
             Self::TypescriptDotNotation(rule) => rule.run_info(),
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.run_info(),
+            Self::TypescriptExplicitMemberAccessibility(rule) => rule.run_info(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run_info(),
             Self::TypescriptNoArrayDelete(rule) => rule.run_info(),
             Self::TypescriptNoBaseToString(rule) => rule.run_info(),
@@ -19149,6 +19193,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::TypescriptDotNotation(TypescriptDotNotation::default()),
         RuleEnum::TypescriptExplicitFunctionReturnType(
             TypescriptExplicitFunctionReturnType::default(),
+        ),
+        RuleEnum::TypescriptExplicitMemberAccessibility(
+            TypescriptExplicitMemberAccessibility::default(),
         ),
         RuleEnum::TypescriptExplicitModuleBoundaryTypes(
             TypescriptExplicitModuleBoundaryTypes::default(),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -232,6 +232,7 @@ pub(crate) mod typescript {
     pub mod consistent_type_imports;
     pub mod dot_notation;
     pub mod explicit_function_return_type;
+    pub mod explicit_member_accessibility;
     pub mod explicit_module_boundary_types;
     pub mod no_array_delete;
     pub mod no_base_to_string;

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -437,310 +437,302 @@ fn test() {
     let pass = vec![
         (
             "
-			class Test {
-			  public constructor(private foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "explicit" },
-            }])),
+            class Test {
+              public constructor(private foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "explicit" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public constructor(private readonly foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "explicit" },
-            }])),
+            class Test {
+              public constructor(private readonly foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "explicit" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public constructor(private foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "off" },
-            }])),
+            class Test {
+              public constructor(private foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "off" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public constructor(protected foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "off" },
-            }])),
+            class Test {
+              public constructor(protected foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "off" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public constructor(public foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "off" },
-            }])),
+            class Test {
+              public constructor(public foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "off" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public constructor(readonly foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "off" },
-            }])),
+            class Test {
+              public constructor(readonly foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "off" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public constructor(private readonly foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "off" },
-            }])),
+            class Test {
+              public constructor(private readonly foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "off" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  protected name: string;
-			  private x: number;
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              private x: number;
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  protected name: string;
-			  protected foo?: string;
-			  public 'foo-bar'?: string;
-			}
-			      ",
+            class Test {
+              protected name: string;
+              protected foo?: string;
+              public 'foo-bar'?: string;
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  public constructor({ x, y }: { x: number; y: number }) {}
-			}
-			      ",
+            class Test {
+              public constructor({ x, y }: { x: number; y: number }) {}
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  protected name: string;
-			  protected foo?: string;
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              protected foo?: string;
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			class Test {
-			  protected name: string;
-			  protected foo?: string;
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              protected foo?: string;
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  name: string;
-			  foo?: string;
-			  getX() {
-			    return this.x;
-			  }
-			  get fooName(): string {
-			    return this.foo + ' ' + this.name;
-			  }
-			}
-			      ",
+            class Test {
+              name: string;
+              foo?: string;
+              getX() {
+                return this.x;
+              }
+              get fooName(): string {
+                return this.foo + ' ' + this.name;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  private x: number;
-			  constructor(x: number) {
-			    this.x = x;
-			  }
-			  get internalValue() {
-			    return this.x;
-			  }
-			  private set internalValue(value: number) {
-			    this.x = value;
-			  }
-			  public square(): number {
-			    return this.x * this.x;
-			  }
-			}
-			      ",
+            class Test {
+              private x: number;
+              constructor(x: number) {
+                this.x = x;
+              }
+              get internalValue() {
+                return this.x;
+              }
+              private set internalValue(value: number) {
+                this.x = value;
+              }
+              public square(): number {
+                return this.x * this.x;
+              }
+            }
+                  ",
             Some(
                 serde_json::json!([{ "overrides": { "accessors": "off", "constructors": "off" } }]),
             ),
         ),
         (
             "
-			class Test {
-			  private x: number;
-			  public constructor(x: number) {
-			    this.x = x;
-			  }
-			  public get internalValue() {
-			    return this.x;
-			  }
-			  public set internalValue(value: number) {
-			    this.x = value;
-			  }
-			  public square(): number {
-			    return this.x * this.x;
-			  }
-			  half(): number {
-			    return this.x / 2;
-			  }
-			}
-			      ",
+            class Test {
+              private x: number;
+              public constructor(x: number) {
+                this.x = x;
+              }
+              public get internalValue() {
+                return this.x;
+              }
+              public set internalValue(value: number) {
+                this.x = value;
+              }
+              public square(): number {
+                return this.x * this.x;
+              }
+              half(): number {
+                return this.x / 2;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "overrides": { "methods": "off" } }])),
         ),
         (
             "
-			class Test {
-			  constructor(private x: number) {}
-			}
-			      ",
+            class Test {
+              constructor(private x: number) {}
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  constructor(public x: number) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "off" },
-            }])),
+            class Test {
+              constructor(public x: number) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "off" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  constructor(public foo: number) {}
-			}
-			      ",
+            class Test {
+              constructor(public foo: number) {}
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
         ),
         (
             "
-			class Test {
-			  public static getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              public static getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
         ),
         (
             "
-			class Test {
-			  get getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              get getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
         ),
         (
             "
-			class Test {
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
         ),
         (
             "
-			class Test {
-			  x = 2;
-			}
-			      ",
+            class Test {
+              x = 2;
+            }
+                  ",
             Some(serde_json::json!([{ "overrides": { "properties": "off" } }])),
         ),
         (
             "
-			class Test {
-			  private x = 2;
-			}
-			      ",
+            class Test {
+              private x = 2;
+            }
+                  ",
             Some(serde_json::json!([{ "overrides": { "properties": "explicit" } }])),
         ),
         (
             "
-			class Test {
-			  x = 2;
-			  private x = 2;
-			}
-			      ",
+            class Test {
+              x = 2;
+              private x = 2;
+            }
+                  ",
             Some(serde_json::json!([{ "overrides": { "properties": "no-public" } }])),
         ),
         (
             "
-			class Test {
-			  #foo = 1;
-			  #bar() {}
-			}
-			      ",
+            class Test {
+              #foo = 1;
+              #bar() {}
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			class Test {
-			  private accessor foo = 1;
-			}
-			      ",
+            class Test {
+              private accessor foo = 1;
+            }
+                  ",
             None,
         ),
         (
             "
-			abstract class Test {
-			  private abstract accessor foo: number;
-			}
-			      ",
+            abstract class Test {
+              private abstract accessor foo: number;
+            }
+                  ",
             None,
         ),
     ];
@@ -748,379 +740,363 @@ fn test() {
     let fail = vec![
         (
             "
-			export class XXXX {
-			  public constructor(readonly value: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "off",
-                "overrides": { "parameterProperties": "explicit" },
-            }])),
+            export class XXXX {
+              public constructor(readonly value: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "off", "overrides": { "parameterProperties": "explicit", }, }, ]),
+            ),
         ),
         (
             "
-			export class WithParameterProperty {
-			  public constructor(readonly value: string) {}
-			}
-			      ",
+            export class WithParameterProperty {
+              public constructor(readonly value: string) {}
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			export class XXXX {
-			  public constructor(readonly samosa: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "off",
-                "overrides": {
-                    "constructors": "explicit",
-                    "parameterProperties": "explicit",
-                },
-            }])),
+            export class XXXX {
+              public constructor(readonly samosa: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "off", "overrides": { "constructors": "explicit", "parameterProperties": "explicit", }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public constructor(readonly foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "explicit",
-                "overrides": { "parameterProperties": "explicit" },
-            }])),
+            class Test {
+              public constructor(readonly foo: string) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "explicit", "overrides": { "parameterProperties": "explicit" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  x: number;
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              x: number;
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  private x: number;
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              private x: number;
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  x?: number;
-			  getX?() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              x?: number;
+              getX?() {
+                return this.x;
+              }
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  protected name: string;
-			  protected foo?: string;
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              protected foo?: string;
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  protected name: string;
-			  public foo?: string;
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              public foo?: string;
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  public x: number;
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              public x: number;
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  private x: number;
-			  constructor(x: number) {
-			    this.x = x;
-			  }
-			  get internalValue() {
-			    return this.x;
-			  }
-			  set internalValue(value: number) {
-			    this.x = value;
-			  }
-			}
-			      ",
+            class Test {
+              private x: number;
+              constructor(x: number) {
+                this.x = x;
+              }
+              get internalValue() {
+                return this.x;
+              }
+              set internalValue(value: number) {
+                this.x = value;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "overrides": { "constructors": "no-public" } }])),
         ),
         (
             "
-			class Test {
-			  private x: number;
-			  constructor(x: number) {
-			    this.x = x;
-			  }
-			  get internalValue() {
-			    return this.x;
-			  }
-			  set internalValue(value: number) {
-			    this.x = value;
-			  }
-			}
-			      ",
+            class Test {
+              private x: number;
+              constructor(x: number) {
+                this.x = x;
+              }
+              get internalValue() {
+                return this.x;
+              }
+              set internalValue(value: number) {
+                this.x = value;
+              }
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  constructor(public x: number) {}
-			  public foo(): string {
-			    return 'foo';
-			  }
-			}
-			      ",
-            Some(serde_json::json!([{
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
+            class Test {
+              constructor(public x: number) {}
+              public foo(): string {
+                return 'foo';
+              }
+            }
+                  ",
+            Some(serde_json::json!([ { "overrides": { "parameterProperties": "no-public" }, }, ])),
         ),
         (
             "
-			class Test {
-			  constructor(public x: number) {}
-			}
-			      ",
+            class Test {
+              constructor(public x: number) {}
+            }
+                  ",
             None,
         ),
         (
             "
-			class Test {
-			  constructor(public readonly x: number) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "off",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
+            class Test {
+              constructor(public readonly x: number) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "off", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  x = 2;
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "off",
-                "overrides": { "properties": "explicit" },
-            }])),
+            class Test {
+              x = 2;
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "off", "overrides": { "properties": "explicit" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public x = 2;
-			  private x = 2;
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "off",
-                "overrides": { "properties": "no-public" },
-            }])),
+            class Test {
+              public x = 2;
+              private x = 2;
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "off", "overrides": { "properties": "no-public" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  constructor(public x: any[]) {}
-			}
-			      ",
+            class Test {
+              constructor(public x: any[]) {}
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			class Test {
-			  public /*public*/constructor(private foo: string) {}
-			}
-			      ",
+            class Test {
+              public /*public*/constructor(private foo: string) {}
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              @public
+              public foo() {}
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              @public
+              public foo;
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              public foo = '';
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              constructor(public/* Hi there */ readonly foo) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
+        ),
+        (
+            "
+            class Test {
+              constructor(public readonly foo: string) {}
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class EnsureWhiteSPaceSpan {
+              public constructor() {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
+        ),
+        (
+            "
+            class EnsureWhiteSPaceSpan {
+              public /* */ constructor() {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
+        ),
+        (
+            "
+            class Test {
+              public 'foo' = 1;
+              public 'foo foo' = 2;
+              public 'bar'() {}
+              public 'bar bar'() {}
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  @public
-			  public foo() {}
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			class Test {
-			  @public
-			  public foo;
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			class Test {
-			  public foo = '';
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			class Test {
-			  constructor(public/* Hi there */ readonly foo) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
-        ),
-        (
-            "
-			class Test {
-			  constructor(public readonly foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			class EnsureWhiteSPaceSpan {
-			  public constructor() {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
-        ),
-        (
-            "
-			class EnsureWhiteSPaceSpan {
-			  public /* */ constructor() {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
-        ),
-        (
-            "
-			class Test {
-			  public 'foo' = 1;
-			  public 'foo foo' = 2;
-			  public 'bar'() {}
-			  public 'bar bar'() {}
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			abstract class SomeClass {
-			  abstract method(): string;
-			}
-			      ",
+            abstract class SomeClass {
+              abstract method(): string;
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			abstract class SomeClass {
-			  public abstract method(): string;
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
+            abstract class SomeClass {
+              public abstract method(): string;
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
         ),
         (
             "
-			abstract class SomeClass {
-			  abstract x: string;
-			}
-			      ",
+            abstract class SomeClass {
+              abstract x: string;
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			abstract class SomeClass {
-			  public abstract x: string;
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
+            abstract class SomeClass {
+              public abstract x: string;
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
         ),
         (
             "
-			class SomeClass {
-			  accessor foo = 1;
-			}
-			      ",
+            class SomeClass {
+              accessor foo = 1;
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			abstract class SomeClass {
-			  abstract accessor foo: string;
-			}
-			      ",
+            abstract class SomeClass {
+              abstract accessor foo: string;
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
         (
             "
-			class DecoratedClass {
-			  constructor(@foo @bar() readonly arg: string) {}
-			  @foo @bar() x: string;
-			  @foo @bar() getX() {
-			    return this.x;
-			  }
-			  @foo
-			  @bar()
-			  get y() {
-			    return this.x;
-			  }
-			  @foo @bar() set z(@foo @bar() value: x) {
-			    this.x = x;
-			  }
-			}
-			      ",
+            class DecoratedClass {
+              constructor(@foo @bar() readonly arg: string) {}
+              @foo @bar() x: string;
+              @foo @bar() getX() {
+                return this.x;
+              }
+              @foo
+              @bar()
+              get y() {
+                return this.x;
+              }
+              @foo @bar() set z(@foo @bar() value: x) {
+                this.x = x;
+              }
+            }
+                  ",
             None,
         ),
         (
             "
-			abstract class SomeClass {
-			  abstract ['computed-method-name'](): string;
-			}
-			      ",
+            abstract class SomeClass {
+              abstract ['computed-method-name'](): string;
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "explicit" }])),
         ),
     ];
@@ -1128,268 +1104,262 @@ fn test() {
     let fix = vec![
         (
             "
-			class Test {
-			  protected name: string;
-			  protected foo?: string;
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              protected foo?: string;
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             "
-			class Test {
-			  protected name: string;
-			  protected foo?: string;
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              protected foo?: string;
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  protected name: string;
-			  public foo?: string;
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              public foo?: string;
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             "
-			class Test {
-			  protected name: string;
-			  foo?: string;
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              protected name: string;
+              foo?: string;
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  public x: number;
-			  public getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              public x: number;
+              public getX() {
+                return this.x;
+              }
+            }
+                  ",
             "
-			class Test {
-			  x: number;
-			  getX() {
-			    return this.x;
-			  }
-			}
-			      ",
+            class Test {
+              x: number;
+              getX() {
+                return this.x;
+              }
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  constructor(public readonly x: number) {}
-			}
-			      ",
+            class Test {
+              constructor(public readonly x: number) {}
+            }
+                  ",
             "
-			class Test {
-			  constructor(readonly x: number) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "off",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
+            class Test {
+              constructor(readonly x: number) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "off", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public x = 2;
-			  private x = 2;
-			}
-			      ",
+            class Test {
+              public x = 2;
+              private x = 2;
+            }
+                  ",
             "
-			class Test {
-			  x = 2;
-			  private x = 2;
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "off",
-                "overrides": { "properties": "no-public" },
-            }])),
+            class Test {
+              x = 2;
+              private x = 2;
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "off", "overrides": { "properties": "no-public" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  public /*public*/constructor(private foo: string) {}
-			}
-			      ",
+            class Test {
+              public /*public*/constructor(private foo: string) {}
+            }
+                  ",
             "
-			class Test {
-			  /*public*/constructor(private foo: string) {}
-			}
-			      ",
+            class Test {
+              /*public*/constructor(private foo: string) {}
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              @public
+              public foo() {}
+            }
+                  ",
+            "
+            class Test {
+              @public
+              foo() {}
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              @public
+              public foo;
+            }
+                  ",
+            "
+            class Test {
+              @public
+              foo;
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              public foo = '';
+            }
+                  ",
+            "
+            class Test {
+              foo = '';
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class Test {
+              constructor(public/* Hi there */ readonly foo) {}
+            }
+                  ",
+            "
+            class Test {
+              constructor(/* Hi there */ readonly foo) {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
+        ),
+        (
+            "
+            class Test {
+              constructor(public readonly foo: string) {}
+            }
+                  ",
+            "
+            class Test {
+              constructor(readonly foo: string) {}
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
+        ),
+        (
+            "
+            class EnsureWhiteSPaceSpan {
+              public constructor() {}
+            }
+                  ",
+            "
+            class EnsureWhiteSPaceSpan {
+              constructor() {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
+        ),
+        (
+            "
+            class EnsureWhiteSPaceSpan {
+              public /* */ constructor() {}
+            }
+                  ",
+            "
+            class EnsureWhiteSPaceSpan {
+              /* */ constructor() {}
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
+        ),
+        (
+            "
+            class Test {
+              public 'foo' = 1;
+              public 'foo foo' = 2;
+              public 'bar'() {}
+              public 'bar bar'() {}
+            }
+                  ",
+            "
+            class Test {
+              'foo' = 1;
+              'foo foo' = 2;
+              'bar'() {}
+              'bar bar'() {}
+            }
+                  ",
             Some(serde_json::json!([{ "accessibility": "no-public" }])),
         ),
         (
             "
-			class Test {
-			  @public
-			  public foo() {}
-			}
-			      ",
+            abstract class SomeClass {
+              public abstract method(): string;
+            }
+                  ",
             "
-			class Test {
-			  @public
-			  foo() {}
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+            abstract class SomeClass {
+              abstract method(): string;
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
         ),
         (
             "
-			class Test {
-			  @public
-			  public foo;
-			}
-			      ",
+            abstract class SomeClass {
+              public abstract x: string;
+            }
+                  ",
             "
-			class Test {
-			  @public
-			  foo;
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			class Test {
-			  public foo = '';
-			}
-			      ",
-            "
-			class Test {
-			  foo = '';
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			class Test {
-			  constructor(public/* Hi there */ readonly foo) {}
-			}
-			      ",
-            "
-			class Test {
-			  constructor(/* Hi there */ readonly foo) {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
-        ),
-        (
-            "
-			class Test {
-			  constructor(public readonly foo: string) {}
-			}
-			      ",
-            "
-			class Test {
-			  constructor(readonly foo: string) {}
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			class EnsureWhiteSPaceSpan {
-			  public constructor() {}
-			}
-			      ",
-            "
-			class EnsureWhiteSPaceSpan {
-			  constructor() {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
-        ),
-        (
-            "
-			class EnsureWhiteSPaceSpan {
-			  public /* */ constructor() {}
-			}
-			      ",
-            "
-			class EnsureWhiteSPaceSpan {
-			  /* */ constructor() {}
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
-        ),
-        (
-            "
-			class Test {
-			  public 'foo' = 1;
-			  public 'foo foo' = 2;
-			  public 'bar'() {}
-			  public 'bar bar'() {}
-			}
-			      ",
-            "
-			class Test {
-			  'foo' = 1;
-			  'foo foo' = 2;
-			  'bar'() {}
-			  'bar bar'() {}
-			}
-			      ",
-            Some(serde_json::json!([{ "accessibility": "no-public" }])),
-        ),
-        (
-            "
-			abstract class SomeClass {
-			  public abstract method(): string;
-			}
-			      ",
-            "
-			abstract class SomeClass {
-			  abstract method(): string;
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
-        ),
-        (
-            "
-			abstract class SomeClass {
-			  public abstract x: string;
-			}
-			      ",
-            "
-			abstract class SomeClass {
-			  abstract x: string;
-			}
-			      ",
-            Some(serde_json::json!([{
-                "accessibility": "no-public",
-                "overrides": { "parameterProperties": "no-public" },
-            }])),
+            abstract class SomeClass {
+              abstract x: string;
+            }
+                  ",
+            Some(
+                serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
+            ),
         ),
     ];
+
     Tester::new(ExplicitMemberAccessibility::NAME, ExplicitMemberAccessibility::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -1,0 +1,1408 @@
+use std::borrow::Cow;
+
+use oxc_ast::{
+    AstKind,
+    ast::{
+        AccessorProperty, Decorator, FormalParameter, MethodDefinition, MethodDefinitionKind,
+        PropertyDefinition, TSAccessibility,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+enum AccessibilityLevel {
+    /// Always require an accessibility modifier.
+    #[default]
+    Explicit,
+    /// Require an accessibility modifier except when public.
+    NoPublic,
+    /// Never check whether there is an accessibility modifier.
+    Off,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct AccessibilityOverrides {
+    /// Which member accessibility modifier requirements to apply for accessors (getters/setters).
+    accessors: Option<AccessibilityLevel>,
+    /// Which member accessibility modifier requirements to apply for constructors.
+    constructors: Option<AccessibilityLevel>,
+    /// Which member accessibility modifier requirements to apply for methods.
+    methods: Option<AccessibilityLevel>,
+    /// Which member accessibility modifier requirements to apply for parameter properties.
+    parameter_properties: Option<AccessibilityLevel>,
+    /// Which member accessibility modifier requirements to apply for properties.
+    properties: Option<AccessibilityLevel>,
+}
+
+impl Default for AccessibilityOverrides {
+    fn default() -> Self {
+        Self {
+            accessors: None,
+            constructors: None,
+            methods: None,
+            parameter_properties: None,
+            properties: None,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct ExplicitMemberAccessibility(Box<ExplicitMemberAccessibilityConfig>);
+
+impl std::ops::Deref for ExplicitMemberAccessibility {
+    type Target = ExplicitMemberAccessibilityConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ExplicitMemberAccessibilityConfig {
+    /// Which accessibility modifier is required to exist or not exist.
+    accessibility: AccessibilityLevel,
+    /// Changes to required accessibility modifiers for specific kinds of class members.
+    overrides: AccessibilityOverrides,
+    /// Specific method names that may be ignored.
+    ignored_method_names: Vec<String>,
+}
+
+impl Default for ExplicitMemberAccessibilityConfig {
+    fn default() -> Self {
+        Self {
+            accessibility: AccessibilityLevel::Explicit,
+            overrides: AccessibilityOverrides::default(),
+            ignored_method_names: Vec::new(),
+        }
+    }
+}
+
+fn missing_accessibility_diagnostic(span: Span, member_type: &str, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing accessibility modifier on {member_type} {name}."))
+        .with_help("Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.")
+        .with_label(span)
+}
+
+fn unwanted_public_accessibility_diagnostic(
+    span: Span,
+    member_type: &str,
+    name: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Public accessibility modifier on {member_type} {name}."))
+        .with_help("Remove the 'public' modifier. Members are public by default, so the modifier is redundant.")
+        .with_label(span)
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Require explicit accessibility modifiers on class properties and methods.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// TypeScript allows placing explicit `public`, `protected`, and `private`
+    /// accessibility modifiers in front of class members. The modifiers exist
+    /// solely in the type system and serve to describe who is allowed to access
+    /// those members.
+    ///
+    /// Leaving off accessibility modifiers makes for less code to read and
+    /// write. Members are `public` by default. However, adding explicit
+    /// modifiers can make code more readable and explicit about who can use
+    /// which properties.
+    ///
+    /// ### Examples
+    ///
+    /// #### `{ "accessibility": "explicit" }` (default)
+    ///
+    /// Examples of **incorrect** code:
+    /// ```ts
+    /// class Animal {
+    ///   constructor(name: string) {}
+    ///   animalName: string;
+    ///   get name(): string { return this.animalName; }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code:
+    /// ```ts
+    /// class Animal {
+    ///   public constructor(name: string) {}
+    ///   private animalName: string;
+    ///   public get name(): string { return this.animalName; }
+    /// }
+    /// ```
+    ///
+    /// #### `{ "accessibility": "no-public" }`
+    ///
+    /// Examples of **incorrect** code:
+    /// ```ts
+    /// class Animal {
+    ///   public constructor(public breed: string, name: string) {}
+    ///   public animalName: string;
+    ///   public get name(): string { return this.animalName; }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code:
+    /// ```ts
+    /// class Animal {
+    ///   constructor(protected breed: string, name: string) {}
+    ///   private animalName: string;
+    ///   get name(): string { return this.animalName; }
+    /// }
+    /// ```
+    ///
+    /// #### `{ "overrides": { "constructors": "no-public" } }`
+    ///
+    /// Disallow the use of `public` on constructors while requiring explicit
+    /// modifiers everywhere else.
+    ///
+    /// Examples of **incorrect** code:
+    /// ```ts
+    /// class Animal {
+    ///   public constructor(protected animalName: string) {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code:
+    /// ```ts
+    /// class Animal {
+    ///   constructor(protected animalName: string) {}
+    ///   public get name(): string { return this.animalName; }
+    /// }
+    /// ```
+    ///
+    /// #### `{ "accessibility": "no-public", "overrides": { "properties": "explicit" } }`
+    ///
+    /// Require explicit modifiers on properties while disallowing `public`
+    /// everywhere else.
+    ///
+    /// Examples of **incorrect** code:
+    /// ```ts
+    /// class Animal {
+    ///   legs: number;
+    ///   private hasFleas: boolean;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code:
+    /// ```ts
+    /// class Animal {
+    ///   public legs: number;
+    ///   private hasFleas: boolean;
+    /// }
+    /// ```
+    ExplicitMemberAccessibility,
+    typescript,
+    restriction,
+    conditional_fix_suggestion,
+    config = ExplicitMemberAccessibilityConfig,
+    version = "next",
+);
+
+impl Rule for ExplicitMemberAccessibility {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::MethodDefinition(method) => self.check_method(method, ctx),
+            AstKind::PropertyDefinition(prop) => self.check_property(prop, ctx),
+            AstKind::AccessorProperty(prop) => self.check_accessor_property(prop, ctx),
+            AstKind::FormalParameter(param) => self.check_parameter_property(param, ctx),
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+impl ExplicitMemberAccessibility {
+    fn check_method<'a>(&self, method: &MethodDefinition<'a>, ctx: &LintContext<'a>) {
+        if method.key.is_private_identifier() {
+            return;
+        }
+
+        let (check, node_type) = match method.kind {
+            MethodDefinitionKind::Constructor => {
+                (self.overrides.constructors.unwrap_or(self.accessibility), "method definition")
+            }
+            MethodDefinitionKind::Get => {
+                (self.overrides.accessors.unwrap_or(self.accessibility), "get property accessor")
+            }
+            MethodDefinitionKind::Set => {
+                (self.overrides.accessors.unwrap_or(self.accessibility), "set property accessor")
+            }
+            MethodDefinitionKind::Method => {
+                (self.overrides.methods.unwrap_or(self.accessibility), "method definition")
+            }
+        };
+
+        let method_name = method.key.name().unwrap_or(Cow::Borrowed(""));
+
+        if check == AccessibilityLevel::Off
+            || self.ignored_method_names.iter().any(|n| n.as_str() == &*method_name)
+        {
+            return;
+        }
+
+        Self::check_member_accessibility(
+            check,
+            method.accessibility,
+            node_type,
+            &method_name,
+            method.span,
+            method.key.span(),
+            &method.decorators,
+            ctx,
+        );
+    }
+
+    fn check_property<'a>(&self, prop: &PropertyDefinition<'a>, ctx: &LintContext<'a>) {
+        if prop.key.is_private_identifier() {
+            return;
+        }
+
+        let check = self.overrides.properties.unwrap_or(self.accessibility);
+        if check == AccessibilityLevel::Off {
+            return;
+        }
+
+        let name = prop.key.name().unwrap_or(Cow::Borrowed(""));
+        Self::check_member_accessibility(
+            check,
+            prop.accessibility,
+            "class property",
+            &name,
+            prop.span,
+            prop.key.span(),
+            &prop.decorators,
+            ctx,
+        );
+    }
+
+    fn check_accessor_property<'a>(&self, prop: &AccessorProperty<'a>, ctx: &LintContext<'a>) {
+        if prop.key.is_private_identifier() {
+            return;
+        }
+
+        let check = self.overrides.properties.unwrap_or(self.accessibility);
+        if check == AccessibilityLevel::Off {
+            return;
+        }
+
+        let name = prop.key.name().unwrap_or(Cow::Borrowed(""));
+        Self::check_member_accessibility(
+            check,
+            prop.accessibility,
+            "class property",
+            &name,
+            prop.span,
+            prop.key.span(),
+            &prop.decorators,
+            ctx,
+        );
+    }
+
+    fn check_parameter_property<'a>(&self, param: &FormalParameter<'a>, ctx: &LintContext<'a>) {
+        if !param.has_modifier() {
+            return;
+        }
+
+        let check = self.overrides.parameter_properties.unwrap_or(self.accessibility);
+        if check == AccessibilityLevel::Off {
+            return;
+        }
+
+        let name = param
+            .pattern
+            .get_binding_identifier()
+            .map_or(Cow::Borrowed(""), |id| Cow::Borrowed(id.name.as_str()));
+
+        match check {
+            AccessibilityLevel::Explicit => {
+                if param.accessibility.is_none() {
+                    let report_span = param.pattern.span();
+                    ctx.diagnostic_with_suggestion(
+                        missing_accessibility_diagnostic(report_span, "parameter property", &name),
+                        |fixer| {
+                            let insert_pos = find_insert_position(
+                                param.span,
+                                &param.decorators,
+                                ctx.source_text(),
+                            );
+                            fixer.insert_text_before_range(
+                                Span::new(insert_pos, insert_pos),
+                                "public ",
+                            )
+                        },
+                    );
+                }
+            }
+            AccessibilityLevel::NoPublic => {
+                if param.accessibility == Some(TSAccessibility::Public) && param.readonly {
+                    let search_start = search_start_after_decorators(param.span, &param.decorators);
+                    let (public_span, removal_range) =
+                        find_public_spans(ctx.source_text(), search_start);
+                    ctx.diagnostic_with_fix(
+                        unwanted_public_accessibility_diagnostic(
+                            public_span,
+                            "parameter property",
+                            &name,
+                        ),
+                        |fixer| fixer.delete_range(removal_range),
+                    );
+                }
+            }
+            AccessibilityLevel::Off => {}
+        }
+    }
+
+    fn check_member_accessibility(
+        check: AccessibilityLevel,
+        accessibility: Option<TSAccessibility>,
+        node_type: &str,
+        name: &str,
+        node_span: Span,
+        key_span: Span,
+        decorators: &[Decorator<'_>],
+        ctx: &LintContext<'_>,
+    ) {
+        if check == AccessibilityLevel::Explicit && accessibility.is_none() {
+            ctx.diagnostic_with_suggestion(
+                missing_accessibility_diagnostic(key_span, node_type, name),
+                |fixer| {
+                    let insert_pos = find_insert_position(node_span, decorators, ctx.source_text());
+                    fixer.insert_text_before_range(Span::new(insert_pos, insert_pos), "public ")
+                },
+            );
+        } else if check == AccessibilityLevel::NoPublic
+            && accessibility == Some(TSAccessibility::Public)
+        {
+            let search_start = search_start_after_decorators(node_span, decorators);
+            let (public_span, removal_range) = find_public_spans(ctx.source_text(), search_start);
+            ctx.diagnostic_with_fix(
+                unwanted_public_accessibility_diagnostic(public_span, node_type, name),
+                |fixer| fixer.delete_range(removal_range),
+            );
+        }
+    }
+}
+
+fn search_start_after_decorators(node_span: Span, decorators: &[Decorator<'_>]) -> u32 {
+    decorators.last().map_or(node_span.start, |d| d.span.end)
+}
+
+fn find_insert_position(node_span: Span, decorators: &[Decorator<'_>], source: &str) -> u32 {
+    let start = search_start_after_decorators(node_span, decorators);
+    let bytes = source.as_bytes();
+    let mut pos = start;
+    while (pos as usize) < bytes.len() {
+        match bytes[pos as usize] {
+            b' ' | b'\t' | b'\n' | b'\r' => pos += 1,
+            _ => break,
+        }
+    }
+    pos
+}
+
+/// Returns `(keyword_span, removal_span)` where `keyword_span` covers just the `public` keyword
+/// and `removal_span` also includes trailing whitespace.
+fn find_public_spans(source: &str, search_start: u32) -> (Span, Span) {
+    let text = &source[search_start as usize..];
+    let offset = text.find("public").expect("Expected 'public' keyword in source");
+    #[expect(clippy::cast_possible_truncation)]
+    let start = search_start + offset as u32;
+    let keyword_span = Span::new(start, start + 6);
+
+    let bytes = source.as_bytes();
+    let mut end = start + 6;
+    while (end as usize) < bytes.len() {
+        match bytes[end as usize] {
+            b' ' | b'\t' | b'\n' | b'\r' => end += 1,
+            _ => break,
+        }
+    }
+    (keyword_span, Span::new(start, end))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+			class Test {
+			  public constructor(private foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "explicit" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public constructor(private readonly foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "explicit" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public constructor(private foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "off" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public constructor(protected foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "off" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public constructor(public foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "off" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public constructor(readonly foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "off" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public constructor(private readonly foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "off" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  protected name: string;
+			  private x: number;
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  protected name: string;
+			  protected foo?: string;
+			  public 'foo-bar'?: string;
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  public constructor({ x, y }: { x: number; y: number }) {}
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  protected name: string;
+			  protected foo?: string;
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			class Test {
+			  protected name: string;
+			  protected foo?: string;
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  name: string;
+			  foo?: string;
+			  getX() {
+			    return this.x;
+			  }
+			  get fooName(): string {
+			    return this.foo + ' ' + this.name;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  private x: number;
+			  constructor(x: number) {
+			    this.x = x;
+			  }
+			  get internalValue() {
+			    return this.x;
+			  }
+			  private set internalValue(value: number) {
+			    this.x = value;
+			  }
+			  public square(): number {
+			    return this.x * this.x;
+			  }
+			}
+			      ",
+            Some(
+                serde_json::json!([{ "overrides": { "accessors": "off", "constructors": "off" } }]),
+            ),
+        ),
+        (
+            "
+			class Test {
+			  private x: number;
+			  public constructor(x: number) {
+			    this.x = x;
+			  }
+			  public get internalValue() {
+			    return this.x;
+			  }
+			  public set internalValue(value: number) {
+			    this.x = value;
+			  }
+			  public square(): number {
+			    return this.x * this.x;
+			  }
+			  half(): number {
+			    return this.x / 2;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "overrides": { "methods": "off" } }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(private x: number) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public x: number) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "off" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public foo: number) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
+        ),
+        (
+            "
+			class Test {
+			  public static getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
+        ),
+        (
+            "
+			class Test {
+			  get getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
+        ),
+        (
+            "
+			class Test {
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "ignoredMethodNames": ["getX"] }])),
+        ),
+        (
+            "
+			class Test {
+			  x = 2;
+			}
+			      ",
+            Some(serde_json::json!([{ "overrides": { "properties": "off" } }])),
+        ),
+        (
+            "
+			class Test {
+			  private x = 2;
+			}
+			      ",
+            Some(serde_json::json!([{ "overrides": { "properties": "explicit" } }])),
+        ),
+        (
+            "
+			class Test {
+			  x = 2;
+			  private x = 2;
+			}
+			      ",
+            Some(serde_json::json!([{ "overrides": { "properties": "no-public" } }])),
+        ),
+        (
+            "
+			class Test {
+			  #foo = 1;
+			  #bar() {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			class Test {
+			  private accessor foo = 1;
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			abstract class Test {
+			  private abstract accessor foo: number;
+			}
+			      ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+			export class XXXX {
+			  public constructor(readonly value: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "off",
+                "overrides": { "parameterProperties": "explicit" },
+            }])),
+        ),
+        (
+            "
+			export class WithParameterProperty {
+			  public constructor(readonly value: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			export class XXXX {
+			  public constructor(readonly samosa: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "off",
+                "overrides": {
+                    "constructors": "explicit",
+                    "parameterProperties": "explicit",
+                },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public constructor(readonly foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "explicit",
+                "overrides": { "parameterProperties": "explicit" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  x: number;
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  private x: number;
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  x?: number;
+			  getX?() {
+			    return this.x;
+			  }
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  protected name: string;
+			  protected foo?: string;
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  protected name: string;
+			  public foo?: string;
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  public x: number;
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  private x: number;
+			  constructor(x: number) {
+			    this.x = x;
+			  }
+			  get internalValue() {
+			    return this.x;
+			  }
+			  set internalValue(value: number) {
+			    this.x = value;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "overrides": { "constructors": "no-public" } }])),
+        ),
+        (
+            "
+			class Test {
+			  private x: number;
+			  constructor(x: number) {
+			    this.x = x;
+			  }
+			  get internalValue() {
+			    return this.x;
+			  }
+			  set internalValue(value: number) {
+			    this.x = value;
+			  }
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  constructor(public x: number) {}
+			  public foo(): string {
+			    return 'foo';
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public x: number) {}
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			class Test {
+			  constructor(public readonly x: number) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "off",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  x = 2;
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "off",
+                "overrides": { "properties": "explicit" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public x = 2;
+			  private x = 2;
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "off",
+                "overrides": { "properties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public x: any[]) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			class Test {
+			  public /*public*/constructor(private foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  @public
+			  public foo() {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  @public
+			  public foo;
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  public foo = '';
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public/* Hi there */ readonly foo) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public readonly foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class EnsureWhiteSPaceSpan {
+			  public constructor() {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class EnsureWhiteSPaceSpan {
+			  public /* */ constructor() {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public 'foo' = 1;
+			  public 'foo foo' = 2;
+			  public 'bar'() {}
+			  public 'bar bar'() {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  abstract method(): string;
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  public abstract method(): string;
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  abstract x: string;
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  public abstract x: string;
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class SomeClass {
+			  accessor foo = 1;
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  abstract accessor foo: string;
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+        (
+            "
+			class DecoratedClass {
+			  constructor(@foo @bar() readonly arg: string) {}
+			  @foo @bar() x: string;
+			  @foo @bar() getX() {
+			    return this.x;
+			  }
+			  @foo
+			  @bar()
+			  get y() {
+			    return this.x;
+			  }
+			  @foo @bar() set z(@foo @bar() value: x) {
+			    this.x = x;
+			  }
+			}
+			      ",
+            None,
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  abstract ['computed-method-name'](): string;
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "explicit" }])),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "
+			class Test {
+			  protected name: string;
+			  protected foo?: string;
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            "
+			class Test {
+			  protected name: string;
+			  protected foo?: string;
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  protected name: string;
+			  public foo?: string;
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            "
+			class Test {
+			  protected name: string;
+			  foo?: string;
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  public x: number;
+			  public getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            "
+			class Test {
+			  x: number;
+			  getX() {
+			    return this.x;
+			  }
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public readonly x: number) {}
+			}
+			      ",
+            "
+			class Test {
+			  constructor(readonly x: number) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "off",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public x = 2;
+			  private x = 2;
+			}
+			      ",
+            "
+			class Test {
+			  x = 2;
+			  private x = 2;
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "off",
+                "overrides": { "properties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public /*public*/constructor(private foo: string) {}
+			}
+			      ",
+            "
+			class Test {
+			  /*public*/constructor(private foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  @public
+			  public foo() {}
+			}
+			      ",
+            "
+			class Test {
+			  @public
+			  foo() {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  @public
+			  public foo;
+			}
+			      ",
+            "
+			class Test {
+			  @public
+			  foo;
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  public foo = '';
+			}
+			      ",
+            "
+			class Test {
+			  foo = '';
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public/* Hi there */ readonly foo) {}
+			}
+			      ",
+            "
+			class Test {
+			  constructor(/* Hi there */ readonly foo) {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  constructor(public readonly foo: string) {}
+			}
+			      ",
+            "
+			class Test {
+			  constructor(readonly foo: string) {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			class EnsureWhiteSPaceSpan {
+			  public constructor() {}
+			}
+			      ",
+            "
+			class EnsureWhiteSPaceSpan {
+			  constructor() {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class EnsureWhiteSPaceSpan {
+			  public /* */ constructor() {}
+			}
+			      ",
+            "
+			class EnsureWhiteSPaceSpan {
+			  /* */ constructor() {}
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			class Test {
+			  public 'foo' = 1;
+			  public 'foo foo' = 2;
+			  public 'bar'() {}
+			  public 'bar bar'() {}
+			}
+			      ",
+            "
+			class Test {
+			  'foo' = 1;
+			  'foo foo' = 2;
+			  'bar'() {}
+			  'bar bar'() {}
+			}
+			      ",
+            Some(serde_json::json!([{ "accessibility": "no-public" }])),
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  public abstract method(): string;
+			}
+			      ",
+            "
+			abstract class SomeClass {
+			  abstract method(): string;
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+        (
+            "
+			abstract class SomeClass {
+			  public abstract x: string;
+			}
+			      ",
+            "
+			abstract class SomeClass {
+			  abstract x: string;
+			}
+			      ",
+            Some(serde_json::json!([{
+                "accessibility": "no-public",
+                "overrides": { "parameterProperties": "no-public" },
+            }])),
+        ),
+    ];
+    Tester::new(ExplicitMemberAccessibility::NAME, ExplicitMemberAccessibility::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -340,8 +340,9 @@ impl ExplicitMemberAccessibility {
             AccessibilityLevel::NoPublic => {
                 if param.accessibility == Some(TSAccessibility::Public) && param.readonly {
                     let search_start = search_start_after_decorators(param.span, &param.decorators);
+                    let search_end = param.pattern.span().start;
                     let (public_span, removal_range) =
-                        find_public_spans(ctx.source_text(), search_start);
+                        find_public_spans(ctx, search_start, search_end);
                     ctx.diagnostic_with_fix(
                         unwanted_public_accessibility_diagnostic(
                             public_span,
@@ -378,7 +379,7 @@ impl ExplicitMemberAccessibility {
             && accessibility == Some(TSAccessibility::Public)
         {
             let search_start = search_start_after_decorators(node_span, decorators);
-            let (public_span, removal_range) = find_public_spans(ctx.source_text(), search_start);
+            let (public_span, removal_range) = find_public_spans(ctx, search_start, key_span.start);
             ctx.diagnostic_with_fix(
                 unwanted_public_accessibility_diagnostic(public_span, node_type, name),
                 |fixer| fixer.delete_range(removal_range),
@@ -406,11 +407,11 @@ fn find_insert_position(node_span: Span, decorators: &[Decorator<'_>], source: &
 
 /// Returns `(keyword_span, removal_span)` where `keyword_span` covers just the `public` keyword
 /// and `removal_span` also includes trailing whitespace.
-fn find_public_spans(source: &str, search_start: u32) -> (Span, Span) {
-    let text = &source[search_start as usize..];
-    let offset = text.find("public").expect("Expected 'public' keyword in source");
-    #[expect(clippy::cast_possible_truncation)]
-    let start = search_start + offset as u32;
+fn find_public_spans(ctx: &LintContext<'_>, search_start: u32, search_end: u32) -> (Span, Span) {
+    let start = search_start
+        + ctx
+            .find_next_token_within(search_start, search_end, "public")
+            .expect("Expected 'public' keyword in source");
     let keyword_span = Span::new(start, start + 6);
 
     let bytes = source.as_bytes();

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -393,16 +393,7 @@ fn search_start_after_decorators(node_span: Span, decorators: &[Decorator<'_>]) 
 }
 
 fn find_insert_position(node_span: Span, decorators: &[Decorator<'_>], source: &str) -> u32 {
-    let start = search_start_after_decorators(node_span, decorators);
-    let bytes = source.as_bytes();
-    let mut pos = start;
-    while (pos as usize) < bytes.len() {
-        match bytes[pos as usize] {
-            b' ' | b'\t' | b'\n' | b'\r' => pos += 1,
-            _ => break,
-        }
-    }
-    pos
+    skip_ascii_whitespace(source, search_start_after_decorators(node_span, decorators))
 }
 
 /// Returns `(keyword_span, removal_span)` where `keyword_span` covers just the `public` keyword
@@ -413,16 +404,15 @@ fn find_public_spans(ctx: &LintContext<'_>, search_start: u32, search_end: u32) 
             .find_next_token_within(search_start, search_end, "public")
             .expect("Expected 'public' keyword in source");
     let keyword_span = Span::new(start, start + 6);
-
-    let bytes = source.as_bytes();
-    let mut end = start + 6;
-    while (end as usize) < bytes.len() {
-        match bytes[end as usize] {
-            b' ' | b'\t' | b'\n' | b'\r' => end += 1,
-            _ => break,
-        }
-    }
+    let end = skip_ascii_whitespace(ctx.source_text(), start + 6);
     (keyword_span, Span::new(start, end))
+}
+
+#[expect(clippy::cast_possible_truncation)]
+fn skip_ascii_whitespace(source: &str, start: u32) -> u32 {
+    let bytes = &source.as_bytes()[start as usize..];
+    let offset = bytes.iter().position(|byte| !byte.is_ascii_whitespace()).unwrap_or(bytes.len());
+    start + offset as u32
 }
 
 fn method_definition_kind_to_str(kind: MethodDefinitionKind) -> &'static str {
@@ -1360,6 +1350,19 @@ fn test() {
             Some(
                 serde_json::json!([ { "accessibility": "no-public", "overrides": { "parameterProperties": "no-public" }, }, ]),
             ),
+        ),
+        (
+            "
+            class Test {
+              @dec /*public*/ public foo() {}
+            }
+                  ",
+            "
+            class Test {
+              @dec /*public*/ foo() {}
+            }
+                  ",
+            Some(serde_json::json!([ { "accessibility": "no-public", }, ])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -1,5 +1,8 @@
 use std::borrow::Cow;
 
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{
@@ -10,8 +13,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -31,7 +31,7 @@ enum AccessibilityLevel {
     Off,
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct AccessibilityOverrides {
     /// Which member accessibility modifier requirements to apply for accessors (getters/setters).
@@ -44,18 +44,6 @@ struct AccessibilityOverrides {
     parameter_properties: Option<AccessibilityLevel>,
     /// Which member accessibility modifier requirements to apply for properties.
     properties: Option<AccessibilityLevel>,
-}
-
-impl Default for AccessibilityOverrides {
-    fn default() -> Self {
-        Self {
-            accessors: None,
-            constructors: None,
-            methods: None,
-            parameter_properties: None,
-            properties: None,
-        }
-    }
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -228,20 +228,13 @@ impl ExplicitMemberAccessibility {
             return;
         }
 
-        let (check, node_type) = match method.kind {
-            MethodDefinitionKind::Constructor => {
-                (self.overrides.constructors.unwrap_or(self.accessibility), "method definition")
-            }
-            MethodDefinitionKind::Get => {
-                (self.overrides.accessors.unwrap_or(self.accessibility), "get property accessor")
-            }
-            MethodDefinitionKind::Set => {
-                (self.overrides.accessors.unwrap_or(self.accessibility), "set property accessor")
-            }
-            MethodDefinitionKind::Method => {
-                (self.overrides.methods.unwrap_or(self.accessibility), "method definition")
-            }
+        let check = match method.kind {
+            MethodDefinitionKind::Constructor => self.overrides.constructors,
+            MethodDefinitionKind::Get | MethodDefinitionKind::Set => self.overrides.accessors,
+            MethodDefinitionKind::Method => self.overrides.methods,
         };
+
+        let check = check.unwrap_or(self.accessibility);
 
         let method_name = method.key.name().unwrap_or(Cow::Borrowed(""));
 
@@ -254,7 +247,7 @@ impl ExplicitMemberAccessibility {
         Self::check_member_accessibility(
             check,
             method.accessibility,
-            node_type,
+            method_definition_kind_to_str(method.kind),
             &method_name,
             method.span,
             method.key.span(),
@@ -429,6 +422,14 @@ fn find_public_spans(source: &str, search_start: u32) -> (Span, Span) {
         }
     }
     (keyword_span, Span::new(start, end))
+}
+
+fn method_definition_kind_to_str(kind: MethodDefinitionKind) -> &'static str {
+    match kind {
+        MethodDefinitionKind::Method | MethodDefinitionKind::Constructor => "method definition",
+        MethodDefinitionKind::Get => "get property accessor",
+        MethodDefinitionKind::Set => "set property accessor",
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
@@ -1,0 +1,435 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property value.
+   ╭─[explicit_member_accessibility.tsx:3:34]
+ 2 │             export class XXXX {
+ 3 │               public constructor(readonly value: string) {}
+   ·                                           ─────
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property value.
+   ╭─[explicit_member_accessibility.tsx:3:34]
+ 2 │             export class WithParameterProperty {
+ 3 │               public constructor(readonly value: string) {}
+   ·                                           ─────
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property samosa.
+   ╭─[explicit_member_accessibility.tsx:3:34]
+ 2 │             export class XXXX {
+ 3 │               public constructor(readonly samosa: string) {}
+   ·                                           ──────
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property foo.
+   ╭─[explicit_member_accessibility.tsx:3:34]
+ 2 │             class Test {
+ 3 │               public constructor(readonly foo: string) {}
+   ·                                           ───
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               x: number;
+   ·               ─
+ 4 │               public getX() {
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               private x: number;
+ 4 │               getX() {
+   ·               ────
+ 5 │                 return this.x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               x?: number;
+   ·               ─
+ 4 │               getX?() {
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               x?: number;
+ 4 │               getX?() {
+   ·               ────
+ 5 │                 return this.x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition getX.
+   ╭─[explicit_member_accessibility.tsx:5:6]
+ 4 │               protected foo?: string;
+ 5 │               public getX() {
+   ·               ──────
+ 6 │                 return this.x;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               protected name: string;
+ 4 │               public foo?: string;
+   ·               ──────
+ 5 │               getX() {
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               public x: number;
+   ·               ──────
+ 4 │               public getX() {
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition getX.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               public x: number;
+ 4 │               public getX() {
+   ·               ──────
+ 5 │                 return this.x;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on get property accessor internalValue.
+   ╭─[explicit_member_accessibility.tsx:7:10]
+ 6 │               }
+ 7 │               get internalValue() {
+   ·                   ─────────────
+ 8 │                 return this.x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on set property accessor internalValue.
+    ╭─[explicit_member_accessibility.tsx:10:10]
+  9 │               }
+ 10 │               set internalValue(value: number) {
+    ·                   ─────────────
+ 11 │                 this.x = value;
+    ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               private x: number;
+ 4 │               constructor(x: number) {
+   ·               ───────────
+ 5 │                 this.x = x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on get property accessor internalValue.
+   ╭─[explicit_member_accessibility.tsx:7:10]
+ 6 │               }
+ 7 │               get internalValue() {
+   ·                   ─────────────
+ 8 │                 return this.x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on set property accessor internalValue.
+    ╭─[explicit_member_accessibility.tsx:10:10]
+  9 │               }
+ 10 │               set internalValue(value: number) {
+    ·                   ─────────────
+ 11 │                 this.x = value;
+    ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               constructor(public x: number) {}
+   ·               ───────────
+ 4 │               public foo(): string {
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               constructor(public x: number) {}
+   ·               ───────────
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on parameter property x.
+   ╭─[explicit_member_accessibility.tsx:3:18]
+ 2 │             class Test {
+ 3 │               constructor(public readonly x: number) {}
+   ·                           ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               x = 2;
+   ·               ─
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               public x = 2;
+   ·               ──────
+ 4 │               private x = 2;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               constructor(public x: any[]) {}
+   ·               ───────────
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               public /*public*/constructor(private foo: string) {}
+   ·               ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition foo.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               @public
+ 4 │               public foo() {}
+   ·               ──────
+ 5 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               @public
+ 4 │               public foo;
+   ·               ──────
+ 5 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               public foo = '';
+   ·               ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on parameter property foo.
+   ╭─[explicit_member_accessibility.tsx:3:18]
+ 2 │             class Test {
+ 3 │               constructor(public/* Hi there */ readonly foo) {}
+   ·                           ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on parameter property foo.
+   ╭─[explicit_member_accessibility.tsx:3:18]
+ 2 │             class Test {
+ 3 │               constructor(public readonly foo: string) {}
+   ·                           ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class EnsureWhiteSPaceSpan {
+ 3 │               public constructor() {}
+   ·               ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class EnsureWhiteSPaceSpan {
+ 3 │               public /* */ constructor() {}
+   ·               ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class Test {
+ 3 │               public 'foo' = 1;
+   ·               ──────
+ 4 │               public 'foo foo' = 2;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo foo.
+   ╭─[explicit_member_accessibility.tsx:4:6]
+ 3 │               public 'foo' = 1;
+ 4 │               public 'foo foo' = 2;
+   ·               ──────
+ 5 │               public 'bar'() {}
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition bar.
+   ╭─[explicit_member_accessibility.tsx:5:6]
+ 4 │               public 'foo foo' = 2;
+ 5 │               public 'bar'() {}
+   ·               ──────
+ 6 │               public 'bar bar'() {}
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition bar bar.
+   ╭─[explicit_member_accessibility.tsx:6:6]
+ 5 │               public 'bar'() {}
+ 6 │               public 'bar bar'() {}
+   ·               ──────
+ 7 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition method.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             abstract class SomeClass {
+ 3 │               abstract method(): string;
+   ·                        ──────
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition method.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             abstract class SomeClass {
+ 3 │               public abstract method(): string;
+   ·               ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             abstract class SomeClass {
+ 3 │               abstract x: string;
+   ·                        ─
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             abstract class SomeClass {
+ 3 │               public abstract x: string;
+   ·               ──────
+ 4 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class SomeClass {
+ 3 │               accessor foo = 1;
+   ·                        ───
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:3:24]
+ 2 │             abstract class SomeClass {
+ 3 │               abstract accessor foo: string;
+   ·                                 ───
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:6]
+ 2 │             class DecoratedClass {
+ 3 │               constructor(@foo @bar() readonly arg: string) {}
+   ·               ───────────
+ 4 │               @foo @bar() x: string;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property arg.
+   ╭─[explicit_member_accessibility.tsx:3:39]
+ 2 │             class DecoratedClass {
+ 3 │               constructor(@foo @bar() readonly arg: string) {}
+   ·                                                ───
+ 4 │               @foo @bar() x: string;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:4:18]
+ 3 │               constructor(@foo @bar() readonly arg: string) {}
+ 4 │               @foo @bar() x: string;
+   ·                           ─
+ 5 │               @foo @bar() getX() {
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
+   ╭─[explicit_member_accessibility.tsx:5:18]
+ 4 │               @foo @bar() x: string;
+ 5 │               @foo @bar() getX() {
+   ·                           ────
+ 6 │                 return this.x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on get property accessor y.
+    ╭─[explicit_member_accessibility.tsx:10:10]
+  9 │               @bar()
+ 10 │               get y() {
+    ·                   ─
+ 11 │                 return this.x;
+    ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on set property accessor z.
+    ╭─[explicit_member_accessibility.tsx:13:22]
+ 12 │               }
+ 13 │               @foo @bar() set z(@foo @bar() value: x) {
+    ·                               ─
+ 14 │                 this.x = x;
+    ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition computed-method-name.
+   ╭─[explicit_member_accessibility.tsx:3:16]
+ 2 │             abstract class SomeClass {
+ 3 │               abstract ['computed-method-name'](): string;
+   ·                         ──────────────────────
+ 4 │             }
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property value.
-   ╭─[explicit_member_accessibility.tsx:3:34]
+   ╭─[explicit_member_accessibility.tsx:3:43]
  2 │             export class XXXX {
  3 │               public constructor(readonly value: string) {}
    ·                                           ─────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property value.
-   ╭─[explicit_member_accessibility.tsx:3:34]
+   ╭─[explicit_member_accessibility.tsx:3:43]
  2 │             export class WithParameterProperty {
  3 │               public constructor(readonly value: string) {}
    ·                                           ─────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property samosa.
-   ╭─[explicit_member_accessibility.tsx:3:34]
+   ╭─[explicit_member_accessibility.tsx:3:43]
  2 │             export class XXXX {
  3 │               public constructor(readonly samosa: string) {}
    ·                                           ──────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property foo.
-   ╭─[explicit_member_accessibility.tsx:3:34]
+   ╭─[explicit_member_accessibility.tsx:3:43]
  2 │             class Test {
  3 │               public constructor(readonly foo: string) {}
    ·                                           ───
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               x: number;
    ·               ─
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               private x: number;
  4 │               getX() {
    ·               ────
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               x?: number;
    ·               ─
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               x?: number;
  4 │               getX?() {
    ·               ────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition getX.
-   ╭─[explicit_member_accessibility.tsx:5:6]
+   ╭─[explicit_member_accessibility.tsx:5:15]
  4 │               protected foo?: string;
  5 │               public getX() {
    ·               ──────
@@ -84,7 +84,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               protected name: string;
  4 │               public foo?: string;
    ·               ──────
@@ -93,7 +93,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               public x: number;
    ·               ──────
@@ -102,7 +102,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition getX.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               public x: number;
  4 │               public getX() {
    ·               ──────
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on get property accessor internalValue.
-   ╭─[explicit_member_accessibility.tsx:7:10]
+   ╭─[explicit_member_accessibility.tsx:7:19]
  6 │               }
  7 │               get internalValue() {
    ·                   ─────────────
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on set property accessor internalValue.
-    ╭─[explicit_member_accessibility.tsx:10:10]
+    ╭─[explicit_member_accessibility.tsx:10:19]
   9 │               }
  10 │               set internalValue(value: number) {
     ·                   ─────────────
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               private x: number;
  4 │               constructor(x: number) {
    ·               ───────────
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on get property accessor internalValue.
-   ╭─[explicit_member_accessibility.tsx:7:10]
+   ╭─[explicit_member_accessibility.tsx:7:19]
  6 │               }
  7 │               get internalValue() {
    ·                   ─────────────
@@ -147,7 +147,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on set property accessor internalValue.
-    ╭─[explicit_member_accessibility.tsx:10:10]
+    ╭─[explicit_member_accessibility.tsx:10:19]
   9 │               }
  10 │               set internalValue(value: number) {
     ·                   ─────────────
@@ -156,7 +156,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               constructor(public x: number) {}
    ·               ───────────
@@ -165,7 +165,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               constructor(public x: number) {}
    ·               ───────────
@@ -174,7 +174,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on parameter property x.
-   ╭─[explicit_member_accessibility.tsx:3:18]
+   ╭─[explicit_member_accessibility.tsx:3:27]
  2 │             class Test {
  3 │               constructor(public readonly x: number) {}
    ·                           ──────
@@ -183,7 +183,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               x = 2;
    ·               ─
@@ -192,7 +192,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               public x = 2;
    ·               ──────
@@ -201,7 +201,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               constructor(public x: any[]) {}
    ·               ───────────
@@ -210,7 +210,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               public /*public*/constructor(private foo: string) {}
    ·               ──────
@@ -219,7 +219,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition foo.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               @public
  4 │               public foo() {}
    ·               ──────
@@ -228,7 +228,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               @public
  4 │               public foo;
    ·               ──────
@@ -237,7 +237,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               public foo = '';
    ·               ──────
@@ -246,7 +246,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on parameter property foo.
-   ╭─[explicit_member_accessibility.tsx:3:18]
+   ╭─[explicit_member_accessibility.tsx:3:27]
  2 │             class Test {
  3 │               constructor(public/* Hi there */ readonly foo) {}
    ·                           ──────
@@ -255,7 +255,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on parameter property foo.
-   ╭─[explicit_member_accessibility.tsx:3:18]
+   ╭─[explicit_member_accessibility.tsx:3:27]
  2 │             class Test {
  3 │               constructor(public readonly foo: string) {}
    ·                           ──────
@@ -264,7 +264,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class EnsureWhiteSPaceSpan {
  3 │               public constructor() {}
    ·               ──────
@@ -273,7 +273,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class EnsureWhiteSPaceSpan {
  3 │               public /* */ constructor() {}
    ·               ──────
@@ -282,7 +282,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class Test {
  3 │               public 'foo' = 1;
    ·               ──────
@@ -291,7 +291,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property foo foo.
-   ╭─[explicit_member_accessibility.tsx:4:6]
+   ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               public 'foo' = 1;
  4 │               public 'foo foo' = 2;
    ·               ──────
@@ -300,7 +300,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition bar.
-   ╭─[explicit_member_accessibility.tsx:5:6]
+   ╭─[explicit_member_accessibility.tsx:5:15]
  4 │               public 'foo foo' = 2;
  5 │               public 'bar'() {}
    ·               ──────
@@ -309,7 +309,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition bar bar.
-   ╭─[explicit_member_accessibility.tsx:6:6]
+   ╭─[explicit_member_accessibility.tsx:6:15]
  5 │               public 'bar'() {}
  6 │               public 'bar bar'() {}
    ·               ──────
@@ -318,7 +318,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition method.
-   ╭─[explicit_member_accessibility.tsx:3:15]
+   ╭─[explicit_member_accessibility.tsx:3:24]
  2 │             abstract class SomeClass {
  3 │               abstract method(): string;
    ·                        ──────
@@ -327,7 +327,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on method definition method.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             abstract class SomeClass {
  3 │               public abstract method(): string;
    ·               ──────
@@ -336,7 +336,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:15]
+   ╭─[explicit_member_accessibility.tsx:3:24]
  2 │             abstract class SomeClass {
  3 │               abstract x: string;
    ·                        ─
@@ -345,7 +345,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Public accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             abstract class SomeClass {
  3 │               public abstract x: string;
    ·               ──────
@@ -354,7 +354,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:3:15]
+   ╭─[explicit_member_accessibility.tsx:3:24]
  2 │             class SomeClass {
  3 │               accessor foo = 1;
    ·                        ───
@@ -363,7 +363,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:3:24]
+   ╭─[explicit_member_accessibility.tsx:3:33]
  2 │             abstract class SomeClass {
  3 │               abstract accessor foo: string;
    ·                                 ───
@@ -372,7 +372,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:6]
+   ╭─[explicit_member_accessibility.tsx:3:15]
  2 │             class DecoratedClass {
  3 │               constructor(@foo @bar() readonly arg: string) {}
    ·               ───────────
@@ -381,7 +381,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on parameter property arg.
-   ╭─[explicit_member_accessibility.tsx:3:39]
+   ╭─[explicit_member_accessibility.tsx:3:48]
  2 │             class DecoratedClass {
  3 │               constructor(@foo @bar() readonly arg: string) {}
    ·                                                ───
@@ -390,7 +390,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:4:18]
+   ╭─[explicit_member_accessibility.tsx:4:27]
  3 │               constructor(@foo @bar() readonly arg: string) {}
  4 │               @foo @bar() x: string;
    ·                           ─
@@ -399,7 +399,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
-   ╭─[explicit_member_accessibility.tsx:5:18]
+   ╭─[explicit_member_accessibility.tsx:5:27]
  4 │               @foo @bar() x: string;
  5 │               @foo @bar() getX() {
    ·                           ────
@@ -408,7 +408,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on get property accessor y.
-    ╭─[explicit_member_accessibility.tsx:10:10]
+    ╭─[explicit_member_accessibility.tsx:10:19]
   9 │               @bar()
  10 │               get y() {
     ·                   ─
@@ -417,7 +417,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on set property accessor z.
-    ╭─[explicit_member_accessibility.tsx:13:22]
+    ╭─[explicit_member_accessibility.tsx:13:31]
  12 │               }
  13 │               @foo @bar() set z(@foo @bar() value: x) {
     ·                               ─
@@ -426,7 +426,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript-eslint(explicit-member-accessibility): Missing accessibility modifier on method definition computed-method-name.
-   ╭─[explicit_member_accessibility.tsx:3:16]
+   ╭─[explicit_member_accessibility.tsx:3:25]
  2 │             abstract class SomeClass {
  3 │               abstract ['computed-method-name'](): string;
    ·                         ──────────────────────


### PR DESCRIPTION
This PR adds the `typescript/explicit-member-accessibility` rule for #2180 and was generated using Cursor and Opus 4.6 Extra High. 

I don't have much Rust experience, but I have worked with linters for many years and use oxlint at my company on a large monorepo. 



<details><summary>Here's the plan I refined with Cursor to faciliate this PR, if this is of use:</summary>
<p>

---
name: explicit-member-accessibility rule
overview: Implement the `typescript/explicit-member-accessibility` rule that requires (or forbids) explicit `public`/`private`/`protected` modifiers on class members, with per-member-kind overrides and autofix support.
todos:
  - id: scaffold
    content: Run `just new-typescript-rule explicit-member-accessibility` to generate boilerplate and register the rule
    status: completed
  - id: config
    content: Define `AccessibilityLevel` enum, config struct with `accessibility`, `ignoredMethodNames`, `overrides`, and implement `from_configuration`
    status: completed
  - id: diagnostics
    content: Define `missing_accessibility` and `unwanted_public_accessibility` diagnostic helper functions
    status: completed
  - id: run-methods
    content: Implement `Rule::run` for `MethodDefinition` -- check constructors, methods, getters/setters with correct override resolution
    status: completed
  - id: run-properties
    content: Implement `Rule::run` for `PropertyDefinition` and `AccessorProperty`
    status: completed
  - id: run-params
    content: Implement `Rule::run` for `FormalParameter` (parameter properties)
    status: completed
  - id: fixes
    content: Implement fix (remove `public`) and suggestions (add `public`/`private`/`protected`)
    status: completed
  - id: tests
    content: Add comprehensive test cases covering all config permutations, member types, private identifiers, and fixes
    status: completed
  - id: finalize
    content: Run `just fmt`, `cargo test -p oxc_linter`, and `just ready`
    status: completed
isProject: false
---

# Implement `typescript/explicit-member-accessibility`

## Reference

- **typescript-eslint docs**: https://typescript-eslint.io/rules/explicit-member-accessibility
- **Upstream source**: [explicit-member-accessibility.ts](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts)

## Rule behavior

The rule has three accessibility-level modes:

- `"explicit"` (default) -- every class member must have an explicit `public`, `private`, or `protected` modifier
- `"no-public"` -- the `public` keyword is forbidden (the other two are fine)
- `"off"` -- no checking

A top-level `accessibility` option sets the default. Per-member-kind `overrides` can specialize behavior for: `constructors`, `methods`, `accessors`, `properties`, `parameterProperties`.

An `ignoredMethodNames` option (string array) skips named methods.

Fixes:
- `"no-public"` violations get a **fix** that removes the `public` keyword
- `"explicit"` violations get **suggestions** (not auto-fix) offering to add `public`, `private`, or `protected`

Members with `#private` identifier keys are always skipped (JS private fields already have inherent privacy).

## Key AST types

All live in `crates/oxc_ast/src/ast/js.rs` and `crates/oxc_ast/src/ast/ts.rs`:

- `MethodDefinition` -- has `accessibility: Option<TSAccessibility>`, `kind: MethodDefinitionKind`, `key: PropertyKey`
- `PropertyDefinition` -- has `accessibility: Option<TSAccessibility>`, `key: PropertyKey`
- `AccessorProperty` -- has `accessibility: Option<TSAccessibility>`, `key: PropertyKey`
- `FormalParameter` -- has `accessibility: Option<TSAccessibility>`, `readonly: bool`, `has_modifier()` (parameter properties)
- `TSAccessibility` -- enum: `Public`, `Protected`, `Private`
- `PropertyKey::is_private_identifier()` -- detect `#foo` private fields

## Implementation plan

### 1. Scaffold with `just new-typescript-rule`

```sh
just new-typescript-rule explicit-member-accessibility
```

This generates [crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs](crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs), registers the module in [crates/oxc_linter/src/rules.rs](crates/oxc_linter/src/rules.rs), and runs codegen.

### 2. Define config struct

In the new rule file, define the configuration following the pattern in [no_extraneous_class.rs](crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs):

```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
enum AccessibilityLevel { Explicit, NoPublic, Off }

#[derive(Debug, Clone, Default, JsonSchema)]
#[serde(rename_all = "camelCase", default)]
pub struct ExplicitMemberAccessibility {
    accessibility: AccessibilityLevel, // default: Explicit
    ignored_method_names: Vec<String>,
    overrides: AccessibilityOverrides,
}

#[derive(Debug, Clone, Default, JsonSchema)]
#[serde(rename_all = "camelCase", default)]
struct AccessibilityOverrides {
    accessors: Option<AccessibilityLevel>,
    constructors: Option<AccessibilityLevel>,
    methods: Option<AccessibilityLevel>,
    parameter_properties: Option<AccessibilityLevel>,
    properties: Option<AccessibilityLevel>,
}
```

Implement `Rule::from_configuration` to parse the JSON options (array with one object element), resolving each override against the base `accessibility`.

### 3. Implement `Rule::run`

Match on three `AstKind` variants:

- **`AstKind::MethodDefinition(method)`**: Skip if `key.is_private_identifier()`. Determine the effective check level based on `method.kind` (Constructor -> `ctorCheck`, Get/Set -> `accessorCheck`, Method -> `methodCheck`). Skip if the method name is in `ignoredMethodNames`. Then:
  - `"no-public"` + `accessibility == Some(Public)` -> report `unwantedPublicAccessibility` with a **fix** removing `public ` 
  - `"explicit"` + `accessibility.is_none()` -> report `missingAccessibility` with **suggestions** to add each modifier

- **`AstKind::PropertyDefinition(prop)`**: Skip if `key.is_private_identifier()`. Use `propCheck`. Same check/report pattern.

- **`AstKind::AccessorProperty(prop)`**: Skip if `key.is_private_identifier()`. Use `propCheck` (following the upstream which uses `propCheck` for all property-like members). Same check/report pattern.

For **parameter properties**, match on `AstKind::FormalParameter(param)` when `param.has_modifier()`. Use `paramPropCheck`. The `"no-public"` case only applies when `accessibility == Some(Public)` AND `readonly == true` (matches upstream behavior). The `"explicit"` case reports when `accessibility.is_none()` (the param has `readonly`/`override` but no explicit visibility keyword).

### 4. Diagnostics

Define helper functions:

```rust
fn missing_accessibility(span, member_type, name) -> OxcDiagnostic
fn unwanted_public_accessibility(span, member_type, name) -> OxcDiagnostic
```

### 5. Fixes and suggestions

- **Removing `public`** (`no-public` violations): Use `fixer.delete_range(...)` targeting the `public ` keyword span. The span can be computed as `Span::new(node.span.start, <first-non-public-token-start>)` -- but we need to be careful about decorators. A simpler approach: search for "public " in the source text within the member's span and remove it.
- **Adding modifiers** (`explicit` violations): Use `ctx.diagnostic_with_suggestion(...)` with suggestions for `public `, `private `, and `protected `. Insert text before the member's key (or before the first token after decorators).

### 6. Tests

Add comprehensive test cases following the upstream test file patterns, using `Tester`:
- Default `{ accessibility: "explicit" }` -- missing modifiers on methods, properties, accessors, constructors, parameter properties
- `{ accessibility: "no-public" }` -- unwanted `public` on each member type
- `{ accessibility: "off" }` -- no reports
- Override combinations (e.g. `{ accessibility: "no-public", overrides: { properties: "explicit" } }`)
- `ignoredMethodNames` option
- Private identifier (`#foo`) members are always skipped
- Fix tests for `public` removal, suggestion tests for adding modifiers

### 7. Finalize

- Run `just fmt`
- Run `cargo test -p oxc_linter` to verify tests pass
- Run `cargo insta review` if needed to accept snapshots
- Run `just ready` for final checks


</p>
</details> 


