### PR TITLE
fix(formatter): Preserve more `intrinsic` parens

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -1315,9 +1315,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeReference<'a>> {
 }
 
 /// The parser treats a leading `intrinsic` identifier in a type alias annotation
-/// as `TSIntrinsicKeyword` (e.g. `type t = intrinsic`). Source like `type t = (intrinsic);`
-/// loses its parens (`preserve_parens: false`), so without re-emitting them the output
-/// re-parses as `TSIntrinsicKeyword` (or fails to parse when followed by `|`/`&`).
+/// as `TSIntrinsicKeyword` (e.g. `type t = intrinsic`).
+/// Source like `type t = (intrinsic);` loses its parens (`preserve_parens: false`),
+/// so without re-emitting them the output re-parses as `TSIntrinsicKeyword`.
+/// (or fails to parse when followed by `|`/`&`)
 ///
 /// See: <https://github.com/oxc-project/oxc/issues/20205>
 fn is_leftmost_intrinsic_in_type_alias(reference: &AstNode<'_, TSTypeReference<'_>>) -> bool {
@@ -1343,6 +1344,15 @@ fn is_leftmost_intrinsic_in_type_alias(reference: &AstNode<'_, TSTypeReference<'
                     return false;
                 }
                 parent = intersection.parent();
+            }
+            AstNodes::TSConditionalType(cond) => {
+                if cond.check_type().span().start != span_start {
+                    return false;
+                }
+                parent = cond.parent();
+            }
+            AstNodes::TSArrayType(array) => {
+                parent = array.parent();
             }
             _ => return false,
         }

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts
@@ -6,3 +6,5 @@ type t5 = string | (intrinsic);
 type t6 = [intrinsic];
 type t7 = { x: intrinsic };
 type t8 = Array<intrinsic>;
+type t9 = (intrinsic) extends string ? 1 : 0
+type t10 = (intrinsic)[]

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/intrinsic.ts.snap
@@ -10,6 +10,8 @@ type t5 = string | (intrinsic);
 type t6 = [intrinsic];
 type t7 = { x: intrinsic };
 type t8 = Array<intrinsic>;
+type t9 = (intrinsic) extends string ? 1 : 0
+type t10 = (intrinsic)[]
 
 ==================== Output ====================
 ------------------
@@ -23,6 +25,8 @@ type t5 = string | intrinsic;
 type t6 = [intrinsic];
 type t7 = { x: intrinsic };
 type t8 = Array<intrinsic>;
+type t9 = (intrinsic) extends string ? 1 : 0;
+type t10 = (intrinsic)[];
 
 -------------------
 { printWidth: 100 }
@@ -35,5 +39,7 @@ type t5 = string | intrinsic;
 type t6 = [intrinsic];
 type t7 = { x: intrinsic };
 type t8 = Array<intrinsic>;
+type t9 = (intrinsic) extends string ? 1 : 0;
+type t10 = (intrinsic)[];
 
 ===================== End =====================


### PR DESCRIPTION
Follow up on #21410

Added more test cases and fixes.
