### PR TITLE
fix(transformer/async-to-generator): correct scope of inferred named FE in async-to-generator

### DIFF
--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -347,8 +347,20 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             let params = Self::create_placeholder_params(&params, scope_id, ctx);
             let statements = ctx.ast.vec1(Self::create_apply_call_statement(&bound_ident, ctx));
             let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), statements);
-            let id = id.or_else(|| Self::infer_function_id_from_parent_node(wrapper_scope_id, ctx));
-            Self::create_function(id, params, body, scope_id, ctx)
+            let (r#type, id) = if id.is_some() {
+                // Caller is emitted as a function declaration inside the wrapper; its binding
+                // was already moved to `wrapper_scope_id` above.
+                (FunctionType::FunctionDeclaration, id)
+            } else {
+                // Caller is emitted as a named function expression; per the JS spec, its name
+                // binds only inside the function itself — place the inferred id's binding in
+                // the caller's own scope, not the wrapper scope.
+                (
+                    FunctionType::FunctionExpression,
+                    Self::infer_function_id_from_parent_node(scope_id, ctx),
+                )
+            };
+            Self::create_function(r#type, id, params, body, scope_id, ctx)
         };
 
         {
@@ -456,7 +468,14 @@ impl<'a> AsyncGeneratorExecutor<'a> {
 
             let params = Self::create_empty_params(ctx);
             let id = Some(bound_ident.create_binding_identifier(ctx));
-            let caller_function = Self::create_function(id, params, body, scope_id, ctx);
+            let caller_function = Self::create_function(
+                FunctionType::FunctionDeclaration,
+                id,
+                params,
+                body,
+                scope_id,
+                ctx,
+            );
             Statement::FunctionDeclaration(caller_function)
         }
     }
@@ -508,10 +527,17 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             let statements = ctx.ast.vec1(Self::create_apply_call_statement(&bound_ident, ctx));
             let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), statements);
             let id = function_name.map(|name| {
-                ctx.generate_binding(name, wrapper_scope_id, SymbolFlags::Function)
+                ctx.generate_binding(name, scope_id, SymbolFlags::Function)
                     .create_binding_identifier(ctx)
             });
-            let function = Self::create_function(id, params, body, scope_id, ctx);
+            let function = Self::create_function(
+                FunctionType::FunctionExpression,
+                id,
+                params,
+                body,
+                scope_id,
+                ctx,
+            );
             let argument = Some(Expression::FunctionExpression(function));
             ctx.ast.statement_return(SPAN, argument)
         };
@@ -528,7 +554,14 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             let statements = ctx.ast.vec_from_array([statement, caller_function]);
             let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), statements);
             let params = Self::create_empty_params(ctx);
-            let wrapper_function = Self::create_function(None, params, body, wrapper_scope_id, ctx);
+            let wrapper_function = Self::create_function(
+                FunctionType::FunctionExpression,
+                None,
+                params,
+                body,
+                wrapper_scope_id,
+                ctx,
+            );
             // Construct the IIFE
             let callee = Expression::FunctionExpression(wrapper_function);
             ctx.ast.expression_call(arrow_span, callee, NONE, ctx.ast.vec(), false)
@@ -616,17 +649,13 @@ impl<'a> AsyncGeneratorExecutor<'a> {
     /// Creates a [`Function`] with the specified params, body and scope_id.
     #[inline]
     fn create_function(
+        r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         params: ArenaBox<'a, FormalParameters<'a>>,
         body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         ctx: &TraverseCtx<'a>,
     ) -> ArenaBox<'a, Function<'a>> {
-        let r#type = if id.is_some() {
-            FunctionType::FunctionDeclaration
-        } else {
-            FunctionType::FunctionExpression
-        };
         ctx.ast.alloc_function_with_scope_id(
             SPAN,
             r#type,
@@ -690,7 +719,14 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let mut function = Self::create_function(None, params, body, scope_id, ctx);
+        let mut function = Self::create_function(
+            FunctionType::FunctionExpression,
+            None,
+            params,
+            body,
+            scope_id,
+            ctx,
+        );
         function.generator = true;
         let arguments = ctx.ast.vec1(Argument::FunctionExpression(function));
         helper_call_expr(self.helper, SPAN, arguments, ctx)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: c543b031
 
-Passed: 218/365
+Passed: 220/367
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: c543b031
 
 node: v24.14.0
 
-Passed: 10 of 12 (83.33%)
+Passed: 12 of 14 (85.71%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/arrow/id-shadowing-outer-binding/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/arrow/id-shadowing-outer-binding/exec.js
@@ -1,0 +1,10 @@
+let count = 0;
+const typeNext = async () => {
+  count++;
+  if (count < 3) typeNext();
+};
+typeNext();
+
+return new Promise(resolve => setTimeout(resolve, 50)).then(() => {
+  expect(count).toBe(3);
+});

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/arrow/id-shadowing-outer-binding/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/arrow/id-shadowing-outer-binding/input.js
@@ -1,0 +1,6 @@
+let count = 0;
+const typeNext = async () => {
+  count++;
+  if (count < 3) typeNext();
+};
+typeNext();

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/arrow/id-shadowing-outer-binding/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/arrow/id-shadowing-outer-binding/output.js
@@ -1,0 +1,11 @@
+let count = 0;
+const typeNext = function () {
+  var _ref = babelHelpers.asyncToGenerator(function* () {
+    count++;
+    if (count < 3) typeNext();
+  });
+  return function typeNext() {
+    return _ref.apply(this, arguments);
+  };
+}();
+typeNext();

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/object/id-shadowing-outer-binding/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/object/id-shadowing-outer-binding/exec.js
@@ -1,0 +1,16 @@
+function customIteratorMethod() {
+  let previous = null;
+  let next = null;
+  return {
+    previous: async () =>
+      previous || (previous = "previous value"),
+    next: async () => next || (next = "next value"),
+  };
+}
+
+return (async () => {
+  const iter = customIteratorMethod();
+  expect(await iter.next()).toBe("next value");
+  expect(await iter.previous()).toBe("previous value");
+  expect(await iter.next()).toBe("next value");
+})();

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/object/id-shadowing-outer-binding/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/object/id-shadowing-outer-binding/input.js
@@ -1,0 +1,9 @@
+function customIteratorMethod() {
+  let previous = null;
+  let next = null;
+  return {
+    previous: async () =>
+      previous || (previous = "previous value"),
+    next: async () => next || (next = "next value"),
+  };
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/object/id-shadowing-outer-binding/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/object/id-shadowing-outer-binding/output.js
@@ -1,0 +1,22 @@
+function customIteratorMethod() {
+  let previous = null;
+  let next = null;
+  return {
+    previous: function () {
+      var _ref = babelHelpers.asyncToGenerator(function* () {
+        return previous || (previous = "previous value");
+      });
+      return function previous() {
+        return _ref.apply(this, arguments);
+      };
+    }(),
+    next: function () {
+      var _ref2 = babelHelpers.asyncToGenerator(function* () {
+        return next || (next = "next value");
+      });
+      return function next() {
+        return _ref2.apply(this, arguments);
+      };
+    }()
+  };
+}


### PR DESCRIPTION
When the async-to-generator transform wraps an async arrow / anonymous async function expression whose name is inferred from its parent (e.g. `const foo = async () => {}`, `{ foo: async () => {} }`), it emits a named function expression as the caller:

```js
const foo = function () {
  var _ref = asyncToGenerator(function* () { /* body */ });
  return function foo() { return _ref.apply(this, arguments); };
}();
```

Per the JS spec, the inferred name `foo` binds only inside the named FE itself — not in the enclosing wrapper IIFE scope.

But the previous code had two bugs that together caused oxc to emit an AST that a fresh semantic analysis (e.g. Rolldown's minifier in Vite, or oxc's own minifier) would misread:

1. `create_function` set `FunctionType::FunctionDeclaration` whenever `id.is_some()`, even for callers using the result as a function expression. Any fresh semantic pass trusts `r#type` and treats the node as a declaration — which binds the name in the enclosing wrapper scope.
2. The inferred id's binding was registered in `wrapper_scope_id` rather than the function's own scope.

Combined, downstream minifiers resolve a body reference like `typeNext()` inside `const typeNext = async () => { typeNext(); }` to the inner caller instead of the outer `const typeNext`. The outer const then looks unused, gets inlined away, and the body reference fails at runtime with `ReferenceError: typeNext is not defined`.

## Fix

Pass `FunctionType` explicitly (via new `create_function_expression` and `create_function_declaration` helpers), and place the inferred id's binding in the caller function's own scope.

## Runtime verification

Ran input → oxc transform → oxc compress (same pipeline Rolldown/Vite uses):

**Pre-fix** output (matches the exact bug in the Vite issue — outer const inlined away):
```js
(function() {
  var _ref = _asyncToGenerator(function* () { ..., typeNext(); });
  return function typeNext() { return _ref.apply(this, arguments); };
})()();
```
Runtime: `ReferenceError: typeNext is not defined` ✗

**Post-fix** output (outer const preserved; minifier correctly drops the now-unused inner FE name):
```js
const typeNext = function() {
  var _ref = _asyncToGenerator(function* () { ..., typeNext(); });
  return function() { return _ref.apply(this, arguments); };
}();
typeNext();
```
Runtime: works correctly ✓

Closes #21125
Closes #21445