### PR TITLE
feat(linter/unicorn): add help messages to 3 rule diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -10,15 +10,24 @@ use crate::{AstNode, context::LintContext, rule::Rule, utils::BUILT_IN_ERRORS};
 
 fn missing_message(ctor_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Pass a message to the {ctor_name:1} constructor."))
+        .with_help(
+            "A descriptive message makes the error easier to debug when it is caught or logged.",
+        )
         .with_label(span)
 }
 
 fn empty_message(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Error message should not be an empty string.").with_label(span)
+    OxcDiagnostic::warn("Error message should not be an empty string.")
+        .with_help("Provide a non-empty string that describes what went wrong.")
+        .with_label(span)
 }
 
 fn not_string(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Error message should be a string.").with_label(span)
+    OxcDiagnostic::warn("Error message should be a string.")
+        .with_help(
+            "The first argument to an error constructor should be a string describing the error.",
+        )
+        .with_label(span)
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -7,6 +7,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_static_only_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use an object instead of a `class` with only `static` members.")
+        .with_help("Convert to an object instead of a class with only static members.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -7,6 +7,9 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn prefer_add_event_listener_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `addEventListener()` over their `on`-function counterparts.")
+        .with_help(
+            "`addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.",
+        )
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/unicorn_error_message.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_error_message.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ throw new Error()
    ·       ───────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the Error constructor.
    ╭─[error_message.tsx:1:7]
  1 │ throw Error()
    ·       ───────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should not be an empty string.
    ╭─[error_message.tsx:1:17]
  1 │ throw new Error('')
    ·                 ──
    ╰────
+  help: Provide a non-empty string that describes what went wrong.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should not be an empty string.
    ╭─[error_message.tsx:1:17]
  1 │ throw new Error(``)
    ·                 ──
    ╰────
+  help: Provide a non-empty string that describes what went wrong.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the Error constructor.
    ╭─[error_message.tsx:1:13]
@@ -32,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────
  2 │             throw err;
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the Error constructor.
    ╭─[error_message.tsx:2:19]
@@ -40,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───────────
  3 │             throw err;
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the Error constructor.
    ╭─[error_message.tsx:1:11]
@@ -47,111 +53,130 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───────────
  2 │             err = 1;
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the TypeError constructor.
    ╭─[error_message.tsx:1:13]
  1 │ const foo = new TypeError()
    ·             ───────────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the SyntaxError constructor.
    ╭─[error_message.tsx:1:13]
  1 │ const foo = new SyntaxError()
    ·             ─────────────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:17]
  1 │ throw new Error([])
    ·                 ──
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:17]
  1 │ throw new Error([foo])
    ·                 ─────
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:17]
  1 │ throw new Error({})
    ·                 ──
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:17]
  1 │ throw new Error({foo})
    ·                 ─────
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the RangeError constructor.
    ╭─[error_message.tsx:1:15]
  1 │ const error = new RangeError;
    ·               ──────────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the Error constructor.
    ╭─[error_message.tsx:1:21]
  1 │ throw Object.assign(new Error(), {foo})
    ·                     ───────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the AggregateError constructor.
    ╭─[error_message.tsx:1:1]
  1 │ new AggregateError(errors)
    · ──────────────────────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the AggregateError constructor.
    ╭─[error_message.tsx:1:1]
  1 │ AggregateError(errors)
    · ──────────────────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should not be an empty string.
    ╭─[error_message.tsx:1:28]
  1 │ new AggregateError(errors, "")
    ·                            ──
    ╰────
+  help: Provide a non-empty string that describes what went wrong.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should not be an empty string.
    ╭─[error_message.tsx:1:28]
  1 │ new AggregateError(errors, ``)
    ·                            ──
    ╰────
+  help: Provide a non-empty string that describes what went wrong.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should not be an empty string.
    ╭─[error_message.tsx:1:28]
  1 │ new AggregateError(errors, "", extraArgument)
    ·                            ──
    ╰────
+  help: Provide a non-empty string that describes what went wrong.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:28]
  1 │ new AggregateError(errors, [])
    ·                            ──
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:28]
  1 │ new AggregateError(errors, [foo])
    ·                            ─────
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:28]
  1 │ new AggregateError(errors, {})
    ·                            ──
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Error message should be a string.
    ╭─[error_message.tsx:1:28]
  1 │ new AggregateError(errors, {foo})
    ·                            ─────
    ╰────
+  help: The first argument to an error constructor should be a string describing the error.
 
   ⚠ eslint-plugin-unicorn(error-message): Pass a message to the AggregateError constructor.
    ╭─[error_message.tsx:1:15]
  1 │ const error = new AggregateError;
    ·               ──────────────────
    ╰────
+  help: A descriptive message makes the error easier to debug when it is caught or logged.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_static_only_class.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_static_only_class.snap
@@ -21,6 +21,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const A = class A { static a() {}; }
    ·           ──────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a `class` with only `static` members.
    ╭─[no_static_only_class.tsx:1:11]
@@ -41,6 +42,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export default class A { static a() {}; }
    ·                ──────────────────────────
    ╰────
+  help: Convert to an object instead of a class with only static members.
 
   ⚠ eslint-plugin-unicorn(no-static-only-class): Use an object instead of a `class` with only `static` members.
    ╭─[no_static_only_class.tsx:1:16]

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_add_event_listener.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_add_event_listener.snap
@@ -7,36 +7,42 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo.onclick = () => {}
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = 1
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:9]
  1 │ foo.bar.onclick = onClick
    ·         ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:23]
  1 │ const bar = null; foo.onclick = bar;
    ·                       ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onkeydown = () => {}
    ·     ─────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.ondragend = () => {}
    ·     ─────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
@@ -44,42 +50,49 @@ source: crates/oxc_linter/src/tester.rs
    ·     ───────
  2 │                 console.log(e);
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = null
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = undefined
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onbeforeunload = null
    ·        ──────────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onbeforeunload = undefined
    ·        ──────────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onbeforeunload = foo
    ·        ──────────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onbeforeunload = () => 'foo'
    ·        ──────────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
@@ -87,6 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ·        ──────────────
  2 │                 return bar;
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
@@ -94,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·        ──────────────
  2 │                 return 'bar';
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
@@ -101,6 +116,7 @@ source: crates/oxc_linter/src/tester.rs
    ·        ──────────────
  2 │                 return;
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
@@ -108,6 +124,7 @@ source: crates/oxc_linter/src/tester.rs
    ·        ──────────────
  2 │                 (() => {
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
@@ -115,6 +132,7 @@ source: crates/oxc_linter/src/tester.rs
    ·        ──────────────
  2 │                 console.log(e);
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:2:17]
@@ -122,6 +140,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             foo.onerror = () => {};
    ·                 ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:2:17]
@@ -129,6 +148,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             foo.onerror = () => {};
    ·                 ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
@@ -136,6 +156,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ───────
  2 │             function bar() {
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:4:21]
@@ -144,93 +165,109 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────
  5 │             }
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:15]
  1 │ myWorker.port.onmessage = function(e) {}
    ·               ─────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:9]
  1 │ ((foo)).onclick = ((0, listener))
    ·         ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onload = window.onunload = function() {};
    ·        ──────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:24]
  1 │ window.onload = window.onunload = function() {};
    ·                        ────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onunload ??= function() {};
    ·        ────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onunload ||= function() {};
    ·        ────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:8]
  1 │ window.onunload += function() {};
    ·        ────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = true
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = 'bar'
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = `bar`
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = {}
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = []
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = void 0
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:5]
  1 │ foo.onclick = new Handler()
    ·     ───────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.
 
   ⚠ eslint-plugin-unicorn(prefer-add-event-listener): Prefer `addEventListener()` over their `on`-function counterparts.
    ╭─[prefer_add_event_listener.tsx:1:21]
  1 │ (el as HTMLElement).onmouseenter = onAnchorMouseEnter;
    ·                     ────────────
    ╰────
+  help: `addEventListener()` can register multiple handlers and accepts options such as `{ once: true }`; assigning to `on<event>` replaces any previously registered handler.


### PR DESCRIPTION
## Summary

Part of the #19121 cleanup — adds actionable `with_help` text to three unicorn rules flagged by `diagnostic-missing-help-or-note.yml` as having no help or note.

### Rules touched

| Rule | Diagnostics | Help text source |
|------|-------------|------------------|
| `unicorn/error_message` | missing_message, empty_message, not_string (3 distinct) | tailored per-diagnostic |
| `unicorn/no_static_only_class` | 1 diagnostic | matches the existing fixer `with_message` so the CLI and fixer stay in sync |
| `unicorn/prefer_add_event_listener` | 1 diagnostic | explains multiple-handlers / `{ once: true }` vs `on<event>` assignment |

### Snapshots

Regenerated via `cargo insta`. For `no_static_only_class`, the help line previously rendered in snapshots only for fixable cases (through the fixer's `with_message`); the diff shows it now appears on non-fixable cases as well, which is the goal.

### Verification

- [x] `cargo check -p oxc_linter` — clean
- [x] `cargo test -p oxc_linter --lib error_message` — passes
- [x] `cargo test -p oxc_linter --lib no_static_only_class` — passes
- [x] `cargo test -p oxc_linter --lib prefer_add_event_listener` — passes

Part of #19121