### PR TITLE
refactor(allocator): use const assertions for `MIN_ALIGN` validation in `Arena` construction methods

### DIFF
--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -166,22 +166,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     ///     assert_eq!((x as *mut _ as usize) % 8, 0, "x is aligned to 8");
     /// }
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid minimum alignments.
     //
     // Because of `rustc`'s poor type inference for default type/const parameters (see the comment above
     // the `impl Arena` block with no const `MIN_ALIGN` parameter), and because we don't want to force everyone
     // to specify a minimum alignment with `Arena::new()` et al, we have a separate constructor
     // for specifying the minimum alignment.
     pub fn with_min_align() -> Self {
-        assert!(MIN_ALIGN.is_power_of_two(), "MIN_ALIGN must be a power of two; found {MIN_ALIGN}");
-        assert!(
-            MIN_ALIGN <= CHUNK_ALIGN,
-            "MIN_ALIGN may not be larger than {CHUNK_ALIGN}; found {MIN_ALIGN}"
-        );
-
         Self::new_impl(EMPTY_CHUNK.get())
     }
 
@@ -211,8 +201,6 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// ```
     ///
     /// # Panics
-    ///
-    /// Panics on invalid minimum alignments.
     ///
     /// Panics if allocating the initial capacity fails.
     pub fn with_min_align_and_capacity(capacity: usize) -> Self {
@@ -246,11 +234,6 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// # }
     /// ```
     ///
-    /// # Panics
-    ///
-    /// * Panics on invalid minimum alignments.
-    /// * Panics if allocating the initial capacity fails.
-    ///
     /// # Errors
     ///
     /// Returns `Err(AllocErr)` if any of:
@@ -262,12 +245,6 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     ///
     /// When `capacity` is 0, no allocation is performed, and `Ok` is always returned.
     pub fn try_with_min_align_and_capacity(capacity: usize) -> Result<Self, AllocErr> {
-        assert!(MIN_ALIGN.is_power_of_two(), "MIN_ALIGN must be a power of two; found {MIN_ALIGN}");
-        assert!(
-            MIN_ALIGN <= CHUNK_ALIGN,
-            "MIN_ALIGN may not be larger than {CHUNK_ALIGN}; found {MIN_ALIGN}"
-        );
-
         if capacity == 0 {
             return Ok(Self::new_impl(EMPTY_CHUNK.get()));
         }
@@ -292,8 +269,15 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Create a new `Arena` from a chunk footer pointer.
     ///
     /// This is a helper function for all code paths which create an `Arena`.
+    /// All code paths which create an `Arena` must go through this method in order to validate `MIN_ALIGN`.
     #[inline(always)]
     pub(super) fn new_impl(chunk_footer_ptr: NonNull<ChunkFooter>) -> Self {
+        // Const assert that `MIN_ALIGN` is valid.
+        // This line must be present - the validation assertions don't run unless the const is referenced
+        // in active code paths. This method is called by all other methods which create an `Arena`,
+        // so we only need it here to ensure that it's impossible to create an `Arena` with an invalid `MIN_ALIGN`.
+        const { Self::MIN_ALIGN };
+
         Self {
             current_chunk_footer: Cell::new(chunk_footer_ptr),
             can_grow: true,

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -28,18 +28,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     ///   from system allocator with alignment of [`CHUNK_ALIGN`] (or caller must wrap the `Arena` in `ManuallyDrop`
     ///   and ensure the backing memory is freed correctly themselves).
     /// * `ptr` must have permission for writes.
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid minimum alignments.
     pub unsafe fn from_raw_parts(ptr: NonNull<u8>, size: usize) -> Self {
-        // Validate `MIN_ALIGN`. These checks will be removed by compiler as `MIN_ALIGN` is statically known.
-        assert!(MIN_ALIGN.is_power_of_two(), "MIN_ALIGN must be a power of two; found {MIN_ALIGN}");
-        assert!(
-            MIN_ALIGN <= CHUNK_ALIGN,
-            "MIN_ALIGN may not be larger than {CHUNK_ALIGN}; found {MIN_ALIGN}"
-        );
-
         // Debug assert that `ptr` and `size` fulfill size and alignment requirements
         debug_assert!((ptr.as_ptr() as usize).is_multiple_of(CHUNK_ALIGN));
         debug_assert!(size.is_multiple_of(CHUNK_ALIGN));

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -170,9 +170,26 @@ pub struct Arena<const MIN_ALIGN: usize = 1> {
 }
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
+    /// Alignment at which all allocations in this arena will be made.
+    ///
+    /// e.g. if `MIN_ALIGN` is 8, then a `u8` allocated in the arena will be placed at an address
+    /// which is a multiple of 8, even though `u8` has no alignment requirements.
+    //
+    // This constant must be referenced in all code paths which create an `Arena`, in order to validate `MIN_ALIGN`.
+    pub const MIN_ALIGN: usize = {
+        assert!(MIN_ALIGN.is_power_of_two(), "MIN_ALIGN must be a power of 2");
+        assert!(MIN_ALIGN <= CHUNK_ALIGN, "MIN_ALIGN may not be larger than `CHUNK_ALIGN`");
+        MIN_ALIGN
+    };
+
     /// Get this arena's minimum alignment.
     ///
-    /// All objects allocated in this arena get aligned to this value.
+    /// All allocations in this arena will be made at an address which is a multiple of this value.
+    ///
+    /// e.g. if `min_align()` is 8, then a `u8` allocated in the arena will be placed at an address
+    /// which is a multiple of 8, even though `u8` has no alignment requirements.
+    ///
+    /// This value is also available as [`MIN_ALIGN`] constant on the [`Arena`] type itself.
     ///
     /// # Example
     ///
@@ -185,10 +202,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// let arena4 = Arena::<4>::with_min_align();
     /// assert_eq!(arena4.min_align(), 4);
     /// ```
-    #[inline]
-    #[expect(clippy::unused_self, reason = "part of public API")]
-    pub fn min_align(&self) -> usize {
-        MIN_ALIGN
+    ///
+    /// [`MIN_ALIGN`]: Self::MIN_ALIGN
+    #[expect(clippy::unused_self)]
+    #[inline(always)]
+    pub const fn min_align(&self) -> usize {
+        Self::MIN_ALIGN
     }
 }
 


### PR DESCRIPTION
Methods that create an `Arena` contain assertions that `MIN_ALIGN` is valid. Convert them to const assertions, so checks happen at build time instead of runtime.

Also expose `MIN_ALIGN` as an associated const.