### PR TITLE
refactor(allocator): rename `ChunkFooter` fields

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -69,19 +69,19 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             let footer_ptr = self.current_chunk_footer.get();
             let footer = footer_ptr.as_ref();
 
-            let ptr = footer.ptr.get().as_ptr();
-            let start = footer.data.as_ptr();
+            let cursor_ptr = footer.cursor_ptr.get().as_ptr();
+            let start_ptr = footer.start_ptr.as_ptr();
             debug_assert!(
-                start <= ptr,
-                "start pointer {start:#p} should be less than or equal to bump pointer {ptr:#p}"
+                start_ptr <= cursor_ptr,
+                "start pointer {start_ptr:#p} should be less than or equal to bump pointer {cursor_ptr:#p}"
             );
             debug_assert!(
-                ptr <= footer_ptr.cast::<u8>().as_ptr(),
-                "bump pointer {ptr:#p} should be less than or equal to footer pointer {footer_ptr:#p}"
+                cursor_ptr <= footer_ptr.cast::<u8>().as_ptr(),
+                "bump pointer {cursor_ptr:#p} should be less than or equal to footer pointer {footer_ptr:#p}"
             );
             debug_assert!(
-                is_pointer_aligned_to(ptr, MIN_ALIGN),
-                "bump pointer {ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
+                is_pointer_aligned_to(cursor_ptr, MIN_ALIGN),
+                "bump pointer {cursor_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
             );
             // This `match` should be boiled away by LLVM: `MIN_ALIGN` is a constant and the layout's alignment
             // is also constant in practice after inlining
@@ -91,12 +91,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                     // This might overflow since we cannot rely on `Layout`'s guarantees.
                     let aligned_size = round_up_to(layout.size(), MIN_ALIGN)?;
 
-                    let capacity = (ptr as usize) - (start as usize);
+                    let capacity = (cursor_ptr as usize) - (start_ptr as usize);
                     if aligned_size > capacity {
                         return None;
                     }
 
-                    ptr.wrapping_sub(aligned_size)
+                    cursor_ptr.wrapping_sub(aligned_size)
                 }
                 Ordering::Equal => {
                     // `Layout` guarantees that rounding the size up to its align cannot overflow
@@ -104,12 +104,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                     // which is why we need to do this rounding)
                     let aligned_size = round_up_to_unchecked(layout.size(), layout.align());
 
-                    let capacity = (ptr as usize) - (start as usize);
+                    let capacity = (cursor_ptr as usize) - (start_ptr as usize);
                     if aligned_size > capacity {
                         return None;
                     }
 
-                    ptr.wrapping_sub(aligned_size)
+                    cursor_ptr.wrapping_sub(aligned_size)
                 }
                 Ordering::Greater => {
                     // `Layout` guarantees that rounding the size up to its align cannot overflow
@@ -117,9 +117,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                     // which is why we need to do this rounding)
                     let aligned_size = round_up_to_unchecked(layout.size(), layout.align());
 
-                    let aligned_ptr = round_mut_ptr_down_to(ptr, layout.align());
-                    let capacity = (aligned_ptr as usize).wrapping_sub(start as usize);
-                    if aligned_ptr < start || aligned_size > capacity {
+                    let aligned_ptr = round_mut_ptr_down_to(cursor_ptr, layout.align());
+                    let capacity = (aligned_ptr as usize).wrapping_sub(start_ptr as usize);
+                    if aligned_ptr < start_ptr || aligned_size > capacity {
                         return None;
                     }
 
@@ -137,14 +137,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 "pointer {aligned_ptr:#p} should be aligned to minimum alignment of {MIN_ALIGN:#}"
             );
             debug_assert!(
-                start <= aligned_ptr && aligned_ptr <= ptr,
-                "pointer {aligned_ptr:#p} should be in range {start:#p}..{ptr:#p}"
+                start_ptr <= aligned_ptr && aligned_ptr <= cursor_ptr,
+                "pointer {aligned_ptr:#p} should be in range {start_ptr:#p}..{cursor_ptr:#p}"
             );
 
             debug_assert!(!aligned_ptr.is_null());
             let aligned_ptr = NonNull::new_unchecked(aligned_ptr);
 
-            footer.ptr.set(aligned_ptr);
+            footer.cursor_ptr.set(aligned_ptr);
             Some(aligned_ptr)
         }
     }
@@ -183,7 +183,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 Self::new_chunk(new_chunk_memory_details, layout, current_footer)
             })?;
 
-            debug_assert_eq!(new_footer.as_ref().data.as_ptr() as usize % layout.align(), 0);
+            debug_assert_eq!(new_footer.as_ref().start_ptr.as_ptr() as usize % layout.align(), 0);
 
             // Set the new chunk as our new current chunk
             self.current_chunk_footer.set(new_footer);
@@ -201,16 +201,16 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // otherwise they are simply leaked - at least until somebody calls `reset()`
         unsafe {
             if self.is_last_allocation(ptr) {
-                let ptr = self.current_chunk_footer.get().as_ref().ptr.get();
-                let ptr = ptr.as_ptr().add(layout.size());
+                let cursor_ptr = self.current_chunk_footer.get().as_ref().cursor_ptr.get();
+                let cursor_ptr = cursor_ptr.as_ptr().add(layout.size());
 
-                let ptr = round_mut_ptr_up_to_unchecked(ptr, MIN_ALIGN);
+                let cursor_ptr = round_mut_ptr_up_to_unchecked(cursor_ptr, MIN_ALIGN);
                 debug_assert!(
-                    is_pointer_aligned_to(ptr, MIN_ALIGN),
-                    "bump pointer {ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
+                    is_pointer_aligned_to(cursor_ptr, MIN_ALIGN),
+                    "bump pointer {cursor_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
                 );
-                let ptr = NonNull::new_unchecked(ptr);
-                self.current_chunk_footer.get().as_ref().ptr.set(ptr);
+                let cursor_ptr = NonNull::new_unchecked(cursor_ptr);
+                self.current_chunk_footer.get().as_ref().cursor_ptr.set(cursor_ptr);
             }
         }
     }
@@ -292,12 +292,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 let footer = footer.as_ref();
 
                 // Note: `new_ptr` is aligned, because ptr *has to* be aligned, and we made sure delta is aligned
-                let new_ptr = NonNull::new_unchecked(footer.ptr.get().as_ptr().add(delta));
+                let new_ptr = NonNull::new_unchecked(footer.cursor_ptr.get().as_ptr().add(delta));
                 debug_assert!(
                     is_pointer_aligned_to(new_ptr.as_ptr(), MIN_ALIGN),
                     "bump pointer {new_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
                 );
-                footer.ptr.set(new_ptr);
+                footer.cursor_ptr.set(new_ptr);
 
                 // Note: We know it is non-overlapping because of the size check in the `if` condition
                 ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
@@ -362,7 +362,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     unsafe fn is_last_allocation(&self, ptr: NonNull<u8>) -> bool {
         let footer = self.current_chunk_footer.get();
         let footer = unsafe { footer.as_ref() };
-        footer.ptr.get() == ptr
+        footer.cursor_ptr.get() == ptr
     }
 }
 

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -21,7 +21,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         let current_footer = self.current_chunk_footer.get();
         let current_footer = unsafe { current_footer.as_ref() };
 
-        current_footer.ptr.get().as_ptr() as usize - current_footer.data.as_ptr() as usize
+        current_footer.cursor_ptr.get().as_ptr() as usize
+            - current_footer.start_ptr.as_ptr() as usize
     }
 
     /// Get an iterator over each chunk of allocated memory that this arena has allocated into.
@@ -152,7 +153,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         unsafe {
             while !footer_ptr.as_ref().is_empty() {
                 total += footer_ptr.as_ref().layout.size() - CHUNK_FOOTER_SIZE;
-                footer_ptr = footer_ptr.as_ref().prev.get();
+                footer_ptr = footer_ptr.as_ref().previous_chunk_footer_ptr.get();
             }
         }
         total
@@ -213,7 +214,7 @@ impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
                 return None;
             }
             let (ptr, len) = foot.as_raw_parts();
-            self.footer = foot.prev.get();
+            self.footer = foot.previous_chunk_footer_ptr.get();
             Some((ptr, len))
         }
     }

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -341,12 +341,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
             debug_assert!(size >= requested_layout.size());
 
-            let data = alloc::alloc(layout);
-            let data = NonNull::new(data)?;
+            let start_ptr = alloc::alloc(layout);
+            let start_ptr = NonNull::new(start_ptr)?;
 
             // The `ChunkFooter` is at the end of the chunk
-            let footer_ptr = data.as_ptr().add(new_size_without_footer);
-            debug_assert_eq!((data.as_ptr() as usize) % align, 0);
+            let footer_ptr = start_ptr.as_ptr().add(new_size_without_footer);
+            debug_assert_eq!((start_ptr.as_ptr() as usize) % align, 0);
             debug_assert_eq!(footer_ptr as usize % CHUNK_ALIGN, 0);
             #[expect(
                 clippy::cast_ptr_alignment,
@@ -357,18 +357,29 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // The bump pointer is initialized to the end of the range we will bump out of, rounded down to
             // the minimum alignment. It is the `NewChunkMemoryDetails` constructor's responsibility to ensure
             // that even after this rounding we have enough non-zero capacity in the chunk.
-            let ptr = round_mut_ptr_down_to(footer_ptr.cast::<u8>(), MIN_ALIGN);
-            debug_assert_eq!(ptr as usize % MIN_ALIGN, 0);
+            let cursor_ptr = round_mut_ptr_down_to(footer_ptr.cast::<u8>(), MIN_ALIGN);
+            debug_assert_eq!(cursor_ptr as usize % MIN_ALIGN, 0);
             debug_assert!(
-                data.as_ptr() <= ptr,
-                "bump pointer {ptr:#p} should still be greater than or equal to the \
-                 start of the bump chunk {data:#p}"
+                start_ptr.as_ptr() <= cursor_ptr,
+                "bump pointer {cursor_ptr:#p} should still be greater than or equal to the \
+                 start of the bump chunk {start_ptr:#p}"
             );
-            debug_assert_eq!((ptr as usize) - (data.as_ptr() as usize), new_size_without_footer);
+            debug_assert_eq!(
+                (cursor_ptr as usize) - (start_ptr.as_ptr() as usize),
+                new_size_without_footer
+            );
 
-            let ptr = Cell::new(NonNull::new_unchecked(ptr));
+            let cursor_ptr = Cell::new(NonNull::new_unchecked(cursor_ptr));
 
-            ptr::write(footer_ptr, ChunkFooter { data, layout, prev: Cell::new(prev), ptr });
+            ptr::write(
+                footer_ptr,
+                ChunkFooter {
+                    start_ptr,
+                    layout,
+                    previous_chunk_footer_ptr: Cell::new(prev),
+                    cursor_ptr,
+                },
+            );
 
             Some(NonNull::new_unchecked(footer_ptr))
         }

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -53,24 +53,26 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             let cur_chunk = self.current_chunk_footer.get();
 
             // Deallocate all chunks except the current one
-            let prev_chunk = cur_chunk.as_ref().prev.replace(EMPTY_CHUNK.get());
+            let prev_chunk =
+                cur_chunk.as_ref().previous_chunk_footer_ptr.replace(EMPTY_CHUNK.get());
             dealloc_chunk_list(prev_chunk);
 
-            // Reset the bump finger to the end of the chunk
+            // Reset the bump cursor to the end of the chunk
             debug_assert!(
                 is_pointer_aligned_to(cur_chunk.as_ptr(), MIN_ALIGN),
                 "bump pointer {cur_chunk:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
             );
-            cur_chunk.as_ref().ptr.set(cur_chunk.cast());
+            cur_chunk.as_ref().cursor_ptr.set(cur_chunk.cast());
 
+            let current_chunk_footer = self.current_chunk_footer.get().as_ref();
             debug_assert!(
-                self.current_chunk_footer.get().as_ref().prev.get().as_ref().is_empty(),
+                current_chunk_footer.previous_chunk_footer_ptr.get().as_ref().is_empty(),
                 "We should only have a single chunk"
             );
             debug_assert_eq!(
-                self.current_chunk_footer.get().as_ref().ptr.get(),
+                current_chunk_footer.cursor_ptr.get(),
                 self.current_chunk_footer.get().cast(),
-                "Our chunk's bump finger should be reset to the start of its allocation"
+                "Our chunk's bump cursor should be reset to the start of its allocation"
             );
         }
     }
@@ -90,8 +92,8 @@ unsafe fn dealloc_chunk_list(mut footer: NonNull<ChunkFooter>) {
     unsafe {
         while !footer.as_ref().is_empty() {
             let f = footer;
-            footer = f.as_ref().prev.get();
-            alloc::dealloc(f.as_ref().data.as_ptr(), f.as_ref().layout);
+            footer = f.as_ref().previous_chunk_footer_ptr.get();
+            alloc::dealloc(f.as_ref().start_ptr.as_ptr(), f.as_ref().layout);
         }
     }
 }

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -45,10 +45,10 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // Caller guarantees region from `ptr` to `ptr + size` forms a single allocation, so it must be a valid layout.
         let layout = unsafe { Layout::from_size_align_unchecked(size, CHUNK_ALIGN) };
         let chunk_footer = ChunkFooter {
-            data: ptr,
+            start_ptr: ptr,
             layout,
-            prev: Cell::new(EMPTY_CHUNK.get()),
-            ptr: Cell::new(chunk_footer_ptr.cast::<u8>()),
+            previous_chunk_footer_ptr: Cell::new(EMPTY_CHUNK.get()),
+            cursor_ptr: Cell::new(chunk_footer_ptr.cast::<u8>()),
         };
 
         // SAFETY: If caller has upheld safety requirements, `chunk_footer_ptr` is `CHUNK_FOOTER_SIZE` bytes
@@ -82,13 +82,13 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // SAFETY: `current_chunk_footer` always points to a valid `ChunkFooter`
         let chunk_footer = unsafe { self.current_chunk_footer.get().as_ref() };
 
-        debug_assert!(ptr.as_ptr() >= chunk_footer.data.as_ptr());
+        debug_assert!(ptr.as_ptr() >= chunk_footer.start_ptr.as_ptr());
         debug_assert!(ptr.as_ptr().cast_const() <= ptr::from_ref(chunk_footer).cast::<u8>());
         debug_assert!(ptr.addr().get().is_multiple_of(MIN_ALIGN));
 
         // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `ptr` is valid
         #[expect(clippy::unnecessary_safety_comment)]
-        chunk_footer.ptr.set(ptr);
+        chunk_footer.cursor_ptr.set(ptr);
     }
 
     /// Get pointer to end of the data region of this [`Arena`]'s current chunk

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -223,19 +223,19 @@ unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 struct ChunkFooter {
     /// Pointer to the start of this chunk allocation.
     /// This footer is always at the end of the chunk.
-    data: NonNull<u8>,
+    start_ptr: NonNull<u8>,
 
     /// The layout of this chunk's allocation.
     layout: Layout,
 
     /// Link to the previous chunk.
     ///
-    /// The last node in the `prev` linked list is the canonical empty chunk, whose `prev` link points to
-    /// itself.
-    prev: Cell<NonNull<ChunkFooter>>,
+    /// The last node in the `previous_chunk_footer_ptr` linked list is the canonical empty chunk,
+    /// whose `previous_chunk_footer_ptr` link points to itself.
+    previous_chunk_footer_ptr: Cell<NonNull<ChunkFooter>>,
 
-    /// Bump allocation finger that is always in the range `self.data..=self`.
-    ptr: Cell<NonNull<u8>>,
+    /// Bump allocation cursor that is always in the range `self.start_ptr..=self`.
+    cursor_ptr: Cell<NonNull<u8>>,
 }
 
 /// We only support alignments of up to 16 bytes for `iter_allocated_chunks`.
@@ -259,14 +259,14 @@ static EMPTY_CHUNK: EmptyChunkFooter = EmptyChunkFooter(ChunkFooter {
     layout: Layout::new::<ChunkFooter>(),
 
     // The start of the (empty) allocatable region for this chunk is itself
-    data: NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>(),
+    start_ptr: NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>(),
 
     // The end of the (empty) allocatable region for this chunk is also itself
-    ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>()),
+    cursor_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>()),
 
-    // Invariant: The last chunk footer in all `ChunkFooter::prev` linked lists is the empty chunk footer,
-    // whose `prev` points to itself
-    prev: Cell::new(NonNull::from_ref(&EMPTY_CHUNK.0)),
+    // Invariant: The last chunk footer in all `ChunkFooter::previous_chunk_footer_ptr` linked lists
+    // is the empty chunk footer, whose `previous_chunk_footer_ptr` points to itself
+    previous_chunk_footer_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK.0)),
 });
 
 impl EmptyChunkFooter {
@@ -278,14 +278,14 @@ impl EmptyChunkFooter {
 impl ChunkFooter {
     /// Returns the start and length of the currently allocated region of this chunk.
     fn as_raw_parts(&self) -> (*mut u8, usize) {
-        let data = self.data.as_ptr().cast_const();
-        let ptr = self.ptr.get().as_ptr();
-        debug_assert!(data <= ptr);
-        debug_assert!(ptr.cast_const() <= ptr::from_ref::<ChunkFooter>(self).cast::<u8>());
-        // SAFETY: `ptr` is always before or equal to footer
-        let len =
-            unsafe { ptr::from_ref::<ChunkFooter>(self).cast::<u8>().offset_from_unsigned(ptr) };
-        (ptr, len)
+        let start_ptr = self.start_ptr.as_ptr().cast_const();
+        let cursor_ptr = self.cursor_ptr.get().as_ptr();
+        let end_ptr = ptr::from_ref(self).cast::<u8>();
+        debug_assert!(start_ptr <= cursor_ptr.cast_const());
+        debug_assert!(cursor_ptr.cast_const() <= end_ptr);
+        // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`
+        let len = unsafe { end_ptr.offset_from_unsigned(cursor_ptr) };
+        (cursor_ptr, len)
     }
 
     /// Returns `true` if this chunk is the empty chunk (end of the linked list).


### PR DESCRIPTION
Pure refactor. Rename the fields of `ChunkFooter` to make them more descriptive.