### PR TITLE
docs(lsp): document Errors on `run_` worker methods

### DIFF
--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -22,10 +22,10 @@ use crate::{
 };
 
 /// A worker that manages the individual tool for a specific workspace
-/// and reports back the results to the [`Backend`](crate::backend::Backend).
+/// and returns back the results of the running tool.
 ///
 /// Each worker is responsible for a specific root URI and configures the tool's `cwd` to that root URI.
-/// The [`Backend`](crate::backend::Backend) is responsible to target the correct worker for a given file URI.
+/// The [`WorkerManager`](crate::worker_manager::WorkerManager) is responsible to target the correct worker for a given file URI.
 pub struct WorkspaceWorker {
     root_uri: Uri,
     tool: RwLock<Option<Box<dyn Tool>>>,
@@ -149,6 +149,9 @@ impl WorkspaceWorker {
     }
 
     /// Run different tools to collect diagnostics.
+    ///
+    /// # Errors
+    /// When calling `Tool::run_diagnostic` results into an error.
     pub async fn run_diagnostic(
         &self,
         document: &TextDocument<'_>,
@@ -158,6 +161,9 @@ impl WorkspaceWorker {
     }
 
     /// Run different tools to collect diagnostics on change.
+    ///
+    /// # Errors
+    /// When calling `Tool::run_diagnostic_on_change` results into an error.
     pub async fn run_diagnostic_on_change(
         &self,
         document: &TextDocument<'_>,
@@ -169,6 +175,9 @@ impl WorkspaceWorker {
     }
 
     /// Run different tools to collect diagnostics on save.
+    ///
+    /// # Errors
+    /// When calling `Tool::run_diagnostic_on_save` results into an error.
     pub async fn run_diagnostic_on_save(
         &self,
         document: &TextDocument<'_>,
@@ -183,6 +192,9 @@ impl WorkspaceWorker {
     /// - If the file is not formattable or is ignored, an empty vector is returned
     /// - If the file is formattable, but no changes are made, an empty vector is returned
     /// - If a tool error occurs, an Err is returned
+    ///
+    /// # Errors
+    /// When calling `Tool::run_format` results into an error.
     pub async fn format_file(&self, document: &TextDocument<'_>) -> Result<Vec<TextEdit>, String> {
         let tool_guard = self.tool.read().await;
         let Some(tool) = tool_guard.as_ref() else {


### PR DESCRIPTION
Added some error docs, for later when we "maybe" make the Worker & Manager public.
Should not be wrong to have it even when we not make it public :) 