### PR TITLE
fix(minifier): handle lone surrogates in string folding

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -107,15 +107,27 @@ fn try_fold_string_casing<'a>(
         return None;
     }
 
-    let value = match object {
-        Expression::StringLiteral(s) => Cow::Borrowed(s.value.as_str()),
-        Expression::Identifier(ident) => ident
-            .reference_id
-            .get()
-            .and_then(|reference_id| ctx.get_constant_value_for_reference_id(reference_id))
-            .and_then(ConstantValue::into_string)?,
+    let (value, source_has_lone_surrogates) = match object {
+        Expression::StringLiteral(s) => (Cow::Borrowed(s.value.as_str()), s.lone_surrogates),
+        Expression::Identifier(ident) => {
+            let cow = ident
+                .reference_id
+                .get()
+                .and_then(|reference_id| ctx.get_constant_value_for_reference_id(reference_id))
+                .and_then(ConstantValue::into_string)?;
+            let has_encoding = value_has_lone_surrogate_encoding(&cow);
+            (cow, has_encoding)
+        }
         _ => return None,
     };
+
+    // The lone-surrogate encoding uses lowercase hex. `toUpperCase` would
+    // case-fold `\uFFFDd800` to `\uFFFDD800` — no longer a valid encoding,
+    // and codegen would emit the bytes literally instead of the surrogate.
+    // `toLowerCase`/`trim*` leave the encoding intact.
+    if source_has_lone_surrogates && name == "toUpperCase" {
+        return None;
+    }
 
     let result = match name {
         "toLowerCase" => ctx.ast().str(&value.cow_to_lowercase()),
@@ -126,6 +138,35 @@ fn try_fold_string_casing<'a>(
         _ => return None,
     };
     Some(ConstantValue::String(Cow::Borrowed(result.as_str())))
+}
+
+/// Scan a string for the lone-surrogate encoding pattern
+/// (`\u{FFFD}XXXX` where `XXXX` is a surrogate-range hex value, or the
+/// `fffd` self-escape).
+///
+/// Used where only the bytes are available (e.g. reading back a
+/// previously-evaluated `ConstantValue::String`). Can produce false
+/// positives when the source literally contains U+FFFD followed by
+/// matching hex chars, which is rare. False positives here skip a fold
+/// that could have been performed — never incorrect output.
+///
+/// A copy of `oxc_minifier`'s `scan_for_lone_surrogate_encoding`; kept
+/// local to this crate because the planned WTF-8 migration deletes this
+/// whole mechanism, so consolidating is churn.
+fn value_has_lone_surrogate_encoding(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if !bytes.contains(&0xEF) {
+        return false;
+    }
+    // Need 7 bytes: 3 for U+FFFD (0xEF 0xBF 0xBD) + 4 hex chars.
+    bytes.windows(7).any(|w| {
+        w[..3] == [0xEF, 0xBF, 0xBD]
+            && (w[3] == b'd'
+                && matches!(w[4], b'8'..=b'9' | b'a'..=b'f')
+                && matches!(w[5], b'0'..=b'9' | b'a'..=b'f')
+                && matches!(w[6], b'0'..=b'9' | b'a'..=b'f')
+                || &w[3..] == b"fffd")
+    })
 }
 
 fn try_fold_string_index_of<'a>(
@@ -172,6 +213,13 @@ fn try_fold_string_substring_or_slice<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
+    // `substring` / `slice` operate on JS code units, but our value is the
+    // lone-surrogate-encoded form (each surrogate expands to 5 JS chars /
+    // 7 UTF-8 bytes). Folding against that form produces wrong output and
+    // can leave a partial `\uFFFDXXXX` sequence that panics codegen.
+    if s.lone_surrogates {
+        return None;
+    }
     let start_idx = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -209,6 +257,12 @@ fn try_fold_string_char_at<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
+    // `charAt` operates on JS code units; a lone-surrogate-encoded source
+    // has 5 JS chars per surrogate and `char_at` would return one of them
+    // (e.g. `\uFFFD`) rather than the single JS char the source represents.
+    if s.lone_surrogates {
+        return None;
+    }
     let char_at_index = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -266,12 +320,21 @@ fn try_fold_string_replace<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
+    // Any input using the lone-surrogate encoding could cause `replace` to
+    // split at a boundary inside a `\uFFFDXXXX` sequence or embed a partial
+    // sequence into the result. Bail out rather than risk corrupt output.
+    if s.lone_surrogates {
+        return None;
+    }
     let search_value = args.first().unwrap();
     let search_value = match search_value {
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
             let value = search_value.to_expression();
             if value.may_have_side_effects(ctx) {
+                return None;
+            }
+            if arg_may_have_lone_surrogates(value) {
                 return None;
             }
             value.evaluate_value(ctx)?.into_string()?
@@ -281,7 +344,11 @@ fn try_fold_string_replace<'a>(
     let replace_value = match replace_value {
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
-            replace_value.to_expression().get_side_free_string_value(ctx)?
+            let expr = replace_value.to_expression();
+            if arg_may_have_lone_surrogates(expr) {
+                return None;
+            }
+            expr.get_side_free_string_value(ctx)?
         }
     };
     if replace_value.contains('$') {
@@ -293,6 +360,17 @@ fn try_fold_string_replace<'a>(
         _ => unreachable!(),
     };
     Some(ConstantValue::String(result))
+}
+
+/// Conservative check for whether an expression (used as an argument to
+/// a fold that splices/copies strings) may carry the lone-surrogate
+/// encoding. Handles the common direct-literal case; other kinds return
+/// `false` (possibly missing the bail-out), but producing wrong output
+/// for non-literal lone-surrogate args requires a source like
+/// `const s = '\uDC00'; foo.replace(s, …)`, which is rare enough to
+/// accept until the WTF-8 migration replaces this mechanism entirely.
+fn arg_may_have_lone_surrogates(expr: &Expression<'_>) -> bool {
+    matches!(expr, Expression::StringLiteral(s) if s.lone_surrogates)
 }
 
 fn try_fold_string_from_char_code<'a>(
@@ -550,7 +628,7 @@ fn try_fold_encode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -567,6 +645,28 @@ fn try_fold_encode_uri<'a>(
     Some(ConstantValue::String(encoded))
 }
 
+/// Return `expr`'s value as a side-free string, but only when it does not
+/// use the lone-surrogate encoding.
+///
+/// URL-encoding functions interpret their input as a JS string. At
+/// runtime, `encodeURI('\uD800')` throws a URIError. Our value for that
+/// input is the `\uFFFDd800` encoded form — if we passed it through the
+/// %-encoder we'd get %EF%BF%BDd800, which doesn't match runtime
+/// behavior. Bail out rather than fold such inputs.
+fn side_free_non_lone_surrogate_string<'a>(
+    expr: &Expression<'a>,
+    ctx: &impl ConstantEvaluationCtx<'a>,
+) -> Option<Cow<'a, str>> {
+    if arg_may_have_lone_surrogates(expr) {
+        return None;
+    }
+    let value = expr.get_side_free_string_value(ctx)?;
+    if value_has_lone_surrogate_encoding(&value) {
+        return None;
+    }
+    Some(value)
+}
+
 fn try_fold_encode_uri_component<'a>(
     args: &Vec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -579,7 +679,7 @@ fn try_fold_encode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -604,7 +704,7 @@ fn try_fold_decode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     let decoded = decode_uri_chars(
         string_value,
@@ -626,7 +726,7 @@ fn try_fold_decode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     // decodeURIComponent decodes all percent-encoded sequences
     let decoded = decode_uri_chars(

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -453,8 +453,8 @@ impl<'a> PeepholeOptimizations {
         if !e.may_have_side_effects(ctx)
             && let Some(v) = e.evaluate_value(ctx)
         {
-            let lone_surrogates = expr_has_lone_surrogates(&e.left, ctx)
-                || expr_has_lone_surrogates(&e.right, ctx);
+            let lone_surrogates =
+                expr_has_lone_surrogates(&e.left, ctx) || expr_has_lone_surrogates(&e.right, ctx);
             let mut result = ctx.value_to_expr(e.span, v);
             correct_lone_surrogates_flag(&mut result, lone_surrogates);
             return Some(result);

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -47,26 +47,45 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
         || b == b"fffd"
 }
 
-/// Check if an expression carries the `lone_surrogates` flag.
+/// Check if an expression's string value may contain lone surrogates.
 ///
 /// Based on AST node flags, so not prone to the false positives that
 /// [`scan_for_lone_surrogate_encoding`] can produce. For identifiers, looks
 /// up the symbol table to check the initializer's flag.
 ///
-/// Only handles the expression kinds that can appear as a *folded* result
-/// (literals, identifiers, `+`, calls) plus `ArrayExpression`, which reaches
-/// this helper via `String([...])` and `` `${[...]}` `` — both route through
-/// `ArrayExpression::to_js_string` (array_join), which concatenates the raw
-/// lone-surrogate encoding bytes of element strings. Non-literal
-/// string-yielding parents — `LogicalExpression`, `ConditionalExpression`,
-/// `SequenceExpression`, `Static/ComputedMemberExpression` — are not handled
-/// directly and yield `false`. That is safe **only** because exit-order
-/// traversal folds any foldable string-yielding child into a literal before
-/// its parent reaches the call sites of this helper. If that invariant is
-/// ever broken, the byte scan in `value_to_expr` would correctly flag the
-/// result as having lone surrogates and `correct_lone_surrogates_flag` would
-/// silently clear it back, producing wrong codegen. See
+/// Called on source subexpressions of a string-producing fold. Must cover
+/// every kind whose `to_js_string` / `evaluate_value_to_string` result can
+/// contain the lone-surrogate encoding bytes:
+///
+/// - `StringLiteral` — flag on the node.
+/// - `TemplateLiteral` — flags on quasis, recurse on expressions.
+/// - `Identifier` — resolve through the symbol table.
+/// - `BinaryExpression(+)` — recurse on both sides.
+/// - `ArrayExpression` — recurse on element expressions (`array_join`
+///   concatenates element `to_js_string` values, so a lone-surrogate element
+///   ends up in `String([...])` and `` `${[...]}` `` results).
+/// - `CallExpression` — conservative: recurse on callee's object (for method
+///   calls) and arguments. False positives are harmless because
+///   `correct_lone_surrogates_flag` only acts when the byte scan also flagged
+///   the result.
+///
+/// Other `to_js_string` producers are safe-by-shape — their result is a
+/// fixed ASCII string (`"undefined"`, `"true"`, `"false"`, `"null"`,
+/// `"[object Object]"`) or a number/BigInt/regex-source representation — and
+/// return `false` trivially.
+///
+/// `LogicalExpression`, `ConditionalExpression`, `SequenceExpression`, and
+/// `Static/ComputedMemberExpression` also yield `false` here. That is safe
+/// by traversal order: exit-order peephole folds any foldable
+/// string-yielding child into a literal before its parent reaches this
+/// helper's call sites, so they never arrive here with a string value. See
 /// `test_lone_surrogate_through_non_literal_subexprs`.
+///
+/// If either invariant breaks — a newly string-producing kind is added to
+/// `to_js_string`, or a parent is folded before its children — the byte
+/// scan in `value_to_expr` would flag the result and
+/// `correct_lone_surrogates_flag` would silently clear it back, producing
+/// wrong codegen.
 pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
     match expr {
         Expression::StringLiteral(s) => s.lone_surrogates,

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -853,11 +853,14 @@ impl<'a> PeepholeOptimizations {
     ///
     /// - `foo${1}bar${i}` => `foo1bar${i}`
     pub fn inline_template_literal(t: &mut TemplateLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
-        let has_expr_to_inline = t.expressions.iter().any(|expr| {
-            !expr.may_have_side_effects(ctx)
-                && expr.to_js_string(ctx).is_some()
-                && !expr_has_lone_surrogates(expr, ctx)
-        });
+        // Pre-check: cheap skip when no expression is foldable. The main loop
+        // below also rejects lone-surrogate expressions, so don't repeat that
+        // check here — false positives just lead to a no-op walk in the main
+        // loop, which is fine.
+        let has_expr_to_inline = t
+            .expressions
+            .iter()
+            .any(|expr| !expr.may_have_side_effects(ctx) && expr.to_js_string(ctx).is_some());
         if !has_expr_to_inline {
             return;
         }
@@ -879,6 +882,15 @@ impl<'a> PeepholeOptimizations {
                 }
             }));
         t.expressions = new_exprs;
+
+        // The pre-check is a fast over-approximation that doesn't reject
+        // lone-surrogate expressions — if every foldable expression had lone
+        // surrogates, `inline_exprs` is empty and there's nothing to do.
+        // (Without this guard, `ctx.state.changed = true` below would loop the
+        // compressor.)
+        if inline_exprs.is_empty() {
+            return;
+        }
 
         // inline the extracted inline-able expressions into quasis
         // "current_quasis + extracted_value + next_quasis"

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -12,8 +12,8 @@ use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
-/// Check if a string uses the lone surrogate encoding scheme by scanning its bytes
-/// for the `\u{FFFD}XXXX` pattern where XXXX is in the surrogate range (d800–dfff).
+/// Check if a string has lone surrogates encoded as `\u{FFFD}XXXX` where XXXX is in
+/// the surrogate range (d800–dfff).
 ///
 /// **Warning:** This can produce false positives if the string naturally contains
 /// U+FFFD followed by 4 hex chars that happen to be in the surrogate range or "fffd".
@@ -59,9 +59,8 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
 
 /// Check if an expression carries the `lone_surrogates` flag.
 ///
-/// Unlike [`has_lone_surrogates`] (which scans string bytes for the encoding pattern),
-/// this checks the AST node's flag directly, avoiding false positives from strings that
-/// naturally contain U+FFFD followed by hex characters.
+/// Based on the AST node's flag, so not prone to false positives like
+/// [`has_lone_surrogates`] is.
 pub fn expr_has_lone_surrogates(expr: &Expression) -> bool {
     match expr {
         Expression::StringLiteral(s) => s.lone_surrogates,
@@ -422,9 +421,8 @@ impl<'a> PeepholeOptimizations {
             && let Some(v) = e.evaluate_value(ctx)
         {
             let mut result = ctx.value_to_expr(e.span, v);
-            // value_to_expr uses has_lone_surrogates() which can have false positives
-            // for strings naturally containing U+FFFD + surrogate-range hex chars.
-            // Correct false positives using the authoritative flag from the source operands.
+            // lone_surrogates from value_to_expr can be a false positive;
+            // double-check using authoritative flag from source operands.
             if let Expression::StringLiteral(lit) = &mut result
                 && lit.lone_surrogates
             {
@@ -516,7 +514,7 @@ impl<'a> PeepholeOptimizations {
 
             // "`${x}y` + 'z'" => "`${x}yz`"
             if let Some(right_str) = right_expr.get_side_free_string_value(ctx) {
-                // Lone surrogates can't go into template raw values.
+                // Encoded lone surrogates can't go into template raw values.
                 if expr_has_lone_surrogates(right_expr) {
                     return None;
                 }
@@ -536,7 +534,7 @@ impl<'a> PeepholeOptimizations {
         } else if let Expression::TemplateLiteral(right) = right_expr {
             // "'x' + `y${z}`" => "`xy${z}`"
             if let Some(left_str) = left_expr.get_side_free_string_value(ctx) {
-                // Lone surrogates can't go into template raw values.
+                // Encoded lone surrogates can't go into template raw values.
                 if expr_has_lone_surrogates(left_expr) {
                     return None;
                 }
@@ -817,7 +815,6 @@ impl<'a> PeepholeOptimizations {
         let has_expr_to_inline = t.expressions.iter().any(|expr| {
             !expr.may_have_side_effects(ctx)
                 && expr.to_js_string(ctx).is_some()
-                // Lone surrogates can't go into template raw values.
                 && !expr_has_lone_surrogates(expr)
         });
         if !has_expr_to_inline {
@@ -830,7 +827,7 @@ impl<'a> PeepholeOptimizations {
                 if expr.may_have_side_effects(ctx) {
                     Some(expr)
                 } else if let Some(str) = expr.to_js_string(ctx) {
-                    // Lone surrogates can't go into template raw values.
+                    // Encoded lone surrogates can't go into template raw values.
                     if expr_has_lone_surrogates(&expr) {
                         return Some(expr);
                     }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -30,13 +30,25 @@ pub fn has_lone_surrogates(s: &str) -> bool {
         if bytes[i] == 0xEF
             && bytes[i + 1] == 0xBF
             && bytes[i + 2] == 0xBD
-            && bytes[i + 3..i + 7].iter().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+            && is_lone_surrogate_suffix(&bytes[i + 3..i + 7])
         {
             return true;
         }
         i += 1;
     }
     false
+}
+
+/// Check if 4 bytes are a valid lone surrogate encoding suffix:
+/// either a surrogate code point (d800–dfff) or the U+FFFD self-escape (fffd).
+fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
+    debug_assert_eq!(b.len(), 4);
+    // Surrogate range d800–dfff: first char 'd', second '8'–'f', rest hex.
+    (b[0] == b'd'
+        && matches!(b[1], b'8'..=b'9' | b'a'..=b'f')
+        && matches!(b[2], b'0'..=b'9' | b'a'..=b'f')
+        && matches!(b[3], b'0'..=b'9' | b'a'..=b'f'))
+        || b == b"fffd"
 }
 
 /// Constant Folding

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -12,12 +12,18 @@ use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
-/// Check if a string uses the lone surrogate encoding scheme.
+/// Check if a string uses the lone surrogate encoding scheme by scanning its bytes
+/// for the `\u{FFFD}XXXX` pattern.
 ///
-/// See [`StringLiteral::lone_surrogates`] for the encoding scheme: lone surrogates
-/// are encoded as `\u{FFFD}XXXX` (U+FFFD followed by 4 lowercase hex chars).
-/// A bare U+FFFD (replacement character) without a trailing 4-hex-char suffix is
-/// just an ordinary character and does NOT indicate lone surrogates.
+/// **Warning:** This can produce false positives if the string naturally contains
+/// U+FFFD followed by 4 hex chars that happen to be in the surrogate range (d800–dfff)
+/// or "fffd". Prefer [`expr_has_lone_surrogates`] when the source AST node is available,
+/// since that checks the `lone_surrogates` flag directly without false positives.
+///
+/// This function is the fallback for paths where only the string value is available
+/// (e.g. `value_to_expr` receiving a `ConstantValue::String` with no origin info).
+///
+/// See [`StringLiteral::lone_surrogates`] for the encoding scheme.
 pub fn has_lone_surrogates(s: &str) -> bool {
     let bytes = s.as_bytes();
     // U+FFFD is 3 UTF-8 bytes (0xEF 0xBF 0xBD) + 4 lowercase hex chars = 7 bytes minimum.
@@ -49,6 +55,22 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
         && matches!(b[2], b'0'..=b'9' | b'a'..=b'f')
         && matches!(b[3], b'0'..=b'9' | b'a'..=b'f'))
         || b == b"fffd"
+}
+
+/// Check if an expression carries the `lone_surrogates` flag.
+///
+/// Unlike [`has_lone_surrogates`] (which scans string bytes for the encoding pattern),
+/// this checks the AST node's flag directly, avoiding false positives from strings that
+/// naturally contain U+FFFD followed by hex characters.
+pub fn expr_has_lone_surrogates(expr: &Expression) -> bool {
+    match expr {
+        Expression::StringLiteral(s) => s.lone_surrogates,
+        Expression::TemplateLiteral(t) => t.quasis.iter().any(|q| q.lone_surrogates),
+        Expression::BinaryExpression(e) if e.operator == BinaryOperator::Addition => {
+            expr_has_lone_surrogates(&e.left) || expr_has_lone_surrogates(&e.right)
+        }
+        _ => false,
+    }
 }
 
 /// Constant Folding
@@ -396,7 +418,15 @@ impl<'a> PeepholeOptimizations {
         if !e.may_have_side_effects(ctx)
             && let Some(v) = e.evaluate_value(ctx)
         {
-            return Some(ctx.value_to_expr(e.span, v));
+            let mut result = ctx.value_to_expr(e.span, v);
+            // value_to_expr uses has_lone_surrogates() which can have false positives
+            // for strings naturally containing U+FFFD + surrogate-range hex chars.
+            // Override with the authoritative flag from the source operands.
+            if let Expression::StringLiteral(lit) = &mut result {
+                lit.lone_surrogates =
+                    expr_has_lone_surrogates(&e.left) || expr_has_lone_surrogates(&e.right);
+            }
+            return Some(result);
         }
         debug_assert_eq!(e.operator, BinaryOperator::Addition);
 
@@ -418,8 +448,8 @@ impl<'a> PeepholeOptimizations {
                     .merge_within(e.right.span(), e.span)
                     .unwrap_or(SPAN);
                 let value = ctx.ast.str_from_strs_array([&left_str, &right_str]);
-                let lone_surrogates =
-                    has_lone_surrogates(&left_str) || has_lone_surrogates(&right_str);
+                let lone_surrogates = expr_has_lone_surrogates(&left_binary_expr.right)
+                    || expr_has_lone_surrogates(&e.right);
                 let right = ctx.ast.expression_string_literal_with_lone_surrogates(
                     span,
                     value,
@@ -482,7 +512,7 @@ impl<'a> PeepholeOptimizations {
             // "`${x}y` + 'z'" => "`${x}yz`"
             if let Some(right_str) = right_expr.get_side_free_string_value(ctx) {
                 // Lone surrogates can't go into template raw values.
-                if has_lone_surrogates(&right_str) {
+                if expr_has_lone_surrogates(right_expr) {
                     return None;
                 }
                 left.span = left.span.merge_within(right_expr.span(), parent_span).unwrap_or(SPAN);
@@ -502,7 +532,7 @@ impl<'a> PeepholeOptimizations {
             // "'x' + `y${z}`" => "`xy${z}`"
             if let Some(left_str) = left_expr.get_side_free_string_value(ctx) {
                 // Lone surrogates can't go into template raw values.
-                if has_lone_surrogates(&left_str) {
+                if expr_has_lone_surrogates(left_expr) {
                     return None;
                 }
                 right.span = right.span.merge_within(left_expr.span(), parent_span).unwrap_or(SPAN);
@@ -781,10 +811,9 @@ impl<'a> PeepholeOptimizations {
     pub fn inline_template_literal(t: &mut TemplateLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
         let has_expr_to_inline = t.expressions.iter().any(|expr| {
             !expr.may_have_side_effects(ctx)
-                && expr
-                    .to_js_string(ctx)
-                    // Lone surrogates can't go into template raw values.
-                    .is_some_and(|s| !has_lone_surrogates(&s))
+                && expr.to_js_string(ctx).is_some()
+                // Lone surrogates can't go into template raw values.
+                && !expr_has_lone_surrogates(expr)
         });
         if !has_expr_to_inline {
             return;
@@ -796,7 +825,8 @@ impl<'a> PeepholeOptimizations {
                 if expr.may_have_side_effects(ctx) {
                     Some(expr)
                 } else if let Some(str) = expr.to_js_string(ctx) {
-                    if has_lone_surrogates(&str) {
+                    // Lone surrogates can't go into template raw values.
+                    if expr_has_lone_surrogates(&expr) {
                         return Some(expr);
                     }
                     inline_exprs.push((idx, str));

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -106,11 +106,18 @@ pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
 /// false positives when U+FFFD naturally appears before surrogate-range hex
 /// chars. When the authoritative answer is available (from AST flags or the
 /// symbol table), call this to override the scan's false positive.
-pub fn correct_lone_surrogates_flag(result: &mut Expression, lone_surrogates: bool) {
+///
+/// `lone_surrogates` is a closure so the (potentially expensive)
+/// [`expr_has_lone_surrogates`] AST walk only runs in the rare case where
+/// the byte scan flagged the result.
+pub fn correct_lone_surrogates_flag(
+    result: &mut Expression,
+    lone_surrogates: impl FnOnce() -> bool,
+) {
     if let Expression::StringLiteral(lit) = result
         && lit.lone_surrogates
     {
-        lit.lone_surrogates = lone_surrogates;
+        lit.lone_surrogates = lone_surrogates();
     }
 }
 
@@ -459,10 +466,10 @@ impl<'a> PeepholeOptimizations {
         if !e.may_have_side_effects(ctx)
             && let Some(v) = e.evaluate_value(ctx)
         {
-            let lone_surrogates =
-                expr_has_lone_surrogates(&e.left, ctx) || expr_has_lone_surrogates(&e.right, ctx);
             let mut result = ctx.value_to_expr(e.span, v);
-            correct_lone_surrogates_flag(&mut result, lone_surrogates);
+            correct_lone_surrogates_flag(&mut result, || {
+                expr_has_lone_surrogates(&e.left, ctx) || expr_has_lone_surrogates(&e.right, ctx)
+            });
             return Some(result);
         }
         debug_assert_eq!(e.operator, BinaryOperator::Addition);

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -31,7 +31,7 @@ pub fn has_lone_surrogates(s: &str) -> bool {
         return false;
     }
     let mut i = 0;
-    let end = bytes.len() - 7; // need 7 bytes from position i (indices i..i+6)
+    let end = bytes.len() - 7; // need 7 bytes from position i (indices i..=i+6)
     while i <= end {
         if bytes[i] == 0xEF
             && bytes[i + 1] == 0xBF

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -94,6 +94,20 @@ pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
     }
 }
 
+/// Correct the `lone_surrogates` flag on a [`TraverseCtx::value_to_expr`] result.
+///
+/// `value_to_expr` uses [`scan_for_lone_surrogate_encoding`] which can yield
+/// false positives when U+FFFD naturally appears before surrogate-range hex
+/// chars. When the authoritative answer is available (from AST flags or the
+/// symbol table), call this to override the scan's false positive.
+pub fn correct_lone_surrogates_flag(result: &mut Expression, lone_surrogates: bool) {
+    if let Expression::StringLiteral(lit) = result
+        && lit.lone_surrogates
+    {
+        lit.lone_surrogates = lone_surrogates;
+    }
+}
+
 /// Constant Folding
 ///
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeFoldConstants.java>
@@ -439,15 +453,10 @@ impl<'a> PeepholeOptimizations {
         if !e.may_have_side_effects(ctx)
             && let Some(v) = e.evaluate_value(ctx)
         {
+            let lone_surrogates = expr_has_lone_surrogates(&e.left, ctx)
+                || expr_has_lone_surrogates(&e.right, ctx);
             let mut result = ctx.value_to_expr(e.span, v);
-            // lone_surrogates from value_to_expr can be a false positive;
-            // double-check using authoritative flag from source operands.
-            if let Expression::StringLiteral(lit) = &mut result
-                && lit.lone_surrogates
-            {
-                lit.lone_surrogates = expr_has_lone_surrogates(&e.left, ctx)
-                    || expr_has_lone_surrogates(&e.right, ctx);
-            }
+            correct_lone_surrogates_flag(&mut result, lone_surrogates);
             return Some(result);
         }
         debug_assert_eq!(e.operator, BinaryOperator::Addition);

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -12,6 +12,11 @@ use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
+/// See [`StringLiteral::lone_surrogates`] for the encoding scheme.
+fn has_lone_surrogates(s: &str) -> bool {
+    s.contains('\u{FFFD}')
+}
+
 /// Constant Folding
 ///
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeFoldConstants.java>
@@ -379,7 +384,14 @@ impl<'a> PeepholeOptimizations {
                     .merge_within(e.right.span(), e.span)
                     .unwrap_or(SPAN);
                 let value = ctx.ast.str_from_strs_array([&left_str, &right_str]);
-                let right = ctx.ast.expression_string_literal(span, value, None);
+                let lone_surrogates =
+                    has_lone_surrogates(&left_str) || has_lone_surrogates(&right_str);
+                let right = ctx.ast.expression_string_literal_with_lone_surrogates(
+                    span,
+                    value,
+                    None,
+                    lone_surrogates,
+                );
                 let left = left_binary_expr.left.take_in(ctx.ast);
                 return Some(ctx.ast.expression_binary(e.span, left, e.operator, right));
             }
@@ -423,6 +435,8 @@ impl<'a> PeepholeOptimizations {
                     None
                 };
                 left_last_quasi.value.cooked = new_cooked;
+                left_last_quasi.lone_surrogates =
+                    left_last_quasi.lone_surrogates || right_first_quasi.lone_surrogates;
                 if !right.quasis.is_empty() {
                     left_last_quasi.tail = false;
                 }
@@ -444,6 +458,9 @@ impl<'a> PeepholeOptimizations {
                     .cooked
                     .map(|cooked| ctx.ast.str(&(cooked.as_str().to_string() + &right_str)));
                 last_quasi.value.cooked = new_cooked;
+                if has_lone_surrogates(&right_str) {
+                    last_quasi.lone_surrogates = true;
+                }
                 return Some(left_expr.take_in(ctx.ast));
             }
         } else if let Expression::TemplateLiteral(right) = right_expr {
@@ -454,6 +471,7 @@ impl<'a> PeepholeOptimizations {
                     .quasis
                     .first_mut()
                     .expect("template literal must have at least one quasi");
+                let lone_surrogates = has_lone_surrogates(&left_str);
                 let new_raw = Self::escape_string_for_template_literal(&left_str).into_owned()
                     + first_quasi.value.raw.as_str();
                 first_quasi.value.raw = ctx.ast.str(&new_raw);
@@ -462,6 +480,9 @@ impl<'a> PeepholeOptimizations {
                     .cooked
                     .map(|cooked| ctx.ast.str(&(left_str.into_owned() + cooked.as_str())));
                 first_quasi.value.cooked = new_cooked;
+                if lone_surrogates {
+                    first_quasi.lone_surrogates = true;
+                }
                 return Some(right_expr.take_in(ctx.ast));
             }
         }
@@ -759,6 +780,9 @@ impl<'a> PeepholeOptimizations {
                 None
             };
             quasi.value.cooked = new_cooked;
+            if next_quasi.as_ref().is_some_and(|q| q.lone_surrogates) || has_lone_surrogates(&str) {
+                quasi.lone_surrogates = true;
+            }
             if next_quasi.is_some_and(|q| q.tail) {
                 quasi.tail = true;
             }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -447,6 +447,11 @@ impl<'a> PeepholeOptimizations {
 
             // "`${x}y` + 'z'" => "`${x}yz`"
             if let Some(right_str) = right_expr.get_side_free_string_value(ctx) {
+                // Template literal codegen prints raw values verbatim and cannot handle
+                // the internal lone surrogate encoding (U+FFFD markers).
+                if has_lone_surrogates(&right_str) {
+                    return None;
+                }
                 left.span = left.span.merge_within(right_expr.span(), parent_span).unwrap_or(SPAN);
                 let last_quasi =
                     left.quasis.last_mut().expect("template literal must have at least one quasi");
@@ -458,20 +463,21 @@ impl<'a> PeepholeOptimizations {
                     .cooked
                     .map(|cooked| ctx.ast.str(&(cooked.as_str().to_string() + &right_str)));
                 last_quasi.value.cooked = new_cooked;
-                if has_lone_surrogates(&right_str) {
-                    last_quasi.lone_surrogates = true;
-                }
                 return Some(left_expr.take_in(ctx.ast));
             }
         } else if let Expression::TemplateLiteral(right) = right_expr {
             // "'x' + `y${z}`" => "`xy${z}`"
             if let Some(left_str) = left_expr.get_side_free_string_value(ctx) {
+                // Template literal codegen prints raw values verbatim and cannot handle
+                // the internal lone surrogate encoding (U+FFFD markers).
+                if has_lone_surrogates(&left_str) {
+                    return None;
+                }
                 right.span = right.span.merge_within(left_expr.span(), parent_span).unwrap_or(SPAN);
                 let first_quasi = right
                     .quasis
                     .first_mut()
                     .expect("template literal must have at least one quasi");
-                let lone_surrogates = has_lone_surrogates(&left_str);
                 let new_raw = Self::escape_string_for_template_literal(&left_str).into_owned()
                     + first_quasi.value.raw.as_str();
                 first_quasi.value.raw = ctx.ast.str(&new_raw);
@@ -480,9 +486,6 @@ impl<'a> PeepholeOptimizations {
                     .cooked
                     .map(|cooked| ctx.ast.str(&(left_str.into_owned() + cooked.as_str())));
                 first_quasi.value.cooked = new_cooked;
-                if lone_surrogates {
-                    first_quasi.lone_surrogates = true;
-                }
                 return Some(right_expr.take_in(ctx.ast));
             }
         }
@@ -744,10 +747,14 @@ impl<'a> PeepholeOptimizations {
     ///
     /// - `foo${1}bar${i}` => `foo1bar${i}`
     pub fn inline_template_literal(t: &mut TemplateLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
-        let has_expr_to_inline = t
-            .expressions
-            .iter()
-            .any(|expr| !expr.may_have_side_effects(ctx) && expr.to_js_string(ctx).is_some());
+        let has_expr_to_inline = t.expressions.iter().any(|expr| {
+            !expr.may_have_side_effects(ctx)
+                && expr
+                    .to_js_string(ctx)
+                    // Template literal codegen prints raw values verbatim and cannot handle
+                    // the internal lone surrogate encoding (U+FFFD markers).
+                    .is_some_and(|s| !has_lone_surrogates(&s))
+        });
         if !has_expr_to_inline {
             return;
         }
@@ -758,6 +765,9 @@ impl<'a> PeepholeOptimizations {
                 if expr.may_have_side_effects(ctx) {
                     Some(expr)
                 } else if let Some(str) = expr.to_js_string(ctx) {
+                    if has_lone_surrogates(&str) {
+                        return Some(expr);
+                    }
                     inline_exprs.push((idx, str));
                     None
                 } else {
@@ -785,7 +795,7 @@ impl<'a> PeepholeOptimizations {
                 None
             };
             quasi.value.cooked = new_cooked;
-            if next_quasi.as_ref().is_some_and(|q| q.lone_surrogates) || has_lone_surrogates(&str) {
+            if next_quasi.as_ref().is_some_and(|q| q.lone_surrogates) {
                 quasi.lone_surrogates = true;
             }
             if next_quasi.is_some_and(|q| q.tail) {

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -78,6 +78,18 @@ pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
             .and_then(|rid| ctx.scoping().get_reference(rid).symbol_id())
             .and_then(|sid| ctx.state.symbol_values.get_symbol_value(sid))
             .is_some_and(|sv| sv.lone_surrogates),
+        Expression::CallExpression(call) => {
+            let object_has = match &call.callee {
+                Expression::StaticMemberExpression(m) => expr_has_lone_surrogates(&m.object, ctx),
+                Expression::ComputedMemberExpression(m) => expr_has_lone_surrogates(&m.object, ctx),
+                _ => false,
+            };
+            object_has
+                || call
+                    .arguments
+                    .iter()
+                    .any(|a| a.as_expression().is_some_and(|e| expr_has_lone_surrogates(e, ctx)))
+        }
         _ => false,
     }
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -13,12 +13,12 @@ use crate::TraverseCtx;
 use super::PeepholeOptimizations;
 
 /// Check if a string uses the lone surrogate encoding scheme by scanning its bytes
-/// for the `\u{FFFD}XXXX` pattern.
+/// for the `\u{FFFD}XXXX` pattern where XXXX is in the surrogate range (d800–dfff).
 ///
 /// **Warning:** This can produce false positives if the string naturally contains
-/// U+FFFD followed by 4 hex chars that happen to be in the surrogate range (d800–dfff)
-/// or "fffd". Prefer [`expr_has_lone_surrogates`] when the source AST node is available,
-/// since that checks the `lone_surrogates` flag directly without false positives.
+/// U+FFFD followed by 4 hex chars that happen to be in the surrogate range or "fffd".
+/// Prefer [`expr_has_lone_surrogates`] when the source AST node is available, since
+/// that checks the `lone_surrogates` flag directly without false positives.
 ///
 /// This function is the fallback for paths where only the string value is available
 /// (e.g. `value_to_expr` receiving a `ConstantValue::String` with no origin info).
@@ -421,8 +421,10 @@ impl<'a> PeepholeOptimizations {
             let mut result = ctx.value_to_expr(e.span, v);
             // value_to_expr uses has_lone_surrogates() which can have false positives
             // for strings naturally containing U+FFFD + surrogate-range hex chars.
-            // Override with the authoritative flag from the source operands.
-            if let Expression::StringLiteral(lit) = &mut result {
+            // Correct false positives using the authoritative flag from the source operands.
+            if let Expression::StringLiteral(lit) = &mut result
+                && lit.lone_surrogates
+            {
                 lit.lone_surrogates =
                     expr_has_lone_surrogates(&e.left) || expr_has_lone_surrogates(&e.right);
             }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -25,7 +25,7 @@ pub fn has_lone_surrogates(s: &str) -> bool {
         return false;
     }
     let mut i = 0;
-    let end = bytes.len() - 6; // need at least 7 bytes from position i
+    let end = bytes.len() - 7; // need 7 bytes from position i (indices i..i+6)
     while i <= end {
         if bytes[i] == 0xEF
             && bytes[i + 1] == 0xBF

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -12,9 +12,31 @@ use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
-/// See [`StringLiteral::lone_surrogates`] for the encoding scheme.
-fn has_lone_surrogates(s: &str) -> bool {
-    s.contains('\u{FFFD}')
+/// Check if a string uses the lone surrogate encoding scheme.
+///
+/// See [`StringLiteral::lone_surrogates`] for the encoding scheme: lone surrogates
+/// are encoded as `\u{FFFD}XXXX` (U+FFFD followed by 4 lowercase hex chars).
+/// A bare U+FFFD (replacement character) without a trailing 4-hex-char suffix is
+/// just an ordinary character and does NOT indicate lone surrogates.
+pub fn has_lone_surrogates(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    // U+FFFD is 3 UTF-8 bytes (0xEF 0xBF 0xBD) + 4 lowercase hex chars = 7 bytes minimum.
+    if bytes.len() < 7 {
+        return false;
+    }
+    let mut i = 0;
+    let end = bytes.len() - 6; // need at least 7 bytes from position i
+    while i <= end {
+        if bytes[i] == 0xEF
+            && bytes[i + 1] == 0xBF
+            && bytes[i + 2] == 0xBD
+            && bytes[i + 3..i + 7].iter().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Constant Folding

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -62,6 +62,17 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
 /// Based on AST node flags, so not prone to the false positives that
 /// [`scan_for_lone_surrogate_encoding`] can produce. For identifiers, looks
 /// up the symbol table to check the initializer's flag.
+///
+/// Only handles the expression kinds that can appear as a *folded* result
+/// (literals, identifiers, `+`, calls). Non-literal string-yielding parents —
+/// `LogicalExpression`, `ConditionalExpression`, `SequenceExpression`,
+/// `Static/ComputedMemberExpression` — are not handled directly and yield
+/// `false`. That is safe **only** because exit-order traversal folds any
+/// foldable string-yielding child into a literal before its parent reaches
+/// the call sites of this helper. If that invariant is ever broken, the byte
+/// scan in `value_to_expr` would correctly flag the result as having lone
+/// surrogates and `correct_lone_surrogates_flag` would silently clear it
+/// back, producing wrong codegen. See `test_lone_surrogate_through_non_literal_subexprs`.
 pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
     match expr {
         Expression::StringLiteral(s) => s.lone_surrogates,
@@ -79,6 +90,11 @@ pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
             .and_then(|sid| ctx.state.symbol_values.get_symbol_value(sid))
             .is_some_and(|sv| sv.lone_surrogates),
         Expression::CallExpression(call) => {
+            // Conservatively true if the receiver or any argument carries
+            // lone surrogates, even when the callee doesn't actually reflect
+            // them into its return value (e.g. `arr.find('\uDC00')`). False
+            // positives here are harmless: `correct_lone_surrogates_flag` only
+            // acts when the byte scan also flagged the result.
             let object_has = match &call.callee {
                 Expression::StaticMemberExpression(m) => expr_has_lone_surrogates(&m.object, ctx),
                 Expression::ComputedMemberExpression(m) => expr_has_lone_surrogates(&m.object, ctx),

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -12,8 +12,8 @@ use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
-/// Check if a string has lone surrogates encoded as `\u{FFFD}XXXX` where XXXX is in
-/// the surrogate range (d800–dfff).
+/// Scan a string for the lone surrogate encoding pattern `\u{FFFD}XXXX` where
+/// XXXX is in the surrogate range (d800–dfff) or the self-escape "fffd".
 ///
 /// **Warning:** This can produce false positives if the string naturally contains
 /// U+FFFD followed by 4 hex chars that happen to be in the surrogate range or "fffd".
@@ -24,7 +24,7 @@ use super::PeepholeOptimizations;
 /// (e.g. `value_to_expr` receiving a `ConstantValue::String` with no origin info).
 ///
 /// See [`StringLiteral::lone_surrogates`] for the encoding scheme.
-pub fn has_lone_surrogates(s: &str) -> bool {
+pub fn scan_for_lone_surrogate_encoding(s: &str) -> bool {
     let bytes = s.as_bytes();
     // U+FFFD is 3 UTF-8 bytes (0xEF 0xBF 0xBD) + 4 lowercase hex chars = 7 bytes minimum.
     if bytes.len() < 7 {
@@ -59,18 +59,25 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
 
 /// Check if an expression carries the `lone_surrogates` flag.
 ///
-/// Based on the AST node's flag, so not prone to false positives like
-/// [`has_lone_surrogates`] is.
-pub fn expr_has_lone_surrogates(expr: &Expression) -> bool {
+/// Based on AST node flags, so not prone to the false positives that
+/// [`scan_for_lone_surrogate_encoding`] can produce. For identifiers, looks
+/// up the symbol table to check the initializer's flag.
+pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
     match expr {
         Expression::StringLiteral(s) => s.lone_surrogates,
         Expression::TemplateLiteral(t) => {
             t.quasis.iter().any(|q| q.lone_surrogates)
-                || t.expressions.iter().any(|e| expr_has_lone_surrogates(e))
+                || t.expressions.iter().any(|e| expr_has_lone_surrogates(e, ctx))
         }
         Expression::BinaryExpression(e) if e.operator == BinaryOperator::Addition => {
-            expr_has_lone_surrogates(&e.left) || expr_has_lone_surrogates(&e.right)
+            expr_has_lone_surrogates(&e.left, ctx) || expr_has_lone_surrogates(&e.right, ctx)
         }
+        Expression::Identifier(ident) => ident
+            .reference_id
+            .get()
+            .and_then(|rid| ctx.scoping().get_reference(rid).symbol_id())
+            .and_then(|sid| ctx.state.symbol_values.get_symbol_value(sid))
+            .is_some_and(|sv| sv.lone_surrogates),
         _ => false,
     }
 }
@@ -426,8 +433,8 @@ impl<'a> PeepholeOptimizations {
             if let Expression::StringLiteral(lit) = &mut result
                 && lit.lone_surrogates
             {
-                lit.lone_surrogates =
-                    expr_has_lone_surrogates(&e.left) || expr_has_lone_surrogates(&e.right);
+                lit.lone_surrogates = expr_has_lone_surrogates(&e.left, ctx)
+                    || expr_has_lone_surrogates(&e.right, ctx);
             }
             return Some(result);
         }
@@ -451,8 +458,8 @@ impl<'a> PeepholeOptimizations {
                     .merge_within(e.right.span(), e.span)
                     .unwrap_or(SPAN);
                 let value = ctx.ast.str_from_strs_array([&left_str, &right_str]);
-                let lone_surrogates = expr_has_lone_surrogates(&left_binary_expr.right)
-                    || expr_has_lone_surrogates(&e.right);
+                let lone_surrogates = expr_has_lone_surrogates(&left_binary_expr.right, ctx)
+                    || expr_has_lone_surrogates(&e.right, ctx);
                 let right = ctx.ast.expression_string_literal_with_lone_surrogates(
                     span,
                     value,
@@ -515,7 +522,7 @@ impl<'a> PeepholeOptimizations {
             // "`${x}y` + 'z'" => "`${x}yz`"
             if let Some(right_str) = right_expr.get_side_free_string_value(ctx) {
                 // Encoded lone surrogates can't go into template raw values.
-                if expr_has_lone_surrogates(right_expr) {
+                if expr_has_lone_surrogates(right_expr, ctx) {
                     return None;
                 }
                 left.span = left.span.merge_within(right_expr.span(), parent_span).unwrap_or(SPAN);
@@ -535,7 +542,7 @@ impl<'a> PeepholeOptimizations {
             // "'x' + `y${z}`" => "`xy${z}`"
             if let Some(left_str) = left_expr.get_side_free_string_value(ctx) {
                 // Encoded lone surrogates can't go into template raw values.
-                if expr_has_lone_surrogates(left_expr) {
+                if expr_has_lone_surrogates(left_expr, ctx) {
                     return None;
                 }
                 right.span = right.span.merge_within(left_expr.span(), parent_span).unwrap_or(SPAN);
@@ -815,7 +822,7 @@ impl<'a> PeepholeOptimizations {
         let has_expr_to_inline = t.expressions.iter().any(|expr| {
             !expr.may_have_side_effects(ctx)
                 && expr.to_js_string(ctx).is_some()
-                && !expr_has_lone_surrogates(expr)
+                && !expr_has_lone_surrogates(expr, ctx)
         });
         if !has_expr_to_inline {
             return;
@@ -828,7 +835,7 @@ impl<'a> PeepholeOptimizations {
                     Some(expr)
                 } else if let Some(str) = expr.to_js_string(ctx) {
                     // Encoded lone surrogates can't go into template raw values.
-                    if expr_has_lone_surrogates(&expr) {
+                    if expr_has_lone_surrogates(&expr, ctx) {
                         return Some(expr);
                     }
                     inline_exprs.push((idx, str));

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -65,7 +65,10 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
 pub fn expr_has_lone_surrogates(expr: &Expression) -> bool {
     match expr {
         Expression::StringLiteral(s) => s.lone_surrogates,
-        Expression::TemplateLiteral(t) => t.quasis.iter().any(|q| q.lone_surrogates),
+        Expression::TemplateLiteral(t) => {
+            t.quasis.iter().any(|q| q.lone_surrogates)
+                || t.expressions.iter().any(|e| expr_has_lone_surrogates(e))
+        }
         Expression::BinaryExpression(e) if e.operator == BinaryOperator::Addition => {
             expr_has_lone_surrogates(&e.left) || expr_has_lone_surrogates(&e.right)
         }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -469,8 +469,7 @@ impl<'a> PeepholeOptimizations {
 
             // "`${x}y` + 'z'" => "`${x}yz`"
             if let Some(right_str) = right_expr.get_side_free_string_value(ctx) {
-                // Template literal codegen prints raw values verbatim and cannot handle
-                // the internal lone surrogate encoding (U+FFFD markers).
+                // Lone surrogates can't go into template raw values.
                 if has_lone_surrogates(&right_str) {
                     return None;
                 }
@@ -490,8 +489,7 @@ impl<'a> PeepholeOptimizations {
         } else if let Expression::TemplateLiteral(right) = right_expr {
             // "'x' + `y${z}`" => "`xy${z}`"
             if let Some(left_str) = left_expr.get_side_free_string_value(ctx) {
-                // Template literal codegen prints raw values verbatim and cannot handle
-                // the internal lone surrogate encoding (U+FFFD markers).
+                // Lone surrogates can't go into template raw values.
                 if has_lone_surrogates(&left_str) {
                     return None;
                 }
@@ -773,8 +771,7 @@ impl<'a> PeepholeOptimizations {
             !expr.may_have_side_effects(ctx)
                 && expr
                     .to_js_string(ctx)
-                    // Template literal codegen prints raw values verbatim and cannot handle
-                    // the internal lone surrogate encoding (U+FFFD markers).
+                    // Lone surrogates can't go into template raw values.
                     .is_some_and(|s| !has_lone_surrogates(&s))
         });
         if !has_expr_to_inline {

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -571,7 +571,12 @@ impl<'a> PeepholeOptimizations {
                     *expr = ctx.ast.expression_unary(
                         e.span,
                         UnaryOperator::UnaryPlus,
-                        ctx.ast.expression_string_literal(n.span, n.value, n.raw),
+                        ctx.ast.expression_string_literal_with_lone_surrogates(
+                            n.span,
+                            n.value,
+                            n.raw,
+                            n.lone_surrogates,
+                        ),
                     );
                     ctx.state.changed = true;
                     return;

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -26,23 +26,13 @@ use super::PeepholeOptimizations;
 /// See [`StringLiteral::lone_surrogates`] for the encoding scheme.
 pub fn scan_for_lone_surrogate_encoding(s: &str) -> bool {
     let bytes = s.as_bytes();
-    // U+FFFD is 3 UTF-8 bytes (0xEF 0xBF 0xBD) + 4 lowercase hex chars = 7 bytes minimum.
-    if bytes.len() < 7 {
+    // 0xEF is the leading byte of U+FFFD's UTF-8 encoding (0xEF 0xBF 0xBD) and
+    // is rare in typical JS strings. Skip the windowed scan entirely if absent.
+    if !bytes.contains(&0xEF) {
         return false;
     }
-    let mut i = 0;
-    let end = bytes.len() - 7; // need 7 bytes from position i (indices i..=i+6)
-    while i <= end {
-        if bytes[i] == 0xEF
-            && bytes[i + 1] == 0xBF
-            && bytes[i + 2] == 0xBD
-            && is_lone_surrogate_suffix(&bytes[i + 3..i + 7])
-        {
-            return true;
-        }
-        i += 1;
-    }
-    false
+    // Need 7 bytes: 3 for U+FFFD + 4 hex chars.
+    bytes.windows(7).any(|w| w[..3] == [0xEF, 0xBF, 0xBD] && is_lone_surrogate_suffix(&w[3..]))
 }
 
 /// Check if 4 bytes are a valid lone surrogate encoding suffix:

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -54,15 +54,19 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
 /// up the symbol table to check the initializer's flag.
 ///
 /// Only handles the expression kinds that can appear as a *folded* result
-/// (literals, identifiers, `+`, calls). Non-literal string-yielding parents —
-/// `LogicalExpression`, `ConditionalExpression`, `SequenceExpression`,
-/// `Static/ComputedMemberExpression` — are not handled directly and yield
-/// `false`. That is safe **only** because exit-order traversal folds any
-/// foldable string-yielding child into a literal before its parent reaches
-/// the call sites of this helper. If that invariant is ever broken, the byte
-/// scan in `value_to_expr` would correctly flag the result as having lone
-/// surrogates and `correct_lone_surrogates_flag` would silently clear it
-/// back, producing wrong codegen. See `test_lone_surrogate_through_non_literal_subexprs`.
+/// (literals, identifiers, `+`, calls) plus `ArrayExpression`, which reaches
+/// this helper via `String([...])` and `` `${[...]}` `` — both route through
+/// `ArrayExpression::to_js_string` (array_join), which concatenates the raw
+/// lone-surrogate encoding bytes of element strings. Non-literal
+/// string-yielding parents — `LogicalExpression`, `ConditionalExpression`,
+/// `SequenceExpression`, `Static/ComputedMemberExpression` — are not handled
+/// directly and yield `false`. That is safe **only** because exit-order
+/// traversal folds any foldable string-yielding child into a literal before
+/// its parent reaches the call sites of this helper. If that invariant is
+/// ever broken, the byte scan in `value_to_expr` would correctly flag the
+/// result as having lone surrogates and `correct_lone_surrogates_flag` would
+/// silently clear it back, producing wrong codegen. See
+/// `test_lone_surrogate_through_non_literal_subexprs`.
 pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
     match expr {
         Expression::StringLiteral(s) => s.lone_surrogates,
@@ -73,6 +77,10 @@ pub fn expr_has_lone_surrogates(expr: &Expression, ctx: &TraverseCtx) -> bool {
         Expression::BinaryExpression(e) if e.operator == BinaryOperator::Addition => {
             expr_has_lone_surrogates(&e.left, ctx) || expr_has_lone_surrogates(&e.right, ctx)
         }
+        Expression::ArrayExpression(arr) => arr
+            .elements
+            .iter()
+            .any(|el| el.as_expression().is_some_and(|e| expr_has_lone_surrogates(e, ctx))),
         Expression::Identifier(ident) => ident
             .reference_id
             .get()

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -145,7 +145,7 @@ impl<'a> PeepholeOptimizations {
             }
         {
             let mut result = ctx.value_to_expr(expr.span(), cv.clone());
-            correct_lone_surrogates_flag(&mut result, symbol_value.lone_surrogates);
+            correct_lone_surrogates_flag(&mut result, || symbol_value.lone_surrogates);
             *expr = result;
             ctx.state.changed = true;
         }

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -5,7 +5,7 @@ use oxc_span::GetSpan;
 
 use crate::TraverseCtx;
 
-use super::PeepholeOptimizations;
+use super::{PeepholeOptimizations, expr_has_lone_surrogates};
 
 impl<'a> PeepholeOptimizations {
     pub fn init_symbol_value(decl: &VariableDeclarator<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -19,7 +19,8 @@ impl<'a> PeepholeOptimizations {
             decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |e| e.evaluate_value(ctx))
         };
         let is_fresh_value = decl.init.as_ref().is_some_and(Self::is_fresh_value_expression);
-        ctx.init_value(symbol_id, value, is_fresh_value);
+        let lone_surrogates = decl.init.as_ref().is_some_and(|e| expr_has_lone_surrogates(e));
+        ctx.init_value(symbol_id, value, is_fresh_value, lone_surrogates);
     }
 
     /// Check if an expression creates a fresh value that cannot alias another binding
@@ -106,7 +107,7 @@ impl<'a> PeepholeOptimizations {
     ) {
         let Some(id) = id else { return };
         let Some(symbol_id) = id.symbol_id.get() else { return };
-        ctx.init_value(symbol_id, None, true);
+        ctx.init_value(symbol_id, None, true, false);
     }
 
     /// Initialize symbol value for class declarations.
@@ -116,7 +117,7 @@ impl<'a> PeepholeOptimizations {
         let Some(id) = &class.id else { return };
         let Some(symbol_id) = id.symbol_id.get() else { return };
         let is_fresh = !Self::class_may_have_property_side_effects(class);
-        ctx.init_value(symbol_id, None, is_fresh);
+        ctx.init_value(symbol_id, None, is_fresh, false);
     }
 
     fn is_for_statement_init(ctx: &TraverseCtx<'a>) -> bool {
@@ -143,7 +144,14 @@ impl<'a> PeepholeOptimizations {
                 ConstantValue::Boolean(_) | ConstantValue::Undefined | ConstantValue::Null => true,
             }
         {
-            *expr = ctx.value_to_expr(expr.span(), cv.clone());
+            let mut result = ctx.value_to_expr(expr.span(), cv.clone());
+            // Correct false positives from has_lone_surrogates() byte scan.
+            if let Expression::StringLiteral(lit) = &mut result
+                && lit.lone_surrogates
+            {
+                lit.lone_surrogates = symbol_value.lone_surrogates;
+            }
+            *expr = result;
             ctx.state.changed = true;
         }
     }

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -5,7 +5,7 @@ use oxc_span::GetSpan;
 
 use crate::TraverseCtx;
 
-use super::{PeepholeOptimizations, expr_has_lone_surrogates};
+use super::{PeepholeOptimizations, correct_lone_surrogates_flag, expr_has_lone_surrogates};
 
 impl<'a> PeepholeOptimizations {
     pub fn init_symbol_value(decl: &VariableDeclarator<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -145,12 +145,7 @@ impl<'a> PeepholeOptimizations {
             }
         {
             let mut result = ctx.value_to_expr(expr.span(), cv.clone());
-            // Correct false positives from scan_for_lone_surrogate_encoding().
-            if let Expression::StringLiteral(lit) = &mut result
-                && lit.lone_surrogates
-            {
-                lit.lone_surrogates = symbol_value.lone_surrogates;
-            }
+            correct_lone_surrogates_flag(&mut result, symbol_value.lone_surrogates);
             *expr = result;
             ctx.state.changed = true;
         }

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -19,7 +19,7 @@ impl<'a> PeepholeOptimizations {
             decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |e| e.evaluate_value(ctx))
         };
         let is_fresh_value = decl.init.as_ref().is_some_and(Self::is_fresh_value_expression);
-        let lone_surrogates = decl.init.as_ref().is_some_and(|e| expr_has_lone_surrogates(e));
+        let lone_surrogates = decl.init.as_ref().is_some_and(|e| expr_has_lone_surrogates(e, ctx));
         ctx.init_value(symbol_id, value, is_fresh_value, lone_surrogates);
     }
 
@@ -145,7 +145,7 @@ impl<'a> PeepholeOptimizations {
             }
         {
             let mut result = ctx.value_to_expr(expr.span(), cv.clone());
-            // Correct false positives from has_lone_surrogates() byte scan.
+            // Correct false positives from scan_for_lone_surrogate_encoding().
             if let Expression::StringLiteral(lit) = &mut result
                 && lit.lone_surrogates
             {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -27,6 +27,7 @@ use oxc_ast::ast::*;
 
 use crate::{ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx};
 
+pub use self::fold_constants::has_lone_surrogates;
 pub use self::normalize::{Normalize, NormalizeOptions};
 
 /// Stateless peephole optimizer. The `dce` flag and `changed` state are stored in `MinifierState`.

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -27,7 +27,7 @@ use oxc_ast::ast::*;
 
 use crate::{ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx};
 
-pub use self::fold_constants::{expr_has_lone_surrogates, has_lone_surrogates};
+pub use self::fold_constants::{expr_has_lone_surrogates, scan_for_lone_surrogate_encoding};
 pub use self::normalize::{Normalize, NormalizeOptions};
 
 /// Stateless peephole optimizer. The `dce` flag and `changed` state are stored in `MinifierState`.

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -27,7 +27,9 @@ use oxc_ast::ast::*;
 
 use crate::{ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx};
 
-pub use self::fold_constants::{expr_has_lone_surrogates, scan_for_lone_surrogate_encoding};
+pub use self::fold_constants::{
+    correct_lone_surrogates_flag, expr_has_lone_surrogates, scan_for_lone_surrogate_encoding,
+};
 pub use self::normalize::{Normalize, NormalizeOptions};
 
 /// Stateless peephole optimizer. The `dce` flag and `changed` state are stored in `MinifierState`.

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -27,7 +27,7 @@ use oxc_ast::ast::*;
 
 use crate::{ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx};
 
-pub use self::fold_constants::has_lone_surrogates;
+pub use self::fold_constants::{expr_has_lone_surrogates, has_lone_surrogates};
 pub use self::normalize::{Normalize, NormalizeOptions};
 
 /// Stateless peephole optimizer. The `dce` flag and `changed` state are stored in `MinifierState`.

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -287,6 +287,9 @@ impl<'a> PeepholeOptimizations {
                 let string_count = args.len() - expression_count;
 
                 // Encoded lone surrogates can't go into template raw values.
+                // Only StringLiteral args are checked here; non-string args become
+                // `${}` expressions (not quasis), so their content doesn't enter
+                // the template's raw/cooked strings.
                 if expression_count > 0 {
                     let has_lone_surrogates = base_str.lone_surrogates
                         || args.iter().any(

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -284,9 +284,9 @@ impl<'a> PeepholeOptimizations {
                 // the result would be a template literal and any input has lone surrogates.
                 if expression_count > 0 {
                     let has_lone_surrogates = base_str.lone_surrogates
-                        || args.iter().any(|arg| {
-                            matches!(arg, Argument::StringLiteral(s) if s.lone_surrogates)
-                        });
+                        || args.iter().any(
+                            |arg| matches!(arg, Argument::StringLiteral(s) if s.lone_surrogates),
+                        );
                     if has_lone_surrogates {
                         return None;
                     }

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -279,9 +279,7 @@ impl<'a> PeepholeOptimizations {
                     args.iter().filter(|arg| !matches!(arg, Argument::StringLiteral(_))).count();
                 let string_count = args.len() - expression_count;
 
-                // Template literal codegen prints raw values verbatim and cannot handle
-                // the internal lone surrogate encoding (U+FFFD markers). Bail out when
-                // the result would be a template literal and any input has lone surrogates.
+                // Lone surrogates can't go into template raw values.
                 if expression_count > 0 {
                     let has_lone_surrogates = base_str.lone_surrogates
                         || args.iter().any(

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -18,7 +18,7 @@ use oxc_span::SPAN;
 
 use crate::TraverseCtx;
 
-use super::{PeepholeOptimizations, expr_has_lone_surrogates};
+use super::{PeepholeOptimizations, correct_lone_surrogates_flag, expr_has_lone_surrogates};
 
 type Arguments<'a> = oxc_allocator::Vec<'a, Argument<'a>>;
 
@@ -29,15 +29,12 @@ impl<'a> PeepholeOptimizations {
         let Expression::CallExpression(ce) = node else { return };
 
         // Use constant evaluation for known method calls
+        let span = ce.span;
         if let Some(constant_value) = ce.evaluate_value(ctx) {
             ctx.state.changed = true;
-            let mut result = ctx.value_to_expr(ce.span, constant_value);
-            // Correct false positives from scan_for_lone_surrogate_encoding().
-            if let Expression::StringLiteral(lit) = &mut result
-                && lit.lone_surrogates
-            {
-                lit.lone_surrogates = expr_has_lone_surrogates(node, ctx);
-            }
+            let lone_surrogates = expr_has_lone_surrogates(node, ctx);
+            let mut result = ctx.value_to_expr(span, constant_value);
+            correct_lone_surrogates_flag(&mut result, lone_surrogates);
             *node = result;
             return;
         }

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -32,9 +32,8 @@ impl<'a> PeepholeOptimizations {
         let span = ce.span;
         if let Some(constant_value) = ce.evaluate_value(ctx) {
             ctx.state.changed = true;
-            let lone_surrogates = expr_has_lone_surrogates(node, ctx);
             let mut result = ctx.value_to_expr(span, constant_value);
-            correct_lone_surrogates_flag(&mut result, lone_surrogates);
+            correct_lone_surrogates_flag(&mut result, || expr_has_lone_surrogates(node, ctx));
             *node = result;
             return;
         }

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -279,7 +279,7 @@ impl<'a> PeepholeOptimizations {
                     args.iter().filter(|arg| !matches!(arg, Argument::StringLiteral(_))).count();
                 let string_count = args.len() - expression_count;
 
-                // Lone surrogates can't go into template raw values.
+                // Encoded lone surrogates can't go into template raw values.
                 if expression_count > 0 {
                     let has_lone_surrogates = base_str.lone_surrogates
                         || args.iter().any(

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -18,7 +18,7 @@ use oxc_span::SPAN;
 
 use crate::TraverseCtx;
 
-use super::PeepholeOptimizations;
+use super::{PeepholeOptimizations, expr_has_lone_surrogates};
 
 type Arguments<'a> = oxc_allocator::Vec<'a, Argument<'a>>;
 
@@ -31,7 +31,14 @@ impl<'a> PeepholeOptimizations {
         // Use constant evaluation for known method calls
         if let Some(constant_value) = ce.evaluate_value(ctx) {
             ctx.state.changed = true;
-            *node = ctx.value_to_expr(ce.span, constant_value);
+            let mut result = ctx.value_to_expr(ce.span, constant_value);
+            // Correct false positives from scan_for_lone_surrogate_encoding().
+            if let Expression::StringLiteral(lit) = &mut result
+                && lit.lone_surrogates
+            {
+                lit.lone_surrogates = expr_has_lone_surrogates(node, ctx);
+            }
+            *node = result;
             return;
         }
 

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -279,6 +279,19 @@ impl<'a> PeepholeOptimizations {
                     args.iter().filter(|arg| !matches!(arg, Argument::StringLiteral(_))).count();
                 let string_count = args.len() - expression_count;
 
+                // Template literal codegen prints raw values verbatim and cannot handle
+                // the internal lone surrogate encoding (U+FFFD markers). Bail out when
+                // the result would be a template literal and any input has lone surrogates.
+                if expression_count > 0 {
+                    let has_lone_surrogates = base_str.lone_surrogates
+                        || args.iter().any(|arg| {
+                            matches!(arg, Argument::StringLiteral(s) if s.lone_surrogates)
+                        });
+                    if has_lone_surrogates {
+                        return None;
+                    }
+                }
+
                 // whether it is shorter to use `String::concat`
                 if ".concat()".len() + args.len() + "''".len() * string_count
                     < "${}".len() * expression_count
@@ -288,10 +301,12 @@ impl<'a> PeepholeOptimizations {
 
                 let mut quasi_strs: Vec<Cow<'a, str>> =
                     vec![Cow::Borrowed(base_str.value.as_str())];
+                let mut lone_surrogates = base_str.lone_surrogates;
                 let mut expressions = ctx.ast.vec_with_capacity(expression_count);
                 let mut pushed_quasi = true;
                 for argument in args.drain(..) {
                     if let Argument::StringLiteral(str_lit) = argument {
+                        lone_surrogates |= str_lit.lone_surrogates;
                         if pushed_quasi {
                             let last_quasi = quasi_strs
                                 .last_mut()
@@ -317,10 +332,11 @@ impl<'a> PeepholeOptimizations {
 
                 if expressions.is_empty() {
                     debug_assert_eq!(quasi_strs.len(), 1);
-                    return Some(ctx.ast.expression_string_literal(
+                    return Some(ctx.ast.expression_string_literal_with_lone_surrogates(
                         span,
                         ctx.ast.str_from_cow(&quasi_strs.pop().unwrap()),
                         None,
+                        lone_surrogates,
                     ));
                 }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1028,11 +1028,11 @@ impl<'a> PeepholeOptimizations {
                         .filter(|_| !arg.may_have_side_effects(ctx))
                         .map(|s| {
                             let mut result = ctx.value_to_expr(span, ConstantValue::String(s));
-                            // Correct false positives from has_lone_surrogates() scan.
+                            // Correct false positives from scan_for_lone_surrogate_encoding().
                             if let Expression::StringLiteral(lit) = &mut result
                                 && lit.lone_surrogates
                             {
-                                lit.lone_surrogates = expr_has_lone_surrogates(arg);
+                                lit.lone_surrogates = expr_has_lone_surrogates(arg, ctx);
                             }
                             result
                         }),
@@ -1269,7 +1269,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let lone_surrogates = expr_has_lone_surrogates(expr);
+        let lone_surrogates = expr_has_lone_surrogates(expr, ctx);
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
         *expr = ctx.ast.expression_string_literal_with_lone_surrogates(

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1023,23 +1023,20 @@ impl<'a> PeepholeOptimizations {
                 match arg {
                     // `String()` -> `''`
                     None => Some(ctx.ast.expression_string_literal(span, "", None)),
-                    Some(arg) => {
-                        // Compute before the closure to avoid borrow conflict with `e.span`.
-                        let lone_surrogates = expr_has_lone_surrogates(arg);
-                        arg.evaluate_value_to_string(ctx)
-                            .filter(|_| !arg.may_have_side_effects(ctx))
-                            .map(|s| {
-                                let mut result =
-                                    ctx.value_to_expr(e.span, ConstantValue::String(s));
-                                // Correct false positives from has_lone_surrogates() scan.
-                                if let Expression::StringLiteral(lit) = &mut result
-                                    && lit.lone_surrogates
-                                {
-                                    lit.lone_surrogates = lone_surrogates;
-                                }
-                                result
-                            })
-                    }
+                    Some(arg) => arg
+                        .evaluate_value_to_string(ctx)
+                        .filter(|_| !arg.may_have_side_effects(ctx))
+                        .map(|s| {
+                            let mut result =
+                                ctx.value_to_expr(span, ConstantValue::String(s));
+                            // Correct false positives from has_lone_surrogates() scan.
+                            if let Expression::StringLiteral(lit) = &mut result
+                                && lit.lone_surrogates
+                            {
+                                lit.lone_surrogates = expr_has_lone_surrogates(arg);
+                            }
+                            result
+                        }),
                 }
             }
             "Number" => Some(ctx.ast.expression_numeric_literal(

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1263,9 +1263,9 @@ impl<'a> PeepholeOptimizations {
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
         let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates)
-            || t.expressions.iter().any(|expr| {
-                matches!(expr, Expression::StringLiteral(s) if s.lone_surrogates)
-            });
+            || t.expressions
+                .iter()
+                .any(|expr| matches!(expr, Expression::StringLiteral(s) if s.lone_surrogates));
         *expr = ctx.ast.expression_string_literal_with_lone_surrogates(
             t.span(),
             ctx.ast.str_from_cow(&val),

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -19,7 +19,7 @@ use oxc_syntax::{
 
 use crate::TraverseCtx;
 
-use super::PeepholeOptimizations;
+use super::{PeepholeOptimizations, has_lone_surrogates};
 
 /// A peephole optimization that minimizes code by simplifying conditional
 /// expressions, replacing IFs with HOOKs, replacing object constructors
@@ -1262,10 +1262,7 @@ impl<'a> PeepholeOptimizations {
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
-        let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates)
-            || t.expressions
-                .iter()
-                .any(|expr| matches!(expr, Expression::StringLiteral(s) if s.lone_surrogates));
+        let lone_surrogates = has_lone_surrogates(&val);
         *expr = ctx.ast.expression_string_literal_with_lone_surrogates(
             t.span(),
             ctx.ast.str_from_cow(&val),

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -19,7 +19,7 @@ use oxc_syntax::{
 
 use crate::TraverseCtx;
 
-use super::{PeepholeOptimizations, has_lone_surrogates};
+use super::{PeepholeOptimizations, expr_has_lone_surrogates};
 
 /// A peephole optimization that minimizes code by simplifying conditional
 /// expressions, replacing IFs with HOOKs, replacing object constructors
@@ -1023,10 +1023,20 @@ impl<'a> PeepholeOptimizations {
                 match arg {
                     // `String()` -> `''`
                     None => Some(ctx.ast.expression_string_literal(span, "", None)),
-                    Some(arg) => arg
-                        .evaluate_value_to_string(ctx)
-                        .filter(|_| !arg.may_have_side_effects(ctx))
-                        .map(|s| ctx.value_to_expr(e.span, ConstantValue::String(s))),
+                    Some(arg) => {
+                        let lone_surrogates = expr_has_lone_surrogates(arg);
+                        arg.evaluate_value_to_string(ctx)
+                            .filter(|_| !arg.may_have_side_effects(ctx))
+                            .map(|s| {
+                                let mut result =
+                                    ctx.value_to_expr(e.span, ConstantValue::String(s));
+                                // Override has_lone_surrogates() scan with the flag.
+                                if let Expression::StringLiteral(lit) = &mut result {
+                                    lit.lone_surrogates = lone_surrogates;
+                                }
+                                result
+                            })
+                    }
                 }
             }
             "Number" => Some(ctx.ast.expression_numeric_literal(
@@ -1262,7 +1272,8 @@ impl<'a> PeepholeOptimizations {
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
-        let lone_surrogates = has_lone_surrogates(&val);
+        let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates)
+            || t.expressions.iter().any(|e| expr_has_lone_surrogates(e));
         *expr = ctx.ast.expression_string_literal_with_lone_surrogates(
             t.span(),
             ctx.ast.str_from_cow(&val),

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1024,14 +1024,17 @@ impl<'a> PeepholeOptimizations {
                     // `String()` -> `''`
                     None => Some(ctx.ast.expression_string_literal(span, "", None)),
                     Some(arg) => {
+                        // Compute before the closure to avoid borrow conflict with `e.span`.
                         let lone_surrogates = expr_has_lone_surrogates(arg);
                         arg.evaluate_value_to_string(ctx)
                             .filter(|_| !arg.may_have_side_effects(ctx))
                             .map(|s| {
                                 let mut result =
                                     ctx.value_to_expr(e.span, ConstantValue::String(s));
-                                // Override has_lone_surrogates() scan with the flag.
-                                if let Expression::StringLiteral(lit) = &mut result {
+                                // Correct false positives from has_lone_surrogates() scan.
+                                if let Expression::StringLiteral(lit) = &mut result
+                                    && lit.lone_surrogates
+                                {
                                     lit.lone_surrogates = lone_surrogates;
                                 }
                                 result

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1262,7 +1262,10 @@ impl<'a> PeepholeOptimizations {
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
-        let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates);
+        let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates)
+            || t.expressions.iter().any(|expr| {
+                matches!(expr, Expression::StringLiteral(s) if s.lone_surrogates)
+            });
         *expr = ctx.ast.expression_string_literal_with_lone_surrogates(
             t.span(),
             ctx.ast.str_from_cow(&val),

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1543,6 +1543,11 @@ impl<'a> PeepholeOptimizations {
         });
         let Some(delimiter) = Self::pick_delimiter(&strings) else { return };
 
+        let lone_surrogates = array.elements.iter().any(|element| {
+            let Expression::StringLiteral(str) = element.to_expression() else { unreachable!() };
+            str.lone_surrogates
+        });
+
         let concatenated_string = strings.collect::<std::vec::Vec<_>>().join(delimiter);
 
         // "str1,str2".split(',')
@@ -1550,10 +1555,11 @@ impl<'a> PeepholeOptimizations {
             expr.span(),
             Expression::StaticMemberExpression(ctx.ast.alloc_static_member_expression(
                 expr.span(),
-                ctx.ast.expression_string_literal(
+                ctx.ast.expression_string_literal_with_lone_surrogates(
                     expr.span(),
                     ctx.ast.str(&concatenated_string),
                     None,
+                    lone_surrogates,
                 ),
                 ctx.ast.identifier_name(expr.span(), "split"),
                 false,

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1269,6 +1269,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Check before destructuring, since the destructure borrows `expr`.
         let lone_surrogates = expr_has_lone_surrogates(expr, ctx);
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -19,7 +19,7 @@ use oxc_syntax::{
 
 use crate::TraverseCtx;
 
-use super::{PeepholeOptimizations, expr_has_lone_surrogates};
+use super::{PeepholeOptimizations, correct_lone_surrogates_flag, expr_has_lone_surrogates};
 
 /// A peephole optimization that minimizes code by simplifying conditional
 /// expressions, replacing IFs with HOOKs, replacing object constructors
@@ -1027,13 +1027,9 @@ impl<'a> PeepholeOptimizations {
                         .evaluate_value_to_string(ctx)
                         .filter(|_| !arg.may_have_side_effects(ctx))
                         .map(|s| {
+                            let lone_surrogates = expr_has_lone_surrogates(arg, ctx);
                             let mut result = ctx.value_to_expr(span, ConstantValue::String(s));
-                            // Correct false positives from scan_for_lone_surrogate_encoding().
-                            if let Expression::StringLiteral(lit) = &mut result
-                                && lit.lone_surrogates
-                            {
-                                lit.lone_surrogates = expr_has_lone_surrogates(arg, ctx);
-                            }
+                            correct_lone_surrogates_flag(&mut result, lone_surrogates);
                             result
                         }),
                 }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1270,10 +1270,9 @@ impl<'a> PeepholeOptimizations {
     }
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        let lone_surrogates = expr_has_lone_surrogates(expr);
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
-        let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates)
-            || t.expressions.iter().any(|e| expr_has_lone_surrogates(e));
         *expr = ctx.ast.expression_string_literal_with_lone_surrogates(
             t.span(),
             ctx.ast.str_from_cow(&val),

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1027,9 +1027,10 @@ impl<'a> PeepholeOptimizations {
                         .evaluate_value_to_string(ctx)
                         .filter(|_| !arg.may_have_side_effects(ctx))
                         .map(|s| {
-                            let lone_surrogates = expr_has_lone_surrogates(arg, ctx);
                             let mut result = ctx.value_to_expr(span, ConstantValue::String(s));
-                            correct_lone_surrogates_flag(&mut result, lone_surrogates);
+                            correct_lone_surrogates_flag(&mut result, || {
+                                expr_has_lone_surrogates(arg, ctx)
+                            });
                             result
                         }),
                 }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1027,8 +1027,7 @@ impl<'a> PeepholeOptimizations {
                         .evaluate_value_to_string(ctx)
                         .filter(|_| !arg.may_have_side_effects(ctx))
                         .map(|s| {
-                            let mut result =
-                                ctx.value_to_expr(span, ConstantValue::String(s));
+                            let mut result = ctx.value_to_expr(span, ConstantValue::String(s));
                             // Correct false positives from has_lone_surrogates() scan.
                             if let Expression::StringLiteral(lit) = &mut result
                                 && lit.lone_surrogates

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1266,13 +1266,15 @@ impl<'a> PeepholeOptimizations {
     }
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Check before destructuring, since the destructure borrows `expr`.
-        let lone_surrogates = expr_has_lone_surrogates(expr, ctx);
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
+        let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates)
+            || t.expressions.iter().any(|e| expr_has_lone_surrogates(e, ctx));
+        let span = t.span();
+        let value = ctx.ast.str_from_cow(&val);
         *expr = ctx.ast.expression_string_literal_with_lone_surrogates(
-            t.span(),
-            ctx.ast.str_from_cow(&val),
+            span,
+            value,
             None,
             lone_surrogates,
         );

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1262,7 +1262,13 @@ impl<'a> PeepholeOptimizations {
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
-        *expr = ctx.ast.expression_string_literal(t.span(), ctx.ast.str_from_cow(&val), None);
+        let lone_surrogates = t.quasis.iter().any(|q| q.lone_surrogates);
+        *expr = ctx.ast.expression_string_literal_with_lone_surrogates(
+            t.span(),
+            ctx.ast.str_from_cow(&val),
+            None,
+            lone_surrogates,
+        );
         ctx.state.changed = true;
     }
 

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -25,6 +25,10 @@ pub struct SymbolValue<'a> {
     /// with object/array/function/class literals.
     pub is_fresh_value: bool,
 
+    /// Whether the initializer expression contains lone surrogates.
+    /// Used to correct false positives from the byte-pattern scan in `value_to_expr`.
+    pub lone_surrogates: bool,
+
     pub scope_id: ScopeId,
 }
 

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -14,8 +14,8 @@ use oxc_str::format_str;
 use oxc_syntax::{reference::ReferenceId, scope::ScopeFlags};
 
 use crate::{
-    generated::ancestor::Ancestor, options::CompressOptions, state::MinifierState,
-    symbol_value::SymbolValue,
+    generated::ancestor::Ancestor, options::CompressOptions, peephole::has_lone_surrogates,
+    state::MinifierState, symbol_value::SymbolValue,
 };
 
 use super::TraverseCtx;
@@ -206,7 +206,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
                 self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
             ConstantValue::String(s) => {
-                let lone_surrogates = s.contains('\u{FFFD}');
+                let lone_surrogates = has_lone_surrogates(&s);
                 self.ast.expression_string_literal_with_lone_surrogates(
                     span,
                     self.ast.str_from_cow(&s),

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -206,10 +206,10 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
                 self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
             ConstantValue::String(s) => {
-                // has_lone_surrogates scans for the encoding pattern in the string bytes.
-                // This can have false positives if the string naturally contains U+FFFD
-                // followed by surrogate-range hex chars. Callers that have access to the
-                // source expression should override this with expr_has_lone_surrogates().
+                // has_lone_surrogates can yield false positives in the edge case where
+                // the original string contains U+FFFD followed by surrogate-range hex
+                // chars. Callers that have access to the source expression should
+                // double-check this using expr_has_lone_surrogates().
                 let lone_surrogates = has_lone_surrogates(&s);
                 self.ast.expression_string_literal_with_lone_surrogates(
                     span,

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -247,6 +247,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         symbol_id: SymbolId,
         constant: Option<ConstantValue<'a>>,
         is_fresh_value: bool,
+        lone_surrogates: bool,
     ) {
         let mut exported = false;
         if self.scoping.current_scope_id() == self.scoping().root_scope_id() {
@@ -288,6 +289,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             write_references_count,
             member_write_target_read_count,
             is_fresh_value,
+            lone_surrogates,
             scope_id,
         };
         self.state.symbol_values.init_value(symbol_id, symbol_value);

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -206,7 +206,13 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
                 self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
             ConstantValue::String(s) => {
-                self.ast.expression_string_literal(span, self.ast.str_from_cow(&s), None)
+                let lone_surrogates = s.contains('\u{FFFD}');
+                self.ast.expression_string_literal_with_lone_surrogates(
+                    span,
+                    self.ast.str_from_cow(&s),
+                    None,
+                    lone_surrogates,
+                )
             }
             ConstantValue::Boolean(b) => self.ast.expression_boolean_literal(span, b),
             ConstantValue::Undefined => self.ast.void_0(span),

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -14,8 +14,8 @@ use oxc_str::format_str;
 use oxc_syntax::{reference::ReferenceId, scope::ScopeFlags};
 
 use crate::{
-    generated::ancestor::Ancestor, options::CompressOptions, peephole::has_lone_surrogates,
-    state::MinifierState, symbol_value::SymbolValue,
+    generated::ancestor::Ancestor, options::CompressOptions,
+    peephole::scan_for_lone_surrogate_encoding, state::MinifierState, symbol_value::SymbolValue,
 };
 
 use super::TraverseCtx;
@@ -206,11 +206,11 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
                 self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
             ConstantValue::String(s) => {
-                // has_lone_surrogates can yield false positives in the edge case where
-                // the original string contains U+FFFD followed by surrogate-range hex
-                // chars. Callers that have access to the source expression should
-                // double-check this using expr_has_lone_surrogates().
-                let lone_surrogates = has_lone_surrogates(&s);
+                // scan_for_lone_surrogate_encoding can yield false positives in the
+                // edge case where the original string contains U+FFFD followed by
+                // surrogate-range hex chars. Callers that have access to the source
+                // expression should double-check using expr_has_lone_surrogates().
+                let lone_surrogates = scan_for_lone_surrogate_encoding(&s);
                 self.ast.expression_string_literal_with_lone_surrogates(
                     span,
                     self.ast.str_from_cow(&s),

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -206,6 +206,10 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
                 self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
             ConstantValue::String(s) => {
+                // has_lone_surrogates scans for the encoding pattern in the string bytes.
+                // This can have false positives if the string naturally contains U+FFFD
+                // followed by surrogate-range hex chars. Callers that have access to the
+                // source expression should override this with expr_has_lone_surrogates().
                 let lone_surrogates = has_lone_surrogates(&s);
                 self.ast.expression_string_literal_with_lone_surrogates(
                     span,

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1224,6 +1224,17 @@ fn test_lone_surrogate_propagation() {
     fold("'\\uFFFD' + '0000'", "'\\uFFFD0000'");
     // U+FFFD not at position 0 with a short string (regression test for off-by-one in scan bounds)
     fold("'x\\uFFFD' + 'abc'", "'x\\uFFFDabc'");
+
+    // U+FFFD followed by 4 hex chars that ARE in the surrogate range is still NOT a lone
+    // surrogate encoding when the source StringLiteral has lone_surrogates: false.
+    // These would be false positives if we relied on byte-pattern scanning instead of flags.
+    fold("'\\uFFFD' + 'dc00'", "'\\uFFFDdc00'");
+    fold("'\\uFFFD' + 'dfff'", "'\\uFFFDdfff'");
+    fold("'\\uFFFD' + 'd800'", "'\\uFFFDd800'");
+    // U+FFFD followed by "fffd" (the self-escape suffix) — also not a lone surrogate.
+    fold("'\\uFFFD' + 'fffd'", "'\\uFFFDfffd'");
+    // Multi-char string with U+FFFD + surrogate-range hex across a concat boundary
+    fold("'a\\uFFFD' + 'dc00b'", "'a\\uFFFDdc00b'");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1211,6 +1211,11 @@ fn test_lone_surrogate_propagation() {
     // Inline string with lone surrogates into template that retains other expressions:
     // skip inlining because template raw values can't represent lone surrogates
     test_same("x = `${a}${'[\\uDC00]'}${b}`");
+    // Partial inline: a clean foldable is inlined into the surrounding quasis,
+    // while the lone-surrogate foldable is kept as a template expression. This
+    // exercises `inline_template_literal` with a non-empty `inline_exprs` where
+    // not all foldables were inlined.
+    test("x = `${a}${'foo'}${'[\\uDC00]'}${b}`", "x = `${a}foo${'[\\uDC00]'}${b}`");
 
     // String + string with lone surrogates: exercises evaluate_value → value_to_expr path
     fold("'[\\uDC00]' + '[\\uDFFF]'", "'[\\udc00][\\udfff]'");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1211,6 +1211,14 @@ fn test_lone_surrogate_propagation() {
     // Inline string with lone surrogates into template that retains other expressions:
     // skip inlining because template raw values can't represent lone surrogates
     test_same("x = `${a}${'[\\uDC00]'}${b}`");
+
+    // String + string with lone surrogates: exercises evaluate_value → value_to_expr path
+    fold("'[\\uDC00]' + '[\\uDFFF]'", "'[\\udc00][\\udfff]'");
+    fold("'a' + '[\\uDC00]'", "'a[\\udc00]'");
+    fold("'[\\uDC00]' + 'a'", "'[\\udc00]a'");
+
+    // U+FFFD (replacement character) is NOT a lone surrogate — should still fold correctly
+    fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1290,18 +1290,37 @@ fn test_lone_surrogate_propagation() {
 }
 
 #[test]
+fn test_lone_surrogate_safe_by_shape() {
+    // Lock in the "safe-by-shape" kinds listed in expr_has_lone_surrogates'
+    // doc comment: their `to_js_string` result is an ASCII-only string that
+    // cannot carry lone surrogates, so returning `false` from the helper is
+    // correct even when a subexpression carries lone surrogates.
+    //
+    // If any of these grows a `to_js_string` case that can include string
+    // content (e.g. `ObjectExpression` ever stringifies a property value),
+    // the scan in `value_to_expr` would flag the result and the helper would
+    // fail to mirror it — one of these tests would then catch the divergence
+    // by producing garbage codegen for the lone-surrogate half.
+    fold("String({a: '\\uDC00'})", "'[object Object]'");
+    fold("String(void '\\uDC00')", "'undefined'");
+    fold("String(!'\\uDC00')", "'false'");
+    fold("`${{a: '\\uDC00'}}`", "'[object Object]'");
+}
+
+#[test]
 fn test_lone_surrogate_through_non_literal_subexprs() {
     // expr_has_lone_surrogates only handles a subset of expression types
-    // (string/template literals, identifiers, addition, call). It relies on the
-    // invariant that exit traversal folds string-yielding sub-expressions
-    // (LogicalExpression, ConditionalExpression, SequenceExpression, …) into
-    // string literals *before* their parent is folded — so by the time the
-    // helper sees a child, that child is either a literal/identifier or
-    // unfoldable (and therefore can't contribute a constant string anyway).
-    // These tests lock that invariant in: if a future change folds a parent
-    // before its children, the byte scan in `value_to_expr` would set the
-    // flag and `correct_lone_surrogates_flag` would clear it back — silently
-    // producing wrong codegen — and one of these would catch it.
+    // (string/template literals, identifiers, addition, arrays, calls). It
+    // relies on the invariant that exit traversal folds string-yielding
+    // sub-expressions (LogicalExpression, ConditionalExpression,
+    // SequenceExpression, …) into string literals *before* their parent is
+    // folded — so by the time the helper sees a child, that child is either
+    // a literal/identifier or unfoldable (and therefore can't contribute a
+    // constant string anyway). These tests lock that invariant in: if a
+    // future change folds a parent before its children, the byte scan in
+    // `value_to_expr` would set the flag and `correct_lone_surrogates_flag`
+    // would clear it back — silently producing wrong codegen — and one of
+    // these would catch it.
     fold("'' || '\\uDC00'", "'\\udc00'");
     fold("(true ? '\\uDC00' : 'a')", "'\\udc00'");
     fold("(0, '\\uDC00')", "'\\udc00'");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1260,6 +1260,31 @@ fn test_lone_surrogate_propagation() {
     test("x = `a${'[\\uDC00]'}` + `${b}c`", "x = 'a[\\uDC00]' + `${b}c`");
 }
 
+#[test]
+fn test_lone_surrogate_through_non_literal_subexprs() {
+    // expr_has_lone_surrogates only handles a subset of expression types
+    // (string/template literals, identifiers, addition, call). It relies on the
+    // invariant that exit traversal folds string-yielding sub-expressions
+    // (LogicalExpression, ConditionalExpression, SequenceExpression, …) into
+    // string literals *before* their parent is folded — so by the time the
+    // helper sees a child, that child is either a literal/identifier or
+    // unfoldable (and therefore can't contribute a constant string anyway).
+    // These tests lock that invariant in: if a future change folds a parent
+    // before its children, the byte scan in `value_to_expr` would set the
+    // flag and `correct_lone_surrogates_flag` would clear it back — silently
+    // producing wrong codegen — and one of these would catch it.
+    fold("'' || '\\uDC00'", "'\\udc00'");
+    fold("(true ? '\\uDC00' : 'a')", "'\\udc00'");
+    fold("(0, '\\uDC00')", "'\\udc00'");
+    fold("'a' + (true ? '\\uDC00' : '')", "'a\\udc00'");
+    fold("'a' + (0, '\\uDC00')", "'a\\udc00'");
+    fold("'a' + ('' || '\\uDC00')", "'a\\udc00'");
+    fold("String(true ? '\\uDC00' : 'a')", "'\\udc00'");
+    fold("String((0, '\\uDC00'))", "'\\udc00'");
+    fold("String('' || '\\uDC00')", "'\\udc00'");
+    fold("`x${(0, '\\uDC00')}y`", "'x\\udc00y'");
+}
+
 mod bigint {
     use super::{
         MAX_SAFE_FLOAT, MAX_SAFE_INT, NEG_MAX_SAFE_FLOAT, NEG_MAX_SAFE_INT, fold, fold_same,

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1236,10 +1236,14 @@ fn test_lone_surrogate_propagation() {
     // Multi-char string with U+FFFD + surrogate-range hex across a concat boundary
     fold("'a\\uFFFD' + 'dc00b'", "'a\\uFFFDdc00b'");
 
-    // Triple concatenation: exercises the `a + 'bc'` path where left_binary_expr.right
-    // carries the lone_surrogates flag through multi-step folding.
+    // All-constant triple concatenation: each `+` folds via evaluate_value →
+    // value_to_expr, confirming the lone_surrogates flag survives multi-step folding.
     fold("'a' + '[\\uDC00]' + 'b'", "'a[\\udc00]b'");
     fold("'[\\uDC00]' + 'a' + '[\\uDFFF]'", "'[\\udc00]a[\\udfff]'");
+    // Non-constant left operand: exercises the `a + 'b' + 'c' → a + 'bc'` path
+    // where left_binary_expr.right carries the lone_surrogates flag.
+    test("x = a + '[\\uDC00]' + 'b'", "x=a+'[\\udc00]b'");
+    test("x = a + 'b' + '[\\uDC00]'", "x=a+'b[\\udc00]'");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1254,6 +1254,13 @@ fn test_lone_surrogate_propagation() {
         "const a = '\\uDC00'; log(a); log(String(a))",
         "const a = '\\uDC00'; log('\\udc00'), log('\\udc00')",
     );
+
+    // Template with lone surrogate expression folds to a string, then the
+    // string + template-with-expressions correctly bails out of merging.
+    test(
+        "x = `a${'[\\uDC00]'}` + `${b}c`",
+        "x = 'a[\\uDC00]' + `${b}c`",
+    );
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1235,6 +1235,11 @@ fn test_lone_surrogate_propagation() {
     fold("'\\uFFFD' + 'fffd'", "'\\uFFFDfffd'");
     // Multi-char string with U+FFFD + surrogate-range hex across a concat boundary
     fold("'a\\uFFFD' + 'dc00b'", "'a\\uFFFDdc00b'");
+
+    // Triple concatenation: exercises the `a + 'bc'` path where left_binary_expr.right
+    // carries the lone_surrogates flag through multi-step folding.
+    fold("'a' + '[\\uDC00]' + 'b'", "'a[\\udc00]b'");
+    fold("'[\\uDC00]' + 'a' + '[\\uDFFF]'", "'[\\udc00]a[\\udfff]'");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1270,6 +1270,23 @@ fn test_lone_surrogate_propagation() {
     // Template with lone surrogate expression folds to a string, then the
     // string + template-with-expressions correctly bails out of merging.
     test("x = `a${'[\\uDC00]'}` + `${b}c`", "x = 'a[\\uDC00]' + `${b}c`");
+
+    // ArrayExpression in string context: `String([...])` and
+    // `` `${[...]}` `` both route through `ArrayExpression::to_js_string`
+    // (array_join), which emits the raw lone-surrogate encoding bytes.
+    // `expr_has_lone_surrogates` must recurse into array elements so
+    // `correct_lone_surrogates_flag` keeps the flag set on the folded string.
+    fold("String(['\\uDC00', 'y'])", "'\\udc00,y'");
+    fold("String(['a', '\\uDC00'])", "'a,\\udc00'");
+    fold("`${['\\uDC00']}`", "'\\udc00'");
+    fold("`${['a', '\\uDC00']}`", "'a,\\udc00'");
+    // Nested array: recursion into element arrays.
+    fold("String([['\\uDC00']])", "'\\udc00'");
+    // U+FFFD followed by surrogate-range hex inside an array element is NOT
+    // a lone surrogate when the source StringLiteral has lone_surrogates: false.
+    fold("String(['\\uFFFDdc00'])", "'\\uFFFDdc00'");
+    // Elision elements contribute empty strings — not lone surrogates.
+    fold("String(['\\uDC00',,'y'])", "'\\udc00,,y'");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1216,6 +1216,13 @@ fn test_lone_surrogate_propagation() {
     // exercises `inline_template_literal` with a non-empty `inline_exprs` where
     // not all foldables were inlined.
     test("x = `${a}${'foo'}${'[\\uDC00]'}${b}`", "x = `${a}foo${'[\\uDC00]'}${b}`");
+    // Multi-iteration quasi merge with lone surrogates in a middle quasi:
+    // after the first inline absorbs `1` + the `\uDC00` quasi into the left
+    // quasi (setting its `lone_surrogates` flag via `next_quasi`), the second
+    // inline must preserve that flag when merging in the trailing quasi.
+    // `substitute_template_literal` then folds the single-quasi template to a
+    // string literal whose `lone_surrogates` flag governs the codegen escape.
+    fold("`a${1}\\uDC00${2}b`", "'a1\\udc002b'");
 
     // String + string with lone surrogates: exercises evaluate_value → value_to_expr path
     fold("'[\\uDC00]' + '[\\uDFFF]'", "'[\\udc00][\\udfff]'");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1202,6 +1202,15 @@ fn test_lone_surrogate_propagation() {
     test("x = `a${b}[\\uDC00]` + `[\\uDFFF]${c}d`", "x=`a${b}[\\uDC00][\\uDFFF]${c}d`");
     // Inline values in template with lone surrogates
     fold("`foo${1}[\\uDC00]`", "'foo1[\\udc00]'");
+    // String with lone surrogates + template with expressions: bail out
+    test_same("x = '[\\uDC00]' + `${a}`");
+    // Template with expressions + string with lone surrogates: bail out
+    test_same("x = `${a}` + '[\\uDC00]'");
+    // Inline string literal with lone surrogates into template (fully inlines to string)
+    test("x = `foo${'[\\uDC00]'}bar`", "x='foo[\\udc00]bar'");
+    // Inline string with lone surrogates into template that retains other expressions:
+    // skip inlining because template raw values can't represent lone surrogates
+    test_same("x = `${a}${'[\\uDC00]'}${b}`");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1257,10 +1257,7 @@ fn test_lone_surrogate_propagation() {
 
     // Template with lone surrogate expression folds to a string, then the
     // string + template-with-expressions correctly bails out of merging.
-    test(
-        "x = `a${'[\\uDC00]'}` + `${b}c`",
-        "x = 'a[\\uDC00]' + `${b}c`",
-    );
+    test("x = `a${'[\\uDC00]'}` + `${b}c`", "x = 'a[\\uDC00]' + `${b}c`");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1188,6 +1188,22 @@ fn test_inline_values_in_template_literal() {
     fold_same("foo`foo${1}bar`");
 }
 
+#[test]
+fn test_lone_surrogate_propagation() {
+    // The exact bug from https://github.com/oxc-project/oxc/issues/15524
+    test("console.log(':' + `[\\uDC00-\\uDFFF]`)", "console.log(':[\\udc00-\\udfff]')");
+    // Template literal to string substitution
+    fold("`[\\uDC00-\\uDFFF]`", "'[\\udc00-\\udfff]'");
+    // String + template
+    fold("':' + `[\\uDC00]`", "':[\\udc00]'");
+    // Template + string
+    fold("`[\\uDC00]` + ':'", "'[\\udc00]:'");
+    // Template + template with lone surrogates (raw values preserve original casing)
+    test("x = `a${b}[\\uDC00]` + `[\\uDFFF]${c}d`", "x=`a${b}[\\uDC00][\\uDFFF]${c}d`");
+    // Inline values in template with lone surrogates
+    fold("`foo${1}[\\uDC00]`", "'foo1[\\udc00]'");
+}
+
 mod bigint {
     use super::{
         MAX_SAFE_FLOAT, MAX_SAFE_INT, NEG_MAX_SAFE_FLOAT, NEG_MAX_SAFE_INT, fold, fold_same,

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1222,6 +1222,8 @@ fn test_lone_surrogate_propagation() {
     // U+FFFD followed by 4 hex chars that aren't in the surrogate range is NOT
     // a lone surrogate encoding — it should fold normally.
     fold("'\\uFFFD' + '0000'", "'\\uFFFD0000'");
+    // U+FFFD not at position 0 with a short string (regression test for off-by-one in scan bounds)
+    fold("'x\\uFFFD' + 'abc'", "'x\\uFFFDabc'");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1219,6 +1219,9 @@ fn test_lone_surrogate_propagation() {
 
     // U+FFFD (replacement character) is NOT a lone surrogate — should still fold correctly
     fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");
+    // U+FFFD followed by 4 hex chars that aren't in the surrogate range is NOT
+    // a lone surrogate encoding — it should fold normally.
+    fold("'\\uFFFD' + '0000'", "'\\uFFFD0000'");
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1244,6 +1244,16 @@ fn test_lone_surrogate_propagation() {
     // where left_binary_expr.right carries the lone_surrogates flag.
     test("x = a + '[\\uDC00]' + 'b'", "x=a+'[\\udc00]b'");
     test("x = a + 'b' + '[\\uDC00]'", "x=a+'b[\\udc00]'");
+
+    // Multi-referenced constant with lone surrogates passed to String():
+    // the identifier isn't inlined (>3 bytes, 2 references), so
+    // evaluate_value_to_string resolves it via the symbol table. The
+    // lone_surrogates flag must survive the round-trip through
+    // ConstantValue::String → value_to_expr.
+    test(
+        "const a = '\\uDC00'; log(a); log(String(a))",
+        "const a = '\\uDC00'; log('\\udc00'), log('\\udc00')",
+    );
 }
 
 mod bigint {

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -39,4 +39,9 @@ fn small_value() {
         r#"console.log('<p autocapitalize="words" contenteditable="false"/>');"#,
         &options,
     );
+
+    // U+FFFD followed by surrogate-range hex is NOT a lone surrogate when
+    // the source StringLiteral has lone_surrogates: false.
+    // Inlining must preserve the original flag, not re-scan the bytes.
+    test_options("const x = '\\uFFFDdc00'; log(x)", "log('\\uFFFDdc00')", &options);
 }

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -949,6 +949,13 @@ fn test_fold_string_concat() {
     test("x = '\\uFFFD'.concat('dc00')", "x = '\\uFFFDdc00'");
     // lone surrogates in a non-base string arg with expression args: bail out
     test_same("x = 'a'.concat(b, '[\\uDC00]')");
+    // lone surrogate behind an identifier arg with multiple references (so it
+    // won't be inlined): the identifier becomes a template expression (not a
+    // quasi), so the template itself is valid.
+    test(
+        "const a = '[\\uDC00]'; log(a); x = 'y'.concat(a, b)",
+        "const a = '[\\udc00]'; log(a), x = `y${a}${b}`",
+    );
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -420,6 +420,11 @@ fn test_to_lower() {
     test("x = 'SS'.toLowerCase()", "x = 'ss'");
     test("x = 'Σ'.toLowerCase()", "x = 'σ'");
     test("x = 'ΣΣ'.toLowerCase()", "x = 'σς'");
+
+    // U+FFFD followed by uppercase surrogate-range hex — NOT a lone surrogate.
+    // toLowerCase creates a result that matches the lone surrogate encoding pattern,
+    // but the source has lone_surrogates: false so the result must too.
+    test("x = '\\uFFFDDC00'.toLowerCase()", "x = '\\uFFFDdc00'");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -942,6 +942,8 @@ fn test_fold_string_concat() {
     test("x = '\\uFFFD'.concat(a)", "x = `\u{FFFD}${a}`");
     // U+FFFD followed by surrogate-range hex in all-string concat: NOT a lone surrogate
     test("x = '\\uFFFD'.concat('dc00')", "x = '\\uFFFDdc00'");
+    // lone surrogates in a non-base string arg with expression args: bail out
+    test_same("x = 'a'.concat(b, '[\\uDC00]')");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -938,6 +938,8 @@ fn test_fold_string_concat() {
     // lone surrogates in concat with non-string args: bail out of template conversion
     // because template literal codegen can't handle the internal lone surrogate encoding
     test_same("x = '[\\uDC00]'.concat(a)");
+    // U+FFFD (replacement character) is NOT a lone surrogate — should still fold
+    test("x = '\\uFFFD'.concat(a)", "x = `\u{FFFD}${a}`");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -940,6 +940,8 @@ fn test_fold_string_concat() {
     test_same("x = '[\\uDC00]'.concat(a)");
     // U+FFFD (replacement character) is NOT a lone surrogate — should still fold
     test("x = '\\uFFFD'.concat(a)", "x = `\u{FFFD}${a}`");
+    // U+FFFD followed by surrogate-range hex in all-string concat: NOT a lone surrogate
+    test("x = '\\uFFFD'.concat('dc00')", "x = '\\uFFFDdc00'");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -932,6 +932,12 @@ fn test_fold_string_concat() {
     test("x = '\\\\s'.concat(a)", "x = `\\\\s${a}`");
     test("x = '`'.concat(a)", "x = `\\`${a}`");
     test("x = '${'.concat(a)", "x = `\\${${a}`");
+
+    // lone surrogates in concat (all string args → string literal)
+    test("x = ''.concat('[\\uDC00]')", "x = '[\\udc00]'");
+    // lone surrogates in concat with non-string args: bail out of template conversion
+    // because template literal codegen can't handle the internal lone surrogate encoding
+    test_same("x = '[\\uDC00]'.concat(a)");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -442,6 +442,54 @@ fn test_fold_string_trim() {
     test_same("x = 'abc'.trimEnd(1)");
 }
 
+/// Folds that consume individual JS code units (substring/slice/charAt/
+/// replace/toUpperCase) or re-encode the value (encodeURI*, decodeURI*)
+/// don't understand the `\uFFFDXXXX` lone-surrogate encoding that
+/// `StringLiteral::lone_surrogates: true` signals. Running them against
+/// the encoded form would either split the encoding, case-fold its hex
+/// digits out of validity, or (for toUpperCase / URL fns) diverge from
+/// runtime behavior — at best yielding wrong codegen, at worst panicking
+/// the codegen's surrogate-decoder on a partial sequence. The fold paths
+/// bail out in `oxc_ecmascript::constant_evaluation::call_expr`. Lock
+/// that bail-out in so a future "optimization" doesn't silently regress.
+#[test]
+fn test_lone_surrogate_bailouts() {
+    // substring / slice: JS char-unit ops would slice through the 5-char
+    // `\uFFFDd800` encoding.
+    test_same("x = '[\\uDC00]'.substring(0, 1)");
+    test_same("x = '[\\uDC00]'.substring(1)");
+    test_same("x = '[\\uDC00]'.slice(0, 1)");
+    test_same("x = '[\\uDC00]'.slice(1)");
+
+    // charAt: same reason.
+    test_same("x = '[\\uDC00]'.charAt(0)");
+    test_same("x = '\\uDC00'.charAt(0)");
+
+    // replace / replaceAll: any input using the encoding could cause the
+    // replacement boundaries to cut through a `\uFFFDXXXX` run.
+    test_same("x = '[\\uDC00]'.replace('[', '(')");
+    test_same("x = '[\\uDC00]'.replaceAll('[', '(')");
+    test_same("x = 'abc'.replace('\\uDC00', 'x')");
+    test_same("x = 'abc'.replace('b', '\\uDC00')");
+
+    // toUpperCase: the encoding's lowercase hex would become `D800`, which
+    // doesn't match the lowercase-only decoder in oxc_codegen.
+    test_same("x = '\\uDC00'.toUpperCase()");
+    test_same("x = '[\\uDC00]'.toUpperCase()");
+
+    // toLowerCase / trim preserve the encoding intact and DO still fold.
+    test("x = '\\uDC00'.toLowerCase()", "x = '\\udc00'");
+    test("x = '  \\uDC00  '.trim()", "x = '\\udc00'");
+
+    // URL encode/decode: `encodeURI('\uD800')` throws at runtime, so
+    // folding it against our encoded form would produce a string that
+    // doesn't match runtime behavior.
+    test_same("x = encodeURI('\\uDC00')");
+    test_same("x = encodeURIComponent('\\uDC00')");
+    test_same("x = decodeURI('\\uDC00')");
+    test_same("x = decodeURIComponent('\\uDC00')");
+}
+
 #[test]
 fn test_fold_math_functions_bug() {
     test_same("Math[0]()");

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -315,6 +315,9 @@ fn test_template_string_to_string() {
     // Template with lone surrogates folds to string with lone_surrogates flag
     test("x = `[\\uDC00]`", "x = '[\\udc00]'");
     test("x = `a[\\uDC00]b`", "x = 'a[\\udc00]b'");
+    // Template containing U+FFFD followed by surrogate-range hex — NOT a lone surrogate.
+    // This exercises the expr_has_lone_surrogates path (checks the flag, not string bytes).
+    test("x = `\\uFFFDdc00`", "x = '\\uFFFDdc00'");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -295,6 +295,9 @@ fn test_string_array_splitting() {
     // all possible delimiters used, leave it alone
     test_same_with_longer_args("'.', ',', '(', ')', ' '");
 
+    // Lone surrogates in array elements propagate to the joined string.
+    test_with_longer_args("'[\\uDC00]','2','3','4','5','6'", "[\\udc00].2.3.4.5.6", ".");
+
     test_options(
         &format!("var x=['1','2','3','4','5','6'{additional_args}]"),
         "",

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -312,6 +312,9 @@ fn test_template_string_to_string() {
     test("x = `hello ${'foo'}`", "x = 'hello foo'");
     test("x = `${2} bananas`", "x = '2 bananas'");
     test("x = `This is ${true}`", "x = 'This is true'");
+    // Template with lone surrogates folds to string with lone_surrogates flag
+    test("x = `[\\uDC00]`", "x = '[\\udc00]'");
+    test("x = `a[\\uDC00]b`", "x = 'a[\\udc00]b'");
 }
 
 #[test]


### PR DESCRIPTION
What
---

Fix #15524. While #16886 (WTF-8 encoding for lone surrogates) is probably a better long-term design, this narrower fix solves the immediate problem within the current encoding scheme.

How
---

Template literal codegen prints raw values verbatim and doesn't understand the internal `\u{FFFD}XXXX` lone surrogate encoding, so folding a string with lone surrogates into a template literal produces garbage output. Separately, several char-unit string folds in `oxc_ecmascript` were operating on the encoded form as if it were ordinary JS text.

- **Propagate `lone_surrogates`** when producing new `StringLiteral` or merging `TemplateElement` nodes from folded strings — previously these paths always set `lone_surrogates = false`.
- **Bail out of template literal conversion** when a string operand has lone surrogates and the result would contain template expressions.
- **Bail out of char-unit folds** when any input uses the encoding. `substring` / `slice` / `charAt` / `replace` / `replaceAll` / `toUpperCase` and the `encodeURI*` / `decodeURI*` folds were splitting `\uFFFDXXXX` sequences or case-folding their hex digits out of validity, producing wrong codegen — and, for partial sequences, risking a panic in `oxc_codegen`'s surrogate decoder. These now refuse to fold on lone-surrogate input. `toLowerCase` / `trim*` keep folding because the encoding is already lowercase and doesn't border whitespace.
- **Two-tier detection**: `value_to_expr` only has a `ConstantValue::String` with no AST origin, so it runs `scan_for_lone_surrogate_encoding` (byte-pattern scan for U+FFFD + surrogate-range hex or `fffd` self-escape). This can false-positive when U+FFFD naturally precedes such hex chars. Callers that have the source expression correct the flag via `correct_lone_surrogates_flag`, which defers to `expr_has_lone_surrogates` — an authoritative check that walks AST node flags and resolves identifiers through `SymbolValue.lone_surrogates` (a new field tracking whether a symbol's initializer contains lone surrogates).

Testing
---

The invariants are locked in by `test_lone_surrogate_propagation`, `test_lone_surrogate_safe_by_shape`, `test_lone_surrogate_through_non_literal_subexprs` (in `tests/peephole/fold_constants.rs`) and `test_lone_surrogate_bailouts` (in `tests/peephole/replace_known_methods.rs`).
