### PR TITLE
perf(allocator): store pointers directly in `Arena`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -66,18 +66,16 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // the pointer will be bumped by zero bytes, modulo alignment.
         // This keeps the fast path optimized for non-ZSTs, which are much more common.
         unsafe {
-            let footer_ptr = self.current_chunk_footer.get();
-            let footer = footer_ptr.as_ref();
-
-            let cursor_ptr = footer.cursor_ptr.get().as_ptr();
-            let start_ptr = footer.start_ptr.as_ptr();
+            let cursor_ptr = self.cursor_ptr.get().as_ptr();
+            let start_ptr = self.start_ptr.get().as_ptr();
             debug_assert!(
                 start_ptr <= cursor_ptr,
                 "start pointer {start_ptr:#p} should be less than or equal to bump pointer {cursor_ptr:#p}"
             );
             debug_assert!(
-                cursor_ptr <= footer_ptr.cast::<u8>().as_ptr(),
-                "bump pointer {cursor_ptr:#p} should be less than or equal to footer pointer {footer_ptr:#p}"
+                cursor_ptr <= self.current_chunk_footer.get().cast::<u8>().as_ptr(),
+                "bump pointer {cursor_ptr:#p} should be less than or equal to footer pointer {:#p}",
+                self.current_chunk_footer.get()
             );
             debug_assert!(
                 is_pointer_aligned_to(cursor_ptr, MIN_ALIGN),
@@ -144,7 +142,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             debug_assert!(!aligned_ptr.is_null());
             let aligned_ptr = NonNull::new_unchecked(aligned_ptr);
 
-            footer.cursor_ptr.set(aligned_ptr);
+            self.cursor_ptr.set(aligned_ptr);
             Some(aligned_ptr)
         }
     }
@@ -185,7 +183,23 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
             debug_assert_eq!(new_footer.as_ref().start_ptr.as_ptr() as usize % layout.align(), 0);
 
-            // Set the new chunk as our new current chunk
+            // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
+            // can read its final cursor position later.
+            //
+            // Do not update `cursor_ptr` of the empty chunk.
+            // That update would be a no-op - when current chunk is the empty chunk, `self.cursor_ptr` always points
+            // to the empty chunk's footer, which is the existing value of empty chunk footer's `cursor_ptr` anyway.
+            // But nonetheless, the empty chunk footer is a `static`, accessible from all threads simultaneously.
+            // Updating it from 2 threads simultaneously would be a data race (UB), even though both writes are no-ops.
+            if !current_footer.as_ref().is_empty() {
+                current_footer.as_ref().cursor_ptr.set(self.cursor_ptr.get());
+            }
+
+            // Set the new chunk as our new current chunk, and sync `start_ptr` and `cursor_ptr` accordingly.
+            // Initial cursor sits at the footer (end of the allocatable region).
+            // The footer is aligned on `CHUNK_ALIGN >= MIN_ALIGN`, so no rounding is needed.
+            self.start_ptr.set(new_footer.as_ref().start_ptr);
+            self.cursor_ptr.set(new_footer.cast::<u8>());
             self.current_chunk_footer.set(new_footer);
 
             // And then we can rely on `try_alloc_layout_fast` to allocate space within this chunk
@@ -201,8 +215,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // otherwise they are simply leaked - at least until somebody calls `reset()`
         unsafe {
             if self.is_last_allocation(ptr) {
-                let cursor_ptr = self.current_chunk_footer.get().as_ref().cursor_ptr.get();
-                let cursor_ptr = cursor_ptr.as_ptr().add(layout.size());
+                let cursor_ptr = self.cursor_ptr.get().as_ptr().add(layout.size());
 
                 let cursor_ptr = round_mut_ptr_up_to_unchecked(cursor_ptr, MIN_ALIGN);
                 debug_assert!(
@@ -210,7 +223,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                     "bump pointer {cursor_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
                 );
                 let cursor_ptr = NonNull::new_unchecked(cursor_ptr);
-                self.current_chunk_footer.get().as_ref().cursor_ptr.set(cursor_ptr);
+                self.cursor_ptr.set(cursor_ptr);
             }
         }
     }
@@ -288,16 +301,13 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 && delta >= old_size.div_ceil(2)
         {
             unsafe {
-                let footer = self.current_chunk_footer.get();
-                let footer = footer.as_ref();
-
                 // Note: `new_ptr` is aligned, because ptr *has to* be aligned, and we made sure delta is aligned
-                let new_ptr = NonNull::new_unchecked(footer.cursor_ptr.get().as_ptr().add(delta));
+                let new_ptr = NonNull::new_unchecked(self.cursor_ptr.get().as_ptr().add(delta));
                 debug_assert!(
                     is_pointer_aligned_to(new_ptr.as_ptr(), MIN_ALIGN),
                     "bump pointer {new_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
                 );
-                footer.cursor_ptr.set(new_ptr);
+                self.cursor_ptr.set(new_ptr);
 
                 // Note: We know it is non-overlapping because of the size check in the `if` condition
                 ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
@@ -360,9 +370,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
     #[inline]
     unsafe fn is_last_allocation(&self, ptr: NonNull<u8>) -> bool {
-        let footer = self.current_chunk_footer.get();
-        let footer = unsafe { footer.as_ref() };
-        footer.cursor_ptr.get() == ptr
+        self.cursor_ptr.get() == ptr
     }
 }
 

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -1,6 +1,12 @@
 //! Methods to get info about the chunks of memory allocated by an `Arena`, and associated iterator types.
 
-use std::{iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull, slice};
+use std::{
+    iter::FusedIterator,
+    marker::PhantomData,
+    mem,
+    ptr::{self, NonNull},
+    slice,
+};
 
 use super::{Arena, CHUNK_FOOTER_SIZE, ChunkFooter};
 
@@ -18,11 +24,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// assert!(capacity >= 100);
     /// ```
     pub fn chunk_capacity(&self) -> usize {
-        let current_footer = self.current_chunk_footer.get();
-        let current_footer = unsafe { current_footer.as_ref() };
-
-        current_footer.cursor_ptr.get().as_ptr() as usize
-            - current_footer.start_ptr.as_ptr() as usize
+        self.cursor_ptr.get().as_ptr() as usize - self.start_ptr.get().as_ptr() as usize
     }
 
     /// Get an iterator over each chunk of allocated memory that this arena has allocated into.
@@ -122,7 +124,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// In addition, all of the caveats when reading the chunk data from
     /// [`iter_allocated_chunks()`](Arena::iter_allocated_chunks) still apply.
     pub unsafe fn iter_allocated_chunks_raw(&self) -> ChunkRawIter<'_, MIN_ALIGN> {
-        ChunkRawIter { footer: self.current_chunk_footer.get(), arena: PhantomData }
+        ChunkRawIter {
+            footer: self.current_chunk_footer.get(),
+            // Authoritative cursor for the current chunk lives on `Arena`, not on the chunk's footer.
+            // The iterator consumes this value on its first step, then reads cursors from each
+            // retired chunk's footer.
+            current_chunk_cursor_ptr: Some(self.cursor_ptr.get()),
+            arena: PhantomData,
+        }
     }
 
     /// Calculate the number of bytes currently allocated across all chunks in this arena.
@@ -202,20 +211,38 @@ impl<const MIN_ALIGN: usize> FusedIterator for ChunkIter<'_, MIN_ALIGN> {}
 #[derive(Debug)]
 pub struct ChunkRawIter<'a, const MIN_ALIGN: usize = 1> {
     footer: NonNull<ChunkFooter>,
+    /// Cursor for the current chunk, taken from `Arena::cursor_ptr` at iterator creation.
+    /// Consumed on the first iteration. Subsequent iterations read the cursor from each retired chunk's footer.
+    current_chunk_cursor_ptr: Option<NonNull<u8>>,
     arena: PhantomData<&'a Arena<MIN_ALIGN>>,
 }
 
 impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
     type Item = (*mut u8, usize);
+
     fn next(&mut self) -> Option<(*mut u8, usize)> {
         unsafe {
             let foot = self.footer.as_ref();
             if foot.is_empty() {
                 return None;
             }
-            let (ptr, len) = foot.as_raw_parts();
+
+            let start_ptr = foot.start_ptr.as_ptr();
+            let cursor_ptr = self
+                .current_chunk_cursor_ptr
+                .take()
+                .unwrap_or_else(|| foot.cursor_ptr.get())
+                .as_ptr();
+            let end_ptr = ptr::from_ref(foot).cast::<u8>();
+
+            debug_assert!(start_ptr <= cursor_ptr);
+            debug_assert!(cursor_ptr.cast_const() <= end_ptr);
+
+            // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`
+            let len = end_ptr.offset_from_unsigned(cursor_ptr.cast_const());
             self.footer = foot.previous_chunk_footer_ptr.get();
-            Some((ptr, len))
+
+            Some((cursor_ptr, len))
         }
     }
 }

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -278,8 +278,18 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // so we only need it here to ensure that it's impossible to create an `Arena` with an invalid `MIN_ALIGN`.
         const { Self::MIN_ALIGN };
 
+        // SAFETY: `chunk_footer_ptr` points to a valid `ChunkFooter` (either a freshly allocated chunk,
+        // a caller-provided chunk in `from_raw_parts`, or the canonical empty chunk)
+        let start_ptr = unsafe { chunk_footer_ptr.as_ref().start_ptr };
+
+        // Initial cursor sits at the footer, which is the end of the allocatable region.
+        // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
+        let cursor_ptr = chunk_footer_ptr.cast::<u8>();
+
         Self {
+            cursor_ptr: Cell::new(cursor_ptr),
             current_chunk_footer: Cell::new(chunk_footer_ptr),
+            start_ptr: Cell::new(start_ptr),
             can_grow: true,
             #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
             stats: AllocationStats::default(),

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -57,12 +57,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 cur_chunk.as_ref().previous_chunk_footer_ptr.replace(EMPTY_CHUNK.get());
             dealloc_chunk_list(prev_chunk);
 
-            // Reset the bump cursor to the end of the chunk
+            // Reset the bump cursor to the end of the chunk.
+            // We don't need to reset `cursor_ptr` in `ChunkFooter`, as it'll be set if the chunk is retired later on.
+            // `iter_allocated_chunks_raw` ignores `cursor_ptr` of the current chunk.
             debug_assert!(
                 is_pointer_aligned_to(cur_chunk.as_ptr(), MIN_ALIGN),
                 "bump pointer {cur_chunk:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
             );
-            cur_chunk.as_ref().cursor_ptr.set(cur_chunk.cast());
+            self.cursor_ptr.set(cur_chunk.cast::<u8>());
 
             let current_chunk_footer = self.current_chunk_footer.get().as_ref();
             debug_assert!(
@@ -70,8 +72,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 "We should only have a single chunk"
             );
             debug_assert_eq!(
-                current_chunk_footer.cursor_ptr.get(),
-                self.current_chunk_footer.get().cast(),
+                self.cursor_ptr.get(),
+                self.current_chunk_footer.get().cast::<u8>(),
                 "Our chunk's bump cursor should be reset to the start of its allocation"
             );
         }

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -1,11 +1,7 @@
 //! Methods only available when `from_raw_parts` feature is enabled.
 //! These methods are only used by raw transfer.
 
-use std::{
-    alloc::Layout,
-    cell::Cell,
-    ptr::{self, NonNull},
-};
+use std::{alloc::Layout, cell::Cell, ptr::NonNull};
 
 use super::{Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK};
 
@@ -79,16 +75,13 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// * `ptr` must be aligned to `MIN_ALIGN`.
     /// * No live references to data in the current chunk before `ptr` can exist.
     pub unsafe fn set_cursor_ptr(&self, ptr: NonNull<u8>) {
-        // SAFETY: `current_chunk_footer` always points to a valid `ChunkFooter`
-        let chunk_footer = unsafe { self.current_chunk_footer.get().as_ref() };
-
-        debug_assert!(ptr.as_ptr() >= chunk_footer.start_ptr.as_ptr());
-        debug_assert!(ptr.as_ptr().cast_const() <= ptr::from_ref(chunk_footer).cast::<u8>());
+        debug_assert!(ptr.as_ptr() >= self.start_ptr.get().as_ptr());
+        debug_assert!(ptr.as_ptr() <= self.current_chunk_footer.get().as_ptr().cast::<u8>());
         debug_assert!(ptr.addr().get().is_multiple_of(MIN_ALIGN));
 
         // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `ptr` is valid
         #[expect(clippy::unnecessary_safety_comment)]
-        chunk_footer.cursor_ptr.set(ptr);
+        self.cursor_ptr.set(ptr);
     }
 
     /// Get pointer to end of the data region of this [`Arena`]'s current chunk

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -158,12 +158,32 @@ mod tests;
 /// [`oxc_allocator::Vec`]: crate::Vec
 /// [`oxc_allocator::Box::new_in`]: crate::Box::new_in
 /// [`alloc`]: Arena::alloc
+//
+// `#[repr(C)]` plus deliberate field ordering to defeat a store-to-load forwarding hazard on aarch64.
+// The fast path reads `cursor_ptr` and `start_ptr`, and writes `cursor_ptr` on every allocation.
+// If `cursor_ptr` and `start_ptr` were adjacent (offsets 0 and 8), LLVM's aarch64 backend fuses them
+// into a single 16-byte `ldp` instruction. That `ldp` then partial-overlaps the 8-byte `cursor_ptr` store
+// from the previous iteration, which breaks store-to-load forwarding and causes a ~3x slowdown in tight allocation loops.
+// `current_chunk_footer` is placed between the two hot pointers so they sit at offsets 0 and 16,
+// forcing LLVM to emit two independent 8-byte `ldr`s, each of which forwards cleanly.
+// More background here: https://eme64.github.io/blog/2024/06/24/Auto-Vectorization-and-Store-to-Load-Forwarding.html
+#[repr(C)]
 #[derive(Debug)]
 pub struct Arena<const MIN_ALIGN: usize = 1> {
+    /// Bump allocation cursor. Always in the range `self.start_ptr..=self.current_chunk_footer`.
+    cursor_ptr: Cell<NonNull<u8>>,
+
     /// The current chunk we are bump allocating within.
     current_chunk_footer: Cell<NonNull<ChunkFooter>>,
+
+    /// Pointer to the start of the current chunk's allocatable region.
+    ///
+    /// Stored here as well as in the `ChunkFooter` so it can be accessed without indirection through the footer.
+    start_ptr: Cell<NonNull<u8>>,
+
     /// Whether this `Arena` is allowed to allocate additional chunks when the current one is full.
     can_grow: bool,
+
     /// Used to track number of allocations made in this `Arena` when `track_allocations` feature is enabled.
     #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
     pub(crate) stats: AllocationStats,
@@ -217,12 +237,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 // therefore prevent sending the `Arena` across threads until the borrows end.
 unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 
-#[repr(C)]
-#[repr(align(16))]
+#[repr(C, align(16))]
 #[derive(Debug)]
 struct ChunkFooter {
     /// Pointer to the start of this chunk allocation.
     /// This footer is always at the end of the chunk.
+    ///
+    /// Only used when deallocating chunks, and when iterating over chunks. Allocation methods use
+    /// `Arena::start_ptr` instead, to avoid the indirection through the footer.
     start_ptr: NonNull<u8>,
 
     /// The layout of this chunk's allocation.
@@ -234,7 +256,9 @@ struct ChunkFooter {
     /// whose `previous_chunk_footer_ptr` link points to itself.
     previous_chunk_footer_ptr: Cell<NonNull<ChunkFooter>>,
 
-    /// Bump allocation cursor that is always in the range `self.start_ptr..=self`.
+    /// Bump allocation cursor, valid only for retired (non-current) chunks. For the current chunk,
+    /// the authoritative cursor lives in `Arena::cursor_ptr`. This field is written when a chunk
+    /// is retired (in the slow path of allocation), so iteration over chunks can read it.
     cursor_ptr: Cell<NonNull<u8>>,
 }
 
@@ -255,18 +279,18 @@ struct EmptyChunkFooter(ChunkFooter);
 unsafe impl Sync for EmptyChunkFooter {}
 
 static EMPTY_CHUNK: EmptyChunkFooter = EmptyChunkFooter(ChunkFooter {
-    // This chunk is empty (except the foot itself)
-    layout: Layout::new::<ChunkFooter>(),
-
     // The start of the (empty) allocatable region for this chunk is itself
     start_ptr: NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>(),
 
-    // The end of the (empty) allocatable region for this chunk is also itself
-    cursor_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>()),
+    // This chunk is empty (except the foot itself)
+    layout: Layout::new::<ChunkFooter>(),
 
     // Invariant: The last chunk footer in all `ChunkFooter::previous_chunk_footer_ptr` linked lists
     // is the empty chunk footer, whose `previous_chunk_footer_ptr` points to itself
     previous_chunk_footer_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK.0)),
+
+    // The end of the (empty) allocatable region for this chunk is also itself
+    cursor_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>()),
 });
 
 impl EmptyChunkFooter {
@@ -276,18 +300,6 @@ impl EmptyChunkFooter {
 }
 
 impl ChunkFooter {
-    /// Returns the start and length of the currently allocated region of this chunk.
-    fn as_raw_parts(&self) -> (*mut u8, usize) {
-        let start_ptr = self.start_ptr.as_ptr().cast_const();
-        let cursor_ptr = self.cursor_ptr.get().as_ptr();
-        let end_ptr = ptr::from_ref(self).cast::<u8>();
-        debug_assert!(start_ptr <= cursor_ptr.cast_const());
-        debug_assert!(cursor_ptr.cast_const() <= end_ptr);
-        // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`
-        let len = unsafe { end_ptr.offset_from_unsigned(cursor_ptr) };
-        (cursor_ptr, len)
-    }
-
     /// Returns `true` if this chunk is the empty chunk (end of the linked list).
     fn is_empty(&self) -> bool {
         ptr::eq(self, EMPTY_CHUNK.get().as_ptr())


### PR DESCRIPTION
`Arena` stores pointers to current bump cursor, and start of the chunk in `ChunkFooter`.

This means that every allocation involves pointer chasing - read the pointer to the`ChunkFooter`, then read the `ChunkFooter`'s `cursor_ptr` and `start_ptr` fields. Because the pointer to the `ChunkFooter` is wrapped in a `Cell`, compiler likely cannot assume the value is still what it was last time it read the field, and will read it over and over repeatedly. This adds ~4 cycles of latency to every allocation.

Instead, store these pointers as fields of the `Arena` itself, to avoid this indirection.

`start_ptr` still also needs to be stored in `ChunkFooter` for use when deallocating chunks. And `cursor_ptr` is also stored in `ChunkFooter` to support `iter_allocated_chunks` and `iter_allocated_chunks_raw` methods.

0.3% - 0.5% perf improvement in parser benchmarks. Allocation is so fast already, that the impact is small - allocation is not the bottleneck. But a micro-benchmark testing allocation in isolation shows that allocation itself gets a 2x speed-up.

See comment on `Arena` for details of a field layout oddity which has a huge impact on aarch64 (Apple Silicon).