### PR TITLE
feat(linter): support dynamic import() in no-restricted-imports

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -936,8 +936,10 @@ impl RuleRunner for crate::rules::eslint::no_restricted_globals::NoRestrictedGlo
 }
 
 impl RuleRunner for crate::rules::eslint::no_restricted_imports::NoRestrictedImports {
-    const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::TSImportEqualsDeclaration]));
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ImportExpression,
+        AstType::TSImportEqualsDeclaration,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -8,11 +8,14 @@ use serde_json::Value;
 
 use oxc_ast::{
     AstKind,
-    ast::{Expression, ImportOrExportKind, TSImportEqualsDeclaration, TSModuleReference},
+    ast::{
+        BindingPattern, BindingProperty, Expression, ImportExpression, ImportOrExportKind,
+        ObjectPattern, TSImportEqualsDeclaration, TSModuleReference,
+    },
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
 
 use crate::{
@@ -224,7 +227,7 @@ impl<'de> Deserialize<'de> for SerdeRegexWrapper<Regex> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum GlobResult {
     Found,
     Whitelist,
@@ -235,7 +238,9 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// This rule allows you to specify imports that you don’t want to use in your application.
-    /// It applies to static imports only, not dynamic ones.
+    /// It applies to static imports, as well as dynamic `import()` expressions with statically known sources.
+    /// Dynamic `import()` expressions with computed sources, such as `import(name)` or template literals with substitutions, are ignored.
+    /// Options that restrict specific import names apply to dynamic `import()` expressions only when the resulting module namespace is destructured.
     ///
     /// ### Why is this bad?
     ///
@@ -769,6 +774,14 @@ impl RestrictedPath {
             NameSpanAllowedResult::Allowed => ImportNameResult::Allowed,
         }
     }
+
+    fn is_dynamic_import_restricted(&self) -> bool {
+        self.import_names.is_none() && self.allow_import_names.is_none()
+    }
+
+    fn has_dynamic_import_name_restriction(&self) -> bool {
+        self.import_names.is_some() || self.allow_import_names.is_some()
+    }
 }
 
 impl RestrictedPattern {
@@ -875,6 +888,20 @@ impl RestrictedPattern {
         }
     }
 
+    fn is_dynamic_import_restricted(&self) -> bool {
+        self.import_names.is_none()
+            && self.import_name_pattern.is_none()
+            && self.allow_import_names.is_none()
+            && self.allow_import_name_pattern.is_none()
+    }
+
+    fn has_dynamic_import_name_restriction(&self) -> bool {
+        self.import_names.is_some()
+            || self.import_name_pattern.is_some()
+            || self.allow_import_names.is_some()
+            || self.allow_import_name_pattern.is_some()
+    }
+
     fn is_side_effect_import_allowed(&self) -> bool {
         let unused_name = CompactStr::from("__<>import_name_that_cant_be_used<>__");
         self.is_name_span_allowed(&unused_name) == NameSpanAllowedResult::Allowed
@@ -927,6 +954,60 @@ impl RestrictedPattern {
     fn get_allow_import_name_pattern_result(&self, name: &CompactStr) -> bool {
         self.allow_import_name_pattern.as_ref().is_some_and(|regex| regex.is_match(name))
     }
+}
+
+fn get_static_import_expression_source<'a>(
+    import_expr: &'a ImportExpression<'a>,
+) -> Option<&'a str> {
+    match import_expr.source.get_inner_expression() {
+        Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+        Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => {
+            Some(tpl.quasis.first()?.value.cooked.as_ref()?.as_str())
+        }
+        _ => None,
+    }
+}
+
+fn get_binding_property_import_name(property: &BindingProperty<'_>) -> Option<ImportImportName> {
+    if property.computed {
+        return None;
+    }
+
+    let name = property.key.static_name()?;
+    Some(ImportImportName::Name(NameSpan::new(
+        CompactStr::from(name.as_ref()),
+        property.key.span(),
+    )))
+}
+
+fn get_import_expression_destructure_pattern<'a>(
+    ctx: &LintContext<'a>,
+    node: &oxc_semantic::AstNode<'a>,
+) -> Option<&'a ObjectPattern<'a>> {
+    let mut has_await_ancestor = false;
+
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        match ancestor.kind() {
+            AstKind::ParenthesizedExpression(_)
+            | AstKind::TSAsExpression(_)
+            | AstKind::TSSatisfiesExpression(_)
+            | AstKind::TSInstantiationExpression(_)
+            | AstKind::TSNonNullExpression(_)
+            | AstKind::TSTypeAssertion(_) => {}
+            AstKind::AwaitExpression(_) if !has_await_ancestor => {
+                has_await_ancestor = true;
+            }
+            AstKind::VariableDeclarator(declarator) if has_await_ancestor => {
+                let BindingPattern::ObjectPattern(object_pattern) = &declarator.id else {
+                    return None;
+                };
+                return Some(object_pattern);
+            }
+            _ => return None,
+        }
+    }
+
+    None
 }
 
 impl Rule for NoRestrictedImports {
@@ -988,29 +1069,18 @@ impl Rule for NoRestrictedImports {
                 self.report_ts_import_equals_declaration_allowed(ctx, declaration);
             }
             AstKind::ImportExpression(import_expr) => {
-                let source = import_expr.source.get_inner_expression();
-                match source {
-                    Expression::StringLiteral(lit) => {
-                        self.report_import_expression_allowed(
+                if let Some(source) = get_static_import_expression_source(import_expr) {
+                    self.report_import_expression_allowed(ctx, source, import_expr.span);
+
+                    if let Some(object_pattern) =
+                        get_import_expression_destructure_pattern(ctx, node)
+                    {
+                        self.report_import_expression_destructure_allowed(
                             ctx,
-                            &lit.value,
-                            lit.span,
-                            import_expr.span,
+                            source,
+                            object_pattern,
                         );
                     }
-                    Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => {
-                        let Some(cooked) = tpl.quasis.first().and_then(|q| q.value.cooked.as_ref())
-                        else {
-                            return;
-                        };
-                        self.report_import_expression_allowed(
-                            ctx,
-                            cooked,
-                            tpl.span,
-                            import_expr.span,
-                        );
-                    }
-                    _ => {}
                 }
             }
             _ => {}
@@ -1308,7 +1378,6 @@ impl NoRestrictedImports {
         &self,
         ctx: &LintContext<'_>,
         source_value: &str,
-        source_span: Span,
         expr_span: Span,
     ) {
         for path in &self.paths {
@@ -1316,27 +1385,18 @@ impl NoRestrictedImports {
                 continue;
             }
 
-            // Dynamic imports are never type-only
-            let result = &path.get_string_literal_result(source_value, source_span, false);
-
-            if *result == ImportNameResult::Allowed {
+            if !path.is_dynamic_import_restricted() {
                 continue;
             }
 
-            let diagnostic =
-                get_diagnostic_from_import_name_result_path(expr_span, source_value, result, path);
-
-            ctx.diagnostic(diagnostic);
+            ctx.diagnostic(diagnostic_path(expr_span, path.message.clone(), source_value));
         }
 
         let mut whitelist_found = false;
         let mut found_errors = vec![];
 
         for pattern in &self.patterns {
-            // Dynamic imports are never type-only
-            let result = &pattern.get_string_literal_result(source_value, source_span, false);
-
-            if *result == ImportNameResult::Allowed {
+            if !pattern.is_dynamic_import_restricted() {
                 continue;
             }
 
@@ -1346,25 +1406,107 @@ impl NoRestrictedImports {
                     break;
                 }
                 GlobResult::Found => {
-                    let diagnostic = get_diagnostic_from_import_name_result_pattern(
+                    found_errors.push(diagnostic_pattern(
                         expr_span,
+                        pattern.message.clone(),
                         source_value,
-                        result,
-                        pattern,
-                    );
-
-                    found_errors.push(diagnostic);
+                    ));
                 }
                 GlobResult::None => (),
             }
 
             if pattern.get_regex_result(source_value) {
-                ctx.diagnostic(get_diagnostic_from_import_name_result_pattern(
+                ctx.diagnostic(diagnostic_pattern(
                     expr_span,
+                    pattern.message.clone(),
+                    source_value,
+                ));
+            }
+        }
+
+        if !whitelist_found && !found_errors.is_empty() {
+            for diagnostic in found_errors {
+                ctx.diagnostic(diagnostic);
+            }
+        }
+    }
+
+    fn report_import_expression_destructure_allowed(
+        &self,
+        ctx: &LintContext<'_>,
+        source_value: &str,
+        object_pattern: &ObjectPattern<'_>,
+    ) {
+        for path in &self.paths {
+            if source_value != path.name.as_str() || !path.has_dynamic_import_name_restriction() {
+                continue;
+            }
+
+            for property in &object_pattern.properties {
+                let Some(import_name) = get_binding_property_import_name(property) else {
+                    continue;
+                };
+                let result = &path.get_import_name_result(&import_name, false);
+
+                if *result == ImportNameResult::Allowed {
+                    continue;
+                }
+
+                ctx.diagnostic(get_diagnostic_from_import_name_result_path(
+                    property.key.span(),
                     source_value,
                     result,
-                    pattern,
+                    path,
                 ));
+            }
+        }
+
+        let mut whitelist_found = false;
+        let mut found_errors = vec![];
+
+        for pattern in &self.patterns {
+            if !pattern.has_dynamic_import_name_restriction() {
+                continue;
+            }
+
+            let group_result = pattern.get_group_glob_result(source_value);
+            if group_result == GlobResult::Whitelist {
+                whitelist_found = true;
+                break;
+            }
+
+            let regex_found = pattern.get_regex_result(source_value);
+            if group_result == GlobResult::None && !regex_found {
+                continue;
+            }
+
+            for property in &object_pattern.properties {
+                let Some(import_name) = get_binding_property_import_name(property) else {
+                    continue;
+                };
+                let result = &pattern.get_import_name_result(&import_name, false);
+
+                if *result == ImportNameResult::Allowed {
+                    continue;
+                }
+
+                if group_result == GlobResult::Found {
+                    found_errors.push(get_diagnostic_from_import_name_result_pattern(
+                        property.key.span(),
+                        source_value,
+                        result,
+                        pattern,
+                    ));
+                }
+
+                if regex_found {
+                    ctx.diagnostic(get_diagnostic_from_import_name_result_pattern(
+                        property.key.span(),
+                        source_value,
+                        result,
+                        pattern,
+                    ));
+                }
             }
         }
 
@@ -3576,7 +3718,7 @@ fn test() {
         (r"import('bar')", Some(serde_json::json!(["foo"]))),
         // Non-string-literal argument (variable) should be ignored
         (r"import(variable)", Some(serde_json::json!(["foo"]))),
-        // importNames should NOT apply to dynamic imports
+        // importNames should NOT apply to bare dynamic imports
         (
             r"import('foo')",
             Some(serde_json::json!([{
@@ -3584,6 +3726,92 @@ fn test() {
                     "name": "foo",
                     "importNames": ["default"],
                     "message": "Use bar instead."
+                }]
+            }])),
+        ),
+        // allowImportNames should NOT apply to bare dynamic imports
+        (
+            r"import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "allowImportNames": ["allowed"]
+                }]
+            }])),
+        ),
+        // Named restrictions in patterns should NOT apply to bare dynamic imports
+        (
+            r"import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "importNames": ["default"]
+                }]
+            }])),
+        ),
+        (
+            r"import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "importNamePattern": "^default$"
+                }]
+            }])),
+        ),
+        (
+            r"import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "allowImportNames": ["allowed"]
+                }]
+            }])),
+        ),
+        (
+            r"import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "allowImportNamePattern": "^allowed$"
+                }]
+            }])),
+        ),
+        // allowImportNames should allow known destructured dynamic import names
+        (
+            r"const { AllowedObject } = await import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "allowImportNames": ["AllowedObject"]
+                }]
+            }])),
+        ),
+        (
+            r"const { AllowedObject: renamed } = await import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "allowImportNames": ["AllowedObject"]
+                }]
+            }])),
+        ),
+        // Non-awaited dynamic imports are not treated as module namespace destructuring
+        (
+            r"const { DisallowedObject } = import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "importNames": ["DisallowedObject"]
+                }]
+            }])),
+        ),
+        // Computed destructuring keys are not statically known
+        (
+            r"const { [key]: value } = await import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "importNames": ["DisallowedObject"]
                 }]
             }])),
         ),
@@ -3619,6 +3847,53 @@ fn test() {
                 }]
             }])),
         ),
+        // Destructured dynamic imports expose statically known import names
+        (
+            r"const { DisallowedObject } = await import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "importNames": ["DisallowedObject"]
+                }]
+            }])),
+        ),
+        (
+            r"const { DisallowedObject: renamed } = await import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "importNames": ["DisallowedObject"]
+                }]
+            }])),
+        ),
+        (
+            r"const { default: foo } = await import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "importNames": ["default"]
+                }]
+            }])),
+        ),
+        (
+            r"const { DisallowedObject } = await import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "allowImportNames": ["AllowedObject"]
+                }]
+            }])),
+        ),
+        // Dynamic imports are never type-only, so allowTypeImports does not exempt them
+        (
+            r"import('foo')",
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "allowTypeImports": true
+                }]
+            }])),
+        ),
         // Pattern restriction
         (
             r"import('lodash/pick')",
@@ -3633,6 +3908,53 @@ fn test() {
                 "patterns": [{
                     "group": ["foo"],
                     "message": "No foo."
+                }]
+            }])),
+        ),
+        // Named restrictions in patterns apply to destructured dynamic imports
+        (
+            r"const { DisallowedObject } = await import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "importNames": ["DisallowedObject"]
+                }]
+            }])),
+        ),
+        (
+            r"const { DisallowedObject } = await import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "allowImportNames": ["AllowedObject"]
+                }]
+            }])),
+        ),
+        (
+            r"const { useThing } = await import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "importNamePattern": "^use"
+                }]
+            }])),
+        ),
+        (
+            r"const { makeThing } = await import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "allowImportNamePattern": "^use"
+                }]
+            }])),
+        ),
+        // Dynamic imports are never type-only, so allowTypeImports does not exempt patterns
+        (
+            r"import('foo')",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "allowTypeImports": true
                 }]
             }])),
         ),

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -8,9 +8,7 @@ use serde_json::Value;
 
 use oxc_ast::{
     AstKind,
-    ast::{
-        Expression, ImportOrExportKind, TSImportEqualsDeclaration, TSModuleReference,
-    },
+    ast::{Expression, ImportOrExportKind, TSImportEqualsDeclaration, TSModuleReference},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -1001,8 +999,7 @@ impl Rule for NoRestrictedImports {
                         );
                     }
                     Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => {
-                        let Some(cooked) =
-                            tpl.quasis.first().and_then(|q| q.value.cooked.as_ref())
+                        let Some(cooked) = tpl.quasis.first().and_then(|q| q.value.cooked.as_ref())
                         else {
                             return;
                         };

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -3549,12 +3549,12 @@ fn test() {
     // Dynamic import() tests
     let pass_dynamic_import = vec![
         // Non-matching source
-        (r#"import('bar')"#, Some(serde_json::json!(["foo"]))),
+        (r"import('bar')", Some(serde_json::json!(["foo"]))),
         // Non-string-literal argument (variable) should be ignored
-        (r#"import(variable)"#, Some(serde_json::json!(["foo"]))),
+        (r"import(variable)", Some(serde_json::json!(["foo"]))),
         // importNames should NOT apply to dynamic imports
         (
-            r#"import('foo')"#,
+            r"import('foo')",
             Some(serde_json::json!([{
                 "paths": [{
                     "name": "foo",
@@ -3569,10 +3569,10 @@ fn test() {
 
     let fail_dynamic_import = vec![
         // Simple string restriction
-        (r#"import('fs')"#, Some(serde_json::json!(["fs"]))),
+        (r"import('fs')", Some(serde_json::json!(["fs"]))),
         // Path with message
         (
-            r#"import('foo')"#,
+            r"import('foo')",
             Some(serde_json::json!([{
                 "paths": [{
                     "name": "foo",
@@ -3582,14 +3582,14 @@ fn test() {
         ),
         // Pattern restriction
         (
-            r#"import('lodash/pick')"#,
+            r"import('lodash/pick')",
             Some(serde_json::json!([{
                 "patterns": ["lodash/*"]
             }])),
         ),
         // Pattern with group and message
         (
-            r#"import('foo')"#,
+            r"import('foo')",
             Some(serde_json::json!([{
                 "patterns": [{
                     "group": ["foo"],
@@ -3599,7 +3599,7 @@ fn test() {
         ),
         // Regex pattern
         (
-            r#"import('@app/api')"#,
+            r"import('@app/api')",
             Some(serde_json::json!([{
                 "patterns": [{
                     "regex": "@app/(api|enums).*"

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use oxc_ast::{
     AstKind,
     ast::{
-        Expression, ImportOrExportKind, StringLiteral, TSImportEqualsDeclaration, TSModuleReference,
+        Expression, ImportOrExportKind, TSImportEqualsDeclaration, TSModuleReference,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -752,19 +752,20 @@ impl RestrictedPath {
 
     fn get_string_literal_result(
         &self,
-        literal: &StringLiteral,
+        value: &str,
+        span: Span,
         is_type: bool,
     ) -> ImportNameResult {
         if is_type && self.allow_type_imports.is_some_and(|x| x) {
             return ImportNameResult::Allowed;
         }
 
-        let name = literal.value.into_compact_str();
+        let name = CompactStr::from(value);
         let unused_name = &CompactStr::from("__<>import_name_that_cant_be_used<>__");
 
         match self.is_name_span_allowed(unused_name) {
             NameSpanAllowedResult::NameDisallowed => {
-                ImportNameResult::NameDisallowed(NameSpan::new(name, literal.span))
+                ImportNameResult::NameDisallowed(NameSpan::new(name, span))
             }
             NameSpanAllowedResult::GeneralDisallowed => ImportNameResult::GeneralDisallowed,
             NameSpanAllowedResult::Allowed => ImportNameResult::Allowed,
@@ -856,19 +857,20 @@ impl RestrictedPattern {
 
     fn get_string_literal_result(
         &self,
-        literal: &StringLiteral,
+        value: &str,
+        span: Span,
         is_type: bool,
     ) -> ImportNameResult {
         if is_type && self.allow_type_imports.is_some_and(|x| x) {
             return ImportNameResult::Allowed;
         }
 
-        let name = literal.value.into_compact_str();
+        let name = CompactStr::from(value);
         let unused_name = &CompactStr::from("__<>import_name_that_cant_be_used<>__");
 
         match self.is_name_span_allowed(unused_name) {
             NameSpanAllowedResult::NameDisallowed => {
-                ImportNameResult::NameDisallowed(NameSpan::new(name, literal.span))
+                ImportNameResult::NameDisallowed(NameSpan::new(name, span))
             }
             NameSpanAllowedResult::GeneralDisallowed => ImportNameResult::GeneralDisallowed,
             NameSpanAllowedResult::Allowed => ImportNameResult::Allowed,
@@ -988,8 +990,30 @@ impl Rule for NoRestrictedImports {
                 self.report_ts_import_equals_declaration_allowed(ctx, declaration);
             }
             AstKind::ImportExpression(import_expr) => {
-                if let Expression::StringLiteral(source) = &import_expr.source {
-                    self.report_import_expression_allowed(ctx, source, import_expr.span);
+                let source = import_expr.source.get_inner_expression();
+                match source {
+                    Expression::StringLiteral(lit) => {
+                        self.report_import_expression_allowed(
+                            ctx,
+                            &lit.value,
+                            lit.span,
+                            import_expr.span,
+                        );
+                    }
+                    Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() => {
+                        let Some(cooked) =
+                            tpl.quasis.first().and_then(|q| q.value.cooked.as_ref())
+                        else {
+                            return;
+                        };
+                        self.report_import_expression_allowed(
+                            ctx,
+                            cooked,
+                            tpl.span,
+                            import_expr.span,
+                        );
+                    }
+                    _ => {}
                 }
             }
             _ => {}
@@ -1225,7 +1249,8 @@ impl NoRestrictedImports {
             }
 
             let result = &path.get_string_literal_result(
-                &reference.expression,
+                &reference.expression.value,
+                reference.expression.span,
                 entry.import_kind == ImportOrExportKind::Type,
             );
 
@@ -1244,7 +1269,8 @@ impl NoRestrictedImports {
 
         for pattern in &self.patterns {
             let result = &pattern.get_string_literal_result(
-                &reference.expression,
+                &reference.expression.value,
+                reference.expression.span,
                 entry.import_kind == ImportOrExportKind::Type,
             );
 
@@ -1284,23 +1310,24 @@ impl NoRestrictedImports {
     fn report_import_expression_allowed(
         &self,
         ctx: &LintContext<'_>,
-        source: &StringLiteral,
-        span: Span,
+        source_value: &str,
+        source_span: Span,
+        expr_span: Span,
     ) {
         for path in &self.paths {
-            if source.value.as_str() != path.name.as_str() {
+            if source_value != path.name.as_str() {
                 continue;
             }
 
             // Dynamic imports are never type-only
-            let result = &path.get_string_literal_result(source, false);
+            let result = &path.get_string_literal_result(source_value, source_span, false);
 
             if *result == ImportNameResult::Allowed {
                 continue;
             }
 
             let diagnostic =
-                get_diagnostic_from_import_name_result_path(span, &source.value, result, path);
+                get_diagnostic_from_import_name_result_path(expr_span, source_value, result, path);
 
             ctx.diagnostic(diagnostic);
         }
@@ -1310,21 +1337,21 @@ impl NoRestrictedImports {
 
         for pattern in &self.patterns {
             // Dynamic imports are never type-only
-            let result = &pattern.get_string_literal_result(source, false);
+            let result = &pattern.get_string_literal_result(source_value, source_span, false);
 
             if *result == ImportNameResult::Allowed {
                 continue;
             }
 
-            match pattern.get_group_glob_result(&source.value) {
+            match pattern.get_group_glob_result(source_value) {
                 GlobResult::Whitelist => {
                     whitelist_found = true;
                     break;
                 }
                 GlobResult::Found => {
                     let diagnostic = get_diagnostic_from_import_name_result_pattern(
-                        span,
-                        &source.value,
+                        expr_span,
+                        source_value,
                         result,
                         pattern,
                     );
@@ -1334,10 +1361,10 @@ impl NoRestrictedImports {
                 GlobResult::None => (),
             }
 
-            if pattern.get_regex_result(&source.value) {
+            if pattern.get_regex_result(source_value) {
                 ctx.diagnostic(get_diagnostic_from_import_name_result_pattern(
-                    span,
-                    &source.value,
+                    expr_span,
+                    source_value,
                     result,
                     pattern,
                 ));
@@ -3563,13 +3590,28 @@ fn test() {
                 }]
             }])),
         ),
-        // Template literal (not a string literal) should be ignored
-        ("import(`foo`)", Some(serde_json::json!(["foo"]))),
+        // Template literal with substitutions can't be resolved statically
+        ("import(`foo${bar}`)", Some(serde_json::json!(["foo"]))),
+        // Tagged templates are not a statically-resolvable string source
+        ("import(tag`foo`)", Some(serde_json::json!(["foo"]))),
     ];
 
     let fail_dynamic_import = vec![
         // Simple string restriction
         (r"import('fs')", Some(serde_json::json!(["fs"]))),
+        // Template literal without substitutions should be treated like a string literal
+        ("import(`foo`)", Some(serde_json::json!(["foo"]))),
+        // TypeScript `as` cast wrapping a string literal should be unwrapped
+        (r#"import("foo" as string)"#, Some(serde_json::json!(["foo"]))),
+        // TypeScript `satisfies` operator should also be unwrapped
+        (r#"import("foo" satisfies string)"#, Some(serde_json::json!(["foo"]))),
+        // Template literal sources should also match patterns
+        (
+            "import(`lodash/pick`)",
+            Some(serde_json::json!([{
+                "patterns": ["lodash/*"]
+            }])),
+        ),
         // Path with message
         (
             r"import('foo')",

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -8,7 +8,9 @@ use serde_json::Value;
 
 use oxc_ast::{
     AstKind,
-    ast::{Expression, ImportOrExportKind, StringLiteral, TSImportEqualsDeclaration, TSModuleReference},
+    ast::{
+        Expression, ImportOrExportKind, StringLiteral, TSImportEqualsDeclaration, TSModuleReference,
+    },
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -3551,13 +3553,16 @@ fn test() {
         // Non-string-literal argument (variable) should be ignored
         (r#"import(variable)"#, Some(serde_json::json!(["foo"]))),
         // importNames should NOT apply to dynamic imports
-        (r#"import('foo')"#, Some(serde_json::json!([{
-            "paths": [{
-                "name": "foo",
-                "importNames": ["default"],
-                "message": "Use bar instead."
-            }]
-        }]))),
+        (
+            r#"import('foo')"#,
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "importNames": ["default"],
+                    "message": "Use bar instead."
+                }]
+            }])),
+        ),
         // Template literal (not a string literal) should be ignored
         ("import(`foo`)", Some(serde_json::json!(["foo"]))),
     ];
@@ -3566,29 +3571,41 @@ fn test() {
         // Simple string restriction
         (r#"import('fs')"#, Some(serde_json::json!(["fs"]))),
         // Path with message
-        (r#"import('foo')"#, Some(serde_json::json!([{
-            "paths": [{
-                "name": "foo",
-                "message": "Use bar instead."
-            }]
-        }]))),
+        (
+            r#"import('foo')"#,
+            Some(serde_json::json!([{
+                "paths": [{
+                    "name": "foo",
+                    "message": "Use bar instead."
+                }]
+            }])),
+        ),
         // Pattern restriction
-        (r#"import('lodash/pick')"#, Some(serde_json::json!([{
-            "patterns": ["lodash/*"]
-        }]))),
+        (
+            r#"import('lodash/pick')"#,
+            Some(serde_json::json!([{
+                "patterns": ["lodash/*"]
+            }])),
+        ),
         // Pattern with group and message
-        (r#"import('foo')"#, Some(serde_json::json!([{
-            "patterns": [{
-                "group": ["foo"],
-                "message": "No foo."
-            }]
-        }]))),
+        (
+            r#"import('foo')"#,
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "group": ["foo"],
+                    "message": "No foo."
+                }]
+            }])),
+        ),
         // Regex pattern
-        (r#"import('@app/api')"#, Some(serde_json::json!([{
-            "patterns": [{
-                "regex": "@app/(api|enums).*"
-            }]
-        }]))),
+        (
+            r#"import('@app/api')"#,
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "regex": "@app/(api|enums).*"
+                }]
+            }])),
+        ),
     ];
 
     pass.extend(pass_dynamic_import);

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use oxc_ast::{
     AstKind,
-    ast::{ImportOrExportKind, StringLiteral, TSImportEqualsDeclaration, TSModuleReference},
+    ast::{Expression, ImportOrExportKind, StringLiteral, TSImportEqualsDeclaration, TSModuleReference},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -981,11 +981,17 @@ impl Rule for NoRestrictedImports {
     }
 
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::TSImportEqualsDeclaration(declaration) = node.kind() else {
-            return;
-        };
-
-        self.report_ts_import_equals_declaration_allowed(ctx, declaration);
+        match node.kind() {
+            AstKind::TSImportEqualsDeclaration(declaration) => {
+                self.report_ts_import_equals_declaration_allowed(ctx, declaration);
+            }
+            AstKind::ImportExpression(import_expr) => {
+                if let Expression::StringLiteral(source) = &import_expr.source {
+                    self.report_import_expression_allowed(ctx, source, import_expr.span);
+                }
+            }
+            _ => {}
+        }
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {
@@ -1262,6 +1268,76 @@ impl NoRestrictedImports {
             if pattern.get_regex_result(&reference.expression.value) {
                 ctx.diagnostic(get_diagnostic_from_import_name_result_pattern(
                     entry.span, source, result, pattern,
+                ));
+            }
+        }
+
+        if !whitelist_found && !found_errors.is_empty() {
+            for diagnostic in found_errors {
+                ctx.diagnostic(diagnostic);
+            }
+        }
+    }
+
+    fn report_import_expression_allowed(
+        &self,
+        ctx: &LintContext<'_>,
+        source: &StringLiteral,
+        span: Span,
+    ) {
+        for path in &self.paths {
+            if source.value.as_str() != path.name.as_str() {
+                continue;
+            }
+
+            // Dynamic imports are never type-only
+            let result = &path.get_string_literal_result(source, false);
+
+            if *result == ImportNameResult::Allowed {
+                continue;
+            }
+
+            let diagnostic =
+                get_diagnostic_from_import_name_result_path(span, &source.value, result, path);
+
+            ctx.diagnostic(diagnostic);
+        }
+
+        let mut whitelist_found = false;
+        let mut found_errors = vec![];
+
+        for pattern in &self.patterns {
+            // Dynamic imports are never type-only
+            let result = &pattern.get_string_literal_result(source, false);
+
+            if *result == ImportNameResult::Allowed {
+                continue;
+            }
+
+            match pattern.get_group_glob_result(&source.value) {
+                GlobResult::Whitelist => {
+                    whitelist_found = true;
+                    break;
+                }
+                GlobResult::Found => {
+                    let diagnostic = get_diagnostic_from_import_name_result_pattern(
+                        span,
+                        &source.value,
+                        result,
+                        pattern,
+                    );
+
+                    found_errors.push(diagnostic);
+                }
+                GlobResult::None => (),
+            }
+
+            if pattern.get_regex_result(&source.value) {
+                ctx.diagnostic(get_diagnostic_from_import_name_result_pattern(
+                    span,
+                    &source.value,
+                    result,
+                    pattern,
                 ));
             }
         }
@@ -3467,6 +3543,56 @@ fn test() {
             ])),
         ),
     ];
+
+    // Dynamic import() tests
+    let pass_dynamic_import = vec![
+        // Non-matching source
+        (r#"import('bar')"#, Some(serde_json::json!(["foo"]))),
+        // Non-string-literal argument (variable) should be ignored
+        (r#"import(variable)"#, Some(serde_json::json!(["foo"]))),
+        // importNames should NOT apply to dynamic imports
+        (r#"import('foo')"#, Some(serde_json::json!([{
+            "paths": [{
+                "name": "foo",
+                "importNames": ["default"],
+                "message": "Use bar instead."
+            }]
+        }]))),
+        // Template literal (not a string literal) should be ignored
+        ("import(`foo`)", Some(serde_json::json!(["foo"]))),
+    ];
+
+    let fail_dynamic_import = vec![
+        // Simple string restriction
+        (r#"import('fs')"#, Some(serde_json::json!(["fs"]))),
+        // Path with message
+        (r#"import('foo')"#, Some(serde_json::json!([{
+            "paths": [{
+                "name": "foo",
+                "message": "Use bar instead."
+            }]
+        }]))),
+        // Pattern restriction
+        (r#"import('lodash/pick')"#, Some(serde_json::json!([{
+            "patterns": ["lodash/*"]
+        }]))),
+        // Pattern with group and message
+        (r#"import('foo')"#, Some(serde_json::json!([{
+            "patterns": [{
+                "group": ["foo"],
+                "message": "No foo."
+            }]
+        }]))),
+        // Regex pattern
+        (r#"import('@app/api')"#, Some(serde_json::json!([{
+            "patterns": [{
+                "regex": "@app/(api|enums).*"
+            }]
+        }]))),
+    ];
+
+    pass.extend(pass_dynamic_import);
+    fail.extend(fail_dynamic_import);
 
     pass.extend(pass_typescript);
     fail.extend(fail_typescript);

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -837,6 +837,38 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Example: React is not allowed to be imported
 
+  ⚠ eslint(no-restricted-imports): 'fs' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import('fs')
+   · ────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import('foo')
+   · ─────────────
+   ╰────
+  help: Use bar instead.
+
+  ⚠ eslint(no-restricted-imports): 'lodash/pick' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import('lodash/pick')
+   · ─────────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import('foo')
+   · ─────────────
+   ╰────
+  help: No foo.
+
+  ⚠ eslint(no-restricted-imports): '@app/api' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import('@app/api')
+   · ──────────────────
+   ╰────
+
   ⚠ eslint(no-restricted-imports): 'import1' import is restricted from being used.
    ╭─[no_restricted_imports.tsx:1:1]
  1 │ import foo from 'import1';

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(no-restricted-imports): 'fs' import is restricted from being used.
@@ -841,6 +842,30 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_restricted_imports.tsx:1:1]
  1 │ import('fs')
    · ────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import(`foo`)
+   · ─────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import("foo" as string)
+   · ───────────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import("foo" satisfies string)
+   · ──────────────────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'lodash/pick' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import(`lodash/pick`)
+   · ─────────────────────
    ╰────
 
   ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(no-restricted-imports): 'fs' import is restricted from being used.
@@ -875,6 +874,36 @@ assertion_line: 444
    ╰────
   help: Use bar instead.
 
+  ⚠ eslint(no-restricted-imports): 'DisallowedObject' import from 'foo' is restricted.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { DisallowedObject } = await import('foo')
+   ·         ────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'DisallowedObject' import from 'foo' is restricted.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { DisallowedObject: renamed } = await import('foo')
+   ·         ────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'default' import from 'foo' is restricted.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { default: foo } = await import('foo')
+   ·         ───────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'DisallowedObject' import from 'foo' is restricted because only AllowedObject import(s) is/are allowed.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { DisallowedObject } = await import('foo')
+   ·         ────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import('foo')
+   · ─────────────
+   ╰────
+
   ⚠ eslint(no-restricted-imports): 'lodash/pick' import is restricted from being used by a pattern.
    ╭─[no_restricted_imports.tsx:1:1]
  1 │ import('lodash/pick')
@@ -887,6 +916,36 @@ assertion_line: 444
    · ─────────────
    ╰────
   help: No foo.
+
+  ⚠ eslint(no-restricted-imports): 'DisallowedObject' import from 'foo' is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { DisallowedObject } = await import('foo')
+   ·         ────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'DisallowedObject' import from 'foo' is restricted because only AllowedObject import(s) is/are allowed.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { DisallowedObject } = await import('foo')
+   ·         ────────────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'useThing' import from 'foo' is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { useThing } = await import('foo')
+   ·         ────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'makeThing' import from 'foo' is restricted because only imports that match the pattern '^use' are allowed from 'foo'.
+   ╭─[no_restricted_imports.tsx:1:9]
+ 1 │ const { makeThing } = await import('foo')
+   ·         ─────────
+   ╰────
+
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import('foo')
+   · ─────────────
+   ╰────
 
   ⚠ eslint(no-restricted-imports): '@app/api' import is restricted from being used by a pattern.
    ╭─[no_restricted_imports.tsx:1:1]


### PR DESCRIPTION
## Summary

- Add `ImportExpression` handling to `no-restricted-imports` so that `import('source')` with string literal arguments is checked against configured `paths` and `patterns`
- Only path-level restrictions apply — `importNames` filtering is skipped since dynamic imports have no named bindings

## Why

The rule currently only handles static `import`/`export` declarations and `TSImportEqualsDeclaration`. Dynamic `import()` expressions bypass restrictions entirely, allowing restricted modules to be imported at runtime.

## Design

The implementation follows the existing `report_ts_import_equals_declaration_allowed()` pattern, using the same `get_string_literal_result()` method on both `RestrictedPath` and `RestrictedPattern`. Non-string-literal arguments (variables, template literals with substitutions) are ignored since the source cannot be statically analyzed.

## Test cases

**Pass (4):** non-matching source, non-string argument, `importNames` doesn't apply to dynamic import, template literal
**Fail (5):** simple string restriction, path with message, pattern with glob, pattern with group/message, regex pattern

Closes #21411