### PR TITLE
refactor(oxfmt): Move `ignorePatterns` related functions to `ConfigResolver`

### DIFF
--- a/apps/oxfmt/src/cli/runner.rs
+++ b/apps/oxfmt/src/cli/runner.rs
@@ -93,13 +93,10 @@ impl CliRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         };
-        let root_ignore_patterns = match root_config_resolver.build_and_validate() {
-            Ok(patterns) => patterns,
-            Err(err) => {
-                utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
-                return CliRunResult::InvalidOptionConfig;
-            }
-        };
+        if let Err(err) = root_config_resolver.build_and_validate() {
+            utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
+            return CliRunResult::InvalidOptionConfig;
+        }
 
         // Use `block_in_place()` to avoid nested async runtime access
         #[cfg(feature = "napi")]
@@ -165,7 +162,6 @@ impl CliRunner {
         // Run scoped walks (root + nested) — sends entries to `tx_entry`
         let any_config_found = match scoped_walker.run(
             root_config_resolver,
-            &root_ignore_patterns,
             &resolved_ignore_paths,
             ignore_options.with_node_modules,
             // Nested config detection is disabled when `--config` is explicitly specified

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -12,20 +12,13 @@ use tracing::instrument;
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
 use crate::core::{
-    ConfigResolver, FormatFileStrategy, all_config_file_names, utils::normalize_relative_path,
+    ConfigResolver, FormatFileStrategy, has_config_in_directory, utils::normalize_relative_path,
 };
 
 /// A file entry paired with its scope's config resolver.
 pub struct FormatEntry {
     pub strategy: FormatFileStrategy,
     pub config_resolver: Arc<ConfigResolver>,
-}
-
-/// A scope's config and ignore matchers. Used for both root and child scopes.
-#[derive(Clone)]
-struct ScopeConfig {
-    config_resolver: Arc<ConfigResolver>,
-    ignore_pattern_matchers: Arc<[Gitignore]>,
 }
 
 /// Orchestrates file discovery with nested config and ignore handling.
@@ -128,7 +121,6 @@ impl ScopedWalker {
     pub fn run(
         &self,
         root_config: ConfigResolver,
-        root_ignore_patterns: &[String],
         ignore_paths: &[PathBuf],
         with_node_modules: bool,
         detect_nested: bool,
@@ -138,24 +130,12 @@ impl ScopedWalker {
     ) -> Result<bool, String> {
         let root_config_resolver = Arc::new(root_config);
 
-        let config_candidates: Vec<String> =
-            if detect_nested { all_config_file_names().collect() } else { vec![] };
-
         // Global ignores: .prettierignore, --ignore-path, CLI `!` patterns
         let ignore_file_matchers: Arc<[Gitignore]> = Arc::from(build_global_ignore_matchers(
             &self.cwd,
             &self.exclude_patterns,
             ignore_paths,
         )?);
-
-        // ROOT config's ignorePatterns (child scopes' are loaded in `load_child_scopes()`)
-        let ignore_pattern_matchers: Arc<[Gitignore]> =
-            if let Some(config_dir) = root_config_resolver.config_dir() {
-                Arc::from(build_ignore_patterns_matcher(config_dir, root_ignore_patterns)?)
-            } else {
-                // No config → no ignorePatterns
-                Arc::from(Vec::<Gitignore>::new())
-            };
 
         let mut any_config = root_config_resolver.config_dir().is_some();
 
@@ -200,7 +180,7 @@ impl ScopedWalker {
         let mut directly_processed: FxHashSet<PathBuf> = FxHashSet::default();
         if !file_targets.is_empty() {
             // Cache scope resolution results by parent directory to avoid redundant lookups
-            type ScopeEntry = Option<(Arc<ConfigResolver>, Arc<[Gitignore]>)>;
+            type ScopeEntry = Option<Arc<ConfigResolver>>;
 
             let mut scope_cache: FxHashMap<&Path, ScopeEntry> = FxHashMap::default();
             for file in &file_targets {
@@ -210,45 +190,32 @@ impl ScopedWalker {
                 }
 
                 // Resolve which scope (config) this file belongs to
-                let (file_config, file_ignore_matchers) = if detect_nested {
+                let file_config = if detect_nested {
                     let parent = file.parent().unwrap();
                     if !scope_cache.contains_key(parent) {
-                        let result = resolve_file_scope_config(
+                        let cached = resolve_file_scope_config(
                             file,
                             root_config_resolver.config_dir(),
                             editorconfig_path,
                             #[cfg(feature = "napi")]
                             js_config_loader,
-                        )?;
-                        let cached = if let Some((resolver, ignore_patterns)) = result {
-                            let matchers = Arc::from(build_ignore_patterns_matcher(
-                                resolver.config_dir().expect(
-                                    "`resolve_file_scope_config()` guarantees `config_dir` is Some",
-                                ),
-                                &ignore_patterns,
-                            )?);
-                            Some((Arc::from(resolver), matchers))
-                        } else {
-                            None
-                        };
+                        )?
+                        .map(Arc::from);
                         scope_cache.insert(parent, cached);
                     }
 
                     match &scope_cache[parent] {
-                        Some((resolver, matchers)) => {
+                        Some(resolver) => {
                             any_config = true;
-                            (Arc::clone(resolver), Arc::clone(matchers))
+                            Arc::clone(resolver)
                         }
-                        None => (
-                            Arc::clone(&root_config_resolver),
-                            Arc::clone(&ignore_pattern_matchers),
-                        ),
+                        None => Arc::clone(&root_config_resolver),
                     }
                 } else {
-                    (Arc::clone(&root_config_resolver), Arc::clone(&ignore_pattern_matchers))
+                    Arc::clone(&root_config_resolver)
                 };
 
-                if is_ignored(&file_ignore_matchers, file, false, true) {
+                if file_config.is_path_ignored(file, false) {
                     continue;
                 }
                 let Ok(strategy) = FormatFileStrategy::try_from(file.clone()) else {
@@ -278,12 +245,7 @@ impl ScopedWalker {
 
         // Pre-scan: discover nested config file locations
         let config_dirs = if detect_nested {
-            prescan_config_locations(
-                &walk_targets,
-                &config_candidates,
-                &ignore_file_matchers,
-                with_node_modules,
-            )
+            prescan_config_locations(&walk_targets, &ignore_file_matchers, with_node_modules)
         } else {
             vec![]
         };
@@ -306,8 +268,8 @@ impl ScopedWalker {
 
             // Build ancestor set for directory-level ignorePatterns skipping,
             // only when any scope (root or child) has ignorePatterns.
-            let ancestors = if !ignore_pattern_matchers.is_empty()
-                || map.values().any(|s| !s.ignore_pattern_matchers.is_empty())
+            let ancestors = if root_config_resolver.has_ignore_patterns()
+                || map.values().any(|r| r.has_ignore_patterns())
             {
                 Some(build_config_ancestors(&config_dirs))
             } else {
@@ -320,7 +282,6 @@ impl ScopedWalker {
         walk_and_stream(
             &walk_targets,
             Arc::clone(&ignore_file_matchers),
-            Arc::clone(&ignore_pattern_matchers),
             with_node_modules,
             glob_matcher.as_ref(),
             &root_config_resolver,
@@ -379,27 +340,6 @@ fn build_global_ignore_matchers(
     Ok(matchers)
 }
 
-/// Build ignore matchers from config `ignorePatterns`.
-/// Patterns are resolved relative to the config file's directory.
-fn build_ignore_patterns_matcher(
-    config_dir: &Path,
-    ignore_patterns: &[String],
-) -> Result<Vec<Gitignore>, String> {
-    if ignore_patterns.is_empty() {
-        return Ok(vec![]);
-    }
-
-    let mut builder = GitignoreBuilder::new(config_dir);
-    for pattern in ignore_patterns {
-        if builder.add_line(None, pattern).is_err() {
-            return Err(format!("Failed to add ignore pattern `{pattern}` from `.ignorePatterns`"));
-        }
-    }
-    let gitignore = builder.build().map_err(|_| "Failed to build ignores".to_string())?;
-
-    Ok(vec![gitignore])
-}
-
 /// Resolve ignore file paths from CLI args or defaults.
 ///
 /// Called early (before walk) to validate that specified ignore files exist.
@@ -434,7 +374,7 @@ fn resolve_file_scope_config(
     root_config_dir: Option<&Path>,
     editorconfig_path: Option<&Path>,
     #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
-) -> Result<Option<(ConfigResolver, Vec<String>)>, String> {
+) -> Result<Option<ConfigResolver>, String> {
     let Some(parent) = file.parent() else {
         return Ok(None);
     };
@@ -453,10 +393,10 @@ fn resolve_file_scope_config(
         return Ok(None);
     }
 
-    let ignore_patterns = resolver
+    resolver
         .build_and_validate()
         .map_err(|err| format!("Failed to parse config for {}: {err}", file.display()))?;
-    Ok(Some((resolver, ignore_patterns)))
+    Ok(Some(resolver))
 }
 
 // ---
@@ -540,7 +480,6 @@ impl GlobMatcher {
 #[instrument(level = "debug", name = "oxfmt::walk::prescan_config_locations", skip_all)]
 fn prescan_config_locations(
     target_paths: &[PathBuf],
-    config_candidates: &[String],
     ignore_file_matchers: &Arc<[Gitignore]>,
     with_node_modules: bool,
 ) -> Vec<PathBuf> {
@@ -563,7 +502,7 @@ fn prescan_config_locations(
     let mut config_dirs = vec![];
     for entry in configure_walk_builder(builder).build().flatten() {
         let dir = entry.path();
-        if config_candidates.iter().any(|name| dir.join(name).exists()) {
+        if has_config_in_directory(dir) {
             config_dirs.push(dir.to_path_buf());
         }
     }
@@ -582,7 +521,7 @@ fn resolve_child_scope_configs(
     root_config_dir: Option<&Path>,
     editorconfig_path: Option<&Path>,
     #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
-) -> Result<(FxHashMap<PathBuf, ScopeConfig>, bool), String> {
+) -> Result<(FxHashMap<PathBuf, Arc<ConfigResolver>>, bool), String> {
     let mut map = FxHashMap::default();
     let mut has_children = false;
     for config_dir in config_dirs {
@@ -604,20 +543,12 @@ fn resolve_child_scope_configs(
             continue;
         }
 
-        let ignore_patterns = resolver
+        resolver
             .build_and_validate()
             .map_err(|err| format!("Failed to parse config in {}: {err}", config_dir.display()))?;
 
-        let config_resolver = Arc::from(resolver);
         has_children = true;
-
-        let scope_dir = config_resolver
-            .config_dir()
-            .expect("checked above that config_dir is Some and not root");
-        let ignore_pattern_matchers: Arc<[Gitignore]> =
-            Arc::from(build_ignore_patterns_matcher(scope_dir, &ignore_patterns)?);
-
-        map.insert(config_dir.clone(), ScopeConfig { config_resolver, ignore_pattern_matchers });
+        map.insert(config_dir.clone(), Arc::from(resolver));
     }
 
     Ok((map, has_children))
@@ -645,13 +576,12 @@ fn build_config_ancestors(config_dirs: &[PathBuf]) -> Arc<FxHashSet<PathBuf>> {
 fn walk_and_stream(
     target_paths: &[PathBuf],
     ignore_file_matchers: Arc<[Gitignore]>,
-    ignore_pattern_matchers: Arc<[Gitignore]>,
     with_node_modules: bool,
     glob_matcher: Option<&Arc<GlobMatcher>>,
     root_config_resolver: &Arc<ConfigResolver>,
     directly_processed: &Arc<FxHashSet<PathBuf>>,
     config_ancestors: Option<&Arc<FxHashSet<PathBuf>>>,
-    child_scope_map: &Arc<FxHashMap<PathBuf, ScopeConfig>>,
+    child_scope_map: &Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
     sender: &mpsc::Sender<FormatEntry>,
 ) {
     let Some(first_path) = target_paths.first() else {
@@ -664,7 +594,7 @@ fn walk_and_stream(
     }
 
     let filter_global = Arc::clone(&ignore_file_matchers);
-    let filter_root_patterns = Arc::clone(&ignore_pattern_matchers);
+    let filter_root_resolver = Arc::clone(root_config_resolver);
     let filter_ancestors = config_ancestors.cloned();
     let filter_child_scopes = Arc::clone(child_scope_map);
     // NOTE: If return `false` here, it will not be `visit()`ed at all
@@ -686,12 +616,12 @@ fn walk_and_stream(
         // then checks that scope's ignorePatterns.
         // Safe to skip when pre-scan confirms no config descendant exists beneath.
         if is_dir && filter_ancestors.as_ref().is_some_and(|a| !a.contains(entry.path())) {
-            let scope_matchers: &[Gitignore] = entry
+            let resolver: &ConfigResolver = entry
                 .path()
                 .ancestors()
-                .find_map(|a| filter_child_scopes.get(a))
-                .map_or(&*filter_root_patterns, |s| &*s.ignore_pattern_matchers);
-            if is_ignored(scope_matchers, entry.path(), true, true) {
+                .find_map(|a| filter_child_scopes.get(a).map(AsRef::as_ref))
+                .unwrap_or(&filter_root_resolver);
+            if resolver.is_path_ignored(entry.path(), true) {
                 return false;
             }
         }
@@ -703,11 +633,9 @@ fn walk_and_stream(
         true
     });
 
-    let root_scope =
-        ScopeConfig { config_resolver: Arc::clone(root_config_resolver), ignore_pattern_matchers };
     let mut builder = WalkVisitorBuilder {
         sender: sender.clone(),
-        root_scope,
+        root_config_resolver: Arc::clone(root_config_resolver),
         glob_matcher: glob_matcher.cloned(),
         child_scope_map: Arc::clone(child_scope_map),
         directly_processed: Arc::clone(directly_processed),
@@ -750,9 +678,9 @@ fn configure_walk_builder(mut builder: ignore::WalkBuilder) -> ignore::WalkBuild
 
 struct WalkVisitorBuilder {
     sender: mpsc::Sender<FormatEntry>,
-    root_scope: ScopeConfig,
+    root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
-    child_scope_map: Arc<FxHashMap<PathBuf, ScopeConfig>>,
+    child_scope_map: Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
     /// Files already processed as direct file targets (for dedup with walk results).
     directly_processed: Arc<FxHashSet<PathBuf>>,
 }
@@ -761,7 +689,7 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkVisitorBuilder {
     fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
         Box::new(WalkVisitor {
             sender: self.sender.clone(),
-            root_scope: self.root_scope.clone(),
+            root_config_resolver: Arc::clone(&self.root_config_resolver),
             glob_matcher: self.glob_matcher.clone(),
             child_scope_map: Arc::clone(&self.child_scope_map),
             directly_processed: Arc::clone(&self.directly_processed),
@@ -772,12 +700,12 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkVisitorBuilder {
 
 struct WalkVisitor {
     sender: mpsc::Sender<FormatEntry>,
-    root_scope: ScopeConfig,
+    root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
-    child_scope_map: Arc<FxHashMap<PathBuf, ScopeConfig>>,
+    child_scope_map: Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
     directly_processed: Arc<FxHashSet<PathBuf>>,
-    /// Cache: parent dir → (resolved scope, parent_ignored flag).
-    scope_cache: FxHashMap<PathBuf, (ScopeConfig, bool)>,
+    /// Cache: parent dir → (resolved config, parent_ignored flag).
+    scope_cache: FxHashMap<PathBuf, (Arc<ConfigResolver>, bool)>,
 }
 
 impl WalkVisitor {
@@ -791,14 +719,14 @@ impl WalkVisitor {
             return;
         }
 
-        let scope = parent
+        let resolver = parent
             .ancestors()
             .find_map(|a| self.child_scope_map.get(a))
             .cloned()
-            .unwrap_or_else(|| self.root_scope.clone());
+            .unwrap_or_else(|| Arc::clone(&self.root_config_resolver));
 
-        let parent_ignored = is_ignored(&scope.ignore_pattern_matchers, parent, true, true);
-        self.scope_cache.insert(parent.to_path_buf(), (scope, parent_ignored));
+        let parent_ignored = resolver.is_path_ignored(parent, true);
+        self.scope_cache.insert(parent.to_path_buf(), (resolver, parent_ignored));
     }
 }
 
@@ -826,7 +754,7 @@ impl ignore::ParallelVisitor for WalkVisitor {
                     // Resolve this file's scope (cached per parent directory)
                     let parent = path.parent().expect("walk yields absolute paths");
                     self.ensure_scope_cached(parent);
-                    let (scope, parent_ignored) = &self.scope_cache[parent];
+                    let (resolver, parent_ignored) = &self.scope_cache[parent];
 
                     // Check scope's `ignorePatterns` per-file.
                     //
@@ -834,9 +762,7 @@ impl ignore::ParallelVisitor for WalkVisitor {
                     // 1. Parent directory (cached): catches directory patterns like "lib" that match all files under lib/.
                     //    Uses check_ancestors so "lib" also catches files under lib/packages/.
                     // 2. File-level: catches file-specific patterns like "temp.js".
-                    if *parent_ignored
-                        || is_ignored(&scope.ignore_pattern_matchers, &path, false, false)
-                    {
+                    if *parent_ignored || resolver.is_path_ignored(&path, false) {
                         return ignore::WalkState::Continue;
                     }
 
@@ -863,10 +789,7 @@ impl ignore::ParallelVisitor for WalkVisitor {
 
                     if self
                         .sender
-                        .send(FormatEntry {
-                            strategy,
-                            config_resolver: Arc::clone(&scope.config_resolver),
-                        })
+                        .send(FormatEntry { strategy, config_resolver: Arc::clone(resolver) })
                         .is_err()
                     {
                         return ignore::WalkState::Quit;

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -5,6 +5,7 @@ use editorconfig_parser::{
     MaxLineLength, QuoteType,
 };
 use fast_glob::glob_match;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use serde_json::Value;
 use tracing::instrument;
 
@@ -54,22 +55,21 @@ fn is_vite_plus_mode() -> bool {
 ///
 /// When `VP_VERSION` env var is set, only `vite.config.ts` is recognized.
 /// When it is not set, `vite.config.ts` is excluded from the candidates.
-pub fn all_config_file_names() -> impl Iterator<Item = String> {
+pub fn all_config_file_names() -> impl Iterator<Item = &'static str> {
     #[cfg(feature = "napi")]
     {
         if is_vite_plus_mode() {
-            return vec![VITE_PLUS_CONFIG_NAME.to_string()].into_iter();
+            return vec![VITE_PLUS_CONFIG_NAME].into_iter();
         }
         JSON_CONFIG_FILES
             .iter()
             .copied()
             .chain([OXFMT_JS_CONFIG_NAME])
-            .map(ToString::to_string)
             .collect::<Vec<_>>()
             .into_iter()
     }
     #[cfg(not(feature = "napi"))]
-    JSON_CONFIG_FILES.iter().map(|f| (*f).to_string()).collect::<Vec<_>>().into_iter()
+    JSON_CONFIG_FILES.iter().copied()
 }
 
 pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
@@ -208,6 +208,8 @@ pub struct ConfigResolver {
     oxfmtrc_overrides: Option<OxfmtrcOverrides>,
     /// Parsed `.editorconfig`, if any.
     editorconfig: Option<EditorConfig>,
+    /// Ignore glob built from this config's `ignorePatterns`.
+    ignore_glob: Option<Gitignore>,
 }
 
 impl ConfigResolver {
@@ -218,12 +220,33 @@ impl ConfigResolver {
         config_dir: Option<PathBuf>,
         editorconfig: Option<EditorConfig>,
     ) -> Self {
-        Self { raw_config, config_dir, cached_options: None, oxfmtrc_overrides: None, editorconfig }
+        Self {
+            raw_config,
+            config_dir,
+            cached_options: None,
+            oxfmtrc_overrides: None,
+            editorconfig,
+            ignore_glob: None,
+        }
     }
 
     /// Returns the directory containing the config file, if any was loaded.
     pub fn config_dir(&self) -> Option<&Path> {
         self.config_dir.as_deref()
+    }
+
+    /// Returns `true` if this config has any `ignorePatterns`.
+    pub fn has_ignore_patterns(&self) -> bool {
+        self.ignore_glob.is_some()
+    }
+
+    /// Returns `true` if the given path should be ignored by this config's `ignorePatterns`.
+    pub fn is_path_ignored(&self, path: &Path, is_dir: bool) -> bool {
+        self.ignore_glob.as_ref().is_some_and(|glob| {
+            // `matched_path_or_any_parents()` panics if path is not under the glob's root.
+            path.starts_with(glob.path())
+                && glob.matched_path_or_any_parents(path, is_dir).is_ignore()
+        })
     }
 
     /// Create a resolver, handling both JSON/JSONC and JS/TS config files.
@@ -310,7 +333,7 @@ impl ConfigResolver {
         editorconfig_path: Option<&Path>,
         #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
     ) -> Result<Self, String> {
-        let candidates: Vec<String> = all_config_file_names().collect();
+        let candidates: Vec<&str> = all_config_file_names().collect();
         for dir in cwd.ancestors() {
             for filename in &candidates {
                 let path = dir.join(filename);
@@ -392,7 +415,7 @@ impl ConfigResolver {
     /// # Errors
     /// Returns error if config deserialization fails.
     #[instrument(level = "debug", name = "oxfmt::config::build_and_validate", skip_all)]
-    pub fn build_and_validate(&mut self) -> Result<Vec<String>, String> {
+    pub fn build_and_validate(&mut self) -> Result<(), String> {
         let oxfmtrc: Oxfmtrc =
             serde_json::from_value(self.raw_config.clone()).map_err(|err| err.to_string())?;
 
@@ -437,8 +460,11 @@ impl ConfigResolver {
         // Save cache for fast path: no per-file overrides
         self.cached_options = Some((oxfmt_options, external_options));
 
+        // Build ignore glob from `ignorePatterns` config field
         let ignore_patterns = oxfmtrc.ignore_patterns.unwrap_or_default();
-        Ok(ignore_patterns)
+        self.ignore_glob = build_ignore_glob(self.config_dir.as_deref(), &ignore_patterns)?;
+
+        Ok(())
     }
 
     /// Resolve format options for a specific file.
@@ -726,4 +752,34 @@ fn apply_editorconfig(config: &mut FormatConfig, props: &EditorConfigProperties)
             _ => {}
         }
     }
+}
+
+// ---
+
+/// Check if a directory contains any recognized config file.
+pub fn has_config_in_directory(dir: &Path) -> bool {
+    all_config_file_names().any(|name| dir.join(name).exists())
+}
+
+/// Build an ignore glob from config `ignorePatterns`.
+/// Patterns are resolved relative to the config file's directory.
+fn build_ignore_glob(
+    config_dir: Option<&Path>,
+    ignore_patterns: &[String],
+) -> Result<Option<Gitignore>, String> {
+    if ignore_patterns.is_empty() {
+        return Ok(None);
+    }
+    let Some(config_dir) = config_dir else {
+        return Ok(None);
+    };
+
+    let mut builder = GitignoreBuilder::new(config_dir);
+    for pattern in ignore_patterns {
+        if builder.add_line(None, pattern).is_err() {
+            return Err(format!("Failed to add ignore pattern `{pattern}` from `ignorePatterns`"));
+        }
+    }
+    let gitignore = builder.build().map_err(|_| "Failed to build ignores".to_string())?;
+    Ok(Some(gitignore))
 }

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -9,7 +9,9 @@ mod external_formatter;
 #[cfg(feature = "napi")]
 mod js_config;
 
+#[cfg(feature = "napi")]
 pub use config::all_config_file_names;
+pub use config::has_config_in_directory;
 #[cfg(feature = "napi")]
 pub use config::resolve_options_from_value;
 pub use config::{ConfigResolver, ResolvedOptions, resolve_editorconfig_path};

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -12,7 +12,8 @@ use oxc_language_server::{
 
 use crate::core::{
     ConfigResolver, ExternalFormatter, FormatFileStrategy, FormatResult, JsConfigLoaderCb,
-    SourceFormatter, all_config_file_names, resolve_editorconfig_path, utils,
+    SourceFormatter, all_config_file_names, has_config_in_directory, resolve_editorconfig_path,
+    utils,
 };
 use crate::lsp::create_fake_file_path_from_language_id;
 use crate::lsp::options::FormatOptions as LSPFormatOptions;
@@ -124,17 +125,10 @@ enum ConfigScope {
     Explicit,
 }
 
-/// A cached config entry: resolver + per-scope ignore patterns.
-struct CachedConfig {
-    resolver: ConfigResolver,
-    /// Ignore glob built from this config's `ignorePatterns`.
-    ignore_glob: Option<Gitignore>,
-}
-
 pub struct ServerFormatter {
     root_path: PathBuf,
     source_formatter: SourceFormatter,
-    config_cache: ConcurrentHashMap<ConfigScope, CachedConfig>,
+    config_cache: ConcurrentHashMap<ConfigScope, ConfigResolver>,
     js_config_loader: JsConfigLoaderCb,
     editorconfig_path: Option<PathBuf>,
     /// `.prettierignore` glob (workspace-level, shared across all scopes).
@@ -307,20 +301,17 @@ impl ServerFormatter {
         };
 
         for dir in start_dir.ancestors() {
-            for filename in all_config_file_names() {
-                let path = dir.join(filename);
-                if path.exists() {
-                    return ConfigScope::Dir(dir.to_path_buf());
-                }
+            if has_config_in_directory(dir) {
+                return ConfigScope::Dir(dir.to_path_buf());
             }
         }
 
         ConfigScope::Fallback
     }
 
-    /// Load a `CachedConfig` for the given directory.
+    /// Load a `ConfigResolver` for the given directory.
     /// Falls back to default config on any error.
-    fn load_cached_config(&self, cwd: &Path) -> CachedConfig {
+    fn load_cached_config(&self, cwd: &Path) -> ConfigResolver {
         let result = ConfigResolver::from_config(
             cwd,
             self.explicit_config_path.as_deref(),
@@ -328,9 +319,8 @@ impl ServerFormatter {
             Some(&self.js_config_loader),
         )
         .and_then(|mut resolver| {
-            let ignore_patterns = resolver.build_and_validate()?;
-            let ignore_glob = Self::build_scope_ignore_glob(cwd, &ignore_patterns);
-            Ok(CachedConfig { resolver, ignore_glob })
+            resolver.build_and_validate()?;
+            Ok(resolver)
         });
 
         result.unwrap_or_else(|err| {
@@ -340,22 +330,8 @@ impl ServerFormatter {
             resolver
                 .build_and_validate()
                 .expect("Default ConfigResolver validation should never fail");
-            CachedConfig { resolver, ignore_glob: None }
+            resolver
         })
-    }
-
-    /// Build an ignore glob from per-scope `ignorePatterns`.
-    fn build_scope_ignore_glob(cwd: &Path, ignore_patterns: &[String]) -> Option<Gitignore> {
-        if ignore_patterns.is_empty() {
-            return None;
-        }
-        let mut builder = GitignoreBuilder::new(cwd);
-        for pattern in ignore_patterns {
-            if let Err(err) = builder.add_line(None, pattern) {
-                warn!("Invalid ignore pattern: {pattern}: {err}");
-            }
-        }
-        builder.build().ok()
     }
 
     /// Resolve config and format a file at the given path.
@@ -376,16 +352,12 @@ impl ServerFormatter {
             self.load_cached_config(cwd)
         });
 
-        if cached
-            .ignore_glob
-            .as_ref()
-            .is_some_and(|glob| glob.matched_path_or_any_parents(path, path.is_dir()).is_ignore())
-        {
+        if cached.is_path_ignored(path, path.is_dir()) {
             debug!("File is ignored by config ignorePatterns: {}", path.display());
             return None;
         }
 
-        let resolved_options = cached.resolver.resolve(&strategy);
+        let resolved_options = cached.resolve(&strategy);
         debug!("resolved_options = {resolved_options:?}");
 
         Some(tokio::task::block_in_place(|| {

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -72,12 +72,9 @@ impl StdinRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         };
-        match config_resolver.build_and_validate() {
-            Ok(_) => {}
-            Err(err) => {
-                utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
-                return CliRunResult::InvalidOptionConfig;
-            }
+        if let Err(err) = config_resolver.build_and_validate() {
+            utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
+            return CliRunResult::InvalidOptionConfig;
         }
 
         // Use `block_in_place()` to avoid nested async runtime access


### PR DESCRIPTION
Since local ignores related to `ignorePatterns` can be derived from the config, consolidate them.

It's getting bloated, so I'll clean it up later.