### PR TITLE
fix(linter/array-callback-return): ignore non-exit CFG dead ends

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -608,6 +608,21 @@ fn test() {
         ("Array.fromAsync(x, function * () {})", None),
         ("Float64Array.fromAsync(x, function() {})", None),
         ("Array.fromAsync(function() {})", None),
+        (
+            "function filterNested(allItems, group) {
+  return Array.from(allItems).filter(item => {
+    let current = item.parentElement
+    while (current && current !== group) {
+      if (current.getAttribute('aria-hidden') === 'true') {
+        return false
+      }
+      current = current.parentElement
+    }
+    return true
+  })
+}",
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
@@ -160,6 +160,13 @@ pub fn check_function_body(function_node_id: NodeId, semantic: &Semantic) -> Sta
         }
 
         if !has_successor {
+            // Only treat dead ends as function exits if the path is already carrying a
+            // return/throw from an earlier block (e.g. through `finally`), or if this
+            // terminal block has instructions of its own. CFG lowering can otherwise
+            // leave behind empty helper blocks that are not observable callback exits.
+            if matches!(state_after_block, PendingExit::None) && block.instructions().is_empty() {
+                continue;
+            }
             terminal_states.push(state_after_block);
         }
     }


### PR DESCRIPTION
fixes #21485