### PR TITLE
fix(oxlint): dont enable gitlab formatter by default

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -266,8 +266,6 @@ fn default_output_format() -> Result<OutputFormat, std::convert::Infallible> {
         Ok(OutputFormat::Default)
     } else if std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true") {
         Ok(OutputFormat::Github)
-    } else if std::env::var("GITLAB_CI").ok().is_some_and(|value| value == "true") {
-        Ok(OutputFormat::Gitlab)
     } else {
         Ok(OutputFormat::Default)
     }


### PR DESCRIPTION
See details in 21500, but this doesn't work how I expected, you need to manually configure it in gitlab for it to work properly, hence it should be an explicit opt-in rather than a default

fixes https://github.com/oxc-project/oxc/issues/21500

related #20074