### PR TITLE
fix(isolated_declarations): collect types from private accessors for paired inference

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -367,8 +367,10 @@ impl<'a> IsolatedDeclarations<'a> {
         let mut method_annotations: Vec<(PropertyKey<'_>, AccessorAnnotation<'_>)> = Vec::new();
         for element in &decl.body.body {
             if let ClassElement::MethodDefinition(method) = element {
-                if (method.key.is_private_identifier()
-                    || method.accessibility.is_some_and(TSAccessibility::is_private))
+                // Note: do not skip `private`-modifier accessors. Their types are still
+                // valid sources for pair-based inference on a public/protected counterpart
+                // (e.g. untyped getter paired with a `private set(v: T)`).
+                if method.key.is_private_identifier()
                     || (method.computed && !Self::is_valid_property_key(&method.key))
                 {
                     continue;
@@ -397,7 +399,17 @@ impl<'a> IsolatedDeclarations<'a> {
                     }
                     MethodDefinitionKind::Get => {
                         let function = &method.value;
-                        if let Some(annotation) = self.infer_function_return_type(function) {
+                        // For a private getter, only collect an explicit return type. Running
+                        // body inference here would surface errors (e.g. TS9038) that are not
+                        // relevant, since the private accessor itself is emitted as a
+                        // type-erased class member.
+                        let annotation =
+                            if method.accessibility.is_some_and(TSAccessibility::is_private) {
+                                function.return_type.clone_in(self.ast.allocator)
+                            } else {
+                                self.infer_function_return_type(function)
+                            };
+                        if let Some(annotation) = annotation {
                             if let Some(entry) = method_annotations
                                 .iter_mut()
                                 .find(|(key, _)| method.key.content_eq(key))

--- a/crates/oxc_isolated_declarations/tests/fixtures/class.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/class.ts
@@ -155,3 +155,22 @@ export class PrivateConstructorWithDefaultParameters {
 		normalParam: string = "normal",
 	) {}
 }
+
+// https://github.com/oxc-project/oxc/issues/21503
+// A typed private setter should provide the return type for its paired
+// public/protected getter when the getter has no explicit return type.
+export class AccessorPairWithPrivateSetter {
+	get isRunning() {
+		return true;
+	}
+
+	private set isRunning(val: boolean) {}
+}
+
+export class AccessorPairWithProtectedPrivateSetter {
+	protected get value() {
+		return 1;
+	}
+
+	private set value(v: number) {}
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/class.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/class.snap
@@ -120,6 +120,14 @@ export declare class PrivateConstructorWithDefaultParameters {
 	readonly prop3: boolean;
 	private constructor();
 }
+export declare class AccessorPairWithPrivateSetter {
+	get isRunning(): boolean;
+	private set isRunning(value);
+}
+export declare class AccessorPairWithProtectedPrivateSetter {
+	protected get value(): number;
+	private set value(value);
+}
 
 
 ==================== Errors ====================


### PR DESCRIPTION
## Summary

A public (or protected) getter paired with a `private set(v: T)` should get its return type from the setter's parameter annotation — that's the standard `isolatedDeclarations` accessor-pair inference rule ("one annotated side is enough"). Previously, `collect_accessor_annotations` skipped any accessor with a `private` modifier, so the pairing never happened and `TS9009` fired on the untyped getter.

This change:

- No longer skips `private`-modifier accessors when collecting annotations for paired inference.
- For private **setters**, collects the explicit parameter type annotation — same behavior as before for non-private setters (no body inference).
- For private **getters**, only uses an explicit return type annotation. Running body inference would surface errors like `TS9038` on the private accessor's body, which is irrelevant because the private accessor is emitted as a type-erased class member anyway.

## Example

```ts
export class MockProxy {
  get isRunning() {
    return this._state.isRunning;
  }

  private set isRunning(val: boolean) {
    this._state.isRunning = val;
  }
}
```

Before: `TS9009: At least one accessor must have an explicit return type annotation`.
After: no error — emits `get isRunning(): boolean;` and `private set isRunning(value);`, matching tsc.

## Test plan

- [x] Added fixtures for both a public getter + private setter pair and a protected getter + private setter pair
- [x] `cargo test -p oxc_isolated_declarations` — no regression on existing private-accessor snapshots

Closes #21503 (case 2)