### PR TITLE
perf(oxfmt): Skip ancestors check when no nested config found

### DIFF
--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -719,11 +719,16 @@ impl WalkVisitor {
             return;
         }
 
-        let resolver = parent
-            .ancestors()
-            .find_map(|a| self.child_scope_map.get(a))
-            .cloned()
-            .unwrap_or_else(|| Arc::clone(&self.root_config_resolver));
+        // PERF: Skip ancestors traversal when no child scopes exist (e.g. `--disable-nested-config`)
+        let resolver = if self.child_scope_map.is_empty() {
+            Arc::clone(&self.root_config_resolver)
+        } else {
+            parent
+                .ancestors()
+                .find_map(|a| self.child_scope_map.get(a))
+                .cloned()
+                .unwrap_or_else(|| Arc::clone(&self.root_config_resolver))
+        };
 
         let parent_ignored = resolver.is_path_ignored(parent, true);
         self.scope_cache.insert(parent.to_path_buf(), (resolver, parent_ignored));


### PR DESCRIPTION
By doing this, v0.45 and v0.46 w/ `--disable-nested-config` having comparable performance.

```
# In next.js repo
# v0.45: --check "**/*.{js,ts,tsx}"
# v0.46: --check --disable-nested-config "**/*.{js,ts,tsx}"

Benchmark 1: v0.45 (root config only)
  Time (mean ± σ):     583.5 ms ±  17.5 ms    [User: 2126.3 ms, System: 1310.4 ms]
  Range (min … max):   556.8 ms … 610.6 ms    10 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: v0.46 (root config only)
  Time (mean ± σ):     575.5 ms ±  18.8 ms    [User: 2168.0 ms, System: 1340.9 ms]
  Range (min … max):   557.6 ms … 611.8 ms    10 runs

  Warning: Ignoring non-zero exit code.

Summary
  v0.46 (root config only) ran
    1.01 ± 0.05 times faster than v0.45 (root config only)
```