### PR TITLE
feat(linter): Implemented `version` for jest settings in config file.

### DIFF
--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -49,7 +49,7 @@ working directory:
       "typecheck": false
     },
     "jest": {
-      "version": 29
+      "version": null
     }
   },
   "env": {

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -47,6 +47,9 @@ working directory:
     },
     "vitest": {
       "typecheck": false
+    },
+    "jest": {
+      "version": 29
     }
   },
   "env": {

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -40,6 +40,9 @@ working directory: fixtures
     },
     "vitest": {
       "typecheck": false
+    },
+    "jest": {
+      "version": 29
     }
   },
   "env": {

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -42,7 +42,7 @@ working directory: fixtures
       "typecheck": false
     },
     "jest": {
-      "version": 29
+      "version": null
     }
   },
   "env": {

--- a/crates/oxc_linter/src/config/settings/jest.rs
+++ b/crates/oxc_linter/src/config/settings/jest.rs
@@ -8,25 +8,36 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///
 /// See [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s
 /// configuration for a full reference.
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Default, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct JestPluginSettings {
     /// Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
-    /// storing only the major version. Default version is 29
-    #[serde(default = "default_jest_version", deserialize_with = "jest_version_deserialize")]
-    pub version: usize,
+    /// storing only the major version.
+    /// ::: warning
+    /// Using this config will override the `no-deprecated-functions`' config set.
+    #[serde(default, deserialize_with = "jest_version_deserialize")]
+    pub version: Option<usize>,
 }
 
-fn jest_version_deserialize<'de, D>(deserializer: D) -> Result<usize, D::Error>
+fn jest_version_deserialize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct VersionVisitor;
 
     impl Visitor<'_> for VersionVisitor {
-        type Value = usize;
+        type Value = Option<usize>;
+
+        // Needed to impl, without this the deserialization will fail if null is provided.
+        // The lack of this impl will cause to fail config test that use Oxlintrc default values.
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(None)
+        }
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            f.write_str("Expecter Jest version as a number or string")
+            f.write_str("Expected Jest version as a number or string")
         }
 
         fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
@@ -34,6 +45,7 @@ where
             E: serde::de::Error,
         {
             usize::try_from(v)
+                .map(Some)
                 .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))
         }
 
@@ -46,6 +58,7 @@ where
             }
 
             usize::try_from(v)
+                .map(Some)
                 .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))
         }
 
@@ -59,21 +72,10 @@ where
                 .nth(skip_v_prefix)
                 .and_then(|semver| semver.split('.').next())
                 .and_then(|s| s.parse::<usize>().ok())
+                .map(Some)
                 .ok_or_else(|| E::custom(format!("Invalid Jest version string: {v:?}")))
         }
     }
 
     deserializer.deserialize_any(VersionVisitor)
-}
-
-fn default_jest_version() -> usize {
-    29
-}
-
-// `default = "fn"` at field level doesn't work, likely on how ancestors deserialization is being done.
-// This is likely affecting serde to know if the field is truly non present to use `default = "fn"`.
-impl Default for JestPluginSettings {
-    fn default() -> Self {
-        Self { version: 29 }
-    }
 }

--- a/crates/oxc_linter/src/config/settings/jest.rs
+++ b/crates/oxc_linter/src/config/settings/jest.rs
@@ -1,0 +1,92 @@
+use std::fmt;
+
+use schemars::JsonSchema;
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Configure Jest plugin rules.
+///
+/// See [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s
+/// configuration for a full reference.
+#[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema, PartialEq, Eq)]
+pub struct JestPluginSettings {
+    /// Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
+    /// storing only the major version.
+    #[serde(default)]
+    pub version: JestVersion,
+}
+
+#[derive(Debug, Clone, JsonSchema, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct JestVersion(pub usize);
+
+impl<'de> Deserialize<'de> for JestVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct VersionVisitor;
+
+        impl Visitor<'_> for VersionVisitor {
+            type Value = JestVersion;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("Expecter Jest version as a number or string")
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(JestVersion(
+                    usize::try_from(v)
+                        .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))?,
+                ))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v < 0 {
+                    return Err(E::custom(format!("Jest version cannot be negative: {v:?}")));
+                }
+
+                Ok(JestVersion(
+                    usize::try_from(v)
+                        .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))?,
+                ))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let skip_v_prefix = usize::from(v.starts_with('v'));
+
+                v.split('v')
+                    .nth(skip_v_prefix)
+                    .and_then(|semver| semver.split('.').next())
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .map(JestVersion)
+                    .ok_or_else(|| E::custom(format!("Invalid Jest version string: {v:?}")))
+            }
+        }
+
+        deserializer.deserialize_any(VersionVisitor)
+    }
+}
+
+impl Default for JestVersion {
+    fn default() -> Self {
+        Self(29)
+    }
+}
+
+impl std::ops::Deref for JestVersion {
+    type Target = usize;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/oxc_linter/src/config/settings/jest.rs
+++ b/crates/oxc_linter/src/config/settings/jest.rs
@@ -8,85 +8,72 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///
 /// See [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s
 /// configuration for a full reference.
-#[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct JestPluginSettings {
     /// Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
-    /// storing only the major version.
-    #[serde(default)]
-    pub version: JestVersion,
+    /// storing only the major version. Default version is 29
+    #[serde(default = "default_jest_version", deserialize_with = "jest_version_deserialize")]
+    pub version: usize,
 }
 
-#[derive(Debug, Clone, JsonSchema, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase", default)]
-pub struct JestVersion(pub usize);
+fn jest_version_deserialize<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct VersionVisitor;
 
-impl<'de> Deserialize<'de> for JestVersion {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct VersionVisitor;
+    impl Visitor<'_> for VersionVisitor {
+        type Value = usize;
 
-        impl Visitor<'_> for VersionVisitor {
-            type Value = JestVersion;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("Expecter Jest version as a number or string")
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(JestVersion(
-                    usize::try_from(v)
-                        .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))?,
-                ))
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                if v < 0 {
-                    return Err(E::custom(format!("Jest version cannot be negative: {v:?}")));
-                }
-
-                Ok(JestVersion(
-                    usize::try_from(v)
-                        .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))?,
-                ))
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                let skip_v_prefix = usize::from(v.starts_with('v'));
-
-                v.split('v')
-                    .nth(skip_v_prefix)
-                    .and_then(|semver| semver.split('.').next())
-                    .and_then(|s| s.parse::<usize>().ok())
-                    .map(JestVersion)
-                    .ok_or_else(|| E::custom(format!("Invalid Jest version string: {v:?}")))
-            }
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("Expecter Jest version as a number or string")
         }
 
-        deserializer.deserialize_any(VersionVisitor)
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            usize::try_from(v)
+                .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            if v < 0 {
+                return Err(E::custom(format!("Jest version cannot be negative: {v:?}")));
+            }
+
+            usize::try_from(v)
+                .map_err(|_| E::custom(format!("Invalid Jest version integer: {v:?}")))
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            let skip_v_prefix = usize::from(v.starts_with('v'));
+
+            v.split('v')
+                .nth(skip_v_prefix)
+                .and_then(|semver| semver.split('.').next())
+                .and_then(|s| s.parse::<usize>().ok())
+                .ok_or_else(|| E::custom(format!("Invalid Jest version string: {v:?}")))
+        }
     }
+
+    deserializer.deserialize_any(VersionVisitor)
 }
 
-impl Default for JestVersion {
+fn default_jest_version() -> usize {
+    29
+}
+
+// `default = "fn"` at field level doesn't work, likely on how ancestors deserialization is being done.
+// This is likely affecting serde to know if the field is truly non present to use `default = "fn"`.
+impl Default for JestPluginSettings {
     fn default() -> Self {
-        Self(29)
-    }
-}
-
-impl std::ops::Deref for JestVersion {
-    type Target = usize;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        Self { version: 29 }
     }
 }

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -316,7 +316,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(settings.jest.version, 20);
+        assert_eq!(settings.jest.version, Some(20));
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], 20);
@@ -332,7 +332,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(settings.jest.version, 20);
+        assert_eq!(settings.jest.version, Some(20));
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], "20");
@@ -348,7 +348,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(settings.jest.version, 20);
+        assert_eq!(settings.jest.version, Some(20));
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], "20.1.23");
@@ -364,7 +364,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(settings.jest.version, 23);
+        assert_eq!(settings.jest.version, Some(23));
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], "v23.12.3");

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -316,7 +316,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(*settings.jest.version, 20);
+        assert_eq!(settings.jest.version, 20);
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], 20);
@@ -332,7 +332,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(*settings.jest.version, 20);
+        assert_eq!(settings.jest.version, 20);
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], "20");
@@ -348,7 +348,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(*settings.jest.version, 20);
+        assert_eq!(settings.jest.version, 20);
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], "20.1.23");
@@ -364,7 +364,7 @@ mod test {
 
         let settings = OxlintSettings::deserialize(&json_value).unwrap();
 
-        assert_eq!(*settings.jest.version, 23);
+        assert_eq!(settings.jest.version, 23);
 
         let raw_json = settings.json.unwrap();
         assert_eq!(raw_json["jest"]["version"], "v23.12.3");

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -1,3 +1,4 @@
+mod jest;
 pub mod jsdoc;
 mod jsx_a11y;
 mod next;
@@ -8,8 +9,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use self::{
-    jsdoc::JSDocPluginSettings, jsx_a11y::JSXA11yPluginSettings, next::NextPluginSettings,
-    react::ReactPluginSettings, vitest::VitestPluginSettings,
+    jest::JestPluginSettings, jsdoc::JSDocPluginSettings, jsx_a11y::JSXA11yPluginSettings,
+    next::NextPluginSettings, react::ReactPluginSettings, vitest::VitestPluginSettings,
 };
 
 pub use self::react::ReactVersion;
@@ -60,6 +61,9 @@ pub struct OxlintSettings {
 
     #[serde(default)]
     pub vitest: VitestPluginSettings,
+
+    #[serde(default)]
+    pub jest: JestPluginSettings,
 }
 
 #[derive(Deserialize, Default)]
@@ -80,6 +84,9 @@ struct WellKnownOxlintSettings {
 
     #[serde(default)]
     pub vitest: VitestPluginSettings,
+
+    #[serde(default)]
+    pub jest: JestPluginSettings,
 }
 
 pub type OxlintSettingsJson = serde_json::Map<String, serde_json::Value>;
@@ -104,6 +111,7 @@ impl<'de> Deserialize<'de> for OxlintSettings {
             react: well_known_settings.react,
             jsdoc: well_known_settings.jsdoc,
             vitest: well_known_settings.vitest,
+            jest: well_known_settings.jest,
         })
     }
 }
@@ -128,6 +136,7 @@ impl OxlintSettings {
                         settings_to_override.react = well_known_settings.react;
                         settings_to_override.jsdoc = well_known_settings.jsdoc;
                         settings_to_override.vitest = well_known_settings.vitest;
+                        settings_to_override.jest = well_known_settings.jest;
                     }
                     Err(e) => {
                         panic!("Failed to parse override settings: {e:?}");
@@ -140,6 +149,7 @@ impl OxlintSettings {
                 settings_to_override.react = self.react.clone();
                 settings_to_override.jsdoc = self.jsdoc.clone();
                 settings_to_override.vitest = self.vitest.clone();
+                settings_to_override.jest = self.jest.clone();
             }
         }
     }
@@ -294,5 +304,80 @@ mod test {
         assert_eq!(raw_json["jsx-a11y"]["polymorphicPropName"], "role");
         assert_eq!(raw_json["unknown-plugin"]["setting"], "value");
         assert_eq!(raw_json["globalSetting"], "value");
+    }
+
+    #[test]
+    fn test_integer_jest_version_settings() {
+        let json_value = serde_json::json!({
+            "jest": {
+                "version": 20
+            }
+        });
+
+        let settings = OxlintSettings::deserialize(&json_value).unwrap();
+
+        assert_eq!(*settings.jest.version, 20);
+
+        let raw_json = settings.json.unwrap();
+        assert_eq!(raw_json["jest"]["version"], 20);
+    }
+
+    #[test]
+    fn test_major_version_jest_as_string_settings() {
+        let json_value = serde_json::json!({
+            "jest": {
+                "version": "20"
+            }
+        });
+
+        let settings = OxlintSettings::deserialize(&json_value).unwrap();
+
+        assert_eq!(*settings.jest.version, 20);
+
+        let raw_json = settings.json.unwrap();
+        assert_eq!(raw_json["jest"]["version"], "20");
+    }
+
+    #[test]
+    fn test_jest_semver_settings() {
+        let json_value = serde_json::json!({
+            "jest": {
+                "version": "20.1.23"
+            }
+        });
+
+        let settings = OxlintSettings::deserialize(&json_value).unwrap();
+
+        assert_eq!(*settings.jest.version, 20);
+
+        let raw_json = settings.json.unwrap();
+        assert_eq!(raw_json["jest"]["version"], "20.1.23");
+    }
+
+    #[test]
+    fn test_jest_semver_prefixed_with_v_settings() {
+        let json_value = serde_json::json!({
+            "jest": {
+                "version": "v23.12.3"
+            }
+        });
+
+        let settings = OxlintSettings::deserialize(&json_value).unwrap();
+
+        assert_eq!(*settings.jest.version, 23);
+
+        let raw_json = settings.json.unwrap();
+        assert_eq!(raw_json["jest"]["version"], "v23.12.3");
+    }
+
+    #[test]
+    fn test_negative_integer_jest_version_fail() {
+        let json_value = serde_json::json!({
+            "jest": {
+                "version": -1
+            }
+        });
+
+        OxlintSettings::deserialize(&json_value).expect_err("Jest Version cannot be negative");
     }
 }

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -4,8 +4,6 @@ use oxc_ast::ast::Expression;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -14,36 +12,8 @@ fn deprecated_function(deprecated: &str, new: &str, span: Span) -> OxcDiagnostic
         .with_label(span)
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
-pub struct JestConfig {
-    /// The version of Jest being used.
-    version: String,
-}
-
-impl Default for JestConfig {
-    fn default() -> Self {
-        Self { version: "29".to_string() }
-    }
-}
-
 #[derive(Debug, Default, Clone)]
-pub struct NoDeprecatedFunctions(Box<NoDeprecatedFunctionsConfig>);
-
-#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
-pub struct NoDeprecatedFunctionsConfig {
-    /// Jest configuration options.
-    jest: JestConfig,
-}
-
-impl std::ops::Deref for NoDeprecatedFunctions {
-    type Target = NoDeprecatedFunctionsConfig;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub struct NoDeprecatedFunctions;
 
 declare_oxc_lint!(
     /// ### What it does
@@ -96,7 +66,6 @@ declare_oxc_lint!(
     jest,
     style,
     fix,
-    config = NoDeprecatedFunctionsConfig,
     version = "0.0.18",
 );
 
@@ -112,25 +81,6 @@ fn deprecated_functions_map(deprecated_fn: &str) -> Option<(usize, &'static str)
 }
 
 impl Rule for NoDeprecatedFunctions {
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let version = value
-            .get(0)
-            .and_then(|v| v.get("jest"))
-            .and_then(|v| v.get("version"))
-            .and_then(|v| serde_json::Value::as_str(v))
-            // Todo: Fixed Me
-            // Currently set the default version to the (maybe) latest, to help to find more problems in
-            // the codebase. In the future, the version should come from the cli option or the config files,
-            // such as `package.json` or `eslint.config.js`.
-            .unwrap_or("29");
-
-        let major: Vec<&str> = version.split('.').collect();
-
-        Ok(Self(Box::new(NoDeprecatedFunctionsConfig {
-            jest: JestConfig { version: major[0].to_string() },
-        })))
-    }
-
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
         let Some(mem_expr) = node.kind().as_member_expression_kind() else {
             return;
@@ -145,11 +95,9 @@ impl Rule for NoDeprecatedFunctions {
         }
 
         let node_name = chain.join(".");
-        // Todo: read from configuration
-        let jest_version_num: usize = self.jest.version.parse().unwrap_or(29);
 
         if let Some((base_version, replacement)) = deprecated_functions_map(&node_name)
-            && jest_version_num >= base_version
+            && *ctx.settings().jest.version >= base_version
         {
             ctx.diagnostic_with_fix(
                 deprecated_function(&node_name, replacement, mem_expr.span()),
@@ -164,51 +112,103 @@ fn tests() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("jest", Some(serde_json::json!([{ "jest": { "version": "14" } }]))),
-        ("require('fs')", Some(serde_json::json!([{ "jest": { "version": "14" } }]))),
-        ("jest.resetModuleRegistry", Some(serde_json::json!([{ "jest": { "version": "14" } }]))),
-        ("require.requireActual", Some(serde_json::json!([{ "jest": { "version": "17" } }]))),
-        ("jest.genMockFromModule", Some(serde_json::json!([{ "jest": { "version": "25" } }]))),
-        ("jest.genMockFromModule", Some(serde_json::json!([{ "jest": { "version": "25.1.1" } }]))),
-        ("require.requireActual", Some(serde_json::json!([{ "jest": { "version": "17.2" } }]))),
+        ("jest", None, Some(serde_json::json!({ "settings": { "jest": { "version": "14" } }}))),
+        (
+            "require('fs')",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "14" } }})),
+        ),
+        (
+            "jest.resetModuleRegistry",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "14" } }})),
+        ),
+        (
+            "require.requireActual",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "17" } } })),
+        ),
+        (
+            "jest.genMockFromModule",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "25" } } })),
+        ),
+        (
+            "jest.genMockFromModule",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "25.1.1" } } })),
+        ),
+        (
+            "require.requireActual",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "17.2" } } })),
+        ),
     ];
 
     let fail = vec![
-        ("jest.resetModuleRegistry", None),
+        ("jest.resetModuleRegistry", None, None),
         // replace with `jest.resetModules` in Jest 15
-        ("jest.resetModuleRegistry", Some(serde_json::json!([{ "jest": { "version": "16" }}]))),
+        (
+            "jest.resetModuleRegistry",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "16" }}})),
+        ),
         // replace with `jest.requireMock` in Jest 17.
-        ("jest.addMatchers", Some(serde_json::json!([{ "jest": { "version": "18" }}]))),
+        (
+            "jest.addMatchers",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "18" }}})),
+        ),
         // replace with `jest.requireMock` in Jest 21.
-        ("require.requireMock", Some(serde_json::json!([{ "jest": { "version": "22" }}]))),
+        (
+            "require.requireMock",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "22" }}})),
+        ),
         // replace with `jest.requireActual` in Jest 21.
-        ("require.requireActual", Some(serde_json::json!([{ "jest": { "version": "22" }}]))),
+        (
+            "require.requireActual",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "22" }}})),
+        ),
         // replace with `jest.advanceTimersByTime` in Jest 22
-        ("jest.runTimersToTime", Some(serde_json::json!([{ "jest": { "version": "23" }}]))),
+        (
+            "jest.runTimersToTime",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "23" }}})),
+        ),
         // replace with `jest.createMockFromModule` in Jest 26
-        ("jest.genMockFromModule", Some(serde_json::json!([{ "jest": { "version": "27" }}]))),
+        (
+            "jest.genMockFromModule",
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "27" }}})),
+        ),
     ];
 
     let fix = vec![
         (
             "jest.resetModuleRegistry()",
             "jest.resetModules()",
-            Some(serde_json::json!([{ "jest": { "version": "21" } }])),
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "21" } }})),
         ),
         (
             "jest.addMatchers",
             "expect.extend",
-            Some(serde_json::json!([{ "jest": { "version": "24" } }])),
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "24" } }})),
         ),
         (
             "jest.genMockFromModule",
             "jest.createMockFromModule",
-            Some(serde_json::json!([{ "jest": { "version": "26" } }])),
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "26" } }})),
         ),
         (
             "jest.genMockFromModule",
             "jest.createMockFromModule",
-            Some(serde_json::json!([{ "jest": { "version": "26.0.0-next.11" } }])),
+            None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "26.0.0-next.11" } }})),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -4,6 +4,8 @@ use oxc_ast::ast::Expression;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{context::LintContext, rule::Rule};
 
@@ -12,8 +14,39 @@ fn deprecated_function(deprecated: &str, new: &str, span: Span) -> OxcDiagnostic
         .with_label(span)
 }
 
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct JestConfig {
+    /// The version of Jest being used.
+    version: String,
+}
+
+impl Default for JestConfig {
+    fn default() -> Self {
+        Self { version: "29".to_string() }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
-pub struct NoDeprecatedFunctions;
+pub struct NoDeprecatedFunctions(Box<NoDeprecatedFunctionsConfig>);
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoDeprecatedFunctionsConfig {
+    /// Jest configuration options.
+    /// Deprecated config, it will be removed in future versions.
+    /// Use please instead { "settings": { "jest": {"version": 29 } } } in `Oxlint config file`.
+    /// Beware the value from the config have higher priority than the rule config.
+    jest: JestConfig,
+}
+
+impl std::ops::Deref for NoDeprecatedFunctions {
+    type Target = NoDeprecatedFunctionsConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -66,6 +99,7 @@ declare_oxc_lint!(
     jest,
     style,
     fix,
+    config = NoDeprecatedFunctionsConfig,
     version = "0.0.18",
 );
 
@@ -81,6 +115,25 @@ fn deprecated_functions_map(deprecated_fn: &str) -> Option<(usize, &'static str)
 }
 
 impl Rule for NoDeprecatedFunctions {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let version = value
+            .get(0)
+            .and_then(|v| v.get("jest"))
+            .and_then(|v| v.get("version"))
+            .and_then(|v| serde_json::Value::as_str(v))
+            // Todo: Fixed Me
+            // Currently set the default version to the (maybe) latest, to help to find more problems in
+            // the codebase. In the future, the version should come from the cli option or the config files,
+            // such as `package.json` or `eslint.config.js`.
+            .unwrap_or("29");
+
+        let major: Vec<&str> = version.split('.').collect();
+
+        Ok(Self(Box::new(NoDeprecatedFunctionsConfig {
+            jest: JestConfig { version: major[0].to_string() },
+        })))
+    }
+
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
         let Some(mem_expr) = node.kind().as_member_expression_kind() else {
             return;
@@ -95,9 +148,14 @@ impl Rule for NoDeprecatedFunctions {
         }
 
         let node_name = chain.join(".");
+        let jest_version_num: usize = if let Some(jest_version) = ctx.settings().jest.version {
+            jest_version
+        } else {
+            self.jest.version.parse().unwrap_or(29)
+        };
 
         if let Some((base_version, replacement)) = deprecated_functions_map(&node_name)
-            && ctx.settings().jest.version >= base_version
+            && jest_version_num >= base_version
         {
             ctx.diagnostic_with_fix(
                 deprecated_function(&node_name, replacement, mem_expr.span()),
@@ -109,6 +167,65 @@ impl Rule for NoDeprecatedFunctions {
 
 #[test]
 fn tests() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("jest", Some(serde_json::json!([{ "jest": { "version": "14" } }]))),
+        ("require('fs')", Some(serde_json::json!([{ "jest": { "version": "14" } }]))),
+        ("jest.resetModuleRegistry", Some(serde_json::json!([{ "jest": { "version": "14" } }]))),
+        ("require.requireActual", Some(serde_json::json!([{ "jest": { "version": "17" } }]))),
+        ("jest.genMockFromModule", Some(serde_json::json!([{ "jest": { "version": "25" } }]))),
+        ("jest.genMockFromModule", Some(serde_json::json!([{ "jest": { "version": "25.1.1" } }]))),
+        ("require.requireActual", Some(serde_json::json!([{ "jest": { "version": "17.2" } }]))),
+    ];
+
+    let fail = vec![
+        ("jest.resetModuleRegistry", None),
+        // replace with `jest.resetModules` in Jest 15
+        ("jest.resetModuleRegistry", Some(serde_json::json!([{ "jest": { "version": "16" }}]))),
+        // replace with `jest.requireMock` in Jest 17.
+        ("jest.addMatchers", Some(serde_json::json!([{ "jest": { "version": "18" }}]))),
+        // replace with `jest.requireMock` in Jest 21.
+        ("require.requireMock", Some(serde_json::json!([{ "jest": { "version": "22" }}]))),
+        // replace with `jest.requireActual` in Jest 21.
+        ("require.requireActual", Some(serde_json::json!([{ "jest": { "version": "22" }}]))),
+        // replace with `jest.advanceTimersByTime` in Jest 22
+        ("jest.runTimersToTime", Some(serde_json::json!([{ "jest": { "version": "23" }}]))),
+        // replace with `jest.createMockFromModule` in Jest 26
+        ("jest.genMockFromModule", Some(serde_json::json!([{ "jest": { "version": "27" }}]))),
+    ];
+
+    let fix = vec![
+        (
+            "jest.resetModuleRegistry()",
+            "jest.resetModules()",
+            Some(serde_json::json!([{ "jest": { "version": "21" } }])),
+        ),
+        (
+            "jest.addMatchers",
+            "expect.extend",
+            Some(serde_json::json!([{ "jest": { "version": "24" } }])),
+        ),
+        (
+            "jest.genMockFromModule",
+            "jest.createMockFromModule",
+            Some(serde_json::json!([{ "jest": { "version": "26" } }])),
+        ),
+        (
+            "jest.genMockFromModule",
+            "jest.createMockFromModule",
+            Some(serde_json::json!([{ "jest": { "version": "26.0.0-next.11" } }])),
+        ),
+    ];
+
+    Tester::new(NoDeprecatedFunctions::NAME, NoDeprecatedFunctions::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_version_from_config() {
     use crate::tester::Tester;
 
     let pass = vec![
@@ -208,6 +325,121 @@ fn tests() {
             "jest.genMockFromModule",
             "jest.createMockFromModule",
             None,
+            Some(serde_json::json!({ "settings": { "jest": { "version": "26.0.0-next.11" } }})),
+        ),
+    ];
+
+    Tester::new(NoDeprecatedFunctions::NAME, NoDeprecatedFunctions::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_override() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "jest",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "14" } }})),
+        ),
+        (
+            "require('fs')",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "14" } }})),
+        ),
+        (
+            "jest.resetModuleRegistry",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "14" } }})),
+        ),
+        (
+            "require.requireActual",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "17" } } })),
+        ),
+        (
+            "jest.genMockFromModule",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "25" } } })),
+        ),
+        (
+            "jest.genMockFromModule",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "25.1.1" } } })),
+        ),
+        (
+            "require.requireActual",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "17.2" } } })),
+        ),
+    ];
+
+    let fail = vec![
+        ("jest.resetModuleRegistry", None, None),
+        // replace with `jest.resetModules` in Jest 15
+        (
+            "jest.resetModuleRegistry",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "16" }}})),
+        ),
+        // replace with `jest.requireMock` in Jest 17.
+        (
+            "jest.addMatchers",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "18" }}})),
+        ),
+        // replace with `jest.requireMock` in Jest 21.
+        (
+            "require.requireMock",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "22" }}})),
+        ),
+        // replace with `jest.requireActual` in Jest 21.
+        (
+            "require.requireActual",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "22" }}})),
+        ),
+        // replace with `jest.advanceTimersByTime` in Jest 22
+        (
+            "jest.runTimersToTime",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "23" }}})),
+        ),
+        // replace with `jest.createMockFromModule` in Jest 26
+        (
+            "jest.genMockFromModule",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "27" }}})),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "jest.resetModuleRegistry()",
+            "jest.resetModules()",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "21" } }})),
+        ),
+        (
+            "jest.addMatchers",
+            "expect.extend",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "24" } }})),
+        ),
+        (
+            "jest.genMockFromModule",
+            "jest.createMockFromModule",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
+            Some(serde_json::json!({ "settings": { "jest": { "version": "26" } }})),
+        ),
+        (
+            "jest.genMockFromModule",
+            "jest.createMockFromModule",
+            Some(serde_json::json!([{ "jest": { "version": "29" } }])),
             Some(serde_json::json!({ "settings": { "jest": { "version": "26.0.0-next.11" } }})),
         ),
     ];

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -97,7 +97,7 @@ impl Rule for NoDeprecatedFunctions {
         let node_name = chain.join(".");
 
         if let Some((base_version, replacement)) = deprecated_functions_map(&node_name)
-            && *ctx.settings().jest.version >= base_version
+            && ctx.settings().jest.version >= base_version
         {
             ctx.diagnostic_with_fix(
                 deprecated_function(&node_name, replacement, mem_expr.span()),

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -133,6 +133,7 @@ pub struct ExpectFixTestCase {
     expected: Vec<ExpectFix>,
     rule_config: Option<Value>,
     path: Option<PathBuf>,
+    eslint_config: Option<Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -149,6 +150,7 @@ impl<S: Into<String>> From<(S, S, Option<Value>)> for ExpectFixTestCase {
             expected: vec![ExpectFix { expected: value.1.into(), kind: ExpectFixKind::Any }],
             rule_config: value.2,
             path: None,
+            eslint_config: None,
         }
     }
 }
@@ -160,6 +162,7 @@ impl<S: Into<String>> From<(S, S)> for ExpectFixTestCase {
             expected: vec![ExpectFix { expected: value.1.into(), kind: ExpectFixKind::Any }],
             rule_config: None,
             path: None,
+            eslint_config: None,
         }
     }
 }
@@ -174,6 +177,7 @@ impl<S: Into<String>> From<(S, (S, S))> for ExpectFixTestCase {
             ],
             rule_config: None,
             path: None,
+            eslint_config: None,
         }
     }
 }
@@ -189,6 +193,7 @@ impl<S: Into<String>> From<(S, (S, S, S))> for ExpectFixTestCase {
             ],
             rule_config: None,
             path: None,
+            eslint_config: None,
         }
     }
 }
@@ -204,6 +209,24 @@ where
             expected: vec![ExpectFix { expected: expected.into(), kind: kind.into() }],
             rule_config: config,
             path: None,
+            eslint_config: None,
+        }
+    }
+}
+
+impl<S> From<(S, S, Option<Value>, Option<Value>)> for ExpectFixTestCase
+where
+    S: Into<String>,
+{
+    fn from(
+        (source, expected, config, eslint_config): (S, S, Option<Value>, Option<Value>),
+    ) -> Self {
+        Self {
+            source: source.into(),
+            expected: vec![ExpectFix { expected: expected.into(), kind: ExpectFixKind::Any }],
+            rule_config: config,
+            path: None,
+            eslint_config,
         }
     }
 }
@@ -215,6 +238,29 @@ impl<S: Into<String>> From<(S, S, Option<Value>, Option<PathBuf>)> for ExpectFix
             expected: vec![ExpectFix { expected: expected.into(), kind: ExpectFixKind::Any }],
             rule_config: config,
             path,
+            eslint_config: None,
+        }
+    }
+}
+
+impl<S: Into<String>> From<(S, S, Option<Value>, Option<PathBuf>, Option<Value>)>
+    for ExpectFixTestCase
+{
+    fn from(
+        (source, expected, config, path, eslint_config): (
+            S,
+            S,
+            Option<Value>,
+            Option<PathBuf>,
+            Option<Value>,
+        ),
+    ) -> Self {
+        Self {
+            source: source.into(),
+            expected: vec![ExpectFix { expected: expected.into(), kind: ExpectFixKind::Any }],
+            rule_config: config,
+            path,
+            eslint_config,
         }
     }
 }
@@ -499,10 +545,17 @@ impl Tester {
         };
 
         for fix in fix_test_cases {
-            let ExpectFixTestCase { source, expected, rule_config: config, path } = fix;
+            let ExpectFixTestCase { source, expected, rule_config: config, path, eslint_config } =
+                fix;
             for (index, expect) in expected.iter().enumerate() {
-                let result =
-                    self.run(&source, config.clone(), None, path.clone(), expect.kind, index as u8);
+                let result = self.run(
+                    &source,
+                    config.clone(),
+                    eslint_config.clone(),
+                    path.clone(),
+                    expect.kind,
+                    index as u8,
+                );
                 match result {
                     TestResult::Fixed(fixed_str) => {
                         if expect.expected != fixed_str {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -384,22 +384,15 @@
       "type": "object",
       "properties": {
         "version": {
-          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.",
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29",
           "default": 29,
-          "allOf": [
-            {
-              "$ref": "#/definitions/JestVersion"
-            }
-          ],
-          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version."
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0,
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29"
         }
       },
       "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."
-    },
-    "JestVersion": {
-      "type": "integer",
-      "format": "uint",
-      "minimum": 0.0
     },
     "LintPluginOptionsSchema": {
       "type": "string",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -141,7 +141,7 @@
           "typecheck": false
         },
         "jest": {
-          "version": 29
+          "version": null
         }
       },
       "allOf": [
@@ -384,12 +384,12 @@
       "type": "object",
       "properties": {
         "version": {
-          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29",
-          "default": 29,
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set.",
+          "default": null,
           "type": "integer",
           "format": "uint",
           "minimum": 0.0,
-          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29"
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set."
         }
       },
       "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."
@@ -630,7 +630,7 @@
       "properties": {
         "jest": {
           "default": {
-            "version": 29
+            "version": null
           },
           "allOf": [
             {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -139,6 +139,9 @@
         },
         "vitest": {
           "typecheck": false
+        },
+        "jest": {
+          "version": 29
         }
       },
       "allOf": [
@@ -376,6 +379,28 @@
       },
       "markdownDescription": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference."
     },
+    "JestPluginSettings": {
+      "description": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.",
+          "default": 29,
+          "allOf": [
+            {
+              "$ref": "#/definitions/JestVersion"
+            }
+          ],
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version."
+        }
+      },
+      "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."
+    },
+    "JestVersion": {
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
     "LintPluginOptionsSchema": {
       "type": "string",
       "enum": [
@@ -610,6 +635,16 @@
       "description": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```",
       "type": "object",
       "properties": {
+        "jest": {
+          "default": {
+            "version": 29
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/JestPluginSettings"
+            }
+          ]
+        },
         "jsdoc": {
           "default": {
             "ignorePrivate": false,

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -388,22 +388,15 @@ expression: json
       "type": "object",
       "properties": {
         "version": {
-          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.",
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29",
           "default": 29,
-          "allOf": [
-            {
-              "$ref": "#/definitions/JestVersion"
-            }
-          ],
-          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version."
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0,
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29"
         }
       },
       "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."
-    },
-    "JestVersion": {
-      "type": "integer",
-      "format": "uint",
-      "minimum": 0.0
     },
     "LintPluginOptionsSchema": {
       "type": "string",

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -145,7 +145,7 @@ expression: json
           "typecheck": false
         },
         "jest": {
-          "version": 29
+          "version": null
         }
       },
       "allOf": [
@@ -388,12 +388,12 @@ expression: json
       "type": "object",
       "properties": {
         "version": {
-          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29",
-          "default": 29,
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set.",
+          "default": null,
           "type": "integer",
           "format": "uint",
           "minimum": 0.0,
-          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version. Default version is 29"
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set."
         }
       },
       "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."
@@ -634,7 +634,7 @@ expression: json
       "properties": {
         "jest": {
           "default": {
-            "version": 29
+            "version": null
           },
           "allOf": [
             {

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -143,6 +143,9 @@ expression: json
         },
         "vitest": {
           "typecheck": false
+        },
+        "jest": {
+          "version": 29
         }
       },
       "allOf": [
@@ -380,6 +383,28 @@ expression: json
       },
       "markdownDescription": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference."
     },
+    "JestPluginSettings": {
+      "description": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.",
+          "default": 29,
+          "allOf": [
+            {
+              "$ref": "#/definitions/JestVersion"
+            }
+          ],
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version."
+        }
+      },
+      "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."
+    },
+    "JestVersion": {
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
     "LintPluginOptionsSchema": {
       "type": "string",
       "enum": [
@@ -614,6 +639,16 @@ expression: json
       "description": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```",
       "type": "object",
       "properties": {
+        "jest": {
+          "default": {
+            "version": 29
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/JestPluginSettings"
+            }
+          ]
+        },
         "jsdoc": {
           "default": {
             "ignorePrivate": false,

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -650,10 +650,12 @@ configuration for a full reference.
 
 type: `integer`
 
-default: `29`
+default: `null`
 
 Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
-storing only the major version. Default version is 29
+storing only the major version.
+::: warning
+Using this config will override the `no-deprecated-functions`' config set.
 
 
 ### settings.jsdoc

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -652,7 +652,8 @@ type: `integer`
 
 default: `29`
 
-
+Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
+storing only the major version. Default version is 29
 
 
 ### settings.jsdoc

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -635,6 +635,26 @@ Here's an example if you're using Next.js in a monorepo:
 ```
 
 
+### settings.jest
+
+type: `object`
+
+
+Configure Jest plugin rules.
+
+See [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s
+configuration for a full reference.
+
+
+#### settings.jest.version
+
+type: `integer`
+
+default: `29`
+
+
+
+
 ### settings.jsdoc
 
 type: `object`


### PR DESCRIPTION
# AI Disclosure
This PR has been done without AI assistance

# Summary

`jest/no-deprecated-function` don't have a config at rule level, his informations comes from the config file. I have move this value to `OxlintSettings`, this is the first step to add the remaining jest configs. Tester now allows a eslint config when the rule depends on config values.

Talked in discord, the current approach is config level has more priority than rule config. Added a message mentioning that rule config will be eliminated at some point.