### PR TITLE
fix(minifier): propagate PURE annotation when inlining pure IIFE

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -645,8 +645,8 @@ pub struct NewExpression<'a> {
     pub callee: Expression<'a>,
     #[ts]
     pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
-    /// `true` if the new expression is marked with a `/* @__PURE__ */` comment
     pub arguments: Vec<'a, Argument<'a>>,
+    /// `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[builder(default)]
     #[estree(skip)]
     pub pure: bool,

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -837,7 +837,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `type_arguments`
-    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `arguments`
     #[inline]
     pub fn expression_new<T1>(
         self,
@@ -865,8 +865,8 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `type_arguments`
-    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
-    /// * `pure`
+    /// * `arguments`
+    /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn expression_new_with_pure<T1>(
         self,
@@ -2209,7 +2209,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `type_arguments`
-    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `arguments`
     #[inline]
     pub fn new_expression<T1>(
         self,
@@ -2240,7 +2240,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `type_arguments`
-    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    /// * `arguments`
     #[inline]
     pub fn alloc_new_expression<T1>(
         self,
@@ -2264,8 +2264,8 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `type_arguments`
-    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
-    /// * `pure`
+    /// * `arguments`
+    /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn new_expression_with_pure<T1>(
         self,
@@ -2297,8 +2297,8 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `type_arguments`
-    /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
-    /// * `pure`
+    /// * `arguments`
+    /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn alloc_new_expression_with_pure<T1>(
         self,

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -72,6 +72,12 @@ impl<'a> MayHaveSideEffects<'a> for Expression<'a> {
             Expression::TaggedTemplateExpression(e) => e.may_have_side_effects(ctx),
             Expression::AssignmentExpression(e) => e.may_have_side_effects(ctx),
             Expression::UpdateExpression(e) => e.may_have_side_effects(ctx),
+            // TS wrappers are runtime-transparent; defer to the inner expression.
+            Expression::TSAsExpression(e) => e.expression.may_have_side_effects(ctx),
+            Expression::TSNonNullExpression(e) => e.expression.may_have_side_effects(ctx),
+            Expression::TSSatisfiesExpression(e) => e.expression.may_have_side_effects(ctx),
+            Expression::TSTypeAssertion(e) => e.expression.may_have_side_effects(ctx),
+            Expression::TSInstantiationExpression(e) => e.expression.may_have_side_effects(ctx),
             _ => true,
         }
     }

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -73,11 +73,13 @@ impl<'a> MayHaveSideEffects<'a> for Expression<'a> {
             Expression::AssignmentExpression(e) => e.may_have_side_effects(ctx),
             Expression::UpdateExpression(e) => e.may_have_side_effects(ctx),
             // TS wrappers are runtime-transparent; defer to the inner expression.
-            Expression::TSAsExpression(e) => e.expression.may_have_side_effects(ctx),
-            Expression::TSNonNullExpression(e) => e.expression.may_have_side_effects(ctx),
-            Expression::TSSatisfiesExpression(e) => e.expression.may_have_side_effects(ctx),
-            Expression::TSTypeAssertion(e) => e.expression.may_have_side_effects(ctx),
-            Expression::TSInstantiationExpression(e) => e.expression.may_have_side_effects(ctx),
+            Expression::TSAsExpression(_)
+            | Expression::TSNonNullExpression(_)
+            | Expression::TSSatisfiesExpression(_)
+            | Expression::TSTypeAssertion(_)
+            | Expression::TSInstantiationExpression(_) => {
+                self.get_inner_expression().may_have_side_effects(ctx)
+            }
             _ => true,
         }
     }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1671,7 +1671,7 @@ impl<'a> PeepholeOptimizations {
                 if is_pure && Self::is_expression_result_unused(ctx) {
                     *e = ctx.ast.void_0(call_expr.span);
                 } else {
-                    *e = Self::take_propagating_pure(expr, is_pure, ctx);
+                    *e = Self::take_and_propagate_pure(expr, is_pure, ctx);
                 }
                 ctx.state.changed = true;
                 return;
@@ -1683,7 +1683,7 @@ impl<'a> PeepholeOptimizations {
                         *e = ctx.ast.void_0(call_expr.span);
                     } else {
                         let inner =
-                            Self::take_propagating_pure(&mut expr_stmt.expression, is_pure, ctx);
+                            Self::take_and_propagate_pure(&mut expr_stmt.expression, is_pure, ctx);
                         *e = ctx.ast.expression_sequence(expr_stmt.span, {
                             let mut sequence = ctx.ast.vec();
                             sequence.push(inner);
@@ -1700,7 +1700,7 @@ impl<'a> PeepholeOptimizations {
                         if is_pure && Self::is_expression_result_unused(ctx) {
                             *e = ctx.ast.void_0(call_expr.span);
                         } else {
-                            *e = Self::take_propagating_pure(argument, is_pure, ctx);
+                            *e = Self::take_and_propagate_pure(argument, is_pure, ctx);
                         }
                         ctx.state.changed = true;
                     }
@@ -1718,7 +1718,7 @@ impl<'a> PeepholeOptimizations {
     /// silently lost when the body is a tagged template. `manual_pure_functions`
     /// can't match an arrow/function-expression callee, so `is_pure` here
     /// really only reflects the outer `/* @__PURE__ */`.
-    fn take_propagating_pure(
+    fn take_and_propagate_pure(
         expr: &mut Expression<'a>,
         is_pure: bool,
         ctx: &TraverseCtx<'a>,

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1732,8 +1732,16 @@ impl<'a> PeepholeOptimizations {
 
     fn mark_inlined_pure(expr: &mut Expression<'a>) {
         match expr {
-            Expression::CallExpression(c) => c.pure = true,
-            Expression::NewExpression(n) => n.pure = true,
+            Expression::CallExpression(c) => {
+                c.pure = true;
+                Self::mark_inlined_pure(&mut c.callee);
+                Self::mark_arguments_pure(&mut c.arguments);
+            }
+            Expression::NewExpression(n) => {
+                n.pure = true;
+                Self::mark_inlined_pure(&mut n.callee);
+                Self::mark_arguments_pure(&mut n.arguments);
+            }
             Expression::SequenceExpression(s) => {
                 for e in &mut s.expressions {
                     Self::mark_inlined_pure(e);
@@ -1755,6 +1763,11 @@ impl<'a> PeepholeOptimizations {
                 Self::mark_inlined_pure(&mut b.right);
             }
             Expression::ChainExpression(c) => Self::mark_chain_element_pure(&mut c.expression),
+            // Member variants have no `pure` flag, but the outer PURE still
+            // covers evaluation of the object, so recurse into it.
+            Expression::StaticMemberExpression(m) => Self::mark_inlined_pure(&mut m.object),
+            Expression::ComputedMemberExpression(m) => Self::mark_inlined_pure(&mut m.object),
+            Expression::PrivateFieldExpression(m) => Self::mark_inlined_pure(&mut m.object),
             Expression::TSAsExpression(_)
             | Expression::TSNonNullExpression(_)
             | Expression::TSSatisfiesExpression(_)
@@ -1766,12 +1779,28 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
+    fn mark_arguments_pure(args: &mut Vec<'a, Argument<'a>>) {
+        for arg in args {
+            match arg {
+                Argument::SpreadElement(s) => Self::mark_inlined_pure(&mut s.argument),
+                match_expression!(Argument) => Self::mark_inlined_pure(arg.to_expression_mut()),
+            }
+        }
+    }
+
     fn mark_chain_element_pure(element: &mut ChainElement<'a>) {
         match element {
-            ChainElement::CallExpression(c) => c.pure = true,
+            ChainElement::CallExpression(c) => {
+                c.pure = true;
+                Self::mark_inlined_pure(&mut c.callee);
+                Self::mark_arguments_pure(&mut c.arguments);
+            }
             ChainElement::TSNonNullExpression(e) => Self::mark_inlined_pure(&mut e.expression),
-            // `MemberExpression` variants have no `pure` flag to set.
-            _ => {}
+            // Member variants have no `pure` flag, but the outer PURE still
+            // covers evaluation of the object, so recurse into it.
+            ChainElement::StaticMemberExpression(m) => Self::mark_inlined_pure(&mut m.object),
+            ChainElement::ComputedMemberExpression(m) => Self::mark_inlined_pure(&mut m.object),
+            ChainElement::PrivateFieldExpression(m) => Self::mark_inlined_pure(&mut m.object),
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1671,7 +1671,11 @@ impl<'a> PeepholeOptimizations {
                 if is_pure && Self::is_expression_result_unused(ctx) {
                     *e = ctx.ast.void_0(call_expr.span);
                 } else {
-                    *e = expr.take_in(ctx.ast);
+                    let mut inner = expr.take_in(ctx.ast);
+                    if is_pure {
+                        Self::propagate_pure_annotation(&mut inner);
+                    }
+                    *e = inner;
                 }
                 ctx.state.changed = true;
                 return;
@@ -1682,9 +1686,13 @@ impl<'a> PeepholeOptimizations {
                     if is_pure && Self::is_expression_result_unused(ctx) {
                         *e = ctx.ast.void_0(call_expr.span);
                     } else {
+                        let mut inner = expr_stmt.expression.take_in(ctx.ast);
+                        if is_pure {
+                            Self::propagate_pure_annotation(&mut inner);
+                        }
                         *e = ctx.ast.expression_sequence(expr_stmt.span, {
                             let mut sequence = ctx.ast.vec();
-                            sequence.push(expr_stmt.expression.take_in(ctx.ast));
+                            sequence.push(inner);
                             sequence.push(ctx.ast.void_0(call_expr.span));
                             sequence
                         });
@@ -1698,13 +1706,27 @@ impl<'a> PeepholeOptimizations {
                         if is_pure && Self::is_expression_result_unused(ctx) {
                             *e = ctx.ast.void_0(call_expr.span);
                         } else {
-                            *e = argument.take_in(ctx.ast);
+                            let mut inner = argument.take_in(ctx.ast);
+                            if is_pure {
+                                Self::propagate_pure_annotation(&mut inner);
+                            }
+                            *e = inner;
                         }
                         ctx.state.changed = true;
                     }
                 }
                 _ => {}
             }
+        }
+    }
+
+    /// When a pure-annotated IIFE is inlined, propagate the annotation onto
+    /// the inner call/new expression so later passes can still drop it.
+    fn propagate_pure_annotation(expr: &mut Expression<'a>) {
+        match expr {
+            Expression::CallExpression(c) => c.pure = true,
+            Expression::NewExpression(n) => n.pure = true,
+            _ => {}
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1755,11 +1755,13 @@ impl<'a> PeepholeOptimizations {
                 Self::mark_inlined_pure(&mut b.right);
             }
             Expression::ChainExpression(c) => Self::mark_chain_element_pure(&mut c.expression),
-            Expression::TSAsExpression(e) => Self::mark_inlined_pure(&mut e.expression),
-            Expression::TSNonNullExpression(e) => Self::mark_inlined_pure(&mut e.expression),
-            Expression::TSSatisfiesExpression(e) => Self::mark_inlined_pure(&mut e.expression),
-            Expression::TSTypeAssertion(e) => Self::mark_inlined_pure(&mut e.expression),
-            Expression::TSInstantiationExpression(e) => Self::mark_inlined_pure(&mut e.expression),
+            Expression::TSAsExpression(_)
+            | Expression::TSNonNullExpression(_)
+            | Expression::TSSatisfiesExpression(_)
+            | Expression::TSTypeAssertion(_)
+            | Expression::TSInstantiationExpression(_) => {
+                Self::mark_inlined_pure(expr.get_inner_expression_mut());
+            }
             _ => {}
         }
     }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1727,7 +1727,10 @@ impl<'a> PeepholeOptimizations {
     ///
     /// - `TaggedTemplateExpression` (and any inner calls inside its `tag`),
     /// - `ArrayExpression` / `ObjectExpression` elements,
-    /// - `TemplateLiteral` interpolations.
+    /// - `TemplateLiteral` interpolations,
+    /// - `AssignmentExpression` right-hand sides (the assignment itself is
+    ///   side-effectful, so it won't drop — but if the assigned value is
+    ///   later substituted, the inner call will have lost its PURE mark).
     ///
     /// These are missed-optimization gaps rather than correctness issues —
     /// the outer call's drop is what matters for the typical pattern, and

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1736,6 +1736,31 @@ impl<'a> PeepholeOptimizations {
                     Self::mark_inlined_pure(e);
                 }
             }
+            Expression::ConditionalExpression(c) => {
+                // The outer PURE covers evaluation of all three sub-expressions.
+                Self::mark_inlined_pure(&mut c.test);
+                Self::mark_inlined_pure(&mut c.consequent);
+                Self::mark_inlined_pure(&mut c.alternate);
+            }
+            Expression::LogicalExpression(l) => {
+                Self::mark_inlined_pure(&mut l.left);
+                Self::mark_inlined_pure(&mut l.right);
+            }
+            Expression::ChainExpression(c) => Self::mark_chain_element_pure(&mut c.expression),
+            Expression::TSAsExpression(e) => Self::mark_inlined_pure(&mut e.expression),
+            Expression::TSNonNullExpression(e) => Self::mark_inlined_pure(&mut e.expression),
+            Expression::TSSatisfiesExpression(e) => Self::mark_inlined_pure(&mut e.expression),
+            Expression::TSTypeAssertion(e) => Self::mark_inlined_pure(&mut e.expression),
+            Expression::TSInstantiationExpression(e) => Self::mark_inlined_pure(&mut e.expression),
+            _ => {}
+        }
+    }
+
+    fn mark_chain_element_pure(element: &mut ChainElement<'a>) {
+        match element {
+            ChainElement::CallExpression(c) => c.pure = true,
+            ChainElement::TSNonNullExpression(e) => Self::mark_inlined_pure(&mut e.expression),
+            // `MemberExpression` variants have no `pure` flag to set.
             _ => {}
         }
     }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1671,11 +1671,7 @@ impl<'a> PeepholeOptimizations {
                 if is_pure && Self::is_expression_result_unused(ctx) {
                     *e = ctx.ast.void_0(call_expr.span);
                 } else {
-                    let mut inner = expr.take_in(ctx.ast);
-                    if is_pure {
-                        Self::propagate_pure_annotation(&mut inner);
-                    }
-                    *e = inner;
+                    *e = Self::take_propagating_pure(expr, is_pure, ctx);
                 }
                 ctx.state.changed = true;
                 return;
@@ -1686,10 +1682,8 @@ impl<'a> PeepholeOptimizations {
                     if is_pure && Self::is_expression_result_unused(ctx) {
                         *e = ctx.ast.void_0(call_expr.span);
                     } else {
-                        let mut inner = expr_stmt.expression.take_in(ctx.ast);
-                        if is_pure {
-                            Self::propagate_pure_annotation(&mut inner);
-                        }
+                        let inner =
+                            Self::take_propagating_pure(&mut expr_stmt.expression, is_pure, ctx);
                         *e = ctx.ast.expression_sequence(expr_stmt.span, {
                             let mut sequence = ctx.ast.vec();
                             sequence.push(inner);
@@ -1706,11 +1700,7 @@ impl<'a> PeepholeOptimizations {
                         if is_pure && Self::is_expression_result_unused(ctx) {
                             *e = ctx.ast.void_0(call_expr.span);
                         } else {
-                            let mut inner = argument.take_in(ctx.ast);
-                            if is_pure {
-                                Self::propagate_pure_annotation(&mut inner);
-                            }
-                            *e = inner;
+                            *e = Self::take_propagating_pure(argument, is_pure, ctx);
                         }
                         ctx.state.changed = true;
                     }
@@ -1720,14 +1710,23 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// When a pure-annotated IIFE is inlined, propagate the annotation onto
-    /// the inner call/new expression so later passes can still drop it.
-    fn propagate_pure_annotation(expr: &mut Expression<'a>) {
-        match expr {
-            Expression::CallExpression(c) => c.pure = true,
-            Expression::NewExpression(n) => n.pure = true,
-            _ => {}
+    /// Take the IIFE body expression out of the AST. If the enclosing IIFE was
+    /// pure-annotated, carry the annotation onto the inlined call/new so
+    /// later passes can still drop it.
+    fn take_propagating_pure(
+        expr: &mut Expression<'a>,
+        is_pure: bool,
+        ctx: &TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let mut taken = expr.take_in(ctx.ast);
+        if is_pure {
+            match &mut taken {
+                Expression::CallExpression(c) => c.pure = true,
+                Expression::NewExpression(n) => n.pure = true,
+                _ => {}
+            }
         }
+        taken
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1710,9 +1710,11 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// Take the IIFE body expression out of the AST. If the enclosing IIFE was
-    /// pure-annotated, carry the annotation onto the inlined call/new so
-    /// later passes can still drop it.
+    /// Take the expression being inlined out of the IIFE body. If the enclosing
+    /// IIFE was pure-annotated, carry the annotation onto the inlined call/new
+    /// (recursing into `SequenceExpression` elements) so later passes can still
+    /// drop it. `manual_pure_functions` can't match an arrow/function-expression
+    /// callee, so `is_pure` here really only reflects the outer `/* @__PURE__ */`.
     fn take_propagating_pure(
         expr: &mut Expression<'a>,
         is_pure: bool,
@@ -1720,13 +1722,22 @@ impl<'a> PeepholeOptimizations {
     ) -> Expression<'a> {
         let mut taken = expr.take_in(ctx.ast);
         if is_pure {
-            match &mut taken {
-                Expression::CallExpression(c) => c.pure = true,
-                Expression::NewExpression(n) => n.pure = true,
-                _ => {}
-            }
+            Self::mark_inlined_pure(&mut taken);
         }
         taken
+    }
+
+    fn mark_inlined_pure(expr: &mut Expression<'a>) {
+        match expr {
+            Expression::CallExpression(c) => c.pure = true,
+            Expression::NewExpression(n) => n.pure = true,
+            Expression::SequenceExpression(s) => {
+                for e in &mut s.expressions {
+                    Self::mark_inlined_pure(e);
+                }
+            }
+            _ => {}
+        }
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1731,6 +1731,9 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn mark_inlined_pure(expr: &mut Expression<'a>) {
+        // Strip TS wrappers (and any `ParenthesizedExpression` layers) in one
+        // step so the match below only has to handle runtime-meaningful shapes.
+        let expr = expr.get_inner_expression_mut();
         match expr {
             Expression::CallExpression(c) => {
                 c.pure = true;
@@ -1768,13 +1771,6 @@ impl<'a> PeepholeOptimizations {
             Expression::StaticMemberExpression(m) => Self::mark_inlined_pure(&mut m.object),
             Expression::ComputedMemberExpression(m) => Self::mark_inlined_pure(&mut m.object),
             Expression::PrivateFieldExpression(m) => Self::mark_inlined_pure(&mut m.object),
-            Expression::TSAsExpression(_)
-            | Expression::TSNonNullExpression(_)
-            | Expression::TSSatisfiesExpression(_)
-            | Expression::TSTypeAssertion(_)
-            | Expression::TSInstantiationExpression(_) => {
-                Self::mark_inlined_pure(expr.get_inner_expression_mut());
-            }
             _ => {}
         }
     }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1712,12 +1712,31 @@ impl<'a> PeepholeOptimizations {
 
     /// Take the expression being inlined out of the IIFE body. If the enclosing
     /// IIFE was pure-annotated, carry the annotation onto the inlined call/new,
-    /// recursing through container shapes (sequence/conditional/logical/unary
-    /// /binary/chain/TS wrappers) so later passes can still drop the inlined
-    /// expression. `TaggedTemplateExpression` has no `pure` flag, so PURE is
-    /// silently lost when the body is a tagged template. `manual_pure_functions`
-    /// can't match an arrow/function-expression callee, so `is_pure` here
-    /// really only reflects the outer `/* @__PURE__ */`.
+    /// recursing through:
+    ///
+    /// - container shapes (sequence/conditional/logical/unary/binary/chain/TS
+    ///   wrappers),
+    /// - `CallExpression`/`NewExpression` callees and arguments (including
+    ///   spread elements), and
+    /// - member-access object positions (static/computed/private),
+    ///
+    /// so later passes can still drop the inlined expression.
+    ///
+    /// PURE is silently lost in a few positions where the AST has no `pure`
+    /// flag of its own and the recursion stops:
+    ///
+    /// - `TaggedTemplateExpression` (and any inner calls inside its `tag`),
+    /// - `ArrayExpression` / `ObjectExpression` elements,
+    /// - `TemplateLiteral` interpolations.
+    ///
+    /// These are missed-optimization gaps rather than correctness issues —
+    /// the outer call's drop is what matters for the typical pattern, and
+    /// these shapes can't appear directly under the IIFE-result position
+    /// without breaking the drop anyway.
+    ///
+    /// `manual_pure_functions` can't match an arrow/function-expression
+    /// callee, so `is_pure` here really only reflects the outer
+    /// `/* @__PURE__ */`.
     fn take_and_propagate_pure(
         expr: &mut Expression<'a>,
         is_pure: bool,
@@ -1730,9 +1749,14 @@ impl<'a> PeepholeOptimizations {
         taken
     }
 
+    /// Recursive PURE marker. Keep in sync with [`Self::mark_chain_element_pure`].
     fn mark_inlined_pure(expr: &mut Expression<'a>) {
-        // Strip TS wrappers (and any `ParenthesizedExpression` layers) in one
-        // step so the match below only has to handle runtime-meaningful shapes.
+        // Strip TS wrappers in one step so the match below only has to handle
+        // runtime-meaningful shapes. This also strips `ParenthesizedExpression`
+        // layers, which is fine here because `normalize.rs` removes parens
+        // before this peephole runs — if this helper is ever called from a
+        // pre-normalization context, parens would silently disappear from the
+        // recursion target.
         let expr = expr.get_inner_expression_mut();
         match expr {
             Expression::CallExpression(c) => {
@@ -1784,6 +1808,9 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
+    /// Chain-element variant of [`Self::mark_inlined_pure`]. Keep the two in
+    /// sync — `ChainElement` and `Expression` overlap on `CallExpression`,
+    /// `TSNonNullExpression`, and the three member-expression variants.
     fn mark_chain_element_pure(element: &mut ChainElement<'a>) {
         match element {
             ChainElement::CallExpression(c) => {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1711,10 +1711,13 @@ impl<'a> PeepholeOptimizations {
     }
 
     /// Take the expression being inlined out of the IIFE body. If the enclosing
-    /// IIFE was pure-annotated, carry the annotation onto the inlined call/new
-    /// (recursing into `SequenceExpression` elements) so later passes can still
-    /// drop it. `manual_pure_functions` can't match an arrow/function-expression
-    /// callee, so `is_pure` here really only reflects the outer `/* @__PURE__ */`.
+    /// IIFE was pure-annotated, carry the annotation onto the inlined call/new,
+    /// recursing through container shapes (sequence/conditional/logical/unary
+    /// /binary/chain/TS wrappers) so later passes can still drop the inlined
+    /// expression. `TaggedTemplateExpression` has no `pure` flag, so PURE is
+    /// silently lost when the body is a tagged template. `manual_pure_functions`
+    /// can't match an arrow/function-expression callee, so `is_pure` here
+    /// really only reflects the outer `/* @__PURE__ */`.
     fn take_propagating_pure(
         expr: &mut Expression<'a>,
         is_pure: bool,
@@ -1745,6 +1748,11 @@ impl<'a> PeepholeOptimizations {
             Expression::LogicalExpression(l) => {
                 Self::mark_inlined_pure(&mut l.left);
                 Self::mark_inlined_pure(&mut l.right);
+            }
+            Expression::UnaryExpression(u) => Self::mark_inlined_pure(&mut u.argument),
+            Expression::BinaryExpression(b) => {
+                Self::mark_inlined_pure(&mut b.left);
+                Self::mark_inlined_pure(&mut b.right);
             }
             Expression::ChainExpression(c) => Self::mark_chain_element_pure(&mut c.expression),
             Expression::TSAsExpression(e) => Self::mark_inlined_pure(&mut e.expression),

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -1254,6 +1254,26 @@ fn test_call_like_expressions() {
 }
 
 #[test]
+fn test_ts_wrapper_expressions() {
+    // TS wrappers are runtime-transparent — delegate to the inner expression.
+    // `<T>x` syntax is not exercised here because `test_ts` parses as TSX,
+    // where `<any>` starts a JSX element; it is covered end-to-end by the
+    // minifier tests in `remove_unused_declaration.rs`.
+    test_ts("foo() as any", true);
+    test_ts("/* #__PURE__ */ foo() as any", false);
+    test_ts("foo()!", true);
+    test_ts("/* #__PURE__ */ foo()!", false);
+    test_ts("foo() satisfies any", true);
+    test_ts("/* #__PURE__ */ foo() satisfies any", false);
+    // TSInstantiationExpression: `foo<T>` is just a value reference, so it's
+    // side-effect-free exactly when `foo` is.
+    test_ts("foo<number>", false);
+    // Nested wrappers unwrap recursively.
+    test_ts("((/* #__PURE__ */ foo() as any) satisfies any)!", false);
+    test_ts("((foo() as any) satisfies any)!", true);
+}
+
+#[test]
 fn test_is_pure_call_support() {
     let ctx = Ctx {
         pure_function_names: vec!["foo".to_string(), "Foo".to_string()],

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -59,6 +59,7 @@ fn remove_unused_variable_declaration() {
     test_options("var removeThis = /* @__PURE__ */ (() => stuff())();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => { return stuff() })();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => new Thing())();", "", &options);
+    test_options("var removeThis = /* @__PURE__ */ (() => { stuff() })();", "", &options);
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -57,11 +57,7 @@ fn remove_unused_variable_declaration() {
 
     // https://github.com/oxc-project/oxc/issues/17480
     test_options("var removeThis = /* @__PURE__ */ (() => stuff())();", "", &options);
-    test_options(
-        "var removeThis = /* @__PURE__ */ (() => { return stuff() })();",
-        "",
-        &options,
-    );
+    test_options("var removeThis = /* @__PURE__ */ (() => { return stuff() })();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => new Thing())();", "", &options);
 }
 

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -74,10 +74,38 @@ fn remove_unused_variable_declaration() {
     );
     test_options("var c; var removeThis = /* @__PURE__ */ (() => c || a())();", "", &options);
     test_options("var a; var removeThis = /* @__PURE__ */ (() => a?.())();", "", &options);
-    // TS wrappers (`as`/`!`/`satisfies`/`<T>x`/generic call) are covered at
-    // the expression level in `test_fold_iife`; the unused-declaration pass
-    // does not unwrap them, so they would stay as e.g.
-    // `var x = /* @__PURE__ */ a() as any;` here.
+    // TS wrappers (`as`/`!`/`satisfies`/`<T>x`) around the inlined pure call
+    // are transparent at runtime, so the declaration also drops.
+    test_options_source_type(
+        "var removeThis = /* @__PURE__ */ (() => a() as any)();",
+        "",
+        SourceType::ts().with_module(true),
+        &options,
+    );
+    test_options_source_type(
+        "var a; var removeThis = /* @__PURE__ */ (() => a()!)();",
+        "",
+        SourceType::ts().with_module(true),
+        &options,
+    );
+    test_options_source_type(
+        "var removeThis = /* @__PURE__ */ (() => a() satisfies any)();",
+        "",
+        SourceType::ts().with_module(true),
+        &options,
+    );
+    test_options_source_type(
+        "var removeThis = /* @__PURE__ */ (() => <any>a())();",
+        "",
+        SourceType::ts().with_module(true),
+        &options,
+    );
+    test_options_source_type(
+        "var a; var removeThis = /* @__PURE__ */ (() => a<number>())();",
+        "",
+        SourceType::ts().with_module(true),
+        &options,
+    );
     // Function-expression IIFEs aren't inlined, but their outer `pure` flag
     // still lets the unused-declaration pass drop them.
     test_options(

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -60,6 +60,13 @@ fn remove_unused_variable_declaration() {
     test_options("var removeThis = /* @__PURE__ */ (() => { return stuff() })();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => new Thing())();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => { stuff() })();", "", &options);
+    // Function-expression IIFEs aren't inlined, but their outer `pure` flag
+    // still lets the unused-declaration pass drop them.
+    test_options(
+        "var removeThis = /* @__PURE__ */ (function() { return stuff() })();",
+        "",
+        &options,
+    );
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -67,13 +67,16 @@ fn remove_unused_variable_declaration() {
     // forward PURE to the inner calls so the declaration drops. (The condition
     // `c` itself is a declared local with no side-effect on read, which is why
     // the minifier can drop everything — an undeclared global would stay.)
-    test_options(
-        "var c; var removeThis = /* @__PURE__ */ (() => c ? a() : b())();",
-        "",
-        &options,
-    );
+    test_options("var c; var removeThis = /* @__PURE__ */ (() => c ? a() : b())();", "", &options);
     test_options("var c; var removeThis = /* @__PURE__ */ (() => c || a())();", "", &options);
     test_options("var a; var removeThis = /* @__PURE__ */ (() => a?.())();", "", &options);
+    // Unary / binary: PURE forwards onto the inner call so `may_have_side_effects`
+    // on the unwrapped body is false. Binary-op `may_have_side_effects` has its
+    // own constraints (for arithmetic, ToPrimitive on unknown calls stays
+    // unknown), so we stick to a comparison operator here where the check is a
+    // pure disjunction over the operands.
+    test_options("var removeThis = /* @__PURE__ */ (() => !a())();", "", &options);
+    test_options("var removeThis = /* @__PURE__ */ (() => a() == b())();", "", &options);
     // TS wrappers (`as`/`!`/`satisfies`/`<T>x`) around the inlined pure call
     // are transparent at runtime, so the declaration also drops.
     test_options_source_type(

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -60,6 +60,9 @@ fn remove_unused_variable_declaration() {
     test_options("var removeThis = /* @__PURE__ */ (() => { return stuff() })();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => new Thing())();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => { stuff() })();", "", &options);
+    // Sequence-expression body: propagating PURE onto each call lets the
+    // unused-declaration pass drop the whole initializer.
+    test_options("var removeThis = /* @__PURE__ */ (() => (a(), b()))();", "", &options);
     // Function-expression IIFEs aren't inlined, but their outer `pure` flag
     // still lets the unused-declaration pass drop them.
     test_options(

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -141,6 +141,11 @@ fn remove_unused_variable_declaration() {
     );
     test_options("var keepThis = /* @__PURE__ */ (() => foo(...xs))();", "[...xs];", &options);
     test_options("var keepThis = /* @__PURE__ */ (() => foo``)();", "foo``;", &options);
+    // Member-access body: the outer PURE is dropped by the inlining and the
+    // member expression has no `pure` flag of its own, so the property read on
+    // an unknown global keeps the declaration alive. Documents the
+    // missed-optimization gap noted on `mark_inlined_pure`.
+    test_options("var keepThis = /* @__PURE__ */ (() => g.x)();", "g.x;", &options);
     // Arithmetic / numeric-coercing operators force `to_numeric` /
     // `to_primitive` on each operand to detect user-visible coercion
     // (`valueOf` / `toString` calls). For an unknown call those return

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -77,6 +77,13 @@ fn remove_unused_variable_declaration() {
     // pure disjunction over the operands.
     test_options("var removeThis = /* @__PURE__ */ (() => !a())();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => a() == b())();", "", &options);
+    // Nested calls in call/new arguments also inherit PURE; the outer call
+    // alone is enough to drop the declaration, and the inner marks keep the
+    // invariant consistent if the outer call is later unwrapped.
+    // (Spread arguments aren't dropped — they invoke the iterator protocol,
+    // which has its own side effects beyond the outer call's PURE scope.)
+    test_options("var removeThis = /* @__PURE__ */ (() => foo(bar()))();", "", &options);
+    test_options("var removeThis = /* @__PURE__ */ (() => new Foo(bar()))();", "", &options);
     // TS wrappers (`as`/`!`/`satisfies`/`<T>x`) around the inlined pure call
     // are transparent at runtime, so the declaration also drops.
     test_options_source_type(

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -54,6 +54,15 @@ fn remove_unused_variable_declaration() {
     test_options("for (var x; ; );", "for (; ;);", &options);
     test_options("for (var x = 1; ; );", "for (; ;);", &options);
     test_same_options("for (var x = foo; ; );", &options); // can be improved
+
+    // https://github.com/oxc-project/oxc/issues/17480
+    test_options("var removeThis = /* @__PURE__ */ (() => stuff())();", "", &options);
+    test_options(
+        "var removeThis = /* @__PURE__ */ (() => { return stuff() })();",
+        "",
+        &options,
+    );
+    test_options("var removeThis = /* @__PURE__ */ (() => new Thing())();", "", &options);
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -63,6 +63,21 @@ fn remove_unused_variable_declaration() {
     // Sequence-expression body: propagating PURE onto each call lets the
     // unused-declaration pass drop the whole initializer.
     test_options("var removeThis = /* @__PURE__ */ (() => (a(), b()))();", "", &options);
+    // Container shapes: conditional / logical / optional-chain bodies also
+    // forward PURE to the inner calls so the declaration drops. (The condition
+    // `c` itself is a declared local with no side-effect on read, which is why
+    // the minifier can drop everything — an undeclared global would stay.)
+    test_options(
+        "var c; var removeThis = /* @__PURE__ */ (() => c ? a() : b())();",
+        "",
+        &options,
+    );
+    test_options("var c; var removeThis = /* @__PURE__ */ (() => c || a())();", "", &options);
+    test_options("var a; var removeThis = /* @__PURE__ */ (() => a?.())();", "", &options);
+    // TS wrappers (`as`/`!`/`satisfies`/`<T>x`/generic call) are covered at
+    // the expression level in `test_fold_iife`; the unused-declaration pass
+    // does not unwrap them, so they would stay as e.g.
+    // `var x = /* @__PURE__ */ a() as any;` here.
     // Function-expression IIFEs aren't inlined, but their outer `pure` flag
     // still lets the unused-declaration pass drop them.
     test_options(

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -123,6 +123,23 @@ fn remove_unused_variable_declaration() {
         "",
         &options,
     );
+
+    // Negative cases: PURE only covers what was inside the IIFE body. When the
+    // body itself touches state outside the call's scope — an undeclared
+    // global, an iterator-invoking spread, a tagged template — the
+    // declaration must not drop.
+    test_options(
+        "var keepThis = /* @__PURE__ */ (() => undeclaredGlobal ? a() : b())();",
+        "undeclaredGlobal;",
+        &options,
+    );
+    test_options(
+        "var keepThis = /* @__PURE__ */ (() => undeclaredGlobal || a())();",
+        "undeclaredGlobal;",
+        &options,
+    );
+    test_options("var keepThis = /* @__PURE__ */ (() => foo(...xs))();", "[...xs];", &options);
+    test_options("var keepThis = /* @__PURE__ */ (() => foo``)();", "foo``;", &options);
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -70,11 +70,12 @@ fn remove_unused_variable_declaration() {
     test_options("var c; var removeThis = /* @__PURE__ */ (() => c ? a() : b())();", "", &options);
     test_options("var c; var removeThis = /* @__PURE__ */ (() => c || a())();", "", &options);
     test_options("var a; var removeThis = /* @__PURE__ */ (() => a?.())();", "", &options);
-    // Unary / binary: PURE forwards onto the inner call so `may_have_side_effects`
-    // on the unwrapped body is false. Binary-op `may_have_side_effects` has its
-    // own constraints (for arithmetic, ToPrimitive on unknown calls stays
-    // unknown), so we stick to a comparison operator here where the check is a
-    // pure disjunction over the operands.
+    // Unary / binary bodies: `mark_inlined_pure` flips `pure = true` on the
+    // inner call(s) themselves, so when `may_have_side_effects` walks the
+    // unwrapped `!a()` / `a() == b()` it finds no side effects and drops the
+    // declaration. `==` (and the other comparison/equality operators) is a
+    // plain disjunction over the operands; arithmetic / numeric operators
+    // are stricter and don't drop — see the negative cases at the end.
     test_options("var removeThis = /* @__PURE__ */ (() => !a())();", "", &options);
     test_options("var removeThis = /* @__PURE__ */ (() => a() == b())();", "", &options);
     // Nested calls in call/new arguments also inherit PURE; the outer call
@@ -140,6 +141,23 @@ fn remove_unused_variable_declaration() {
     );
     test_options("var keepThis = /* @__PURE__ */ (() => foo(...xs))();", "[...xs];", &options);
     test_options("var keepThis = /* @__PURE__ */ (() => foo``)();", "foo``;", &options);
+    // Arithmetic / numeric-coercing operators force `to_numeric` /
+    // `to_primitive` on each operand to detect user-visible coercion
+    // (`valueOf` / `toString` calls). For an unknown call those return
+    // `Undetermined`, so even with both inner calls marked PURE the binary /
+    // unary expression itself stays side-effectful and the var can't drop —
+    // it just collapses to the bare expression statement, with the inner
+    // PURE marks still visible.
+    test_options(
+        "var keepThis = /* @__PURE__ */ (() => a() + b())();",
+        "/* @__PURE__ */ a() + /* @__PURE__ */ b();",
+        &options,
+    );
+    test_options(
+        "var keepThis = /* @__PURE__ */ (() => +a())();",
+        "+/* @__PURE__ */ a();",
+        &options,
+    );
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -343,6 +343,23 @@ fn test_fold_iife() {
         "var a = /* @__PURE__ */ (() => !foo() == bar())()",
         "var a = !/* @__PURE__ */ foo() == /* @__PURE__ */ bar()",
     );
+    // Call/new arguments (including spreads) also inherit the outer PURE, so
+    // nested calls in argument position keep the annotation after inlining.
+    test(
+        "var a = /* @__PURE__ */ (() => foo(bar()))()",
+        "var a = /* @__PURE__ */ foo(/* @__PURE__ */ bar())",
+    );
+    test(
+        "var a = /* @__PURE__ */ (() => foo(...xs, bar()))()",
+        "var a = /* @__PURE__ */ foo(...xs, /* @__PURE__ */ bar())",
+    );
+    test(
+        "var a = /* @__PURE__ */ (() => new Foo(bar()))()",
+        "var a = /* @__PURE__ */ new Foo(/* @__PURE__ */ bar())",
+    );
+    // Member-object positions have no `pure` flag of their own, but inner calls
+    // along the access path still inherit the outer PURE.
+    test("var a = /* @__PURE__ */ (() => foo()?.bar)()", "var a = (/* @__PURE__ */ foo())?.bar");
     // Tagged templates have no `pure` flag, so the annotation can't hop onto
     // them — they're left without PURE after inlining.
     test("var a = /* @__PURE__ */ (() => foo``)()", "var a = foo``");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -308,6 +308,9 @@ fn test_fold_iife() {
     test("var a = /* @__PURE__ */ (() => { return foo() })()", "var a = /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => new Foo())()", "var a = /* @__PURE__ */ new Foo()");
     test("var a = /* @__PURE__ */ (() => { foo() })()", "var a = void 0");
+    // IIFE inlining only handles arrows, so function-expression IIFEs are left
+    // as-is for the outer call's `pure` to be picked up directly.
+    test_same("var a = /* @__PURE__ */ (function() { return foo() })()");
     test_same("var a = /* @__PURE__ */ (() => x)(y, z)");
     test("(/* @__PURE__ */ (() => !0)() ? () => x() : () => {})();", "x();");
     test("/* @__PURE__ */ (() => x)()", "");
@@ -369,6 +372,9 @@ fn treeshake_options_annotations_false() {
     };
     test_same_options("function test() { bar } /* @__PURE__ */ test()", &options);
     test_same_options("function test() {} /* @__PURE__ */ new test()", &options);
+    // Without annotations, IIFE inlining still fires but must not forward the
+    // ignored PURE annotation onto the unwrapped call.
+    test_options("var a = /* @__PURE__ */ (() => foo())()", "var a = foo()", &options);
 
     let options = CompressOptions {
         treeshake: TreeShakeOptions { annotations: true, ..TreeShakeOptions::default() },

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -307,6 +307,7 @@ fn test_fold_iife() {
     test("var a = /* @__PURE__ */ (() => foo())()", "var a = /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => { return foo() })()", "var a = /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => new Foo())()", "var a = /* @__PURE__ */ new Foo()");
+    test("var a = /* @__PURE__ */ (() => { foo() })()", "var a = void 0");
     test_same("var a = /* @__PURE__ */ (() => x)(y, z)");
     test("(/* @__PURE__ */ (() => !0)() ? () => x() : () => {})();", "x();");
     test("/* @__PURE__ */ (() => x)()", "");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -308,6 +308,9 @@ fn test_fold_iife() {
     test("var a = /* @__PURE__ */ (() => { return foo() })()", "var a = /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => new Foo())()", "var a = /* @__PURE__ */ new Foo()");
     test("var a = /* @__PURE__ */ (() => { foo() })()", "var a = void 0");
+    // Sequence-expression body: annotation propagates to each call/new element
+    // so a follow-on pass can drop the unused `foo()` and unwrap the sequence.
+    test("var a = /* @__PURE__ */ (() => (foo(), bar()))()", "var a = /* @__PURE__ */ bar()");
     // IIFE inlining only handles arrows, so function-expression IIFEs are left
     // as-is for the outer call's `pure` to be picked up directly.
     test_same("var a = /* @__PURE__ */ (function() { return foo() })()");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -1,4 +1,5 @@
 use oxc_ecmascript::side_effects::PropertyReadSideEffects;
+use oxc_span::SourceType;
 
 use crate::{
     CompressOptions, CompressOptionsUnused, TreeShakeOptions, default_options, test, test_options,
@@ -316,6 +317,41 @@ fn test_fold_iife() {
     // Sequence-expression body: annotation propagates to each call/new element
     // so a follow-on pass can drop the unused `foo()` and unwrap the sequence.
     test("var a = /* @__PURE__ */ (() => (foo(), bar()))()", "var a = /* @__PURE__ */ bar()");
+    // Container shapes that also forward the outer PURE onto their inner calls.
+    test(
+        "var a = /* @__PURE__ */ (() => c ? foo() : bar())()",
+        "var a = c ? /* @__PURE__ */ foo() : /* @__PURE__ */ bar()",
+    );
+    test(
+        "var a = /* @__PURE__ */ (() => c || foo())()",
+        "var a = c || /* @__PURE__ */ foo()",
+    );
+    test("var a = /* @__PURE__ */ (() => foo?.())()", "var a = /* @__PURE__ */ foo?.()");
+    // TS wrappers around the inlined call also forward the outer PURE.
+    test_options_source_type(
+        "var a = /* @__PURE__ */ (() => foo() as any)()",
+        "var a = /* @__PURE__ */ foo() as any",
+        SourceType::ts(),
+        &default_options(),
+    );
+    test_options_source_type(
+        "var a = /* @__PURE__ */ (() => foo()!)()",
+        "var a = /* @__PURE__ */ foo()!",
+        SourceType::ts(),
+        &default_options(),
+    );
+    test_options_source_type(
+        "var a = /* @__PURE__ */ (() => foo() satisfies any)()",
+        "var a = /* @__PURE__ */ foo() satisfies any",
+        SourceType::ts(),
+        &default_options(),
+    );
+    test_options_source_type(
+        "var a = /* @__PURE__ */ (() => <any>foo())()",
+        "var a = (<any>(/* @__PURE__ */ foo()))",
+        SourceType::ts(),
+        &default_options(),
+    );
     // IIFE inlining only handles arrows, so function-expression IIFEs are left
     // as-is for the outer call's `pure` to be picked up directly.
     test_same("var a = /* @__PURE__ */ (function() { return foo() })()");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -305,10 +305,7 @@ fn test_fold_iife() {
     test("var a = /* @__PURE__ */ (() => x)()", "var a = x");
     // https://github.com/oxc-project/oxc/issues/17480
     test("var a = /* @__PURE__ */ (() => foo())()", "var a = /* @__PURE__ */ foo()");
-    test(
-        "var a = /* @__PURE__ */ (() => { return foo() })()",
-        "var a = /* @__PURE__ */ foo()",
-    );
+    test("var a = /* @__PURE__ */ (() => { return foo() })()", "var a = /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => new Foo())()", "var a = /* @__PURE__ */ new Foo()");
     test_same("var a = /* @__PURE__ */ (() => x)(y, z)");
     test("(/* @__PURE__ */ (() => !0)() ? () => x() : () => {})();", "x();");
@@ -322,7 +319,7 @@ fn test_fold_iife() {
     );
     test(
         "function foo(x) { if (x) { return /* @__PURE__ */ (() => bar())() } return x }",
-        "function foo(x) { return x && bar() }",
+        "function foo(x) { return x && /* @__PURE__ */ bar() }",
     );
     test(
         "function foo(x) { if (x) { return /* @__PURE__ */ (() => { return 42 })() } return x }",

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -337,6 +337,12 @@ fn test_fold_iife() {
         "var a = /* @__PURE__ */ (() => foo() == bar())()",
         "var a = /* @__PURE__ */ foo() == /* @__PURE__ */ bar()",
     );
+    // Nested container recursion: BinaryExpression → UnaryExpression → Call on
+    // the left side, BinaryExpression → Call on the right side.
+    test(
+        "var a = /* @__PURE__ */ (() => !foo() == bar())()",
+        "var a = !/* @__PURE__ */ foo() == /* @__PURE__ */ bar()",
+    );
     // Tagged templates have no `pure` flag, so the annotation can't hop onto
     // them — they're left without PURE after inlining.
     test("var a = /* @__PURE__ */ (() => foo``)()", "var a = foo``");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -303,6 +303,13 @@ fn test_fold_iife() {
     test_same("(function () { return x })()");
 
     test("var a = /* @__PURE__ */ (() => x)()", "var a = x");
+    // https://github.com/oxc-project/oxc/issues/17480
+    test("var a = /* @__PURE__ */ (() => foo())()", "var a = /* @__PURE__ */ foo()");
+    test(
+        "var a = /* @__PURE__ */ (() => { return foo() })()",
+        "var a = /* @__PURE__ */ foo()",
+    );
+    test("var a = /* @__PURE__ */ (() => new Foo())()", "var a = /* @__PURE__ */ new Foo()");
     test_same("var a = /* @__PURE__ */ (() => x)(y, z)");
     test("(/* @__PURE__ */ (() => !0)() ? () => x() : () => {})();", "x();");
     test("/* @__PURE__ */ (() => x)()", "");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -308,6 +308,11 @@ fn test_fold_iife() {
     test("var a = /* @__PURE__ */ (() => { return foo() })()", "var a = /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => new Foo())()", "var a = /* @__PURE__ */ new Foo()");
     test("var a = /* @__PURE__ */ (() => { foo() })()", "var a = void 0");
+    // Idempotent when the inner call already carries its own PURE annotation.
+    test(
+        "var a = /* @__PURE__ */ (() => /* @__PURE__ */ foo())()",
+        "var a = /* @__PURE__ */ foo()",
+    );
     // Sequence-expression body: annotation propagates to each call/new element
     // so a follow-on pass can drop the unused `foo()` and unwrap the sequence.
     test("var a = /* @__PURE__ */ (() => (foo(), bar()))()", "var a = /* @__PURE__ */ bar()");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -455,6 +455,14 @@ fn treeshake_options_annotations_false() {
     // Without annotations, IIFE inlining still fires but must not forward the
     // ignored PURE annotation onto the unwrapped call.
     test_options("var a = /* @__PURE__ */ (() => foo())()", "var a = foo()", &options);
+    // An inner PURE annotation that the parser already attached must survive
+    // the inlining unchanged — the annotations option only governs whether
+    // the minifier acts on the flag, not whether codegen prints it.
+    test_options(
+        "var a = /* @__PURE__ */ (() => /* @__PURE__ */ foo())()",
+        "var a = /* @__PURE__ */ foo()",
+        &options,
+    );
 
     let options = CompressOptions {
         treeshake: TreeShakeOptions { annotations: true, ..TreeShakeOptions::default() },

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -322,6 +322,12 @@ fn test_fold_iife() {
         "var a = /* @__PURE__ */ (() => c ? foo() : bar())()",
         "var a = c ? /* @__PURE__ */ foo() : /* @__PURE__ */ bar()",
     );
+    // The conditional's test itself can also be a call — the outer PURE covers
+    // it too, so it gets the annotation.
+    test(
+        "var a = /* @__PURE__ */ (() => foo() ? x : y)()",
+        "var a = /* @__PURE__ */ foo() ? x : y",
+    );
     test(
         "var a = /* @__PURE__ */ (() => c || foo())()",
         "var a = c || /* @__PURE__ */ foo()",

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -304,6 +304,9 @@ fn test_fold_iife() {
     test_same("(function () { return x })()");
 
     test("var a = /* @__PURE__ */ (() => x)()", "var a = x");
+    // Without an outer PURE, arrow-IIFE inlining still fires but nothing is
+    // marked — the inner call is inlined as-is.
+    test("var a = (() => foo())()", "var a = foo();");
     // https://github.com/oxc-project/oxc/issues/17480
     test("var a = /* @__PURE__ */ (() => foo())()", "var a = /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => { return foo() })()", "var a = /* @__PURE__ */ foo()");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -328,11 +328,18 @@ fn test_fold_iife() {
         "var a = /* @__PURE__ */ (() => foo() ? x : y)()",
         "var a = /* @__PURE__ */ foo() ? x : y",
     );
-    test(
-        "var a = /* @__PURE__ */ (() => c || foo())()",
-        "var a = c || /* @__PURE__ */ foo()",
-    );
+    test("var a = /* @__PURE__ */ (() => c || foo())()", "var a = c || /* @__PURE__ */ foo()");
     test("var a = /* @__PURE__ */ (() => foo?.())()", "var a = /* @__PURE__ */ foo?.()");
+    // Unary / binary bodies: the outer PURE covers the whole expression, so
+    // marking each inner call/new preserves the annotation.
+    test("var a = /* @__PURE__ */ (() => !foo())()", "var a = !/* @__PURE__ */ foo()");
+    test(
+        "var a = /* @__PURE__ */ (() => foo() == bar())()",
+        "var a = /* @__PURE__ */ foo() == /* @__PURE__ */ bar()",
+    );
+    // Tagged templates have no `pure` flag, so the annotation can't hop onto
+    // them — they're left without PURE after inlining.
+    test("var a = /* @__PURE__ */ (() => foo``)()", "var a = foo``");
     // TS wrappers around the inlined call also forward the outer PURE.
     test_options_source_type(
         "var a = /* @__PURE__ */ (() => foo() as any)()",

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -360,6 +360,16 @@ fn test_fold_iife() {
     // Member-object positions have no `pure` flag of their own, but inner calls
     // along the access path still inherit the outer PURE.
     test("var a = /* @__PURE__ */ (() => foo()?.bar)()", "var a = (/* @__PURE__ */ foo())?.bar");
+    // Chain whose tail is a call and whose callee has an inner call: the outer
+    // PURE travels both onto the chain's call (codegen prints it at the front
+    // of the chain) and through the member object onto the inner `foo()`.
+    test(
+        "var a = /* @__PURE__ */ (() => foo()?.bar())()",
+        "var a = /* @__PURE__ */ (/* @__PURE__ */ foo())?.bar()",
+    );
+    // Computed-member chain index isn't recursed into by `mark_chain_element_pure`,
+    // so a call in the index position keeps no PURE annotation after inlining.
+    test("var a = /* @__PURE__ */ (() => foo?.[bar()])()", "var a = foo?.[bar()]");
     // Tagged templates have no `pure` flag, so the annotation can't hop onto
     // them — they're left without PURE after inlining.
     test("var a = /* @__PURE__ */ (() => foo``)()", "var a = foo``");


### PR DESCRIPTION
What
---

Fix bug: pure-annotated IIFEs that should be dead-code-eliminated were leaving behind a bare expression statement. `var removeThis = /* @__PURE__ */ (() => stuff())()` minified to `stuff();` instead of being dropped entirely.

Fixes #17480

Root Cause
---

IIFE substitution runs before the unused-declaration pass and was discarding the outer PURE when unwrapping `(() => foo())()` to `foo()`. By the time the unused-declaration pass saw `var x = foo()` it could no longer prove the RHS pure.

Fix
---

The three inlining branches in `substitute_iife_call` now go through a small helper `take_and_propagate_pure` that, when the outer IIFE was pure, calls `mark_inlined_pure` on the taken expression. `mark_inlined_pure` walks every shape the outer PURE legitimately covers — `Sequence` / `Conditional` / `Logical` / `Unary` / `Binary` / `Chain` containers, call & new callee/argument positions (including spreads), member-object positions, and TS wrappers (stripped via `get_inner_expression_mut`) — stamping `pure = true` on each `Call` / `New` it finds. A sibling `mark_chain_element_pure` mirrors the logic for `ChainElement` children.

`Expression::may_have_side_effects` in `oxc_ecmascript` is also taught that the five TS wrappers are runtime-transparent and delegates to `get_inner_expression`. Required for the IIFE fix to actually drop a `(() => foo() as any)()` repro.

Not addressed
---

A few positions silently lose PURE because the AST has no `pure` flag for them (`TaggedTemplateExpression`, array/object elements, template-literal interpolations, computed-member indices). Missed-optimization gaps, not correctness issues, and pinned by negative tests.

Drive-by
---

The `NewExpression::pure` doc comment was attached to the `arguments` field; moved it onto `pure` where it belongs.