### PR TITLE
🤖🤖🤖 fix(linter): add help text to no_multiple_resolved diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
+++ b/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
@@ -26,11 +26,14 @@ fn already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise should not be resolved multiple times. Promise is already resolved on line {line}."
     ))
+    .with_help("Remove duplicate resolve() calls or move earlier resolve to the end.")
     .with_label(span)
 }
 
 fn potentially_already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}.")).with_label(span)
+    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}."))
+    .with_help("Check for multiple resolve() calls in different code paths.")
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
## Summary

Adds help text to `no_multiple_resolved` linter diagnostics to resolve issue #19121 (E-Help Wanted).

## Changes

- Added `.with_help("Remove duplicate resolve() calls or move earlier resolve to the end.")` to `already_resolved_diagnostic`
- Added `.with_help("Check for multiple resolve() calls in different code paths.")` to `potentially_already_resolved_diagnostic`

## Testing

- Existing tests should pass as the change is additive
- No breaking changes to API

Closes #19121