### PR TITLE
fix(linter/eslint): enhance `no-empty-function` rule to support async and generator functions in VariableDeclarator

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -422,22 +422,23 @@ impl NoEmptyFunction {
                     if let Some(init) = &decl.init {
                         match init.get_inner_expression() {
                             Expression::FunctionExpression(function)
-                                if (function.r#async && self.allow.contains(Allowed::AsyncFunctions)
+                                if (function.r#async
+                                    && self.allow.contains(Allowed::AsyncFunctions)
                                     || function.generator
                                         && self.allow.contains(Allowed::GeneratorFunctions)
                                     || !function.r#async
                                         && !function.generator
-                                        && self.allow.contains(Allowed::Function))
-                                => {
-                                    return ViolationInfo::default();
-                                }
+                                        && self.allow.contains(Allowed::Function)) =>
+                            {
+                                return ViolationInfo::default();
+                            }
                             Expression::ArrowFunctionExpression(function)
                                 if (self.allow.contains(Allowed::ArrowFunction)
                                     || function.r#async
-                                        && self.allow.contains(Allowed::AsyncFunctions))
-                                => {
-                                    return ViolationInfo::default();
-                                }
+                                        && self.allow.contains(Allowed::AsyncFunctions)) =>
+                            {
+                                return ViolationInfo::default();
+                            }
                             _ => {}
                         }
                     }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -421,25 +421,23 @@ impl NoEmptyFunction {
                 AstKind::VariableDeclarator(decl) => {
                     if let Some(init) = &decl.init {
                         match init.get_inner_expression() {
-                            Expression::FunctionExpression(function) => {
-                                if function.r#async && self.allow.contains(Allowed::AsyncFunctions)
+                            Expression::FunctionExpression(function)
+                                if (function.r#async && self.allow.contains(Allowed::AsyncFunctions)
                                     || function.generator
                                         && self.allow.contains(Allowed::GeneratorFunctions)
                                     || !function.r#async
                                         && !function.generator
-                                        && self.allow.contains(Allowed::Function)
-                                {
+                                        && self.allow.contains(Allowed::Function))
+                                => {
                                     return ViolationInfo::default();
                                 }
-                            }
-                            Expression::ArrowFunctionExpression(function) => {
-                                if self.allow.contains(Allowed::ArrowFunction)
+                            Expression::ArrowFunctionExpression(function)
+                                if (self.allow.contains(Allowed::ArrowFunction)
                                     || function.r#async
-                                        && self.allow.contains(Allowed::AsyncFunctions)
-                                {
+                                        && self.allow.contains(Allowed::AsyncFunctions))
+                                => {
                                     return ViolationInfo::default();
                                 }
-                            }
                             _ => {}
                         }
                     }

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -723,6 +723,10 @@ fn test() {
             Some(serde_json::json!([{ "allow": ["generatorFunctions"] }])),
         ),
         (
+            "const foo = function(param: string) {};",
+            Some(serde_json::json!([{ "allow": ["functions"] }])),
+        ),
+        (
             "const foo = function*(param: string) {};",
             Some(serde_json::json!([{ "allow": ["generatorFunctions"] }])),
         ),

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -419,6 +419,30 @@ impl NoEmptyFunction {
                     return ("function", None).into();
                 }
                 AstKind::VariableDeclarator(decl) => {
+                    if let Some(init) = &decl.init {
+                        match init.get_inner_expression() {
+                            Expression::FunctionExpression(function) => {
+                                if function.r#async && self.allow.contains(Allowed::AsyncFunctions)
+                                    || function.generator
+                                        && self.allow.contains(Allowed::GeneratorFunctions)
+                                    || !function.r#async
+                                        && !function.generator
+                                        && self.allow.contains(Allowed::Function)
+                                {
+                                    return ViolationInfo::default();
+                                }
+                            }
+                            Expression::ArrowFunctionExpression(function) => {
+                                if self.allow.contains(Allowed::ArrowFunction)
+                                    || function.r#async
+                                        && self.allow.contains(Allowed::AsyncFunctions)
+                                {
+                                    return ViolationInfo::default();
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
                     return ("function", decl.id.get_identifier_name().map(Into::into)).into();
                 }
                 _ => return ("function", None).into(),
@@ -699,19 +723,18 @@ fn test() {
             "function* foo(param: string) {}",
             Some(serde_json::json!([{ "allow": ["generatorFunctions"] }])),
         ),
-        // TODO: Fix these.
-        // (
-        //     "const foo = function*(param: string) {};",
-        //     Some(serde_json::json!([{ "allow": ["generatorFunctions"] }])),
-        // ),
-        // (
-        //     "const obj = {foo: function*(param: string) {}};",
-        //     Some(serde_json::json!([{ "allow": ["generatorFunctions"] }])),
-        // ),
-        // (
-        //     "const obj = {foo(param: string) {}};",
-        //     Some(serde_json::json!([{ "allow": ["methods"] }])),
-        // ),
+        (
+            "const foo = function*(param: string) {};",
+            Some(serde_json::json!([{ "allow": ["generatorFunctions"] }])),
+        ),
+        (
+            "const obj = {foo: function*(param: string) {}};",
+            Some(serde_json::json!([{ "allow": ["generatorFunctions"] }])),
+        ),
+        (
+            "const obj = {foo(param: string) {}};",
+            Some(serde_json::json!([{ "allow": ["methods"] }])),
+        ),
         ("class A { foo(param: string) {} }", Some(serde_json::json!([{ "allow": ["methods"] }]))),
         ("class A { private foo() {} }", Some(serde_json::json!([{ "allow": ["methods"] }]))),
         ("class A { protected foo() {} }", Some(serde_json::json!([{ "allow": ["methods"] }]))),
@@ -761,11 +784,10 @@ fn test() {
                 serde_json::json!([{ "allow": ["methods", "decoratedFunctions", "overrideMethods"] }]),
             ),
         ),
-        // TODO: Fix.
-        // (
-        //     "const obj = {*foo(param: string) {}};",
-        //     Some(serde_json::json!([{ "allow": ["generatorMethods"] }])),
-        // ),
+        (
+            "const obj = {*foo(param: string) {}};",
+            Some(serde_json::json!([{ "allow": ["generatorMethods"] }])),
+        ),
         (
             "class A { *foo(param: string) {} }",
             Some(serde_json::json!([{ "allow": ["generatorMethods"] }])),
@@ -790,11 +812,10 @@ fn test() {
             "const A = class {static *foo(param: string) {}};",
             Some(serde_json::json!([{ "allow": ["generatorMethods"] }])),
         ),
-        // TODO: Fix.
-        // (
-        //     "const obj = {get foo(): string {}};",
-        //     Some(serde_json::json!([{ "allow": ["getters"] }])),
-        // ),
+        (
+            "const obj = {get foo(): string {}};",
+            Some(serde_json::json!([{ "allow": ["getters"] }])),
+        ),
         ("class A {get foo(): string {}}", Some(serde_json::json!([{ "allow": ["getters"] }]))),
         (
             "class A {static get foo(): string {}}",
@@ -840,11 +861,10 @@ fn test() {
             "const A = class extends B {static override get foo(): string {}};",
             Some(serde_json::json!([{ "allow": ["getters", "overrideMethods"] }])),
         ),
-        // TODO: Fix
-        // (
-        //     "const obj = {set foo(value: string) {}};",
-        //     Some(serde_json::json!([{ "allow": ["setters"] }])),
-        // ),
+        (
+            "const obj = {set foo(value: string) {}};",
+            Some(serde_json::json!([{ "allow": ["setters"] }])),
+        ),
         (
             "class A {set foo(value: string) {}}",
             Some(serde_json::json!([{ "allow": ["setters"] }])),
@@ -917,20 +937,18 @@ fn test() {
             "const B = class { protected constructor() {} }",
             Some(serde_json::json!([{ "allow": ["constructors", "protectedConstructors"] }])),
         ),
-        // TODO: Fix.
-        // (
-        //     "const foo = { async method(param: string) {} }",
-        //     Some(serde_json::json!([{ "allow": ["asyncMethods"] }])),
-        // ),
+        (
+            "const foo = { async method(param: string) {} }",
+            Some(serde_json::json!([{ "allow": ["asyncMethods"] }])),
+        ),
         (
             "async function a(param: string){}",
             Some(serde_json::json!([{ "allow": ["asyncFunctions"] }])),
         ),
-        // TODO: Fix
-        // (
-        //     "const foo = async function(param: string) {}",
-        //     Some(serde_json::json!([{ "allow": ["asyncFunctions"] }])),
-        // ),
+        (
+            "const foo = async function(param: string) {}",
+            Some(serde_json::json!([{ "allow": ["asyncFunctions"] }])),
+        ),
         (
             "class A { async foo(param: string) {} }",
             Some(serde_json::json!([{ "allow": ["asyncMethods"] }])),


### PR DESCRIPTION
Fixes tests:
`const foo = function*(param: string) {};` with `allow: ["generatorFunctions"]`
`const foo = async function(param: string) {}` with `allow: ["asyncFunctions"]`

Other tests were already passing, they were just uncommented