### PR TITLE
chore(lsp): dynamic worker: watch pattern & execute command

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -196,11 +196,11 @@ impl LanguageServer for Backend {
             return;
         };
 
-        let workers = &*self.worker_manager.read_workers().await;
+        let workspace_workers = &*self.worker_manager.read_workspace_workers().await;
         let needed_configurations =
-            ConcurrentHashMap::with_capacity_and_hasher(workers.len(), FxBuildHasher);
+            ConcurrentHashMap::with_capacity_and_hasher(workspace_workers.len(), FxBuildHasher);
         let needed_configurations = needed_configurations.pin_owned();
-        for worker in workers {
+        for worker in workspace_workers {
             if worker.needs_init_options().await {
                 needed_configurations.insert(worker.get_root_uri().clone(), worker);
             }
@@ -280,8 +280,12 @@ impl LanguageServer for Backend {
 
         // init all file watchers
         if capabilities.dynamic_watchers {
-            for worker in workers {
+            for worker in workspace_workers {
                 registrations.extend(worker.init_watchers().await);
+            }
+
+            if let Some(dynamic_worker) = self.worker_manager.read_dynamic_worker().await {
+                registrations.extend(dynamic_worker.init_watchers().await);
             }
         }
 
@@ -317,7 +321,7 @@ impl LanguageServer for Backend {
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeConfiguration>
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
-        let workers = self.worker_manager.read_workers().await;
+        let workers = self.worker_manager.read_workspace_workers().await;
         let mut new_diagnostics = Vec::new();
         let mut removing_registrations = vec![];
         let mut adding_registrations = vec![];
@@ -794,16 +798,32 @@ impl LanguageServer for Backend {
         }
         // Collect all edits under a brief read lock, then release it
         // before performing client RPCs to avoid blocking writers.
+        // TODO: recheck if we should return the first found workspace edit instead of merging edits from all workers.
+        // This can cause edit conflicts when the same line/column on the same file is edited by different workers.
         let edits: Vec<WorkspaceEdit> = {
-            let workers = self.worker_manager.read_workers().await;
             let mut edits = Vec::new();
-            for worker in workers.iter() {
-                match worker.execute_command(&params.command, params.arguments.clone()).await {
-                    Ok(Some(edit)) => edits.push(edit),
-                    Ok(None) => {}
-                    Err(err) => return Err(Error::new(err)),
+            {
+                let workers = self.worker_manager.read_workspace_workers().await;
+                for worker in workers.iter() {
+                    match worker.execute_command(&params.command, params.arguments.clone()).await {
+                        Ok(Some(edit)) => edits.push(edit),
+                        Ok(None) => {}
+                        Err(err) => return Err(Error::new(err)),
+                    }
                 }
             }
+
+            {
+                let dynamic_worker = self.worker_manager.read_dynamic_worker().await;
+                if let Some(worker) = dynamic_worker {
+                    match worker.execute_command(&params.command, params.arguments.clone()).await {
+                        Ok(Some(edit)) => edits.push(edit),
+                        Ok(None) => {}
+                        Err(err) => return Err(Error::new(err)),
+                    }
+                }
+            }
+
             edits
         };
 

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -213,7 +213,7 @@ impl TestServer {
             _params: Value,
         ) -> Result<Value, tower_lsp_server::jsonrpc::Error> {
             let mut configs = vec![];
-            for worker in &*service.worker_manager.read_workers().await {
+            for worker in &*service.worker_manager.read_workspace_workers().await {
                 configs.push(worker.options.lock().await.clone());
             }
             Ok(json!(configs))

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -137,8 +137,19 @@ impl WorkerManager {
     // ── State accessors ───────────────────────────────────────────────────────
 
     /// Acquire a shared read lock over the worker list.
-    pub async fn read_workers(&self) -> RwLockReadGuard<'_, Vec<WorkspaceWorker>> {
+    /// Does not include the dynamic worker in `DynamicWithWorkspaces` mode, which must be accessed by `read_dynamic_worker`.
+    pub async fn read_workspace_workers(&self) -> RwLockReadGuard<'_, Vec<WorkspaceWorker>> {
         self.workers.read().await
+    }
+
+    /// Acquire a shared read lock over the dynamic worker in `DynamicWithWorkspaces` mode, if enabled.
+    #[cfg_attr(not(test), expect(clippy::unused_async))] // when removing the test-only mode, this method will need to perform async initialization for the dynamic worker
+    pub async fn read_dynamic_worker(&self) -> Option<RwLockReadGuard<'_, WorkspaceWorker>> {
+        #[cfg(test)]
+        if let ManagerMode::DynamicWithWorkspaces(worker) = &self.mode {
+            return Some(worker.read().await);
+        }
+        None
     }
 
     /// Access the tool builder.


### PR DESCRIPTION
Added logic for dynamic worker when first initializing the watch patterns. These will never change, not like other watch pattern which can be later be changed with `workspace/didChangeConfiguration`.
Dynamic Workers are not linked into this method, because it is not directly an LSP concept, instead something the LSP server needs to handle internally.
`workspace/executeCommand` is respected too. These are the only missing code paths :) 