### PR TITLE
docs(linter): Improve the `vitest/no-importing-vitest-globals` rule documentation.

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/no_importing_vitest_globals.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_importing_vitest_globals.rs
@@ -16,7 +16,7 @@ use crate::{context::LintContext, rule::Rule};
 fn no_importing_vitest_globals_diagnostic(spans: &[Span]) -> OxcDiagnostic {
     let help = format!("You can import anything except `{}`.", VITEST_GLOBALS.join(", "));
 
-    OxcDiagnostic::warn("Do not import/require global functions from 'vitest'.")
+    OxcDiagnostic::warn("Do not `import`/`require` global functions from 'vitest'.")
         .with_help(help)
         .with_labels(spans.iter().map(|span| span.label("Remove this global vitest import")))
 }
@@ -27,18 +27,22 @@ pub struct NoImportingVitestGlobals;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// The rule disallows import any vitest global function.
+    /// The rule disallows importing any vitest global functions.
     ///
     /// ### Why is this bad?
     ///
-    /// If the project is configured to use globals from vitest, the rule ensure
-    /// that never imports the globals from `import` or `require`.
+    /// If a project is [configured to provide Vitest functions as globals](https://vitest.dev/config/globals.html),
+    /// this rule can be used to ensure that the globals are never imported
+    /// via `import` or `require`.
+    ///
+    /// Note that this rule should *not* be used if the `globals` config
+    /// option is set to `false` in Vitest (`false` is the default configuration).
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// import { test, expect } from 'vitest'
+    /// import { test, expect } from 'vitest';
     ///
     /// test('foo', () => {
     ///   expect(1).toBe(1)
@@ -46,7 +50,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ```js
-    /// const { test, expect } = require('vitest')
+    /// const { test, expect } = require('vitest');
     ///
     /// test('foo', () => {
     ///   expect(1).toBe(1)

--- a/crates/oxc_linter/src/snapshots/vitest_no_importing_vitest_globals.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_importing_vitest_globals.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:10]
  1 │ import { describe } from 'vitest';
    ·          ────┬───
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:10]
  1 │ import { describe, it } from 'vitest';
    ·          ────┬───  ─┬
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:10]
  1 │ import { describe, BenchFactory } from 'vitest';
    ·          ────┬───
@@ -27,7 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:24]
  1 │ import { BenchFactory, describe } from 'vitest';
    ·                        ────┬───
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:10]
  1 │ import { describe, BenchFactory, it } from 'vitest';
    ·          ────┬───                ─┬
@@ -44,7 +44,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:21]
  1 │ import { BenchTask, describe, BenchFactory, it } from 'vitest';
    ·                     ────┬───                ─┬
@@ -53,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:2:19]
  1 │ import type { TestArtifactBase, TestAttachment } from 'vitest'
  2 │          import { it, describe } from 'vitest'
@@ -63,7 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:44]
  1 │ import { type TestArtifactBase, BenchTask, describe, type TestAttachment, BenchFactory, it } from 'vitest';
    ·                                            ────┬───                                     ─┬
@@ -72,7 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:16]
  1 │ const x = 1, { describe } = require('vitest');
    ·                ────┬───
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:16]
  1 │ const x = 1, { describe } = require('vitest'), y = 2;
    ·                ────┬───
@@ -88,7 +88,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:9]
  1 │ const { describe, it } = require('vitest');
    ·         ────┬───  ─┬
@@ -97,7 +97,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:9]
  1 │ const { describe, BenchFactory } = require('vitest');
    ·         ────┬───
@@ -105,7 +105,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:23]
  1 │ const { BenchFactory, describe } = require('vitest');
    ·                       ────┬───
@@ -113,7 +113,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:9]
  1 │ const { describe, BenchFactory, it } = require('vitest');
    ·         ────┬───                ─┬
@@ -122,7 +122,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: You can import anything except `suite, test, chai, describe, it, expectTypeOf, assertType, expect, assert, vitest, vi, beforeAll, afterAll, beforeEach, afterEach, onTestFailed, onTestFinished`.
 
-  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not import/require global functions from 'vitest'.
+  ⚠ eslint-plugin-vitest(no-importing-vitest-globals): Do not `import`/`require` global functions from 'vitest'.
    ╭─[no_importing_vitest_globals.tsx:1:20]
  1 │ const { BenchTask, describe, BenchFactory, it } = require('vitest');
    ·                    ────┬───                ─┬


### PR DESCRIPTION
Fix up the grammar and provide further context as to when you'd want to use this rule.