### PR TITLE
fix(linter): no-irregular-whitespace: add config options

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -704,8 +704,13 @@ impl RuleRunner for crate::rules::eslint::no_invalid_regexp::NoInvalidRegexp {
 }
 
 impl RuleRunner for crate::rules::eslint::no_irregular_whitespace::NoIrregularWhitespace {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::JSXText,
+        AstType::RegExpLiteral,
+        AstType::StringLiteral,
+        AstType::TemplateLiteral,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
 }
 
 impl RuleRunner for crate::rules::eslint::no_iterator::NoIterator {

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -1,8 +1,20 @@
+use std::ops::Deref;
+
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use oxc_syntax::{
+    identifier::is_irregular_whitespace, line_terminator::is_irregular_line_terminator,
+};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn no_irregular_whitespace_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected irregular whitespace")
@@ -10,8 +22,44 @@ fn no_irregular_whitespace_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct NoIrregularWhitespace;
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoIrregularWhitespaceConfig {
+    /// Whether to skip irregular whitespace in string literals.
+    skip_strings: bool,
+    /// Whether to skip irregular whitespace in comments.
+    skip_comments: bool,
+    /// Whether to skip irregular whitespace in regular expression literals.
+    skip_reg_exps: bool,
+    /// Whether to skip irregular whitespace in template literals.
+    skip_templates: bool,
+    /// Whether to skip irregular whitespace in JSX text.
+    #[serde(rename = "skipJSXText")]
+    skip_jsx_text: bool,
+}
+
+impl Default for NoIrregularWhitespaceConfig {
+    fn default() -> Self {
+        Self {
+            skip_strings: true,
+            skip_comments: true,
+            skip_reg_exps: true,
+            skip_templates: true,
+            skip_jsx_text: true,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct NoIrregularWhitespace(Box<NoIrregularWhitespaceConfig>);
+
+impl Deref for NoIrregularWhitespace {
+    type Target = NoIrregularWhitespaceConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -43,14 +91,79 @@ declare_oxc_lint!(
     NoIrregularWhitespace,
     eslint,
     correctness,
+    config = NoIrregularWhitespaceConfig,
     version = "0.1.1",
 );
 
+/// Check if a character is irregular whitespace for linting purposes.
+/// This includes irregular whitespace characters, irregular line terminators
+/// (U+2028/U+2029), and U+180E (Mongolian Vowel Separator) to match ESLint's
+/// behavior. U+180E is not in `is_irregular_whitespace` because it's Unicode
+/// category "Cf" (Format), not "Zs" (Space Separator), so the parser must not
+/// treat it as whitespace per the ECMAScript spec.
+fn is_lint_irregular_whitespace(c: char) -> bool {
+    is_irregular_whitespace(c) || is_irregular_line_terminator(c) || c == '\u{180e}'
+}
+
+/// Report irregular whitespace characters found within a span of source text.
+fn report_irregular_whitespace_in_span(ctx: &LintContext, source_text: &str, span: Span) {
+    let start = span.start as usize;
+    let slice = &source_text[start..span.end as usize];
+    for (i, c) in slice.char_indices() {
+        if is_lint_irregular_whitespace(c) {
+            #[expect(clippy::cast_possible_truncation)]
+            let offset = span.start + i as u32;
+            #[expect(clippy::cast_possible_truncation)]
+            let len = c.len_utf8() as u32;
+            ctx.diagnostic(no_irregular_whitespace_diagnostic(Span::new(offset, offset + len)));
+        }
+    }
+}
+
 impl Rule for NoIrregularWhitespace {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
-        let irregular_whitespaces = ctx.semantic().irregular_whitespaces();
-        for irregular_whitespace in irregular_whitespaces {
-            ctx.diagnostic(no_irregular_whitespace_diagnostic(*irregular_whitespace));
+        // Report code-context irregular whitespace detected by the lexer.
+        // Skip BOM (U+FEFF) at position 0 — it's a valid byte order mark.
+        for span in ctx.semantic().irregular_whitespaces() {
+            if span.start == 0 && ctx.source_range(*span) == "\u{feff}" {
+                continue;
+            }
+            ctx.diagnostic(no_irregular_whitespace_diagnostic(*span));
+        }
+
+        // Report irregular whitespace inside comments when not skipping them.
+        if !self.skip_comments {
+            let source_text = ctx.semantic().source_text();
+            for comment in ctx.semantic().comments() {
+                report_irregular_whitespace_in_span(ctx, source_text, comment.span);
+            }
+        }
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::StringLiteral(lit) if !self.skip_strings => {
+                report_irregular_whitespace_in_span(ctx, ctx.semantic().source_text(), lit.span);
+            }
+            AstKind::RegExpLiteral(lit) if !self.skip_reg_exps => {
+                report_irregular_whitespace_in_span(ctx, ctx.semantic().source_text(), lit.span);
+            }
+            AstKind::TemplateLiteral(lit) if !self.skip_templates => {
+                let source_text = ctx.semantic().source_text();
+                // Only check template element (quasis) spans, not the full template literal.
+                // Expressions inside ${...} are code context, already handled by run_once.
+                for element in &lit.quasis {
+                    report_irregular_whitespace_in_span(ctx, source_text, element.span);
+                }
+            }
+            AstKind::JSXText(text) if !self.skip_jsx_text => {
+                report_irregular_whitespace_in_span(ctx, ctx.semantic().source_text(), text.span);
+            }
+            _ => {}
         }
     }
 }
@@ -84,340 +197,340 @@ fn test() {
         (r"'\u202F';", None),
         (r"'\u205f';", None),
         (r"'\u3000';", None),
-        (r"'';", None),
-        (r"'';", None),
-        (r"'';", None),
-        (r"' ';", None),
-        (r"'᠎';", None),
-        (r"'﻿';", None),
+        ("'';", None),
+        ("'';", None),
+        ("'';", None),
+        ("' ';", None),
+        ("'᠎';", None),
+        ("'﻿';", None),
         ("' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"'​';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("' ';", None),
+        ("'​';", None),
         (r"'\ ';", None),
         (r"'\ ';", None),
-        (r"' ';", None),
-        (r"' ';", None),
-        (r"'　';", None),
-        (r"// ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"// ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"// ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"// ᠎", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"// ﻿", Some(serde_json::json!([{ "skipComments": true }]))),
-        // (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))), lint error
-        // (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))), lint error
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        // (r"// ​", Some(serde_json::json!([{ "skipComments": true }]))), lint error
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//  ", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"// 　", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*  */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*  */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*  */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/* ᠎ */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/* ﻿ */", Some(serde_json::json!([{ "skipComments": true }]))),
-        // (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))), lint error
-        // (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))), lint error
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        // (r"/* ​ */", Some(serde_json::json!([{ "skipComments": true }]))), lint error
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"/* 　 */", Some(serde_json::json!([{ "skipComments": true }]))),
-        (r"//", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"//", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"//", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/᠎/", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/﻿/", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        // (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))), lint error
-        // (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))), lint error
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        // (r"/​/", Some(serde_json::json!([{ "skipRegExps": true }]))),  lint error
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/ /", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"/　/", Some(serde_json::json!([{ "skipRegExps": true }]))),
-        (r"``", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"``", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"``", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"`᠎`", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"`﻿`", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        // (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),  lint error
-        // (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),  lint error
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        // (r"`​`", Some(serde_json::json!([{ "skipTemplates": true }]))),  lint error
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"` `", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"`　`", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"`　${foo}　`", Some(serde_json::json!([{ "skipTemplates": true }]))),
-        (r"const error = ` 　 `;", Some(serde_json::json!([{ "skipTemplates": true }]))),
+        ("' ';", None),
+        ("' ';", None),
+        ("'　';", None),
+        ("// ", None),
+        ("// ", None),
+        ("// ", None),
+        ("//  ", None),
+        ("// ᠎", None),
+        ("// ﻿", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("// ​", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("// 　", None),
+        ("/*  */", None),
+        ("/*  */", None),
+        ("/*  */", None),
+        ("/*   */", None),
+        ("/* ᠎ */", None),
+        ("/* ﻿ */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/* ​ */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/* 　 */", None),
+        ("//", None),
+        ("//", None),
+        ("//", None),
+        ("/ /", None),
+        ("/᠎/", None),
+        ("/﻿/", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/​/", None),
+        ("/ /", None),
+        ("/ /", None),
+        ("/　/", None),
+        ("``", None),                   // { "ecmaVersion": 6 },
+        ("``", None),                   // { "ecmaVersion": 6 },
+        ("``", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("`᠎`", None),                    // { "ecmaVersion": 6 },
+        ("`﻿`", None),                    // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("`​`", None),                    // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("` `", None),                   // { "ecmaVersion": 6 },
+        ("`　`", None),                  // { "ecmaVersion": 6 },
+        ("`　${foo}　`", None),          // { "ecmaVersion": 6 },
+        ("const error = ` 　 `;", None), // { "ecmaVersion": 6 },
         (
-            r"const error = `
-			　`;",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
+            "const error = `
+            　`;",
+            None,
+        ), // { "ecmaVersion": 6 },
         (
-            r"const error = `　
-			`;",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
+            "const error = `　
+            `;",
+            None,
+        ), // { "ecmaVersion": 6 },
         (
-            r"const error = `
-			　
-			`;",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
+            "const error = `
+            　
+            `;",
+            None,
+        ), // { "ecmaVersion": 6 },
         (
-            r"const error = `foo　bar
-			foo　bar`;",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
-        (r"<div></div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div></div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div></div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div>᠎</div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div>﻿</div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        // (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),  lint error
-        // (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),  lint error
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        // (r"<div>​</div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),  lint error
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div> </div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        (r"<div>　</div>;", Some(serde_json::json!([{ "skipJSXText": true }]))),
-        // (r"﻿console.log('hello BOM');", None),
+            "const error = `foo　bar
+            foo　bar`;",
+            None,
+        ), // { "ecmaVersion": 6 },
+        ("<div></div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div></div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div></div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div>᠎</div>;", None),  // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div>﻿</div>;", None),  // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div>​</div>;", None),  // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("<div>　</div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        ("﻿console.log('hello BOM');", None),
+        ("// ", None),
+        ("// ", None),
+        ("// ", None),
+        ("//  ", None),
+        ("// ᠎", None),
+        ("// ﻿", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("// ​", None),
+        ("//  ", None),
+        ("//  ", None),
+        ("// 　", None),
+        ("/*  */", None),
+        ("/*  */", None),
+        ("/*  */", None),
+        ("/*   */", None),
+        ("/* ᠎ */", None),
+        ("/* ﻿ */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/* ​ */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/*   */", None),
+        ("/* 　 */", None),
+        ("var any = /　/, other = //;", None),
+        ("var any = `　`, other = ``;", None), // { "ecmaVersion": 6 },
+        ("<div></div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div></div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div></div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div>᠎</div>;", None),  // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div>﻿</div>;", None),  // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div>​</div>;", None),  // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div> </div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
+        ("<div>　</div>;", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true, }, }, },
     ];
 
     let fail = vec![
-        (r"var any  = 'thing';", None),
-        (r"var any  = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any ﻿ = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any   = 'thing';", None),
-        (r"var any 　 = 'thing';", None),
+        ("var any  = 'thing';", None),
+        ("var any  = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any ﻿ = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any   = 'thing';", None),
+        ("var any 　 = 'thing';", None),
         (
-            r"var a = 'b', c = 'd',
-          e = 'f' ",
+            "var a = 'b', c = 'd',
+            e = 'f' ",
             None,
         ),
         (
-            r"var any 　 = 'thing', other 　 = 'thing';
-			var third 　 = 'thing';",
+            "var any 　 = 'thing', other 　 = 'thing';
+            var third 　 = 'thing';",
             None,
         ),
-        // (r"// ", None),
-        // (r"// ", None),
-        // (r"// ", None),
-        // (r"//  ", None),
-        // (r"// ᠎", None),
-        // (r"// ﻿", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"// ​", None),
-        // (r"//  ", None),
-        // (r"//  ", None),
-        // (r"// 　", None),
-        // (r"/*  */", None),
-        // (r"/*  */", None),
-        // (r"/*  */", None),
-        // (r"/*   */", None),
-        // (r"/* ᠎ */", None),
-        // (r"/* ﻿ */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/* ​ */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/*   */", None),
-        // (r"/* 　 */", None),
-        // (r"var any = /　/, other = //;", None),
-        // (r"var any = '　', other = '';", Some(serde_json::json!([{ "skipStrings": false }]))),
-        // (r"var any = `　`, other = ``;", Some(serde_json::json!([{ "skipTemplates": false }]))),
+        ("var any = '　', other = '';", Some(serde_json::json!([{ "skipStrings": false }]))),
+        ("var any = `　`, other = ``;", Some(serde_json::json!([{ "skipTemplates": false }]))), // { "ecmaVersion": 6 },
+        ("`something ${　 10} another thing`", None), // { "ecmaVersion": 6 },
+        ("`something ${10　} another thing`", None),  // { "ecmaVersion": 6 },
         (
-            r"`something ${　 10} another thing`",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
+            "　
+            `　template`",
+            None,
+        ), // { "ecmaVersion": 6 },
         (
-            r"`something ${10　} another thing`",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
+            "　
+            `　multiline
+            template`",
+            None,
+        ), // { "ecmaVersion": 6 },
+        ("　`　template`", None),                     // { "ecmaVersion": 6 },
         (
-            r"　
-			`　template`",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
+            "　`　multiline
+            template`",
+            None,
+        ), // { "ecmaVersion": 6 },
+        ("`　template`　", None),                     // { "ecmaVersion": 6 },
         (
-            r"　
-			`　multiline
-			template`",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
-        (r"　`　template`", Some(serde_json::json!([{ "skipTemplates": true }]))),
+            "`　multiline
+            template`　",
+            None,
+        ), // { "ecmaVersion": 6 },
         (
-            r"　`　multiline
-			template`",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
-        (r"`　template`　", Some(serde_json::json!([{ "skipTemplates": true }]))),
+            "`　template`
+            　",
+            None,
+        ), // { "ecmaVersion": 6 },
         (
-            r"`　multiline
-			template`　",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
-        (
-            r"`　template`
-			　",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
-        (
-            r"`　multiline
-			template`
-			　",
-            Some(serde_json::json!([{ "skipTemplates": true }])),
-        ),
-        (r"var foo =  bar;", None),
-        (r"var foo =bar;", None),
-        (r"var foo =  bar;", None),
-        (r"var foo =  bar;", None),
-        (r"var foo =   bar;", None),
-        (r"var foo = bar;", None),
-        (r"", None),
+            "`　multiline
+            template`
+            　",
+            None,
+        ), // { "ecmaVersion": 6 },
+        ("var foo =  bar;", None),
+        ("var foo =bar;", None),
+        ("var foo =  bar;", None),
+        ("var foo =  bar;", None),
+        ("var foo =   bar;", None),
+        ("var foo = bar;", None),
+        ("", None),
         ("   ", None),
-        // (
-        // r"var foo =
-        // bar;",
-        // None,
-        // ),
         (
-            r"var foo =
-        bar;",
+            "var foo = 
+            bar;",
             None,
         ),
         (
-            r"var foo =
-        bar
-        ;
-        ",
+            "var foo =
+            bar;",
             None,
         ),
-        (r"var foo =  bar;", None),
-        (r"var foo =  bar;", None),
-        (r"var foo = bar; ", None),
-        (r" ", None),
-        (r"foo  ", None),
-        (r"foo  ", None),
         (
-            r"foo
-         ",
+            "var foo = 
+            bar
+            ;
+            ",
             None,
         ),
-        // (r"foo ", None),
-        // (r"<div></div>;", None),
-        // (r"<div></div>;", None),
-        // (r"<div></div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div>᠎</div>;", None),
-        // (r"<div>﻿</div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div>​</div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div> </div>;", None),
-        // (r"<div>　</div>;", None),
+        ("var foo =  bar;", None),
+        ("var foo =  bar;", None),
+        ("var foo = bar; ", None),
+        (" ", None),
+        ("foo  ", None),
+        ("foo  ", None),
+        (
+            "foo 
+             ",
+            None,
+        ),
+        ("foo ", None),
+        ("// 　", Some(serde_json::json!([{ "skipComments": false }]))),
+        ("/* 　 */", Some(serde_json::json!([{ "skipComments": false }]))),
+        ("var any = /　/, other = /​/;", Some(serde_json::json!([{ "skipRegExps": false }]))),
+        ("var any = `　`, other = `​`;", Some(serde_json::json!([{ "skipTemplates": false }]))),
+        ("<div>　</div>;", Some(serde_json::json!([{ "skipJSXText": false }]))),
     ];
 
     Tester::new(NoIrregularWhitespace::NAME, NoIrregularWhitespace::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_no_irregular_whitespace.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_irregular_whitespace.snap
@@ -146,15 +146,15 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_irregular_whitespace.tsx:1:13]
  1 │ var a = 'b', c = 'd',
    ·             ─
- 2 │           e = 'f' 
+ 2 │             e = 'f' 
    ╰────
   help: Try to remove the irregular whitespace
 
   ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:18]
+   ╭─[no_irregular_whitespace.tsx:2:20]
  1 │ var a = 'b', c = 'd',
- 2 │           e = 'f' 
-   ·                  ─
+ 2 │             e = 'f' 
+   ·                    ─
    ╰────
   help: Try to remove the irregular whitespace
 
@@ -175,10 +175,38 @@ source: crates/oxc_linter/src/tester.rs
   help: Try to remove the irregular whitespace
 
   ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:14]
+   ╭─[no_irregular_whitespace.tsx:2:23]
  1 │ var any 　 = 'thing', other 　 = 'thing';
  2 │             var third 　 = 'thing';
-   ·                       ─
+   ·                       ──
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:12]
+ 1 │ var any = '　', other = '';
+   ·            ──
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:27]
+ 1 │ var any = '　', other = '';
+   ·                          ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:12]
+ 1 │ var any = `　`, other = ``;
+   ·            ──
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:27]
+ 1 │ var any = `　`, other = ``;
+   ·                          ─
    ╰────
   help: Try to remove the irregular whitespace
 
@@ -235,26 +263,26 @@ source: crates/oxc_linter/src/tester.rs
   help: Try to remove the irregular whitespace
 
   ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:13]
+   ╭─[no_irregular_whitespace.tsx:2:22]
  1 │ `　multiline
  2 │             template`　
-   ·                      ─
+   ·                      ──
    ╰────
   help: Try to remove the irregular whitespace
 
   ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:4]
+   ╭─[no_irregular_whitespace.tsx:2:13]
  1 │ `　template`
  2 │             　
-   ·             ─
+   ·             ──
    ╰────
   help: Try to remove the irregular whitespace
 
   ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:3:4]
+   ╭─[no_irregular_whitespace.tsx:3:13]
  2 │             template`
  3 │             　
-   ·             ─
+   ·             ──
    ╰────
   help: Try to remove the irregular whitespace
 
@@ -357,37 +385,87 @@ source: crates/oxc_linter/src/tester.rs
   help: Try to remove the irregular whitespace
 
   ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:9]
- 1 │ var foo =
- 2 │         bar;
-   ·         ─
-   ╰────
-  help: Try to remove the irregular whitespace
-
-  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:9]
- 1 │ var foo =
- 2 │         bar
-   ·         ─
- 3 │         ;
-   ╰────
-  help: Try to remove the irregular whitespace
-
-  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:10]
- 1 │ var foo =
- 2 │         bar
-   ·          ─
- 3 │         ;
-   ╰────
-  help: Try to remove the irregular whitespace
-
-  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:11]
- 1 │ var foo =
- 2 │         bar
+   ╭─[no_irregular_whitespace.tsx:1:11]
+ 1 │ var foo = 
    ·           ─
- 3 │         ;
+ 2 │             bar;
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:10]
+ 1 │ var foo =
+   ·          ─
+ 2 │             bar;
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:2:13]
+ 1 │ var foo =
+ 2 │             bar;
+   ·             ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:11]
+ 1 │ var foo = 
+   ·           ─
+ 2 │             bar
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:12]
+ 1 │ var foo = 
+   ·            ─
+ 2 │             bar
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:2:13]
+ 1 │ var foo = 
+ 2 │             bar
+   ·             ─
+ 3 │             ;
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:2:14]
+ 1 │ var foo = 
+ 2 │             bar
+   ·              ─
+ 3 │             ;
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:2:15]
+ 1 │ var foo = 
+ 2 │             bar
+   ·               ─
+ 3 │             ;
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:3:14]
+ 2 │             bar
+ 3 │             ;
+   ·              ─
+ 4 │             
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:3:15]
+ 2 │             bar
+ 3 │             ;
+   ·               ─
+ 4 │             
    ╰────
   help: Try to remove the irregular whitespace
 
@@ -448,9 +526,87 @@ source: crates/oxc_linter/src/tester.rs
   help: Try to remove the irregular whitespace
 
   ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
-   ╭─[no_irregular_whitespace.tsx:2:9]
- 1 │ foo
- 2 │          
-   ·         ─
+   ╭─[no_irregular_whitespace.tsx:1:4]
+ 1 │ foo 
+   ·    ─
+ 2 │              
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:2:13]
+ 1 │ foo 
+ 2 │              
+   ·             ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:4]
+ 1 │ foo 
+   ·    ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:5]
+ 1 │ foo 
+   ·     ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:8]
+ 1 │ foo 
+   ·      ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:4]
+ 1 │ // 　
+   ·    ──
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:4]
+ 1 │ /* 　 */
+   ·    ──
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:12]
+ 1 │ var any = /　/, other = /​/;
+   ·            ──
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:27]
+ 1 │ var any = /　/, other = /​/;
+   ·                          ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:12]
+ 1 │ var any = `　`, other = `​`;
+   ·            ──
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:27]
+ 1 │ var any = `　`, other = `​`;
+   ·                          ─
+   ╰────
+  help: Try to remove the irregular whitespace
+
+  ⚠ eslint(no-irregular-whitespace): Unexpected irregular whitespace
+   ╭─[no_irregular_whitespace.tsx:1:6]
+ 1 │ <div>　</div>;
+   ·      ──
    ╰────
   help: Try to remove the irregular whitespace


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/11977

Adds the configuration options:

- `skipStrings`
- `skipComments`
- `skipRegExps`
- `skipTemplates`
- `skipJSXText`

which all default to `true`, unlike ESLint, which only defaults `skipStrings` to `true`.

The reasoning for defaulting them all to `true` is this: we currently categorize this as `correctness` so it runs by default, since ESLint also runs it by default. It's a good idea for a codebase to not contain irregular whitespace like this probably. However, probably 99.9% (or more) of code files do not contain irregular whitespace and never will.

The cost of enabling these options by default is that we have to search all comment bytes that we skipped over in the lexer, as well as iterate over the source text for the matching AST nodes, which adds quite a bit of work. On the codspeed benchmarks, it's like -3% on the Radix UI JSX benchmark and -1% on all other files. We could theoretically make this better by refactoring the lexer to look for these bytes in comments and so on, but I don't think it's worth it. 

So the tradeoff is this: We implement these config options, but we diverge from ESLint's configuration options in exchange for ensuring that linter performance stays fast for the 99.9% case where irregular whitespace isn't in those files. If you really want to check for irregular whitespace in comments, templates, etc. then we can do it you'll just pay for it in speed.