### PR TITLE
chore(oxfmt): Test walk-then-format like oxlint

### DIFF
--- a/apps/oxfmt/src/cli/runner.rs
+++ b/apps/oxfmt/src/cli/runner.rs
@@ -152,12 +152,20 @@ impl CliRunner {
         #[cfg(feature = "napi")]
         let source_formatter = source_formatter.with_external_formatter(self.external_formatter);
 
-        // Spawn formatting service on a dedicated thread so it doesn't occupy the rayon pool.
-        // It just blocks on `rx_entry` waiting for entries; `par_bridge()` inside still uses rayon.
-        std::thread::spawn(move || {
-            let format_service = FormatService::new(cwd, format_mode, source_formatter);
-            format_service.run_streaming(rx_entry, &tx_error, &tx_success);
-        });
+        let walk_then_format = env::var("OXFMT_WALK_THEN_FORMAT").is_ok();
+
+        // In streaming mode, spawn format service BEFORE walk starts (original behavior)
+        let batch_ctx = if walk_then_format {
+            Some((cwd, source_formatter, rx_entry, tx_error, tx_success))
+        } else {
+            // Spawn formatting service on a dedicated thread so it doesn't occupy the rayon pool.
+            // It just blocks on `rx_entry` waiting for entries; `par_bridge()` inside still uses rayon.
+            std::thread::spawn(move || {
+                let format_service = FormatService::new(cwd, format_mode, source_formatter);
+                format_service.run_streaming(rx_entry, &tx_error, &tx_success);
+            });
+            None
+        };
 
         // Run scoped walks (root + nested) — sends entries to `tx_entry`
         let any_config_found = match scoped_walker.run(
@@ -179,8 +187,16 @@ impl CliRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         };
-        // Drop sender so the formatting service knows no more entries are coming
         drop(tx_entry);
+
+        // In walk-then-format mode, collect entries and format after walk completes
+        if let Some((cwd, source_formatter, rx_entry, tx_error, tx_success)) = batch_ctx {
+            let entries: Vec<FormatEntry> = rx_entry.into_iter().collect();
+            let format_service = FormatService::new(cwd, format_mode, source_formatter);
+            format_service.run_batch(entries, &tx_error, &tx_success);
+            drop(tx_success);
+            drop(tx_error);
+        }
 
         // Collect results and separate changed paths from unchanged count
         let mut changed_paths: Vec<String> = vec![];

--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -28,6 +28,93 @@ impl FormatService {
         Self { cwd: cwd.into(), format_mode, formatter }
     }
 
+    /// Process all entries in batch (walk-then-format approach)
+    pub fn run_batch(
+        &self,
+        entries: Vec<FormatEntry>,
+        tx_error: &DiagnosticSender,
+        tx_success: &mpsc::Sender<SuccessResult>,
+    ) {
+        entries.into_par_iter().for_each(|entry| {
+            let start_time = matches!(self.format_mode, OutputMode::Check).then(Instant::now);
+
+            let FormatEntry { strategy, config_resolver } = entry;
+            let path = strategy.path();
+            let Ok(source_text) = utils::read_to_string(path) else {
+                let diagnostics = DiagnosticService::wrap_diagnostics(
+                    self.cwd.clone(),
+                    path,
+                    "",
+                    vec![
+                        oxc_diagnostics::OxcDiagnostic::error(format!(
+                            "Failed to read file: {}",
+                            path.display()
+                        ))
+                        .with_help("This may be due to the file being a binary or inaccessible."),
+                    ],
+                );
+                let _ = tx_error.send(diagnostics);
+                return;
+            };
+
+            let resolved_options = config_resolver.resolve(&strategy);
+
+            let (code, is_changed) =
+                match self.formatter.format(&strategy, &source_text, resolved_options) {
+                    FormatResult::Success { code, is_changed } => (code, is_changed),
+                    FormatResult::Error(diagnostics) => {
+                        let errors = DiagnosticService::wrap_diagnostics(
+                            self.cwd.clone(),
+                            path,
+                            &source_text,
+                            diagnostics,
+                        );
+                        let _ = tx_error.send(errors);
+                        return;
+                    }
+                };
+
+            if matches!(self.format_mode, OutputMode::Write) && is_changed {
+                match fs::write(path, &code) {
+                    Ok(()) => (),
+                    Err(err) => {
+                        let diagnostics = DiagnosticService::wrap_diagnostics(
+                            self.cwd.clone(),
+                            path,
+                            "",
+                            vec![oxc_diagnostics::OxcDiagnostic::error(format!(
+                                "Failed to save '{}': {err}",
+                                path.display()
+                            ))],
+                        );
+                        let _ = tx_error.send(diagnostics);
+                        return;
+                    }
+                }
+            }
+
+            let result = match (&self.format_mode, is_changed) {
+                (OutputMode::Check | OutputMode::ListDifferent, true) => {
+                    let display_path = path
+                        .strip_prefix(&self.cwd)
+                        .unwrap_or(path)
+                        .to_string_lossy()
+                        .cow_replace('\\', "/")
+                        .to_string();
+
+                    if matches!(self.format_mode, OutputMode::Check) {
+                        let elapsed = start_time.unwrap().elapsed().as_millis();
+                        SuccessResult::Changed(format!("{display_path} ({elapsed}ms)"))
+                    } else {
+                        SuccessResult::Changed(display_path)
+                    }
+                }
+                _ => SuccessResult::Unchanged,
+            };
+            let _ = tx_success.send(result);
+        });
+    }
+
     /// Process entries as they are received from the channel
     pub fn run_streaming(
         &self,


### PR DESCRIPTION
The biggest barrier to sharing CLI code between oxlint and oxfmt is their differing traversal strategies.

- oxlint: Loads all file paths into memory beforehand (to enable cross-file analysis), then lint
- oxfmt: Does not load paths into memory, but streams them for formatting immediately

It is a known fact that this degrades performance. Since earlier versions of oxfmt used a "walk-then-format" approach, which was slow, leading to the current implementation.

However, we would like to re-examine the current extent of this performance impact.