### PR TITLE
ci: remove pull_request_target from PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,29 +3,21 @@ name: Check PR
 permissions: {}
 
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
-    branches-ignore:
-      - "**/graphite-base/**"
 
 jobs:
   pr:
     if: github.repository == 'oxc-project/oxc'
-    name: Label and Check PR Title
+    name: Check PR Title
     permissions:
-      contents: read
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-slim
     steps:
-      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-
-      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
-
       - name: Validate PR title
-        id: pr-title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,18 +36,3 @@ jobs:
             revert
             style
             test
-
-      - name: Add category label
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
-        env:
-          CATEGORY: ${{ case(
-            steps.pr-title.outputs.type == 'feat', 'C-enhancement',
-            steps.pr-title.outputs.type == 'fix', 'C-bug',
-            steps.pr-title.outputs.type == 'test', 'C-test',
-            contains(fromJson('["refactor", "chore", "style"]'), steps.pr-title.outputs.type), 'C-cleanup',
-            steps.pr-title.outputs.type == 'docs', 'C-docs',
-            steps.pr-title.outputs.type == 'perf', 'C-performance',
-            '') }}
-        if: ${{ env.CATEGORY != '' }}
-        with:
-          labels: ${{ env.CATEGORY }}


### PR DESCRIPTION
## Summary

- Replace the `Check PR` workflow trigger from `pull_request_target` to `pull_request`.
- Remove the label-writing tasks from this workflow.
- Keep semantic PR title validation with read-only pull request permissions.

## Rationale

We are banning `pull_request_target` without trying to reason about what this workflow currently does, because the trigger runs in a privileged context and is too dangerous to allow by default.

## Testing

- `ruby -e 'require "psych"; Psych.safe_load(File.read(".github/workflows/pr.yml"), aliases: true); puts "ok"'`\n- `git diff --check`\n- `zizmor .github/workflows/pr.yml`\n\n## AI disclosure\n\nThis PR was prepared with AI assistance.