### PR TITLE
fix(minifier): preserve annotation comments when inlining single-use variables during DCE

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -9,7 +9,7 @@ use oxc_ecmascript::{
     side_effects::MayHaveSideEffects,
 };
 use oxc_semantic::ScopeFlags;
-use oxc_span::{ContentEq, GetSpan};
+use oxc_span::{ContentEq, GetSpan, GetSpanMut};
 
 use crate::{TraverseCtx, keep_var::KeepVar};
 
@@ -1308,7 +1308,13 @@ impl<'a> PeepholeOptimizations {
         match target_expr {
             Expression::Identifier(id) => {
                 if id.name == search_for {
+                    // Preserve the span of the target identifier so that comments
+                    // attached to it (via `attached_to`) remain correctly associated
+                    // with the replacement expression.
+                    // https://github.com/rolldown/rolldown/issues/8248
+                    let target_span = target_expr.span();
                     *target_expr = replacement.take_in(ctx.ast);
+                    *target_expr.span_mut() = target_span;
                     return Some(true);
                 }
                 // If the identifier is not a getter and the identifier is read-only,

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -414,3 +414,23 @@ fn drop_labels_with_vars() {
 fn keep_use_strict_directives() {
     test_same("'use strict'; export function foo() { 'use strict'; return 1; }");
 }
+
+#[test]
+fn preserve_annotation_comments_when_inlining_single_use_variable() {
+    // https://github.com/rolldown/rolldown/issues/8248
+    test(
+        "const bar = 'some-url'; import(/* @vite-ignore */ bar);",
+        "import(/* @vite-ignore */ 'some-url');",
+    );
+    // `test` replaces "true"/"false" literals, so use `test_with_options` for webpackIgnore
+    test_with_options(
+        "const bar = 'some-url'; import(/* webpackIgnore: true */ bar);",
+        "import(/* webpackIgnore: true */ 'some-url');",
+        CompressOptions::dce(),
+    );
+    test_with_options(
+        "const bar = 'some-url'; import(/* @vite-ignore */ /* webpackIgnore: true */ bar);",
+        "import(/* @vite-ignore */ /* webpackIgnore: true */ 'some-url');",
+        CompressOptions::dce(),
+    );
+}


### PR DESCRIPTION
When `substitute_single_use_symbol_in_expression` inlines a single-use `const` variable, it replaced the identifier with the init expression using `replacement.take_in()`, which kept the replacement's original span from the variable declaration site. Since comments are associated with AST nodes via the `attached_to` field (keyed by span start), `@vite-ignore` and `webpackIgnore` comments attached to the original identifier were lost because the replacement expression had a different span start.

This only manifested in DCE mode (used by rolldown) because in full optimization mode, `inline_identifier_reference` runs first and correctly preserves the span via `ctx.value_to_expr(expr.span(), ...)`.

The fix preserves the target identifier's span on the replacement expression after substitution.

Fixes https://github.com/rolldown/rolldown/issues/8248
Closes https://github.com/vitejs/vite/issues/21950