### PR TITLE
fix(minifier): drop `this` after unconditional `super()` in derived constructors

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -443,6 +443,18 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
+    /// Whether an expression is or contains a `super()` call at the top level
+    /// (i.e., in a sequence expression, but not nested inside conditionals/functions).
+    fn expression_contains_super_call(expr: &Expression<'a>) -> bool {
+        match expr {
+            _ if expr.is_super_call_expression() => true,
+            Expression::SequenceExpression(seq) => {
+                seq.expressions.iter().any(Expression::is_super_call_expression)
+            }
+            _ => false,
+        }
+    }
+
     fn handle_expression_statement(
         mut expr_stmt: Box<'a, ExpressionStatement<'a>>,
         result: &mut Vec<'a, Statement<'a>>,
@@ -457,6 +469,24 @@ impl<'a> PeepholeOptimizations {
         );
         if changed {
             ctx.state.changed = true;
+        }
+
+        // In a derived constructor, `this` after an unconditional `super()` is safe to drop.
+        // Walk backwards through preceding sibling statements looking for `super()`.
+        // Only consider top-level expression statements — `super()` inside `if`/loops
+        // is conditional and doesn't guarantee `this` is initialized.
+        if matches!(expr_stmt.expression, Expression::ThisExpression(_))
+            && Self::this_is_inside_derived_constructor(ctx)
+            && result.iter().rev().any(|stmt| {
+                matches!(
+                    stmt,
+                    Statement::ExpressionStatement(prev)
+                        if Self::expression_contains_super_call(&prev.expression)
+                )
+            })
+        {
+            ctx.state.changed = true;
+            return;
         }
 
         if ctx.options().sequences

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -40,7 +40,7 @@ impl<'a> PeepholeOptimizations {
     /// Whether the nearest non-arrow, non-block function scope is a constructor
     /// of a class that extends another class (derived class).
     /// Only derived constructors have the TDZ for `this` before `super()`.
-    fn this_is_inside_derived_constructor(ctx: &TraverseCtx<'a>) -> bool {
+    pub(crate) fn this_is_inside_derived_constructor(ctx: &TraverseCtx<'a>) -> bool {
         for scope_id in ctx.ancestor_scopes() {
             let flags = ctx.scoping().scope_flags(scope_id);
             if flags.is_block() || flags.is_arrow() {

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -40,11 +40,44 @@ fn test_remove_unused_this() {
 
     // Non-derived constructors always have `this` initialized — safe to drop.
     test("export class Foo { constructor() { this; } }", "export class Foo { constructor() {} }");
-    // Derived constructor, but `this` is after `super()` — still kept conservatively
-    // because we don't track whether `super()` has been called.
+    // Derived constructor, but `this` is after `super()` — safe to drop.
     test(
         "export class Foo extends Bar { constructor() { super(); this; } }",
-        "export class Foo extends Bar { constructor() { super(), this; } }",
+        "export class Foo extends Bar { constructor() { super(); } }",
+    );
+
+    // Non-adjacent `super()` and `this` — `this` is dropped because `super()`
+    // was called unconditionally in a preceding statement.
+    test(
+        "export class Foo extends Bar { constructor() { super(); foo(); this; } }",
+        "export class Foo extends Bar { constructor() { super(), foo(); } }",
+    );
+    // Conditional `super()` — `this` must be kept.
+    test(
+        "export class Foo extends Bar { constructor() { if (x) { super(); } this; } }",
+        "export class Foo extends Bar { constructor() { x && super(), this; } }",
+    );
+    test(
+        "export class Foo extends Bar { constructor() { x ? super() : foo(); this; } }",
+        "export class Foo extends Bar { constructor() { x ? super() : foo(), this; } }",
+    );
+    // `super()` in closure — `this` must be kept (it's before the `super()` call).
+    test(
+        "export class Foo extends Bar { constructor() { const s = () => super(); this; s(); } }",
+        "export class Foo extends Bar { constructor() { this, super(); } }",
+    );
+
+    // A regular function inside a derived constructor has its own `this` — safe to drop.
+    test(
+        "export class Foo extends Bar { constructor() { (function() { this; })(); super(); } }",
+        "export class Foo extends Bar { constructor() { super(); } }",
+    );
+
+    // Nested class constructor inside a derived constructor — the inner `this`
+    // belongs to the inner constructor, not the outer one.
+    test(
+        "export class A extends B { constructor() { class C { constructor() { this; } } super(); } }",
+        "export class A extends B { constructor() { class C { constructor() {} } super(); } }",
     );
 
     // In all other positions `this` is always initialized and can be dropped.
@@ -53,6 +86,8 @@ fn test_remove_unused_this() {
     test("export class Foo { static foo() { this; } }", "export class Foo { static foo() {} }");
     test("export class Foo { static { this; } }", "export class Foo {}");
     test("export function foo() { this; }", "export function foo() {}");
+    test("export class Foo { get bar() { this; } }", "export class Foo { get bar() {} }");
+    test("export class Foo { set bar(v) { this; } }", "export class Foo { set bar(v) {} }");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- In a derived constructor, scan backwards through preceding sibling statements for an unconditional `super()` call
- If `super()` was called unconditionally, `this` is guaranteed to be initialized and can be safely dropped
- Only top-level expression statements are considered — `super()` inside conditionals (`if`/ternary) is correctly kept

Stacked on #21568.

## Test plan

- Tests for adjacent `super(); this;` → `super()` dropped
- Tests for non-adjacent `super(); foo(); this;` → `this` dropped
- Tests for conditional `super()` (`if (x) { super(); } this;`, `x ? super() : foo(); this;`) → `this` kept
- Tests for nested class/function `this` scoping
- Tests for getter/setter `this` removal
- All 481 minifier tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)