### PR TITLE
fix(formatter): escape backticks in JSDoc inline code spans

### DIFF
--- a/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/collect.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/collect.rs
@@ -44,9 +44,23 @@ fn collect_inline_impl(node: &Node, out: &mut String, inside_link: bool) {
             out.push_str("**");
         }
         Node::InlineCode(code) => {
-            out.push('`');
-            out.push_str(&code.value);
-            out.push('`');
+            let value = &code.value;
+            let delimiter_len = min_not_present_backtick_run(value);
+            let needs_padding = value.starts_with('`')
+                || value.ends_with('`')
+                || (value.starts_with([' ', '\n'])
+                    && value.ends_with([' ', '\n'])
+                    && value.chars().any(|c| c != ' ' && c != '\n'));
+            let delim = "`".repeat(delimiter_len);
+            out.push_str(&delim);
+            if needs_padding {
+                out.push(' ');
+            }
+            out.push_str(value);
+            if needs_padding {
+                out.push(' ');
+            }
+            out.push_str(&delim);
         }
         Node::Link(link) if inside_link => {
             // Nested link (e.g. GFM autolink inside explicit link text) —
@@ -161,4 +175,30 @@ fn collect_inline_impl(node: &Node, out: &mut String, inside_link: bool) {
             out.push_str(&node.to_string());
         }
     }
+}
+
+/// Returns the smallest `n >= 1` such that a maximal run of exactly `n`
+/// backticks does not appear in `text`. Matches Prettier's
+/// `getMinNotPresentContinuousCount`. Used to pick an inline code span
+/// delimiter that won't collide with backticks in the content.
+fn min_not_present_backtick_run(text: &str) -> usize {
+    let mut present: Vec<bool> = Vec::new();
+    let mut current = 0usize;
+    for ch in text.chars().chain(std::iter::once(' ')) {
+        if ch == '`' {
+            current += 1;
+        } else if current > 0 {
+            if present.len() <= current {
+                present.resize(current + 1, false);
+            }
+            present[current] = true;
+            current = 0;
+        }
+    }
+    for (i, is_present) in present.iter().enumerate().skip(1) {
+        if !is_present {
+            return i;
+        }
+    }
+    present.len().max(1)
 }

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/inline-code-backticks.js
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/inline-code-backticks.js
@@ -1,0 +1,29 @@
+/**
+ * `` ```js /Hello|Hi/ ``
+ *
+ * Meta word highlight
+ *
+ * @param parser - Code parser instance
+ * @param meta - Meta string
+ */
+function highlight(parser, meta) {}
+
+/**
+ * Single backtick: `foo` and double-backtick escaping: `` a`b ``.
+ */
+function a() {}
+
+/**
+ * Content with leading backtick: `` `leading ``, trailing: `` trailing` ``.
+ */
+function b() {}
+
+/**
+ * *emph* triggers mdast parsing. Pure single backtick: `` ` ``.
+ */
+function c() {}
+
+/**
+ * *emph* then double-backtick escape: `` a`b ``.
+ */
+function d() {}

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/inline-code-backticks.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/inline-code-backticks.js.snap
@@ -1,0 +1,86 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/**
+ * `` ```js /Hello|Hi/ ``
+ *
+ * Meta word highlight
+ *
+ * @param parser - Code parser instance
+ * @param meta - Meta string
+ */
+function highlight(parser, meta) {}
+
+/**
+ * Single backtick: `foo` and double-backtick escaping: `` a`b ``.
+ */
+function a() {}
+
+/**
+ * Content with leading backtick: `` `leading ``, trailing: `` trailing` ``.
+ */
+function b() {}
+
+/**
+ * *emph* triggers mdast parsing. Pure single backtick: `` ` ``.
+ */
+function c() {}
+
+/**
+ * *emph* then double-backtick escape: `` a`b ``.
+ */
+function d() {}
+
+==================== Output ====================
+-----------------------------
+{ jsdoc: {}, printWidth: 80 }
+-----------------------------
+/**
+ * ` ```js /Hello|Hi/ `
+ *
+ * Meta word highlight
+ *
+ * @param parser - Code parser instance
+ * @param meta - Meta string
+ */
+function highlight(parser, meta) {}
+
+/** Single backtick: `foo` and double-backtick escaping: `` a`b ``. */
+function a() {}
+
+/** Content with leading backtick: `` `leading ``, trailing: `` trailing` ``. */
+function b() {}
+
+/** _emph_ triggers mdast parsing. Pure single backtick: `` ` ``. */
+function c() {}
+
+/** _emph_ then double-backtick escape: ``a`b``. */
+function d() {}
+
+------------------------------
+{ jsdoc: {}, printWidth: 100 }
+------------------------------
+/**
+ * ` ```js /Hello|Hi/ `
+ *
+ * Meta word highlight
+ *
+ * @param parser - Code parser instance
+ * @param meta - Meta string
+ */
+function highlight(parser, meta) {}
+
+/** Single backtick: `foo` and double-backtick escaping: `` a`b ``. */
+function a() {}
+
+/** Content with leading backtick: `` `leading ``, trailing: `` trailing` ``. */
+function b() {}
+
+/** _emph_ triggers mdast parsing. Pure single backtick: `` ` ``. */
+function c() {}
+
+/** _emph_ then double-backtick escape: ``a`b``. */
+function d() {}
+
+===================== End =====================


### PR DESCRIPTION
closes #21550