### PR TITLE
fix(transformer): use SPAN for synthesized helper calls to prevent comment misattribution

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -269,13 +269,15 @@ impl HelperLoaderStore<'_> {
 /// This is a free function to avoid borrow conflicts when accessing state through `ctx.state`.
 pub fn helper_call<'a>(
     helper: Helper,
-    span: Span,
+    _span: Span,
     arguments: ArenaVec<'a, Argument<'a>>,
     ctx: &mut TraverseCtx<'a>,
 ) -> CallExpression<'a> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    ctx.ast.call_expression_with_pure(span, callee, NONE, arguments, false, pure)
+    // Use `SPAN` for synthesized calls so codegen doesn't match unrelated comments
+    // from the original source via `span.end - 1`.
+    ctx.ast.call_expression_with_pure(SPAN, callee, NONE, arguments, false, pure)
 }
 
 /// Same as [`helper_call`], but returns a `CallExpression` wrapped in an `Expression`.
@@ -283,13 +285,13 @@ pub fn helper_call<'a>(
 /// This is a free function to avoid borrow conflicts when accessing state through `ctx.state`.
 pub fn helper_call_expr<'a>(
     helper: Helper,
-    span: Span,
+    _span: Span,
     arguments: ArenaVec<'a, Argument<'a>>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    ctx.ast.expression_call_with_pure(span, callee, NONE, arguments, false, pure)
+    ctx.ast.expression_call_with_pure(SPAN, callee, NONE, arguments, false, pure)
 }
 
 /// Load a helper function and return a callee expression.

--- a/crates/oxc_transformer/tests/integrations/helper_call.rs
+++ b/crates/oxc_transformer/tests/integrations/helper_call.rs
@@ -1,0 +1,46 @@
+use oxc_allocator::Allocator;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+use crate::test;
+
+fn codegen_options() -> CodegenOptions {
+    CodegenOptions { single_quote: true, ..CodegenOptions::default() }
+}
+
+/// Verify that transform → codegen is idempotent (the second codegen pass produces the same output).
+/// Helper calls like `_defineProperty` must not pick up unrelated comments from the original source.
+#[test]
+fn helper_call_idempotency() {
+    use std::str::FromStr;
+    let options = oxc_transformer::TransformOptions::from(
+        oxc_transformer::ESTarget::from_str("es2015").unwrap(),
+    );
+
+    let cases = [
+        // `_defineProperty` — comment inside the value argument should not break formatting
+        "class C { prop = new Foo(1 /* type */); }",
+        // `_classPrivateFieldSet` — comment inside nested call
+        "class C { #x; constructor() { this.#x = new Foo(1 /* type */); } }",
+        // `_defineProperty` — comment inside function body argument
+        "class C { prop = function() { /* comment */ return 1; }; }",
+        // `_defineProperty` — trailing comment after last argument
+        "class C { prop = foo(a, b /* last */); }",
+    ];
+
+    for source in cases {
+        let first = test(source, &options).expect("transform should succeed");
+
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        let ret = Parser::new(&allocator, &first, source_type).parse();
+        assert!(ret.errors.is_empty(), "Parse errors on second pass for: {source}");
+        let second = Codegen::new().with_options(codegen_options()).build(&ret.program).code;
+
+        assert_eq!(
+            first, second,
+            "Codegen not idempotent after transform.\nInput: {source}\nFirst:  {first}\nSecond: {second}"
+        );
+    }
+}

--- a/crates/oxc_transformer/tests/integrations/main.rs
+++ b/crates/oxc_transformer/tests/integrations/main.rs
@@ -1,4 +1,5 @@
 mod es_target;
+mod helper_call;
 mod targets;
 
 use std::path::Path;


### PR DESCRIPTION
Fixes https://github.com/oxc-project/monitor-oxc/actions/runs/24666844194/job/72126949181
## Summary

Helper calls like `_defineProperty` and `_classPrivateFieldSet2` were using the original expression's span. Codegen's `print_arguments` checks `span.end - 1` for comments before the closing paren — when the original span's end coincided with a comment's `attached_to` position, codegen would incorrectly switch to multi-line formatting, breaking idempotency.

Use `SPAN` (zero span) for synthesized calls since they have no original source position. This is consistent with how TypeScript (`pos=-1`), SWC (`DUMMY_SP`), and esbuild handle generated nodes.

No sourcemap impact — codegen already skips source mapping for empty spans (`!span.is_empty()` guard). The arguments inside the call still have their own valid spans and map correctly.

## Test plan

- Added `helper_call_idempotency` test: transform class with comments inside property values → verify codegen is idempotent
- `cargo test -p oxc_transformer` — all pass
- `cargo run -p oxc_transform_conformance` — no snapshot changes