### PR TITLE
refactor(transformer): remove unused span parameter from helper_call/helper_call_expr

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -76,7 +76,7 @@ use oxc_ast::{
     ast::{Argument, CallExpression, Expression},
 };
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
-use oxc_span::{SPAN, Span};
+use oxc_span::SPAN;
 use oxc_str::Str;
 use oxc_traverse::BoundIdentifier;
 
@@ -267,16 +267,15 @@ impl HelperLoaderStore<'_> {
 /// Load and call a helper function and return a `CallExpression`.
 ///
 /// This is a free function to avoid borrow conflicts when accessing state through `ctx.state`.
+///
+/// Uses `SPAN` for the call expression since it's synthesized and has no original source position.
 pub fn helper_call<'a>(
     helper: Helper,
-    _span: Span,
     arguments: ArenaVec<'a, Argument<'a>>,
     ctx: &mut TraverseCtx<'a>,
 ) -> CallExpression<'a> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    // Use `SPAN` for synthesized calls so codegen doesn't match unrelated comments
-    // from the original source via `span.end - 1`.
     ctx.ast.call_expression_with_pure(SPAN, callee, NONE, arguments, false, pure)
 }
 
@@ -285,7 +284,6 @@ pub fn helper_call<'a>(
 /// This is a free function to avoid borrow conflicts when accessing state through `ctx.state`.
 pub fn helper_call_expr<'a>(
     helper: Helper,
-    _span: Span,
     arguments: ArenaVec<'a, Argument<'a>>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -779,7 +779,7 @@ impl<'a> LegacyDecoratorMetadata<'a> {
             Argument::from(ctx.ast.expression_string_literal(SPAN, key, None)),
             Argument::from(value),
         ]);
-        helper_call_expr(Helper::DecorateMetadata, SPAN, arguments, ctx)
+        helper_call_expr(Helper::DecorateMetadata, arguments, ctx)
     }
 
     // `_metadata(key, value)

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -1099,7 +1099,7 @@ impl<'a> LegacyDecorator<'a> {
             Argument::from(decorations),
             Argument::from(class_binding.create_read_expression(ctx)),
         ]);
-        let helper = helper_call_expr(Helper::Decorate, SPAN, arguments, ctx);
+        let helper = helper_call_expr(Helper::Decorate, arguments, ctx);
         let operator = AssignmentOperator::Assign;
         let left = class_binding.create_write_target(ctx);
         let right = Self::get_class_initializer(helper, class_alias_binding, ctx);
@@ -1168,7 +1168,6 @@ impl<'a> LegacyDecorator<'a> {
                 // _decorateParam(index, decorator)
                 ArrayExpressionElement::from(helper_call_expr(
                     Helper::DecorateParam,
-                    decorator.span,
                     arguments,
                     ctx,
                 ))
@@ -1395,7 +1394,7 @@ impl<'a> LegacyDecorator<'a> {
             Argument::from(name),
             Argument::from(descriptor),
         ]);
-        let helper = helper_call_expr(Helper::Decorate, SPAN, arguments, ctx);
+        let helper = helper_call_expr(Helper::Decorate, arguments, ctx);
         ctx.ast.statement_expression(SPAN, helper)
     }
 

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -729,7 +729,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         );
         function.generator = true;
         let arguments = ctx.ast.vec1(Argument::FunctionExpression(function));
-        helper_call_expr(self.helper, SPAN, arguments, ctx)
+        helper_call_expr(self.helper, arguments, ctx)
     }
 
     /// Creates a helper declaration statement for async-to-generator transformation.

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -150,12 +150,8 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         };
 
         let iterator = stmt.right.take_in(ctx.ast);
-        let iterator = helper_call_expr(
-            Helper::AsyncIterator,
-            SPAN,
-            ctx.ast.vec1(Argument::from(iterator)),
-            ctx,
-        );
+        let iterator =
+            helper_call_expr(Helper::AsyncIterator, ctx.ast.vec1(Argument::from(iterator)), ctx);
         Self::build_for_await(
             iterator,
             &step_key,

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -174,9 +174,9 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         expr.argument.as_mut().map(|argument| {
             let argument = Argument::from(argument.take_in(ctx.ast));
             let arguments = ctx.ast.vec1(argument);
-            let mut argument = helper_call_expr(Helper::AsyncIterator, SPAN, arguments, ctx);
+            let mut argument = helper_call_expr(Helper::AsyncIterator, arguments, ctx);
             let arguments = ctx.ast.vec1(Argument::from(argument));
-            argument = helper_call_expr(Helper::AsyncGeneratorDelegate, SPAN, arguments, ctx);
+            argument = helper_call_expr(Helper::AsyncGeneratorDelegate, arguments, ctx);
             ctx.ast.expression_yield(SPAN, expr.delegate, Some(argument))
         })
     }
@@ -208,7 +208,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
 
         let mut argument = expr.argument.take_in(ctx.ast);
         let arguments = ctx.ast.vec1(Argument::from(argument));
-        argument = helper_call_expr(Helper::AwaitAsyncGenerator, SPAN, arguments, ctx);
+        argument = helper_call_expr(Helper::AwaitAsyncGenerator, arguments, ctx);
 
         Some(ctx.ast.expression_yield(SPAN, false, Some(argument)))
     }

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -542,7 +542,7 @@ impl<'a> ObjectRestSpread<'a> {
         } else {
             ctx.ast.vec1(Argument::from(obj))
         };
-        let new_expr = helper_call(Helper::ObjectSpread2, SPAN, arguments, ctx);
+        let new_expr = helper_call(Helper::ObjectSpread2, arguments, ctx);
         expr.replace(ctx.ast.alloc(new_expr));
     }
 }
@@ -1119,7 +1119,6 @@ impl<'a> SpreadPair<'a> {
                     let mut sequence = ctx.ast.vec();
                     sequence.push(helper_call_expr(
                         Helper::ObjectDestructuringEmpty,
-                        SPAN,
                         ctx.ast.vec1(Argument::from(reference_builder.create_read_expression(ctx))),
                         ctx,
                     ));
@@ -1127,7 +1126,7 @@ impl<'a> SpreadPair<'a> {
                     sequence
                 },
             )));
-            helper_call_expr(Helper::Extends, SPAN, arguments, ctx)
+            helper_call_expr(Helper::Extends, arguments, ctx)
         } else {
             // / `let { a, b, ...c } = z` -> _objectWithoutProperties(_z, ["a", "b"]);
             // / `_objectWithoutProperties(_z, ["a", "b"])`
@@ -1168,7 +1167,7 @@ impl<'a> SpreadPair<'a> {
                 key_expression
             };
             arguments.push(Argument::from(key_expression));
-            helper_call_expr(Helper::ObjectWithoutProperties, SPAN, arguments, ctx)
+            helper_call_expr(Helper::ObjectWithoutProperties, arguments, ctx)
         };
         (self.lhs, rhs)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -854,7 +854,6 @@ impl<'a> ClassProperties<'a> {
     fn create_private_prop_key_loose(name: Ident<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldLooseKey,
-            SPAN,
             ctx.ast.vec1(Argument::from(ctx.ast.expression_string_literal(SPAN, name, None))),
             ctx,
         )

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -189,7 +189,7 @@ impl<'a> ClassProperties<'a> {
             self.create_to_setter_for_private_field_set(prop_ident, object, span, ctx)
         } else {
             // `_classPrivateFieldGet2(_prop, object)`
-            self.create_private_field_get(prop_ident, object, span, ctx)
+            self.create_private_field_get(prop_ident, object, ctx)
         }
     }
 
@@ -443,7 +443,7 @@ impl<'a> ClassProperties<'a> {
             let (object1, object2) = self.duplicate_object(object, ctx);
 
             // `_classPrivateFieldGet2(_prop, object)`
-            (self.create_private_field_get(prop_ident, object1, span, ctx), object2)
+            (self.create_private_field_get(prop_ident, object1, ctx), object2)
         }
     }
 
@@ -1859,7 +1859,7 @@ impl<'a> ClassProperties<'a> {
         if is_static {
             let class_binding = class_bindings.get_or_init_static_binding(ctx);
             let class_ident = class_binding.create_read_expression(ctx);
-            let left = self.create_check_in_rhs(right, SPAN, ctx);
+            let left = self.create_check_in_rhs(right, ctx);
             return ctx.ast.expression_binary(
                 span,
                 left,
@@ -1874,7 +1874,7 @@ impl<'a> ClassProperties<'a> {
             prop_binding.create_read_expression(ctx)
         };
         let callee = create_member_callee(callee, "has", span, ctx);
-        let argument = self.create_check_in_rhs(right, SPAN, ctx);
+        let argument = self.create_check_in_rhs(right, ctx);
         ctx.ast.expression_call(span, callee, NONE, ctx.ast.vec1(Argument::from(argument)), false)
     }
 
@@ -1930,7 +1930,6 @@ impl<'a> ClassProperties<'a> {
     ) -> MemberExpression<'a> {
         let call_expr = helper_call_expr(
             Helper::ClassPrivateFieldLooseBase,
-            SPAN,
             ctx.ast.vec_from_array([
                 Argument::from(object),
                 Argument::from(prop_binding.create_read_expression(ctx)),
@@ -1951,12 +1950,10 @@ impl<'a> ClassProperties<'a> {
         &self,
         prop_ident: Expression<'a>,
         object: Expression<'a>,
-        span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldGet2,
-            span,
             ctx.ast.vec_from_array([Argument::from(prop_ident), Argument::from(object)]),
             ctx,
         )
@@ -1969,12 +1966,10 @@ impl<'a> ClassProperties<'a> {
         prop_ident: Expression<'a>,
         object: Expression<'a>,
         value: Expression<'a>,
-        span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldSet2,
-            span,
             ctx.ast.vec_from_array([
                 Argument::from(prop_ident),
                 Argument::from(object),
@@ -2004,7 +1999,7 @@ impl<'a> ClassProperties<'a> {
             Argument::from(helper_load(Helper::ClassPrivateFieldSet2, ctx)),
             Argument::from(arguments),
         ]);
-        let call = helper_call_expr(Helper::ToSetter, span, arguments, ctx);
+        let call = helper_call_expr(Helper::ToSetter, arguments, ctx);
         Self::create_underscore_member_expression(call, span, ctx)
     }
 
@@ -2019,7 +2014,7 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         let prop_call = create_bind_call(prop_ident, object, span, ctx);
         let arguments = ctx.ast.vec_from_array([Argument::from(prop_call)]);
-        let call = helper_call_expr(Helper::ToSetter, span, arguments, ctx);
+        let call = helper_call_expr(Helper::ToSetter, arguments, ctx);
         Self::create_underscore_member_expression(call, span, ctx)
     }
 
@@ -2030,12 +2025,11 @@ impl<'a> ClassProperties<'a> {
         class_ident: Expression<'a>,
         object: Expression<'a>,
         value_or_prop_ident: Expression<'a>,
-        span: Span,
+        _span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         helper_call_expr(
             Helper::AssertClassBrand,
-            span,
             ctx.ast.vec_from_array([
                 Argument::from(class_ident),
                 Argument::from(object),
@@ -2055,7 +2049,7 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         let arguments =
             ctx.ast.vec_from_array([Argument::from(class_ident), Argument::from(object)]);
-        helper_call_expr(Helper::AssertClassBrand, SPAN, arguments, ctx)
+        helper_call_expr(Helper::AssertClassBrand, arguments, ctx)
     }
 
     /// `_assertClassBrand(Class, object, _prop)._`
@@ -2122,7 +2116,7 @@ impl<'a> ClassProperties<'a> {
             create_call_call(prop_ident, object, span, ctx)
         } else {
             // `_privateFieldGet(_prop, object)`
-            self.create_private_field_get(prop_ident, object, span, ctx)
+            self.create_private_field_get(prop_ident, object, ctx)
         }
     }
 
@@ -2159,7 +2153,7 @@ impl<'a> ClassProperties<'a> {
             ctx.ast.expression_call(span, callee, NONE, arguments, false)
         } else {
             // `_privateFieldSet(_prop, object, value)`
-            self.create_private_field_set(prop_ident, object, value, span, ctx)
+            self.create_private_field_set(prop_ident, object, value, ctx)
         }
     }
 
@@ -2174,7 +2168,7 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         let message = ctx.ast.str_from_strs_array(["#", private_name]);
         let message = ctx.ast.expression_string_literal(SPAN, message, None);
-        helper_call_expr(helper, SPAN, ctx.ast.vec1(Argument::from(message)), ctx)
+        helper_call_expr(helper, ctx.ast.vec1(Argument::from(message)), ctx)
     }
 
     /// `object, value, _readOnlyError("#method")`
@@ -2219,9 +2213,8 @@ impl<'a> ClassProperties<'a> {
     fn create_check_in_rhs(
         &self,
         object: Expression<'a>,
-        span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        helper_call_expr(Helper::CheckInRHS, span, ctx.ast.vec1(Argument::from(object)), ctx)
+        helper_call_expr(Helper::CheckInRHS, ctx.ast.vec1(Argument::from(object)), ctx)
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -89,7 +89,7 @@ impl<'a> ClassProperties<'a> {
             Argument::from(ctx.ast.expression_this(SPAN)),
             Argument::from(brand.create_read_expression(ctx)),
         ]);
-        helper_call_expr(Helper::ClassPrivateMethodInitSpec, SPAN, arguments, ctx)
+        helper_call_expr(Helper::ClassPrivateMethodInitSpec, arguments, ctx)
     }
 }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -70,7 +70,7 @@ impl<'a> ClassProperties<'a> {
             let this = ctx.ast.expression_this(SPAN);
             self.create_private_init_assignment_loose(ident, value, this, span, ctx)
         } else {
-            self.create_private_instance_init_assignment_not_loose(ident, value, span, ctx)
+            self.create_private_instance_init_assignment_not_loose(ident, value, ctx)
         }
     }
 
@@ -79,7 +79,6 @@ impl<'a> ClassProperties<'a> {
         &self,
         ident: &PrivateIdentifier<'a>,
         value: Expression<'a>,
-        span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let private_props = self.current_class().private_props.as_ref().unwrap();
@@ -89,7 +88,7 @@ impl<'a> ClassProperties<'a> {
             Argument::from(prop.binding.create_read_expression(ctx)),
             Argument::from(value),
         ]);
-        helper_call_expr(Helper::ClassPrivateFieldInitSpec, span, arguments, ctx)
+        helper_call_expr(Helper::ClassPrivateFieldInitSpec, arguments, ctx)
     }
 }
 
@@ -335,7 +334,7 @@ impl<'a> ClassProperties<'a> {
             Argument::from(key),
             Argument::from(value),
         ]);
-        helper_call_expr(Helper::DefineProperty, prop.span, arguments, ctx)
+        helper_call_expr(Helper::DefineProperty, arguments, ctx)
     }
 
     /// `Object.defineProperty(<assignee>, _prop, {writable: true, value: value})`

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -551,7 +551,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
     ///  `_superPropGet(_Class, prop, _Class, 2)`
     fn create_super_prop_get(
         &mut self,
-        span: Span,
+        _span: Span,
         property: Expression<'a>,
         is_callee: bool,
         ctx: &mut TraverseCtx<'a>,
@@ -569,13 +569,13 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         };
 
         // `_superPropGet(_Class, prop, _Class)` or `_superPropGet(_Class, prop, _Class, 2)`
-        helper_call_expr(Helper::SuperPropGet, span, arguments, ctx)
+        helper_call_expr(Helper::SuperPropGet, arguments, ctx)
     }
 
     /// `_superPropSet(_Class, prop, value, _Class, 1)`
     fn create_super_prop_set(
         &mut self,
-        span: Span,
+        _span: Span,
         property: Expression<'a>,
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
@@ -593,7 +593,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
                 NumberBase::Decimal,
             )),
         ]);
-        helper_call_expr(Helper::SuperPropSet, span, arguments, ctx)
+        helper_call_expr(Helper::SuperPropSet, arguments, ctx)
     }
 
     /// * [`ClassPropertiesSuperConverterMode::Static`]

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -181,7 +181,7 @@ impl<'a> TaggedTemplateTransform {
 
         // `babelHelpers.taggedTemplateLiteral([<...cooked>], [<...raw>]?)`
         let template_call =
-            helper_call_expr(Helper::TaggedTemplateLiteral, SPAN, template_arguments, ctx);
+            helper_call_expr(Helper::TaggedTemplateLiteral, template_arguments, ctx);
         // `binding || (binding = babelHelpers.taggedTemplateLiteral([<...cooked>], [<...raw>]?))`
         let template_call =
             Argument::from(Self::create_logical_or_expression(binding, template_call, ctx));


### PR DESCRIPTION
## Summary

Follow-up to #21578. Since helper calls now always use `SPAN`, the `span` parameter is unnecessary. This removes it from `helper_call` and `helper_call_expr` and cleans up all 28 call sites across 12 files.

Also removes now-unused `span` parameters from internal functions that only existed to pass through to helper calls:
- `create_private_field_get`
- `create_private_field_set`
- `create_check_in_rhs`
- `create_private_instance_init_assignment_not_loose`

## Test plan

- `cargo build -p oxc_transformer` — no warnings (except pre-existing `oxc_allocator`)
- `cargo test -p oxc_transformer` — all pass
- `cargo run -p oxc_transform_conformance` — no snapshot changes