### PR TITLE
fix(linter/no-useless-assignment): improve diagnostic spans

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
@@ -146,6 +146,7 @@ impl Rule for NoUselessAssignment {
         let mut cfg_ops: CfgOps = IndexVec::with_capacity(num_blocks);
         cfg_ops.resize_with(num_blocks, Vec::new);
         let mut used_compact_indices: SmallVec<[u32; 32]> = SmallVec::new();
+        let mut compact_to_symbol: Vec<SymbolId> = Vec::new();
         let mut compact_to_scope: Vec<ScopeId> = Vec::new();
         let mut exported_compact_indices: SmallVec<[u32; 8]> = SmallVec::new();
         let mut captured_read_compact_indices: SmallVec<[u32; 8]> = SmallVec::new();
@@ -168,6 +169,7 @@ impl Rule for NoUselessAssignment {
 
             let compact_idx = num_tracked;
             num_tracked += 1;
+            compact_to_symbol.push(symbol_id);
             compact_to_scope.push(ctx.scoping().symbol_scope_id(symbol_id));
             if Self::is_exported(ctx, symbol_id) {
                 exported_compact_indices.push(compact_idx);
@@ -424,9 +426,14 @@ impl Rule for NoUselessAssignment {
                                         ctx.nodes().get_node(op.node).scope_id(),
                                     )
                                 {
-                                    ctx.diagnostic(no_useless_assignment_diagnostic(
-                                        ctx.nodes().get_node(op.node).span(),
-                                    ));
+                                    let symbol_id = compact_to_symbol[compact_idx];
+                                    let span =
+                                        if ctx.scoping().symbol_declaration(symbol_id) == op.node {
+                                            ctx.scoping().symbol_span(symbol_id)
+                                        } else {
+                                            ctx.nodes().get_node(op.node).span()
+                                        };
+                                    ctx.diagnostic(no_useless_assignment_diagnostic(span));
                                 }
                                 scratch_live.unset_bit(compact_idx);
                             }
@@ -1421,6 +1428,13 @@ fn test() {
                             a,
                             b = (a = 2)
                         } = obj;
+                        a = 3
+                        console.log(a, b);",
+        "const arr = [1, 2];
+                        let [
+                            a,
+                            b
+                        ] = arr;
                         a = 3
                         console.log(a, b);",
         r#"function App() {

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_assignment.snap
@@ -68,7 +68,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:33]
  1 │ function foo() {
  2 │                             let v = 'unused';
-   ·                                 ────────────
+   ·                                 ─
  3 │                             if (condition) {
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -131,7 +131,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:33]
  1 │ function foo() {
  2 │                             let v = 'unused';
-   ·                                 ────────────
+   ·                                 ─
  3 │                             if (condition) {
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -328,7 +328,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(no-useless-assignment): This assigned value is not used in subsequent statements.
    ╭─[no_useless_assignment.tsx:1:5]
  1 │ let message = 'unused';
-   ·     ──────────────────
+   ·     ───────
  2 │                         try {
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -336,7 +336,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(no-useless-assignment): This assigned value is not used in subsequent statements.
    ╭─[no_useless_assignment.tsx:1:5]
  1 │ let message = 'unused';
-   ·     ──────────────────
+   ·     ───────
  2 │                         try {
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -344,7 +344,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(no-useless-assignment): This assigned value is not used in subsequent statements.
    ╭─[no_useless_assignment.tsx:1:5]
  1 │ let message = 'unused';
-   ·     ──────────────────
+   ·     ───────
  2 │                         try {
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -352,7 +352,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(no-useless-assignment): This assigned value is not used in subsequent statements.
    ╭─[no_useless_assignment.tsx:1:5]
  1 │ let v = 'unused';
-   ·     ────────────
+   ·     ─
  2 │                         try {
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -376,13 +376,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing or reusing the assigned value.
 
   ⚠ eslint(no-useless-assignment): This assigned value is not used in subsequent statements.
-   ╭─[no_useless_assignment.tsx:2:29]
- 1 │     const obj = { a: 1 };
- 2 │ ╭─▶                         let {
- 3 │ │                               a,
- 4 │ │                               b = (a = 2)
- 5 │ ╰─▶                         } = obj;
- 6 │                             a = 3
+   ╭─[no_useless_assignment.tsx:3:29]
+ 2 │                         let {
+ 3 │                             a,
+   ·                             ─
+ 4 │                             b = (a = 2)
+   ╰────
+  help: Consider removing or reusing the assigned value.
+
+  ⚠ eslint(no-useless-assignment): This assigned value is not used in subsequent statements.
+   ╭─[no_useless_assignment.tsx:3:29]
+ 2 │                         let [
+ 3 │                             a,
+   ·                             ─
+ 4 │                             b
    ╰────
   help: Consider removing or reusing the assigned value.
 
@@ -390,7 +397,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:29]
  1 │ function App() {
  2 │                         let A = "unused";
-   ·                             ────────────
+   ·                             ─
  3 │                         A = "used";
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -399,7 +406,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:29]
  1 │ function App() {
  2 │                         let A = "unused";
-   ·                             ────────────
+   ·                             ─
  3 │                         A = "used";
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -408,7 +415,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:29]
  1 │ function App() {
  2 │                         let A = "unused";
-   ·                             ────────────
+   ·                             ─
  3 │                         A = "used";
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -435,7 +442,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:29]
  1 │ function App() {
  2 │                         let message = 'unused';
-   ·                             ──────────────────
+   ·                             ───────
  3 │                         try {
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -453,7 +460,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:29]
  1 │ function App() {
  2 │                         let x = 1;
-   ·                             ─────
+   ·                             ─
  3 │                         x = 2;
    ╰────
   help: Consider removing or reusing the assigned value.
@@ -471,7 +478,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_useless_assignment.tsx:2:29]
  1 │ function App() {
  2 │                         let x = 0;
-   ·                             ─────
+   ·                             ─
  3 │                         x = 1;
    ╰────
   help: Consider removing or reusing the assigned value.


### PR DESCRIPTION
## Summary

- track each compact liveness index back to its SymbolId
- report dead declaration initializers on the symbol binding span instead of the full declarator node
- add object and array destructuring snapshot coverage for binding-focused diagnostics

## Test plan

- just fmt
- cargo test -p oxc_linter no_useless_assignment::test

AI assistance used: OpenAI Codex.