### PR TITLE
feat(linter/no-unknown-property): support React 19 `precedence` prop

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -204,6 +204,8 @@ const ATTRIBUTE_TAGS_MAP: Map<&'static str, Set<&'static str>> = phf_map! {
     "shadowrootdelegatesfocus" => phf_set! {"template"},
     "shadowrootserializable" => phf_set! {"template"},
     "transform-origin" => phf_set! {"rect"},
+    // React 19: https://react.dev/reference/react-dom/components/link#props
+    "precedence" => phf_set! {"style", "link"},
 };
 
 const DOM_PROPERTIES_NAMES: Set<&'static str> = phf_set! {
@@ -748,6 +750,31 @@ fn test() {
             "#,
             None,
         ),
+        // React 19 `precedence` on stylesheet resources: `<link rel="stylesheet">` and `<style>`
+        // https://react.dev/reference/react-dom/components/link
+        (
+            r#"
+                <Suspense fallback="loading...">
+                  <link rel="stylesheet" href="foo" precedence="default" />
+                  <link rel="stylesheet" href="bar" precedence="high" />
+                  <article className="foo-class bar-class" />
+                </Suspense>
+            "#,
+            None,
+        ),
+        (
+            r#"
+                <div>
+                  <p>hello</p>
+                  <link rel="stylesheet" href="baz" precedence="default" />
+                </div>
+            "#,
+            None,
+        ),
+        (
+            r#"<style precedence="default" href="custom-style">{`body { color: red; }`}</style>"#,
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -806,6 +833,8 @@ fn test() {
             None,
         ),
         ("<t onChñnge/>", None),
+        (r#"<div precedence="default" />"#, None),
+        (r#"<script precedence="high" src="foo.js" />"#, None),
     ];
 
     // TODO: Add a fixer for this rule.

--- a/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
@@ -353,3 +353,17 @@ source: crates/oxc_linter/src/tester.rs
    ·    ────────
    ╰────
   help: Remove unknown property
+
+  ⚠ eslint-plugin-react(no-unknown-property): Invalid property found
+   ╭─[no_unknown_property.tsx:1:6]
+ 1 │ <div precedence="default" />
+   ·      ──────────
+   ╰────
+  help: Property 'precedence' is only allowed on: style, link
+
+  ⚠ eslint-plugin-react(no-unknown-property): Invalid property found
+   ╭─[no_unknown_property.tsx:1:9]
+ 1 │ <script precedence="high" src="foo.js" />
+   ·         ──────────
+   ╰────
+  help: Property 'precedence' is only allowed on: style, link


### PR DESCRIPTION
I noticed `precedence` was throwing an unknown property error on my codebase.

```
× eslint-plugin-react(no-unknown-property): Unknown property found
    ╭─[Layout.tsx]
 31 │       <style precedence="high">
    ·                                      ──────────
 32 │         {`html,body{background-color:oklch(var(--bg-inverted-neutral));color:oklch(var(--text-inverted-strong))}`}
    ╰────
  help: Remove unknown property
```

Since `precedence` is a valid React 19 prop ([React docs](https://react.dev/reference/react-dom/components/link#special-rendering-behavior) - [Types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L3355)) supported on `<link>` and `<style>` elements, I added it to the `no_unknown_property` file with the assistance from AI.