### PR TITLE
fix(linter): ignore enum members in no-shadow

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_shadow/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow/mod.rs
@@ -143,6 +143,7 @@ impl NoShadow {
         symbol_name: &str,
     ) -> bool {
         self.allow.iter().any(|allowed| allowed.as_str() == symbol_name)
+            || ctx.scoping().symbol_flags(symbol_id).is_enum_member()
             || Self::is_declare_in_definition_file(ctx, symbol_id)
             || Self::is_in_global_augmentation(ctx, symbol_id)
     }

--- a/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
@@ -1515,6 +1515,29 @@ fn test_eslint() {
         ), // { "globals": { "Foopy5": false, }, },
         (
             "
+              export const Priority = 1234;
+              export enum SomeEnum {
+                Priority = 'PRIORITY',
+              }
+                    ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+              const A = 2;
+              enum Test {
+                A = 1,
+                B = A,
+              }
+                    ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
               declare;
               foo5: boolean;
                     ",
@@ -2295,18 +2318,6 @@ fn test_eslint() {
             None,
             Some(PathBuf::from("foo.d.ts")),
         ), // { "globals": { "has": false, }, },
-        (
-            "
-                        const A = 2;
-                        enum Test {
-                            A = 1,
-                            B = A,
-                        }
-                    ",
-            None,
-            None,
-            None,
-        ),
     ];
 
     Tester::new(NoShadow::NAME, NoShadow::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
@@ -1417,17 +1417,3 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     
    ╰────
   help: Consider renaming 'has' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:2:31]
- 1 │ 
- 2 │                         const A = 2;
-   ·                               ┬
-   ·                               ╰── shadowed declaration is here
- 3 │                         enum Test {
- 4 │                             A = 1,
-   ·                             ──┬──
-   ·                               ╰── 'A' is declared here
- 5 │                             B = A,
-   ╰────
-  help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.


### PR DESCRIPTION
fixes #21604

