### PR TITLE
fix(linter/no-shadow): add note explaining enum member shadowing

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_shadow/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow/mod.rs
@@ -27,15 +27,29 @@ use crate::{
 
 pub use options::{HoistOption, NoShadowConfig};
 
-pub fn no_shadow_diagnostic(span: Span, name: &str, shadowed_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{name}' is already declared in the upper scope."))
-        .with_help(format!(
-            "Consider renaming '{name}' to avoid shadowing the variable from the outer scope."
+pub fn no_shadow_diagnostic(
+    span: Span,
+    name: &str,
+    shadowed_span: Span,
+    is_enum_member: bool,
+) -> OxcDiagnostic {
+    let diagnostic =
+        OxcDiagnostic::warn(format!("'{name}' is already declared in the upper scope."))
+            .with_help(format!(
+                "Consider renaming '{name}' to avoid shadowing the variable from the outer scope."
+            ))
+            .with_labels([
+                span.label(format!("'{name}' is declared here")),
+                shadowed_span.label("shadowed declaration is here"),
+            ]);
+
+    if is_enum_member {
+        diagnostic.with_note(format!(
+            "Enum members are added to the enum scope, so references to '{name}' in enum member initializers resolve to this member instead of the declaration in the upper scope."
         ))
-        .with_labels([
-            span.label(format!("'{name}' is declared here")),
-            shadowed_span.label("shadowed declaration is here"),
-        ])
+    } else {
+        diagnostic
+    }
 }
 
 pub fn no_shadow_global_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
@@ -115,6 +129,7 @@ impl Rule for NoShadow {
                         symbol_span,
                         symbol_name_str,
                         shadowed_span,
+                        scoping.symbol_flags(symbol_id).is_enum_member(),
                     ));
                 }
                 continue;
@@ -123,7 +138,12 @@ impl Rule for NoShadow {
             if let Some(shadowed_span) =
                 Self::function_expression_name_shadow_span(ctx, symbol_id, symbol_name_str)
             {
-                ctx.diagnostic(no_shadow_diagnostic(symbol_span, symbol_name_str, shadowed_span));
+                ctx.diagnostic(no_shadow_diagnostic(
+                    symbol_span,
+                    symbol_name_str,
+                    shadowed_span,
+                    false,
+                ));
                 continue;
             }
 

--- a/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
@@ -2307,6 +2307,17 @@ fn test_eslint() {
             None,
             None,
         ),
+        (
+            "
+                        enum Example {
+                            NotExample,
+                            Example,
+                        }
+                    ",
+            None,
+            None,
+            None,
+        ),
     ];
 
     Tester::new(NoShadow::NAME, NoShadow::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
@@ -1431,3 +1431,19 @@ source: crates/oxc_linter/src/tester.rs
  5 │                             B = A,
    ╰────
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
+  note: Enum members are added to the enum scope, so references to 'A' in enum member initializers resolve to this member instead of the declaration in the upper scope.
+
+  ⚠ eslint(no-shadow): 'Example' is already declared in the upper scope.
+   ╭─[no_shadow.tsx:2:30]
+ 1 │ 
+ 2 │                         enum Example {
+   ·                              ───┬───
+   ·                                 ╰── shadowed declaration is here
+ 3 │                             NotExample,
+ 4 │                             Example,
+   ·                             ───┬───
+   ·                                ╰── 'Example' is declared here
+ 5 │                         }
+   ╰────
+  help: Consider renaming 'Example' to avoid shadowing the variable from the outer scope.
+  note: Enum members are added to the enum scope, so references to 'Example' in enum member initializers resolve to this member instead of the declaration in the upper scope.


### PR DESCRIPTION
## Summary

- Add a specialized diagnostic note when `eslint/no-shadow` reports an enum member shadowing an upper declaration
- Cover the enum self-shadowing case from typescript-eslint/typescript-eslint#9755
- Update the `eslint_no_shadow` snapshot with the new note text

## Context

This mirrors the explanation in https://github.com/typescript-eslint/typescript-eslint/issues/9755: enum members are added to the enum scope, so an enum member with the same name as an upper declaration can affect references inside enum member initializers.

## Tests

- `just fmt`
- `cargo test -p oxc_linter no_shadow -- --nocapture`
- `cargo insta pending-snapshots`

AI-assisted by OpenAI Codex; reviewed and tested by the contributor.
