### PR TITLE
feat(linter/react): mark react/prop-types as unsupported

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -125,6 +125,7 @@
     "react/static-property-placement": "This rule only applies to legacy class components, which are not widely used in modern React.",
     "react/require-optimization": "This rule only applies to legacy class components, which are not widely used in modern React.",
     "react/prefer-read-only-props": "This rule is niche and primarily applies to legacy class components, which are not widely used in modern React.",
+    "react/prop-types": "PropTypes are ignored in React 19, and TypeScript + the `no-unsafe-xxx` rules already catches unsafe props in most cases.",
 
     "typescript/sort-type-constituents": "Deprecated, replaced by `perfectionist/sort-intersection-types` and `perfectionist/sort-union-types` rules.",
     "typescript/no-type-alias": "Deprecated, replaced by `typescript-eslint/consistent-type-definitions` rule.",


### PR DESCRIPTION
PropTypes are deprecated and ignored by React 19, we don't support Flow checks, so what remains is TypeScript which is already covered by TypeScript itself + the `no-unsafe-xxx` rules.