### PR TITLE
feat(linter/getter-return): move rule from nursery to correctness

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__cli__linter__.customignore --no-ignore fixtures__cli__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__cli__linter__.customignore --no-ignore fixtures__cli__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__cli__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__cli__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/cli/linte
 working directory: 
 ----------
 No files found to lint. Please check your paths and ignore patterns.
-Finished in <variable>ms on 0 files with 93 rules using 1 threads.
+Finished in <variable>ms on 0 files with 94 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__cli__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__cli__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/cli/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 95 rules using 1 threads.
+Finished in <variable>ms on 2 files with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__cli__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__cli__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/cli/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--no-error-on-unmatched-pattern foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--no-error-on-unmatched-pattern foo.asdf@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --no-error-on-unmatched-pattern foo.asdf
 working directory: 
 ----------
-Finished in <variable>ms on 0 files with 93 rules using 1 threads.
+Finished in <variable>ms on 0 files with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__cli__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__cli__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/cli/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 92 rules using 1 threads.
+Finished in <variable>ms on 1 file with 93 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__eslintrc_env__eslintrc_no_env.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__eslintrc_env__eslintrc_no_env.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Either define 'console' or remove the reference to it. If 'console' is a global variable, add it to the 'globals' configuration.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__no_undef__eslintrc.json fixtures__cli__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__no_undef__eslintrc.json fixtures__cli__no_undef__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Either define 'console' or remove the reference to it. If 'console' is a global variable, add it to the 'globals' configuration.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_env__eslintrc_env_browser.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_env__eslintrc_env_browser.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/cli/eslintrc_env/eslintrc_env_browser.json fixtures/cli/e
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_off__eslintrc.json fixtures__cli__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_off__eslintrc.json fixtures__cli__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__linter__eslintrc.json fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__linter__eslintrc.json fixtures__cli__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__no_console_off__eslintrc.json fixtures__cli__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__no_console_off__eslintrc.json fixtures__cli__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/cli/no_console_off/eslintrc.json fixtures/cli/no_console_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__overrides__directories-config.json fixtures__cli__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__overrides__directories-config.json fixtures__cli__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 92 rules using 1 threads.
+Finished in <variable>ms on 7 files with 93 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__cli__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__cli__typescript_eslint__test.ts@oxlint.snap
@@ -34,7 +34,7 @@ working directory:
   help: Consider using this expression or removing it
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 55 rules using 1 threads.
+Finished in <variable>ms on 1 file with 56 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__typescript_eslint__eslintrc.json fixtures__cli__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__typescript_eslint__eslintrc.json fixtures__cli__typescript_eslint__test.ts@oxlint.snap
@@ -42,7 +42,7 @@ working directory:
   help: Consider using this expression or removing it
 
 Found 3 warnings and 1 error.
-Finished in <variable>ms on 1 file with 68 rules using 1 threads.
+Finished in <variable>ms on 1 file with 69 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter@oxlint.snap
@@ -36,7 +36,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 93 rules using 1 threads.
+Finished in <variable>ms on 3 files with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js fixtures__cli__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js fixtures__cli__linter__nan.js@oxlint.snap
@@ -28,7 +28,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 93 rules using 1 threads.
+Finished in <variable>ms on 2 files with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter__js_as_jsx.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__svelte__debugger.svelte@oxlint.snap
@@ -34,7 +34,7 @@ working directory:
   help: Variable declared without assignment. Either assign a value or remove the declaration.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/cli/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__vue__invalid.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__vue__invalid.vue@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Add an initializer (e.g. ` = undefined`) here
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 No files found to lint. Please check your paths and ignore patterns.
-Finished in <variable>ms on 0 files with 93 rules using 1 threads.
+Finished in <variable>ms on 0 files with 94 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c ./test/eslintrc.json --ignore-pattern *.ts .
 working directory: fixtures/cli/config_ignore_patterns/with_oxlintrc
 ----------
 No files found to lint. Please check your paths and ignore patterns.
-Finished in <variable>ms on 0 files with 93 rules using 1 threads.
+Finished in <variable>ms on 0 files with 94 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc-eslint.json test.js
 working directory: fixtures/cli/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 55 rules using 1 threads.
+Finished in <variable>ms on 1 file with 56 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: -c .oxlintrc-unicorn.json test.js
 working directory: fixtures/cli/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 68 rules using 1 threads.
+Finished in <variable>ms on 1 file with 69 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__dot_folder_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__dot_folder_@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/dot_folder
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/cli/extends_config
   help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 93 rules using 1 threads.
+Finished in <variable>ms on 4 files with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/cli/import-cycle
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 96 rules using 1 threads.
+Finished in <variable>ms on 2 files with 97 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__issue_10394_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__issue_10394_-c .oxlintrc.json@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/cli/issue_10394
   help: Write a meaningful title for your test
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_--deny-warnings -c config-deny-warnings-false.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_--deny-warnings -c config-deny-warnings-false.json debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintNoWarningsAllowed
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_--max-warnings 1 -c config-max-warnings.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_--max-warnings 1 -c config-max-warnings.json debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-deny-warnings.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-deny-warnings.json debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintNoWarningsAllowed
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-max-warnings.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-max-warnings.json debugger.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/cli/linter
 
 Found 1 warning and 0 errors.
 Exceeded maximum number of warnings. Found 1.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintMaxWarningsExceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__nested_config__package4-as-cwd_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__nested_config__package4-as-cwd_@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/cli/nested_config/package4-as-cwd
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/cli/overrides
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/cli/overrides
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.ts@oxlint.snap
@@ -23,7 +23,7 @@ working directory: fixtures/cli/overrides
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -42,7 +42,7 @@ working directory: fixtures/cli/overrides_with_plugin
   help: Consider removing this declaration.
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 93 rules using 1 threads.
+Finished in <variable>ms on 2 files with 94 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json --report-unused-disable-directives-severity=off@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json --report-unused-disable-directives-severity=off@oxlint.snap
@@ -106,7 +106,7 @@ working directory: fixtures/cli/report_unused_directives
   help: Delete this console statement.
 
 Found 11 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 94 rules using 1 threads.
+Finished in <variable>ms on 5 files with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json@oxlint.snap
@@ -321,7 +321,7 @@ working directory: fixtures/cli/report_unused_directives
     `----
 
 Found 38 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 94 rules using 1 threads.
+Finished in <variable>ms on 5 files with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
@@ -321,7 +321,7 @@ working directory: fixtures/cli/report_unused_directives
     `----
 
 Found 38 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 94 rules using 1 threads.
+Finished in <variable>ms on 5 files with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_--type-aware -c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_--type-aware -c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
@@ -25,7 +25,7 @@ working directory: fixtures/cli/tsgolint
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 108 rules using 1 threads.
+Finished in <variable>ms on 1 file with 109 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false-with-overrides.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false-with-overrides.json no-floating-promises.ts@oxlint.snap
@@ -16,7 +16,7 @@ working directory: fixtures/cli/tsgolint
   help: Consider using this expression or removing it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
@@ -16,7 +16,7 @@ working directory: fixtures/cli/tsgolint
   help: Consider using this expression or removing it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 93 rules using 1 threads.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-with-overrides.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-with-overrides.json no-floating-promises.ts@oxlint.snap
@@ -25,7 +25,7 @@ working directory: fixtures/cli/tsgolint
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 107 rules using 1 threads.
+Finished in <variable>ms on 1 file with 108 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_config_error_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_config_error_--type-aware@oxlint.snap
@@ -17,7 +17,7 @@ working directory: fixtures/cli/tsgolint_config_error
         See https://github.com/oxc-project/tsgolint/issues/351 for more information.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 108 rules using 1 threads.
+Finished in <variable>ms on 1 file with 109 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
@@ -77,7 +77,7 @@ working directory: fixtures/cli/tsgolint_disable_directives
     `----
 
 Found 8 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 108 rules using 1 threads.
+Finished in <variable>ms on 1 file with 109 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware@oxlint.snap
@@ -142,7 +142,7 @@ working directory: fixtures/cli/tsgolint_disable_directives
   help: Consider removing this declaration.
 
 Found 15 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 108 rules using 1 threads.
+Finished in <variable>ms on 3 files with 109 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_tsconfig_extends_config_err_--type-aware -D no-floating-promises@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_tsconfig_extends_config_err_--type-aware -D no-floating-promises@oxlint.snap
@@ -11,7 +11,7 @@ working directory: fixtures/cli/tsgolint_tsconfig_extends_config_err
         See https://github.com/oxc-project/tsgolint/issues/351 for more information.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 108 rules using 1 threads.
+Finished in <variable>ms on 1 file with 109 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check -c config-type-check-false.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check -c config-type-check-false.json@oxlint.snap
@@ -30,7 +30,7 @@ working directory: fixtures/cli/tsgolint_type_error
    `----
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 2 files with 108 rules using 1 threads.
+Finished in <variable>ms on 2 files with 109 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check-false.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check-false.json@oxlint.snap
@@ -24,7 +24,7 @@ working directory: fixtures/cli/tsgolint_type_error
   help: Consider removing this declaration.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 108 rules using 1 threads.
+Finished in <variable>ms on 2 files with 109 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check.json@oxlint.snap
@@ -30,7 +30,7 @@ working directory: fixtures/cli/tsgolint_type_error
    `----
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 2 files with 108 rules using 1 threads.
+Finished in <variable>ms on 2 files with 109 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json test.js
 working directory: fixtures/cli/two_rules_with_same_rule_name
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 68 rules using 1 threads.
+Finished in <variable>ms on 1 file with 69 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__lsp__ts_path_alias_--import-plugin -D import__no-cycle deep__src__dep-a.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__lsp__ts_path_alias_--import-plugin -D import__no-cycle deep__src__dep-a.ts@oxlint.snap
@@ -21,7 +21,7 @@ working directory: fixtures/lsp/ts_path_alias
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 58 rules using 1 threads.
+Finished in <variable>ms on 1 file with 59 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/test/fixtures/basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic/output.snap.md
@@ -17,7 +17,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
@@ -264,7 +264,7 @@
   help: Remove the debugger statement
 
 Found 20 warnings and 20 errors.
-Finished in Xms on 20 files with 58 rules using X threads.
+Finished in Xms on 20 files with 59 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_basic/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_basic_cli_arg/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_basic_cli_arg/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_define_config/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_define_config/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_extends_multiple/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_multiple/output.snap.md
@@ -12,7 +12,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 93 rules using X threads.
+Finished in Xms on 1 file with 94 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_extends_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_rules/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_overrides/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_overrides/output.snap.md
@@ -12,7 +12,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 2 files with 92 rules using X threads.
+Finished in Xms on 2 files with 93 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/report_legacy_positional_args/output.snap.md
+++ b/apps/oxlint/test/fixtures/report_legacy_positional_args/output.snap.md
@@ -17,7 +17,7 @@
    `----
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_config_ignored/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_config_ignored/output.snap.md
@@ -12,7 +12,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in Xms on 1 file with 93 rules using X threads.
+Finished in Xms on 1 file with 94 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_basic/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_fn_export/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_fn_export/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in Xms on 1 file with 93 rules using X threads.
+Finished in Xms on 1 file with 94 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_no_lint_field/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_no_lint_field/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in Xms on 1 file with 93 rules using X threads.
+Finished in Xms on 1 file with 94 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_priority/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_priority/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 2 warnings and 0 errors.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -84,7 +84,7 @@ declare_oxc_lint!(
     /// ```
     GetterReturn,
     eslint,
-    nursery,
+    correctness,
     config = GetterReturn,
     version = "0.0.3",
 );


### PR DESCRIPTION
This rule has been in in nursey for a significant amount of time, it should now be stable enough to promote to correctness.

