### PR TITLE
fix(codegen): add mapping before printing `#` for private ident

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2879,8 +2879,8 @@ impl Gen for AccessorProperty<'_> {
 
 impl Gen for PrivateIdentifier<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
-        p.print_ascii_byte(b'#');
         p.add_source_mapping_for_name(self.span, &self.name);
+        p.print_ascii_byte(b'#');
 
         if let Some(mangled) = p.private_member_mappings.as_ref().and_then(|mappings| {
             p.current_class_ids()


### PR DESCRIPTION
Before:



![Screenshot 2026-04-21 at 19.39.46.png](https://app.graphite.com/user-attachments/assets/4ddfd06d-f6d7-4cba-84cd-76aac4af9f94.png)

After:



![Screenshot 2026-04-21 at 19.40.39.png](https://app.graphite.com/user-attachments/assets/b5fbcdf4-68ec-49d1-b686-63d4fb8a23e2.png)



