### PR TITLE
refactor(allocator): rename vars in `Arena`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc.rs
+++ b/crates/oxc_allocator/src/arena/alloc.rs
@@ -97,10 +97,10 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         let layout = Layout::new::<T>();
 
         unsafe {
-            let p = self.alloc_layout(layout);
-            let p = p.as_ptr().cast::<T>();
-            inner_writer(p, f);
-            &mut *p
+            let ptr = self.alloc_layout(layout);
+            let ptr = ptr.as_ptr().cast::<T>();
+            inner_writer(ptr, f);
+            &mut *ptr
         }
     }
 
@@ -147,14 +147,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             unsafe { ptr::write(ptr, f()) };
         }
 
-        // Self-contained: `p` is allocated for `T` and then a `T` is written.
+        // Self-contained: `ptr` is allocated for `T` and then a `T` is written.
         let layout = Layout::new::<T>();
-        let p = self.try_alloc_layout(layout)?;
-        let p = p.as_ptr().cast::<T>();
+        let ptr = self.try_alloc_layout(layout)?;
+        let ptr = ptr.as_ptr().cast::<T>();
 
         unsafe {
-            inner_writer(p, f);
-            Ok(&mut *p)
+            inner_writer(ptr, f);
+            Ok(&mut *ptr)
         }
     }
 
@@ -180,11 +180,11 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         T: Copy,
     {
         let layout = Layout::for_value(src);
-        let dst = self.alloc_layout(layout).cast::<T>();
+        let dst_ptr = self.alloc_layout(layout).cast::<T>();
 
         unsafe {
-            ptr::copy_nonoverlapping(src.as_ptr(), dst.as_ptr(), src.len());
-            slice::from_raw_parts_mut(dst.as_ptr(), src.len())
+            ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr.as_ptr(), src.len());
+            slice::from_raw_parts_mut(dst_ptr.as_ptr(), src.len())
         }
     }
 
@@ -222,14 +222,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         T: Clone,
     {
         let layout = Layout::for_value(src);
-        let dst = self.alloc_layout(layout).cast::<T>();
+        let dst_ptr = self.alloc_layout(layout).cast::<T>();
 
         unsafe {
             for (i, val) in src.iter().cloned().enumerate() {
-                ptr::write(dst.as_ptr().add(i), val);
+                ptr::write(dst_ptr.as_ptr().add(i), val);
             }
 
-            slice::from_raw_parts_mut(dst.as_ptr(), src.len())
+            slice::from_raw_parts_mut(dst_ptr.as_ptr(), src.len())
         }
     }
 
@@ -283,14 +283,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         F: FnMut(usize) -> T,
     {
         let layout = Layout::array::<T>(len).unwrap_or_else(|_| oom());
-        let dst = self.alloc_layout(layout).cast::<T>();
+        let dst_ptr = self.alloc_layout(layout).cast::<T>();
 
         unsafe {
             for i in 0..len {
-                ptr::write(dst.as_ptr().add(i), f(i));
+                ptr::write(dst_ptr.as_ptr().add(i), f(i));
             }
 
-            let result = slice::from_raw_parts_mut(dst.as_ptr(), len);
+            let result = slice::from_raw_parts_mut(dst_ptr.as_ptr(), len);
             debug_assert_eq!(Layout::for_value(result), layout);
             result
         }

--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -54,8 +54,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Errors if reserving space matching `layout` fails.
     #[inline(always)]
     pub fn try_alloc_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        let res = if let Some(p) = self.try_alloc_layout_fast(layout) {
-            Ok(p)
+        let res = if let Some(ptr) = self.try_alloc_layout_fast(layout) {
+            Ok(ptr)
         } else {
             self.try_alloc_layout_slow(layout).ok_or(AllocErr)
         };
@@ -334,8 +334,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             }
 
             // Get a new chunk from the global allocator
-            let current_footer = self.current_chunk_footer.get();
-            let current_layout = current_footer.as_ref().layout;
+            let current_footer_ptr = self.current_chunk_footer.get();
+            let current_layout = current_footer_ptr.as_ref().layout;
 
             // By default, we want our new chunk to be about twice as big as the previous chunk.
             // If the global allocator refuses it, we try to divide it by half until it works
@@ -353,11 +353,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 }
             });
 
-            let new_footer = chunk_memory_details.find_map(|new_chunk_memory_details| {
-                Self::new_chunk(new_chunk_memory_details, layout, current_footer)
+            let new_footer_ptr = chunk_memory_details.find_map(|new_chunk_memory_details| {
+                Self::new_chunk(new_chunk_memory_details, layout, current_footer_ptr)
             })?;
 
-            debug_assert_eq!(new_footer.as_ref().start_ptr.as_ptr() as usize % layout.align(), 0);
+            debug_assert_eq!(
+                new_footer_ptr.as_ref().start_ptr.as_ptr() as usize % layout.align(),
+                0
+            );
 
             // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
             // can read its final cursor position later.
@@ -367,16 +370,16 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // to the empty chunk's footer, which is the existing value of empty chunk footer's `cursor_ptr` anyway.
             // But nonetheless, the empty chunk footer is a `static`, accessible from all threads simultaneously.
             // Updating it from 2 threads simultaneously would be a data race (UB), even though both writes are no-ops.
-            if !current_footer.as_ref().is_empty() {
-                current_footer.as_ref().cursor_ptr.set(self.cursor_ptr.get());
+            if !current_footer_ptr.as_ref().is_empty() {
+                current_footer_ptr.as_ref().cursor_ptr.set(self.cursor_ptr.get());
             }
 
             // Set the new chunk as our new current chunk, and sync `start_ptr` and `cursor_ptr` accordingly.
             // Initial cursor sits at the footer (end of the allocatable region).
             // The footer is aligned on `CHUNK_ALIGN >= MIN_ALIGN`, so no rounding is needed.
-            self.start_ptr.set(new_footer.as_ref().start_ptr);
-            self.cursor_ptr.set(new_footer.cast::<u8>());
-            self.current_chunk_footer.set(new_footer);
+            self.start_ptr.set(new_footer_ptr.as_ref().start_ptr);
+            self.cursor_ptr.set(new_footer_ptr.cast::<u8>());
+            self.current_chunk_footer.set(new_footer_ptr);
 
             // And then we can rely on `try_alloc_layout_fast` to allocate space within this chunk
             let ptr = self.try_alloc_layout_fast(layout);
@@ -519,10 +522,10 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         if align_is_compatible && unsafe { self.is_last_allocation(ptr) } {
             // Try to allocate the delta size within this same block so we can reuse the currently allocated space
             let delta = new_size - old_size;
-            if let Some(p) =
+            if let Some(new_ptr) =
                 self.try_alloc_layout_fast(layout_from_size_align(delta, old_layout.align())?)
             {
-                unsafe { ptr::copy(ptr.as_ptr(), p.as_ptr(), old_size) };
+                unsafe { ptr::copy(ptr.as_ptr(), new_ptr.as_ptr(), old_size) };
 
                 #[cfg(all(
                     feature = "track_allocations",
@@ -530,7 +533,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 ))]
                 self.stats.record_reallocation();
 
-                return Ok(p);
+                return Ok(new_ptr);
             }
         }
 

--- a/crates/oxc_allocator/src/arena/bumpalo_alloc.rs
+++ b/crates/oxc_allocator/src/arena/bumpalo_alloc.rs
@@ -364,11 +364,11 @@ pub unsafe trait Alloc {
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         let size = layout.size();
-        let p = unsafe { self.alloc(layout) };
-        if let Ok(p) = p {
-            unsafe { ptr::write_bytes(p.as_ptr(), 0, size) };
+        let res = unsafe { self.alloc(layout) };
+        if let Ok(ptr) = res {
+            unsafe { ptr::write_bytes(ptr.as_ptr(), 0, size) };
         }
-        p
+        res
     }
 
     /// Behaves like `alloc`, but also returns the whole size of the returned block. For some `layout` inputs,
@@ -389,7 +389,7 @@ pub unsafe trait Alloc {
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     unsafe fn alloc_excess(&mut self, layout: Layout) -> Result<Excess, AllocErr> {
         let usable_size = self.usable_size(&layout);
-        unsafe { self.alloc(layout) }.map(|p| Excess(p, usable_size.1))
+        unsafe { self.alloc(layout) }.map(|ptr| Excess(ptr, usable_size.1))
     }
 
     /// Behaves like `realloc`, but also returns the whole size of the returned block. For some `layout`
@@ -416,7 +416,7 @@ pub unsafe trait Alloc {
     ) -> Result<Excess, AllocErr> {
         let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, layout.align()) };
         let usable_size = self.usable_size(&new_layout);
-        unsafe { self.realloc(ptr, layout, new_size) }.map(|p| Excess(p, usable_size.1))
+        unsafe { self.realloc(ptr, layout, new_size) }.map(|ptr| Excess(ptr, usable_size.1))
     }
 
     /// Attempts to extend the allocation referenced by `ptr` to fit `new_size`.

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -125,7 +125,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// [`iter_allocated_chunks()`](Arena::iter_allocated_chunks) still apply.
     pub unsafe fn iter_allocated_chunks_raw(&self) -> ChunkRawIter<'_, MIN_ALIGN> {
         ChunkRawIter {
-            footer: self.current_chunk_footer.get(),
+            footer_ptr: self.current_chunk_footer.get(),
             // Authoritative cursor for the current chunk lives on `Arena`, not on the chunk's footer.
             // The iterator consumes this value on its first step, then reads cursors from each
             // retired chunk's footer.
@@ -210,7 +210,7 @@ impl<const MIN_ALIGN: usize> FusedIterator for ChunkIter<'_, MIN_ALIGN> {}
 /// [`iter_allocated_chunks_raw`]: Arena::iter_allocated_chunks_raw
 #[derive(Debug)]
 pub struct ChunkRawIter<'a, const MIN_ALIGN: usize = 1> {
-    footer: NonNull<ChunkFooter>,
+    footer_ptr: NonNull<ChunkFooter>,
     /// Cursor for the current chunk, taken from `Arena::cursor_ptr` at iterator creation.
     /// Consumed on the first iteration. Subsequent iterations read the cursor from each retired chunk's footer.
     current_chunk_cursor_ptr: Option<NonNull<u8>>,
@@ -222,25 +222,25 @@ impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
 
     fn next(&mut self) -> Option<(*mut u8, usize)> {
         unsafe {
-            let foot = self.footer.as_ref();
-            if foot.is_empty() {
+            let footer = self.footer_ptr.as_ref();
+            if footer.is_empty() {
                 return None;
             }
 
-            let start_ptr = foot.start_ptr.as_ptr();
+            let start_ptr = footer.start_ptr.as_ptr();
             let cursor_ptr = self
                 .current_chunk_cursor_ptr
                 .take()
-                .unwrap_or_else(|| foot.cursor_ptr.get())
+                .unwrap_or_else(|| footer.cursor_ptr.get())
                 .as_ptr();
-            let end_ptr = ptr::from_ref(foot).cast::<u8>();
+            let end_ptr = ptr::from_ref(footer).cast::<u8>();
 
             debug_assert!(start_ptr <= cursor_ptr);
             debug_assert!(cursor_ptr.cast_const() <= end_ptr);
 
             // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`
             let len = end_ptr.offset_from_unsigned(cursor_ptr.cast_const());
-            self.footer = foot.previous_chunk_footer_ptr.get();
+            self.footer_ptr = footer.previous_chunk_footer_ptr.get();
 
             Some((cursor_ptr, len))
         }

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -251,7 +251,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         let layout = layout_from_size_align(capacity, MIN_ALIGN)?;
 
-        let chunk_footer = unsafe {
+        let chunk_footer_ptr = unsafe {
             Self::new_chunk(
                 // `new_size_without_footer` here was `None` in original `bumpalo` code.
                 // Changed to `Some(capacity)` when we increased `FIRST_ALLOCATION_GOAL` to 16 KiB,
@@ -263,7 +263,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             .ok_or(AllocErr)?
         };
 
-        Ok(Self::new_impl(chunk_footer))
+        Ok(Self::new_impl(chunk_footer_ptr))
     }
 
     /// Create a new `Arena` from a chunk footer pointer.
@@ -341,7 +341,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     pub(super) unsafe fn new_chunk(
         new_chunk_memory_details: NewChunkMemoryDetails,
         requested_layout: Layout,
-        prev: NonNull<ChunkFooter>,
+        previous_chunk_footer_ptr: NonNull<ChunkFooter>,
     ) -> Option<NonNull<ChunkFooter>> {
         unsafe {
             let NewChunkMemoryDetails { new_size_without_footer, align, size } =
@@ -374,7 +374,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 ChunkFooter {
                     start_ptr,
                     layout,
-                    previous_chunk_footer_ptr: Cell::new(prev),
+                    previous_chunk_footer_ptr: Cell::new(previous_chunk_footer_ptr),
                     cursor_ptr: Cell::new(cursor_ptr),
                 },
             );

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -50,21 +50,21 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 return;
             }
 
-            let cur_chunk = self.current_chunk_footer.get();
+            let current_footer_ptr = self.current_chunk_footer.get();
 
             // Deallocate all chunks except the current one
-            let prev_chunk =
-                cur_chunk.as_ref().previous_chunk_footer_ptr.replace(EMPTY_CHUNK.get());
-            dealloc_chunk_list(prev_chunk);
+            let prev_footer_ptr =
+                current_footer_ptr.as_ref().previous_chunk_footer_ptr.replace(EMPTY_CHUNK.get());
+            dealloc_chunk_list(prev_footer_ptr);
 
             // Reset the bump cursor to the end of the chunk.
             // We don't need to reset `cursor_ptr` in `ChunkFooter`, as it'll be set if the chunk is retired later on.
             // `iter_allocated_chunks_raw` ignores `cursor_ptr` of the current chunk.
             debug_assert!(
-                is_pointer_aligned_to(cur_chunk.as_ptr(), MIN_ALIGN),
-                "bump pointer {cur_chunk:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
+                is_pointer_aligned_to(current_footer_ptr.as_ptr(), MIN_ALIGN),
+                "bump pointer {current_footer_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
             );
-            self.cursor_ptr.set(cur_chunk.cast::<u8>());
+            self.cursor_ptr.set(current_footer_ptr.cast::<u8>());
 
             let current_chunk_footer = self.current_chunk_footer.get().as_ref();
             debug_assert!(
@@ -90,12 +90,15 @@ impl<const MIN_ALIGN: usize> Drop for Arena<MIN_ALIGN> {
 }
 
 #[inline]
-unsafe fn dealloc_chunk_list(mut footer: NonNull<ChunkFooter>) {
+unsafe fn dealloc_chunk_list(mut footer_ptr: NonNull<ChunkFooter>) {
     unsafe {
-        while !footer.as_ref().is_empty() {
-            let f = footer;
-            footer = f.as_ref().previous_chunk_footer_ptr.get();
-            alloc::dealloc(f.as_ref().start_ptr.as_ptr(), f.as_ref().layout);
+        while !footer_ptr.as_ref().is_empty() {
+            let current_footer_ptr = footer_ptr;
+            footer_ptr = current_footer_ptr.as_ref().previous_chunk_footer_ptr.get();
+            alloc::dealloc(
+                current_footer_ptr.as_ref().start_ptr.as_ptr(),
+                current_footer_ptr.as_ref().layout,
+            );
         }
     }
 }

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -16,17 +16,17 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     ///
     /// # SAFETY
     ///
-    /// * `ptr` must be aligned on [`CHUNK_ALIGN`].
+    /// * `start_ptr` must be aligned on [`CHUNK_ALIGN`].
     /// * `size` must be a multiple of [`CHUNK_ALIGN`].
     /// * `size` must be at least [`CHUNK_FOOTER_SIZE`].
-    /// * The memory region starting at `ptr` and encompassing `size` bytes must be within a single allocation.
-    /// * The memory region starting at `ptr` and encompassing `size` bytes must have been allocated
+    /// * The memory region starting at `start_ptr` and encompassing `size` bytes must be within a single allocation.
+    /// * The memory region starting at `start_ptr` and encompassing `size` bytes must have been allocated
     ///   from system allocator with alignment of [`CHUNK_ALIGN`] (or caller must wrap the `Arena` in `ManuallyDrop`
     ///   and ensure the backing memory is freed correctly themselves).
-    /// * `ptr` must have permission for writes.
-    pub unsafe fn from_raw_parts(ptr: NonNull<u8>, size: usize) -> Self {
-        // Debug assert that `ptr` and `size` fulfill size and alignment requirements
-        debug_assert!((ptr.as_ptr() as usize).is_multiple_of(CHUNK_ALIGN));
+    /// * `start_ptr` must have permission for writes.
+    pub unsafe fn from_raw_parts(start_ptr: NonNull<u8>, size: usize) -> Self {
+        // Debug assert that `start_ptr` and `size` fulfill size and alignment requirements
+        debug_assert!((start_ptr.as_ptr() as usize).is_multiple_of(CHUNK_ALIGN));
         debug_assert!(size.is_multiple_of(CHUNK_ALIGN));
         debug_assert!(size >= CHUNK_FOOTER_SIZE);
 
@@ -34,14 +34,15 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         // Construct `ChunkFooter` and write into end of allocation.
         // SAFETY: Caller guarantees:
-        // * `ptr` is the start of an allocation of `size` bytes.
+        // * `start_ptr` is the start of an allocation of `size` bytes.
         // * `size` is `>= CHUNK_FOOTER_SIZE` - so `size - CHUNK_FOOTER_SIZE` cannot wrap around.
-        let chunk_footer_ptr = unsafe { ptr.add(size_without_footer) }.cast::<ChunkFooter>();
+        let chunk_footer_ptr = unsafe { start_ptr.add(size_without_footer) }.cast::<ChunkFooter>();
         // SAFETY: Caller guarantees `size` is a multiple of `CHUNK_ALIGN`.
-        // Caller guarantees region from `ptr` to `ptr + size` forms a single allocation, so it must be a valid layout.
+        // Caller guarantees region from `start_ptr` to `start_ptr + size` forms a single allocation,
+        // so it must be a valid layout.
         let layout = unsafe { Layout::from_size_align_unchecked(size, CHUNK_ALIGN) };
         let chunk_footer = ChunkFooter {
-            start_ptr: ptr,
+            start_ptr,
             layout,
             previous_chunk_footer_ptr: Cell::new(EMPTY_CHUNK.get()),
             cursor_ptr: Cell::new(chunk_footer_ptr.cast::<u8>()),
@@ -69,19 +70,19 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     ///
     /// * `Arena` must have at least 1 allocated chunk.
     ///   It is UB to call this method on an `Arena` which has not allocated i.e. fresh from `Arena::new`.
-    /// * `ptr` must point to within the `Arena`'s current chunk.
-    /// * `ptr` must be equal to or after data pointer for this chunk.
-    /// * `ptr` must be equal to or before the chunk's `ChunkFooter`.
-    /// * `ptr` must be aligned to `MIN_ALIGN`.
-    /// * No live references to data in the current chunk before `ptr` can exist.
-    pub unsafe fn set_cursor_ptr(&self, ptr: NonNull<u8>) {
-        debug_assert!(ptr.as_ptr() >= self.start_ptr.get().as_ptr());
-        debug_assert!(ptr.as_ptr() <= self.current_chunk_footer.get().as_ptr().cast::<u8>());
-        debug_assert!(ptr.addr().get().is_multiple_of(MIN_ALIGN));
+    /// * `cursor_ptr` must point to within the `Arena`'s current chunk.
+    /// * `cursor_ptr` must be equal to or after data pointer for this chunk.
+    /// * `cursor_ptr` must be equal to or before the chunk's `ChunkFooter`.
+    /// * `cursor_ptr` must be aligned to `MIN_ALIGN`.
+    /// * No live references to data in the current chunk before `cursor_ptr` can exist.
+    pub unsafe fn set_cursor_ptr(&self, cursor_ptr: NonNull<u8>) {
+        debug_assert!(cursor_ptr.as_ptr() >= self.start_ptr.get().as_ptr());
+        debug_assert!(cursor_ptr.as_ptr() <= self.current_chunk_footer.get().as_ptr().cast::<u8>());
+        debug_assert!(cursor_ptr.addr().get().is_multiple_of(MIN_ALIGN));
 
-        // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `ptr` is valid
+        // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `cursor_ptr` is valid
         #[expect(clippy::unnecessary_safety_comment)]
-        self.cursor_ptr.set(ptr);
+        self.cursor_ptr.set(cursor_ptr);
     }
 
     /// Get pointer to end of the data region of this [`Arena`]'s current chunk

--- a/crates/oxc_allocator/src/arena/utils.rs
+++ b/crates/oxc_allocator/src/arena/utils.rs
@@ -5,12 +5,12 @@ use std::{alloc::Layout, hint::unreachable_unchecked};
 pub use super::bumpalo_alloc::AllocErr;
 
 #[inline]
-pub fn is_pointer_aligned_to<T>(pointer: *mut T, align: usize) -> bool {
+pub fn is_pointer_aligned_to<T>(ptr: *mut T, align: usize) -> bool {
     debug_assert!(align.is_power_of_two());
 
-    let pointer = pointer as usize;
-    let pointer_aligned = round_down_to(pointer, align);
-    pointer == pointer_aligned
+    let addr = ptr as usize;
+    let aligned_addr = round_down_to(addr, align);
+    addr == aligned_addr
 }
 
 #[inline]


### PR DESCRIPTION
Pure refactor. Just rename all vars containing pointers to have a `_ptr` suffix.