### PR TITLE
refactor(allocator): rename `Arena::current_chunk_footer_ptr` field

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -79,9 +79,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             "start pointer {start_ptr:#p} should be less than or equal to bump pointer {cursor_ptr:#p}"
         );
         debug_assert!(
-            cursor_ptr <= self.current_chunk_footer.get().cast::<u8>().as_ptr(),
+            cursor_ptr <= self.current_chunk_footer_ptr.get().cast::<u8>().as_ptr(),
             "bump pointer {cursor_ptr:#p} should be less than or equal to footer pointer {:#p}",
-            self.current_chunk_footer.get()
+            self.current_chunk_footer_ptr.get()
         );
         #[expect(clippy::checked_conversions)]
         {
@@ -334,7 +334,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             }
 
             // Get a new chunk from the global allocator
-            let current_footer_ptr = self.current_chunk_footer.get();
+            let current_footer_ptr = self.current_chunk_footer_ptr.get();
             let current_layout = current_footer_ptr.as_ref().layout;
 
             // By default, we want our new chunk to be about twice as big as the previous chunk.
@@ -379,7 +379,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // The footer is aligned on `CHUNK_ALIGN >= MIN_ALIGN`, so no rounding is needed.
             self.start_ptr.set(new_footer_ptr.as_ref().start_ptr);
             self.cursor_ptr.set(new_footer_ptr.cast::<u8>());
-            self.current_chunk_footer.set(new_footer_ptr);
+            self.current_chunk_footer_ptr.set(new_footer_ptr);
 
             // And then we can rely on `try_alloc_layout_fast` to allocate space within this chunk
             let ptr = self.try_alloc_layout_fast(layout);

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -125,7 +125,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// [`iter_allocated_chunks()`](Arena::iter_allocated_chunks) still apply.
     pub unsafe fn iter_allocated_chunks_raw(&self) -> ChunkRawIter<'_, MIN_ALIGN> {
         ChunkRawIter {
-            footer_ptr: self.current_chunk_footer.get(),
+            footer_ptr: self.current_chunk_footer_ptr.get(),
             // Authoritative cursor for the current chunk lives on `Arena`, not on the chunk's footer.
             // The iterator consumes this value on its first step, then reads cursors from each
             // retired chunk's footer.
@@ -156,7 +156,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// ```
     pub fn allocated_bytes(&self) -> usize {
         let mut total = 0;
-        let mut footer_ptr = self.current_chunk_footer.get();
+        let mut footer_ptr = self.current_chunk_footer_ptr.get();
         // SAFETY: Walk the chunk list until the empty sentinel chunk.
         // Every non-empty chunk is a live allocation whose `layout.size()` includes the footer.
         unsafe {

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -288,7 +288,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         Self {
             cursor_ptr: Cell::new(cursor_ptr),
-            current_chunk_footer: Cell::new(chunk_footer_ptr),
+            current_chunk_footer_ptr: Cell::new(chunk_footer_ptr),
             start_ptr: Cell::new(start_ptr),
             can_grow: true,
             #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -46,11 +46,11 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // Takes `&mut self` so `self` must be unique, and there can't be any borrows active
         // that would get invalidated by resetting
         unsafe {
-            if self.current_chunk_footer.get().as_ref().is_empty() {
+            if self.current_chunk_footer_ptr.get().as_ref().is_empty() {
                 return;
             }
 
-            let current_footer_ptr = self.current_chunk_footer.get();
+            let current_footer_ptr = self.current_chunk_footer_ptr.get();
 
             // Deallocate all chunks except the current one
             let prev_footer_ptr =
@@ -66,14 +66,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             );
             self.cursor_ptr.set(current_footer_ptr.cast::<u8>());
 
-            let current_chunk_footer = self.current_chunk_footer.get().as_ref();
+            let current_chunk_footer = self.current_chunk_footer_ptr.get().as_ref();
             debug_assert!(
                 current_chunk_footer.previous_chunk_footer_ptr.get().as_ref().is_empty(),
                 "We should only have a single chunk"
             );
             debug_assert_eq!(
                 self.cursor_ptr.get(),
-                self.current_chunk_footer.get().cast::<u8>(),
+                self.current_chunk_footer_ptr.get().cast::<u8>(),
                 "Our chunk's bump cursor should be reset to the start of its allocation"
             );
         }
@@ -84,7 +84,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 impl<const MIN_ALIGN: usize> Drop for Arena<MIN_ALIGN> {
     fn drop(&mut self) {
         unsafe {
-            dealloc_chunk_list(self.current_chunk_footer.get());
+            dealloc_chunk_list(self.current_chunk_footer_ptr.get());
         }
     }
 }

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -77,7 +77,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// * No live references to data in the current chunk before `cursor_ptr` can exist.
     pub unsafe fn set_cursor_ptr(&self, cursor_ptr: NonNull<u8>) {
         debug_assert!(cursor_ptr.as_ptr() >= self.start_ptr.get().as_ptr());
-        debug_assert!(cursor_ptr.as_ptr() <= self.current_chunk_footer.get().as_ptr().cast::<u8>());
+        debug_assert!(
+            cursor_ptr.as_ptr() <= self.current_chunk_footer_ptr.get().as_ptr().cast::<u8>()
+        );
         debug_assert!(cursor_ptr.addr().get().is_multiple_of(MIN_ALIGN));
 
         // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `cursor_ptr` is valid
@@ -88,12 +90,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Get pointer to end of the data region of this [`Arena`]'s current chunk
     /// i.e to the start of the `ChunkFooter`.
     pub fn data_end_ptr(&self) -> NonNull<u8> {
-        self.current_chunk_footer.get().cast::<u8>()
+        self.current_chunk_footer_ptr.get().cast::<u8>()
     }
 
     /// Get pointer to end of this [`Arena`]'s current chunk (after the `ChunkFooter`).
     pub fn end_ptr(&self) -> NonNull<u8> {
-        let chunk_footer_ptr = self.current_chunk_footer.get();
+        let chunk_footer_ptr = self.current_chunk_footer_ptr.get();
 
         // SAFETY: `chunk_footer_ptr` always points to a valid `ChunkFooter`, so stepping past it cannot be
         // out of bounds of the chunk's allocation. If `Arena` has not allocated, `chunk_footer_ptr`

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -166,17 +166,17 @@ mod tests_alloc;
 // If `cursor_ptr` and `start_ptr` were adjacent (offsets 0 and 8), LLVM's aarch64 backend fuses them
 // into a single 16-byte `ldp` instruction. That `ldp` then partial-overlaps the 8-byte `cursor_ptr` store
 // from the previous iteration, which breaks store-to-load forwarding and causes a ~3x slowdown in tight allocation loops.
-// `current_chunk_footer` is placed between the two hot pointers so they sit at offsets 0 and 16,
+// `current_chunk_footer_ptr` is placed between the two hot pointers so they sit at offsets 0 and 16,
 // forcing LLVM to emit two independent 8-byte `ldr`s, each of which forwards cleanly.
 // More background here: https://eme64.github.io/blog/2024/06/24/Auto-Vectorization-and-Store-to-Load-Forwarding.html
 #[repr(C)]
 #[derive(Debug)]
 pub struct Arena<const MIN_ALIGN: usize = 1> {
-    /// Bump allocation cursor. Always in the range `self.start_ptr..=self.current_chunk_footer`.
+    /// Bump allocation cursor. Always in the range `self.start_ptr..=self.current_chunk_footer_ptr`.
     cursor_ptr: Cell<NonNull<u8>>,
 
-    /// The current chunk we are bump allocating within.
-    current_chunk_footer: Cell<NonNull<ChunkFooter>>,
+    /// Pointer to footer of current chunk we are bump allocating within.
+    current_chunk_footer_ptr: Cell<NonNull<ChunkFooter>>,
 
     /// Pointer to the start of the current chunk's allocatable region.
     ///

--- a/crates/oxc_allocator/src/arena/tests_alloc.rs
+++ b/crates/oxc_allocator/src/arena/tests_alloc.rs
@@ -22,7 +22,7 @@ struct TestArena<const MIN_ALIGN: usize = 1> {
 
 impl<const MIN_ALIGN: usize> TestArena<MIN_ALIGN> {
     /// Create a `TestArena` with `cursor_ptr` and `start_ptr` set to the given addresses.
-    /// `current_chunk_footer` is pointed at `cursor` (satisfying `cursor <= footer` debug assert).
+    /// `current_chunk_footer_ptr` is pointed at `cursor` (satisfying `cursor <= footer` debug assert).
     /// The footer pointer is never dereferenced in `try_alloc_layout_fast`.
     fn new(start: usize, cursor: usize) -> Self {
         // Check input is valid
@@ -44,7 +44,7 @@ impl<const MIN_ALIGN: usize> TestArena<MIN_ALIGN> {
         let start_ptr = NonNull::new(start as *mut u8).unwrap();
         let arena = Arena {
             cursor_ptr: Cell::new(cursor_ptr),
-            current_chunk_footer: Cell::new(cursor_ptr.cast::<ChunkFooter>()),
+            current_chunk_footer_ptr: Cell::new(cursor_ptr.cast::<ChunkFooter>()),
             start_ptr: Cell::new(start_ptr),
             can_grow: false,
             #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]


### PR DESCRIPTION
Pure refactor. Rename `current_chunk_footer` field of `Arena` to `current_chunk_footer_ptr`. This matches convention of all other field that fields containing pointers, have `_ptr` on the end of their name.