### PR TITLE
feat(linter/no-underscore-dangle): implement no-underscore-dangle rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1014,6 +1014,11 @@ impl RuleRunner for crate::rules::eslint::no_undefined::NoUndefined {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::no_underscore_dangle::NoUnderscoreDangle {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::no_unexpected_multiline::NoUnexpectedMultiline {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::BinaryExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -130,6 +130,7 @@ pub use crate::rules::eslint::no_throw_literal::NoThrowLiteral as EslintNoThrowL
 pub use crate::rules::eslint::no_unassigned_vars::NoUnassignedVars as EslintNoUnassignedVars;
 pub use crate::rules::eslint::no_undef::NoUndef as EslintNoUndef;
 pub use crate::rules::eslint::no_undefined::NoUndefined as EslintNoUndefined;
+pub use crate::rules::eslint::no_underscore_dangle::NoUnderscoreDangle as EslintNoUnderscoreDangle;
 pub use crate::rules::eslint::no_unexpected_multiline::NoUnexpectedMultiline as EslintNoUnexpectedMultiline;
 pub use crate::rules::eslint::no_unmodified_loop_condition::NoUnmodifiedLoopCondition as EslintNoUnmodifiedLoopCondition;
 pub use crate::rules::eslint::no_unneeded_ternary::NoUnneededTernary as EslintNoUnneededTernary;
@@ -894,6 +895,7 @@ pub enum RuleEnum {
     EslintNoUnassignedVars(EslintNoUnassignedVars),
     EslintNoUndef(EslintNoUndef),
     EslintNoUndefined(EslintNoUndefined),
+    EslintNoUnderscoreDangle(EslintNoUnderscoreDangle),
     EslintNoUnexpectedMultiline(EslintNoUnexpectedMultiline),
     EslintNoUnmodifiedLoopCondition(EslintNoUnmodifiedLoopCondition),
     EslintNoUnneededTernary(EslintNoUnneededTernary),
@@ -1622,7 +1624,8 @@ const ESLINT_NO_THROW_LITERAL_ID: usize = ESLINT_NO_THIS_BEFORE_SUPER_ID + 1usiz
 const ESLINT_NO_UNASSIGNED_VARS_ID: usize = ESLINT_NO_THROW_LITERAL_ID + 1usize;
 const ESLINT_NO_UNDEF_ID: usize = ESLINT_NO_UNASSIGNED_VARS_ID + 1usize;
 const ESLINT_NO_UNDEFINED_ID: usize = ESLINT_NO_UNDEF_ID + 1usize;
-const ESLINT_NO_UNEXPECTED_MULTILINE_ID: usize = ESLINT_NO_UNDEFINED_ID + 1usize;
+const ESLINT_NO_UNDERSCORE_DANGLE_ID: usize = ESLINT_NO_UNDEFINED_ID + 1usize;
+const ESLINT_NO_UNEXPECTED_MULTILINE_ID: usize = ESLINT_NO_UNDERSCORE_DANGLE_ID + 1usize;
 const ESLINT_NO_UNMODIFIED_LOOP_CONDITION_ID: usize = ESLINT_NO_UNEXPECTED_MULTILINE_ID + 1usize;
 const ESLINT_NO_UNNEEDED_TERNARY_ID: usize = ESLINT_NO_UNMODIFIED_LOOP_CONDITION_ID + 1usize;
 const ESLINT_NO_UNREACHABLE_ID: usize = ESLINT_NO_UNNEEDED_TERNARY_ID + 1usize;
@@ -2440,6 +2443,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => ESLINT_NO_UNASSIGNED_VARS_ID,
             Self::EslintNoUndef(_) => ESLINT_NO_UNDEF_ID,
             Self::EslintNoUndefined(_) => ESLINT_NO_UNDEFINED_ID,
+            Self::EslintNoUnderscoreDangle(_) => ESLINT_NO_UNDERSCORE_DANGLE_ID,
             Self::EslintNoUnexpectedMultiline(_) => ESLINT_NO_UNEXPECTED_MULTILINE_ID,
             Self::EslintNoUnmodifiedLoopCondition(_) => ESLINT_NO_UNMODIFIED_LOOP_CONDITION_ID,
             Self::EslintNoUnneededTernary(_) => ESLINT_NO_UNNEEDED_TERNARY_ID,
@@ -3279,6 +3283,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => EslintNoUnassignedVars::NAME,
             Self::EslintNoUndef(_) => EslintNoUndef::NAME,
             Self::EslintNoUndefined(_) => EslintNoUndefined::NAME,
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::NAME,
             Self::EslintNoUnexpectedMultiline(_) => EslintNoUnexpectedMultiline::NAME,
             Self::EslintNoUnmodifiedLoopCondition(_) => EslintNoUnmodifiedLoopCondition::NAME,
             Self::EslintNoUnneededTernary(_) => EslintNoUnneededTernary::NAME,
@@ -4108,6 +4113,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => EslintNoUnassignedVars::CATEGORY,
             Self::EslintNoUndef(_) => EslintNoUndef::CATEGORY,
             Self::EslintNoUndefined(_) => EslintNoUndefined::CATEGORY,
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::CATEGORY,
             Self::EslintNoUnexpectedMultiline(_) => EslintNoUnexpectedMultiline::CATEGORY,
             Self::EslintNoUnmodifiedLoopCondition(_) => EslintNoUnmodifiedLoopCondition::CATEGORY,
             Self::EslintNoUnneededTernary(_) => EslintNoUnneededTernary::CATEGORY,
@@ -4988,6 +4994,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => EslintNoUnassignedVars::FIX,
             Self::EslintNoUndef(_) => EslintNoUndef::FIX,
             Self::EslintNoUndefined(_) => EslintNoUndefined::FIX,
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::FIX,
             Self::EslintNoUnexpectedMultiline(_) => EslintNoUnexpectedMultiline::FIX,
             Self::EslintNoUnmodifiedLoopCondition(_) => EslintNoUnmodifiedLoopCondition::FIX,
             Self::EslintNoUnneededTernary(_) => EslintNoUnneededTernary::FIX,
@@ -5836,6 +5843,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => EslintNoUnassignedVars::documentation(),
             Self::EslintNoUndef(_) => EslintNoUndef::documentation(),
             Self::EslintNoUndefined(_) => EslintNoUndefined::documentation(),
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::documentation(),
             Self::EslintNoUnexpectedMultiline(_) => EslintNoUnexpectedMultiline::documentation(),
             Self::EslintNoUnmodifiedLoopCondition(_) => {
                 EslintNoUnmodifiedLoopCondition::documentation()
@@ -7092,6 +7100,8 @@ impl RuleEnum {
             }
             Self::EslintNoUndefined(_) => EslintNoUndefined::config_schema(generator)
                 .or_else(|| EslintNoUndefined::schema(generator)),
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::config_schema(generator)
+                .or_else(|| EslintNoUnderscoreDangle::schema(generator)),
             Self::EslintNoUnexpectedMultiline(_) => {
                 EslintNoUnexpectedMultiline::config_schema(generator)
                     .or_else(|| EslintNoUnexpectedMultiline::schema(generator))
@@ -8932,6 +8942,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => "eslint",
             Self::EslintNoUndef(_) => "eslint",
             Self::EslintNoUndefined(_) => "eslint",
+            Self::EslintNoUnderscoreDangle(_) => "eslint",
             Self::EslintNoUnexpectedMultiline(_) => "eslint",
             Self::EslintNoUnmodifiedLoopCondition(_) => "eslint",
             Self::EslintNoUnneededTernary(_) => "eslint",
@@ -9966,6 +9977,9 @@ impl RuleEnum {
             Self::EslintNoUndefined(_) => {
                 Ok(Self::EslintNoUndefined(EslintNoUndefined::from_configuration(value)?))
             }
+            Self::EslintNoUnderscoreDangle(_) => Ok(Self::EslintNoUnderscoreDangle(
+                EslintNoUnderscoreDangle::from_configuration(value)?,
+            )),
             Self::EslintNoUnexpectedMultiline(_) => Ok(Self::EslintNoUnexpectedMultiline(
                 EslintNoUnexpectedMultiline::from_configuration(value)?,
             )),
@@ -11991,6 +12005,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(rule) => rule.to_configuration(),
             Self::EslintNoUndef(rule) => rule.to_configuration(),
             Self::EslintNoUndefined(rule) => rule.to_configuration(),
+            Self::EslintNoUnderscoreDangle(rule) => rule.to_configuration(),
             Self::EslintNoUnexpectedMultiline(rule) => rule.to_configuration(),
             Self::EslintNoUnmodifiedLoopCondition(rule) => rule.to_configuration(),
             Self::EslintNoUnneededTernary(rule) => rule.to_configuration(),
@@ -12722,6 +12737,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(rule) => rule.run(node, ctx),
             Self::EslintNoUndef(rule) => rule.run(node, ctx),
             Self::EslintNoUndefined(rule) => rule.run(node, ctx),
+            Self::EslintNoUnderscoreDangle(rule) => rule.run(node, ctx),
             Self::EslintNoUnexpectedMultiline(rule) => rule.run(node, ctx),
             Self::EslintNoUnmodifiedLoopCondition(rule) => rule.run(node, ctx),
             Self::EslintNoUnneededTernary(rule) => rule.run(node, ctx),
@@ -13449,6 +13465,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(rule) => rule.run_once(ctx),
             Self::EslintNoUndef(rule) => rule.run_once(ctx),
             Self::EslintNoUndefined(rule) => rule.run_once(ctx),
+            Self::EslintNoUnderscoreDangle(rule) => rule.run_once(ctx),
             Self::EslintNoUnexpectedMultiline(rule) => rule.run_once(ctx),
             Self::EslintNoUnmodifiedLoopCondition(rule) => rule.run_once(ctx),
             Self::EslintNoUnneededTernary(rule) => rule.run_once(ctx),
@@ -14180,6 +14197,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUndef(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUndefined(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoUnderscoreDangle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUnexpectedMultiline(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUnmodifiedLoopCondition(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoUnneededTernary(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15007,6 +15025,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(rule) => rule.should_run(ctx),
             Self::EslintNoUndef(rule) => rule.should_run(ctx),
             Self::EslintNoUndefined(rule) => rule.should_run(ctx),
+            Self::EslintNoUnderscoreDangle(rule) => rule.should_run(ctx),
             Self::EslintNoUnexpectedMultiline(rule) => rule.should_run(ctx),
             Self::EslintNoUnmodifiedLoopCondition(rule) => rule.should_run(ctx),
             Self::EslintNoUnneededTernary(rule) => rule.should_run(ctx),
@@ -15754,6 +15773,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => EslintNoUnassignedVars::IS_TSGOLINT_RULE,
             Self::EslintNoUndef(_) => EslintNoUndef::IS_TSGOLINT_RULE,
             Self::EslintNoUndefined(_) => EslintNoUndefined::IS_TSGOLINT_RULE,
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::IS_TSGOLINT_RULE,
             Self::EslintNoUnexpectedMultiline(_) => EslintNoUnexpectedMultiline::IS_TSGOLINT_RULE,
             Self::EslintNoUnmodifiedLoopCondition(_) => {
                 EslintNoUnmodifiedLoopCondition::IS_TSGOLINT_RULE
@@ -16783,6 +16803,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => EslintNoUnassignedVars::VERSION,
             Self::EslintNoUndef(_) => EslintNoUndef::VERSION,
             Self::EslintNoUndefined(_) => EslintNoUndefined::VERSION,
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::VERSION,
             Self::EslintNoUnexpectedMultiline(_) => EslintNoUnexpectedMultiline::VERSION,
             Self::EslintNoUnmodifiedLoopCondition(_) => EslintNoUnmodifiedLoopCondition::VERSION,
             Self::EslintNoUnneededTernary(_) => EslintNoUnneededTernary::VERSION,
@@ -17669,6 +17690,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(_) => EslintNoUnassignedVars::HAS_CONFIG,
             Self::EslintNoUndef(_) => EslintNoUndef::HAS_CONFIG,
             Self::EslintNoUndefined(_) => EslintNoUndefined::HAS_CONFIG,
+            Self::EslintNoUnderscoreDangle(_) => EslintNoUnderscoreDangle::HAS_CONFIG,
             Self::EslintNoUnexpectedMultiline(_) => EslintNoUnexpectedMultiline::HAS_CONFIG,
             Self::EslintNoUnmodifiedLoopCondition(_) => EslintNoUnmodifiedLoopCondition::HAS_CONFIG,
             Self::EslintNoUnneededTernary(_) => EslintNoUnneededTernary::HAS_CONFIG,
@@ -18570,6 +18592,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(rule) => rule.types_info(),
             Self::EslintNoUndef(rule) => rule.types_info(),
             Self::EslintNoUndefined(rule) => rule.types_info(),
+            Self::EslintNoUnderscoreDangle(rule) => rule.types_info(),
             Self::EslintNoUnexpectedMultiline(rule) => rule.types_info(),
             Self::EslintNoUnmodifiedLoopCondition(rule) => rule.types_info(),
             Self::EslintNoUnneededTernary(rule) => rule.types_info(),
@@ -19297,6 +19320,7 @@ impl RuleEnum {
             Self::EslintNoUnassignedVars(rule) => rule.run_info(),
             Self::EslintNoUndef(rule) => rule.run_info(),
             Self::EslintNoUndefined(rule) => rule.run_info(),
+            Self::EslintNoUnderscoreDangle(rule) => rule.run_info(),
             Self::EslintNoUnexpectedMultiline(rule) => rule.run_info(),
             Self::EslintNoUnmodifiedLoopCondition(rule) => rule.run_info(),
             Self::EslintNoUnneededTernary(rule) => rule.run_info(),
@@ -20046,6 +20070,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoUnassignedVars(EslintNoUnassignedVars::default()),
         RuleEnum::EslintNoUndef(EslintNoUndef::default()),
         RuleEnum::EslintNoUndefined(EslintNoUndefined::default()),
+        RuleEnum::EslintNoUnderscoreDangle(EslintNoUnderscoreDangle::default()),
         RuleEnum::EslintNoUnexpectedMultiline(EslintNoUnexpectedMultiline::default()),
         RuleEnum::EslintNoUnmodifiedLoopCondition(EslintNoUnmodifiedLoopCondition::default()),
         RuleEnum::EslintNoUnneededTernary(EslintNoUnneededTernary::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -162,6 +162,7 @@ pub(crate) mod eslint {
     pub mod no_unassigned_vars;
     pub mod no_undef;
     pub mod no_undefined;
+    pub mod no_underscore_dangle;
     pub mod no_unexpected_multiline;
     pub mod no_unmodified_loop_condition;
     pub mod no_unneeded_ternary;

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_ast::{
     AstKind,
     ast::{BindingIdentifier, Expression, FunctionType, PropertyKey, StaticMemberExpression},
@@ -6,8 +9,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -16,7 +17,6 @@ use crate::{
 };
 
 fn no_underscore_dangle_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn(format!("Unexpected dangling '_' in '`{name}`'."))
         .with_help(format!("Remove the dangling '_' or add `{name}` to the 'allow' configuration."))
         .with_label(span)
@@ -72,7 +72,6 @@ impl Default for NoUnderscoreDangleConfig {
     }
 }
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///
@@ -109,6 +108,28 @@ declare_oxc_lint!(
     config = NoUnderscoreDangle,
     version = "next",
 );
+
+impl Rule for NoUnderscoreDangle {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::StaticMemberExpression(expr) => self.check_member(ctx, expr),
+            AstKind::BindingIdentifier(ident) => self.check_binding(ctx, node.id(), ident),
+            AstKind::MethodDefinition(_) | AstKind::ObjectProperty(_)
+                if !self.enforce_in_method_names => {}
+            AstKind::PropertyDefinition(_) if !self.enforce_in_class_fields => {}
+            AstKind::Function(func) if func.r#type == FunctionType::FunctionExpression => {}
+            _ => {
+                if let Some((name, span)) = get_identifier(node) {
+                    self.report(ctx, span, name);
+                }
+            }
+        }
+    }
+}
 
 enum BindingContext {
     ArrayDestructure,
@@ -166,28 +187,6 @@ impl NoUnderscoreDangle {
             return;
         }
         self.report(ctx, ident.span, ident.name.as_str());
-    }
-}
-
-impl Rule for NoUnderscoreDangle {
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
-    }
-
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        match node.kind() {
-            AstKind::StaticMemberExpression(expr) => self.check_member(ctx, expr),
-            AstKind::BindingIdentifier(ident) => self.check_binding(ctx, node.id(), ident),
-            AstKind::MethodDefinition(_) | AstKind::ObjectProperty(_)
-                if !self.enforce_in_method_names => {}
-            AstKind::PropertyDefinition(_) if !self.enforce_in_class_fields => {}
-            AstKind::Function(func) if func.r#type == FunctionType::FunctionExpression => {}
-            _ => {
-                if let Some((name, span)) = get_identifier(node) {
-                    self.report(ctx, span, name);
-                }
-            }
-        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -366,6 +366,11 @@ fn test() {
         ("import('foo.json', { _with: { _type: 'json' } })", None), // { "ecmaVersion": 2025 },
         ("import('foo.json', { 'with': { _type: 'json' } })", None), // { "ecmaVersion": 2025 },
         ("import('foo.json', { _with: { _type } })", None),         // { "ecmaVersion": 2025 }
+        ("const o = { _foo: 'bar' }", Some(serde_json::json!([{ "enforceInMethodNames": true }]))), // { "ecmaVersion": 6 },
+        (
+            "function foo([_bar]) {}",
+            Some(serde_json::json!([{ "allowInArrayDestructuring": false }])),
+        ), // { "ecmaVersion": 6 },
     ];
 
     let fail = vec![
@@ -487,7 +492,9 @@ fn test() {
         ("class foo { _field; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
         ("class foo { #_field; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
         ("class foo { field_; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
-        ("class foo { #field_; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 }
+        ("class foo { #field_; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
+        ("var __filename = 1;", None),
+        ("class Foo { #_x; foo() { this.#_x; } }", None),
     ];
 
     Tester::new(NoUnderscoreDangle::NAME, NoUnderscoreDangle::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use oxc_ast::{
     AstKind,
-    ast::{BindingIdentifier, Expression, FunctionType, PropertyKey, StaticMemberExpression},
+    ast::{
+        BindingIdentifier, Expression, FunctionType, PrivateFieldExpression, PropertyKey,
+        StaticMemberExpression,
+    },
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -117,6 +120,7 @@ impl Rule for NoUnderscoreDangle {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::StaticMemberExpression(expr) => self.check_member(ctx, expr),
+            AstKind::PrivateFieldExpression(expr) => self.check_private_member(ctx, expr),
             AstKind::BindingIdentifier(ident) => self.check_binding(ctx, node.id(), ident),
             AstKind::MethodDefinition(_) | AstKind::ObjectProperty(_)
                 if !self.enforce_in_method_names => {}
@@ -162,6 +166,13 @@ impl NoUnderscoreDangle {
         self.report(ctx, prop.span, prop.name.as_str());
     }
 
+    fn check_private_member(&self, ctx: &LintContext, expr: &PrivateFieldExpression) {
+        if self.member_object_is_allowed(&expr.object) {
+            return;
+        }
+        self.report(ctx, expr.field.span, expr.field.name.as_str());
+    }
+
     fn member_object_is_allowed(&self, object: &Expression) -> bool {
         match object.get_inner_expression() {
             Expression::ThisExpression(_) => self.allow_after_this,
@@ -191,6 +202,7 @@ impl NoUnderscoreDangle {
 }
 
 fn binding_context(ctx: &LintContext, id: NodeId) -> BindingContext {
+    let mut destructure_context = None;
     for ancestor in ctx.nodes().ancestors(id) {
         match ancestor.kind() {
             // skip transparent wrappers
@@ -199,10 +211,22 @@ fn binding_context(ctx: &LintContext, id: NodeId) -> BindingContext {
             | AstKind::BindingRestElement(_)
             | AstKind::FormalParameter(_)
             | AstKind::FormalParameterRest(_) => {}
-            AstKind::ArrayPattern(_) => return BindingContext::ArrayDestructure,
-            AstKind::ObjectPattern(_) => return BindingContext::ObjectDestructure,
-            AstKind::FormalParameters(_) => return BindingContext::FunctionParam,
-            AstKind::VariableDeclarator(_) => return BindingContext::Plain,
+            AstKind::ArrayPattern(_) => {
+                destructure_context.get_or_insert(BindingContext::ArrayDestructure);
+            }
+            AstKind::ObjectPattern(_) => {
+                destructure_context.get_or_insert(BindingContext::ObjectDestructure);
+            }
+            AstKind::FormalParameters(_) => {
+                return if destructure_context.is_some() {
+                    BindingContext::NotInteresting
+                } else {
+                    BindingContext::FunctionParam
+                };
+            }
+            AstKind::VariableDeclarator(_) => {
+                return destructure_context.unwrap_or(BindingContext::Plain);
+            }
             _ => return BindingContext::NotInteresting,
         }
     }
@@ -214,7 +238,7 @@ fn get_identifier<'a>(node: &AstNode<'a>) -> Option<(&'a str, Span)> {
         AstKind::Function(f) => f.id.as_ref().map(|id| (id.name.as_str(), id.span)),
         AstKind::MethodDefinition(m) => property_key_name_span(&m.key),
         AstKind::PropertyDefinition(p) => property_key_name_span(&p.key),
-        AstKind::ObjectProperty(o) => property_key_name_span(&o.key),
+        AstKind::ObjectProperty(o) if o.method => property_key_name_span(&o.key),
         _ => None,
     }
 }
@@ -227,16 +251,12 @@ fn is_underscore_only(name: &str) -> bool {
     name == "_"
 }
 
-fn is_path_globals(name: &str) -> bool {
-    name == "__dirname" || name == "__filename"
-}
-
 fn is_prototype_accessor(name: &str) -> bool {
     name == "__proto__"
 }
 
 fn is_always_allowed(name: &str) -> bool {
-    !has_dangling_underscore(name) || is_underscore_only(name) || is_path_globals(name)
+    !has_dangling_underscore(name) || is_underscore_only(name)
 }
 
 fn property_key_name_span<'a>(key: &PropertyKey<'a>) -> Option<(&'a str, Span)> {

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -1,0 +1,496 @@
+use oxc_ast::{
+    AstKind,
+    ast::{BindingIdentifier, Expression, FunctionType, PropertyKey, StaticMemberExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::NodeId;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn no_underscore_dangle_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn(format!("Unexpected dangling '_' in '`{name}`'."))
+        .with_help(format!("Remove the dangling '_' or add `{name}` to the 'allow' configuration."))
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoUnderscoreDangleConfig {
+    // Whether to allow dangling underscores in members of the `super` object.
+    allow_after_super: bool,
+    // Whether to allow dangling underscores in members of the `this.constructor` object.
+    allow_after_this_constructor: bool,
+    // An array of variable names that are allowed to have dangling underscores.
+    allow: Vec<String>,
+    // Whether to allow dangling underscores in members of the `this` object.
+    allow_after_this: bool,
+    // Whether to allow dangling underscores in variable names assigned by array destructuring.
+    allow_in_array_destructuring: bool,
+    // Whether to allow dangling underscores in variable names assigned by object destructuring.
+    allow_in_object_destructuring: bool,
+    // Whether to allow dangling underscores in function parameter names.
+    allow_function_params: bool,
+    // Whether to enforce dangling underscores in class field names.
+    enforce_in_class_fields: bool,
+    // Whether to enforce dangling underscores in method names.
+    enforce_in_method_names: bool,
+}
+
+impl std::ops::Deref for NoUnderscoreDangle {
+    type Target = NoUnderscoreDangleConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct NoUnderscoreDangle(Box<NoUnderscoreDangleConfig>);
+
+impl Default for NoUnderscoreDangleConfig {
+    fn default() -> Self {
+        Self {
+            allow_after_super: false,
+            allow_after_this_constructor: false,
+            allow: Vec::new(),
+            allow_after_this: false,
+            allow_in_array_destructuring: true,
+            allow_in_object_destructuring: true,
+            allow_function_params: true,
+            enforce_in_class_fields: false,
+            enforce_in_method_names: false,
+        }
+    }
+}
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows dangling underscores in identifiers.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// There is a long history of using `_` as a prefix or suffix for private members in JavaScript.
+    /// It is however recommended to use the formal private class feature introduced in ES2022.
+    /// See  <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements> for more information.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// let foo_;
+    /// const __proto__ = {};
+    /// foo._bar();
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const _ = require('underscore');
+    /// const obj = _.contains(items, item);
+    /// obj.__proto__ = {};
+    /// const file = __filename;
+    /// function foo(_bar) {};
+    /// const bar = { onClick(_bar) {} };
+    /// const baz = (_bar) => {};
+    /// ```
+    NoUnderscoreDangle,
+    eslint,
+    suspicious,
+    config = NoUnderscoreDangle,
+    version = "next",
+);
+
+enum BindingContext {
+    ArrayDestructure,
+    ObjectDestructure,
+    FunctionParam,
+    Plain,
+    NotInteresting,
+}
+
+impl NoUnderscoreDangle {
+    fn is_allowed(&self, name: &str) -> bool {
+        is_always_allowed(name) || self.allow.contains(&name.to_string())
+    }
+
+    fn report(&self, ctx: &LintContext, span: Span, name: &str) {
+        if self.is_allowed(name) {
+            return;
+        }
+        ctx.diagnostic(no_underscore_dangle_diagnostic(span, name));
+    }
+
+    fn check_member(&self, ctx: &LintContext, expr: &StaticMemberExpression) {
+        let prop = &expr.property;
+        if is_prototype_accessor(prop.name.as_str()) {
+            return;
+        }
+        if self.member_object_is_allowed(&expr.object) {
+            return;
+        }
+        self.report(ctx, prop.span, prop.name.as_str());
+    }
+
+    fn member_object_is_allowed(&self, object: &Expression) -> bool {
+        match object.get_inner_expression() {
+            Expression::ThisExpression(_) => self.allow_after_this,
+            Expression::Super(_) => self.allow_after_super,
+            Expression::StaticMemberExpression(inner) => {
+                self.allow_after_this_constructor
+                    && inner.property.name == "constructor"
+                    && matches!(inner.object, Expression::ThisExpression(_))
+            }
+            _ => false,
+        }
+    }
+
+    fn check_binding(&self, ctx: &LintContext, id: NodeId, ident: &BindingIdentifier) {
+        let allowed = match binding_context(ctx, id) {
+            BindingContext::ArrayDestructure => self.allow_in_array_destructuring,
+            BindingContext::ObjectDestructure => self.allow_in_object_destructuring,
+            BindingContext::FunctionParam => self.allow_function_params,
+            BindingContext::Plain => false,
+            BindingContext::NotInteresting => return,
+        };
+        if allowed {
+            return;
+        }
+        self.report(ctx, ident.span, ident.name.as_str());
+    }
+}
+
+impl Rule for NoUnderscoreDangle {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::StaticMemberExpression(expr) => self.check_member(ctx, expr),
+            AstKind::BindingIdentifier(ident) => self.check_binding(ctx, node.id(), ident),
+            AstKind::MethodDefinition(_) | AstKind::ObjectProperty(_)
+                if !self.enforce_in_method_names => {}
+            AstKind::PropertyDefinition(_) if !self.enforce_in_class_fields => {}
+            AstKind::Function(func) if func.r#type == FunctionType::FunctionExpression => {}
+            _ => {
+                if let Some((name, span)) = get_identifier(node) {
+                    self.report(ctx, span, name);
+                }
+            }
+        }
+    }
+}
+
+fn binding_context(ctx: &LintContext, id: NodeId) -> BindingContext {
+    for ancestor in ctx.nodes().ancestors(id) {
+        match ancestor.kind() {
+            // skip transparent wrappers
+            AstKind::AssignmentPattern(_)
+            | AstKind::BindingProperty(_)
+            | AstKind::BindingRestElement(_)
+            | AstKind::FormalParameter(_)
+            | AstKind::FormalParameterRest(_) => {}
+            AstKind::ArrayPattern(_) => return BindingContext::ArrayDestructure,
+            AstKind::ObjectPattern(_) => return BindingContext::ObjectDestructure,
+            AstKind::FormalParameters(_) => return BindingContext::FunctionParam,
+            AstKind::VariableDeclarator(_) => return BindingContext::Plain,
+            _ => return BindingContext::NotInteresting,
+        }
+    }
+    BindingContext::NotInteresting
+}
+
+fn get_identifier<'a>(node: &AstNode<'a>) -> Option<(&'a str, Span)> {
+    match node.kind() {
+        AstKind::Function(f) => f.id.as_ref().map(|id| (id.name.as_str(), id.span)),
+        AstKind::MethodDefinition(m) => property_key_name_span(&m.key),
+        AstKind::PropertyDefinition(p) => property_key_name_span(&p.key),
+        AstKind::ObjectProperty(o) => property_key_name_span(&o.key),
+        _ => None,
+    }
+}
+
+fn has_dangling_underscore(name: &str) -> bool {
+    name.starts_with('_') || name.starts_with("#_") || name.ends_with('_')
+}
+
+fn is_underscore_only(name: &str) -> bool {
+    name == "_"
+}
+
+fn is_path_globals(name: &str) -> bool {
+    name == "__dirname" || name == "__filename"
+}
+
+fn is_prototype_accessor(name: &str) -> bool {
+    name == "__proto__"
+}
+
+fn is_always_allowed(name: &str) -> bool {
+    !has_dangling_underscore(name) || is_underscore_only(name) || is_path_globals(name)
+}
+
+fn property_key_name_span<'a>(key: &PropertyKey<'a>) -> Option<(&'a str, Span)> {
+    match key {
+        PropertyKey::StaticIdentifier(i) => Some((i.name.as_str(), i.span)),
+        PropertyKey::PrivateIdentifier(i) => Some((i.name.as_str(), i.span)),
+        _ => None,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var foo_bar = 1;", None),
+        ("function foo_bar() {}", None),
+        ("foo.bar.__proto__;", None),
+        ("console.log(__filename); console.log(__dirname);", None),
+        ("var _ = require('underscore');", None),
+        ("var a = b._;", None),
+        ("function foo(_bar) {}", None),
+        ("function foo(bar_) {}", None),
+        ("(function _foo() {})", None),
+        ("function foo(_bar) {}", Some(serde_json::json!([{}]))),
+        ("function foo( _bar = 0) {}", None), // { "ecmaVersion": 6 },
+        ("const foo = { onClick(_bar) { } }", None), // { "ecmaVersion": 6 },
+        ("const foo = { onClick(_bar = 0) { } }", None), // { "ecmaVersion": 6 },
+        ("const foo = (_bar) => {}", None),   // { "ecmaVersion": 6 },
+        ("const foo = (_bar = 0) => {}", None), // { "ecmaVersion": 6 },
+        ("function foo( ..._bar) {}", None),  // { "ecmaVersion": 6 },
+        ("const foo = (..._bar) => {}", None), // { "ecmaVersion": 6 },
+        ("const foo = { onClick(..._bar) { } }", None), // { "ecmaVersion": 6 },
+        ("export default function() {}", None), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("var _foo = 1", Some(serde_json::json!([{ "allow": ["_foo"] }]))),
+        ("var __proto__ = 1;", Some(serde_json::json!([{ "allow": ["__proto__"] }]))),
+        ("foo._bar;", Some(serde_json::json!([{ "allow": ["_bar"] }]))),
+        ("function _foo() {}", Some(serde_json::json!([{ "allow": ["_foo"] }]))),
+        ("this._bar;", Some(serde_json::json!([{ "allowAfterThis": true }]))),
+        (
+            "class foo { constructor() { super._bar; } }",
+            Some(serde_json::json!([{ "allowAfterSuper": true }])),
+        ), // { "ecmaVersion": 6 },
+        ("class foo { _onClick() { } }", None), // { "ecmaVersion": 6 },
+        ("class foo { onClick_() { } }", None), // { "ecmaVersion": 6 },
+        ("const o = { _onClick() { } }", None), // { "ecmaVersion": 6 },
+        ("const o = { onClick_() { } }", None), // { "ecmaVersion": 6 },
+        (
+            "const o = { _onClick() { } }",
+            Some(serde_json::json!([{ "allow": ["_onClick"], "enforceInMethodNames": true }])),
+        ), // { "ecmaVersion": 6 },
+        ("const o = { _foo: 'bar' }", None),    // { "ecmaVersion": 6 },
+        ("const o = { foo_: 'bar' }", None),    // { "ecmaVersion": 6 },
+        ("this.constructor._bar", Some(serde_json::json!([{ "allowAfterThisConstructor": true }]))),
+        ("const foo = { onClick(bar) { } }", None), // { "ecmaVersion": 6 },
+        ("const foo = (bar) => {}", None),          // { "ecmaVersion": 6 },
+        ("function foo(_bar) {}", Some(serde_json::json!([{ "allowFunctionParams": true }]))),
+        ("function foo( _bar = 0) {}", Some(serde_json::json!([{ "allowFunctionParams": true }]))), // { "ecmaVersion": 6 },
+        (
+            "const foo = { onClick(_bar) { } }",
+            Some(serde_json::json!([{ "allowFunctionParams": true }])),
+        ), // { "ecmaVersion": 6 },
+        ("const foo = (_bar) => {}", Some(serde_json::json!([{ "allowFunctionParams": true }]))), // { "ecmaVersion": 6 },
+        ("function foo(bar) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 6 },
+        (
+            "const foo = { onClick(bar) { } }",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        ("const foo = (bar) => {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 6 },
+        (
+            "function foo(_bar) {}",
+            Some(serde_json::json!([{ "allowFunctionParams": false, "allow": ["_bar"] }])),
+        ),
+        (
+            "const foo = { onClick(_bar) { } }",
+            Some(serde_json::json!([{ "allowFunctionParams": false, "allow": ["_bar"] }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const foo = (_bar) => {}",
+            Some(serde_json::json!([{ "allowFunctionParams": false, "allow": ["_bar"] }])),
+        ), // { "ecmaVersion": 6 },
+        ("function foo([_bar]) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 6 },
+        (
+            "function foo([_bar] = []) {}",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        ("function foo( { _bar }) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 6 },
+        (
+            "function foo( { _bar = 0 } = {}) {}",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        ("function foo(...[_bar]) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 2016 },
+        ("const [_foo] = arr", None), // { "ecmaVersion": 6 },
+        ("const [_foo] = arr", Some(serde_json::json!([{}]))), // { "ecmaVersion": 6 },
+        ("const [_foo] = arr", Some(serde_json::json!([{ "allowInArrayDestructuring": true }]))), // { "ecmaVersion": 6 },
+        (
+            "const [foo, ...rest] = [1, 2, 3]",
+            Some(serde_json::json!([{ "allowInArrayDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const [foo, _bar] = [1, 2, 3]",
+            Some(serde_json::json!([{ "allowInArrayDestructuring": false, "allow": ["_bar"] }])),
+        ), // { "ecmaVersion": 2022 },
+        ("const { _foo } = obj", None), // { "ecmaVersion": 6 },
+        ("const { _foo } = obj", Some(serde_json::json!([{}]))), // { "ecmaVersion": 6 },
+        ("const { _foo } = obj", Some(serde_json::json!([{ "allowInObjectDestructuring": true }]))), // { "ecmaVersion": 6 },
+        (
+            "const { foo, bar: _bar } = { foo: 1, bar: 2 }",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false, "allow": ["_bar"] }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { foo, _bar } = { foo: 1, _bar: 2 }",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false, "allow": ["_bar"] }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { foo, _bar: bar } = { foo: 1, _bar: 2 }",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        ("class foo { _field; }", None), // { "ecmaVersion": 2022 },
+        ("class foo { _field; }", Some(serde_json::json!([{ "enforceInClassFields": false }]))), // { "ecmaVersion": 2022 },
+        ("class foo { #_field; }", None), // { "ecmaVersion": 2022 },
+        ("class foo { #_field; }", Some(serde_json::json!([{ "enforceInClassFields": false }]))), // { "ecmaVersion": 2022 },
+        ("class foo { _field; }", Some(serde_json::json!([{}]))), // { "ecmaVersion": 2022 },
+        ("import foo from 'foo.json' with { _type: 'json' }", None), // { "ecmaVersion": 2025 },
+        ("export * from 'foo.json' with { _type: 'json' }", None), // { "ecmaVersion": 2025 },
+        ("export { default } from 'foo.json' with { _type: 'json' }", None), // { "ecmaVersion": 2025 },
+        ("import('foo.json', { _with: { _type: 'json' } })", None), // { "ecmaVersion": 2025 },
+        ("import('foo.json', { 'with': { _type: 'json' } })", None), // { "ecmaVersion": 2025 },
+        ("import('foo.json', { _with: { _type } })", None),         // { "ecmaVersion": 2025 }
+    ];
+
+    let fail = vec![
+        ("var _foo = 1", None),
+        ("var foo_ = 1", None),
+        ("function _foo() {}", None),
+        ("function foo_() {}", None),
+        ("var __proto__ = 1;", None),
+        ("foo._bar;", None),
+        ("this._prop;", None),
+        ("class foo { constructor() { super._prop; } }", None), // { "ecmaVersion": 6 },
+        (
+            "class foo { constructor() { this._prop; } }",
+            Some(serde_json::json!([{ "allowAfterSuper": true }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "class foo { _onClick() { } }",
+            Some(serde_json::json!([{ "enforceInMethodNames": true }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "class foo { onClick_() { } }",
+            Some(serde_json::json!([{ "enforceInMethodNames": true }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const o = { _onClick() { } }",
+            Some(serde_json::json!([{ "enforceInMethodNames": true }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const o = { onClick_() { } }",
+            Some(serde_json::json!([{ "enforceInMethodNames": true }])),
+        ), // { "ecmaVersion": 6 },
+        ("this.constructor._bar", None),
+        ("function foo(_bar) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))),
+        ("(function foo(_bar) {})", Some(serde_json::json!([{ "allowFunctionParams": false }]))),
+        ("function foo(bar, _foo) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))),
+        (
+            "const foo = { onClick(_bar) { } }",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        ("const foo = (_bar) => {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 6 },
+        ("function foo(_bar = 0) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 6 },
+        (
+            "const foo = { onClick(_bar = 0) { } }",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const foo = (_bar = 0) => {}",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        ("function foo(..._bar) {}", Some(serde_json::json!([{ "allowFunctionParams": false }]))), // { "ecmaVersion": 6 },
+        (
+            "const foo = { onClick(..._bar) { } }",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const foo = (..._bar) => {}",
+            Some(serde_json::json!([{ "allowFunctionParams": false }])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "const [foo, _bar] = [1, 2]",
+            Some(serde_json::json!([{ "allowInArrayDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const [_foo = 1] = arr",
+            Some(serde_json::json!([{ "allowInArrayDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const [foo, ..._rest] = [1, 2, 3]",
+            Some(serde_json::json!([{ "allowInArrayDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const [foo, [bar_, baz]] = [1, [2, 3]]",
+            Some(serde_json::json!([{ "allowInArrayDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { _foo, bar } = { _foo: 1, bar: 2 }",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { _foo = 1 } = obj",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { bar: _foo = 1 } = obj",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { foo: _foo, bar } = { foo: 1, bar: 2 }",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { foo, ..._rest} = { foo: 1, bar: 2, baz: 3 }",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { foo: [_bar, { a: _a, b } ] } = { foo: [1, { a: 'a', b: 'b' }] }",
+            Some(
+                serde_json::json!([ { "allowInArrayDestructuring": false, "allowInObjectDestructuring": false, }, ]),
+            ),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { foo: [_bar, { a: _a, b } ] } = { foo: [1, { a: 'a', b: 'b' }] }",
+            Some(
+                serde_json::json!([ { "allowInArrayDestructuring": true, "allowInObjectDestructuring": false, }, ]),
+            ),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const [{ foo: [_bar, _, { bar: _baz }] }] = [{ foo: [1, 2, { bar: 'a' }] }]",
+            Some(
+                serde_json::json!([ { "allowInArrayDestructuring": false, "allowInObjectDestructuring": false, }, ]),
+            ),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "const { foo, bar: { baz, _qux } } = { foo: 1, bar: { baz: 3, _qux: 4 } }",
+            Some(serde_json::json!([{ "allowInObjectDestructuring": false }])),
+        ), // { "ecmaVersion": 2022 },
+        ("class foo { #_bar() {} }", Some(serde_json::json!([{ "enforceInMethodNames": true }]))), // { "ecmaVersion": 2022 },
+        ("class foo { #bar_() {} }", Some(serde_json::json!([{ "enforceInMethodNames": true }]))), // { "ecmaVersion": 2022 },
+        ("class foo { _field; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
+        ("class foo { #_field; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
+        ("class foo { field_; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
+        ("class foo { #field_; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 }
+    ];
+
+    Tester::new(NoUnderscoreDangle::NAME, NoUnderscoreDangle::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/eslint_no_underscore_dangle.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_underscore_dangle.snap
@@ -1,0 +1,325 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:5]
+ 1 │ var _foo = 1
+   ·     ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`foo_`'.
+   ╭─[no_underscore_dangle.tsx:1:5]
+ 1 │ var foo_ = 1
+   ·     ────
+   ╰────
+  help: Remove the dangling '_' or add `foo_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:10]
+ 1 │ function _foo() {}
+   ·          ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`foo_`'.
+   ╭─[no_underscore_dangle.tsx:1:10]
+ 1 │ function foo_() {}
+   ·          ────
+   ╰────
+  help: Remove the dangling '_' or add `foo_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`__proto__`'.
+   ╭─[no_underscore_dangle.tsx:1:5]
+ 1 │ var __proto__ = 1;
+   ·     ─────────
+   ╰────
+  help: Remove the dangling '_' or add `__proto__` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:5]
+ 1 │ foo._bar;
+   ·     ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_prop`'.
+   ╭─[no_underscore_dangle.tsx:1:6]
+ 1 │ this._prop;
+   ·      ─────
+   ╰────
+  help: Remove the dangling '_' or add `_prop` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_prop`'.
+   ╭─[no_underscore_dangle.tsx:1:35]
+ 1 │ class foo { constructor() { super._prop; } }
+   ·                                   ─────
+   ╰────
+  help: Remove the dangling '_' or add `_prop` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_prop`'.
+   ╭─[no_underscore_dangle.tsx:1:34]
+ 1 │ class foo { constructor() { this._prop; } }
+   ·                                  ─────
+   ╰────
+  help: Remove the dangling '_' or add `_prop` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_onClick`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { _onClick() { } }
+   ·             ────────
+   ╰────
+  help: Remove the dangling '_' or add `_onClick` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`onClick_`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { onClick_() { } }
+   ·             ────────
+   ╰────
+  help: Remove the dangling '_' or add `onClick_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_onClick`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ const o = { _onClick() { } }
+   ·             ────────
+   ╰────
+  help: Remove the dangling '_' or add `_onClick` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`onClick_`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ const o = { onClick_() { } }
+   ·             ────────
+   ╰────
+  help: Remove the dangling '_' or add `onClick_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:18]
+ 1 │ this.constructor._bar
+   ·                  ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:14]
+ 1 │ function foo(_bar) {}
+   ·              ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:15]
+ 1 │ (function foo(_bar) {})
+   ·               ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:19]
+ 1 │ function foo(bar, _foo) {}
+   ·                   ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:23]
+ 1 │ const foo = { onClick(_bar) { } }
+   ·                       ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:14]
+ 1 │ const foo = (_bar) => {}
+   ·              ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:14]
+ 1 │ function foo(_bar = 0) {}
+   ·              ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:23]
+ 1 │ const foo = { onClick(_bar = 0) { } }
+   ·                       ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:14]
+ 1 │ const foo = (_bar = 0) => {}
+   ·              ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:17]
+ 1 │ function foo(..._bar) {}
+   ·                 ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:26]
+ 1 │ const foo = { onClick(..._bar) { } }
+   ·                          ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:17]
+ 1 │ const foo = (..._bar) => {}
+   ·                 ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ const [foo, _bar] = [1, 2]
+   ·             ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:8]
+ 1 │ const [_foo = 1] = arr
+   ·        ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_rest`'.
+   ╭─[no_underscore_dangle.tsx:1:16]
+ 1 │ const [foo, ..._rest] = [1, 2, 3]
+   ·                ─────
+   ╰────
+  help: Remove the dangling '_' or add `_rest` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`bar_`'.
+   ╭─[no_underscore_dangle.tsx:1:14]
+ 1 │ const [foo, [bar_, baz]] = [1, [2, 3]]
+   ·              ────
+   ╰────
+  help: Remove the dangling '_' or add `bar_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:9]
+ 1 │ const { _foo, bar } = { _foo: 1, bar: 2 }
+   ·         ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:9]
+ 1 │ const { _foo = 1 } = obj
+   ·         ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:14]
+ 1 │ const { bar: _foo = 1 } = obj
+   ·              ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_foo`'.
+   ╭─[no_underscore_dangle.tsx:1:14]
+ 1 │ const { foo: _foo, bar } = { foo: 1, bar: 2 }
+   ·              ────
+   ╰────
+  help: Remove the dangling '_' or add `_foo` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_rest`'.
+   ╭─[no_underscore_dangle.tsx:1:17]
+ 1 │ const { foo, ..._rest} = { foo: 1, bar: 2, baz: 3 }
+   ·                 ─────
+   ╰────
+  help: Remove the dangling '_' or add `_rest` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:15]
+ 1 │ const { foo: [_bar, { a: _a, b } ] } = { foo: [1, { a: 'a', b: 'b' }] }
+   ·               ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_a`'.
+   ╭─[no_underscore_dangle.tsx:1:26]
+ 1 │ const { foo: [_bar, { a: _a, b } ] } = { foo: [1, { a: 'a', b: 'b' }] }
+   ·                          ──
+   ╰────
+  help: Remove the dangling '_' or add `_a` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_a`'.
+   ╭─[no_underscore_dangle.tsx:1:26]
+ 1 │ const { foo: [_bar, { a: _a, b } ] } = { foo: [1, { a: 'a', b: 'b' }] }
+   ·                          ──
+   ╰────
+  help: Remove the dangling '_' or add `_a` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:16]
+ 1 │ const [{ foo: [_bar, _, { bar: _baz }] }] = [{ foo: [1, 2, { bar: 'a' }] }]
+   ·                ────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_baz`'.
+   ╭─[no_underscore_dangle.tsx:1:32]
+ 1 │ const [{ foo: [_bar, _, { bar: _baz }] }] = [{ foo: [1, 2, { bar: 'a' }] }]
+   ·                                ────
+   ╰────
+  help: Remove the dangling '_' or add `_baz` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_qux`'.
+   ╭─[no_underscore_dangle.tsx:1:26]
+ 1 │ const { foo, bar: { baz, _qux } } = { foo: 1, bar: { baz: 3, _qux: 4 } }
+   ·                          ────
+   ╰────
+  help: Remove the dangling '_' or add `_qux` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_bar`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { #_bar() {} }
+   ·             ─────
+   ╰────
+  help: Remove the dangling '_' or add `_bar` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`bar_`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { #bar_() {} }
+   ·             ─────
+   ╰────
+  help: Remove the dangling '_' or add `bar_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_field`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { _field; }
+   ·             ──────
+   ╰────
+  help: Remove the dangling '_' or add `_field` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_field`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { #_field; }
+   ·             ───────
+   ╰────
+  help: Remove the dangling '_' or add `_field` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`field_`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { field_; }
+   ·             ──────
+   ╰────
+  help: Remove the dangling '_' or add `field_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`field_`'.
+   ╭─[no_underscore_dangle.tsx:1:13]
+ 1 │ class foo { #field_; }
+   ·             ───────
+   ╰────
+  help: Remove the dangling '_' or add `field_` to the 'allow' configuration.

--- a/crates/oxc_linter/src/snapshots/eslint_no_underscore_dangle.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_underscore_dangle.snap
@@ -323,3 +323,17 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────
    ╰────
   help: Remove the dangling '_' or add `field_` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`__filename`'.
+   ╭─[no_underscore_dangle.tsx:1:5]
+ 1 │ var __filename = 1;
+   ·     ──────────
+   ╰────
+  help: Remove the dangling '_' or add `__filename` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_x`'.
+   ╭─[no_underscore_dangle.tsx:1:31]
+ 1 │ class Foo { #_x; foo() { this.#_x; } }
+   ·                               ───
+   ╰────
+  help: Remove the dangling '_' or add `_x` to the 'allow' configuration.


### PR DESCRIPTION
This PR adds eslint's  `no-underscore-dangle` rule. (#479)

AI disclosure: AI was used to help me familiarize myself with the language and for some code refinement. I have re-read and tried to understand suggestions to the best of my ability before applying.

As a first time contributor and Rust noob, I look forward to any guidance that will help move this PR forward.