### PR TITLE
fix(oxfmt/lsp): format non `file://` URIs without a authority

### DIFF
--- a/apps/oxfmt/src/lsp/mod.rs
+++ b/apps/oxfmt/src/lsp/mod.rs
@@ -44,7 +44,17 @@ pub fn create_fake_file_path_from_language_id(
     uri: &Uri,
 ) -> Option<PathBuf> {
     let file_extension = get_file_extension_from_language_id(language_id)?;
-    let file_name = format!("{}.{}", uri.authority()?, file_extension);
+    // Use the authority (if available) or the last segment of the path as the file name, defaulting to "Untitled" if neither is available
+    let mut name = uri.authority().map_or_else(
+        || uri.path().rsplit_once('/').map_or_else(|| "Untitled", |(_, s)| s.as_str()),
+        |s| s.as_str(),
+    );
+    // if the last character is `/`, the name will be empty, so we need to check for that as well
+    if name.is_empty() {
+        name = "Untitled";
+    }
+
+    let file_name = format!("{name}.{file_extension}");
     Some(root.join(file_name))
 }
 
@@ -67,4 +77,30 @@ pub async fn run_lsp(js_config_loader: JsConfigLoaderCb, external_formatter: Ext
         )),
     )
     .await;
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use oxc_language_server::LanguageId;
+    use tower_lsp_server::ls_types::Uri;
+
+    use crate::lsp::create_fake_file_path_from_language_id;
+
+    #[test]
+    fn test_create_fake_file_path_from_language_id() {
+        let language_id = LanguageId::new("jsonc".to_string());
+        let root = std::env::temp_dir();
+
+        let uri = Uri::from_str("vscode-userdata:/c%3A/Users/User/settings.json").unwrap();
+        let result = create_fake_file_path_from_language_id(&language_id, &root, &uri).unwrap();
+        assert!(result.extension().unwrap() == "jsonc");
+        assert!(result.starts_with(&root));
+
+        let uri = Uri::from_str("Untitled://Untitled-1").unwrap();
+        let result = create_fake_file_path_from_language_id(&language_id, &root, &uri).unwrap();
+        assert!(result.extension().unwrap() == "jsonc");
+        assert!(result.starts_with(&root));
+    }
 }

--- a/apps/oxfmt/test/lsp/format/__snapshots__/format.test.ts.snap
+++ b/apps/oxfmt/test/lsp/format/__snapshots__/format.test.ts.snap
@@ -313,21 +313,21 @@ const   x   =   1
 --------------------"
 `;
 
-exports[`LSP formatting > in-memory document > should format ccsettings file format/formatted.ts 1`] = `
+exports[`LSP formatting > in-memory document > should format uri untitled://Untitled-1 1`] = `
 "--- URI -----------
-ccsettings://typescript
+untitled://Untitled-1
 --- BEFORE ---------
-const x = 1;
+const   App:   React.FC   =   ()   =>   <div>Hello</div>
 
 --- AFTER ----------
-const x = 1;
+const App: React.FC = () => <div>Hello</div>;
 
 --------------------"
 `;
 
-exports[`LSP formatting > in-memory document > should format ccsettings file format/test.json 1`] = `
+exports[`LSP formatting > in-memory document > should format uri untitled://Untitled-2 1`] = `
 "--- URI -----------
-ccsettings://json
+untitled://Untitled-2
 --- BEFORE ---------
 {"name":"test","version":"1.0.0"}
 
@@ -337,9 +337,23 @@ ccsettings://json
 --------------------"
 `;
 
-exports[`LSP formatting > in-memory document > should format ccsettings file format/test.toml 1`] = `
+exports[`LSP formatting > in-memory document > should format uri untitled://Untitled-3 1`] = `
 "--- URI -----------
-ccsettings://toml
+untitled://Untitled-3
+--- BEFORE ---------
+<script>const   x   =   1;</script>
+
+--- AFTER ----------
+<script>
+const x = 1;
+</script>
+
+--------------------"
+`;
+
+exports[`LSP formatting > in-memory document > should format uri untitled://Untitled-4 1`] = `
+"--- URI -----------
+untitled://Untitled-4
 --- BEFORE ---------
 [package]
 name="test"
@@ -353,196 +367,38 @@ version = "1.0.0"
 --------------------"
 `;
 
-exports[`LSP formatting > in-memory document > should format ccsettings file format/test.tsx 1`] = `
+exports[`LSP formatting > in-memory document > should format uri untitled://Untitled-5 1`] = `
 "--- URI -----------
-ccsettings://typescriptreact
+untitled://Untitled-5
+--- BEFORE ---------
+const x = 1;
+
+--- AFTER ----------
+const x = 1;
+
+--------------------"
+`;
+
+exports[`LSP formatting > in-memory document > should format uri untitled://Untitled-6 1`] = `
+"--- URI -----------
+untitled://Untitled-6
+--- BEFORE ---------
+hello   world
+
+--- AFTER ----------
+hello   world
+
+--------------------"
+`;
+
+exports[`LSP formatting > in-memory document > should format uri vscode-userdata:/c%3A/Users/User/settings.json 1`] = `
+"--- URI -----------
+vscode-userdata:/c%3A/Users/User/settings.json
 --- BEFORE ---------
 const   App:   React.FC   =   ()   =>   <div>Hello</div>
 
 --- AFTER ----------
 const App: React.FC = () => <div>Hello</div>;
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format ccsettings file format/test.txt 1`] = `
-"--- URI -----------
-ccsettings://plaintext
---- BEFORE ---------
-hello   world
-
---- AFTER ----------
-hello   world
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format ccsettings file format/test.vue 1`] = `
-"--- URI -----------
-ccsettings://vue
---- BEFORE ---------
-<script>const   x   =   1;</script>
-
---- AFTER ----------
-<script>
-const x = 1;
-</script>
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format untitled file format/formatted.ts 1`] = `
-"--- URI -----------
-untitled://Untitled-typescript
---- BEFORE ---------
-const x = 1;
-
---- AFTER ----------
-const x = 1;
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format untitled file format/test.json 1`] = `
-"--- URI -----------
-untitled://Untitled-json
---- BEFORE ---------
-{"name":"test","version":"1.0.0"}
-
---- AFTER ----------
-{ "name": "test", "version": "1.0.0" }
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format untitled file format/test.toml 1`] = `
-"--- URI -----------
-untitled://Untitled-toml
---- BEFORE ---------
-[package]
-name="test"
-version="1.0.0"
-
---- AFTER ----------
-[package]
-name = "test"
-version = "1.0.0"
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format untitled file format/test.tsx 1`] = `
-"--- URI -----------
-untitled://Untitled-typescriptreact
---- BEFORE ---------
-const   App:   React.FC   =   ()   =>   <div>Hello</div>
-
---- AFTER ----------
-const App: React.FC = () => <div>Hello</div>;
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format untitled file format/test.txt 1`] = `
-"--- URI -----------
-untitled://Untitled-plaintext
---- BEFORE ---------
-hello   world
-
---- AFTER ----------
-hello   world
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format untitled file format/test.vue 1`] = `
-"--- URI -----------
-untitled://Untitled-vue
---- BEFORE ---------
-<script>const   x   =   1;</script>
-
---- AFTER ----------
-<script>
-const x = 1;
-</script>
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format vscode-userdata file format/formatted.ts 1`] = `
-"--- URI -----------
-vscode-userdata://typescript
---- BEFORE ---------
-const x = 1;
-
---- AFTER ----------
-const x = 1;
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format vscode-userdata file format/test.json 1`] = `
-"--- URI -----------
-vscode-userdata://json
---- BEFORE ---------
-{"name":"test","version":"1.0.0"}
-
---- AFTER ----------
-{ "name": "test", "version": "1.0.0" }
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format vscode-userdata file format/test.toml 1`] = `
-"--- URI -----------
-vscode-userdata://toml
---- BEFORE ---------
-[package]
-name="test"
-version="1.0.0"
-
---- AFTER ----------
-[package]
-name = "test"
-version = "1.0.0"
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format vscode-userdata file format/test.tsx 1`] = `
-"--- URI -----------
-vscode-userdata://typescriptreact
---- BEFORE ---------
-const   App:   React.FC   =   ()   =>   <div>Hello</div>
-
---- AFTER ----------
-const App: React.FC = () => <div>Hello</div>;
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format vscode-userdata file format/test.txt 1`] = `
-"--- URI -----------
-vscode-userdata://plaintext
---- BEFORE ---------
-hello   world
-
---- AFTER ----------
-hello   world
-
---------------------"
-`;
-
-exports[`LSP formatting > in-memory document > should format vscode-userdata file format/test.vue 1`] = `
-"--- URI -----------
-vscode-userdata://vue
---- BEFORE ---------
-<script>const   x   =   1;</script>
-
---- AFTER ----------
-<script>
-const x = 1;
-</script>
 
 --------------------"
 `;

--- a/apps/oxfmt/test/lsp/format/format.test.ts
+++ b/apps/oxfmt/test/lsp/format/format.test.ts
@@ -81,52 +81,17 @@ describe("LSP formatting", () => {
 
   describe("in-memory document", () => {
     it.each([
-      ["format/test.tsx", "typescriptreact"],
-      ["format/test.json", "json"],
-      ["format/test.vue", "vue"],
-      ["format/test.toml", "toml"],
-      ["format/formatted.ts", "typescript"],
-      ["format/test.txt", "plaintext"],
-    ])("should format untitled file %s", async (path, languageId) => {
-      expect(
-        await formatFixtureContent(
-          FIXTURES_DIR,
-          path,
-          "untitled://Untitled-" + languageId,
-          languageId,
-        ),
-      ).toMatchSnapshot();
-    });
-
-    it.each([
-      ["format/test.tsx", "typescriptreact"],
-      ["format/test.json", "json"],
-      ["format/test.vue", "vue"],
-      ["format/test.toml", "toml"],
-      ["format/formatted.ts", "typescript"],
-      ["format/test.txt", "plaintext"],
-    ])("should format vscode-userdata file %s", async (path, languageId) => {
-      expect(
-        await formatFixtureContent(
-          FIXTURES_DIR,
-          path,
-          "vscode-userdata://" + languageId,
-          languageId,
-        ),
-      ).toMatchSnapshot();
-    });
-
-    it.each([
-      ["format/test.tsx", "typescriptreact"],
-      ["format/test.json", "json"],
-      ["format/test.vue", "vue"],
-      ["format/test.toml", "toml"],
-      ["format/formatted.ts", "typescript"],
-      ["format/test.txt", "plaintext"],
-    ])("should format ccsettings file %s", async (path, languageId) => {
-      expect(
-        await formatFixtureContent(FIXTURES_DIR, path, "ccsettings://" + languageId, languageId),
-      ).toMatchSnapshot();
+      // basic (authority)
+      ["untitled://Untitled-1", "format/test.tsx", "typescriptreact"],
+      ["untitled://Untitled-2", "format/test.json", "json"],
+      ["untitled://Untitled-3", "format/test.vue", "vue"],
+      ["untitled://Untitled-4", "format/test.toml", "toml"],
+      ["untitled://Untitled-5", "format/formatted.ts", "typescript"],
+      ["untitled://Untitled-6", "format/test.txt", "plaintext"],
+      // with path
+      ["vscode-userdata:/c%3A/Users/User/settings.json", "format/test.tsx", "typescriptreact"],
+    ])("should format uri %s", async (uri, path, languageId) => {
+      expect(await formatFixtureContent(FIXTURES_DIR, path, uri, languageId)).toMatchSnapshot();
     });
   });
 


### PR DESCRIPTION
> ## Pull request overview

> This PR updates oxfmt’s LSP in-memory formatting to handle URIs that don’t have an authority component (i.e., non-`file://` URIs like `vscode-userdata:/...`) by deriving a “fake” file path from the URI’s authority *or* path, and updates the LSP formatting tests/snapshots accordingly.
