### PR TITLE
feat(ast): generate node_id accessors for AST enum wrappers

### DIFF
--- a/crates/oxc_ast/src/generated/get_id.rs
+++ b/crates/oxc_ast/src/generated/get_id.rs
@@ -1,6 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/get_id.rs`.
 
+#![expect(clippy::inline_always)]
+#![expect(clippy::match_same_arms)]
 use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
 use crate::ast::*;
@@ -3452,5 +3454,937 @@ impl JSDocUnknownType {
     #[inline]
     pub fn set_node_id(&self, node_id: NodeId) {
         self.node_id.set(node_id);
+    }
+}
+
+impl Expression<'_> {
+    /// Get [`NodeId`] of [`Expression`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NullLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::RegExpLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::Identifier(it) => it.node_id(),
+            Self::MetaProperty(it) => it.node_id(),
+            Self::Super(it) => it.node_id(),
+            Self::ArrayExpression(it) => it.node_id(),
+            Self::ArrowFunctionExpression(it) => it.node_id(),
+            Self::AssignmentExpression(it) => it.node_id(),
+            Self::AwaitExpression(it) => it.node_id(),
+            Self::BinaryExpression(it) => it.node_id(),
+            Self::CallExpression(it) => it.node_id(),
+            Self::ChainExpression(it) => it.node_id(),
+            Self::ClassExpression(it) => it.node_id(),
+            Self::ConditionalExpression(it) => it.node_id(),
+            Self::FunctionExpression(it) => it.node_id(),
+            Self::ImportExpression(it) => it.node_id(),
+            Self::LogicalExpression(it) => it.node_id(),
+            Self::NewExpression(it) => it.node_id(),
+            Self::ObjectExpression(it) => it.node_id(),
+            Self::ParenthesizedExpression(it) => it.node_id(),
+            Self::SequenceExpression(it) => it.node_id(),
+            Self::TaggedTemplateExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+            Self::UpdateExpression(it) => it.node_id(),
+            Self::YieldExpression(it) => it.node_id(),
+            Self::PrivateInExpression(it) => it.node_id(),
+            Self::JSXElement(it) => it.node_id(),
+            Self::JSXFragment(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSInstantiationExpression(it) => it.node_id(),
+            Self::V8IntrinsicExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl ArrayExpressionElement<'_> {
+    /// Get [`NodeId`] of [`ArrayExpressionElement`].
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::SpreadElement(it) => it.node_id(),
+            Self::Elision(it) => it.node_id(),
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NullLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::RegExpLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::Identifier(it) => it.node_id(),
+            Self::MetaProperty(it) => it.node_id(),
+            Self::Super(it) => it.node_id(),
+            Self::ArrayExpression(it) => it.node_id(),
+            Self::ArrowFunctionExpression(it) => it.node_id(),
+            Self::AssignmentExpression(it) => it.node_id(),
+            Self::AwaitExpression(it) => it.node_id(),
+            Self::BinaryExpression(it) => it.node_id(),
+            Self::CallExpression(it) => it.node_id(),
+            Self::ChainExpression(it) => it.node_id(),
+            Self::ClassExpression(it) => it.node_id(),
+            Self::ConditionalExpression(it) => it.node_id(),
+            Self::FunctionExpression(it) => it.node_id(),
+            Self::ImportExpression(it) => it.node_id(),
+            Self::LogicalExpression(it) => it.node_id(),
+            Self::NewExpression(it) => it.node_id(),
+            Self::ObjectExpression(it) => it.node_id(),
+            Self::ParenthesizedExpression(it) => it.node_id(),
+            Self::SequenceExpression(it) => it.node_id(),
+            Self::TaggedTemplateExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+            Self::UpdateExpression(it) => it.node_id(),
+            Self::YieldExpression(it) => it.node_id(),
+            Self::PrivateInExpression(it) => it.node_id(),
+            Self::JSXElement(it) => it.node_id(),
+            Self::JSXFragment(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSInstantiationExpression(it) => it.node_id(),
+            Self::V8IntrinsicExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl ObjectPropertyKind<'_> {
+    /// Get [`NodeId`] of [`ObjectPropertyKind`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::ObjectProperty(it) => it.node_id(),
+            Self::SpreadProperty(it) => it.node_id(),
+        }
+    }
+}
+
+impl PropertyKey<'_> {
+    /// Get [`NodeId`] of [`PropertyKey`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::StaticIdentifier(it) => it.node_id(),
+            Self::PrivateIdentifier(it) => it.node_id(),
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NullLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::RegExpLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::Identifier(it) => it.node_id(),
+            Self::MetaProperty(it) => it.node_id(),
+            Self::Super(it) => it.node_id(),
+            Self::ArrayExpression(it) => it.node_id(),
+            Self::ArrowFunctionExpression(it) => it.node_id(),
+            Self::AssignmentExpression(it) => it.node_id(),
+            Self::AwaitExpression(it) => it.node_id(),
+            Self::BinaryExpression(it) => it.node_id(),
+            Self::CallExpression(it) => it.node_id(),
+            Self::ChainExpression(it) => it.node_id(),
+            Self::ClassExpression(it) => it.node_id(),
+            Self::ConditionalExpression(it) => it.node_id(),
+            Self::FunctionExpression(it) => it.node_id(),
+            Self::ImportExpression(it) => it.node_id(),
+            Self::LogicalExpression(it) => it.node_id(),
+            Self::NewExpression(it) => it.node_id(),
+            Self::ObjectExpression(it) => it.node_id(),
+            Self::ParenthesizedExpression(it) => it.node_id(),
+            Self::SequenceExpression(it) => it.node_id(),
+            Self::TaggedTemplateExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+            Self::UpdateExpression(it) => it.node_id(),
+            Self::YieldExpression(it) => it.node_id(),
+            Self::PrivateInExpression(it) => it.node_id(),
+            Self::JSXElement(it) => it.node_id(),
+            Self::JSXFragment(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSInstantiationExpression(it) => it.node_id(),
+            Self::V8IntrinsicExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl MemberExpression<'_> {
+    /// Get [`NodeId`] of [`MemberExpression`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl Argument<'_> {
+    /// Get [`NodeId`] of [`Argument`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::SpreadElement(it) => it.node_id(),
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NullLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::RegExpLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::Identifier(it) => it.node_id(),
+            Self::MetaProperty(it) => it.node_id(),
+            Self::Super(it) => it.node_id(),
+            Self::ArrayExpression(it) => it.node_id(),
+            Self::ArrowFunctionExpression(it) => it.node_id(),
+            Self::AssignmentExpression(it) => it.node_id(),
+            Self::AwaitExpression(it) => it.node_id(),
+            Self::BinaryExpression(it) => it.node_id(),
+            Self::CallExpression(it) => it.node_id(),
+            Self::ChainExpression(it) => it.node_id(),
+            Self::ClassExpression(it) => it.node_id(),
+            Self::ConditionalExpression(it) => it.node_id(),
+            Self::FunctionExpression(it) => it.node_id(),
+            Self::ImportExpression(it) => it.node_id(),
+            Self::LogicalExpression(it) => it.node_id(),
+            Self::NewExpression(it) => it.node_id(),
+            Self::ObjectExpression(it) => it.node_id(),
+            Self::ParenthesizedExpression(it) => it.node_id(),
+            Self::SequenceExpression(it) => it.node_id(),
+            Self::TaggedTemplateExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+            Self::UpdateExpression(it) => it.node_id(),
+            Self::YieldExpression(it) => it.node_id(),
+            Self::PrivateInExpression(it) => it.node_id(),
+            Self::JSXElement(it) => it.node_id(),
+            Self::JSXFragment(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSInstantiationExpression(it) => it.node_id(),
+            Self::V8IntrinsicExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl AssignmentTarget<'_> {
+    /// Get [`NodeId`] of [`AssignmentTarget`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::AssignmentTargetIdentifier(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+            Self::ArrayAssignmentTarget(it) => it.node_id(),
+            Self::ObjectAssignmentTarget(it) => it.node_id(),
+        }
+    }
+}
+
+impl SimpleAssignmentTarget<'_> {
+    /// Get [`NodeId`] of [`SimpleAssignmentTarget`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::AssignmentTargetIdentifier(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl AssignmentTargetPattern<'_> {
+    /// Get [`NodeId`] of [`AssignmentTargetPattern`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::ArrayAssignmentTarget(it) => it.node_id(),
+            Self::ObjectAssignmentTarget(it) => it.node_id(),
+        }
+    }
+}
+
+impl AssignmentTargetMaybeDefault<'_> {
+    /// Get [`NodeId`] of [`AssignmentTargetMaybeDefault`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::AssignmentTargetWithDefault(it) => it.node_id(),
+            Self::AssignmentTargetIdentifier(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+            Self::ArrayAssignmentTarget(it) => it.node_id(),
+            Self::ObjectAssignmentTarget(it) => it.node_id(),
+        }
+    }
+}
+
+impl AssignmentTargetProperty<'_> {
+    /// Get [`NodeId`] of [`AssignmentTargetProperty`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::AssignmentTargetPropertyIdentifier(it) => it.node_id(),
+            Self::AssignmentTargetPropertyProperty(it) => it.node_id(),
+        }
+    }
+}
+
+impl ChainElement<'_> {
+    /// Get [`NodeId`] of [`ChainElement`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::CallExpression(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl Statement<'_> {
+    /// Get [`NodeId`] of [`Statement`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::BlockStatement(it) => it.node_id(),
+            Self::BreakStatement(it) => it.node_id(),
+            Self::ContinueStatement(it) => it.node_id(),
+            Self::DebuggerStatement(it) => it.node_id(),
+            Self::DoWhileStatement(it) => it.node_id(),
+            Self::EmptyStatement(it) => it.node_id(),
+            Self::ExpressionStatement(it) => it.node_id(),
+            Self::ForInStatement(it) => it.node_id(),
+            Self::ForOfStatement(it) => it.node_id(),
+            Self::ForStatement(it) => it.node_id(),
+            Self::IfStatement(it) => it.node_id(),
+            Self::LabeledStatement(it) => it.node_id(),
+            Self::ReturnStatement(it) => it.node_id(),
+            Self::SwitchStatement(it) => it.node_id(),
+            Self::ThrowStatement(it) => it.node_id(),
+            Self::TryStatement(it) => it.node_id(),
+            Self::WhileStatement(it) => it.node_id(),
+            Self::WithStatement(it) => it.node_id(),
+            Self::VariableDeclaration(it) => it.node_id(),
+            Self::FunctionDeclaration(it) => it.node_id(),
+            Self::ClassDeclaration(it) => it.node_id(),
+            Self::TSTypeAliasDeclaration(it) => it.node_id(),
+            Self::TSInterfaceDeclaration(it) => it.node_id(),
+            Self::TSEnumDeclaration(it) => it.node_id(),
+            Self::TSModuleDeclaration(it) => it.node_id(),
+            Self::TSGlobalDeclaration(it) => it.node_id(),
+            Self::TSImportEqualsDeclaration(it) => it.node_id(),
+            Self::ImportDeclaration(it) => it.node_id(),
+            Self::ExportAllDeclaration(it) => it.node_id(),
+            Self::ExportDefaultDeclaration(it) => it.node_id(),
+            Self::ExportNamedDeclaration(it) => it.node_id(),
+            Self::TSExportAssignment(it) => it.node_id(),
+            Self::TSNamespaceExportDeclaration(it) => it.node_id(),
+        }
+    }
+}
+
+impl Declaration<'_> {
+    /// Get [`NodeId`] of [`Declaration`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::VariableDeclaration(it) => it.node_id(),
+            Self::FunctionDeclaration(it) => it.node_id(),
+            Self::ClassDeclaration(it) => it.node_id(),
+            Self::TSTypeAliasDeclaration(it) => it.node_id(),
+            Self::TSInterfaceDeclaration(it) => it.node_id(),
+            Self::TSEnumDeclaration(it) => it.node_id(),
+            Self::TSModuleDeclaration(it) => it.node_id(),
+            Self::TSGlobalDeclaration(it) => it.node_id(),
+            Self::TSImportEqualsDeclaration(it) => it.node_id(),
+        }
+    }
+}
+
+impl ForStatementInit<'_> {
+    /// Get [`NodeId`] of [`ForStatementInit`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::VariableDeclaration(it) => it.node_id(),
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NullLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::RegExpLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::Identifier(it) => it.node_id(),
+            Self::MetaProperty(it) => it.node_id(),
+            Self::Super(it) => it.node_id(),
+            Self::ArrayExpression(it) => it.node_id(),
+            Self::ArrowFunctionExpression(it) => it.node_id(),
+            Self::AssignmentExpression(it) => it.node_id(),
+            Self::AwaitExpression(it) => it.node_id(),
+            Self::BinaryExpression(it) => it.node_id(),
+            Self::CallExpression(it) => it.node_id(),
+            Self::ChainExpression(it) => it.node_id(),
+            Self::ClassExpression(it) => it.node_id(),
+            Self::ConditionalExpression(it) => it.node_id(),
+            Self::FunctionExpression(it) => it.node_id(),
+            Self::ImportExpression(it) => it.node_id(),
+            Self::LogicalExpression(it) => it.node_id(),
+            Self::NewExpression(it) => it.node_id(),
+            Self::ObjectExpression(it) => it.node_id(),
+            Self::ParenthesizedExpression(it) => it.node_id(),
+            Self::SequenceExpression(it) => it.node_id(),
+            Self::TaggedTemplateExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+            Self::UpdateExpression(it) => it.node_id(),
+            Self::YieldExpression(it) => it.node_id(),
+            Self::PrivateInExpression(it) => it.node_id(),
+            Self::JSXElement(it) => it.node_id(),
+            Self::JSXFragment(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSInstantiationExpression(it) => it.node_id(),
+            Self::V8IntrinsicExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl ForStatementLeft<'_> {
+    /// Get [`NodeId`] of [`ForStatementLeft`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::VariableDeclaration(it) => it.node_id(),
+            Self::AssignmentTargetIdentifier(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+            Self::ArrayAssignmentTarget(it) => it.node_id(),
+            Self::ObjectAssignmentTarget(it) => it.node_id(),
+        }
+    }
+}
+
+impl BindingPattern<'_> {
+    /// Get [`NodeId`] of [`BindingPattern`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::BindingIdentifier(it) => it.node_id(),
+            Self::ObjectPattern(it) => it.node_id(),
+            Self::ArrayPattern(it) => it.node_id(),
+            Self::AssignmentPattern(it) => it.node_id(),
+        }
+    }
+}
+
+impl ClassElement<'_> {
+    /// Get [`NodeId`] of [`ClassElement`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::StaticBlock(it) => it.node_id(),
+            Self::MethodDefinition(it) => it.node_id(),
+            Self::PropertyDefinition(it) => it.node_id(),
+            Self::AccessorProperty(it) => it.node_id(),
+            Self::TSIndexSignature(it) => it.node_id(),
+        }
+    }
+}
+
+impl ModuleDeclaration<'_> {
+    /// Get [`NodeId`] of [`ModuleDeclaration`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::ImportDeclaration(it) => it.node_id(),
+            Self::ExportAllDeclaration(it) => it.node_id(),
+            Self::ExportDefaultDeclaration(it) => it.node_id(),
+            Self::ExportNamedDeclaration(it) => it.node_id(),
+            Self::TSExportAssignment(it) => it.node_id(),
+            Self::TSNamespaceExportDeclaration(it) => it.node_id(),
+        }
+    }
+}
+
+impl ImportDeclarationSpecifier<'_> {
+    /// Get [`NodeId`] of [`ImportDeclarationSpecifier`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::ImportSpecifier(it) => it.node_id(),
+            Self::ImportDefaultSpecifier(it) => it.node_id(),
+            Self::ImportNamespaceSpecifier(it) => it.node_id(),
+        }
+    }
+}
+
+impl ImportAttributeKey<'_> {
+    /// Get [`NodeId`] of [`ImportAttributeKey`].
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Identifier(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+        }
+    }
+}
+
+impl ExportDefaultDeclarationKind<'_> {
+    /// Get [`NodeId`] of [`ExportDefaultDeclarationKind`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::FunctionDeclaration(it) => it.node_id(),
+            Self::ClassDeclaration(it) => it.node_id(),
+            Self::TSInterfaceDeclaration(it) => it.node_id(),
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NullLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::RegExpLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::Identifier(it) => it.node_id(),
+            Self::MetaProperty(it) => it.node_id(),
+            Self::Super(it) => it.node_id(),
+            Self::ArrayExpression(it) => it.node_id(),
+            Self::ArrowFunctionExpression(it) => it.node_id(),
+            Self::AssignmentExpression(it) => it.node_id(),
+            Self::AwaitExpression(it) => it.node_id(),
+            Self::BinaryExpression(it) => it.node_id(),
+            Self::CallExpression(it) => it.node_id(),
+            Self::ChainExpression(it) => it.node_id(),
+            Self::ClassExpression(it) => it.node_id(),
+            Self::ConditionalExpression(it) => it.node_id(),
+            Self::FunctionExpression(it) => it.node_id(),
+            Self::ImportExpression(it) => it.node_id(),
+            Self::LogicalExpression(it) => it.node_id(),
+            Self::NewExpression(it) => it.node_id(),
+            Self::ObjectExpression(it) => it.node_id(),
+            Self::ParenthesizedExpression(it) => it.node_id(),
+            Self::SequenceExpression(it) => it.node_id(),
+            Self::TaggedTemplateExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+            Self::UpdateExpression(it) => it.node_id(),
+            Self::YieldExpression(it) => it.node_id(),
+            Self::PrivateInExpression(it) => it.node_id(),
+            Self::JSXElement(it) => it.node_id(),
+            Self::JSXFragment(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSInstantiationExpression(it) => it.node_id(),
+            Self::V8IntrinsicExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl ModuleExportName<'_> {
+    /// Get [`NodeId`] of [`ModuleExportName`].
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::IdentifierName(it) => it.node_id(),
+            Self::IdentifierReference(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+        }
+    }
+}
+
+impl JSXElementName<'_> {
+    /// Get [`NodeId`] of [`JSXElementName`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Identifier(it) => it.node_id(),
+            Self::IdentifierReference(it) => it.node_id(),
+            Self::NamespacedName(it) => it.node_id(),
+            Self::MemberExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl JSXMemberExpressionObject<'_> {
+    /// Get [`NodeId`] of [`JSXMemberExpressionObject`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::IdentifierReference(it) => it.node_id(),
+            Self::MemberExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl JSXExpression<'_> {
+    /// Get [`NodeId`] of [`JSXExpression`].
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::EmptyExpression(it) => it.node_id(),
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NullLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::RegExpLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::Identifier(it) => it.node_id(),
+            Self::MetaProperty(it) => it.node_id(),
+            Self::Super(it) => it.node_id(),
+            Self::ArrayExpression(it) => it.node_id(),
+            Self::ArrowFunctionExpression(it) => it.node_id(),
+            Self::AssignmentExpression(it) => it.node_id(),
+            Self::AwaitExpression(it) => it.node_id(),
+            Self::BinaryExpression(it) => it.node_id(),
+            Self::CallExpression(it) => it.node_id(),
+            Self::ChainExpression(it) => it.node_id(),
+            Self::ClassExpression(it) => it.node_id(),
+            Self::ConditionalExpression(it) => it.node_id(),
+            Self::FunctionExpression(it) => it.node_id(),
+            Self::ImportExpression(it) => it.node_id(),
+            Self::LogicalExpression(it) => it.node_id(),
+            Self::NewExpression(it) => it.node_id(),
+            Self::ObjectExpression(it) => it.node_id(),
+            Self::ParenthesizedExpression(it) => it.node_id(),
+            Self::SequenceExpression(it) => it.node_id(),
+            Self::TaggedTemplateExpression(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+            Self::UpdateExpression(it) => it.node_id(),
+            Self::YieldExpression(it) => it.node_id(),
+            Self::PrivateInExpression(it) => it.node_id(),
+            Self::JSXElement(it) => it.node_id(),
+            Self::JSXFragment(it) => it.node_id(),
+            Self::TSAsExpression(it) => it.node_id(),
+            Self::TSSatisfiesExpression(it) => it.node_id(),
+            Self::TSTypeAssertion(it) => it.node_id(),
+            Self::TSNonNullExpression(it) => it.node_id(),
+            Self::TSInstantiationExpression(it) => it.node_id(),
+            Self::V8IntrinsicExpression(it) => it.node_id(),
+            Self::ComputedMemberExpression(it) => it.node_id(),
+            Self::StaticMemberExpression(it) => it.node_id(),
+            Self::PrivateFieldExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl JSXAttributeItem<'_> {
+    /// Get [`NodeId`] of [`JSXAttributeItem`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Attribute(it) => it.node_id(),
+            Self::SpreadAttribute(it) => it.node_id(),
+        }
+    }
+}
+
+impl JSXAttributeName<'_> {
+    /// Get [`NodeId`] of [`JSXAttributeName`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Identifier(it) => it.node_id(),
+            Self::NamespacedName(it) => it.node_id(),
+        }
+    }
+}
+
+impl JSXAttributeValue<'_> {
+    /// Get [`NodeId`] of [`JSXAttributeValue`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::StringLiteral(it) => it.node_id(),
+            Self::ExpressionContainer(it) => it.node_id(),
+            Self::Element(it) => it.node_id(),
+            Self::Fragment(it) => it.node_id(),
+        }
+    }
+}
+
+impl JSXChild<'_> {
+    /// Get [`NodeId`] of [`JSXChild`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Text(it) => it.node_id(),
+            Self::Element(it) => it.node_id(),
+            Self::Fragment(it) => it.node_id(),
+            Self::ExpressionContainer(it) => it.node_id(),
+            Self::Spread(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSEnumMemberName<'_> {
+    /// Get [`NodeId`] of [`TSEnumMemberName`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Identifier(it) => it.node_id(),
+            Self::String(it) => it.node_id(),
+            Self::ComputedString(it) => it.node_id(),
+            Self::ComputedTemplateString(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSLiteral<'_> {
+    /// Get [`NodeId`] of [`TSLiteral`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::BooleanLiteral(it) => it.node_id(),
+            Self::NumericLiteral(it) => it.node_id(),
+            Self::BigIntLiteral(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+            Self::TemplateLiteral(it) => it.node_id(),
+            Self::UnaryExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSType<'_> {
+    /// Get [`NodeId`] of [`TSType`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::TSAnyKeyword(it) => it.node_id(),
+            Self::TSBigIntKeyword(it) => it.node_id(),
+            Self::TSBooleanKeyword(it) => it.node_id(),
+            Self::TSIntrinsicKeyword(it) => it.node_id(),
+            Self::TSNeverKeyword(it) => it.node_id(),
+            Self::TSNullKeyword(it) => it.node_id(),
+            Self::TSNumberKeyword(it) => it.node_id(),
+            Self::TSObjectKeyword(it) => it.node_id(),
+            Self::TSStringKeyword(it) => it.node_id(),
+            Self::TSSymbolKeyword(it) => it.node_id(),
+            Self::TSUndefinedKeyword(it) => it.node_id(),
+            Self::TSUnknownKeyword(it) => it.node_id(),
+            Self::TSVoidKeyword(it) => it.node_id(),
+            Self::TSArrayType(it) => it.node_id(),
+            Self::TSConditionalType(it) => it.node_id(),
+            Self::TSConstructorType(it) => it.node_id(),
+            Self::TSFunctionType(it) => it.node_id(),
+            Self::TSImportType(it) => it.node_id(),
+            Self::TSIndexedAccessType(it) => it.node_id(),
+            Self::TSInferType(it) => it.node_id(),
+            Self::TSIntersectionType(it) => it.node_id(),
+            Self::TSLiteralType(it) => it.node_id(),
+            Self::TSMappedType(it) => it.node_id(),
+            Self::TSNamedTupleMember(it) => it.node_id(),
+            Self::TSTemplateLiteralType(it) => it.node_id(),
+            Self::TSThisType(it) => it.node_id(),
+            Self::TSTupleType(it) => it.node_id(),
+            Self::TSTypeLiteral(it) => it.node_id(),
+            Self::TSTypeOperatorType(it) => it.node_id(),
+            Self::TSTypePredicate(it) => it.node_id(),
+            Self::TSTypeQuery(it) => it.node_id(),
+            Self::TSTypeReference(it) => it.node_id(),
+            Self::TSUnionType(it) => it.node_id(),
+            Self::TSParenthesizedType(it) => it.node_id(),
+            Self::JSDocNullableType(it) => it.node_id(),
+            Self::JSDocNonNullableType(it) => it.node_id(),
+            Self::JSDocUnknownType(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSTupleElement<'_> {
+    /// Get [`NodeId`] of [`TSTupleElement`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::TSOptionalType(it) => it.node_id(),
+            Self::TSRestType(it) => it.node_id(),
+            Self::TSAnyKeyword(it) => it.node_id(),
+            Self::TSBigIntKeyword(it) => it.node_id(),
+            Self::TSBooleanKeyword(it) => it.node_id(),
+            Self::TSIntrinsicKeyword(it) => it.node_id(),
+            Self::TSNeverKeyword(it) => it.node_id(),
+            Self::TSNullKeyword(it) => it.node_id(),
+            Self::TSNumberKeyword(it) => it.node_id(),
+            Self::TSObjectKeyword(it) => it.node_id(),
+            Self::TSStringKeyword(it) => it.node_id(),
+            Self::TSSymbolKeyword(it) => it.node_id(),
+            Self::TSUndefinedKeyword(it) => it.node_id(),
+            Self::TSUnknownKeyword(it) => it.node_id(),
+            Self::TSVoidKeyword(it) => it.node_id(),
+            Self::TSArrayType(it) => it.node_id(),
+            Self::TSConditionalType(it) => it.node_id(),
+            Self::TSConstructorType(it) => it.node_id(),
+            Self::TSFunctionType(it) => it.node_id(),
+            Self::TSImportType(it) => it.node_id(),
+            Self::TSIndexedAccessType(it) => it.node_id(),
+            Self::TSInferType(it) => it.node_id(),
+            Self::TSIntersectionType(it) => it.node_id(),
+            Self::TSLiteralType(it) => it.node_id(),
+            Self::TSMappedType(it) => it.node_id(),
+            Self::TSNamedTupleMember(it) => it.node_id(),
+            Self::TSTemplateLiteralType(it) => it.node_id(),
+            Self::TSThisType(it) => it.node_id(),
+            Self::TSTupleType(it) => it.node_id(),
+            Self::TSTypeLiteral(it) => it.node_id(),
+            Self::TSTypeOperatorType(it) => it.node_id(),
+            Self::TSTypePredicate(it) => it.node_id(),
+            Self::TSTypeQuery(it) => it.node_id(),
+            Self::TSTypeReference(it) => it.node_id(),
+            Self::TSUnionType(it) => it.node_id(),
+            Self::TSParenthesizedType(it) => it.node_id(),
+            Self::JSDocNullableType(it) => it.node_id(),
+            Self::JSDocNonNullableType(it) => it.node_id(),
+            Self::JSDocUnknownType(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSTypeName<'_> {
+    /// Get [`NodeId`] of [`TSTypeName`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::IdentifierReference(it) => it.node_id(),
+            Self::QualifiedName(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSSignature<'_> {
+    /// Get [`NodeId`] of [`TSSignature`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::TSIndexSignature(it) => it.node_id(),
+            Self::TSPropertySignature(it) => it.node_id(),
+            Self::TSCallSignatureDeclaration(it) => it.node_id(),
+            Self::TSConstructSignatureDeclaration(it) => it.node_id(),
+            Self::TSMethodSignature(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSTypePredicateName<'_> {
+    /// Get [`NodeId`] of [`TSTypePredicateName`].
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Identifier(it) => it.node_id(),
+            Self::This(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSModuleDeclarationName<'_> {
+    /// Get [`NodeId`] of [`TSModuleDeclarationName`].
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Identifier(it) => it.node_id(),
+            Self::StringLiteral(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSModuleDeclarationBody<'_> {
+    /// Get [`NodeId`] of [`TSModuleDeclarationBody`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::TSModuleDeclaration(it) => it.node_id(),
+            Self::TSModuleBlock(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSTypeQueryExprName<'_> {
+    /// Get [`NodeId`] of [`TSTypeQueryExprName`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::TSImportType(it) => it.node_id(),
+            Self::IdentifierReference(it) => it.node_id(),
+            Self::QualifiedName(it) => it.node_id(),
+            Self::ThisExpression(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSImportTypeQualifier<'_> {
+    /// Get [`NodeId`] of [`TSImportTypeQualifier`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Identifier(it) => it.node_id(),
+            Self::QualifiedName(it) => it.node_id(),
+        }
+    }
+}
+
+impl TSModuleReference<'_> {
+    /// Get [`NodeId`] of [`TSModuleReference`].
+    #[inline(always)]
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::ExternalModuleReference(it) => it.node_id(),
+            Self::IdentifierReference(it) => it.node_id(),
+            Self::QualifiedName(it) => it.node_id(),
+        }
     }
 }

--- a/tasks/ast_tools/src/generators/get_id.rs
+++ b/tasks/ast_tools/src/generators/get_id.rs
@@ -10,7 +10,7 @@ use quote::{format_ident, quote};
 use crate::{
     AST_CRATE_PATH, Codegen, Generator,
     output::{Output, output_path},
-    schema::{Def, Schema, StructDef, TypeId},
+    schema::{Def, EnumDef, Schema, StructDef, TypeDef, TypeId},
 };
 
 use super::define_generator;
@@ -31,17 +31,24 @@ impl Generator for GetIdGenerator {
             semantic_id_type_ids[index] = schema.type_names[type_name];
         }
 
-        let impls = schema.structs().filter_map(|struct_def| {
+        let struct_impls = schema.structs().filter_map(|struct_def| {
             generate_for_struct(struct_def, &semantic_id_type_ids, schema)
         });
 
+        let enum_impls = schema.enums().filter_map(|enum_def| generate_for_enum(enum_def, schema));
+
         let output = quote! {
+            #![expect(clippy::inline_always)]
+            #![expect(clippy::match_same_arms)]
+
             use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
             ///@@line_break
             use crate::ast::*;
 
-            #(#impls)*
+            #(#struct_impls)*
+
+            #(#enum_impls)*
         };
 
         Output::Rust { path: output_path(AST_CRATE_PATH, "get_id.rs"), tokens: output }
@@ -139,4 +146,49 @@ fn generate_for_struct(
             #methods
         }
     })
+}
+
+fn generate_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<TokenStream> {
+    if !enum_def.all_variants(schema).all(|variant| {
+        variant.field_type(schema).is_some_and(|field_type| type_has_node_id(field_type, schema))
+    }) {
+        return None;
+    }
+
+    let enum_name = enum_def.name();
+    let enum_ty = enum_def.ty_anon(schema);
+    let matches = enum_def.all_variants(schema).map(|variant| {
+        let variant_ident = variant.ident();
+        quote!( Self::#variant_ident(it) => it.node_id() )
+    });
+    let get_doc = format!(" Get [`NodeId`] of [`{enum_name}`].");
+
+    let should_inline = enum_def.all_variants(schema).all(|variant| {
+        variant.field_type(schema).is_some_and(|field_type| field_type.as_box().is_some())
+    });
+
+    let inline = if should_inline { quote!( #[inline(always)] ) } else { quote!() };
+
+    Some(quote! {
+        ///@@line_break
+        impl #enum_ty {
+            #[doc = #get_doc]
+            #inline
+            pub fn node_id(&self) -> NodeId {
+                match self {
+                    #(#matches),*
+                }
+            }
+        }
+    })
+}
+
+fn type_has_node_id(type_def: &TypeDef, schema: &Schema) -> bool {
+    if let TypeDef::Struct(struct_def) =
+        type_def.as_box().map_or(type_def, |box_def| box_def.inner_type(schema))
+    {
+        return struct_def.kind.has_kind;
+    }
+
+    false
 }

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -106,6 +106,10 @@ impl Schema {
     pub fn structs_mut(&mut self) -> StructsMut<'_> {
         StructsMut::new(self)
     }
+
+    pub fn enums(&self) -> Enums<'_> {
+        Enums::new(self)
+    }
 }
 
 /// Methods for getting a specific type def (e.g. [`StructDef`]) for a [`TypeId`].
@@ -332,3 +336,33 @@ impl<'s> Iterator for StructsMut<'s> {
 }
 
 impl FusedIterator for StructsMut<'_> {}
+
+/// Iterator over enums.
+pub struct Enums<'s> {
+    iter: slice::Iter<'s, TypeDef>,
+}
+
+impl<'s> Enums<'s> {
+    fn new(schema: &'s Schema) -> Self {
+        Self { iter: schema.types.iter() }
+    }
+}
+
+impl<'s> Iterator for Enums<'s> {
+    type Item = &'s EnumDef;
+
+    fn next(&mut self) -> Option<&'s EnumDef> {
+        for type_def in &mut self.iter {
+            match type_def {
+                TypeDef::Enum(enum_def) => return Some(enum_def),
+                TypeDef::Struct(_) => {}
+                // Structs and enums are always first in `Schema::types`,
+                // so if we encounter a different type, iteration is done
+                _ => break,
+            }
+        }
+        None
+    }
+}
+
+impl FusedIterator for Enums<'_> {}


### PR DESCRIPTION
not sure if this is the idomatic way to approach this.

We don't have a use for this at present, but it seems very useful to have