### PR TITLE
chore(lsp): create dynamic worker on `start_manager`

### DIFF
--- a/apps/oxfmt/src/lsp/mod.rs
+++ b/apps/oxfmt/src/lsp/mod.rs
@@ -1,12 +1,10 @@
 use std::{
     fmt::Write,
     path::{Path, PathBuf},
-    str::FromStr,
     sync::Arc,
 };
 
 use oxc_language_server::{LanguageId, run_server};
-use tokio::sync::RwLock;
 use tower_lsp_server::ls_types::Uri;
 
 use crate::core::{ExternalFormatter, JsConfigLoaderCb, utils};
@@ -61,9 +59,6 @@ pub fn create_fake_file_path_from_language_id(
 }
 
 /// Run the language server
-///
-/// # Panics
-/// If `file:///` cannot be converted to `Uri`, which should never happen.
 pub async fn run_lsp(js_config_loader: JsConfigLoaderCb, external_formatter: ExternalFormatter) {
     let version = {
         let mut version = env!("CARGO_PKG_VERSION").to_string();
@@ -73,22 +68,12 @@ pub async fn run_lsp(js_config_loader: JsConfigLoaderCb, external_formatter: Ext
         version
     };
 
-    let builder: Arc<dyn oxc_language_server::ToolBuilder> = Arc::new(
-        server_formatter::ServerFormatterBuilder::new(js_config_loader, external_formatter),
-    );
     run_server(
         "oxfmt".to_string(),
         version,
-        oxc_language_server::WorkerManager::new_with_mode(
-            Arc::clone(&builder),
-            oxc_language_server::ManagerMode::DynamicWithWorkspaces(Box::new(RwLock::new(
-                oxc_language_server::WorkspaceWorker::new(
-                    Uri::from_str("file:///").unwrap(),
-                    builder,
-                    oxc_language_server::DiagnosticMode::None,
-                ),
-            ))),
-        ),
+        oxc_language_server::WorkerManager::new_dynamic(Arc::new(
+            server_formatter::ServerFormatterBuilder::new(js_config_loader, external_formatter),
+        )),
     )
     .await;
 }

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -163,7 +163,7 @@ impl LanguageServer for Backend {
             }
         }
 
-        self.worker_manager.start_manager(workers).await;
+        self.worker_manager.start_manager(workers, capabilities.diagnostic_mode.clone()).await;
 
         self.capabilities.set(capabilities).map_err(|err| {
             let message = match err {
@@ -813,8 +813,7 @@ impl LanguageServer for Backend {
             }
 
             {
-                let dynamic_worker = self.worker_manager.read_dynamic_worker().await;
-                if let Some(worker) = dynamic_worker {
+                if let Some(worker) = self.worker_manager.read_dynamic_worker() {
                     match worker.execute_command(&params.command, params.arguments.clone()).await {
                         Ok(Some(edit)) => edits.push(edit),
                         Ok(None) => {}

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::capabilities::{Capabilities, DiagnosticMode};
 pub use crate::language_id::LanguageId;
 pub use crate::tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges};
 pub use crate::worker::WorkspaceWorker;
-pub use crate::worker_manager::{ManagerMode, WorkerManager};
+pub use crate::worker_manager::WorkerManager;
 
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -4,10 +4,7 @@ use std::{
 };
 
 use serde_json::{Value, json};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt, DuplexStream},
-    sync::RwLock,
-};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tower_lsp_server::{
     Client, LspService, Server,
     jsonrpc::{ErrorCode, Id, Request, Response},
@@ -15,8 +12,8 @@ use tower_lsp_server::{
 };
 
 use crate::{
-    DiagnosticMode, ManagerMode, TextDocument, Tool, ToolBuilder, ToolRestartChanges,
-    WorkerManager, WorkspaceWorker, backend::Backend, tool::DiagnosticResult,
+    DiagnosticMode, TextDocument, Tool, ToolBuilder, ToolRestartChanges, WorkerManager,
+    backend::Backend, tool::DiagnosticResult,
 };
 
 #[derive(Default)]
@@ -588,12 +585,8 @@ fn create_workspace_manager_with_builder(builder: FakeToolBuilder) -> WorkerMana
     WorkerManager::new(Arc::new(builder))
 }
 
-fn create_dynamic_workspace(builder: Arc<dyn ToolBuilder>) -> ManagerMode {
-    ManagerMode::DynamicWithWorkspaces(Box::new(RwLock::new(WorkspaceWorker::new(
-        "file:///".parse().unwrap(),
-        builder,
-        DiagnosticMode::Pull,
-    ))))
+fn create_dynamic_workspace_manager(builder: FakeToolBuilder) -> WorkerManager {
+    WorkerManager::new_dynamic(Arc::new(builder))
 }
 
 #[cfg(test)]
@@ -2070,23 +2063,19 @@ mod test_suite {
     }
 
     mod dynamic_mode {
-        use crate::{ToolBuilder, WorkerManager, tests::create_dynamic_workspace};
+        use crate::tests::create_dynamic_workspace_manager;
 
         use super::*;
         #[tokio::test]
         async fn test_dynamic_mode_pull_diagnostics() {
             let init_options = InitializeRequestOptions { pull_mode: true, ..Default::default() };
-            let builder: Arc<dyn ToolBuilder> = Arc::new(FakeToolBuilder::default());
 
             let mut server = TestServer::new_initialized(
                 |client| {
                     Backend::new(
                         client,
                         server_info(),
-                        WorkerManager::new_with_mode(
-                            Arc::clone(&builder),
-                            create_dynamic_workspace(builder),
-                        ),
+                        create_dynamic_workspace_manager(FakeToolBuilder::default()),
                     )
                 },
                 initialize_request(init_options),
@@ -2133,10 +2122,7 @@ mod test_suite {
                     Backend::new(
                         client,
                         server_info(),
-                        WorkerManager::new_with_mode(
-                            Arc::new(FakeToolBuilder::default()),
-                            create_dynamic_workspace(Arc::new(FakeToolBuilder::default())),
-                        ),
+                        create_dynamic_workspace_manager(FakeToolBuilder::default()),
                     )
                 },
                 initialize_request(InitializeRequestOptions {

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use serde_json::Value;
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::{OnceCell, RwLock, RwLockReadGuard};
 use tower_lsp_server::{
     jsonrpc::{Error, Result},
     ls_types::{Registration, Unregistration, Uri, WorkspaceFolder},
@@ -18,7 +18,7 @@ use crate::{
 
 enum WorkerGuardInner<'a> {
     Vec(RwLockReadGuard<'a, Vec<WorkspaceWorker>>),
-    Single(RwLockReadGuard<'a, WorkspaceWorker>),
+    Single(&'a WorkspaceWorker),
 }
 
 /// A RAII guard that holds a shared read lock over the workers list and exposes
@@ -44,9 +44,6 @@ impl std::ops::Deref for WorkerGuard<'_> {
 
 /// The mode that the [`WorkerManager`] is operating in, which determines how it manages workers and delegates the task to the tool.
 pub enum ManagerMode {
-    // the manager requires an explicit workspace to operate
-    // these workspaces are managed by the client and communicated via `initialize` + `didChangeWorkspaceFolders`
-    RequireWorkspace,
     // the manager works in 2 modes, when no workspaces are configured, it creates workers dynamically for file URIs.
     // When workspaces are reconfigured (added or removed by the client), it creates workers for those and ignores file URIs outside of them.
     DynamicNoWorkspaces(
@@ -55,7 +52,8 @@ pub enum ManagerMode {
     ),
     // The manager will create workers dynamically for file URIs. It also supports workspaces configured by the client, but does not require them.
     // This is useful for tasks on URIs that are outside of any configured workspace.
-    DynamicWithWorkspaces(Box<RwLock<WorkspaceWorker>>),
+    // At first it is `None` until the diagnostic mode is known, then it is set to a worker with the root URI `file:///` and the same diagnostic mode as the other workers.
+    DynamicWithWorkspaces(Box<OnceCell<WorkspaceWorker>>),
 }
 
 /// Manages the lifecycle of [`WorkspaceWorker`]s for the language server.
@@ -88,18 +86,41 @@ impl WorkerManager {
         }
     }
 
-    pub fn new_with_mode(tool_builder: Arc<dyn ToolBuilder>, mode: ManagerMode) -> Self {
-        Self { mode, tool_builder, workers: RwLock::new(vec![]) }
+    /// Create a new [`WorkerManager`] with `DynamicWithWorkspaces` mode.
+    pub fn new_dynamic(tool_builder: Arc<dyn ToolBuilder>) -> Self {
+        Self {
+            mode: ManagerMode::DynamicWithWorkspaces(Box::new(OnceCell::new())),
+            tool_builder,
+            workers: RwLock::new(vec![]),
+        }
     }
 
     // ── Starting / Stopping ───────────────────────────────────────────────────────
 
-    pub async fn start_manager(&self, workers: Vec<WorkspaceWorker>) {
+    /// # Panics
+    /// If `file:///` cannot be converted to `Uri`, which should never happen.
+    pub async fn start_manager(
+        &self,
+        workers: Vec<WorkspaceWorker>,
+        diagnostic_mode: DiagnosticMode,
+    ) {
         *self.workers.write().await = workers;
 
         // for dynamic workspaces we need to start them manually
-        if let ManagerMode::DynamicWithWorkspaces(worker) = &self.mode {
-            worker.read().await.start_worker(serde_json::Value::Null).await;
+        if let ManagerMode::DynamicWithWorkspaces(cell) = &self.mode {
+            debug_assert!(
+                cell.get().is_none(),
+                "dynamic worker should not be set when starting the manager"
+            );
+
+            let worker = WorkspaceWorker::new(
+                "file:///".parse().unwrap(),
+                Arc::clone(&self.tool_builder),
+                diagnostic_mode,
+            );
+            worker.start_worker(serde_json::Value::Null).await;
+
+            let _ = cell.set(worker);
         }
     }
 
@@ -120,8 +141,11 @@ impl WorkerManager {
         }
 
         if let ManagerMode::DynamicWithWorkspaces(worker) = &self.mode {
-            let (worker_uris, _) = worker.read().await.shutdown().await;
-            clear_uris.extend(worker_uris);
+            let dynamic_worker = worker.get();
+            if let Some(dynamic_worker) = dynamic_worker {
+                let (worker_uris, _) = dynamic_worker.shutdown().await;
+                clear_uris.extend(worker_uris);
+            }
         }
 
         clear_uris
@@ -135,10 +159,10 @@ impl WorkerManager {
         self.workers.read().await
     }
 
-    /// Acquire a shared read lock over the dynamic worker in `DynamicWithWorkspaces` mode, if enabled.
-    pub async fn read_dynamic_worker(&self) -> Option<RwLockReadGuard<'_, WorkspaceWorker>> {
+    /// Return the dynamic worker from `DynamicWithWorkspaces` mode, if enabled.
+    pub fn read_dynamic_worker(&self) -> Option<&WorkspaceWorker> {
         if let ManagerMode::DynamicWithWorkspaces(worker) = &self.mode {
-            return Some(worker.read().await);
+            return worker.get();
         }
         None
     }
@@ -232,11 +256,15 @@ impl WorkerManager {
         }
 
         if let ManagerMode::DynamicWithWorkspaces(worker) = &self.mode {
+            let Some(worker) = worker.get() else {
+                debug!(
+                    "dynamic worker is not initialized yet, cannot find worker for URI {}",
+                    uri.as_str()
+                );
+                return None;
+            };
             // In DynamicWithWorkspaces mode, if no worker matches the URI, fallback to the dynamic worker.
-            return Some(WorkerGuard {
-                guard: WorkerGuardInner::Single(worker.read().await),
-                index: 0,
-            });
+            return Some(WorkerGuard { guard: WorkerGuardInner::Single(worker), index: 0 });
         }
 
         None
@@ -427,7 +455,6 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    use tokio::sync::RwLock;
     use tower_lsp_server::ls_types::Uri;
 
     use crate::{
@@ -458,7 +485,7 @@ mod tests {
         );
         let workers = vec![workspace, workspace_deeper];
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
 
         // File in deeper workspace should match the deeper worker
         let file_in_deeper: Uri = "file:///path/to/workspace/deeper/file.js".parse().unwrap();
@@ -492,7 +519,7 @@ mod tests {
         );
         let workers = vec![workspace, workspace2];
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
 
         // File in workspace-2 should match workspace-2 only
         let file_in_workspace2: Uri = "file:///path/to/workspace-2/file.js".parse().unwrap();
@@ -516,7 +543,7 @@ mod tests {
         );
         let workers = vec![workspace];
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
 
         // File in workspace should match
         let file_in_workspace: Uri = "file:///path/to/workspace/file.js".parse().unwrap();
@@ -534,7 +561,7 @@ mod tests {
     async fn test_get_worker_for_uri_no_workers() {
         let workers: Vec<WorkspaceWorker> = vec![];
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
 
         let file: Uri = "file:///path/to/workspace/file.js".parse().unwrap();
         let worker = manager.get_worker_for_uri(&file).await;
@@ -553,7 +580,7 @@ mod tests {
         // non file URI should use first workspace
         let vscode_userdata_file: Uri = "vscode-userdata:///Untitled-1".parse().unwrap();
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
         let worker = manager.get_worker_for_uri(&vscode_userdata_file).await;
         assert!(worker.is_some());
         assert_eq!(worker.unwrap().get_root_uri().as_str(), "file:///path/to/workspace");
@@ -571,7 +598,7 @@ mod tests {
         // non file URI should use first workspace
         let untitled_file: Uri = "untitled:///Untitled-1".parse().unwrap();
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
         let worker = manager.get_worker_for_uri(&untitled_file).await;
         assert!(worker.is_some());
         assert_eq!(worker.unwrap().get_root_uri().as_str(), "file:///path/to/workspace");
@@ -594,7 +621,7 @@ mod tests {
         // non file URI should use first workspace (not second)
         let untitled_file: Uri = "untitled:///Untitled-1".parse().unwrap();
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
         let worker = manager.get_worker_for_uri(&untitled_file).await;
         assert!(worker.is_some());
         assert_eq!(worker.unwrap().get_root_uri().as_str(), "file:///path/to/workspace1");
@@ -607,7 +634,7 @@ mod tests {
         // Untitled file with no workspaces should return None
         let untitled_file: Uri = "untitled:///Untitled-1".parse().unwrap();
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
         let worker = manager.get_worker_for_uri(&untitled_file).await;
         assert!(worker.is_none());
     }
@@ -629,7 +656,7 @@ mod tests {
         // Untitled file should use first workspace (not nested one)
         let untitled_file: Uri = "untitled:///Untitled-1".parse().unwrap();
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
         let worker = manager.get_worker_for_uri(&untitled_file).await;
         assert!(worker.is_some());
         assert_eq!(worker.unwrap().get_root_uri().as_str(), "file:///path/to/workspace");
@@ -679,7 +706,7 @@ mod tests {
         );
         let workers = vec![workspace];
         let manager = WorkerManager::new(create_builder());
-        manager.start_manager(workers).await;
+        manager.start_manager(workers, DiagnosticMode::None).await;
 
         // File with different case should still match on Windows
         let file: Uri = Uri::from_file_path(fixture.join("text.txt")).unwrap();
@@ -689,18 +716,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_worker_for_uri_dynamic_with_workspaces_no_workspaces() {
-        let dynamic_worker = WorkspaceWorker::new(
-            "file:///".parse().unwrap(),
-            create_builder(),
-            DiagnosticMode::None,
-        );
-        let manager = WorkerManager::new_with_mode(
-            create_builder(),
-            crate::worker_manager::ManagerMode::DynamicWithWorkspaces(Box::new(RwLock::new(
-                dynamic_worker,
-            ))),
-        );
-        manager.start_manager(vec![]).await;
+        let manager = WorkerManager::new_dynamic(create_builder());
+        manager.start_manager(vec![], DiagnosticMode::None).await;
 
         // File in workspace should match dynamic worker
         let file: Uri = "file:///any/path/file.js".parse().unwrap();
@@ -717,36 +734,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_worker_for_uri_dynamic_with_workspaces_with_workspaces() {
-        let dynamic_worker = WorkspaceWorker::new(
-            "file:///".parse().unwrap(),
-            create_builder(),
-            DiagnosticMode::None,
-        );
-        let manager = WorkerManager::new_with_mode(
-            create_builder(),
-            crate::worker_manager::ManagerMode::DynamicWithWorkspaces(Box::new(RwLock::new(
-                dynamic_worker,
-            ))),
-        );
-
-        // File in workspace should match dynamic worker
-        let file: Uri = "file:///any/path/file.js".parse().unwrap();
-        let worker = manager.get_worker_for_uri(&file).await;
-        assert!(worker.is_some());
-        assert_eq!(worker.unwrap().get_root_uri().as_str(), "file:///");
-
-        // Non-file URI should also match dynamic worker
-        let non_file_uri: Uri = "untitled:///Untitled-1".parse().unwrap();
-        let worker = manager.get_worker_for_uri(&non_file_uri).await;
-        assert!(worker.is_some());
-        assert_eq!(worker.unwrap().get_root_uri().as_str(), "file:///");
-
+        let manager = WorkerManager::new_dynamic(create_builder());
         manager
-            .start_manager(vec![WorkspaceWorker::new(
-                "file:///path/to/workspace".parse().unwrap(),
-                create_builder(),
+            .start_manager(
+                vec![WorkspaceWorker::new(
+                    "file:///path/to/workspace".parse().unwrap(),
+                    create_builder(),
+                    DiagnosticMode::None,
+                )],
                 DiagnosticMode::None,
-            )])
+            )
             .await;
 
         // Files outside workspace should still match dynamic worker


### PR DESCRIPTION
Because `DiagnosticMode` can only be evaluated with the `ClientCapabilities` from the editor, we need to delay the creation of the dynamic worker.
It works atm, because we know `oxfmt` is always `DiagnosticMode::None`, but I have plans to make `oxlint` compatible with the `ManagerMode::DynamicWithWorkspaces`.

Bonus: The dynamic worker is only created once, use `OnceCell` instead of a lock