### PR TITLE
perf(lexer): fix perf of `Token::set_*` methods on Rust 1.95.0

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -1,6 +1,6 @@
 //! Token
 
-use std::{fmt, mem, ptr};
+use std::{fmt, mem, ptr, ptr::NonNull};
 
 use oxc_span::Span;
 
@@ -27,18 +27,29 @@ const HAS_SEPARATOR_SHIFT: usize = 96;
 const START_MASK: u128 = 0xFFFF_FFFF; // 32 bits
 const END_MASK: u128 = 0xFFFF_FFFF; // 32 bits
 const KIND_MASK: u128 = 0xFF; // 8 bits
+#[expect(dead_code)]
 const BOOL_MASK: u128 = 0xFF; // 8 bits
 
 const _: () = {
-    // Check flags fields are aligned on 8 and in bounds, so can be read via pointers
-    const fn is_valid_shift(shift: usize) -> bool {
-        shift.is_multiple_of(8) && shift < u128::BITS as usize
+    const fn is_valid_shift<T>(shift: usize) -> bool {
+        let align_bits = align_of::<T>() * 8;
+        shift.is_multiple_of(align_bits) && shift < u128::BITS as usize
     }
 
-    assert!(is_valid_shift(IS_ON_NEW_LINE_SHIFT));
-    assert!(is_valid_shift(ESCAPED_SHIFT));
-    assert!(is_valid_shift(LONE_SURROGATES_SHIFT));
-    assert!(is_valid_shift(HAS_SEPARATOR_SHIFT));
+    // Check `u32` fields are aligned on 32 and in bounds, so can be read/written via pointers
+    assert!(is_valid_shift::<u32>(START_SHIFT));
+    assert!(is_valid_shift::<u32>(END_SHIFT));
+
+    // Check `Kind` is 1 byte, and `KIND_SHIFT` is aligned on 8 and in bounds, so can be read/written via pointers
+    assert!(size_of::<Kind>() == 1);
+    assert!(align_of::<Kind>() == 1);
+    assert!(is_valid_shift::<Kind>(KIND_SHIFT));
+
+    // Check flags fields are aligned on 8 and in bounds, so can be read/written via pointers
+    assert!(is_valid_shift::<bool>(IS_ON_NEW_LINE_SHIFT));
+    assert!(is_valid_shift::<bool>(ESCAPED_SHIFT));
+    assert!(is_valid_shift::<bool>(LONE_SURROGATES_SHIFT));
+    assert!(is_valid_shift::<bool>(HAS_SEPARATOR_SHIFT));
 };
 
 #[derive(Clone, Copy)]
@@ -85,7 +96,16 @@ impl Token {
     }
 }
 
-// Getters and setters
+// Getters and setters.
+//
+// Prior to Rust 1.95.0, `set` methods used safe bitwise operations.
+// This regressed heavily in Rust 1.95.0 due to an LLVM bug:
+// https://github.com/oxc-project/oxc/pull/21509
+// https://github.com/rust-lang/rust/issues/155422
+//
+// To obtain the same tight assembly as before on Rust 1.95.0, we now use unsafe pointer manipulation
+// to directly write the "fields" of `Token`.
+// The original implementations are kept in comments, in case we want to revert to them once the LLVM bug is fixed.
 impl Token {
     #[inline]
     pub fn span(&self) -> Span {
@@ -123,8 +143,14 @@ impl Token {
 
     #[inline]
     pub(super) fn set_start(&mut self, start: u32) {
+        /*
+        // Original version. Perf regressed in Rust 1.95.0.
         self.0 &= !(START_MASK << START_SHIFT); // Clear current `start` bits
         self.0 |= u128::from(start) << START_SHIFT;
+        */
+
+        // SAFETY: `START_SHIFT` is a valid `u32` field position in `Token`
+        unsafe { self.write_u32(START_SHIFT, start) };
     }
 
     #[inline]
@@ -136,8 +162,15 @@ impl Token {
     pub(super) fn set_end(&mut self, end: u32) {
         let start = self.start();
         debug_assert!(end >= start, "Token end ({end}) cannot be less than start ({start})");
+
+        /*
+        // Original version. Perf regressed in Rust 1.95.0.
         self.0 &= !(END_MASK << END_SHIFT); // Clear current `end` bits
         self.0 |= u128::from(end) << END_SHIFT;
+        */
+
+        // SAFETY: `END_SHIFT` is a valid `u32` field position in `Token`
+        unsafe { self.write_u32(END_SHIFT, end) };
     }
 
     #[inline]
@@ -164,8 +197,18 @@ impl Token {
 
     #[inline]
     fn set_kind_impl(&mut self, kind: Kind) {
+        /*
+        // Original version. Perf regressed in Rust 1.95.0.
         self.0 &= !(KIND_MASK << KIND_SHIFT); // Clear current `kind` bits
         self.0 |= u128::from(kind as u8) << KIND_SHIFT;
+        */
+
+        const OFFSET: usize =
+            if cfg!(target_endian = "little") { KIND_SHIFT / 8 } else { 15 - (KIND_SHIFT / 8) };
+        // SAFETY: `Kind` is `#[repr(u8)]`, so writing one byte at `OFFSET` overwrites only the `kind` byte
+        // without touching adjacent fields. These bits always represent a valid `Kind`.
+        // `Token` is borrowed mutably, so the write is unaliased.
+        unsafe { *NonNull::from(self).cast::<Kind>().add(OFFSET).as_mut() = kind };
     }
 
     /// Checks if this token appears at the start of a new line.
@@ -183,8 +226,14 @@ impl Token {
 
     #[inline]
     pub(super) fn set_is_on_new_line(&mut self, value: bool) {
+        /*
+        // Original version. Perf regressed in Rust 1.95.0.
         self.0 &= !(BOOL_MASK << IS_ON_NEW_LINE_SHIFT); // Clear current `is_on_new_line` bits
         self.0 |= u128::from(value) << IS_ON_NEW_LINE_SHIFT;
+        */
+
+        // SAFETY: `IS_ON_NEW_LINE_SHIFT` is a valid `bool` field position in `Token`
+        unsafe { self.write_bool(IS_ON_NEW_LINE_SHIFT, value) };
     }
 
     #[inline]
@@ -197,8 +246,14 @@ impl Token {
 
     #[inline]
     pub(super) fn set_escaped(&mut self, escaped: bool) {
+        /*
+        // Original version. Perf regressed in Rust 1.95.0.
         self.0 &= !(BOOL_MASK << ESCAPED_SHIFT); // Clear current `escaped` bits
         self.0 |= u128::from(escaped) << ESCAPED_SHIFT;
+        */
+
+        // SAFETY: `ESCAPED_SHIFT` is a valid `bool` field position in `Token`
+        unsafe { self.write_bool(ESCAPED_SHIFT, escaped) };
     }
 
     #[inline]
@@ -211,8 +266,14 @@ impl Token {
 
     #[inline]
     pub(super) fn set_lone_surrogates(&mut self, value: bool) {
+        /*
+        // Original version. Perf regressed in Rust 1.95.0.
         self.0 &= !(BOOL_MASK << LONE_SURROGATES_SHIFT); // Clear current `lone_surrogates` bits
         self.0 |= u128::from(value) << LONE_SURROGATES_SHIFT;
+        */
+
+        // SAFETY: `LONE_SURROGATES_SHIFT` is a valid `bool` field position in `Token`
+        unsafe { self.write_bool(LONE_SURROGATES_SHIFT, value) };
     }
 
     #[inline]
@@ -225,8 +286,14 @@ impl Token {
 
     #[inline]
     pub(super) fn set_has_separator(&mut self, value: bool) {
+        /*
+        // Original version. Perf regressed in Rust 1.95.0.
         self.0 &= !(BOOL_MASK << HAS_SEPARATOR_SHIFT); // Clear current `has_separator` bits
         self.0 |= u128::from(value) << HAS_SEPARATOR_SHIFT;
+        */
+
+        // SAFETY: `HAS_SEPARATOR_SHIFT` is a valid `bool` field position in `Token`
+        unsafe { self.write_bool(HAS_SEPARATOR_SHIFT, value) };
     }
 
     /// Read `bool` from 8 bits starting at bit position `shift`.
@@ -275,6 +342,50 @@ impl Token {
             debug_assert!(*field_ptr.cast::<u8>() <= 1);
             *field_ptr.as_ref().unwrap_unchecked()
         }
+    }
+
+    /// Write `bool` to the 8 bits starting at bit position `shift`.
+    ///
+    /// # SAFETY
+    ///
+    /// `shift` must be the location of a valid boolean "field" in [`Token`] e.g. `ESCAPED_SHIFT`.
+    ///
+    /// # Performance analysis
+    ///
+    /// Writing the whole byte via a pointer avoids a read-modify-write of the underlying `u128`.
+    /// LLVM stopped folding the safe `self.0 &= !mask; self.0 |= val << shift` pattern
+    /// into a single byte store as of rustc 1.95.0 - see <https://github.com/rust-lang/rust/issues/155422>.
+    /// This implementation produces `mov byte ptr [rdi + N], sil` on both affected and unaffected Rust versions.
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // So `shift` is statically known
+    unsafe fn write_bool(&mut self, shift: usize, value: bool) {
+        // Byte offset depends on endianness of the system
+        let offset = if cfg!(target_endian = "little") { shift / 8 } else { 15 - (shift / 8) };
+        // SAFETY: Caller guarantees `shift` points to a valid `bool` field.
+        // `Token` is borrowed mutably, so the write is unaliased.
+        // `as_mut` produces a `&mut bool` with `noalias` metadata for LLVM.
+        unsafe { *NonNull::from(self).cast::<bool>().add(offset).as_mut() = value };
+    }
+
+    /// Write `u32` to the 32 bits starting at bit position `shift`.
+    ///
+    /// # SAFETY
+    ///
+    /// `shift` must be the location of a valid `u32` "field" in [`Token`] i.e. `START_SHIFT` or `END_SHIFT`.
+    ///
+    /// # Performance analysis
+    ///
+    /// See `write_bool` - same story, but `mov dword ptr [rdi + N], esi`.
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // So `shift` is statically known
+    unsafe fn write_u32(&mut self, shift: usize, value: u32) {
+        // `Token` is 16 bytes = 4 `u32`s wide. Offset in `u32` units depends on endianness.
+        let offset = if cfg!(target_endian = "little") { shift / 32 } else { 3 - (shift / 32) };
+        // SAFETY: Caller guarantees `shift` points to a valid `u32` field (`start` or `end`).
+        // `Token` is `#[repr(transparent)]` over `u128`, so casting `NonNull<Token>` to `NonNull<u32>`
+        // is going from stricter to looser alignment. `Token` is borrowed mutably, so the
+        // write is unaliased - `as_mut` produces a `&mut u32` with `noalias` metadata for LLVM.
+        unsafe { *NonNull::from(self).cast::<u32>().add(offset).as_mut() = value };
     }
 }
 


### PR DESCRIPTION
`Token`'s `set_*` methods used safe bitwise ops to write "fields" of `Token`.

Unfortunately this regressed heavily in Rust 1.95.0, due to a bug in LLVM. Methods which were a single scalar op turned into a string of heavy SIMD ops, impacting performance.

* #21509
* https://github.com/rust-lang/rust/issues/155422

Re-implement these methods using unsafe pointer manipulation, which recovers the original assembly, and reverses the perf regression - gains 3% on parser benchmarks.

The original implementations are left in the code as comments, in case we want to revert to them once the LLVM bug is fixed.