### PR TITLE
fix(linter): support jsx-a11y attributes setting in anchor-is-valid rule

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_overrides@oxlint.snap
@@ -37,7 +37,7 @@ working directory: fixtures/cli/extends_config
    :           ^
  3 | }
    `----
-  help: Provide an `href` for the `a` element.
+  help: Provide the `href` attribute for the `a` element.
 
 Found 1 warning and 3 errors.
 Finished in <variable>ms on 2 files using 1 threads.

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -18,9 +18,16 @@ use crate::{
     utils::{get_element_type, has_jsx_prop_ignore_case},
 };
 
-fn missing_href_attribute(span: Span) -> OxcDiagnostic {
+fn missing_href_attribute<S: AsRef<str>>(span: Span, valid_attrs: &[S]) -> OxcDiagnostic {
+    let help = if valid_attrs.len() == 1 {
+        format!("Provide the `{}` attribute for the `a` element.", valid_attrs[0].as_ref())
+    } else {
+        let list =
+            valid_attrs.iter().map(|a| format!("`{}`", a.as_ref())).collect::<Vec<_>>().join(", ");
+        format!("Provide one of these attributes for the `a` element: {list}")
+    };
     OxcDiagnostic::warn("Missing `href` attribute for the `a` element.")
-        .with_help("Provide an `href` for the `a` element.")
+        .with_help(help)
         .with_label(span)
 }
 
@@ -144,7 +151,17 @@ impl Rule for AnchorIsValid {
             }
             // Don't eagerly get `span` here, to avoid that work unless rule fails
             let get_span = || jsx_el.opening_element.name.span();
-            if let Some(href_attr) = has_jsx_prop_ignore_case(&jsx_el.opening_element, "href") {
+            // Check href or any configured alternative attribute names (e.g. `to` for router Link components)
+            let custom_href_names =
+                ctx.settings().jsx_a11y.attributes.get("href").map(Vec::as_slice);
+            let href_attr = if let Some(href_names) = custom_href_names {
+                href_names
+                    .iter()
+                    .find_map(|n| has_jsx_prop_ignore_case(&jsx_el.opening_element, n.as_str()))
+            } else {
+                has_jsx_prop_ignore_case(&jsx_el.opening_element, "href")
+            };
+            if let Some(href_attr) = href_attr {
                 let JSXAttributeItem::Attribute(attr) = href_attr else {
                     return;
                 };
@@ -174,7 +191,11 @@ impl Rule for AnchorIsValid {
             if has_spread_attr {
                 return;
             }
-            ctx.diagnostic(missing_href_attribute(get_span()));
+            if let Some(href_names) = custom_href_names {
+                ctx.diagnostic(missing_href_attribute(get_span(), href_names));
+            } else {
+                ctx.diagnostic(missing_href_attribute(get_span(), &["href"]));
+            }
         }
     }
 }
@@ -316,6 +337,31 @@ fn test() {
             Some(
                 serde_json::json!({ "settings": { "jsx-a11y": { "components": { "Anchor": "a", "Link": "a" } } } }),
             ),
+        ),
+        // attributes settings: `to` is a valid alternative for `href` on Link components
+        (
+            r"<Link to='https://example.com' />",
+            None,
+            Some(serde_json::json!({
+                "settings": {
+                    "jsx-a11y": {
+                        "components": { "Link": "a" },
+                        "attributes": { "href": ["href", "to"] }
+                    }
+                }
+            })),
+        ),
+        (
+            r"<Link to={dest} />",
+            None,
+            Some(serde_json::json!({
+                "settings": {
+                    "jsx-a11y": {
+                        "components": { "Link": "a" },
+                        "attributes": { "href": ["href", "to"] }
+                    }
+                }
+            })),
         ),
         // (r#"<a {...props} />"#, Some(serde_json::json!(specialLink))),
         // (r#"<a hrefLeft='foo' />"#, Some(serde_json::json!(specialLink))),
@@ -616,6 +662,31 @@ fn test() {
             Some(
                 serde_json::json!({ "settings": { "jsx-a11y": { "components": { "Anchor": "a", "Link": "a" } } } }),
             ),
+        ),
+        // attributes settings: Link without `to` or `href` should still fail
+        (
+            r"<Link />",
+            None,
+            Some(serde_json::json!({
+                "settings": {
+                    "jsx-a11y": {
+                        "components": { "Link": "a" },
+                        "attributes": { "href": ["href", "to"] }
+                    }
+                }
+            })),
+        ),
+        (
+            r"<Link to='#' />",
+            None,
+            Some(serde_json::json!({
+                "settings": {
+                    "jsx-a11y": {
+                        "components": { "Link": "a" },
+                        "attributes": { "href": ["href", "to"] }
+                    }
+                }
+            })),
         ),
         // (r#"<a hrefLeft={undefined} />"#, Some(serde_json::json!(specialLink))),
         // (r#"<a hrefLeft={null} />"#, Some(serde_json::json!(specialLink))),

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_anchor_is_valid.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_anchor_is_valid.snap
@@ -7,7 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <a />
    ·  ─
    ╰────
-  help: Provide an `href` for the `a` element.
+  help: Provide the `href` attribute for the `a` element.
 
   ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): Use of incorrect `href` for the 'a' element.
    ╭─[anchor_is_valid.tsx:1:2]
@@ -70,7 +70,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <a onClick={() => void 0} />
    ·  ─
    ╰────
-  help: Provide an `href` for the `a` element.
+  help: Provide the `href` attribute for the `a` element.
 
   ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): The `a` element has `href` and `onClick`.
    ╭─[anchor_is_valid.tsx:1:2]
@@ -99,3 +99,17 @@ source: crates/oxc_linter/src/tester.rs
    ·  ────
    ╰────
   help: Use a `button` element instead of an `a` element.
+
+  ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): Missing `href` attribute for the `a` element.
+   ╭─[anchor_is_valid.tsx:1:2]
+ 1 │ <Link />
+   ·  ────
+   ╰────
+  help: Provide one of these attributes for the `a` element: `href`, `to`
+
+  ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): Use of incorrect `href` for the 'a' element.
+   ╭─[anchor_is_valid.tsx:1:2]
+ 1 │ <Link to='#' />
+   ·  ────
+   ╰────
+  help: Provide a correct `href` for the `a` element.


### PR DESCRIPTION
- updated version of https://github.com/oxc-project/oxc/pull/19808