### PR TITLE
refactor(formatter): Move oxfmt utils

### DIFF
--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 
 use phf::phf_set;
 
-use oxc_formatter::get_supported_source_type;
 use oxc_span::SourceType;
 
 use super::utils;
@@ -32,8 +31,7 @@ impl TryFrom<PathBuf> for FormatFileStrategy {
 
     fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
         // Check JS/TS files first
-        // TODO: This logic should(can) move to this file, after LSP support is also moved here.
-        if let Some(source_type) = get_supported_source_type(&path) {
+        if let Some(source_type) = get_oxc_formatter_source_type(&path) {
             return Ok(Self::OxcFormatter { path, source_type });
         }
 
@@ -409,6 +407,75 @@ static YAML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "yaml",
     "yaml-tmlanguage",
 };
+
+// ---
+
+// Additional extensions from linguist-languages, which Prettier also supports
+// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/JavaScript.js
+// No special extensions for TypeScript
+// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/TypeScript.js
+// And on top of this data, Prettier adds its own checks.
+// Ultimately, it can be confirmed with the following command.
+// `prettier --support-info | jq '.languages[] | select(.name == "JavaScript")'`
+static ADDITIONAL_JS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
+    "_js",
+    "bones",
+    "es",
+    "es6",
+    "gs",
+    "jake",
+    "javascript",
+    "jsb",
+    "jscad",
+    "jsfl",
+    "jslib",
+    "jsm",
+    "jspre",
+    "jss",
+    "njs",
+    "pac",
+    "sjs",
+    "ssjs",
+    "xsjs",
+    "xsjslib",
+};
+
+// Special filenames that are valid JS files
+static SPECIAL_JS_FILENAMES: phf::Set<&'static str> = phf_set! {
+    "Jakefile",
+    "start.frag",
+    "end.frag",
+};
+
+fn get_oxc_formatter_source_type(path: &Path) -> Option<SourceType> {
+    // Standard extensions, also supported by `oxc_span::VALID_EXTENSIONS`
+    // NOTE: Use `path` directly for `.d.ts` detection
+    if let Ok(source_type) = SourceType::from_path(path) {
+        return Some(source_type);
+    }
+
+    // Check special filenames first
+    if let Some(file_name) = path.file_name()
+        && SPECIAL_JS_FILENAMES.contains(file_name.to_str()?)
+    {
+        return Some(SourceType::default());
+    }
+
+    let extension = path.extension()?.to_string_lossy();
+    // Additional extensions Prettier also supports
+    if ADDITIONAL_JS_EXTENSIONS.contains(extension.as_ref()) {
+        return Some(SourceType::default());
+    }
+    // Special handling for `.frag` files: only allow `*.start.frag` and `*.end.frag`
+    if extension == "frag" {
+        let stem = path.file_stem()?.to_str()?;
+        #[expect(clippy::case_sensitive_file_extension_comparisons)]
+        return (stem.ends_with(".start") || stem.ends_with(".end"))
+            .then_some(SourceType::default());
+    }
+
+    None
+}
 
 // ---
 

--- a/crates/oxc_formatter/src/service/mod.rs
+++ b/crates/oxc_formatter/src/service/mod.rs
@@ -1,6 +1,5 @@
 use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
-use phf::phf_set;
 
 pub fn get_parse_options() -> ParseOptions {
     ParseOptions {
@@ -12,73 +11,6 @@ pub fn get_parse_options() -> ParseOptions {
         // `oxc_formatter` expects this to be `false`, otherwise panics
         preserve_parens: false,
     }
-}
-
-// Additional extensions from linguist-languages, which Prettier also supports
-// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/JavaScript.js
-// No special extensions for TypeScript
-// - https://github.com/ikatyang-collab/linguist-languages/blob/d1dc347c7ced0f5b42dd66c7d1c4274f64a3eb6b/data/TypeScript.js
-// And on top of this data, Prettier adds its own checks.
-// Ultimately, it can be confirmed with the following command.
-// `prettier --support-info | jq '.languages[] | select(.name == "JavaScript")'`
-static ADDITIONAL_JS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
-    "_js",
-    "bones",
-    "es",
-    "es6",
-    "gs",
-    "jake",
-    "javascript",
-    "jsb",
-    "jscad",
-    "jsfl",
-    "jslib",
-    "jsm",
-    "jspre",
-    "jss",
-    "njs",
-    "pac",
-    "sjs",
-    "ssjs",
-    "xsjs",
-    "xsjslib",
-};
-
-// Special filenames that are valid JS files
-static SPECIAL_JS_FILENAMES: phf::Set<&'static str> = phf_set! {
-    "Jakefile",
-    "start.frag",
-    "end.frag",
-};
-
-pub fn get_supported_source_type(path: &std::path::Path) -> Option<SourceType> {
-    // Standard extensions, also supported by `oxc_span::VALID_EXTENSIONS`
-    // NOTE: Use `path` directly for `.d.ts` detection
-    if let Ok(source_type) = SourceType::from_path(path) {
-        return Some(source_type);
-    }
-
-    // Check special filenames first
-    if let Some(file_name) = path.file_name()
-        && SPECIAL_JS_FILENAMES.contains(file_name.to_str()?)
-    {
-        return Some(SourceType::default());
-    }
-
-    let extension = path.extension()?.to_string_lossy();
-    // Additional extensions Prettier also supports
-    if ADDITIONAL_JS_EXTENSIONS.contains(extension.as_ref()) {
-        return Some(SourceType::default());
-    }
-    // Special handling for `.frag` files: only allow `*.start.frag` and `*.end.frag`
-    if extension == "frag" {
-        let stem = path.file_stem()?.to_str()?;
-        #[expect(clippy::case_sensitive_file_extension_comparisons)]
-        return (stem.ends_with(".start") || stem.ends_with(".end"))
-            .then_some(SourceType::default());
-    }
-
-    None
 }
 
 #[must_use]


### PR DESCRIPTION
Resolve TODO comment.

> // TODO: This logic should(can) move to this file, after LSP support is also moved here.
