### PR TITLE
fix(linter/vitest): don't treat `test.extend` or `it.extend` as test functions

### DIFF
--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -791,6 +791,28 @@ fn test() {
             "describe(\"suite\", () => { test(\"foo\") })",
             Some(serde_json::json!([{ "withinDescribe": "test" }])),
         ),
+        (
+            "import {describe, expect, test, it} from 'vitest';
+
+                describe('example', () => {
+                  const testExtended = test.extend<{ result: number }>({
+                    result: async ({}, use) => {
+                      await use(42);
+                    },
+                  });
+
+                  testExtended('works', ({ result }) => {
+                    expect(result).toBe(42);
+                  });
+
+                  it('works', () => {
+                    expect(42).toBe(42);
+                  })
+                });
+
+                ",
+            Some(serde_json::json!([{ "withinDescribe": "it" }])),
+        ),
     ];
 
     let fail_vitest = vec![

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -785,6 +785,24 @@ fn test() {
             ",
             Some(serde_json::json!([{ "assertFunctionNames": ["assertType"] }])),
         ),
+        (
+            "import {describe, expect, test} from 'vitest';
+
+                describe('example', () => {
+                  const it = test.extend<{ result: number }>({
+                    result: async ({}, use) => {
+                      await use(42);
+                    },
+                  });
+
+                  it('works', ({ result }) => {
+                    expect(result).toBe(42);
+                  });
+                });
+
+                ",
+            None,
+        )
     ];
 
     let fail_vitest = vec![

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -518,6 +518,24 @@ fn test() {
 			      });",
             None,
         ),
+        (
+            "import {describe, expect, test} from 'vitest';
+
+                describe('example', () => {
+                  const it = test.extend<{ result: number }>({
+                    result: async ({}, use) => {
+                      await use(42);
+                    },
+                  });
+
+                  it('works', ({ result }) => {
+                    expect(result).toBe(42);
+                  });
+                });
+
+                ",
+            None,
+        ),
     ];
 
     let fail_vitest = vec![

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -109,7 +109,10 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
             let ParsedGeneralJestFnCall { kind, members, name, .. } = jest_fn_call;
             // `test('foo')`
             let kind = match kind {
-                JestFnKind::Expect | JestFnKind::ExpectTypeOf | JestFnKind::Unknown => return,
+                JestFnKind::Expect
+                | JestFnKind::ExpectTypeOf
+                | JestFnKind::Unknown
+                | JestFnKind::VitestFixture => return,
                 JestFnKind::General(kind) => kind,
             };
             if matches!(kind, JestGeneralFnKind::Test)
@@ -256,6 +259,21 @@ fn test() {
             import { test } from './test-utils';
 	    test('something');
         ",
+        "import {describe, expect, test} from 'vitest';
+
+                describe('example', () => {
+                  const it = test.extend<{ result: number }>({
+                    result: async ({}, use) => {
+                      await use(42);
+                    },
+                  });
+
+                  it('works', ({ result }) => {
+                    expect(result).toBe(42);
+                  });
+                });
+
+                ",
     ];
 
     let fail_vitest = vec![

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/vitest.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/tests/vitest.rs
@@ -63,6 +63,20 @@ fn test() {
             });"#,
             None,
         ),
+        (
+            "import {describe, expect, test} from 'vitest';
+
+                    describe('example', () => {
+                      const it = test.extend<{ result: number }>({
+                        result: async ({}, use) => {
+                          await use(42);
+                        },
+                      });
+                    });
+
+                    ",
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/jest/prefer_importing_jest_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_importing_jest_globals.rs
@@ -155,7 +155,10 @@ impl Rule for PreferImportingJestGlobals {
             }
 
             let name = match &jest_fn_call {
-                ParsedJestFnCallNew::GeneralJest(c) => c.name.to_string(),
+                // Fixture is from vitest
+                ParsedJestFnCallNew::GeneralJest(c) | ParsedJestFnCallNew::Fixture(c) => {
+                    c.name.to_string()
+                }
                 ParsedJestFnCallNew::Expect(c) | ParsedJestFnCallNew::ExpectTypeOf(c) => {
                     c.name.to_string()
                 }

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -51,6 +51,7 @@ pub enum JestFnKind {
     Expect,
     ExpectTypeOf,
     General(JestGeneralFnKind),
+    VitestFixture,
     Unknown,
 }
 

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -13,8 +13,10 @@ use oxc_span::Span;
 
 use crate::{
     context::LintContext,
-    utils::jest::{JestFnKind, JestGeneralFnKind, PossibleJestNode},
-    utils::valid_vitest_fn::is_valid_vitest_call,
+    utils::{
+        jest::{JestFnKind, JestGeneralFnKind, PossibleJestNode},
+        valid_vitest_fn::{is_extend_fixture, is_valid_vitest_call},
+    },
 };
 
 pub fn parse_jest_fn_call<'a>(
@@ -125,6 +127,14 @@ pub fn parse_jest_fn_call<'a>(
             (false, false) => {}
         }
 
+        if ctx.frameworks().is_vitest() && is_extend_fixture(&call_chains[1..]) {
+            return Some(ParsedJestFnCall::Fixture(ParsedGeneralJestFnCall {
+                kind: JestFnKind::VitestFixture,
+                members,
+                name: Cow::Borrowed(name),
+                local: Cow::Borrowed(resolved.local),
+            }));
+        }
         return Some(ParsedJestFnCall::GeneralJest(ParsedGeneralJestFnCall {
             kind,
             members,
@@ -361,12 +371,13 @@ pub enum ParsedJestFnCall<'a> {
     GeneralJest(ParsedGeneralJestFnCall<'a>),
     Expect(ParsedExpectFnCall<'a>),
     ExpectTypeOf(ParsedExpectFnCall<'a>),
+    Fixture(ParsedGeneralJestFnCall<'a>),
 }
 
 impl ParsedJestFnCall<'_> {
     pub fn kind(&self) -> JestFnKind {
         match self {
-            Self::GeneralJest(call) => call.kind,
+            Self::GeneralJest(call) | Self::Fixture(call) => call.kind,
             Self::Expect(call) | Self::ExpectTypeOf(call) => call.kind,
         }
     }

--- a/crates/oxc_linter/src/utils/vitest.rs
+++ b/crates/oxc_linter/src/utils/vitest.rs
@@ -16,6 +16,6 @@ pub fn parse_expect_and_typeof_vitest_fn_call<'a>(
     match jest_fn_call {
         ParsedJestFnCallNew::Expect(jest_fn_call)
         | ParsedJestFnCallNew::ExpectTypeOf(jest_fn_call) => Some(jest_fn_call),
-        ParsedJestFnCallNew::GeneralJest(_) => None,
+        ParsedJestFnCallNew::GeneralJest(_) | ParsedJestFnCallNew::Fixture(_) => None,
     }
 }

--- a/crates/oxc_linter/src/utils/vitest/valid_vitest_fn.rs
+++ b/crates/oxc_linter/src/utils/vitest/valid_vitest_fn.rs
@@ -10,6 +10,17 @@ pub fn is_valid_vitest_call<T: AsRef<str>>(members: &[T]) -> bool {
     }
 }
 
+pub fn is_extend_fixture<T: AsRef<str>>(members: &[T]) -> bool {
+    if let Some((i, modifier)) = members.iter().enumerate().next() {
+        match modifier.as_ref() {
+            "extend" => return i == 0,
+            _ => return false,
+        }
+    }
+
+    false
+}
+
 /// Check for duplicate modifiers. This has quadratic complexity, but since we only
 /// have a very small number of modifiers, this is fine.
 fn has_duplicates<T: AsRef<str>>(modifiers: &[T]) -> bool {


### PR DESCRIPTION
# AI Disclosure
The code has been done without AI help.

# Summary

A [previous PR](https://github.com/oxc-project/oxc/pull/21201) fixed this false positive directly in the rule. This PR take another approach, add a new Fixture Kind. This PR solely solve the false positive, a follow PR, or PRs, need to addres the identifier tracking.


closes #21201