### PR TITLE
refactor(ast_tools): remove special-case logic for `NodeId` from `CloneIn` generator

### DIFF
--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -18,7 +18,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Program {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             source_type: CloneIn::clone_in(&self.source_type, allocator),
             source_text: CloneIn::clone_in(&self.source_text, allocator),
@@ -32,7 +32,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Program {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             source_type: CloneIn::clone_in_with_semantic_ids(&self.source_type, allocator),
             source_text: CloneIn::clone_in_with_semantic_ids(&self.source_text, allocator),
@@ -302,7 +302,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierName<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierName {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -310,7 +310,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierName<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierName {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
         }
@@ -322,7 +322,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierReference {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             reference_id: Default::default(),
@@ -331,7 +331,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IdentifierReference {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             reference_id: CloneIn::clone_in_with_semantic_ids(&self.reference_id, allocator),
@@ -344,7 +344,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingIdentifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             symbol_id: Default::default(),
@@ -353,7 +353,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingIdentifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             symbol_id: CloneIn::clone_in_with_semantic_ids(&self.symbol_id, allocator),
@@ -366,7 +366,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabelIdentifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -374,7 +374,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabelIdentifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
         }
@@ -386,14 +386,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for ThisExpression {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ThisExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ThisExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -404,7 +404,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
         }
@@ -412,7 +412,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
         }
@@ -705,15 +705,12 @@ impl<'new_alloc> CloneIn<'new_alloc> for Elision {
     type Cloned = Elision;
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Elision {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
+        Elision { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Elision {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -724,7 +721,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             properties: CloneIn::clone_in(&self.properties, allocator),
         }
@@ -732,7 +729,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             properties: CloneIn::clone_in_with_semantic_ids(&self.properties, allocator),
         }
@@ -770,7 +767,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectProperty<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectProperty {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
@@ -783,7 +780,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectProperty<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectProperty {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
             key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
@@ -1078,7 +1075,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateLiteral<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             quasis: CloneIn::clone_in(&self.quasis, allocator),
             expressions: CloneIn::clone_in(&self.expressions, allocator),
@@ -1087,7 +1084,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateLiteral<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             quasis: CloneIn::clone_in_with_semantic_ids(&self.quasis, allocator),
             expressions: CloneIn::clone_in_with_semantic_ids(&self.expressions, allocator),
@@ -1100,7 +1097,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TaggedTemplateExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             tag: CloneIn::clone_in(&self.tag, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -1110,7 +1107,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TaggedTemplateExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             tag: CloneIn::clone_in_with_semantic_ids(&self.tag, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -1124,7 +1121,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateElement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
             tail: CloneIn::clone_in(&self.tail, allocator),
@@ -1134,7 +1131,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateElement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
             tail: CloneIn::clone_in_with_semantic_ids(&self.tail, allocator),
@@ -1198,7 +1195,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ComputedMemberExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ComputedMemberExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
@@ -1208,7 +1205,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ComputedMemberExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ComputedMemberExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
@@ -1222,7 +1219,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticMemberExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticMemberExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             property: CloneIn::clone_in(&self.property, allocator),
@@ -1232,7 +1229,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticMemberExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticMemberExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
             property: CloneIn::clone_in_with_semantic_ids(&self.property, allocator),
@@ -1246,7 +1243,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateFieldExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateFieldExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             field: CloneIn::clone_in(&self.field, allocator),
@@ -1256,7 +1253,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateFieldExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateFieldExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
             field: CloneIn::clone_in_with_semantic_ids(&self.field, allocator),
@@ -1270,7 +1267,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CallExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CallExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             callee: CloneIn::clone_in(&self.callee, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -1282,7 +1279,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CallExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CallExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             callee: CloneIn::clone_in_with_semantic_ids(&self.callee, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -1298,7 +1295,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NewExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             callee: CloneIn::clone_in(&self.callee, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -1309,7 +1306,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NewExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             callee: CloneIn::clone_in_with_semantic_ids(&self.callee, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -1324,7 +1321,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MetaProperty<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MetaProperty {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             meta: CloneIn::clone_in(&self.meta, allocator),
             property: CloneIn::clone_in(&self.property, allocator),
@@ -1333,7 +1330,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MetaProperty<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MetaProperty {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             meta: CloneIn::clone_in_with_semantic_ids(&self.meta, allocator),
             property: CloneIn::clone_in_with_semantic_ids(&self.property, allocator),
@@ -1346,7 +1343,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SpreadElement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SpreadElement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -1354,7 +1351,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SpreadElement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SpreadElement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
         }
@@ -1610,7 +1607,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UpdateExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             prefix: CloneIn::clone_in(&self.prefix, allocator),
@@ -1620,7 +1617,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UpdateExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
             prefix: CloneIn::clone_in_with_semantic_ids(&self.prefix, allocator),
@@ -1634,7 +1631,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnaryExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UnaryExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
@@ -1643,7 +1640,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnaryExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         UnaryExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
@@ -1656,7 +1653,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BinaryExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BinaryExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
@@ -1666,7 +1663,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BinaryExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BinaryExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
@@ -1680,7 +1677,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateInExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -1689,7 +1686,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateInExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
@@ -1702,7 +1699,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LogicalExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LogicalExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
@@ -1712,7 +1709,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LogicalExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LogicalExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
@@ -1726,7 +1723,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ConditionalExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ConditionalExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             consequent: CloneIn::clone_in(&self.consequent, allocator),
@@ -1736,7 +1733,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ConditionalExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ConditionalExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
             consequent: CloneIn::clone_in_with_semantic_ids(&self.consequent, allocator),
@@ -1750,7 +1747,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
@@ -1760,7 +1757,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
@@ -1938,7 +1935,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayAssignmentTarget {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -1947,7 +1944,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayAssignmentTarget {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
             rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
@@ -1960,7 +1957,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectAssignmentTarget<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectAssignmentTarget {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             properties: CloneIn::clone_in(&self.properties, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -1969,7 +1966,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectAssignmentTarget<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectAssignmentTarget {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             properties: CloneIn::clone_in_with_semantic_ids(&self.properties, allocator),
             rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
@@ -1982,7 +1979,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetRest<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetRest {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             target: CloneIn::clone_in(&self.target, allocator),
         }
@@ -1990,7 +1987,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetRest<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetRest {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             target: CloneIn::clone_in_with_semantic_ids(&self.target, allocator),
         }
@@ -2106,7 +2103,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetWithDefault<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetWithDefault {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             binding: CloneIn::clone_in(&self.binding, allocator),
             init: CloneIn::clone_in(&self.init, allocator),
@@ -2115,7 +2112,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetWithDefault<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetWithDefault {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             binding: CloneIn::clone_in_with_semantic_ids(&self.binding, allocator),
             init: CloneIn::clone_in_with_semantic_ids(&self.init, allocator),
@@ -2162,7 +2159,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyIdentifier<'_> 
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyIdentifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             binding: CloneIn::clone_in(&self.binding, allocator),
             init: CloneIn::clone_in(&self.init, allocator),
@@ -2171,7 +2168,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyIdentifier<'_> 
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyIdentifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             binding: CloneIn::clone_in_with_semantic_ids(&self.binding, allocator),
             init: CloneIn::clone_in_with_semantic_ids(&self.init, allocator),
@@ -2184,7 +2181,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyProperty<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyProperty {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             binding: CloneIn::clone_in(&self.binding, allocator),
@@ -2194,7 +2191,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyProperty<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentTargetPropertyProperty {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             binding: CloneIn::clone_in_with_semantic_ids(&self.binding, allocator),
@@ -2208,7 +2205,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SequenceExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expressions: CloneIn::clone_in(&self.expressions, allocator),
         }
@@ -2216,7 +2213,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SequenceExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expressions: CloneIn::clone_in_with_semantic_ids(&self.expressions, allocator),
         }
@@ -2227,15 +2224,12 @@ impl<'new_alloc> CloneIn<'new_alloc> for Super {
     type Cloned = Super;
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Super {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
+        Super { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Super {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -2246,7 +2240,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AwaitExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AwaitExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -2254,7 +2248,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AwaitExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AwaitExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
         }
@@ -2266,7 +2260,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ChainExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ChainExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -2274,7 +2268,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ChainExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ChainExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -2330,7 +2324,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ParenthesizedExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ParenthesizedExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -2338,7 +2332,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ParenthesizedExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ParenthesizedExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -2540,7 +2534,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Directive<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Directive {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             directive: CloneIn::clone_in(&self.directive, allocator),
@@ -2549,7 +2543,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Directive<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Directive {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             directive: CloneIn::clone_in_with_semantic_ids(&self.directive, allocator),
@@ -2562,7 +2556,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Hashbang<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Hashbang {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
         }
@@ -2570,7 +2564,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Hashbang<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Hashbang {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
         }
@@ -2582,7 +2576,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BlockStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BlockStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
@@ -2591,7 +2585,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BlockStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BlockStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
             scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
@@ -2672,7 +2666,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             declarations: CloneIn::clone_in(&self.declarations, allocator),
@@ -2682,7 +2676,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
             declarations: CloneIn::clone_in_with_semantic_ids(&self.declarations, allocator),
@@ -2710,7 +2704,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclarator {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
@@ -2722,7 +2716,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         VariableDeclarator {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
@@ -2738,14 +2732,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for EmptyStatement {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         EmptyStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         EmptyStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -2756,7 +2750,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExpressionStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExpressionStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -2764,7 +2758,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExpressionStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExpressionStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -2776,7 +2770,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IfStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IfStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             consequent: CloneIn::clone_in(&self.consequent, allocator),
@@ -2786,7 +2780,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IfStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         IfStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
             consequent: CloneIn::clone_in_with_semantic_ids(&self.consequent, allocator),
@@ -2800,7 +2794,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for DoWhileStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         DoWhileStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
@@ -2809,7 +2803,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for DoWhileStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         DoWhileStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
             test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
@@ -2822,7 +2816,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WhileStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WhileStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -2831,7 +2825,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WhileStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WhileStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -2844,7 +2838,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             init: CloneIn::clone_in(&self.init, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
@@ -2856,7 +2850,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             init: CloneIn::clone_in_with_semantic_ids(&self.init, allocator),
             test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
@@ -3144,7 +3138,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForInStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForInStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -3155,7 +3149,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForInStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForInStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
@@ -3250,7 +3244,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForOfStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             r#await: CloneIn::clone_in(&self.r#await, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
@@ -3262,7 +3256,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ForOfStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             r#await: CloneIn::clone_in_with_semantic_ids(&self.r#await, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
@@ -3278,7 +3272,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ContinueStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ContinueStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
         }
@@ -3286,7 +3280,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ContinueStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ContinueStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
         }
@@ -3298,7 +3292,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BreakStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BreakStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
         }
@@ -3306,7 +3300,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BreakStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BreakStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
         }
@@ -3318,7 +3312,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ReturnStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ReturnStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -3326,7 +3320,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ReturnStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ReturnStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
         }
@@ -3338,7 +3332,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -3348,7 +3342,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -3362,7 +3356,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             discriminant: CloneIn::clone_in(&self.discriminant, allocator),
             cases: CloneIn::clone_in(&self.cases, allocator),
@@ -3372,7 +3366,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             discriminant: CloneIn::clone_in_with_semantic_ids(&self.discriminant, allocator),
             cases: CloneIn::clone_in_with_semantic_ids(&self.cases, allocator),
@@ -3386,7 +3380,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchCase<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchCase {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             test: CloneIn::clone_in(&self.test, allocator),
             consequent: CloneIn::clone_in(&self.consequent, allocator),
@@ -3395,7 +3389,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchCase<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         SwitchCase {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             test: CloneIn::clone_in_with_semantic_ids(&self.test, allocator),
             consequent: CloneIn::clone_in_with_semantic_ids(&self.consequent, allocator),
@@ -3408,7 +3402,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabeledStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabeledStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -3417,7 +3411,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabeledStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         LabeledStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -3430,7 +3424,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ThrowStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ThrowStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -3438,7 +3432,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ThrowStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ThrowStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
         }
@@ -3450,7 +3444,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TryStatement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TryStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             block: CloneIn::clone_in(&self.block, allocator),
             handler: CloneIn::clone_in(&self.handler, allocator),
@@ -3460,7 +3454,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TryStatement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TryStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             block: CloneIn::clone_in_with_semantic_ids(&self.block, allocator),
             handler: CloneIn::clone_in_with_semantic_ids(&self.handler, allocator),
@@ -3474,7 +3468,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchClause<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchClause {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             param: CloneIn::clone_in(&self.param, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -3484,7 +3478,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchClause<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchClause {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             param: CloneIn::clone_in_with_semantic_ids(&self.param, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -3498,7 +3492,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchParameter<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchParameter {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             pattern: CloneIn::clone_in(&self.pattern, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -3507,7 +3501,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchParameter<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         CatchParameter {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             pattern: CloneIn::clone_in_with_semantic_ids(&self.pattern, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
@@ -3520,14 +3514,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for DebuggerStatement {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         DebuggerStatement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         DebuggerStatement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -3576,7 +3570,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentPattern<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentPattern {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -3585,7 +3579,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentPattern<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AssignmentPattern {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
@@ -3598,7 +3592,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectPattern<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectPattern {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             properties: CloneIn::clone_in(&self.properties, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -3607,7 +3601,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectPattern<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ObjectPattern {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             properties: CloneIn::clone_in_with_semantic_ids(&self.properties, allocator),
             rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
@@ -3620,7 +3614,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingProperty<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingProperty {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -3631,7 +3625,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingProperty<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingProperty {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
@@ -3646,7 +3640,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayPattern<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayPattern {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -3655,7 +3649,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayPattern<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrayPattern {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
             rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
@@ -3668,7 +3662,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingRestElement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingRestElement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -3676,7 +3670,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingRestElement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BindingRestElement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
         }
@@ -3688,7 +3682,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Function<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Function {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
@@ -3708,7 +3702,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Function<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Function {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
@@ -3746,7 +3740,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameters<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameters {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             kind: CloneIn::clone_in(&self.kind, allocator),
             items: CloneIn::clone_in(&self.items, allocator),
@@ -3756,7 +3750,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameters<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameters {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             kind: CloneIn::clone_in_with_semantic_ids(&self.kind, allocator),
             items: CloneIn::clone_in_with_semantic_ids(&self.items, allocator),
@@ -3770,7 +3764,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameter<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameter {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
             pattern: CloneIn::clone_in(&self.pattern, allocator),
@@ -3785,7 +3779,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameter<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameter {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
             pattern: CloneIn::clone_in_with_semantic_ids(&self.pattern, allocator),
@@ -3818,7 +3812,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterRest<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameterRest {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
@@ -3828,7 +3822,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterRest<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FormalParameterRest {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
             rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
@@ -3842,7 +3836,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FunctionBody<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FunctionBody {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             directives: CloneIn::clone_in(&self.directives, allocator),
             statements: CloneIn::clone_in(&self.statements, allocator),
@@ -3851,7 +3845,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FunctionBody<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         FunctionBody {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             directives: CloneIn::clone_in_with_semantic_ids(&self.directives, allocator),
             statements: CloneIn::clone_in_with_semantic_ids(&self.statements, allocator),
@@ -3864,7 +3858,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrowFunctionExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             r#async: CloneIn::clone_in(&self.r#async, allocator),
@@ -3880,7 +3874,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ArrowFunctionExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             r#async: CloneIn::clone_in_with_semantic_ids(&self.r#async, allocator),
@@ -3900,7 +3894,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for YieldExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         YieldExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             delegate: CloneIn::clone_in(&self.delegate, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
@@ -3909,7 +3903,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for YieldExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         YieldExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             delegate: CloneIn::clone_in_with_semantic_ids(&self.delegate, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
@@ -3922,7 +3916,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Class {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -3940,7 +3934,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Class {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
             decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
@@ -3979,7 +3973,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassBody<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ClassBody {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
         }
@@ -3987,7 +3981,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassBody<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ClassBody {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
         }
@@ -4041,7 +4035,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MethodDefinition {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -4058,7 +4052,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         MethodDefinition {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
             decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
@@ -4093,7 +4087,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PropertyDefinition {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -4113,7 +4107,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PropertyDefinition {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
             decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
@@ -4165,7 +4159,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateIdentifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateIdentifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -4173,7 +4167,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateIdentifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         PrivateIdentifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
         }
@@ -4185,7 +4179,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticBlock<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticBlock {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             scope_id: Default::default(),
@@ -4194,7 +4188,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticBlock<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StaticBlock {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
             scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
@@ -4273,7 +4267,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AccessorProperty {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             r#type: CloneIn::clone_in(&self.r#type, allocator),
             decorators: CloneIn::clone_in(&self.decorators, allocator),
@@ -4290,7 +4284,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         AccessorProperty {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             r#type: CloneIn::clone_in_with_semantic_ids(&self.r#type, allocator),
             decorators: CloneIn::clone_in_with_semantic_ids(&self.decorators, allocator),
@@ -4311,7 +4305,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             source: CloneIn::clone_in(&self.source, allocator),
             options: CloneIn::clone_in(&self.options, allocator),
@@ -4321,7 +4315,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
             options: CloneIn::clone_in_with_semantic_ids(&self.options, allocator),
@@ -4335,7 +4329,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             specifiers: CloneIn::clone_in(&self.specifiers, allocator),
             source: CloneIn::clone_in(&self.source, allocator),
@@ -4347,7 +4341,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             specifiers: CloneIn::clone_in_with_semantic_ids(&self.specifiers, allocator),
             source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
@@ -4413,7 +4407,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportSpecifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportSpecifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             imported: CloneIn::clone_in(&self.imported, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
@@ -4423,7 +4417,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportSpecifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportSpecifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             imported: CloneIn::clone_in_with_semantic_ids(&self.imported, allocator),
             local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
@@ -4437,7 +4431,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDefaultSpecifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDefaultSpecifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
         }
@@ -4445,7 +4439,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDefaultSpecifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportDefaultSpecifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
         }
@@ -4457,7 +4451,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportNamespaceSpecifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportNamespaceSpecifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
         }
@@ -4465,7 +4459,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportNamespaceSpecifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportNamespaceSpecifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
         }
@@ -4477,7 +4471,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithClause<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithClause {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             keyword: CloneIn::clone_in(&self.keyword, allocator),
             with_entries: CloneIn::clone_in(&self.with_entries, allocator),
@@ -4486,7 +4480,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithClause<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         WithClause {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             keyword: CloneIn::clone_in_with_semantic_ids(&self.keyword, allocator),
             with_entries: CloneIn::clone_in_with_semantic_ids(&self.with_entries, allocator),
@@ -4513,7 +4507,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportAttribute<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportAttribute {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -4522,7 +4516,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportAttribute<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ImportAttribute {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
@@ -4561,7 +4555,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportNamedDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportNamedDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             declaration: CloneIn::clone_in(&self.declaration, allocator),
             specifiers: CloneIn::clone_in(&self.specifiers, allocator),
@@ -4573,7 +4567,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportNamedDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportNamedDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             declaration: CloneIn::clone_in_with_semantic_ids(&self.declaration, allocator),
             specifiers: CloneIn::clone_in_with_semantic_ids(&self.specifiers, allocator),
@@ -4589,7 +4583,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             declaration: CloneIn::clone_in(&self.declaration, allocator),
         }
@@ -4597,7 +4591,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             declaration: CloneIn::clone_in_with_semantic_ids(&self.declaration, allocator),
         }
@@ -4609,7 +4603,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportAllDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportAllDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             exported: CloneIn::clone_in(&self.exported, allocator),
             source: CloneIn::clone_in(&self.source, allocator),
@@ -4620,7 +4614,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportAllDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportAllDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             exported: CloneIn::clone_in_with_semantic_ids(&self.exported, allocator),
             source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
@@ -4635,7 +4629,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportSpecifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportSpecifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             local: CloneIn::clone_in(&self.local, allocator),
             exported: CloneIn::clone_in(&self.exported, allocator),
@@ -4645,7 +4639,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportSpecifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportSpecifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             local: CloneIn::clone_in_with_semantic_ids(&self.local, allocator),
             exported: CloneIn::clone_in_with_semantic_ids(&self.exported, allocator),
@@ -5013,7 +5007,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for V8IntrinsicExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         V8IntrinsicExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             arguments: CloneIn::clone_in(&self.arguments, allocator),
@@ -5022,7 +5016,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for V8IntrinsicExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         V8IntrinsicExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             arguments: CloneIn::clone_in_with_semantic_ids(&self.arguments, allocator),
@@ -5035,7 +5029,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BooleanLiteral {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BooleanLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
         }
@@ -5043,7 +5037,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BooleanLiteral {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BooleanLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
         }
@@ -5054,15 +5048,12 @@ impl<'new_alloc> CloneIn<'new_alloc> for NullLiteral {
     type Cloned = NullLiteral;
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        NullLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
+        NullLiteral { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NullLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -5073,7 +5064,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NumericLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
@@ -5083,7 +5074,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         NumericLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
             raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
@@ -5097,7 +5088,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StringLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
@@ -5107,7 +5098,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         StringLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
             raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
@@ -5121,7 +5112,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BigIntLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
@@ -5131,7 +5122,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         BigIntLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
             raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
@@ -5145,7 +5136,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         RegExpLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             regex: CloneIn::clone_in(&self.regex, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
@@ -5154,7 +5145,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         RegExpLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             regex: CloneIn::clone_in_with_semantic_ids(&self.regex, allocator),
             raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
@@ -5203,7 +5194,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXElement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             opening_element: CloneIn::clone_in(&self.opening_element, allocator),
             children: CloneIn::clone_in(&self.children, allocator),
@@ -5213,7 +5204,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXElement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             opening_element: CloneIn::clone_in_with_semantic_ids(&self.opening_element, allocator),
             children: CloneIn::clone_in_with_semantic_ids(&self.children, allocator),
@@ -5227,7 +5218,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningElement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -5237,7 +5228,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningElement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -5251,7 +5242,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXClosingElement {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -5259,7 +5250,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXClosingElement {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
         }
@@ -5271,7 +5262,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXFragment {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             opening_fragment: CloneIn::clone_in(&self.opening_fragment, allocator),
             children: CloneIn::clone_in(&self.children, allocator),
@@ -5281,7 +5272,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXFragment {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             opening_fragment: CloneIn::clone_in_with_semantic_ids(
                 &self.opening_fragment,
@@ -5301,14 +5292,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningFragment {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningFragment {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningFragment {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -5319,14 +5310,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingFragment {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXClosingFragment {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXClosingFragment {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -5379,7 +5370,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXNamespacedName {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             namespace: CloneIn::clone_in(&self.namespace, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
@@ -5388,7 +5379,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXNamespacedName {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             namespace: CloneIn::clone_in_with_semantic_ids(&self.namespace, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
@@ -5401,7 +5392,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXMemberExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             object: CloneIn::clone_in(&self.object, allocator),
             property: CloneIn::clone_in(&self.property, allocator),
@@ -5410,7 +5401,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXMemberExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             object: CloneIn::clone_in_with_semantic_ids(&self.object, allocator),
             property: CloneIn::clone_in_with_semantic_ids(&self.property, allocator),
@@ -5455,7 +5446,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXExpressionContainer {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -5463,7 +5454,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXExpressionContainer {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -5741,14 +5732,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXEmptyExpression {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXEmptyExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXEmptyExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -5783,7 +5774,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXAttribute {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
@@ -5792,7 +5783,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXAttribute {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
@@ -5805,7 +5796,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadAttribute {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             argument: CloneIn::clone_in(&self.argument, allocator),
         }
@@ -5813,7 +5804,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadAttribute {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             argument: CloneIn::clone_in_with_semantic_ids(&self.argument, allocator),
         }
@@ -5883,7 +5874,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXIdentifier {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
         }
@@ -5891,7 +5882,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXIdentifier {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
         }
@@ -5937,7 +5928,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadChild {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -5945,7 +5936,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXSpreadChild {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -5957,7 +5948,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXText<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXText {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
             raw: CloneIn::clone_in(&self.raw, allocator),
@@ -5966,7 +5957,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXText<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXText {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             value: CloneIn::clone_in_with_semantic_ids(&self.value, allocator),
             raw: CloneIn::clone_in_with_semantic_ids(&self.raw, allocator),
@@ -5979,7 +5970,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSThisParameter {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             this_span: CloneIn::clone_in(&self.this_span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -5988,7 +5979,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSThisParameter {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             this_span: CloneIn::clone_in_with_semantic_ids(&self.this_span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
@@ -6001,7 +5992,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -6012,7 +6003,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -6027,7 +6018,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumBody<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumBody {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             members: CloneIn::clone_in(&self.members, allocator),
             scope_id: Default::default(),
@@ -6036,7 +6027,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumBody<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumBody {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             members: CloneIn::clone_in_with_semantic_ids(&self.members, allocator),
             scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),
@@ -6049,7 +6040,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMember<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumMember {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             initializer: CloneIn::clone_in(&self.initializer, allocator),
@@ -6058,7 +6049,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMember<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSEnumMember {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
             initializer: CloneIn::clone_in_with_semantic_ids(&self.initializer, allocator),
@@ -6105,7 +6096,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAnnotation<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAnnotation {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -6113,7 +6104,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAnnotation<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAnnotation {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
         }
@@ -6125,7 +6116,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSLiteralType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSLiteralType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             literal: CloneIn::clone_in(&self.literal, allocator),
         }
@@ -6133,7 +6124,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSLiteralType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSLiteralType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             literal: CloneIn::clone_in_with_semantic_ids(&self.literal, allocator),
         }
@@ -6379,7 +6370,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConditionalType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             check_type: CloneIn::clone_in(&self.check_type, allocator),
             extends_type: CloneIn::clone_in(&self.extends_type, allocator),
@@ -6391,7 +6382,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConditionalType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             check_type: CloneIn::clone_in_with_semantic_ids(&self.check_type, allocator),
             extends_type: CloneIn::clone_in_with_semantic_ids(&self.extends_type, allocator),
@@ -6407,7 +6398,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUnionType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSUnionType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             types: CloneIn::clone_in(&self.types, allocator),
         }
@@ -6415,7 +6406,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUnionType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSUnionType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             types: CloneIn::clone_in_with_semantic_ids(&self.types, allocator),
         }
@@ -6427,7 +6418,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIntersectionType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIntersectionType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             types: CloneIn::clone_in(&self.types, allocator),
         }
@@ -6435,7 +6426,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIntersectionType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIntersectionType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             types: CloneIn::clone_in_with_semantic_ids(&self.types, allocator),
         }
@@ -6447,7 +6438,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSParenthesizedType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSParenthesizedType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -6455,7 +6446,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSParenthesizedType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSParenthesizedType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
         }
@@ -6467,7 +6458,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperator<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeOperator {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             operator: CloneIn::clone_in(&self.operator, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -6476,7 +6467,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperator<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeOperator {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             operator: CloneIn::clone_in_with_semantic_ids(&self.operator, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
@@ -6503,7 +6494,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSArrayType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSArrayType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             element_type: CloneIn::clone_in(&self.element_type, allocator),
         }
@@ -6511,7 +6502,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSArrayType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSArrayType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             element_type: CloneIn::clone_in_with_semantic_ids(&self.element_type, allocator),
         }
@@ -6523,7 +6514,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexedAccessType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexedAccessType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             object_type: CloneIn::clone_in(&self.object_type, allocator),
             index_type: CloneIn::clone_in(&self.index_type, allocator),
@@ -6532,7 +6523,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexedAccessType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexedAccessType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             object_type: CloneIn::clone_in_with_semantic_ids(&self.object_type, allocator),
             index_type: CloneIn::clone_in_with_semantic_ids(&self.index_type, allocator),
@@ -6545,7 +6536,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTupleType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTupleType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             element_types: CloneIn::clone_in(&self.element_types, allocator),
         }
@@ -6553,7 +6544,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTupleType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTupleType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             element_types: CloneIn::clone_in_with_semantic_ids(&self.element_types, allocator),
         }
@@ -6565,7 +6556,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamedTupleMember {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             label: CloneIn::clone_in(&self.label, allocator),
             element_type: CloneIn::clone_in(&self.element_type, allocator),
@@ -6575,7 +6566,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamedTupleMember {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             label: CloneIn::clone_in_with_semantic_ids(&self.label, allocator),
             element_type: CloneIn::clone_in_with_semantic_ids(&self.element_type, allocator),
@@ -6589,7 +6580,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSOptionalType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSOptionalType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -6597,7 +6588,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSOptionalType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSOptionalType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
         }
@@ -6609,7 +6600,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSRestType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSRestType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
         }
@@ -6617,7 +6608,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSRestType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSRestType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
         }
@@ -6862,15 +6853,12 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAnyKeyword {
     type Cloned = TSAnyKeyword;
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSAnyKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
+        TSAnyKeyword { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSAnyKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -6881,14 +6869,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSStringKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSStringKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSStringKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -6899,14 +6887,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSBooleanKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSBooleanKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSBooleanKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -6917,14 +6905,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNumberKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNumberKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNumberKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -6935,14 +6923,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNeverKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNeverKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNeverKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -6953,14 +6941,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIntrinsicKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIntrinsicKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIntrinsicKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -6971,14 +6959,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUnknownKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSUnknownKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSUnknownKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -6989,14 +6977,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNullKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNullKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNullKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -7007,14 +6995,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUndefinedKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSUndefinedKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSUndefinedKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -7025,14 +7013,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSVoidKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSVoidKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSVoidKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -7043,14 +7031,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSymbolKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSSymbolKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSSymbolKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -7060,15 +7048,12 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSThisType {
     type Cloned = TSThisType;
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSThisType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
-            span: CloneIn::clone_in(&self.span, allocator),
-        }
+        TSThisType { node_id: Default::default(), span: CloneIn::clone_in(&self.span, allocator) }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSThisType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -7079,14 +7064,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSObjectKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSObjectKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSObjectKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -7097,14 +7082,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSBigIntKeyword {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSBigIntKeyword {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSBigIntKeyword {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }
@@ -7115,7 +7100,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeReference {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_name: CloneIn::clone_in(&self.type_name, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -7124,7 +7109,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeReference {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_name: CloneIn::clone_in_with_semantic_ids(&self.type_name, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -7167,7 +7152,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSQualifiedName<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSQualifiedName {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -7176,7 +7161,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSQualifiedName<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSQualifiedName {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
@@ -7189,7 +7174,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterInstantiation<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterInstantiation {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
         }
@@ -7197,7 +7182,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterInstantiation<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterInstantiation {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
         }
@@ -7209,7 +7194,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameter<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameter {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             constraint: CloneIn::clone_in(&self.constraint, allocator),
@@ -7222,7 +7207,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameter<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameter {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             constraint: CloneIn::clone_in_with_semantic_ids(&self.constraint, allocator),
@@ -7239,7 +7224,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
         }
@@ -7247,7 +7232,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeParameterDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
         }
@@ -7259,7 +7244,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAliasDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -7271,7 +7256,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAliasDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
             type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
@@ -7301,7 +7286,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSClassImplements {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -7310,7 +7295,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSClassImplements {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -7323,7 +7308,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -7336,7 +7321,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
             type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
@@ -7353,7 +7338,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceBody<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceBody {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
         }
@@ -7361,7 +7346,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceBody<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceBody {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
         }
@@ -7373,7 +7358,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSPropertySignature<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSPropertySignature {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             computed: CloneIn::clone_in(&self.computed, allocator),
             optional: CloneIn::clone_in(&self.optional, allocator),
@@ -7385,7 +7370,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSPropertySignature<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSPropertySignature {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
             optional: CloneIn::clone_in_with_semantic_ids(&self.optional, allocator),
@@ -7447,7 +7432,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignature {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             parameters: CloneIn::clone_in(&self.parameters, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -7458,7 +7443,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignature {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             parameters: CloneIn::clone_in_with_semantic_ids(&self.parameters, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
@@ -7473,7 +7458,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSCallSignatureDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             this_param: CloneIn::clone_in(&self.this_param, allocator),
@@ -7485,7 +7470,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSCallSignatureDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
             this_param: CloneIn::clone_in_with_semantic_ids(&self.this_param, allocator),
@@ -7515,7 +7500,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMethodSignature {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             computed: CloneIn::clone_in(&self.computed, allocator),
@@ -7531,7 +7516,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMethodSignature {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
             computed: CloneIn::clone_in_with_semantic_ids(&self.computed, allocator),
@@ -7551,7 +7536,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructSignatureDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             params: CloneIn::clone_in(&self.params, allocator),
@@ -7562,7 +7547,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructSignatureDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
             params: CloneIn::clone_in_with_semantic_ids(&self.params, allocator),
@@ -7577,7 +7562,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignatureName<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignatureName {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -7586,7 +7571,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignatureName<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSIndexSignatureName {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
@@ -7599,7 +7584,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceHeritage {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -7608,7 +7593,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInterfaceHeritage {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -7621,7 +7606,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicate<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypePredicate {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             parameter_name: CloneIn::clone_in(&self.parameter_name, allocator),
             asserts: CloneIn::clone_in(&self.asserts, allocator),
@@ -7631,7 +7616,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicate<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypePredicate {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             parameter_name: CloneIn::clone_in_with_semantic_ids(&self.parameter_name, allocator),
             asserts: CloneIn::clone_in_with_semantic_ids(&self.asserts, allocator),
@@ -7669,7 +7654,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -7681,7 +7666,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -7763,7 +7748,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSGlobalDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSGlobalDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             global_span: CloneIn::clone_in(&self.global_span, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -7774,7 +7759,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSGlobalDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSGlobalDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             global_span: CloneIn::clone_in_with_semantic_ids(&self.global_span, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -7789,7 +7774,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleBlock<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleBlock {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             directives: CloneIn::clone_in(&self.directives, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
@@ -7798,7 +7783,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleBlock<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSModuleBlock {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             directives: CloneIn::clone_in_with_semantic_ids(&self.directives, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
@@ -7811,7 +7796,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeLiteral<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeLiteral {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             members: CloneIn::clone_in(&self.members, allocator),
         }
@@ -7819,7 +7804,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeLiteral<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeLiteral {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             members: CloneIn::clone_in_with_semantic_ids(&self.members, allocator),
         }
@@ -7831,7 +7816,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInferType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInferType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_parameter: CloneIn::clone_in(&self.type_parameter, allocator),
         }
@@ -7839,7 +7824,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInferType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInferType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_parameter: CloneIn::clone_in_with_semantic_ids(&self.type_parameter, allocator),
         }
@@ -7851,7 +7836,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeQuery {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expr_name: CloneIn::clone_in(&self.expr_name, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -7860,7 +7845,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeQuery {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expr_name: CloneIn::clone_in_with_semantic_ids(&self.expr_name, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -7911,7 +7896,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             source: CloneIn::clone_in(&self.source, allocator),
             options: CloneIn::clone_in(&self.options, allocator),
@@ -7922,7 +7907,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             source: CloneIn::clone_in_with_semantic_ids(&self.source, allocator),
             options: CloneIn::clone_in_with_semantic_ids(&self.options, allocator),
@@ -7963,7 +7948,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifiedName<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportTypeQualifiedName {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
@@ -7972,7 +7957,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifiedName<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportTypeQualifiedName {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             left: CloneIn::clone_in_with_semantic_ids(&self.left, allocator),
             right: CloneIn::clone_in_with_semantic_ids(&self.right, allocator),
@@ -7985,7 +7970,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSFunctionType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             this_param: CloneIn::clone_in(&self.this_param, allocator),
@@ -7997,7 +7982,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSFunctionType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
             this_param: CloneIn::clone_in_with_semantic_ids(&self.this_param, allocator),
@@ -8013,7 +7998,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructorType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
@@ -8025,7 +8010,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSConstructorType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             r#abstract: CloneIn::clone_in_with_semantic_ids(&self.r#abstract, allocator),
             type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
@@ -8041,7 +8026,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMappedType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             key: CloneIn::clone_in(&self.key, allocator),
             constraint: CloneIn::clone_in(&self.constraint, allocator),
@@ -8055,7 +8040,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSMappedType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             key: CloneIn::clone_in_with_semantic_ids(&self.key, allocator),
             constraint: CloneIn::clone_in_with_semantic_ids(&self.constraint, allocator),
@@ -8087,7 +8072,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTemplateLiteralType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTemplateLiteralType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             quasis: CloneIn::clone_in(&self.quasis, allocator),
             types: CloneIn::clone_in(&self.types, allocator),
@@ -8096,7 +8081,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTemplateLiteralType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTemplateLiteralType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             quasis: CloneIn::clone_in_with_semantic_ids(&self.quasis, allocator),
             types: CloneIn::clone_in_with_semantic_ids(&self.types, allocator),
@@ -8109,7 +8094,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAsExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSAsExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -8118,7 +8103,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAsExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSAsExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
@@ -8131,7 +8116,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSatisfiesExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSSatisfiesExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
@@ -8140,7 +8125,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSatisfiesExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSSatisfiesExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
@@ -8153,7 +8138,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAssertion {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
@@ -8162,7 +8147,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSTypeAssertion {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
@@ -8175,7 +8160,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportEqualsDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportEqualsDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
             module_reference: CloneIn::clone_in(&self.module_reference, allocator),
@@ -8185,7 +8170,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportEqualsDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSImportEqualsDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
             module_reference: CloneIn::clone_in_with_semantic_ids(
@@ -8234,7 +8219,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExternalModuleReference<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExternalModuleReference {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -8242,7 +8227,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExternalModuleReference<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExternalModuleReference {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -8254,7 +8239,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNonNullExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNonNullExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -8262,7 +8247,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNonNullExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNonNullExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -8274,7 +8259,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Decorator<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Decorator {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -8282,7 +8267,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Decorator<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         Decorator {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -8294,7 +8279,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExportAssignment<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExportAssignment {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
         }
@@ -8302,7 +8287,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExportAssignment<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSExportAssignment {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
         }
@@ -8314,7 +8299,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamespaceExportDeclaration<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamespaceExportDeclaration {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
         }
@@ -8322,7 +8307,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamespaceExportDeclaration<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSNamespaceExportDeclaration {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
         }
@@ -8334,7 +8319,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInstantiationExpression {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -8343,7 +8328,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TSInstantiationExpression {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
@@ -8370,7 +8355,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNullableType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNullableType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             postfix: CloneIn::clone_in(&self.postfix, allocator),
@@ -8379,7 +8364,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNullableType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNullableType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
             postfix: CloneIn::clone_in_with_semantic_ids(&self.postfix, allocator),
@@ -8392,7 +8377,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'_> {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNonNullableType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
             type_annotation: CloneIn::clone_in(&self.type_annotation, allocator),
             postfix: CloneIn::clone_in(&self.postfix, allocator),
@@ -8401,7 +8386,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'_> {
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocNonNullableType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             type_annotation: CloneIn::clone_in_with_semantic_ids(&self.type_annotation, allocator),
             postfix: CloneIn::clone_in_with_semantic_ids(&self.postfix, allocator),
@@ -8414,14 +8399,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocUnknownType {
 
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocUnknownType {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Default::default(),
             span: CloneIn::clone_in(&self.span, allocator),
         }
     }
 
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSDocUnknownType {
-            node_id: Cell::new(self.node_id.get()),
+            node_id: CloneIn::clone_in_with_semantic_ids(&self.node_id, allocator),
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
         }
     }

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -2,12 +2,14 @@
 
 use bitflags::bitflags;
 
+use oxc_allocator::{Allocator, CloneIn};
 use oxc_ast_macros::ast;
 use oxc_index::define_nonmax_u32_index_type;
 
 define_nonmax_u32_index_type! {
     /// AST Node ID
     #[ast]
+    #[clone_in(default)]
     pub struct NodeId;
 }
 
@@ -19,6 +21,27 @@ impl NodeId {
 
     /// Node id of the Program node.
     pub const ROOT: Self = NodeId::new(0);
+}
+
+impl Default for NodeId {
+    #[inline]
+    fn default() -> Self {
+        Self::DUMMY
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for NodeId {
+    type Cloned = Self;
+
+    fn clone_in(&self, _: &'alloc Allocator) -> Self {
+        // `clone_in` should never reach this, because `CloneIn` skips `node_id` field
+        unreachable!();
+    }
+
+    #[inline]
+    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
+        *self
+    }
 }
 
 bitflags! {

--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -87,10 +87,7 @@ fn derive_struct(struct_def: &StructDef, schema: &Schema) -> TokenStream {
         let clone_in_body = if has_fields {
             let fields = struct_def.fields.iter().map(|field| {
                 let field_ident = field.ident();
-                // Special case: node_id uses Cell::new(NodeId::DUMMY) when cloning
-                if field.name() == "node_id" {
-                    quote!( #field_ident: Cell::new(oxc_syntax::node::NodeId::DUMMY) )
-                } else if struct_field_is_default(field, schema) {
+                if struct_field_is_default(field, schema) {
                     quote!( #field_ident: Default::default() )
                 } else {
                     quote!( #field_ident: CloneIn::clone_in(&self.#field_ident, allocator) )
@@ -104,12 +101,7 @@ fn derive_struct(struct_def: &StructDef, schema: &Schema) -> TokenStream {
         let clone_in_with_semantic_ids_body = if has_fields {
             let fields = struct_def.fields.iter().map(|field| {
                 let field_ident = field.ident();
-                // Special case: node_id is copied via .get() to preserve semantic IDs
-                if field.name() == "node_id" {
-                    quote!( #field_ident: Cell::new(self.#field_ident.get()) )
-                } else {
-                    quote!( #field_ident: CloneIn::clone_in_with_semantic_ids(&self.#field_ident, allocator) )
-                }
+                quote!( #field_ident: CloneIn::clone_in_with_semantic_ids(&self.#field_ident, allocator) )
             });
             quote!( #type_ident { #(#fields),* } )
         } else {


### PR DESCRIPTION
Simplify `CloneIn` generator in `ast_tools`.

Previously it had "special case" code for `NodeId`. Instead, implement `CloneIn` and `Default` on `NodeId`, and then `node_id: Cell<NodeId>` fields can be treated the same as any other field.