### PR TITLE
refactor(ast_tools): remove special-case logic for `NodeId` from `Dummy` generator

### DIFF
--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -18,7 +18,7 @@ impl<'a> Dummy<'a> for Program<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             source_type: Dummy::dummy(allocator),
             source_text: Dummy::dummy(allocator),
@@ -46,7 +46,7 @@ impl<'a> Dummy<'a> for IdentifierName<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
         }
@@ -59,7 +59,7 @@ impl<'a> Dummy<'a> for IdentifierReference<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             reference_id: Dummy::dummy(allocator),
@@ -73,7 +73,7 @@ impl<'a> Dummy<'a> for BindingIdentifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             symbol_id: Dummy::dummy(allocator),
@@ -87,7 +87,7 @@ impl<'a> Dummy<'a> for LabelIdentifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
         }
@@ -99,7 +99,7 @@ impl<'a> Dummy<'a> for ThisExpression {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -109,7 +109,7 @@ impl<'a> Dummy<'a> for ArrayExpression<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             elements: Dummy::dummy(allocator),
         }
@@ -130,7 +130,7 @@ impl<'a> Dummy<'a> for Elision {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -140,7 +140,7 @@ impl<'a> Dummy<'a> for ObjectExpression<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             properties: Dummy::dummy(allocator),
         }
@@ -162,7 +162,7 @@ impl<'a> Dummy<'a> for ObjectProperty<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             kind: Dummy::dummy(allocator),
             key: Dummy::dummy(allocator),
@@ -199,7 +199,7 @@ impl<'a> Dummy<'a> for TemplateLiteral<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             quasis: Dummy::dummy(allocator),
             expressions: Dummy::dummy(allocator),
@@ -213,7 +213,7 @@ impl<'a> Dummy<'a> for TaggedTemplateExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             tag: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -228,7 +228,7 @@ impl<'a> Dummy<'a> for TemplateElement<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
             tail: Dummy::dummy(allocator),
@@ -261,7 +261,7 @@ impl<'a> Dummy<'a> for ComputedMemberExpression<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             object: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
@@ -276,7 +276,7 @@ impl<'a> Dummy<'a> for StaticMemberExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             object: Dummy::dummy(allocator),
             property: Dummy::dummy(allocator),
@@ -291,7 +291,7 @@ impl<'a> Dummy<'a> for PrivateFieldExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             object: Dummy::dummy(allocator),
             field: Dummy::dummy(allocator),
@@ -306,7 +306,7 @@ impl<'a> Dummy<'a> for CallExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             callee: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -323,7 +323,7 @@ impl<'a> Dummy<'a> for NewExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             callee: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -339,7 +339,7 @@ impl<'a> Dummy<'a> for MetaProperty<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             meta: Dummy::dummy(allocator),
             property: Dummy::dummy(allocator),
@@ -353,7 +353,7 @@ impl<'a> Dummy<'a> for SpreadElement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
         }
@@ -375,7 +375,7 @@ impl<'a> Dummy<'a> for UpdateExpression<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             operator: Dummy::dummy(allocator),
             prefix: Dummy::dummy(allocator),
@@ -390,7 +390,7 @@ impl<'a> Dummy<'a> for UnaryExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             operator: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
@@ -404,7 +404,7 @@ impl<'a> Dummy<'a> for BinaryExpression<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             operator: Dummy::dummy(allocator),
@@ -419,7 +419,7 @@ impl<'a> Dummy<'a> for PrivateInExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             right: Dummy::dummy(allocator),
@@ -433,7 +433,7 @@ impl<'a> Dummy<'a> for LogicalExpression<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             operator: Dummy::dummy(allocator),
@@ -448,7 +448,7 @@ impl<'a> Dummy<'a> for ConditionalExpression<'a> {
     /// Has cost of making 3 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             test: Dummy::dummy(allocator),
             consequent: Dummy::dummy(allocator),
@@ -463,7 +463,7 @@ impl<'a> Dummy<'a> for AssignmentExpression<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             operator: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
@@ -505,7 +505,7 @@ impl<'a> Dummy<'a> for ArrayAssignmentTarget<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             elements: Dummy::dummy(allocator),
             rest: Dummy::dummy(allocator),
@@ -519,7 +519,7 @@ impl<'a> Dummy<'a> for ObjectAssignmentTarget<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             properties: Dummy::dummy(allocator),
             rest: Dummy::dummy(allocator),
@@ -533,7 +533,7 @@ impl<'a> Dummy<'a> for AssignmentTargetRest<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             target: Dummy::dummy(allocator),
         }
@@ -555,7 +555,7 @@ impl<'a> Dummy<'a> for AssignmentTargetWithDefault<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             binding: Dummy::dummy(allocator),
             init: Dummy::dummy(allocator),
@@ -578,7 +578,7 @@ impl<'a> Dummy<'a> for AssignmentTargetPropertyIdentifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             binding: Dummy::dummy(allocator),
             init: Dummy::dummy(allocator),
@@ -592,7 +592,7 @@ impl<'a> Dummy<'a> for AssignmentTargetPropertyProperty<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             binding: Dummy::dummy(allocator),
@@ -607,7 +607,7 @@ impl<'a> Dummy<'a> for SequenceExpression<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expressions: Dummy::dummy(allocator),
         }
@@ -619,7 +619,7 @@ impl<'a> Dummy<'a> for Super {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -629,7 +629,7 @@ impl<'a> Dummy<'a> for AwaitExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
         }
@@ -642,7 +642,7 @@ impl<'a> Dummy<'a> for ChainExpression<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -664,7 +664,7 @@ impl<'a> Dummy<'a> for ParenthesizedExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -686,7 +686,7 @@ impl<'a> Dummy<'a> for Directive<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
             directive: Dummy::dummy(allocator),
@@ -700,7 +700,7 @@ impl<'a> Dummy<'a> for Hashbang<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
         }
@@ -713,7 +713,7 @@ impl<'a> Dummy<'a> for BlockStatement<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
             scope_id: Dummy::dummy(allocator),
@@ -736,7 +736,7 @@ impl<'a> Dummy<'a> for VariableDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             kind: Dummy::dummy(allocator),
             declarations: Dummy::dummy(allocator),
@@ -761,7 +761,7 @@ impl<'a> Dummy<'a> for VariableDeclarator<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             kind: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
@@ -777,7 +777,7 @@ impl<'a> Dummy<'a> for EmptyStatement {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -787,7 +787,7 @@ impl<'a> Dummy<'a> for ExpressionStatement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -800,7 +800,7 @@ impl<'a> Dummy<'a> for IfStatement<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             test: Dummy::dummy(allocator),
             consequent: Dummy::dummy(allocator),
@@ -815,7 +815,7 @@ impl<'a> Dummy<'a> for DoWhileStatement<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
             test: Dummy::dummy(allocator),
@@ -829,7 +829,7 @@ impl<'a> Dummy<'a> for WhileStatement<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             test: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -843,7 +843,7 @@ impl<'a> Dummy<'a> for ForStatement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             init: Dummy::dummy(allocator),
             test: Dummy::dummy(allocator),
@@ -869,7 +869,7 @@ impl<'a> Dummy<'a> for ForInStatement<'a> {
     /// Has cost of making 3 allocations (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             right: Dummy::dummy(allocator),
@@ -894,7 +894,7 @@ impl<'a> Dummy<'a> for ForOfStatement<'a> {
     /// Has cost of making 3 allocations (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             r#await: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
@@ -911,7 +911,7 @@ impl<'a> Dummy<'a> for ContinueStatement<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             label: Dummy::dummy(allocator),
         }
@@ -924,7 +924,7 @@ impl<'a> Dummy<'a> for BreakStatement<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             label: Dummy::dummy(allocator),
         }
@@ -937,7 +937,7 @@ impl<'a> Dummy<'a> for ReturnStatement<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
         }
@@ -950,7 +950,7 @@ impl<'a> Dummy<'a> for WithStatement<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             object: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -965,7 +965,7 @@ impl<'a> Dummy<'a> for SwitchStatement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             discriminant: Dummy::dummy(allocator),
             cases: Dummy::dummy(allocator),
@@ -980,7 +980,7 @@ impl<'a> Dummy<'a> for SwitchCase<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             test: Dummy::dummy(allocator),
             consequent: Dummy::dummy(allocator),
@@ -994,7 +994,7 @@ impl<'a> Dummy<'a> for LabeledStatement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             label: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -1008,7 +1008,7 @@ impl<'a> Dummy<'a> for ThrowStatement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
         }
@@ -1021,7 +1021,7 @@ impl<'a> Dummy<'a> for TryStatement<'a> {
     /// Has cost of making 1 allocation (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             block: Dummy::dummy(allocator),
             handler: Dummy::dummy(allocator),
@@ -1036,7 +1036,7 @@ impl<'a> Dummy<'a> for CatchClause<'a> {
     /// Has cost of making 1 allocation (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             param: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -1051,7 +1051,7 @@ impl<'a> Dummy<'a> for CatchParameter<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             pattern: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
@@ -1064,7 +1064,7 @@ impl<'a> Dummy<'a> for DebuggerStatement {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -1083,7 +1083,7 @@ impl<'a> Dummy<'a> for AssignmentPattern<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             right: Dummy::dummy(allocator),
@@ -1097,7 +1097,7 @@ impl<'a> Dummy<'a> for ObjectPattern<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             properties: Dummy::dummy(allocator),
             rest: Dummy::dummy(allocator),
@@ -1111,7 +1111,7 @@ impl<'a> Dummy<'a> for BindingProperty<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             key: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
@@ -1127,7 +1127,7 @@ impl<'a> Dummy<'a> for ArrayPattern<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             elements: Dummy::dummy(allocator),
             rest: Dummy::dummy(allocator),
@@ -1141,7 +1141,7 @@ impl<'a> Dummy<'a> for BindingRestElement<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
         }
@@ -1154,7 +1154,7 @@ impl<'a> Dummy<'a> for Function<'a> {
     /// Has cost of making 1 allocation (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             r#type: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
@@ -1189,7 +1189,7 @@ impl<'a> Dummy<'a> for FormalParameters<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             kind: Dummy::dummy(allocator),
             items: Dummy::dummy(allocator),
@@ -1204,7 +1204,7 @@ impl<'a> Dummy<'a> for FormalParameter<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             decorators: Dummy::dummy(allocator),
             pattern: Dummy::dummy(allocator),
@@ -1234,7 +1234,7 @@ impl<'a> Dummy<'a> for FormalParameterRest<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             decorators: Dummy::dummy(allocator),
             rest: Dummy::dummy(allocator),
@@ -1249,7 +1249,7 @@ impl<'a> Dummy<'a> for FunctionBody<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             directives: Dummy::dummy(allocator),
             statements: Dummy::dummy(allocator),
@@ -1263,7 +1263,7 @@ impl<'a> Dummy<'a> for ArrowFunctionExpression<'a> {
     /// Has cost of making 2 allocations (112 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
             r#async: Dummy::dummy(allocator),
@@ -1284,7 +1284,7 @@ impl<'a> Dummy<'a> for YieldExpression<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             delegate: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
@@ -1298,7 +1298,7 @@ impl<'a> Dummy<'a> for Class<'a> {
     /// Has cost of making 1 allocation (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             r#type: Dummy::dummy(allocator),
             decorators: Dummy::dummy(allocator),
@@ -1331,7 +1331,7 @@ impl<'a> Dummy<'a> for ClassBody<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
         }
@@ -1353,7 +1353,7 @@ impl<'a> Dummy<'a> for MethodDefinition<'a> {
     /// Has cost of making 3 allocations (160 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             r#type: Dummy::dummy(allocator),
             decorators: Dummy::dummy(allocator),
@@ -1385,7 +1385,7 @@ impl<'a> Dummy<'a> for PropertyDefinition<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             r#type: Dummy::dummy(allocator),
             decorators: Dummy::dummy(allocator),
@@ -1430,7 +1430,7 @@ impl<'a> Dummy<'a> for PrivateIdentifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
         }
@@ -1443,7 +1443,7 @@ impl<'a> Dummy<'a> for StaticBlock<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
             scope_id: Dummy::dummy(allocator),
@@ -1476,7 +1476,7 @@ impl<'a> Dummy<'a> for AccessorProperty<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             r#type: Dummy::dummy(allocator),
             decorators: Dummy::dummy(allocator),
@@ -1498,7 +1498,7 @@ impl<'a> Dummy<'a> for ImportExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             source: Dummy::dummy(allocator),
             options: Dummy::dummy(allocator),
@@ -1513,7 +1513,7 @@ impl<'a> Dummy<'a> for ImportDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             specifiers: Dummy::dummy(allocator),
             source: Dummy::dummy(allocator),
@@ -1549,7 +1549,7 @@ impl<'a> Dummy<'a> for ImportSpecifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             imported: Dummy::dummy(allocator),
             local: Dummy::dummy(allocator),
@@ -1564,7 +1564,7 @@ impl<'a> Dummy<'a> for ImportDefaultSpecifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             local: Dummy::dummy(allocator),
         }
@@ -1577,7 +1577,7 @@ impl<'a> Dummy<'a> for ImportNamespaceSpecifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             local: Dummy::dummy(allocator),
         }
@@ -1590,7 +1590,7 @@ impl<'a> Dummy<'a> for WithClause<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             keyword: Dummy::dummy(allocator),
             with_entries: Dummy::dummy(allocator),
@@ -1614,7 +1614,7 @@ impl<'a> Dummy<'a> for ImportAttribute<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             key: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
@@ -1637,7 +1637,7 @@ impl<'a> Dummy<'a> for ExportNamedDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             declaration: Dummy::dummy(allocator),
             specifiers: Dummy::dummy(allocator),
@@ -1654,7 +1654,7 @@ impl<'a> Dummy<'a> for ExportDefaultDeclaration<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             declaration: Dummy::dummy(allocator),
         }
@@ -1667,7 +1667,7 @@ impl<'a> Dummy<'a> for ExportAllDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             exported: Dummy::dummy(allocator),
             source: Dummy::dummy(allocator),
@@ -1683,7 +1683,7 @@ impl<'a> Dummy<'a> for ExportSpecifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             local: Dummy::dummy(allocator),
             exported: Dummy::dummy(allocator),
@@ -1716,7 +1716,7 @@ impl<'a> Dummy<'a> for V8IntrinsicExpression<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             arguments: Dummy::dummy(allocator),
@@ -1730,7 +1730,7 @@ impl<'a> Dummy<'a> for BooleanLiteral {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
         }
@@ -1742,7 +1742,7 @@ impl<'a> Dummy<'a> for NullLiteral {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -1752,7 +1752,7 @@ impl<'a> Dummy<'a> for NumericLiteral<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
             raw: Dummy::dummy(allocator),
@@ -1767,7 +1767,7 @@ impl<'a> Dummy<'a> for StringLiteral<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
             raw: Dummy::dummy(allocator),
@@ -1782,7 +1782,7 @@ impl<'a> Dummy<'a> for BigIntLiteral<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
             raw: Dummy::dummy(allocator),
@@ -1797,7 +1797,7 @@ impl<'a> Dummy<'a> for RegExpLiteral<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             regex: Dummy::dummy(allocator),
             raw: Dummy::dummy(allocator),
@@ -1829,7 +1829,7 @@ impl<'a> Dummy<'a> for JSXElement<'a> {
     /// Has cost of making 2 allocations (80 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             opening_element: Dummy::dummy(allocator),
             children: Dummy::dummy(allocator),
@@ -1844,7 +1844,7 @@ impl<'a> Dummy<'a> for JSXOpeningElement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -1859,7 +1859,7 @@ impl<'a> Dummy<'a> for JSXClosingElement<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
         }
@@ -1872,7 +1872,7 @@ impl<'a> Dummy<'a> for JSXFragment<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             opening_fragment: Dummy::dummy(allocator),
             children: Dummy::dummy(allocator),
@@ -1886,7 +1886,7 @@ impl<'a> Dummy<'a> for JSXOpeningFragment {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -1895,7 +1895,7 @@ impl<'a> Dummy<'a> for JSXClosingFragment {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -1914,7 +1914,7 @@ impl<'a> Dummy<'a> for JSXNamespacedName<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             namespace: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
@@ -1928,7 +1928,7 @@ impl<'a> Dummy<'a> for JSXMemberExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             object: Dummy::dummy(allocator),
             property: Dummy::dummy(allocator),
@@ -1951,7 +1951,7 @@ impl<'a> Dummy<'a> for JSXExpressionContainer<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -1972,7 +1972,7 @@ impl<'a> Dummy<'a> for JSXEmptyExpression {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -1991,7 +1991,7 @@ impl<'a> Dummy<'a> for JSXAttribute<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
@@ -2005,7 +2005,7 @@ impl<'a> Dummy<'a> for JSXSpreadAttribute<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             argument: Dummy::dummy(allocator),
         }
@@ -2036,7 +2036,7 @@ impl<'a> Dummy<'a> for JSXIdentifier<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
         }
@@ -2058,7 +2058,7 @@ impl<'a> Dummy<'a> for JSXSpreadChild<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -2071,7 +2071,7 @@ impl<'a> Dummy<'a> for JSXText<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
             raw: Dummy::dummy(allocator),
@@ -2085,7 +2085,7 @@ impl<'a> Dummy<'a> for TSThisParameter<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             this_span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
@@ -2099,7 +2099,7 @@ impl<'a> Dummy<'a> for TSEnumDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -2115,7 +2115,7 @@ impl<'a> Dummy<'a> for TSEnumBody<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             members: Dummy::dummy(allocator),
             scope_id: Dummy::dummy(allocator),
@@ -2129,7 +2129,7 @@ impl<'a> Dummy<'a> for TSEnumMember<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
             initializer: Dummy::dummy(allocator),
@@ -2152,7 +2152,7 @@ impl<'a> Dummy<'a> for TSTypeAnnotation<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
         }
@@ -2165,7 +2165,7 @@ impl<'a> Dummy<'a> for TSLiteralType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             literal: Dummy::dummy(allocator),
         }
@@ -2196,7 +2196,7 @@ impl<'a> Dummy<'a> for TSConditionalType<'a> {
     /// Has cost of making 4 allocations (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             check_type: Dummy::dummy(allocator),
             extends_type: Dummy::dummy(allocator),
@@ -2213,7 +2213,7 @@ impl<'a> Dummy<'a> for TSUnionType<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             types: Dummy::dummy(allocator),
         }
@@ -2226,7 +2226,7 @@ impl<'a> Dummy<'a> for TSIntersectionType<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             types: Dummy::dummy(allocator),
         }
@@ -2239,7 +2239,7 @@ impl<'a> Dummy<'a> for TSParenthesizedType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
         }
@@ -2252,7 +2252,7 @@ impl<'a> Dummy<'a> for TSTypeOperator<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             operator: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
@@ -2276,7 +2276,7 @@ impl<'a> Dummy<'a> for TSArrayType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             element_type: Dummy::dummy(allocator),
         }
@@ -2289,7 +2289,7 @@ impl<'a> Dummy<'a> for TSIndexedAccessType<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             object_type: Dummy::dummy(allocator),
             index_type: Dummy::dummy(allocator),
@@ -2303,7 +2303,7 @@ impl<'a> Dummy<'a> for TSTupleType<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             element_types: Dummy::dummy(allocator),
         }
@@ -2316,7 +2316,7 @@ impl<'a> Dummy<'a> for TSNamedTupleMember<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             label: Dummy::dummy(allocator),
             element_type: Dummy::dummy(allocator),
@@ -2331,7 +2331,7 @@ impl<'a> Dummy<'a> for TSOptionalType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
         }
@@ -2344,7 +2344,7 @@ impl<'a> Dummy<'a> for TSRestType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
         }
@@ -2365,7 +2365,7 @@ impl<'a> Dummy<'a> for TSAnyKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2374,7 +2374,7 @@ impl<'a> Dummy<'a> for TSStringKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2383,7 +2383,7 @@ impl<'a> Dummy<'a> for TSBooleanKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2392,7 +2392,7 @@ impl<'a> Dummy<'a> for TSNumberKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2401,7 +2401,7 @@ impl<'a> Dummy<'a> for TSNeverKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2410,7 +2410,7 @@ impl<'a> Dummy<'a> for TSIntrinsicKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2419,7 +2419,7 @@ impl<'a> Dummy<'a> for TSUnknownKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2428,7 +2428,7 @@ impl<'a> Dummy<'a> for TSNullKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2437,7 +2437,7 @@ impl<'a> Dummy<'a> for TSUndefinedKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2446,7 +2446,7 @@ impl<'a> Dummy<'a> for TSVoidKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2455,7 +2455,7 @@ impl<'a> Dummy<'a> for TSSymbolKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2464,7 +2464,7 @@ impl<'a> Dummy<'a> for TSThisType {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2473,7 +2473,7 @@ impl<'a> Dummy<'a> for TSObjectKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2482,7 +2482,7 @@ impl<'a> Dummy<'a> for TSBigIntKeyword {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }
 
@@ -2492,7 +2492,7 @@ impl<'a> Dummy<'a> for TSTypeReference<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_name: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -2515,7 +2515,7 @@ impl<'a> Dummy<'a> for TSQualifiedName<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             right: Dummy::dummy(allocator),
@@ -2529,7 +2529,7 @@ impl<'a> Dummy<'a> for TSTypeParameterInstantiation<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             params: Dummy::dummy(allocator),
         }
@@ -2542,7 +2542,7 @@ impl<'a> Dummy<'a> for TSTypeParameter<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             constraint: Dummy::dummy(allocator),
@@ -2560,7 +2560,7 @@ impl<'a> Dummy<'a> for TSTypeParameterDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             params: Dummy::dummy(allocator),
         }
@@ -2573,7 +2573,7 @@ impl<'a> Dummy<'a> for TSTypeAliasDeclaration<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
             type_parameters: Dummy::dummy(allocator),
@@ -2600,7 +2600,7 @@ impl<'a> Dummy<'a> for TSClassImplements<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -2614,7 +2614,7 @@ impl<'a> Dummy<'a> for TSInterfaceDeclaration<'a> {
     /// Has cost of making 1 allocation (40 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
             type_parameters: Dummy::dummy(allocator),
@@ -2632,7 +2632,7 @@ impl<'a> Dummy<'a> for TSInterfaceBody<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
         }
@@ -2645,7 +2645,7 @@ impl<'a> Dummy<'a> for TSPropertySignature<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             computed: Dummy::dummy(allocator),
             optional: Dummy::dummy(allocator),
@@ -2671,7 +2671,7 @@ impl<'a> Dummy<'a> for TSIndexSignature<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             parameters: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
@@ -2687,7 +2687,7 @@ impl<'a> Dummy<'a> for TSCallSignatureDeclaration<'a> {
     /// Has cost of making 1 allocation (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_parameters: Dummy::dummy(allocator),
             this_param: Dummy::dummy(allocator),
@@ -2714,7 +2714,7 @@ impl<'a> Dummy<'a> for TSMethodSignature<'a> {
     /// Has cost of making 2 allocations (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             key: Dummy::dummy(allocator),
             computed: Dummy::dummy(allocator),
@@ -2735,7 +2735,7 @@ impl<'a> Dummy<'a> for TSConstructSignatureDeclaration<'a> {
     /// Has cost of making 1 allocation (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_parameters: Dummy::dummy(allocator),
             params: Dummy::dummy(allocator),
@@ -2751,7 +2751,7 @@ impl<'a> Dummy<'a> for TSIndexSignatureName<'a> {
     /// Has cost of making 2 allocations (48 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
@@ -2765,7 +2765,7 @@ impl<'a> Dummy<'a> for TSInterfaceHeritage<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -2779,7 +2779,7 @@ impl<'a> Dummy<'a> for TSTypePredicate<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             parameter_name: Dummy::dummy(allocator),
             asserts: Dummy::dummy(allocator),
@@ -2803,7 +2803,7 @@ impl<'a> Dummy<'a> for TSModuleDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -2848,7 +2848,7 @@ impl<'a> Dummy<'a> for TSGlobalDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             global_span: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -2864,7 +2864,7 @@ impl<'a> Dummy<'a> for TSModuleBlock<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             directives: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
@@ -2878,7 +2878,7 @@ impl<'a> Dummy<'a> for TSTypeLiteral<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             members: Dummy::dummy(allocator),
         }
@@ -2891,7 +2891,7 @@ impl<'a> Dummy<'a> for TSInferType<'a> {
     /// Has cost of making 1 allocation (80 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_parameter: Dummy::dummy(allocator),
         }
@@ -2904,7 +2904,7 @@ impl<'a> Dummy<'a> for TSTypeQuery<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expr_name: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -2927,7 +2927,7 @@ impl<'a> Dummy<'a> for TSImportType<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             source: Dummy::dummy(allocator),
             options: Dummy::dummy(allocator),
@@ -2952,7 +2952,7 @@ impl<'a> Dummy<'a> for TSImportTypeQualifiedName<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             left: Dummy::dummy(allocator),
             right: Dummy::dummy(allocator),
@@ -2966,7 +2966,7 @@ impl<'a> Dummy<'a> for TSFunctionType<'a> {
     /// Has cost of making 3 allocations (96 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_parameters: Dummy::dummy(allocator),
             this_param: Dummy::dummy(allocator),
@@ -2983,7 +2983,7 @@ impl<'a> Dummy<'a> for TSConstructorType<'a> {
     /// Has cost of making 3 allocations (96 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             r#abstract: Dummy::dummy(allocator),
             type_parameters: Dummy::dummy(allocator),
@@ -3000,7 +3000,7 @@ impl<'a> Dummy<'a> for TSMappedType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             key: Dummy::dummy(allocator),
             constraint: Dummy::dummy(allocator),
@@ -3029,7 +3029,7 @@ impl<'a> Dummy<'a> for TSTemplateLiteralType<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             quasis: Dummy::dummy(allocator),
             types: Dummy::dummy(allocator),
@@ -3043,7 +3043,7 @@ impl<'a> Dummy<'a> for TSAsExpression<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
@@ -3057,7 +3057,7 @@ impl<'a> Dummy<'a> for TSSatisfiesExpression<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
@@ -3071,7 +3071,7 @@ impl<'a> Dummy<'a> for TSTypeAssertion<'a> {
     /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
@@ -3085,7 +3085,7 @@ impl<'a> Dummy<'a> for TSImportEqualsDeclaration<'a> {
     /// Has cost of making 1 allocation (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
             module_reference: Dummy::dummy(allocator),
@@ -3109,7 +3109,7 @@ impl<'a> Dummy<'a> for TSExternalModuleReference<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -3122,7 +3122,7 @@ impl<'a> Dummy<'a> for TSNonNullExpression<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -3135,7 +3135,7 @@ impl<'a> Dummy<'a> for Decorator<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -3148,7 +3148,7 @@ impl<'a> Dummy<'a> for TSExportAssignment<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
         }
@@ -3161,7 +3161,7 @@ impl<'a> Dummy<'a> for TSNamespaceExportDeclaration<'a> {
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
         }
@@ -3174,7 +3174,7 @@ impl<'a> Dummy<'a> for TSInstantiationExpression<'a> {
     /// Has cost of making 2 allocations (56 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),
@@ -3198,7 +3198,7 @@ impl<'a> Dummy<'a> for JSDocNullableType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
             postfix: Dummy::dummy(allocator),
@@ -3212,7 +3212,7 @@ impl<'a> Dummy<'a> for JSDocNonNullableType<'a> {
     /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
-            node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY),
+            node_id: Dummy::dummy(allocator),
             span: Dummy::dummy(allocator),
             type_annotation: Dummy::dummy(allocator),
             postfix: Dummy::dummy(allocator),
@@ -3225,6 +3225,6 @@ impl<'a> Dummy<'a> for JSDocUnknownType {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self { node_id: Cell::new(oxc_syntax::node::NodeId::DUMMY), span: Dummy::dummy(allocator) }
+        Self { node_id: Dummy::dummy(allocator), span: Dummy::dummy(allocator) }
     }
 }

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -2,7 +2,7 @@
 
 use bitflags::bitflags;
 
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, Dummy};
 use oxc_ast_macros::ast;
 use oxc_index::define_nonmax_u32_index_type;
 
@@ -26,6 +26,13 @@ impl NodeId {
 impl Default for NodeId {
     #[inline]
     fn default() -> Self {
+        Self::DUMMY
+    }
+}
+
+impl<'a> Dummy<'a> for NodeId {
+    #[inline]
+    fn dummy(_: &'a Allocator) -> Self {
         Self::DUMMY
     }
 }

--- a/tasks/ast_tools/src/derives/dummy.rs
+++ b/tasks/ast_tools/src/derives/dummy.rs
@@ -201,12 +201,7 @@ fn calculate_alloc_for_enum(type_id: TypeId, schema: &mut Schema) -> Alloc {
 fn generate_impl_for_struct(struct_def: &StructDef, schema: &Schema) -> TokenStream {
     let fields = struct_def.fields.iter().map(|field| {
         let field_ident = field.ident();
-        // Special case: node_id uses NodeId::DUMMY instead of Dummy::dummy
-        if field.name() == "node_id" {
-            quote!(#field_ident: Cell::new(oxc_syntax::node::NodeId::DUMMY))
-        } else {
-            quote!(#field_ident: Dummy::dummy(allocator))
-        }
+        quote!(#field_ident: Dummy::dummy(allocator))
     });
 
     let value = quote! {


### PR DESCRIPTION
Simplify `Dummy` generator in `ast_tools`.

Previously it had "special case" code for `NodeId`. Instead, implement `Dummy` on `NodeId`, and then `node_id: Cell<NodeId>` fields can be treated the same as any other field.