### PR TITLE
refactor(ast_tools): remove special-case logic for `NodeId` from `ContentEq` generator

### DIFF
--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -10,6 +10,7 @@ define_nonmax_u32_index_type! {
     /// AST Node ID
     #[ast]
     #[clone_in(default)]
+    #[content_eq(skip)]
     pub struct NodeId;
 }
 

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -80,8 +80,6 @@ fn derive_struct(struct_def: &StructDef, schema: &Schema) -> TokenStream {
         let fields = struct_def
             .fields
             .iter()
-            // Skip node_id field - it's internal and not part of content equality
-            .filter(|field| field.name() != "node_id")
             .filter(|field| !field.content_eq.skip)
             .filter(|field| {
                 let innermost_type = field.type_def(schema).innermost_type(schema);


### PR DESCRIPTION
Simplify `ContentEq` generator in `ast_tools`.

Previously it had "special case" code for `NodeId`. Instead, add a `#[content_eq(skip)]` attr to `NodeId` type, and then `node_id: Cell<NodeId>` fields can be treated the same as any other field.

Does not alter generated code, only the means by which it's generated.