### PR TITLE
refactor(ast_tools): remove special-case logic for `NodeId` from `ESTree` generator

### DIFF
--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -11,6 +11,7 @@ define_nonmax_u32_index_type! {
     #[ast]
     #[clone_in(default)]
     #[content_eq(skip)]
+    #[estree(skip)]
     pub struct NodeId;
 }
 

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -636,10 +636,6 @@ fn get_converter_path(converter_name: &str, from_krate: &str, schema: &Schema) -
 ///
 /// This function also used by Typescript and raw transfer generators.
 pub fn should_skip_field(field: &FieldDef, schema: &Schema) -> bool {
-    // Always skip node_id field - it's internal and not part of ESTree serialization
-    if field.name() == "node_id" {
-        return true;
-    }
     if field.estree.skip {
         true
     } else {


### PR DESCRIPTION
Simplify `ESTree` generator in `ast_tools`.

Previously it had "special case" code for `NodeId`. Instead, add a `#[estree(skip)]` attr to `NodeId` type, and then `node_id: Cell<NodeId>` fields can be treated the same as any other field.

Does not alter generated code, only the means by which it's generated.