### PR TITLE
refactor(ast): repurpose `CommentNodeId` code in `AstBuilder` codegen for `NodeId`

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -9,7 +9,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::{Allocator, Box, IntoIn, Vec};
-use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
+use oxc_syntax::{reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
 use oxc_str::{Ident, Str};
 
@@ -38,7 +38,7 @@ impl<'a> AstBuilder<'a> {
         body: Vec<'a, Statement<'a>>,
     ) -> Program<'a> {
         Program {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             source_type,
             source_text,
@@ -74,7 +74,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> Program<'a> {
         Program {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             source_type,
             source_text,
@@ -1226,7 +1226,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Ident<'a>>,
     {
-        IdentifierName { node_id: Cell::new(NodeId::DUMMY), span, name: name.into() }
+        IdentifierName { node_id: Default::default(), span, name: name.into() }
     }
 
     /// Build an [`IdentifierName`], and store it in the memory arena.
@@ -1259,7 +1259,7 @@ impl<'a> AstBuilder<'a> {
         A1: Into<Ident<'a>>,
     {
         IdentifierReference {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name: name.into(),
             reference_id: Default::default(),
@@ -1306,7 +1306,7 @@ impl<'a> AstBuilder<'a> {
         A1: Into<Ident<'a>>,
     {
         IdentifierReference {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name: name.into(),
             reference_id: Cell::new(Some(reference_id)),
@@ -1352,7 +1352,7 @@ impl<'a> AstBuilder<'a> {
         A1: Into<Ident<'a>>,
     {
         BindingIdentifier {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name: name.into(),
             symbol_id: Default::default(),
@@ -1399,7 +1399,7 @@ impl<'a> AstBuilder<'a> {
         A1: Into<Ident<'a>>,
     {
         BindingIdentifier {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name: name.into(),
             symbol_id: Cell::new(Some(symbol_id)),
@@ -1438,7 +1438,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Ident<'a>>,
     {
-        LabelIdentifier { node_id: Cell::new(NodeId::DUMMY), span, name: name.into() }
+        LabelIdentifier { node_id: Default::default(), span, name: name.into() }
     }
 
     /// Build a [`ThisExpression`].
@@ -1450,7 +1450,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn this_expression(self, span: Span) -> ThisExpression {
-        ThisExpression { node_id: Cell::new(NodeId::DUMMY), span }
+        ThisExpression { node_id: Default::default(), span }
     }
 
     /// Build a [`ThisExpression`], and store it in the memory arena.
@@ -1479,7 +1479,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         elements: Vec<'a, ArrayExpressionElement<'a>>,
     ) -> ArrayExpression<'a> {
-        ArrayExpression { node_id: Cell::new(NodeId::DUMMY), span, elements }
+        ArrayExpression { node_id: Default::default(), span, elements }
     }
 
     /// Build an [`ArrayExpression`], and store it in the memory arena.
@@ -1530,7 +1530,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn elision(self, span: Span) -> Elision {
-        Elision { node_id: Cell::new(NodeId::DUMMY), span }
+        Elision { node_id: Default::default(), span }
     }
 
     /// Build an [`ObjectExpression`].
@@ -1547,7 +1547,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         properties: Vec<'a, ObjectPropertyKind<'a>>,
     ) -> ObjectExpression<'a> {
-        ObjectExpression { node_id: Cell::new(NodeId::DUMMY), span, properties }
+        ObjectExpression { node_id: Default::default(), span, properties }
     }
 
     /// Build an [`ObjectExpression`], and store it in the memory arena.
@@ -1636,7 +1636,7 @@ impl<'a> AstBuilder<'a> {
         computed: bool,
     ) -> ObjectProperty<'a> {
         ObjectProperty {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             kind,
             key,
@@ -1723,7 +1723,7 @@ impl<'a> AstBuilder<'a> {
         quasis: Vec<'a, TemplateElement<'a>>,
         expressions: Vec<'a, Expression<'a>>,
     ) -> TemplateLiteral<'a> {
-        TemplateLiteral { node_id: Cell::new(NodeId::DUMMY), span, quasis, expressions }
+        TemplateLiteral { node_id: Default::default(), span, quasis, expressions }
     }
 
     /// Build a [`TemplateLiteral`], and store it in the memory arena.
@@ -1767,7 +1767,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TaggedTemplateExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             tag,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -1825,7 +1825,7 @@ impl<'a> AstBuilder<'a> {
             value
         };
         TemplateElement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             value,
             tail,
@@ -1857,7 +1857,7 @@ impl<'a> AstBuilder<'a> {
         } else {
             value
         };
-        TemplateElement { node_id: Cell::new(NodeId::DUMMY), span, value, tail, lone_surrogates }
+        TemplateElement { node_id: Default::default(), span, value, tail, lone_surrogates }
     }
 
     /// Build a [`MemberExpression::ComputedMemberExpression`].
@@ -1944,13 +1944,7 @@ impl<'a> AstBuilder<'a> {
         expression: Expression<'a>,
         optional: bool,
     ) -> ComputedMemberExpression<'a> {
-        ComputedMemberExpression {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            object,
-            expression,
-            optional,
-        }
+        ComputedMemberExpression { node_id: Default::default(), span, object, expression, optional }
     }
 
     /// Build a [`ComputedMemberExpression`], and store it in the memory arena.
@@ -1995,13 +1989,7 @@ impl<'a> AstBuilder<'a> {
         property: IdentifierName<'a>,
         optional: bool,
     ) -> StaticMemberExpression<'a> {
-        StaticMemberExpression {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            object,
-            property,
-            optional,
-        }
+        StaticMemberExpression { node_id: Default::default(), span, object, property, optional }
     }
 
     /// Build a [`StaticMemberExpression`], and store it in the memory arena.
@@ -2043,7 +2031,7 @@ impl<'a> AstBuilder<'a> {
         field: PrivateIdentifier<'a>,
         optional: bool,
     ) -> PrivateFieldExpression<'a> {
-        PrivateFieldExpression { node_id: Cell::new(NodeId::DUMMY), span, object, field, optional }
+        PrivateFieldExpression { node_id: Default::default(), span, object, field, optional }
     }
 
     /// Build a [`PrivateFieldExpression`], and store it in the memory arena.
@@ -2091,7 +2079,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         CallExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             callee,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -2156,7 +2144,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         CallExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             callee,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -2219,7 +2207,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         NewExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             callee,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -2276,7 +2264,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         NewExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             callee,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -2330,7 +2318,7 @@ impl<'a> AstBuilder<'a> {
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
     ) -> MetaProperty<'a> {
-        MetaProperty { node_id: Cell::new(NodeId::DUMMY), span, meta, property }
+        MetaProperty { node_id: Default::default(), span, meta, property }
     }
 
     /// Build a [`MetaProperty`], and store it in the memory arena.
@@ -2362,7 +2350,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn spread_element(self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
-        SpreadElement { node_id: Cell::new(NodeId::DUMMY), span, argument }
+        SpreadElement { node_id: Default::default(), span, argument }
     }
 
     /// Build a [`SpreadElement`], and store it in the memory arena.
@@ -2412,7 +2400,7 @@ impl<'a> AstBuilder<'a> {
         prefix: bool,
         argument: SimpleAssignmentTarget<'a>,
     ) -> UpdateExpression<'a> {
-        UpdateExpression { node_id: Cell::new(NodeId::DUMMY), span, operator, prefix, argument }
+        UpdateExpression { node_id: Default::default(), span, operator, prefix, argument }
     }
 
     /// Build an [`UpdateExpression`], and store it in the memory arena.
@@ -2452,7 +2440,7 @@ impl<'a> AstBuilder<'a> {
         operator: UnaryOperator,
         argument: Expression<'a>,
     ) -> UnaryExpression<'a> {
-        UnaryExpression { node_id: Cell::new(NodeId::DUMMY), span, operator, argument }
+        UnaryExpression { node_id: Default::default(), span, operator, argument }
     }
 
     /// Build an [`UnaryExpression`], and store it in the memory arena.
@@ -2492,7 +2480,7 @@ impl<'a> AstBuilder<'a> {
         operator: BinaryOperator,
         right: Expression<'a>,
     ) -> BinaryExpression<'a> {
-        BinaryExpression { node_id: Cell::new(NodeId::DUMMY), span, left, operator, right }
+        BinaryExpression { node_id: Default::default(), span, left, operator, right }
     }
 
     /// Build a [`BinaryExpression`], and store it in the memory arena.
@@ -2532,7 +2520,7 @@ impl<'a> AstBuilder<'a> {
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
     ) -> PrivateInExpression<'a> {
-        PrivateInExpression { node_id: Cell::new(NodeId::DUMMY), span, left, right }
+        PrivateInExpression { node_id: Default::default(), span, left, right }
     }
 
     /// Build a [`PrivateInExpression`], and store it in the memory arena.
@@ -2572,7 +2560,7 @@ impl<'a> AstBuilder<'a> {
         operator: LogicalOperator,
         right: Expression<'a>,
     ) -> LogicalExpression<'a> {
-        LogicalExpression { node_id: Cell::new(NodeId::DUMMY), span, left, operator, right }
+        LogicalExpression { node_id: Default::default(), span, left, operator, right }
     }
 
     /// Build a [`LogicalExpression`], and store it in the memory arena.
@@ -2614,13 +2602,7 @@ impl<'a> AstBuilder<'a> {
         consequent: Expression<'a>,
         alternate: Expression<'a>,
     ) -> ConditionalExpression<'a> {
-        ConditionalExpression {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            test,
-            consequent,
-            alternate,
-        }
+        ConditionalExpression { node_id: Default::default(), span, test, consequent, alternate }
     }
 
     /// Build a [`ConditionalExpression`], and store it in the memory arena.
@@ -2662,7 +2644,7 @@ impl<'a> AstBuilder<'a> {
         left: AssignmentTarget<'a>,
         right: Expression<'a>,
     ) -> AssignmentExpression<'a> {
-        AssignmentExpression { node_id: Cell::new(NodeId::DUMMY), span, operator, left, right }
+        AssignmentExpression { node_id: Default::default(), span, operator, left, right }
     }
 
     /// Build an [`AssignmentExpression`], and store it in the memory arena.
@@ -2880,7 +2862,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
     {
         ArrayAssignmentTarget {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             elements,
             rest: rest.into_in(self.allocator),
@@ -2929,7 +2911,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
     {
         ObjectAssignmentTarget {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             properties,
             rest: rest.into_in(self.allocator),
@@ -2972,7 +2954,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         target: AssignmentTarget<'a>,
     ) -> AssignmentTargetRest<'a> {
-        AssignmentTargetRest { node_id: Cell::new(NodeId::DUMMY), span, target }
+        AssignmentTargetRest { node_id: Default::default(), span, target }
     }
 
     /// Build an [`AssignmentTargetRest`], and store it in the memory arena.
@@ -3028,7 +3010,7 @@ impl<'a> AstBuilder<'a> {
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
     ) -> AssignmentTargetWithDefault<'a> {
-        AssignmentTargetWithDefault { node_id: Cell::new(NodeId::DUMMY), span, binding, init }
+        AssignmentTargetWithDefault { node_id: Default::default(), span, binding, init }
     }
 
     /// Build an [`AssignmentTargetWithDefault`], and store it in the memory arena.
@@ -3108,12 +3090,7 @@ impl<'a> AstBuilder<'a> {
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
     ) -> AssignmentTargetPropertyIdentifier<'a> {
-        AssignmentTargetPropertyIdentifier {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            binding,
-            init,
-        }
+        AssignmentTargetPropertyIdentifier { node_id: Default::default(), span, binding, init }
     }
 
     /// Build an [`AssignmentTargetPropertyIdentifier`], and store it in the memory arena.
@@ -3154,7 +3131,7 @@ impl<'a> AstBuilder<'a> {
         computed: bool,
     ) -> AssignmentTargetPropertyProperty<'a> {
         AssignmentTargetPropertyProperty {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name,
             binding,
@@ -3200,7 +3177,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expressions: Vec<'a, Expression<'a>>,
     ) -> SequenceExpression<'a> {
-        SequenceExpression { node_id: Cell::new(NodeId::DUMMY), span, expressions }
+        SequenceExpression { node_id: Default::default(), span, expressions }
     }
 
     /// Build a [`SequenceExpression`], and store it in the memory arena.
@@ -3229,7 +3206,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn super_(self, span: Span) -> Super {
-        Super { node_id: Cell::new(NodeId::DUMMY), span }
+        Super { node_id: Default::default(), span }
     }
 
     /// Build a [`Super`], and store it in the memory arena.
@@ -3254,7 +3231,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn await_expression(self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
-        AwaitExpression { node_id: Cell::new(NodeId::DUMMY), span, argument }
+        AwaitExpression { node_id: Default::default(), span, argument }
     }
 
     /// Build an [`AwaitExpression`], and store it in the memory arena.
@@ -3284,7 +3261,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn chain_expression(self, span: Span, expression: ChainElement<'a>) -> ChainExpression<'a> {
-        ChainExpression { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        ChainExpression { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`ChainExpression`], and store it in the memory arena.
@@ -3399,7 +3376,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> ParenthesizedExpression<'a> {
-        ParenthesizedExpression { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        ParenthesizedExpression { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`ParenthesizedExpression`], and store it in the memory arena.
@@ -3873,12 +3850,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Str<'a>>,
     {
-        Directive {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            expression,
-            directive: directive.into(),
-        }
+        Directive { node_id: Default::default(), span, expression, directive: directive.into() }
     }
 
     /// Build a [`Hashbang`].
@@ -3891,7 +3863,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Str<'a>>,
     {
-        Hashbang { node_id: Cell::new(NodeId::DUMMY), span, value: value.into() }
+        Hashbang { node_id: Default::default(), span, value: value.into() }
     }
 
     /// Build a [`BlockStatement`].
@@ -3904,12 +3876,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn block_statement(self, span: Span, body: Vec<'a, Statement<'a>>) -> BlockStatement<'a> {
-        BlockStatement {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            body,
-            scope_id: Default::default(),
-        }
+        BlockStatement { node_id: Default::default(), span, body, scope_id: Default::default() }
     }
 
     /// Build a [`BlockStatement`], and store it in the memory arena.
@@ -3946,7 +3913,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> BlockStatement<'a> {
         BlockStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             body,
             scope_id: Cell::new(Some(scope_id)),
@@ -4525,7 +4492,7 @@ impl<'a> AstBuilder<'a> {
         declarations: Vec<'a, VariableDeclarator<'a>>,
         declare: bool,
     ) -> VariableDeclaration<'a> {
-        VariableDeclaration { node_id: Cell::new(NodeId::DUMMY), span, kind, declarations, declare }
+        VariableDeclaration { node_id: Default::default(), span, kind, declarations, declare }
     }
 
     /// Build a [`VariableDeclaration`], and store it in the memory arena.
@@ -4572,7 +4539,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         VariableDeclarator {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             kind,
             id,
@@ -4591,7 +4558,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn empty_statement(self, span: Span) -> EmptyStatement {
-        EmptyStatement { node_id: Cell::new(NodeId::DUMMY), span }
+        EmptyStatement { node_id: Default::default(), span }
     }
 
     /// Build an [`EmptyStatement`], and store it in the memory arena.
@@ -4620,7 +4587,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> ExpressionStatement<'a> {
-        ExpressionStatement { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        ExpressionStatement { node_id: Default::default(), span, expression }
     }
 
     /// Build an [`ExpressionStatement`], and store it in the memory arena.
@@ -4658,7 +4625,7 @@ impl<'a> AstBuilder<'a> {
         consequent: Statement<'a>,
         alternate: Option<Statement<'a>>,
     ) -> IfStatement<'a> {
-        IfStatement { node_id: Cell::new(NodeId::DUMMY), span, test, consequent, alternate }
+        IfStatement { node_id: Default::default(), span, test, consequent, alternate }
     }
 
     /// Build an [`IfStatement`], and store it in the memory arena.
@@ -4698,7 +4665,7 @@ impl<'a> AstBuilder<'a> {
         body: Statement<'a>,
         test: Expression<'a>,
     ) -> DoWhileStatement<'a> {
-        DoWhileStatement { node_id: Cell::new(NodeId::DUMMY), span, body, test }
+        DoWhileStatement { node_id: Default::default(), span, body, test }
     }
 
     /// Build a [`DoWhileStatement`], and store it in the memory arena.
@@ -4736,7 +4703,7 @@ impl<'a> AstBuilder<'a> {
         test: Expression<'a>,
         body: Statement<'a>,
     ) -> WhileStatement<'a> {
-        WhileStatement { node_id: Cell::new(NodeId::DUMMY), span, test, body }
+        WhileStatement { node_id: Default::default(), span, test, body }
     }
 
     /// Build a [`WhileStatement`], and store it in the memory arena.
@@ -4779,7 +4746,7 @@ impl<'a> AstBuilder<'a> {
         body: Statement<'a>,
     ) -> ForStatement<'a> {
         ForStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             init,
             test,
@@ -4835,7 +4802,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> ForStatement<'a> {
         ForStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             init,
             test,
@@ -4917,7 +4884,7 @@ impl<'a> AstBuilder<'a> {
         body: Statement<'a>,
     ) -> ForInStatement<'a> {
         ForInStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             left,
             right,
@@ -4968,7 +4935,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> ForInStatement<'a> {
         ForInStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             left,
             right,
@@ -5049,7 +5016,7 @@ impl<'a> AstBuilder<'a> {
         body: Statement<'a>,
     ) -> ForOfStatement<'a> {
         ForOfStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#await,
             left,
@@ -5105,7 +5072,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> ForOfStatement<'a> {
         ForOfStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#await,
             left,
@@ -5157,7 +5124,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> ContinueStatement<'a> {
-        ContinueStatement { node_id: Cell::new(NodeId::DUMMY), span, label }
+        ContinueStatement { node_id: Default::default(), span, label }
     }
 
     /// Build a [`ContinueStatement`], and store it in the memory arena.
@@ -5191,7 +5158,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> BreakStatement<'a> {
-        BreakStatement { node_id: Cell::new(NodeId::DUMMY), span, label }
+        BreakStatement { node_id: Default::default(), span, label }
     }
 
     /// Build a [`BreakStatement`], and store it in the memory arena.
@@ -5225,7 +5192,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         argument: Option<Expression<'a>>,
     ) -> ReturnStatement<'a> {
-        ReturnStatement { node_id: Cell::new(NodeId::DUMMY), span, argument }
+        ReturnStatement { node_id: Default::default(), span, argument }
     }
 
     /// Build a [`ReturnStatement`], and store it in the memory arena.
@@ -5262,7 +5229,7 @@ impl<'a> AstBuilder<'a> {
         body: Statement<'a>,
     ) -> WithStatement<'a> {
         WithStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             object,
             body,
@@ -5308,7 +5275,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> WithStatement<'a> {
         WithStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             object,
             body,
@@ -5354,7 +5321,7 @@ impl<'a> AstBuilder<'a> {
         cases: Vec<'a, SwitchCase<'a>>,
     ) -> SwitchStatement<'a> {
         SwitchStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             discriminant,
             cases,
@@ -5400,7 +5367,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> SwitchStatement<'a> {
         SwitchStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             discriminant,
             cases,
@@ -5445,7 +5412,7 @@ impl<'a> AstBuilder<'a> {
         test: Option<Expression<'a>>,
         consequent: Vec<'a, Statement<'a>>,
     ) -> SwitchCase<'a> {
-        SwitchCase { node_id: Cell::new(NodeId::DUMMY), span, test, consequent }
+        SwitchCase { node_id: Default::default(), span, test, consequent }
     }
 
     /// Build a [`LabeledStatement`].
@@ -5464,7 +5431,7 @@ impl<'a> AstBuilder<'a> {
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
     ) -> LabeledStatement<'a> {
-        LabeledStatement { node_id: Cell::new(NodeId::DUMMY), span, label, body }
+        LabeledStatement { node_id: Default::default(), span, label, body }
     }
 
     /// Build a [`LabeledStatement`], and store it in the memory arena.
@@ -5496,7 +5463,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
     #[inline]
     pub fn throw_statement(self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
-        ThrowStatement { node_id: Cell::new(NodeId::DUMMY), span, argument }
+        ThrowStatement { node_id: Default::default(), span, argument }
     }
 
     /// Build a [`ThrowStatement`], and store it in the memory arena.
@@ -5540,7 +5507,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Option<Box<'a, BlockStatement<'a>>>>,
     {
         TryStatement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             block: block.into_in(self.allocator),
             handler: handler.into_in(self.allocator),
@@ -5594,7 +5561,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
     {
         CatchClause {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             param,
             body: body.into_in(self.allocator),
@@ -5646,7 +5613,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
     {
         CatchClause {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             param,
             body: body.into_in(self.allocator),
@@ -5695,7 +5662,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         CatchParameter {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             pattern,
             type_annotation: type_annotation.into_in(self.allocator),
@@ -5711,7 +5678,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn debugger_statement(self, span: Span) -> DebuggerStatement {
-        DebuggerStatement { node_id: Cell::new(NodeId::DUMMY), span }
+        DebuggerStatement { node_id: Default::default(), span }
     }
 
     /// Build a [`DebuggerStatement`], and store it in the memory arena.
@@ -5840,7 +5807,7 @@ impl<'a> AstBuilder<'a> {
         left: BindingPattern<'a>,
         right: Expression<'a>,
     ) -> AssignmentPattern<'a> {
-        AssignmentPattern { node_id: Cell::new(NodeId::DUMMY), span, left, right }
+        AssignmentPattern { node_id: Default::default(), span, left, right }
     }
 
     /// Build an [`AssignmentPattern`], and store it in the memory arena.
@@ -5882,7 +5849,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
     {
         ObjectPattern {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             properties,
             rest: rest.into_in(self.allocator),
@@ -5928,7 +5895,7 @@ impl<'a> AstBuilder<'a> {
         shorthand: bool,
         computed: bool,
     ) -> BindingProperty<'a> {
-        BindingProperty { node_id: Cell::new(NodeId::DUMMY), span, key, value, shorthand, computed }
+        BindingProperty { node_id: Default::default(), span, key, value, shorthand, computed }
     }
 
     /// Build an [`ArrayPattern`].
@@ -5951,7 +5918,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
     {
         ArrayPattern {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             elements,
             rest: rest.into_in(self.allocator),
@@ -5994,7 +5961,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         argument: BindingPattern<'a>,
     ) -> BindingRestElement<'a> {
-        BindingRestElement { node_id: Cell::new(NodeId::DUMMY), span, argument }
+        BindingRestElement { node_id: Default::default(), span, argument }
     }
 
     /// Build a [`BindingRestElement`], and store it in the memory arena.
@@ -6054,7 +6021,7 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Function {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#type,
             id,
@@ -6175,7 +6142,7 @@ impl<'a> AstBuilder<'a> {
         T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
     {
         Function {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#type,
             id,
@@ -6281,7 +6248,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, FormalParameterRest<'a>>>>,
     {
         FormalParameters {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             kind,
             items,
@@ -6343,7 +6310,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Option<Box<'a, Expression<'a>>>>,
     {
         FormalParameter {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             decorators,
             pattern,
@@ -6378,7 +6345,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         FormalParameterRest {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             decorators,
             rest,
@@ -6429,7 +6396,7 @@ impl<'a> AstBuilder<'a> {
         directives: Vec<'a, Directive<'a>>,
         statements: Vec<'a, Statement<'a>>,
     ) -> FunctionBody<'a> {
-        FunctionBody { node_id: Cell::new(NodeId::DUMMY), span, directives, statements }
+        FunctionBody { node_id: Default::default(), span, directives, statements }
     }
 
     /// Build a [`FunctionBody`], and store it in the memory arena.
@@ -6482,7 +6449,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
     {
         ArrowFunctionExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             expression,
             r#async,
@@ -6577,7 +6544,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
     {
         ArrowFunctionExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             expression,
             r#async,
@@ -6660,7 +6627,7 @@ impl<'a> AstBuilder<'a> {
         delegate: bool,
         argument: Option<Expression<'a>>,
     ) -> YieldExpression<'a> {
-        YieldExpression { node_id: Cell::new(NodeId::DUMMY), span, delegate, argument }
+        YieldExpression { node_id: Default::default(), span, delegate, argument }
     }
 
     /// Build a [`YieldExpression`], and store it in the memory arena.
@@ -6720,7 +6687,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         Class {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#type,
             decorators,
@@ -6831,7 +6798,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
     {
         Class {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#type,
             decorators,
@@ -6915,7 +6882,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn class_body(self, span: Span, body: Vec<'a, ClassElement<'a>>) -> ClassBody<'a> {
-        ClassBody { node_id: Cell::new(NodeId::DUMMY), span, body }
+        ClassBody { node_id: Default::default(), span, body }
     }
 
     /// Build a [`ClassBody`], and store it in the memory arena.
@@ -7192,7 +7159,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, Function<'a>>>,
     {
         MethodDefinition {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#type,
             decorators,
@@ -7302,7 +7269,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         PropertyDefinition {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#type,
             decorators,
@@ -7395,7 +7362,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Ident<'a>>,
     {
-        PrivateIdentifier { node_id: Cell::new(NodeId::DUMMY), span, name: name.into() }
+        PrivateIdentifier { node_id: Default::default(), span, name: name.into() }
     }
 
     /// Build a [`PrivateIdentifier`], and store it in the memory arena.
@@ -7428,7 +7395,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn static_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> StaticBlock<'a> {
-        StaticBlock { node_id: Cell::new(NodeId::DUMMY), span, body, scope_id: Default::default() }
+        StaticBlock { node_id: Default::default(), span, body, scope_id: Default::default() }
     }
 
     /// Build a [`StaticBlock`], and store it in the memory arena.
@@ -7464,12 +7431,7 @@ impl<'a> AstBuilder<'a> {
         body: Vec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> StaticBlock<'a> {
-        StaticBlock {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            body,
-            scope_id: Cell::new(Some(scope_id)),
-        }
+        StaticBlock { node_id: Default::default(), span, body, scope_id: Cell::new(Some(scope_id)) }
     }
 
     /// Build a [`StaticBlock`] with `scope_id`, and store it in the memory arena.
@@ -7678,7 +7640,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         AccessorProperty {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#type,
             decorators,
@@ -7764,7 +7726,7 @@ impl<'a> AstBuilder<'a> {
         options: Option<Expression<'a>>,
         phase: Option<ImportPhase>,
     ) -> ImportExpression<'a> {
-        ImportExpression { node_id: Cell::new(NodeId::DUMMY), span, source, options, phase }
+        ImportExpression { node_id: Default::default(), span, source, options, phase }
     }
 
     /// Build an [`ImportExpression`], and store it in the memory arena.
@@ -7814,7 +7776,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
     {
         ImportDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             specifiers,
             source,
@@ -7934,7 +7896,7 @@ impl<'a> AstBuilder<'a> {
         local: BindingIdentifier<'a>,
         import_kind: ImportOrExportKind,
     ) -> ImportSpecifier<'a> {
-        ImportSpecifier { node_id: Cell::new(NodeId::DUMMY), span, imported, local, import_kind }
+        ImportSpecifier { node_id: Default::default(), span, imported, local, import_kind }
     }
 
     /// Build an [`ImportSpecifier`], and store it in the memory arena.
@@ -7972,7 +7934,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDefaultSpecifier<'a> {
-        ImportDefaultSpecifier { node_id: Cell::new(NodeId::DUMMY), span, local }
+        ImportDefaultSpecifier { node_id: Default::default(), span, local }
     }
 
     /// Build an [`ImportDefaultSpecifier`], and store it in the memory arena.
@@ -8006,7 +7968,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportNamespaceSpecifier<'a> {
-        ImportNamespaceSpecifier { node_id: Cell::new(NodeId::DUMMY), span, local }
+        ImportNamespaceSpecifier { node_id: Default::default(), span, local }
     }
 
     /// Build an [`ImportNamespaceSpecifier`], and store it in the memory arena.
@@ -8042,7 +8004,7 @@ impl<'a> AstBuilder<'a> {
         keyword: WithClauseKeyword,
         with_entries: Vec<'a, ImportAttribute<'a>>,
     ) -> WithClause<'a> {
-        WithClause { node_id: Cell::new(NodeId::DUMMY), span, keyword, with_entries }
+        WithClause { node_id: Default::default(), span, keyword, with_entries }
     }
 
     /// Build a [`WithClause`], and store it in the memory arena.
@@ -8077,7 +8039,7 @@ impl<'a> AstBuilder<'a> {
         key: ImportAttributeKey<'a>,
         value: StringLiteral<'a>,
     ) -> ImportAttribute<'a> {
-        ImportAttribute { node_id: Cell::new(NodeId::DUMMY), span, key, value }
+        ImportAttribute { node_id: Default::default(), span, key, value }
     }
 
     /// Build an [`ImportAttributeKey::Identifier`].
@@ -8164,7 +8126,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
     {
         ExportNamedDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             declaration,
             specifiers,
@@ -8226,7 +8188,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ExportDefaultDeclaration<'a> {
-        ExportDefaultDeclaration { node_id: Cell::new(NodeId::DUMMY), span, declaration }
+        ExportDefaultDeclaration { node_id: Default::default(), span, declaration }
     }
 
     /// Build an [`ExportDefaultDeclaration`], and store it in the memory arena.
@@ -8270,7 +8232,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
     {
         ExportAllDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             exported,
             source,
@@ -8323,7 +8285,7 @@ impl<'a> AstBuilder<'a> {
         exported: ModuleExportName<'a>,
         export_kind: ImportOrExportKind,
     ) -> ExportSpecifier<'a> {
-        ExportSpecifier { node_id: Cell::new(NodeId::DUMMY), span, local, exported, export_kind }
+        ExportSpecifier { node_id: Default::default(), span, local, exported, export_kind }
     }
 
     /// Build an [`ExportDefaultDeclarationKind::FunctionDeclaration`].
@@ -8747,7 +8709,7 @@ impl<'a> AstBuilder<'a> {
         name: IdentifierName<'a>,
         arguments: Vec<'a, Argument<'a>>,
     ) -> V8IntrinsicExpression<'a> {
-        V8IntrinsicExpression { node_id: Cell::new(NodeId::DUMMY), span, name, arguments }
+        V8IntrinsicExpression { node_id: Default::default(), span, name, arguments }
     }
 
     /// Build a [`V8IntrinsicExpression`], and store it in the memory arena.
@@ -8779,7 +8741,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The boolean value itself
     #[inline]
     pub fn boolean_literal(self, span: Span, value: bool) -> BooleanLiteral {
-        BooleanLiteral { node_id: Cell::new(NodeId::DUMMY), span, value }
+        BooleanLiteral { node_id: Default::default(), span, value }
     }
 
     /// Build a [`BooleanLiteral`], and store it in the memory arena.
@@ -8804,7 +8766,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     #[inline]
     pub fn null_literal(self, span: Span) -> NullLiteral {
-        NullLiteral { node_id: Cell::new(NodeId::DUMMY), span }
+        NullLiteral { node_id: Default::default(), span }
     }
 
     /// Build a [`NullLiteral`], and store it in the memory arena.
@@ -8837,7 +8799,7 @@ impl<'a> AstBuilder<'a> {
         raw: Option<Str<'a>>,
         base: NumberBase,
     ) -> NumericLiteral<'a> {
-        NumericLiteral { node_id: Cell::new(NodeId::DUMMY), span, value, raw, base }
+        NumericLiteral { node_id: Default::default(), span, value, raw, base }
     }
 
     /// Build a [`NumericLiteral`], and store it in the memory arena.
@@ -8881,7 +8843,7 @@ impl<'a> AstBuilder<'a> {
         A1: Into<Str<'a>>,
     {
         StringLiteral {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             value: value.into(),
             raw,
@@ -8933,7 +8895,7 @@ impl<'a> AstBuilder<'a> {
         A1: Into<Str<'a>>,
     {
         StringLiteral {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             value: value.into(),
             raw,
@@ -8989,7 +8951,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Str<'a>>,
     {
-        BigIntLiteral { node_id: Cell::new(NodeId::DUMMY), span, value: value.into(), raw, base }
+        BigIntLiteral { node_id: Default::default(), span, value: value.into(), raw, base }
     }
 
     /// Build a [`BigIntLiteral`], and store it in the memory arena.
@@ -9032,7 +8994,7 @@ impl<'a> AstBuilder<'a> {
         regex: RegExp<'a>,
         raw: Option<Str<'a>>,
     ) -> RegExpLiteral<'a> {
-        RegExpLiteral { node_id: Cell::new(NodeId::DUMMY), span, regex, raw }
+        RegExpLiteral { node_id: Default::default(), span, regex, raw }
     }
 
     /// Build a [`RegExpLiteral`], and store it in the memory arena.
@@ -9077,7 +9039,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
     {
         JSXElement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             opening_element: opening_element.into_in(self.allocator),
             children,
@@ -9135,7 +9097,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         JSXOpeningElement {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -9184,7 +9146,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         name: JSXElementName<'a>,
     ) -> JSXClosingElement<'a> {
-        JSXClosingElement { node_id: Cell::new(NodeId::DUMMY), span, name }
+        JSXClosingElement { node_id: Default::default(), span, name }
     }
 
     /// Build a [`JSXClosingElement`], and store it in the memory arena.
@@ -9223,7 +9185,7 @@ impl<'a> AstBuilder<'a> {
         closing_fragment: JSXClosingFragment,
     ) -> JSXFragment<'a> {
         JSXFragment {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             opening_fragment,
             children,
@@ -9261,7 +9223,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     #[inline]
     pub fn jsx_opening_fragment(self, span: Span) -> JSXOpeningFragment {
-        JSXOpeningFragment { node_id: Cell::new(NodeId::DUMMY), span }
+        JSXOpeningFragment { node_id: Default::default(), span }
     }
 
     /// Build a [`JSXClosingFragment`].
@@ -9270,7 +9232,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     #[inline]
     pub fn jsx_closing_fragment(self, span: Span) -> JSXClosingFragment {
-        JSXClosingFragment { node_id: Cell::new(NodeId::DUMMY), span }
+        JSXClosingFragment { node_id: Default::default(), span }
     }
 
     /// Build a [`JSXElementName::Identifier`].
@@ -9395,7 +9357,7 @@ impl<'a> AstBuilder<'a> {
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
     ) -> JSXNamespacedName<'a> {
-        JSXNamespacedName { node_id: Cell::new(NodeId::DUMMY), span, namespace, name }
+        JSXNamespacedName { node_id: Default::default(), span, namespace, name }
     }
 
     /// Build a [`JSXNamespacedName`], and store it in the memory arena.
@@ -9433,7 +9395,7 @@ impl<'a> AstBuilder<'a> {
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
     ) -> JSXMemberExpression<'a> {
-        JSXMemberExpression { node_id: Cell::new(NodeId::DUMMY), span, object, property }
+        JSXMemberExpression { node_id: Default::default(), span, object, property }
     }
 
     /// Build a [`JSXMemberExpression`], and store it in the memory arena.
@@ -9545,7 +9507,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXExpressionContainer<'a> {
-        JSXExpressionContainer { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        JSXExpressionContainer { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`JSXExpressionContainer`], and store it in the memory arena.
@@ -9580,7 +9542,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     #[inline]
     pub fn jsx_empty_expression(self, span: Span) -> JSXEmptyExpression {
-        JSXEmptyExpression { node_id: Cell::new(NodeId::DUMMY), span }
+        JSXEmptyExpression { node_id: Default::default(), span }
     }
 
     /// Build a [`JSXAttributeItem::Attribute`].
@@ -9633,7 +9595,7 @@ impl<'a> AstBuilder<'a> {
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
     ) -> JSXAttribute<'a> {
-        JSXAttribute { node_id: Cell::new(NodeId::DUMMY), span, name, value }
+        JSXAttribute { node_id: Default::default(), span, name, value }
     }
 
     /// Build a [`JSXAttribute`], and store it in the memory arena.
@@ -9669,7 +9631,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         argument: Expression<'a>,
     ) -> JSXSpreadAttribute<'a> {
-        JSXSpreadAttribute { node_id: Cell::new(NodeId::DUMMY), span, argument }
+        JSXSpreadAttribute { node_id: Default::default(), span, argument }
     }
 
     /// Build a [`JSXSpreadAttribute`], and store it in the memory arena.
@@ -9856,7 +9818,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Str<'a>>,
     {
-        JSXIdentifier { node_id: Cell::new(NodeId::DUMMY), span, name: name.into() }
+        JSXIdentifier { node_id: Default::default(), span, name: name.into() }
     }
 
     /// Build a [`JSXIdentifier`], and store it in the memory arena.
@@ -9978,7 +9940,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression being spread.
     #[inline]
     pub fn jsx_spread_child(self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
-        JSXSpreadChild { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        JSXSpreadChild { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`JSXSpreadChild`], and store it in the memory arena.
@@ -10012,7 +9974,7 @@ impl<'a> AstBuilder<'a> {
     where
         A1: Into<Str<'a>>,
     {
-        JSXText { node_id: Cell::new(NodeId::DUMMY), span, value: value.into(), raw }
+        JSXText { node_id: Default::default(), span, value: value.into(), raw }
     }
 
     /// Build a [`JSXText`], and store it in the memory arena.
@@ -10057,7 +10019,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSThisParameter {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             this_span,
             type_annotation: type_annotation.into_in(self.allocator),
@@ -10106,7 +10068,7 @@ impl<'a> AstBuilder<'a> {
         r#const: bool,
         declare: bool,
     ) -> TSEnumDeclaration<'a> {
-        TSEnumDeclaration { node_id: Cell::new(NodeId::DUMMY), span, id, body, r#const, declare }
+        TSEnumDeclaration { node_id: Default::default(), span, id, body, r#const, declare }
     }
 
     /// Build a [`TSEnumDeclaration`], and store it in the memory arena.
@@ -10139,12 +10101,7 @@ impl<'a> AstBuilder<'a> {
     /// * `members`
     #[inline]
     pub fn ts_enum_body(self, span: Span, members: Vec<'a, TSEnumMember<'a>>) -> TSEnumBody<'a> {
-        TSEnumBody {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            members,
-            scope_id: Default::default(),
-        }
+        TSEnumBody { node_id: Default::default(), span, members, scope_id: Default::default() }
     }
 
     /// Build a [`TSEnumBody`] with `scope_id`.
@@ -10161,7 +10118,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSEnumBody<'a> {
         TSEnumBody {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             members,
             scope_id: Cell::new(Some(scope_id)),
@@ -10181,7 +10138,7 @@ impl<'a> AstBuilder<'a> {
         id: TSEnumMemberName<'a>,
         initializer: Option<Expression<'a>>,
     ) -> TSEnumMember<'a> {
-        TSEnumMember { node_id: Cell::new(NodeId::DUMMY), span, id, initializer }
+        TSEnumMember { node_id: Default::default(), span, id, initializer }
     }
 
     /// Build a [`TSEnumMemberName::Identifier`].
@@ -10333,7 +10290,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTypeAnnotation<'a> {
-        TSTypeAnnotation { node_id: Cell::new(NodeId::DUMMY), span, type_annotation }
+        TSTypeAnnotation { node_id: Default::default(), span, type_annotation }
     }
 
     /// Build a [`TSTypeAnnotation`], and store it in the memory arena.
@@ -10363,7 +10320,7 @@ impl<'a> AstBuilder<'a> {
     /// * `literal`
     #[inline]
     pub fn ts_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
-        TSLiteralType { node_id: Cell::new(NodeId::DUMMY), span, literal }
+        TSLiteralType { node_id: Default::default(), span, literal }
     }
 
     /// Build a [`TSLiteralType`], and store it in the memory arena.
@@ -11307,7 +11264,7 @@ impl<'a> AstBuilder<'a> {
         false_type: TSType<'a>,
     ) -> TSConditionalType<'a> {
         TSConditionalType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             check_type,
             extends_type,
@@ -11366,7 +11323,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSConditionalType<'a> {
         TSConditionalType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             check_type,
             extends_type,
@@ -11421,7 +11378,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The types in the union.
     #[inline]
     pub fn ts_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSUnionType<'a> {
-        TSUnionType { node_id: Cell::new(NodeId::DUMMY), span, types }
+        TSUnionType { node_id: Default::default(), span, types }
     }
 
     /// Build a [`TSUnionType`], and store it in the memory arena.
@@ -11455,7 +11412,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         types: Vec<'a, TSType<'a>>,
     ) -> TSIntersectionType<'a> {
-        TSIntersectionType { node_id: Cell::new(NodeId::DUMMY), span, types }
+        TSIntersectionType { node_id: Default::default(), span, types }
     }
 
     /// Build a [`TSIntersectionType`], and store it in the memory arena.
@@ -11489,7 +11446,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSParenthesizedType<'a> {
-        TSParenthesizedType { node_id: Cell::new(NodeId::DUMMY), span, type_annotation }
+        TSParenthesizedType { node_id: Default::default(), span, type_annotation }
     }
 
     /// Build a [`TSParenthesizedType`], and store it in the memory arena.
@@ -11525,7 +11482,7 @@ impl<'a> AstBuilder<'a> {
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
     ) -> TSTypeOperator<'a> {
-        TSTypeOperator { node_id: Cell::new(NodeId::DUMMY), span, operator, type_annotation }
+        TSTypeOperator { node_id: Default::default(), span, operator, type_annotation }
     }
 
     /// Build a [`TSTypeOperator`], and store it in the memory arena.
@@ -11557,7 +11514,7 @@ impl<'a> AstBuilder<'a> {
     /// * `element_type`
     #[inline]
     pub fn ts_array_type(self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
-        TSArrayType { node_id: Cell::new(NodeId::DUMMY), span, element_type }
+        TSArrayType { node_id: Default::default(), span, element_type }
     }
 
     /// Build a [`TSArrayType`], and store it in the memory arena.
@@ -11593,7 +11550,7 @@ impl<'a> AstBuilder<'a> {
         object_type: TSType<'a>,
         index_type: TSType<'a>,
     ) -> TSIndexedAccessType<'a> {
-        TSIndexedAccessType { node_id: Cell::new(NodeId::DUMMY), span, object_type, index_type }
+        TSIndexedAccessType { node_id: Default::default(), span, object_type, index_type }
     }
 
     /// Build a [`TSIndexedAccessType`], and store it in the memory arena.
@@ -11629,7 +11586,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         element_types: Vec<'a, TSTupleElement<'a>>,
     ) -> TSTupleType<'a> {
-        TSTupleType { node_id: Cell::new(NodeId::DUMMY), span, element_types }
+        TSTupleType { node_id: Default::default(), span, element_types }
     }
 
     /// Build a [`TSTupleType`], and store it in the memory arena.
@@ -11667,13 +11624,7 @@ impl<'a> AstBuilder<'a> {
         element_type: TSTupleElement<'a>,
         optional: bool,
     ) -> TSNamedTupleMember<'a> {
-        TSNamedTupleMember {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            label,
-            element_type,
-            optional,
-        }
+        TSNamedTupleMember { node_id: Default::default(), span, label, element_type, optional }
     }
 
     /// Build a [`TSNamedTupleMember`], and store it in the memory arena.
@@ -11707,7 +11658,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_optional_type(self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
-        TSOptionalType { node_id: Cell::new(NodeId::DUMMY), span, type_annotation }
+        TSOptionalType { node_id: Default::default(), span, type_annotation }
     }
 
     /// Build a [`TSOptionalType`], and store it in the memory arena.
@@ -11737,7 +11688,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_rest_type(self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
-        TSRestType { node_id: Cell::new(NodeId::DUMMY), span, type_annotation }
+        TSRestType { node_id: Default::default(), span, type_annotation }
     }
 
     /// Build a [`TSRestType`], and store it in the memory arena.
@@ -11798,7 +11749,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_any_keyword(self, span: Span) -> TSAnyKeyword {
-        TSAnyKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSAnyKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSAnyKeyword`], and store it in the memory arena.
@@ -11822,7 +11773,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_string_keyword(self, span: Span) -> TSStringKeyword {
-        TSStringKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSStringKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSStringKeyword`], and store it in the memory arena.
@@ -11846,7 +11797,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_boolean_keyword(self, span: Span) -> TSBooleanKeyword {
-        TSBooleanKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSBooleanKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSBooleanKeyword`], and store it in the memory arena.
@@ -11870,7 +11821,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_number_keyword(self, span: Span) -> TSNumberKeyword {
-        TSNumberKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSNumberKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSNumberKeyword`], and store it in the memory arena.
@@ -11894,7 +11845,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_never_keyword(self, span: Span) -> TSNeverKeyword {
-        TSNeverKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSNeverKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSNeverKeyword`], and store it in the memory arena.
@@ -11918,7 +11869,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_intrinsic_keyword(self, span: Span) -> TSIntrinsicKeyword {
-        TSIntrinsicKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSIntrinsicKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSIntrinsicKeyword`], and store it in the memory arena.
@@ -11942,7 +11893,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_unknown_keyword(self, span: Span) -> TSUnknownKeyword {
-        TSUnknownKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSUnknownKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSUnknownKeyword`], and store it in the memory arena.
@@ -11966,7 +11917,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_null_keyword(self, span: Span) -> TSNullKeyword {
-        TSNullKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSNullKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSNullKeyword`], and store it in the memory arena.
@@ -11990,7 +11941,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_undefined_keyword(self, span: Span) -> TSUndefinedKeyword {
-        TSUndefinedKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSUndefinedKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSUndefinedKeyword`], and store it in the memory arena.
@@ -12014,7 +11965,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_void_keyword(self, span: Span) -> TSVoidKeyword {
-        TSVoidKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSVoidKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSVoidKeyword`], and store it in the memory arena.
@@ -12038,7 +11989,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_symbol_keyword(self, span: Span) -> TSSymbolKeyword {
-        TSSymbolKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSSymbolKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSSymbolKeyword`], and store it in the memory arena.
@@ -12062,7 +12013,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_this_type(self, span: Span) -> TSThisType {
-        TSThisType { node_id: Cell::new(NodeId::DUMMY), span }
+        TSThisType { node_id: Default::default(), span }
     }
 
     /// Build a [`TSThisType`], and store it in the memory arena.
@@ -12086,7 +12037,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_object_keyword(self, span: Span) -> TSObjectKeyword {
-        TSObjectKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSObjectKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSObjectKeyword`], and store it in the memory arena.
@@ -12110,7 +12061,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_big_int_keyword(self, span: Span) -> TSBigIntKeyword {
-        TSBigIntKeyword { node_id: Cell::new(NodeId::DUMMY), span }
+        TSBigIntKeyword { node_id: Default::default(), span }
     }
 
     /// Build a [`TSBigIntKeyword`], and store it in the memory arena.
@@ -12145,7 +12096,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSTypeReference {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_name,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -12259,7 +12210,7 @@ impl<'a> AstBuilder<'a> {
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
     ) -> TSQualifiedName<'a> {
-        TSQualifiedName { node_id: Cell::new(NodeId::DUMMY), span, left, right }
+        TSQualifiedName { node_id: Default::default(), span, left, right }
     }
 
     /// Build a [`TSQualifiedName`], and store it in the memory arena.
@@ -12295,7 +12246,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         params: Vec<'a, TSType<'a>>,
     ) -> TSTypeParameterInstantiation<'a> {
-        TSTypeParameterInstantiation { node_id: Cell::new(NodeId::DUMMY), span, params }
+        TSTypeParameterInstantiation { node_id: Default::default(), span, params }
     }
 
     /// Build a [`TSTypeParameterInstantiation`], and store it in the memory arena.
@@ -12340,7 +12291,7 @@ impl<'a> AstBuilder<'a> {
         r#const: bool,
     ) -> TSTypeParameter<'a> {
         TSTypeParameter {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name,
             constraint,
@@ -12395,7 +12346,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         params: Vec<'a, TSTypeParameter<'a>>,
     ) -> TSTypeParameterDeclaration<'a> {
-        TSTypeParameterDeclaration { node_id: Cell::new(NodeId::DUMMY), span, params }
+        TSTypeParameterDeclaration { node_id: Default::default(), span, params }
     }
 
     /// Build a [`TSTypeParameterDeclaration`], and store it in the memory arena.
@@ -12439,7 +12390,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSTypeAliasDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             id,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -12504,7 +12455,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSTypeAliasDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             id,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -12569,7 +12520,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSClassImplements {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             expression,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -12603,7 +12554,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
     {
         TSInterfaceDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             id,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -12675,7 +12626,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
     {
         TSInterfaceDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             id,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -12742,7 +12693,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         body: Vec<'a, TSSignature<'a>>,
     ) -> TSInterfaceBody<'a> {
-        TSInterfaceBody { node_id: Cell::new(NodeId::DUMMY), span, body }
+        TSInterfaceBody { node_id: Default::default(), span, body }
     }
 
     /// Build a [`TSInterfaceBody`], and store it in the memory arena.
@@ -12788,7 +12739,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSPropertySignature {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             computed,
             optional,
@@ -13151,7 +13102,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignature {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             parameters,
             type_annotation: type_annotation.into_in(self.allocator),
@@ -13216,7 +13167,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSCallSignatureDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_parameters: type_parameters.into_in(self.allocator),
             this_param: this_param.into_in(self.allocator),
@@ -13293,7 +13244,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSCallSignatureDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_parameters: type_parameters.into_in(self.allocator),
             this_param: this_param.into_in(self.allocator),
@@ -13379,7 +13330,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSMethodSignature {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             key,
             computed,
@@ -13480,7 +13431,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSMethodSignature {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             key,
             computed,
@@ -13571,7 +13522,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSConstructSignatureDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_parameters: type_parameters.into_in(self.allocator),
             params: params.into_in(self.allocator),
@@ -13635,7 +13586,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSConstructSignatureDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_parameters: type_parameters.into_in(self.allocator),
             params: params.into_in(self.allocator),
@@ -13699,7 +13650,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignatureName {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             name: name.into(),
             type_annotation: type_annotation.into_in(self.allocator),
@@ -13723,7 +13674,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSInterfaceHeritage {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             expression,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -13752,7 +13703,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSTypePredicate {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             parameter_name,
             asserts,
@@ -13836,7 +13787,7 @@ impl<'a> AstBuilder<'a> {
         declare: bool,
     ) -> TSModuleDeclaration<'a> {
         TSModuleDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             id,
             body,
@@ -13892,7 +13843,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSModuleDeclaration<'a> {
         TSModuleDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             id,
             body,
@@ -14100,7 +14051,7 @@ impl<'a> AstBuilder<'a> {
         declare: bool,
     ) -> TSGlobalDeclaration<'a> {
         TSGlobalDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             global_span,
             body,
@@ -14151,7 +14102,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSGlobalDeclaration<'a> {
         TSGlobalDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             global_span,
             body,
@@ -14202,7 +14153,7 @@ impl<'a> AstBuilder<'a> {
         directives: Vec<'a, Directive<'a>>,
         body: Vec<'a, Statement<'a>>,
     ) -> TSModuleBlock<'a> {
-        TSModuleBlock { node_id: Cell::new(NodeId::DUMMY), span, directives, body }
+        TSModuleBlock { node_id: Default::default(), span, directives, body }
     }
 
     /// Build a [`TSModuleBlock`], and store it in the memory arena.
@@ -14238,7 +14189,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         members: Vec<'a, TSSignature<'a>>,
     ) -> TSTypeLiteral<'a> {
-        TSTypeLiteral { node_id: Cell::new(NodeId::DUMMY), span, members }
+        TSTypeLiteral { node_id: Default::default(), span, members }
     }
 
     /// Build a [`TSTypeLiteral`], and store it in the memory arena.
@@ -14272,7 +14223,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
     {
         TSInferType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_parameter: type_parameter.into_in(self.allocator),
         }
@@ -14314,7 +14265,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSTypeQuery {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             expr_name,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -14400,7 +14351,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSImportType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             source,
             options: options.into_in(self.allocator),
@@ -14494,7 +14445,7 @@ impl<'a> AstBuilder<'a> {
         left: TSImportTypeQualifier<'a>,
         right: IdentifierName<'a>,
     ) -> TSImportTypeQualifiedName<'a> {
-        TSImportTypeQualifiedName { node_id: Cell::new(NodeId::DUMMY), span, left, right }
+        TSImportTypeQualifiedName { node_id: Default::default(), span, left, right }
     }
 
     /// Build a [`TSImportTypeQualifiedName`], and store it in the memory arena.
@@ -14543,7 +14494,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSFunctionType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_parameters: type_parameters.into_in(self.allocator),
             this_param: this_param.into_in(self.allocator),
@@ -14614,7 +14565,7 @@ impl<'a> AstBuilder<'a> {
         T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSFunctionType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             type_parameters: type_parameters.into_in(self.allocator),
             this_param: this_param.into_in(self.allocator),
@@ -14691,7 +14642,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSConstructorType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#abstract,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -14760,7 +14711,7 @@ impl<'a> AstBuilder<'a> {
         T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSConstructorType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             r#abstract,
             type_parameters: type_parameters.into_in(self.allocator),
@@ -14835,7 +14786,7 @@ impl<'a> AstBuilder<'a> {
         readonly: Option<TSMappedTypeModifierOperator>,
     ) -> TSMappedType<'a> {
         TSMappedType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             key,
             constraint,
@@ -14912,7 +14863,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSMappedType<'a> {
         TSMappedType {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             key,
             constraint,
@@ -14981,7 +14932,7 @@ impl<'a> AstBuilder<'a> {
         quasis: Vec<'a, TemplateElement<'a>>,
         types: Vec<'a, TSType<'a>>,
     ) -> TSTemplateLiteralType<'a> {
-        TSTemplateLiteralType { node_id: Cell::new(NodeId::DUMMY), span, quasis, types }
+        TSTemplateLiteralType { node_id: Default::default(), span, quasis, types }
     }
 
     /// Build a [`TSTemplateLiteralType`], and store it in the memory arena.
@@ -15019,7 +14970,7 @@ impl<'a> AstBuilder<'a> {
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
     ) -> TSAsExpression<'a> {
-        TSAsExpression { node_id: Cell::new(NodeId::DUMMY), span, expression, type_annotation }
+        TSAsExpression { node_id: Default::default(), span, expression, type_annotation }
     }
 
     /// Build a [`TSAsExpression`], and store it in the memory arena.
@@ -15057,12 +15008,7 @@ impl<'a> AstBuilder<'a> {
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
     ) -> TSSatisfiesExpression<'a> {
-        TSSatisfiesExpression {
-            node_id: Cell::new(NodeId::DUMMY),
-            span,
-            expression,
-            type_annotation,
-        }
+        TSSatisfiesExpression { node_id: Default::default(), span, expression, type_annotation }
     }
 
     /// Build a [`TSSatisfiesExpression`], and store it in the memory arena.
@@ -15100,7 +15046,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
     ) -> TSTypeAssertion<'a> {
-        TSTypeAssertion { node_id: Cell::new(NodeId::DUMMY), span, type_annotation, expression }
+        TSTypeAssertion { node_id: Default::default(), span, type_annotation, expression }
     }
 
     /// Build a [`TSTypeAssertion`], and store it in the memory arena.
@@ -15141,7 +15087,7 @@ impl<'a> AstBuilder<'a> {
         import_kind: ImportOrExportKind,
     ) -> TSImportEqualsDeclaration<'a> {
         TSImportEqualsDeclaration {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             id,
             module_reference,
@@ -15267,7 +15213,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: StringLiteral<'a>,
     ) -> TSExternalModuleReference<'a> {
-        TSExternalModuleReference { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        TSExternalModuleReference { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`TSExternalModuleReference`], and store it in the memory arena.
@@ -15301,7 +15247,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> TSNonNullExpression<'a> {
-        TSNonNullExpression { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        TSNonNullExpression { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`TSNonNullExpression`], and store it in the memory arena.
@@ -15328,7 +15274,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn decorator(self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
-        Decorator { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        Decorator { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`TSExportAssignment`].
@@ -15345,7 +15291,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
     ) -> TSExportAssignment<'a> {
-        TSExportAssignment { node_id: Cell::new(NodeId::DUMMY), span, expression }
+        TSExportAssignment { node_id: Default::default(), span, expression }
     }
 
     /// Build a [`TSExportAssignment`], and store it in the memory arena.
@@ -15379,7 +15325,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: IdentifierName<'a>,
     ) -> TSNamespaceExportDeclaration<'a> {
-        TSNamespaceExportDeclaration { node_id: Cell::new(NodeId::DUMMY), span, id }
+        TSNamespaceExportDeclaration { node_id: Default::default(), span, id }
     }
 
     /// Build a [`TSNamespaceExportDeclaration`], and store it in the memory arena.
@@ -15419,7 +15365,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
     {
         TSInstantiationExpression {
-            node_id: Cell::new(NodeId::DUMMY),
+            node_id: Default::default(),
             span,
             expression,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -15467,7 +15413,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: TSType<'a>,
         postfix: bool,
     ) -> JSDocNullableType<'a> {
-        JSDocNullableType { node_id: Cell::new(NodeId::DUMMY), span, type_annotation, postfix }
+        JSDocNullableType { node_id: Default::default(), span, type_annotation, postfix }
     }
 
     /// Build a [`JSDocNullableType`], and store it in the memory arena.
@@ -15505,7 +15451,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: TSType<'a>,
         postfix: bool,
     ) -> JSDocNonNullableType<'a> {
-        JSDocNonNullableType { node_id: Cell::new(NodeId::DUMMY), span, type_annotation, postfix }
+        JSDocNonNullableType { node_id: Default::default(), span, type_annotation, postfix }
     }
 
     /// Build a [`JSDocNonNullableType`], and store it in the memory arena.
@@ -15536,7 +15482,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn js_doc_unknown_type(self, span: Span) -> JSDocUnknownType {
-        JSDocUnknownType { node_id: Cell::new(NodeId::DUMMY), span }
+        JSDocUnknownType { node_id: Default::default(), span }
     }
 
     /// Build a [`JSDocUnknownType`], and store it in the memory arena.

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -52,7 +52,8 @@ impl Generator for AstBuilderGenerator {
 
     /// Generate `AstBuilder`.
     fn generate(&self, schema: &Schema, _codegen: &Codegen) -> Output {
-        let comment_node_id_type_id = schema.type_names["NodeId"];
+        let node_id_cell_type_id =
+            schema.type_by_name("NodeId").as_struct().unwrap().containers.cell_id.unwrap();
 
         let fns = schema
             .types
@@ -64,7 +65,7 @@ impl Generator for AstBuilderGenerator {
                 TypeDef::Enum(enum_def) => !enum_def.builder.skip && enum_def.visit.has_visitor(),
                 _ => false,
             })
-            .map(|type_def| generate_builder_methods(type_def, comment_node_id_type_id, schema))
+            .map(|type_def| generate_builder_methods(type_def, node_id_cell_type_id, schema))
             .collect::<TokenStream>();
 
         let output = quote! {
@@ -82,7 +83,7 @@ impl Generator for AstBuilderGenerator {
 
             ///@@line_break
             use oxc_allocator::{Allocator, Box, IntoIn, Vec};
-            use oxc_syntax::{node::NodeId, scope::ScopeId, symbol::SymbolId, reference::ReferenceId};
+            use oxc_syntax::{scope::ScopeId, symbol::SymbolId, reference::ReferenceId};
 
             ///@@line_break
             use oxc_str::{Ident, Str};
@@ -154,9 +155,7 @@ struct Param<'d> {
     fn_param: TokenStream,
     /// `true` if is a default param (semantic ID)
     is_default: bool,
-    /// `true` if is `CommentNodeId` field
-    is_comment_node_id: bool,
-    /// `true` if is `node_id` field
+    /// `true` if is `NodeId` field
     is_node_id: bool,
     /// * `None` if param is not generic.
     /// * `Some(GenericType::Into)` if is generic and uses `Into`
@@ -176,15 +175,15 @@ enum GenericType {
 /// Generate builder methods for a type.
 fn generate_builder_methods(
     type_def: &TypeDef,
-    comment_node_id_type_id: TypeId,
+    node_id_cell_type_id: TypeId,
     schema: &Schema,
 ) -> TokenStream {
     match type_def {
         TypeDef::Struct(struct_def) => {
-            generate_builder_methods_for_struct(struct_def, comment_node_id_type_id, schema)
+            generate_builder_methods_for_struct(struct_def, node_id_cell_type_id, schema)
         }
         TypeDef::Enum(enum_def) => {
-            generate_builder_methods_for_enum(enum_def, comment_node_id_type_id, schema)
+            generate_builder_methods_for_enum(enum_def, node_id_cell_type_id, schema)
         }
         _ => unreachable!(),
     }
@@ -197,15 +196,15 @@ fn generate_builder_methods(
 /// 2. To build a boxed type e.g. `alloc_boolean_literal`.
 fn generate_builder_methods_for_struct(
     struct_def: &StructDef,
-    comment_node_id_type_id: TypeId,
+    node_id_cell_type_id: TypeId,
     schema: &Schema,
 ) -> TokenStream {
     let (mut params, generic_params, where_clause, has_default_fields) =
-        get_struct_params(struct_def, comment_node_id_type_id, schema);
+        get_struct_params(struct_def, node_id_cell_type_id, schema);
     let (fn_params, fields) = get_struct_fn_params_and_fields(&params, true, schema);
 
     let (fn_name_postfix, doc_postfix) = if has_default_fields {
-        // Exclude node_id from the list of default params (it's always set to NodeId::DUMMY)
+        // Exclude `node_id` from the list of default params (it's always set to `NodeId::DUMMY`)
         let default_params = params.iter().filter(|param| param.is_default && !param.is_node_id);
         let fn_name_postfix = format!(
             "_with_{}",
@@ -272,10 +271,7 @@ fn generate_builder_methods_for_struct_impl(
     let struct_ident = struct_def.ident();
     let struct_ty = struct_def.ty(schema);
 
-    let args = params
-        .iter()
-        .filter(|param| !param.is_comment_node_id && !param.is_node_id)
-        .map(|param| &param.ident);
+    let args = params.iter().filter(|param| !param.is_node_id).map(|param| &param.ident);
 
     let mut fn_name_base = struct_def.snake_name();
     if !fn_name_postfix.is_empty() {
@@ -372,7 +368,7 @@ fn generate_builder_methods_for_struct_impl(
 /// ```
 fn get_struct_params<'s>(
     struct_def: &'s StructDef,
-    comment_node_id_type_id: TypeId,
+    node_id_cell_type_id: TypeId,
     schema: &'s Schema,
 ) -> (
     Vec<Param<'s>>, // Params
@@ -444,17 +440,8 @@ fn get_struct_params<'s>(
             let field_ident = field.ident();
             let fn_param = quote!( #field_ident: #fn_param_ty );
 
-            let is_comment_node_id = field.type_id == comment_node_id_type_id;
-            let is_node_id = field.name() == "node_id";
-            Param {
-                field,
-                ident: field_ident,
-                fn_param,
-                is_default,
-                is_comment_node_id,
-                is_node_id,
-                generic_type,
-            }
+            let is_node_id = field.type_id == node_id_cell_type_id;
+            Param { field, ident: field_ident, fn_param, is_default, is_node_id, generic_type }
         })
         .collect();
 
@@ -491,13 +478,9 @@ fn get_struct_fn_params_and_fields(
     let fn_params = params.iter().filter_map(|param| {
         let param_ident = &param.ident;
 
-        // Special case: node_id always uses NodeId::DUMMY and is never a parameter
-        // Must check before is_default to handle cases where node_id might be marked as default
-        if param.is_node_id {
-            fields.push(quote!( #param_ident: Cell::new(NodeId::DUMMY) ));
-            return None;
-        } else if param.is_default {
-            if include_default_fields {
+        // Special case: `NodeId` always uses `NodeId::DUMMY` and is never a parameter
+        if param.is_default || param.is_node_id {
+            if include_default_fields && !param.is_node_id {
                 // Builder functions which take default fields receive the innermost type as param.
                 // So wrap the param's value in `Cell::new(...)`, or `Some(...)` if necessary.
                 let field_type = param.field.type_def(schema);
@@ -534,7 +517,7 @@ fn get_struct_fn_params_and_fields(
 /// Generates a builder method for every variant of the enum (not including inherited variants).
 fn generate_builder_methods_for_enum(
     enum_def: &EnumDef,
-    comment_node_id_type_id: TypeId,
+    node_id_cell_type_id: TypeId,
     schema: &Schema,
 ) -> TokenStream {
     enum_def
@@ -544,7 +527,7 @@ fn generate_builder_methods_for_enum(
             generate_builder_method_for_enum_variant(
                 enum_def,
                 variant,
-                comment_node_id_type_id,
+                node_id_cell_type_id,
                 schema,
             )
         })
@@ -555,7 +538,7 @@ fn generate_builder_methods_for_enum(
 fn generate_builder_method_for_enum_variant(
     enum_def: &EnumDef,
     variant: &VariantDef,
-    comment_node_id_type_id: TypeId,
+    node_id_cell_type_id: TypeId,
     schema: &Schema,
 ) -> TokenStream {
     let mut variant_type = variant.field_type(schema).unwrap();
@@ -567,13 +550,13 @@ fn generate_builder_method_for_enum_variant(
     let TypeDef::Struct(struct_def) = variant_type else { panic!("Unsupported!") };
 
     let (mut params, generic_params, where_clause, has_default_fields) =
-        get_struct_params(struct_def, comment_node_id_type_id, schema);
+        get_struct_params(struct_def, node_id_cell_type_id, schema);
 
     let fn_name = enum_variant_builder_name(enum_def, variant);
     let variant_ident = variant.ident();
 
     let output = has_default_fields.then(|| {
-        // Exclude node_id from the list of default params (it's always set to NodeId::DUMMY)
+        // Exclude `node_id` from the list of default params (it's always set to `NodeId::DUMMY`)
         let default_params = params.iter().filter(|param| param.is_default && !param.is_node_id);
         let fn_name_postfix = format!(
             "_with_{}",
@@ -632,14 +615,8 @@ fn generate_builder_method_for_enum_variant_impl(
     is_boxed: bool,
 ) -> TokenStream {
     let fn_name = format_ident!("{}{}", fn_name, fn_name_postfix);
-    let fn_params = params
-        .iter()
-        .filter(|param| !param.is_comment_node_id && !param.is_node_id)
-        .map(|param| &param.fn_param);
-    let args = params
-        .iter()
-        .filter(|param| !param.is_comment_node_id && !param.is_node_id)
-        .map(|param| &param.ident);
+    let fn_params = params.iter().filter(|param| !param.is_node_id).map(|param| &param.fn_param);
+    let args = params.iter().filter(|param| !param.is_node_id).map(|param| &param.ident);
 
     let enum_ident = enum_def.ident();
     let enum_ty = enum_def.ty(schema);
@@ -735,19 +712,18 @@ fn generate_doc_comment_for_params(params: &[Param]) -> TokenStream {
         return quote!();
     }
 
-    let lines =
-        params.iter().filter(|param| !param.is_comment_node_id && !param.is_node_id).map(|param| {
-            let field = param.field;
-            let field_name = field.name();
-            let field_comment = if let Some(field_comment) = field.doc_comment.as_deref() {
-                format!(" * `{field_name}`: {field_comment}")
-            } else if field.name() == "span" {
-                " * `span`: The [`Span`] covering this node".to_string()
-            } else {
-                format!(" * `{field_name}`")
-            };
-            quote!( #[doc = #field_comment] )
-        });
+    let lines = params.iter().filter(|param| !param.is_node_id).map(|param| {
+        let field = param.field;
+        let field_name = field.name();
+        let field_comment = if let Some(field_comment) = field.doc_comment.as_deref() {
+            format!(" * `{field_name}`: {field_comment}")
+        } else if field.name() == "span" {
+            " * `span`: The [`Span`] covering this node".to_string()
+        } else {
+            format!(" * `{field_name}`")
+        };
+        quote!( #[doc = #field_comment] )
+    });
 
     quote! {
         ///


### PR DESCRIPTION
#21679 remove `CommentNodeId`. Repurpose code in `ast_tools` codegen which was designed for `CommentNodeId`, using it for `NodeId` instead.

Notably:

1. Check if fields are `Cell<NodeId>` with a quick `TypeId` comparison, instead of string comparison on field name (more reliable, and faster).
2. Simplify generator for `AstBuilder` by utilizing existing logic for default fields for `NodeId` fields.