### PR TITLE
docs(ast_tools): correct doc comment for `AstKind` codegen

### DIFF
--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -3,6 +3,7 @@
 //! * `AstType` type definition.
 //! * `AstKind` type definition.
 //! * `AstKind::ty` method.
+//! * `AstKind::node_id` & `AstKind::set_node_id` methods.
 //! * `AstKind::as_*` methods.
 //! * `GetSpan` impl for `AstKind`.
 //! * `GetAddress` impl for `AstKind`.


### PR DESCRIPTION
Just correct a doc comment, so it matches what the generator produces.