### PR TITLE
perf(ast_tools): use `structs` and `structs_and_enums` iterators where possible

### DIFF
--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -8,7 +8,9 @@ use syn::Ident;
 use crate::{
     AST_CRATE_PATH, Codegen, Generator, Result,
     output::{Output, output_path},
-    schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, TypeId, VariantDef},
+    schema::{
+        Def, EnumDef, FieldDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId, VariantDef,
+    },
     utils::{create_safe_ident, is_reserved_name},
 };
 
@@ -56,14 +58,14 @@ impl Generator for AstBuilderGenerator {
             schema.type_by_name("NodeId").as_struct().unwrap().containers.cell_id.unwrap();
 
         let fns = schema
-            .types
-            .iter()
+            .structs_and_enums()
             .filter(|&type_def| match type_def {
-                TypeDef::Struct(struct_def) => {
+                StructOrEnum::Struct(struct_def) => {
                     !struct_def.builder.skip && struct_def.visit.has_visitor()
                 }
-                TypeDef::Enum(enum_def) => !enum_def.builder.skip && enum_def.visit.has_visitor(),
-                _ => false,
+                StructOrEnum::Enum(enum_def) => {
+                    !enum_def.builder.skip && enum_def.visit.has_visitor()
+                }
             })
             .map(|type_def| generate_builder_methods(type_def, node_id_cell_type_id, schema))
             .collect::<TokenStream>();
@@ -174,18 +176,17 @@ enum GenericType {
 
 /// Generate builder methods for a type.
 fn generate_builder_methods(
-    type_def: &TypeDef,
+    type_def: StructOrEnum<'_>,
     node_id_cell_type_id: TypeId,
     schema: &Schema,
 ) -> TokenStream {
     match type_def {
-        TypeDef::Struct(struct_def) => {
+        StructOrEnum::Struct(struct_def) => {
             generate_builder_methods_for_struct(struct_def, node_id_cell_type_id, schema)
         }
-        TypeDef::Enum(enum_def) => {
+        StructOrEnum::Enum(enum_def) => {
             generate_builder_methods_for_enum(enum_def, node_id_cell_type_id, schema)
         }
-        _ => unreachable!(),
     }
 }
 

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -8,7 +8,7 @@ use crate::{
     Codegen, Generator,
     generators::define_generator,
     output::Output,
-    schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, TypeId},
+    schema::{Def, EnumDef, FieldDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId},
 };
 
 const FORMATTER_CRATE_PATH: &str = "crates/oxc_formatter";
@@ -44,15 +44,14 @@ impl Generator for FormatterAstNodesGenerator {
         let no_following_node_type_ids = get_no_following_node_type_ids(schema);
 
         let impls = schema
-            .types
-            .iter()
+            .structs_and_enums()
             .filter_map(|type_def| match type_def {
-                TypeDef::Struct(struct_def)
+                StructOrEnum::Struct(struct_def)
                     if struct_def.visit.has_visitor() && !struct_def.builder.skip =>
                 {
                     Some(generate_struct_impls(struct_def, &no_following_node_type_ids, schema))
                 }
-                TypeDef::Enum(enum_def) if enum_def.visit.has_visitor() => {
+                StructOrEnum::Enum(enum_def) if enum_def.visit.has_visitor() => {
                     Some(generate_enum_impls(enum_def, schema))
                 }
                 _ => None,

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -8,7 +8,7 @@ use crate::{
     Codegen, Generator,
     generators::{define_generator, formatter::ast_nodes::get_node_type},
     output::Output,
-    schema::{Def, EnumDef, Schema, StructDef, TypeDef, TypeId},
+    schema::{Def, EnumDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId},
 };
 
 use super::ast_nodes::formatter_output_path;
@@ -59,15 +59,14 @@ impl Generator for FormatterFormatGenerator {
         let parenthesis_type_ids = get_needs_parentheses_type_ids(schema);
 
         let impls = schema
-            .types
-            .iter()
+            .structs_and_enums()
             .filter_map(|type_def| match type_def {
-                TypeDef::Struct(struct_def)
+                StructOrEnum::Struct(struct_def)
                     if struct_def.visit.has_visitor() && !struct_def.builder.skip =>
                 {
                     Some(generate_struct_implementation(struct_def, &parenthesis_type_ids, schema))
                 }
-                TypeDef::Enum(enum_def) if enum_def.visit.has_visitor() => {
+                StructOrEnum::Enum(enum_def) if enum_def.visit.has_visitor() => {
                     Some(generate_enum_implementation(enum_def, schema))
                 }
                 _ => None,

--- a/tasks/ast_tools/src/generators/get_id.rs
+++ b/tasks/ast_tools/src/generators/get_id.rs
@@ -10,7 +10,7 @@ use quote::{format_ident, quote};
 use crate::{
     AST_CRATE_PATH, Codegen, Generator,
     output::{Output, output_path},
-    schema::{Def, Schema, TypeDef, TypeId},
+    schema::{Def, Schema, StructDef, TypeId},
 };
 
 use super::define_generator;
@@ -31,10 +31,9 @@ impl Generator for GetIdGenerator {
             semantic_id_type_ids[index] = schema.type_names[type_name];
         }
 
-        let impls = schema
-            .types
-            .iter()
-            .filter_map(|type_def| generate_for_type(type_def, &semantic_id_type_ids, schema));
+        let impls = schema.structs().filter_map(|struct_def| {
+            generate_for_struct(struct_def, &semantic_id_type_ids, schema)
+        });
 
         let output = quote! {
             use oxc_syntax::{node::NodeId, reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
@@ -49,13 +48,11 @@ impl Generator for GetIdGenerator {
     }
 }
 
-fn generate_for_type(
-    type_def: &TypeDef,
+fn generate_for_struct(
+    struct_def: &StructDef,
     semantic_id_type_ids: &[TypeId; SEMANTIC_ID_TYPES.len()],
     schema: &Schema,
 ) -> Option<TokenStream> {
-    let TypeDef::Struct(struct_def) = type_def else { return None };
-
     let struct_name = struct_def.name();
 
     // Generate semantic ID getters/setters (`node_id`, `scope_id`, `symbol_id`, `reference_id`)

--- a/tasks/ast_tools/src/generators/scopes_collector.rs
+++ b/tasks/ast_tools/src/generators/scopes_collector.rs
@@ -10,7 +10,7 @@ use oxc_index::IndexVec;
 use crate::{
     Codegen, Generator, TRAVERSE_CRATE_PATH,
     output::{Output, output_path},
-    schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, TypeId},
+    schema::{Def, EnumDef, FieldDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId},
     utils::{create_ident, create_ident_tokens},
 };
 
@@ -226,8 +226,7 @@ fn generate(schema: &Schema) -> TokenStream {
     let scope_id_type_id = schema.type_names["ScopeId"];
 
     let visit_methods = schema
-        .types
-        .iter()
+        .structs_and_enums()
         .filter_map(|type_def| generate_visit_method_for_type(type_def, scope_id_type_id, schema));
 
     quote! {
@@ -293,16 +292,15 @@ impl VisitorOutputs for VisitOnly {
 /// Returns `None` if no visitor method is required
 /// (either the type is not visited, or the default `visit_*` method can be used).
 fn generate_visit_method_for_type(
-    type_def: &TypeDef,
+    type_def: StructOrEnum<'_>,
     scope_id_type_id: TypeId,
     schema: &Schema,
 ) -> Option<TokenStream> {
     match type_def {
-        TypeDef::Struct(struct_def) => {
+        StructOrEnum::Struct(struct_def) => {
             generate_visit_method_for_struct(struct_def, scope_id_type_id, schema)
         }
-        TypeDef::Enum(enum_def) => generate_visit_method_for_enum(enum_def, schema),
-        _ => None,
+        StructOrEnum::Enum(enum_def) => generate_visit_method_for_enum(enum_def, schema),
     }
 }
 


### PR DESCRIPTION
Similar to #20944. In loops where a generator is only interested in structs only, or structs and enums, use the `Structs` / `StructsAndEnums` iterators which exit early, rather than pointlessly continuing iterating over all types.

Does not alter generated code, only the means by which it's generated.