### PR TITLE
feat(oxlint): add `--output-file` with native dual-format output

### DIFF
--- a/apps/oxfmt/src/cli/reporter.rs
+++ b/apps/oxfmt/src/cli/reporter.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use oxc_diagnostics::{
     Error, GraphicalReportHandler,
     reporter::{DiagnosticReporter, DiagnosticResult},
@@ -9,7 +11,7 @@ use oxc_diagnostics::{
 #[derive(Debug)]
 pub struct DefaultReporter {
     handler: GraphicalReportHandler,
-    diagnostics: Vec<Error>,
+    diagnostics: Vec<Arc<Error>>,
 }
 
 impl Default for DefaultReporter {
@@ -19,7 +21,7 @@ impl Default for DefaultReporter {
 }
 
 impl DiagnosticReporter for DefaultReporter {
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         // Collect diagnostics for rendering in finish() at once
         self.diagnostics.push(error);
         None
@@ -30,7 +32,7 @@ impl DiagnosticReporter for DefaultReporter {
 
         // Render all diagnostics (errors only, no warnings)
         for diagnostic in &self.diagnostics {
-            self.handler.render_report(&mut output, diagnostic.as_ref()).unwrap();
+            self.handler.render_report(&mut output, diagnostic.as_ref().as_ref()).unwrap();
         }
 
         Some(output)

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -32,7 +32,7 @@ pub struct LintCommand {
     #[bpaf(external)]
     pub warning_options: WarningOptions,
 
-    #[bpaf(external)]
+    #[bpaf(external, guard(OutputOptions::is_valid, OUTPUT_FILE_FORMAT_REQUIRES_OUTPUT_FILE))]
     pub output_options: OutputOptions,
 
     /// List all the rules that are currently registered
@@ -266,10 +266,36 @@ pub struct WarningOptions {
 /// Output
 #[derive(Debug, Clone, Bpaf)]
 pub struct OutputOptions {
-    /// Use a specific output format. Possible values:
+    /// Use a specific output format for stdout. Possible values:
     /// `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
     #[bpaf(long, short, fallback_with(default_output_format), hide_usage)]
     pub format: OutputFormat,
+
+    /// Write the lint report to PATH (in addition to stdout). Parent directories are created
+    /// if they do not exist; existing files are truncated. Use `--output-file-format` to
+    /// control the format (defaults to `json`).
+    #[bpaf(long("output-file"), short('o'), argument("PATH"), hide_usage)]
+    pub output_file: Option<PathBuf>,
+
+    /// Output format used for `--output-file`. Defaults to `json` when `--output-file` is set.
+    /// Errors when used without `--output-file`. Possible values are the same as `--format`.
+    #[bpaf(long("output-file-format"), argument("FORMAT"), hide_usage)]
+    pub output_file_format: Option<OutputFormat>,
+}
+
+const OUTPUT_FILE_FORMAT_REQUIRES_OUTPUT_FILE: &str =
+    "`--output-file-format` requires `--output-file`";
+
+impl OutputOptions {
+    pub(crate) fn is_valid(opts: &OutputOptions) -> bool {
+        !(opts.output_file.is_none() && opts.output_file_format.is_some())
+    }
+
+    pub fn resolved_output_file_format(&self) -> Option<OutputFormat> {
+        self.output_file
+            .as_ref()
+            .map(|_| self.output_file_format.unwrap_or(OutputFormat::Json))
+    }
 }
 
 #[expect(clippy::unnecessary_wraps)]
@@ -690,6 +716,61 @@ mod lint_options {
         let options = get_lint_options("--suppress-all --prune-suppressions");
         assert!(options.suppression_options.prune_suppressions);
         assert!(options.suppression_options.suppress_all);
+    }
+
+    #[test]
+    fn output_file_long() {
+        let options = get_lint_options("--output-file results.json");
+        assert_eq!(options.output_options.output_file, Some(PathBuf::from("results.json")));
+        assert_eq!(options.output_options.output_file_format, None);
+        assert_eq!(
+            options.output_options.resolved_output_file_format(),
+            Some(OutputFormat::Json),
+        );
+    }
+
+    #[test]
+    fn output_file_short() {
+        let options = get_lint_options("-o results.json");
+        assert_eq!(options.output_options.output_file, Some(PathBuf::from("results.json")));
+    }
+
+    #[test]
+    fn output_file_default_none() {
+        let options = get_lint_options(".");
+        assert_eq!(options.output_options.output_file, None);
+        assert_eq!(options.output_options.output_file_format, None);
+        assert_eq!(options.output_options.resolved_output_file_format(), None);
+    }
+
+    #[test]
+    fn output_file_format_explicit() {
+        let options = get_lint_options("-o report.json --output-file-format checkstyle");
+        assert_eq!(options.output_options.output_file, Some(PathBuf::from("report.json")));
+        assert_eq!(options.output_options.output_file_format, Some(OutputFormat::Checkstyle));
+        assert_eq!(
+            options.output_options.resolved_output_file_format(),
+            Some(OutputFormat::Checkstyle)
+        );
+    }
+
+    #[test]
+    fn output_file_format_without_file_errors() {
+        let args = "--output-file-format json"
+            .split(' ')
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>();
+        let result = lint_command().run_inner(args.as_slice());
+        let err = result.expect_err("expected parse error");
+        assert!(err.unwrap_stderr().contains("`--output-file-format` requires `--output-file`"));
+    }
+
+    #[test]
+    fn format_and_output_file_independent() {
+        let options = get_lint_options("-f stylish -o report.json --output-file-format json");
+        assert_eq!(options.output_options.format, OutputFormat::Stylish);
+        assert_eq!(options.output_options.output_file, Some(PathBuf::from("report.json")));
+        assert_eq!(options.output_options.output_file_format, Some(OutputFormat::Json));
     }
 }
 

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -292,9 +292,7 @@ impl OutputOptions {
     }
 
     pub fn resolved_output_file_format(&self) -> Option<OutputFormat> {
-        self.output_file
-            .as_ref()
-            .map(|_| self.output_file_format.unwrap_or(OutputFormat::Json))
+        self.output_file.as_ref().map(|_| self.output_file_format.unwrap_or(OutputFormat::Json))
     }
 }
 
@@ -723,10 +721,7 @@ mod lint_options {
         let options = get_lint_options("--output-file results.json");
         assert_eq!(options.output_options.output_file, Some(PathBuf::from("results.json")));
         assert_eq!(options.output_options.output_file_format, None);
-        assert_eq!(
-            options.output_options.resolved_output_file_format(),
-            Some(OutputFormat::Json),
-        );
+        assert_eq!(options.output_options.resolved_output_file_format(), Some(OutputFormat::Json),);
     }
 
     #[test]

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -7,6 +7,7 @@ mod init;
 mod lint;
 pub mod lsp;
 mod mode;
+mod output_dispatcher;
 mod output_formatter;
 mod result;
 mod walk;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -11,7 +11,7 @@ use std::{
 use cow_utils::CowUtils;
 use ignore::{gitignore::Gitignore, overrides::OverrideBuilder};
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, GraphicalReportHandler, OxcDiagnostic};
+use oxc_diagnostics::{GraphicalReportHandler, OxcDiagnostic};
 use oxc_linter::{
     AllowWarnDeny, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ExternalLinter,
     ExternalPluginStore, InvalidFilterKind, LintFilter, LintOptions, LintRunner,
@@ -21,9 +21,10 @@ use oxc_linter::{
 #[cfg(feature = "napi")]
 use crate::js_config::JsConfigLoaderCb;
 use crate::{
-    cli::{CliRunResult, LintCommand, MiscOptions, ReportUnusedDirectives, WarningOptions},
+    cli::{CliRunResult, LintCommand, ReportUnusedDirectives},
     config_loader::{CliConfigLoadError, ConfigLoadError, ConfigLoader},
-    output_formatter::{LintCommandInfo, OutputFormatter},
+    output_dispatcher::{DispatcherWriter, MultiSinkDispatcher, OutputSink, open_output_file},
+    output_formatter::{LintCommandInfo, OutputFormat, OutputFormatter},
     walk::Walk,
 };
 use oxc_linter::LintIgnoreMatcher;
@@ -68,8 +69,8 @@ impl CliRunner {
 
     /// # Panics
     pub fn run(self, stdout: &mut dyn Write) -> CliRunResult {
-        let format_str = self.options.output_options.format;
-        let output_formatter = OutputFormatter::new(format_str);
+        let stdout_format = self.options.output_options.format;
+        let output_formatter = OutputFormatter::new(stdout_format);
 
         let LintCommand {
             paths,
@@ -83,6 +84,7 @@ impl CliRunner {
             disable_nested_config,
             inline_config_options,
             suppression_options,
+            output_options,
             ..
         } = self.options;
 
@@ -383,12 +385,10 @@ impl CliRunner {
                 },
             }
         };
-        let (mut diagnostic_service, tx_error) = Self::get_diagnostic_service(
-            &output_formatter,
-            &warning_options,
-            &misc_options,
-            max_warnings,
-        );
+        let output_file_path = output_options.output_file.clone();
+        let output_file_format = output_options.resolved_output_file_format();
+
+        let (tx_error, rx_error) = std::sync::mpsc::channel();
 
         // Send JS plugins config to JS side
         if let Some(external_linter) = &external_linter {
@@ -484,7 +484,25 @@ impl CliRunner {
 
         drop(tx_error);
 
-        let diagnostic_result = diagnostic_service.run(stdout);
+        // Open `--output-file` only now, after all early-exit branches above (invalid tsconfig,
+        // no files found, etc.). Opening earlier would truncate or create the destination file
+        // even when the run produces no diagnostics to write.
+        let mut output_file_writer = match output_file_path.as_deref() {
+            Some(path) => match open_output_file(path) {
+                Ok(writer) => Some(writer),
+                Err(err) => {
+                    #[expect(clippy::print_stderr)]
+                    {
+                        eprintln!(
+                            "oxlint: failed to open --output-file '{}': {err}",
+                            path.display()
+                        );
+                    }
+                    return CliRunResult::OutputFileError;
+                }
+            },
+            None => None,
+        };
 
         let oxlint_suppression_file_action = if let Err(report_suppression_error) = result {
             OxlintSuppressionFileAction::UnableToPerformFsOperation(report_suppression_error)
@@ -497,14 +515,37 @@ impl CliRunner {
             OxlintSuppressionFileAction::HasUnprunedSuppressions
         );
 
-        if let Some(end) = output_formatter.lint_command_info(&LintCommandInfo {
-            number_of_files,
-            number_of_rules,
-            threads_count: rayon::current_num_threads(),
-            start_time: now.elapsed(),
-            oxlint_suppression_file_action,
-        }) {
-            print_and_flush_stdout(stdout, &end);
+        let diagnostic_result = {
+            let mut sinks: Vec<OutputSink<'_>> = Vec::with_capacity(2);
+            sinks.push(
+                OutputSink::new(
+                    OutputFormatter::new(stdout_format),
+                    DispatcherWriter::Borrowed(stdout),
+                )
+                .with_silent(misc_options.silent),
+            );
+            if let Some(writer) = output_file_writer.as_mut() {
+                sinks.push(OutputSink::new(
+                    OutputFormatter::new(output_file_format.unwrap_or(OutputFormat::Json)),
+                    DispatcherWriter::Borrowed(writer),
+                ));
+            }
+            let mut dispatcher = MultiSinkDispatcher::from_receiver(sinks, rx_error)
+                .with_quiet(warning_options.quiet)
+                .with_max_warnings(max_warnings);
+
+            let result = dispatcher.run();
+            dispatcher.write_lint_command_info(&LintCommandInfo {
+                number_of_files,
+                number_of_rules,
+                threads_count: rayon::current_num_threads(),
+                start_time: now.elapsed(),
+                oxlint_suppression_file_action,
+            });
+            result
+        };
+        if let Some(mut writer) = output_file_writer {
+            let _ = writer.flush();
         }
 
         // When --suppress-all is used and the file was written successfully,
@@ -541,22 +582,6 @@ impl CliRunner {
     pub fn with_config_loader(mut self, config_loader: Option<JsConfigLoaderCb>) -> Self {
         self.js_config_loader = config_loader;
         self
-    }
-
-    fn get_diagnostic_service(
-        reporter: &OutputFormatter,
-        warning_options: &WarningOptions,
-        misc_options: &MiscOptions,
-        max_warnings: Option<usize>,
-    ) -> (DiagnosticService, DiagnosticSender) {
-        let (service, sender) = DiagnosticService::new(reporter.get_diagnostic_reporter());
-        (
-            service
-                .with_quiet(warning_options.quiet)
-                .with_silent(misc_options.silent)
-                .with_max_warnings(max_warnings),
-            sender,
-        )
     }
 
     fn handle_no_files_found(
@@ -1809,7 +1834,6 @@ export { redundant };
 
 #[cfg(test)]
 mod suppression {
-
     use crate::{
         cli::CliRunResult,
         tester::{SuppressionTester, Tester},
@@ -2159,5 +2183,231 @@ mod suppression {
             .with_expected_file(false)
             .with_backup_file(false)
             .test(&["--suppress-all", "--type-check"]);
+    }
+}
+
+#[cfg(test)]
+mod output_file_tests {
+    use std::fs;
+
+    use crate::cli::{CliRunResult, CliRunner, lint_command};
+
+    fn run_capture(args: &[&str]) -> (String, CliRunResult) {
+        let options = lint_command().run_inner(args).unwrap();
+        let mut output: Vec<u8> = Vec::new();
+        let result = CliRunner::new(options, None).run(&mut output);
+        (String::from_utf8(output).unwrap(), result)
+    }
+
+    #[test]
+    fn test_output_file_writes_json_alongside_stdout_default() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (stdout, _result) = run_capture(&[
+            "-o",
+            output_path_str.as_str(),
+            "fixtures/cli/linter/debugger.js",
+        ]);
+
+        assert!(stdout.contains("no-debugger") && stdout.contains("Found"));
+        assert!(!stdout.trim_start().starts_with('{') && !stdout.trim_start().starts_with('['));
+
+        let file_contents = fs::read_to_string(&output_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(file_contents.trim()).unwrap();
+        let diagnostics = parsed.get("diagnostics").and_then(serde_json::Value::as_array).unwrap();
+        assert!(!diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_output_file_with_explicit_format_diverges_from_stdout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("report.xml");
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (stdout, _result) = run_capture(&[
+            "-f",
+            "json",
+            "-o",
+            output_path_str.as_str(),
+            "--output-file-format",
+            "checkstyle",
+            "fixtures/cli/linter/debugger.js",
+        ]);
+
+        assert!(stdout.contains("\"diagnostics\""));
+
+        let file_contents = fs::read_to_string(&output_path).unwrap();
+        assert!(file_contents.contains("<?xml") && file_contents.contains("<checkstyle"));
+    }
+
+    #[test]
+    fn test_output_file_clean_run_writes_empty_envelope() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let clean_source = temp_dir.path().join("clean.js");
+        fs::write(&clean_source, "const x = 1;\nexport { x };\n").unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (_stdout, _result) =
+            run_capture(&["-o", output_path_str.as_str(), clean_source.to_str().unwrap()]);
+
+        let file_contents = fs::read_to_string(&output_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(file_contents.trim()).unwrap();
+        let diagnostics = parsed.get("diagnostics").and_then(serde_json::Value::as_array).unwrap();
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_output_file_creates_missing_parent_directories() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let nested = temp_dir.path().join("a/b/c/results.json");
+        let nested_str = nested.to_string_lossy().to_string();
+        assert!(!nested.parent().unwrap().exists());
+
+        let (_stdout, _result) =
+            run_capture(&["-o", nested_str.as_str(), "fixtures/cli/linter/debugger.js"]);
+
+        assert!(nested.exists());
+        let parsed: serde_json::Value =
+            serde_json::from_str(fs::read_to_string(&nested).unwrap().trim()).unwrap();
+        assert!(parsed.get("diagnostics").is_some());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_output_file_unwritable_path_returns_output_file_error() {
+        // `/dev/null` is a character device, so `create_dir_all` on a path beneath it fails.
+        let (_stdout, result) = run_capture(&[
+            "-o",
+            "/dev/null/cannot/create/here.json",
+            "fixtures/cli/linter/debugger.js",
+        ]);
+        assert!(matches!(result, CliRunResult::OutputFileError));
+    }
+
+    #[test]
+    fn test_output_file_format_without_output_file_is_parse_error() {
+        let result = lint_command().run_inner(["--output-file-format", "json"].as_slice());
+        let err = result.expect_err("expected parse error");
+        assert!(err.unwrap_stderr().contains("`--output-file-format` requires `--output-file`"));
+    }
+
+    #[test]
+    fn test_output_file_with_print_config_does_not_create_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (stdout, _result) =
+            run_capture(&["--print-config", "-o", output_path_str.as_str(), "-A", "all"]);
+        assert!(!stdout.is_empty());
+        assert!(!output_path.exists());
+    }
+
+    /// `--silent` is a stdout-only concept: it must not silence diagnostics that the user
+    /// explicitly redirected to `--output-file`.
+    #[test]
+    fn test_output_file_with_silent_still_writes_diagnostics_to_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (stdout, _result) = run_capture(&[
+            "--silent",
+            "-o",
+            output_path_str.as_str(),
+            "fixtures/cli/linter/debugger.js",
+        ]);
+
+        assert!(!stdout.contains("no-debugger"));
+
+        let file_contents = fs::read_to_string(&output_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(file_contents.trim()).unwrap();
+        let diagnostics = parsed.get("diagnostics").and_then(serde_json::Value::as_array).unwrap();
+        assert!(
+            !diagnostics.is_empty(),
+            "file sink should still receive diagnostics under --silent",
+        );
+    }
+
+    /// Regression: an early validation failure (invalid `--tsconfig`) must not create or
+    /// truncate the path passed to `--output-file`.
+    #[test]
+    fn test_output_file_unchanged_when_tsconfig_invalid() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        let sentinel = "SENTINEL_DO_NOT_TRUNCATE\n";
+        fs::write(&output_path, sentinel).unwrap();
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (_stdout, result) = run_capture(&[
+            "-o",
+            output_path_str.as_str(),
+            "--tsconfig",
+            "non-existent-tsconfig.json",
+            "fixtures/cli/linter/debugger.js",
+        ]);
+
+        assert!(matches!(result, CliRunResult::InvalidOptionTsConfig));
+        assert_eq!(fs::read_to_string(&output_path).unwrap(), sentinel);
+    }
+
+    /// Regression: when no files match, `--output-file` must not be created or truncated.
+    #[test]
+    fn test_output_file_unchanged_when_no_files_found() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        let sentinel = "SENTINEL_DO_NOT_TRUNCATE\n";
+        fs::write(&output_path, sentinel).unwrap();
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (_stdout, result) =
+            run_capture(&["-o", output_path_str.as_str(), "does-not-exist.foo.asdf"]);
+
+        assert!(matches!(result, CliRunResult::LintNoFilesFound));
+        assert_eq!(fs::read_to_string(&output_path).unwrap(), sentinel);
+    }
+
+    /// Same as above, but verify with `--no-error-on-unmatched-pattern` (which yields
+    /// `LintSucceeded` instead of `LintNoFilesFound`) the file is also left alone.
+    #[test]
+    fn test_output_file_unchanged_when_no_files_found_with_no_error_flag() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        let sentinel = "SENTINEL_DO_NOT_TRUNCATE\n";
+        fs::write(&output_path, sentinel).unwrap();
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (_stdout, result) = run_capture(&[
+            "--no-error-on-unmatched-pattern",
+            "-o",
+            output_path_str.as_str(),
+            "does-not-exist.foo.asdf",
+        ]);
+
+        assert!(matches!(result, CliRunResult::LintSucceeded));
+        assert_eq!(fs::read_to_string(&output_path).unwrap(), sentinel);
+    }
+
+    /// Documents the success-path truncation contract (existing files are overwritten).
+    #[test]
+    fn test_output_file_truncates_existing_file_on_success() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("results.json");
+        fs::write(&output_path, "STALE_PREVIOUS_REPORT\n").unwrap();
+        let output_path_str = output_path.to_string_lossy().to_string();
+
+        let (_stdout, _result) = run_capture(&[
+            "-o",
+            output_path_str.as_str(),
+            "fixtures/cli/linter/debugger.js",
+        ]);
+
+        let file_contents = fs::read_to_string(&output_path).unwrap();
+        assert!(!file_contents.contains("STALE_PREVIOUS_REPORT"));
+        let parsed: serde_json::Value = serde_json::from_str(file_contents.trim()).unwrap();
+        assert!(parsed.get("diagnostics").is_some());
     }
 }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -2193,6 +2193,8 @@ mod output_file_tests {
     use crate::cli::{CliRunResult, CliRunner, lint_command};
 
     fn run_capture(args: &[&str]) -> (String, CliRunResult) {
+        let _ = rayon::ThreadPoolBuilder::new().num_threads(1).build_global();
+
         let options = lint_command().run_inner(args).unwrap();
         let mut output: Vec<u8> = Vec::new();
         let result = CliRunner::new(options, None).run(&mut output);
@@ -2205,11 +2207,8 @@ mod output_file_tests {
         let output_path = temp_dir.path().join("results.json");
         let output_path_str = output_path.to_string_lossy().to_string();
 
-        let (stdout, _result) = run_capture(&[
-            "-o",
-            output_path_str.as_str(),
-            "fixtures/cli/linter/debugger.js",
-        ]);
+        let (stdout, _result) =
+            run_capture(&["-o", output_path_str.as_str(), "fixtures/cli/linter/debugger.js"]);
 
         assert!(stdout.contains("no-debugger") && stdout.contains("Found"));
         assert!(!stdout.trim_start().starts_with('{') && !stdout.trim_start().starts_with('['));
@@ -2399,11 +2398,8 @@ mod output_file_tests {
         fs::write(&output_path, "STALE_PREVIOUS_REPORT\n").unwrap();
         let output_path_str = output_path.to_string_lossy().to_string();
 
-        let (_stdout, _result) = run_capture(&[
-            "-o",
-            output_path_str.as_str(),
-            "fixtures/cli/linter/debugger.js",
-        ]);
+        let (_stdout, _result) =
+            run_capture(&["-o", output_path_str.as_str(), "fixtures/cli/linter/debugger.js"]);
 
         let file_contents = fs::read_to_string(&output_path).unwrap();
         assert!(!file_contents.contains("STALE_PREVIOUS_REPORT"));

--- a/apps/oxlint/src/output_dispatcher.rs
+++ b/apps/oxlint/src/output_dispatcher.rs
@@ -114,11 +114,8 @@ impl<'a> MultiSinkDispatcher<'a> {
         // Tracked per-sink so a JSON file sink keeps emitting full output while a human-readable
         // stdout sink stops on the same minified file.
         let mut sink_minified: Vec<bool> = vec![false; self.sinks.len()];
-        let sink_supports_fallback: Vec<bool> = self
-            .sinks
-            .iter_mut()
-            .map(|s| s.reporter.supports_minified_file_fallback())
-            .collect();
+        let sink_supports_fallback: Vec<bool> =
+            self.sinks.iter_mut().map(|s| s.reporter.supports_minified_file_fallback()).collect();
 
         while let Ok(diagnostics) = self.receiver.recv() {
             sink_minified.fill(false);
@@ -300,12 +297,8 @@ mod tests {
 
     #[test]
     fn single_sink_runs_and_finishes() {
-        let (result, outputs) = run_dispatch(
-            &[OutputFormat::Json],
-            vec![vec![make_diagnostic("err")]],
-            |d| d,
-            true,
-        );
+        let (result, outputs) =
+            run_dispatch(&[OutputFormat::Json], vec![vec![make_diagnostic("err")]], |d| d, true);
         assert_eq!(result.warnings_count(), 1);
         assert_eq!(result.errors_count(), 0);
         assert!(outputs[0].contains("\"diagnostics\""));
@@ -376,8 +369,7 @@ mod tests {
     #[test]
     fn lint_command_info_only_writes_when_formatter_returns_some() {
         // `Unix` uses the default `lint_command_info` returning None.
-        let (_result, outputs_without) =
-            run_dispatch(&[OutputFormat::Unix], vec![], |d| d, false);
+        let (_result, outputs_without) = run_dispatch(&[OutputFormat::Unix], vec![], |d| d, false);
         let (_result, outputs_with) = run_dispatch(&[OutputFormat::Unix], vec![], |d| d, true);
         assert_eq!(outputs_without[0], outputs_with[0]);
     }

--- a/apps/oxlint/src/output_dispatcher.rs
+++ b/apps/oxlint/src/output_dispatcher.rs
@@ -1,0 +1,384 @@
+//! Multi-sink diagnostic dispatcher: fans each diagnostic out to N
+//! `(formatter, reporter, writer)` sinks, enabling oxlint's dual-output
+//! (`--format` to stdout + `--output-file-format` to a file) in one run.
+
+use std::{
+    fs::{self, File},
+    io::{BufWriter, ErrorKind, Write},
+    path::Path,
+    sync::Arc,
+};
+
+#[cfg(test)]
+use oxc_diagnostics::DiagnosticSender;
+use oxc_diagnostics::{
+    DiagnosticReceiver, Error, OxcDiagnostic, Severity,
+    reporter::{DiagnosticReporter, DiagnosticResult},
+};
+
+use crate::output_formatter::{LintCommandInfo, OutputFormatter};
+
+pub struct OutputSink<'a> {
+    formatter: OutputFormatter,
+    reporter: Box<dyn DiagnosticReporter>,
+    writer: DispatcherWriter<'a>,
+    /// When true, this sink skips per-diagnostic rendering (its `finish` summary is still
+    /// emitted). Set on the stdout sink when `--silent` is used so the file sink can keep
+    /// recording the full report.
+    silent: bool,
+}
+
+impl<'a> OutputSink<'a> {
+    pub fn new(formatter: OutputFormatter, writer: DispatcherWriter<'a>) -> Self {
+        let reporter = formatter.get_diagnostic_reporter();
+        Self { formatter, reporter, writer, silent: false }
+    }
+
+    #[must_use]
+    pub fn with_silent(mut self, yes: bool) -> Self {
+        self.silent = yes;
+        self
+    }
+}
+
+pub enum DispatcherWriter<'a> {
+    Borrowed(&'a mut dyn Write),
+    #[expect(dead_code, reason = "kept for callers that need owned writers")]
+    Owned(Box<dyn Write + 'a>),
+}
+
+impl Write for DispatcherWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Borrowed(w) => w.write(buf),
+            Self::Owned(w) => w.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Borrowed(w) => w.flush(),
+            Self::Owned(w) => w.flush(),
+        }
+    }
+}
+
+pub fn open_output_file(path: &Path) -> std::io::Result<BufWriter<File>> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+    let file = File::create(path)?;
+    Ok(BufWriter::new(file))
+}
+
+pub struct MultiSinkDispatcher<'a> {
+    sinks: Vec<OutputSink<'a>>,
+    receiver: DiagnosticReceiver,
+    quiet: bool,
+    max_warnings: Option<usize>,
+}
+
+impl<'a> MultiSinkDispatcher<'a> {
+    #[cfg(test)]
+    pub fn new(sinks: Vec<OutputSink<'a>>) -> (Self, DiagnosticSender) {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        (Self::from_receiver(sinks, receiver), sender)
+    }
+
+    pub fn from_receiver(sinks: Vec<OutputSink<'a>>, receiver: DiagnosticReceiver) -> Self {
+        debug_assert!(!sinks.is_empty(), "MultiSinkDispatcher requires at least one sink");
+        Self { sinks, receiver, quiet: false, max_warnings: None }
+    }
+
+    #[must_use]
+    pub fn with_quiet(mut self, yes: bool) -> Self {
+        self.quiet = yes;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_warnings(mut self, max_warnings: Option<usize>) -> Self {
+        self.max_warnings = max_warnings;
+        self
+    }
+
+    fn max_warnings_exceeded(&self, warnings_count: usize) -> bool {
+        self.max_warnings.is_some_and(|max_warnings| warnings_count > max_warnings)
+    }
+
+    pub fn run(&mut self) -> DiagnosticResult {
+        let mut warnings_count: usize = 0;
+        let mut errors_count: usize = 0;
+        // Tracked per-sink so a JSON file sink keeps emitting full output while a human-readable
+        // stdout sink stops on the same minified file.
+        let mut sink_minified: Vec<bool> = vec![false; self.sinks.len()];
+        let sink_supports_fallback: Vec<bool> = self
+            .sinks
+            .iter_mut()
+            .map(|s| s.reporter.supports_minified_file_fallback())
+            .collect();
+
+        while let Ok(diagnostics) = self.receiver.recv() {
+            sink_minified.fill(false);
+
+            for diagnostic in diagnostics {
+                let severity = diagnostic.severity();
+                let is_warning = severity == Some(Severity::Warning);
+                let is_error = severity == Some(Severity::Error) || severity.is_none();
+                if is_warning || is_error {
+                    if is_warning {
+                        warnings_count += 1;
+                    }
+                    if is_error {
+                        errors_count += 1;
+                    }
+                    // `--quiet` still counts warnings (so `--max-warnings` triggers) but skips
+                    // rendering them.
+                    else if self.quiet {
+                        continue;
+                    }
+                }
+
+                if self.sinks.iter().all(|s| s.silent) {
+                    continue;
+                }
+
+                let path = diagnostic
+                    .source_code()
+                    .and_then(|source| source.name())
+                    .map(ToString::to_string);
+
+                let shared = Arc::new(diagnostic);
+
+                for (idx, sink) in self.sinks.iter_mut().enumerate() {
+                    if sink.silent || sink_minified[idx] {
+                        continue;
+                    }
+
+                    let Some(rendered) = sink.reporter.render_error(Arc::clone(&shared)) else {
+                        continue;
+                    };
+
+                    if sink_supports_fallback[idx]
+                        && rendered.lines().any(|line| line.len() >= 1200)
+                    {
+                        let mut warning =
+                            OxcDiagnostic::warn("File is too long to fit on the screen");
+                        if let Some(path) = path.as_ref() {
+                            warning =
+                                warning.with_help(format!("{path} seems like a minified file"));
+                        }
+                        let warning = Arc::new(Error::new(warning));
+                        if let Some(fallback) = sink.reporter.render_error(warning) {
+                            write_all(&mut sink.writer, fallback.as_bytes());
+                        }
+                        sink_minified[idx] = true;
+                        continue;
+                    }
+
+                    write_all(&mut sink.writer, rendered.as_bytes());
+                }
+            }
+        }
+
+        let result = DiagnosticResult::new(
+            warnings_count,
+            errors_count,
+            self.max_warnings_exceeded(warnings_count),
+        );
+
+        for sink in &mut self.sinks {
+            if let Some(finish_output) = sink.reporter.finish(&result) {
+                write_all(&mut sink.writer, finish_output.as_bytes());
+            }
+            flush_writer(&mut sink.writer);
+        }
+
+        result
+    }
+
+    pub fn write_lint_command_info(&mut self, info: &LintCommandInfo) {
+        for sink in &mut self.sinks {
+            if let Some(end) = sink.formatter.lint_command_info(info) {
+                write_all(&mut sink.writer, end.as_bytes());
+                flush_writer(&mut sink.writer);
+            }
+        }
+    }
+}
+
+fn write_all(writer: &mut DispatcherWriter<'_>, bytes: &[u8]) {
+    writer.write_all(bytes).or_else(check_for_writer_error).unwrap();
+}
+
+fn flush_writer(writer: &mut DispatcherWriter<'_>) {
+    writer.flush().or_else(check_for_writer_error).unwrap();
+}
+
+fn check_for_writer_error(error: std::io::Error) -> Result<(), std::io::Error> {
+    if matches!(
+        error.kind(),
+        ErrorKind::Interrupted | ErrorKind::BrokenPipe | ErrorKind::WouldBlock
+    ) {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use oxc_diagnostics::{Error, NamedSource, OxcDiagnostic};
+    use oxc_span::Span;
+
+    use oxc_linter::OxlintSuppressionFileAction;
+
+    use crate::output_formatter::{LintCommandInfo, OutputFormat, OutputFormatter};
+
+    use super::{DispatcherWriter, MultiSinkDispatcher, OutputSink};
+
+    fn make_diagnostic(message: &str) -> Error {
+        OxcDiagnostic::warn(message.to_string())
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("file://test.ts", "debugger;"))
+    }
+
+    fn run_dispatch(
+        formats: &[OutputFormat],
+        diagnostics: Vec<Vec<Error>>,
+        configure: impl for<'a> FnOnce(MultiSinkDispatcher<'a>) -> MultiSinkDispatcher<'a>,
+        emit_command_info: bool,
+    ) -> (oxc_diagnostics::reporter::DiagnosticResult, Vec<String>) {
+        run_dispatch_with_sinks(formats, diagnostics, configure, emit_command_info, &[])
+    }
+
+    fn run_dispatch_with_sinks(
+        formats: &[OutputFormat],
+        diagnostics: Vec<Vec<Error>>,
+        configure: impl for<'a> FnOnce(MultiSinkDispatcher<'a>) -> MultiSinkDispatcher<'a>,
+        emit_command_info: bool,
+        silent_flags: &[bool],
+    ) -> (oxc_diagnostics::reporter::DiagnosticResult, Vec<String>) {
+        let mut buffers: Vec<Vec<u8>> =
+            std::iter::repeat_with(Vec::new).take(formats.len()).collect();
+        let result = {
+            let sinks: Vec<OutputSink<'_>> = buffers
+                .iter_mut()
+                .zip(formats.iter())
+                .enumerate()
+                .map(|(idx, (buf, fmt))| {
+                    let silent = silent_flags.get(idx).copied().unwrap_or(false);
+                    OutputSink::new(OutputFormatter::new(*fmt), DispatcherWriter::Borrowed(buf))
+                        .with_silent(silent)
+                })
+                .collect();
+            let (dispatcher, sender) = MultiSinkDispatcher::new(sinks);
+            let mut dispatcher = configure(dispatcher);
+            for batch in diagnostics {
+                sender.send(batch).unwrap();
+            }
+            drop(sender);
+            let result = dispatcher.run();
+            if emit_command_info {
+                dispatcher.write_lint_command_info(&LintCommandInfo {
+                    number_of_files: 1,
+                    number_of_rules: Some(1),
+                    threads_count: 1,
+                    start_time: Duration::from_millis(1),
+                    oxlint_suppression_file_action: OxlintSuppressionFileAction::None,
+                });
+            }
+            result
+        };
+        let outputs = buffers.into_iter().map(|b| String::from_utf8(b).unwrap()).collect();
+        (result, outputs)
+    }
+
+    #[test]
+    fn single_sink_runs_and_finishes() {
+        let (result, outputs) = run_dispatch(
+            &[OutputFormat::Json],
+            vec![vec![make_diagnostic("err")]],
+            |d| d,
+            true,
+        );
+        assert_eq!(result.warnings_count(), 1);
+        assert_eq!(result.errors_count(), 0);
+        assert!(outputs[0].contains("\"diagnostics\""));
+        assert!(outputs[0].contains("\"number_of_files\""));
+    }
+
+    #[test]
+    fn dual_sink_fans_out_per_format() {
+        let (result, outputs) = run_dispatch(
+            &[OutputFormat::Default, OutputFormat::Json],
+            vec![vec![make_diagnostic("dual sink message")]],
+            |d| d,
+            true,
+        );
+        assert_eq!(result.warnings_count(), 1);
+
+        let stdout_str = &outputs[0];
+        let file_str = &outputs[1];
+        assert!(stdout_str.contains("Found") && stdout_str.contains("warning"));
+        assert!(file_str.contains("\"diagnostics\"") && file_str.contains("dual sink message"));
+        assert!(!file_str.contains("Found 1 warning"));
+    }
+
+    #[test]
+    fn quiet_skips_warnings_but_counts_them() {
+        let (result, _outputs) = run_dispatch(
+            &[OutputFormat::Default],
+            vec![vec![make_diagnostic("warn one")]],
+            |d| d.with_quiet(true).with_max_warnings(Some(0)),
+            false,
+        );
+        assert_eq!(result.warnings_count(), 1);
+        assert!(result.max_warnings_exceeded());
+    }
+
+    #[test]
+    fn silent_sink_skips_render_but_still_counts_and_finishes() {
+        let (result, outputs) = run_dispatch_with_sinks(
+            &[OutputFormat::Default],
+            vec![vec![make_diagnostic("hidden")]],
+            |d| d,
+            false,
+            &[true],
+        );
+        assert_eq!(result.warnings_count(), 1);
+        assert!(outputs[0].contains("Found 1 warning"));
+        assert!(!outputs[0].contains("hidden"));
+    }
+
+    #[test]
+    fn silent_is_per_sink_so_file_sink_still_renders() {
+        let (result, outputs) = run_dispatch_with_sinks(
+            &[OutputFormat::Default, OutputFormat::Json],
+            vec![vec![make_diagnostic("dual silent message")]],
+            |d| d,
+            true,
+            &[true, false],
+        );
+        assert_eq!(result.warnings_count(), 1);
+        let stdout_str = &outputs[0];
+        let file_str = &outputs[1];
+        assert!(!stdout_str.contains("dual silent message"));
+        assert!(stdout_str.contains("Found 1 warning"));
+        assert!(file_str.contains("dual silent message"));
+        assert!(file_str.contains("\"diagnostics\""));
+    }
+
+    #[test]
+    fn lint_command_info_only_writes_when_formatter_returns_some() {
+        // `Unix` uses the default `lint_command_info` returning None.
+        let (_result, outputs_without) =
+            run_dispatch(&[OutputFormat::Unix], vec![], |d| d, false);
+        let (_result, outputs_with) = run_dispatch(&[OutputFormat::Unix], vec![], |d| d, true);
+        assert_eq!(outputs_without[0], outputs_with[0]);
+    }
+}

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use oxc_diagnostics::{
     Error, Severity,
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -27,7 +29,7 @@ impl DiagnosticReporter for AgentReporter {
         false
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         Some(format_agent(&error))
     }
 }
@@ -72,6 +74,8 @@ fn compact_message(message: &str) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use oxc_diagnostics::{NamedSource, OxcDiagnostic, reporter::DiagnosticReporter};
     use oxc_span::Span;
 
@@ -86,7 +90,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
-        let result = reporter.render_error(error);
+        let result = reporter.render_error(Arc::new(error));
 
         assert_eq!(
             result.unwrap(),
@@ -101,7 +105,7 @@ mod test {
             .with_label(Span::new(0, 1))
             .with_source_code(NamedSource::new("file://test.js", ":"));
 
-        let result = reporter.render_error(error);
+        let result = reporter.render_error(Arc::new(error));
 
         assert_eq!(result.unwrap(), "file://test.js:1:1: error: Expected `;` but found `:`\n");
     }
@@ -112,7 +116,7 @@ mod test {
         let error = OxcDiagnostic::error("Failed to parse\nconfiguration")
             .with_source_code(NamedSource::new("config.json", ""));
 
-        let result = reporter.render_error(error);
+        let result = reporter.render_error(Arc::new(error));
 
         assert_eq!(result.unwrap(), "config.json: error: Failed to parse configuration\n");
     }

--- a/apps/oxlint/src/output_formatter/checkstyle.rs
+++ b/apps/oxlint/src/output_formatter/checkstyle.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use rustc_hash::FxHashMap;
 
@@ -23,7 +23,7 @@ impl InternalFormatter for CheckStyleOutputFormatter {
 /// Checkstyle Format Documentation: <https://checkstyle.sourceforge.io/>
 #[derive(Default)]
 struct CheckstyleReporter {
-    diagnostics: Vec<Error>,
+    diagnostics: Vec<Arc<Error>>,
 }
 
 impl DiagnosticReporter for CheckstyleReporter {
@@ -31,14 +31,14 @@ impl DiagnosticReporter for CheckstyleReporter {
         Some(format_checkstyle(&self.diagnostics))
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.diagnostics.push(error);
         None
     }
 }
 
-fn format_checkstyle(diagnostics: &[Error]) -> String {
-    let infos = diagnostics.iter().map(Info::new).collect::<Vec<_>>();
+fn format_checkstyle(diagnostics: &[Arc<Error>]) -> String {
+    let infos = diagnostics.iter().map(|e| Info::new(e.as_ref())).collect::<Vec<_>>();
     let mut grouped: FxHashMap<String, Vec<Info>> = FxHashMap::default();
     for info in infos {
         grouped.entry(info.filename.clone()).or_default().push(info);
@@ -68,6 +68,8 @@ fn format_checkstyle(diagnostics: &[Error]) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use oxc_diagnostics::{
         NamedSource, OxcDiagnostic,
         reporter::{DiagnosticReporter, DiagnosticResult},
@@ -84,7 +86,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
-        let first_result = reporter.render_error(error);
+        let first_result = reporter.render_error(Arc::new(error));
 
         // reporter keeps it in memory
         assert!(first_result.is_none());

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::output_formatter::InternalFormatter;
 use oxc_diagnostics::{
     Error, GraphicalReportHandler,
@@ -58,9 +60,9 @@ impl DiagnosticReporter for GraphicalReporter {
         Some(get_diagnostic_result_output(result))
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         let mut output = String::new();
-        self.handler.render_report(&mut output, error.as_ref()).unwrap();
+        self.handler.render_report(&mut output, error.as_ref().as_ref()).unwrap();
         Some(output)
     }
 }
@@ -95,6 +97,8 @@ pub(super) fn get_diagnostic_result_output(result: &DiagnosticResult) -> String 
 
 #[cfg(any(test, feature = "testing"))]
 mod test_implementation {
+    use std::sync::Arc;
+
     use oxc_diagnostics::{
         Error, GraphicalReportHandler, GraphicalTheme,
         reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -104,7 +108,7 @@ mod test_implementation {
 
     #[derive(Default)]
     pub struct GraphicalReporterTester {
-        diagnostics: Vec<Error>,
+        diagnostics: Vec<Arc<Error>>,
     }
 
     impl DiagnosticReporter for GraphicalReporterTester {
@@ -115,12 +119,12 @@ mod test_implementation {
             let mut output = String::new();
 
             self.diagnostics.sort_by_cached_key(|diagnostic| {
-                let info = Info::new(diagnostic);
+                let info = Info::new(diagnostic.as_ref());
                 (info.filename, info.start, info.end, info.rule_id, info.message)
             });
 
             for diagnostic in &self.diagnostics {
-                handler.render_report(&mut output, diagnostic.as_ref()).unwrap();
+                handler.render_report(&mut output, diagnostic.as_ref().as_ref()).unwrap();
             }
 
             output.push_str(&get_diagnostic_result_output(result));
@@ -128,7 +132,7 @@ mod test_implementation {
             Some(output)
         }
 
-        fn render_error(&mut self, error: Error) -> Option<String> {
+        fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
             self.diagnostics.push(error);
             None
         }

--- a/apps/oxlint/src/output_formatter/github.rs
+++ b/apps/oxlint/src/output_formatter/github.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use oxc_diagnostics::{
     Error, Severity,
@@ -34,8 +34,8 @@ impl DiagnosticReporter for GithubReporter {
         false
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
-        Some(format_github(&error))
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
+        Some(format_github(error.as_ref()))
     }
 }
 
@@ -101,6 +101,7 @@ fn escape_property(value: &str) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use oxc_diagnostics::{
@@ -168,7 +169,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
-        let result = reporter.render_error(error);
+        let result = reporter.render_error(Arc::new(error));
 
         assert!(result.is_some());
         assert_eq!(

--- a/apps/oxlint/src/output_formatter/github.rs
+++ b/apps/oxlint/src/output_formatter/github.rs
@@ -169,7 +169,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
-        let result = reporter.render_error(Arc::new(error));
+        let result = reporter.render_error(Arc::new(error.into()));
 
         assert!(result.is_some());
         assert_eq!(
@@ -186,7 +186,7 @@ mod test {
             .with_help("help message")
             .with_note("note message");
 
-        let result = reporter.render_error(error.into());
+        let result = reporter.render_error(Arc::new(error.into()));
 
         assert!(result.is_some());
         assert_eq!(result.as_ref().unwrap(), "::warning title=scope(rule)::warning message\n");
@@ -200,7 +200,7 @@ mod test {
             .with_help("help message")
             .with_note("note message");
 
-        let result = reporter.render_error(error.into());
+        let result = reporter.render_error(Arc::new(error.into()));
 
         assert!(result.is_some());
         assert_eq!(result.as_ref().unwrap(), "::error title=scope(rule)::error message\n");

--- a/apps/oxlint/src/output_formatter/gitlab.rs
+++ b/apps/oxlint/src/output_formatter/gitlab.rs
@@ -1,5 +1,6 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 #[cfg(windows)]
 use cow_utils::CowUtils;
@@ -88,7 +89,7 @@ fn get_repo_path_prefix() -> Option<PathBuf> {
 /// Note that, due to syntactic restrictions of JSON arrays, this reporter waits until all
 /// diagnostics have been reported before writing them to the output stream.
 struct GitlabReporter {
-    diagnostics: Vec<Error>,
+    diagnostics: Vec<Arc<Error>>,
     /// Path prefix to prepend to CWD-relative paths to make them repo-relative.
     /// `None` if CWD is the git root or if we're not in a git repository.
     repo_path_prefix: Option<PathBuf>,
@@ -105,15 +106,15 @@ impl DiagnosticReporter for GitlabReporter {
         Some(format_gitlab(&mut self.diagnostics, self.repo_path_prefix.as_deref()))
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.diagnostics.push(error);
         None
     }
 }
 
-fn format_gitlab(diagnostics: &mut Vec<Error>, repo_path_prefix: Option<&Path>) -> String {
+fn format_gitlab(diagnostics: &mut Vec<Arc<Error>>, repo_path_prefix: Option<&Path>) -> String {
     let errors = diagnostics.drain(..).map(|error| {
-        let Info { start, end, filename, message, severity, rule_id } = Info::new(&error);
+        let Info { start, end, filename, message, severity, rule_id } = Info::new(error.as_ref());
         let severity = match severity {
             Severity::Error => "critical".to_string(),
             Severity::Warning => "major".to_string(),
@@ -165,6 +166,7 @@ fn format_gitlab(diagnostics: &mut Vec<Error>, repo_path_prefix: Option<&Path>) 
 #[cfg(test)]
 mod test {
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
     use oxc_diagnostics::{
         Error, NamedSource, OxcDiagnostic,
@@ -182,7 +184,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("test.ts", "debugger;"));
 
-        let first_result = reporter.render_error(error);
+        let first_result = reporter.render_error(Arc::new(error));
 
         // reporter keeps it in memory
         assert!(first_result.is_none());
@@ -227,11 +229,11 @@ mod test {
 
     #[test]
     fn format_gitlab_with_prefix() {
-        let error = OxcDiagnostic::warn("test error")
+        let error: Error = OxcDiagnostic::warn("test error")
             .with_label(Span::new(0, 5))
             .with_source_code(NamedSource::new("example.js", "const x = 1;"));
 
-        let mut diagnostics: Vec<Error> = vec![error];
+        let mut diagnostics: Vec<Arc<Error>> = vec![Arc::new(error)];
 
         // Test with a prefix
         let result = format_gitlab(&mut diagnostics, Some(Path::new("packages/foo")));
@@ -242,11 +244,11 @@ mod test {
 
     #[test]
     fn format_gitlab_without_prefix() {
-        let error = OxcDiagnostic::warn("test error")
+        let error: Error = OxcDiagnostic::warn("test error")
             .with_label(Span::new(0, 5))
             .with_source_code(NamedSource::new("example.js", "const x = 1;"));
 
-        let mut diagnostics: Vec<Error> = vec![error];
+        let mut diagnostics: Vec<Arc<Error>> = vec![Arc::new(error)];
 
         // Test without a prefix (CWD is at git root)
         let result = format_gitlab(&mut diagnostics, None);
@@ -258,11 +260,11 @@ mod test {
     #[cfg(windows)]
     #[test]
     fn format_gitlab_windows_normalization() {
-        let error = OxcDiagnostic::warn("test error")
+        let error: Error = OxcDiagnostic::warn("test error")
             .with_label(Span::new(0, 5))
             .with_source_code(NamedSource::new("example.js", "const x = 1;"));
 
-        let mut diagnostics: Vec<Error> = vec![error];
+        let mut diagnostics: Vec<Arc<Error>> = vec![Arc::new(error)];
 
         // Windows-style prefix with backslashes should be normalized to forward slashes
         let result = format_gitlab(&mut diagnostics, Some(Path::new(r"packages\foo")));

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use oxc_str::CompactStr;
 
@@ -103,7 +103,7 @@ impl InternalFormatter for JsonOutputFormatter {
 /// diagnostics have been reported before writing them to the output stream.
 #[derive(Default, Debug)]
 struct JsonReporter {
-    diagnostics: Vec<Error>,
+    diagnostics: Vec<Arc<Error>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -114,7 +114,7 @@ impl DiagnosticReporter for JsonReporterWrapper {
         None
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.0.borrow_mut().render_error(error)
     }
 }
@@ -124,7 +124,7 @@ impl DiagnosticReporter for JsonReporter {
         None
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.diagnostics.push(error);
         None
     }
@@ -137,13 +137,13 @@ impl JsonReporter {
 }
 
 /// <https://github.com/fregante/eslint-formatters/tree/ae1fd9748596447d1fd09625c33d9e7ba9a3d06d/packages/eslint-formatter-json>
-fn format_json(diagnostics: &mut Vec<Error>) -> String {
+fn format_json(diagnostics: &mut Vec<Arc<Error>>) -> String {
     let handler = JSONReportHandler::new();
     let messages = diagnostics
         .drain(..)
         .map(|error| {
             let mut output = String::new();
-            handler.render_report(&mut output, error.as_ref()).unwrap();
+            handler.render_report(&mut output, error.as_ref().as_ref()).unwrap();
             output
         })
         .collect::<Vec<_>>()
@@ -153,7 +153,7 @@ fn format_json(diagnostics: &mut Vec<Error>) -> String {
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     use oxc_diagnostics::{NamedSource, OxcDiagnostic, reporter::DiagnosticResult};
     use oxc_span::Span;
@@ -171,7 +171,7 @@ mod test {
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
         let mut diagnostic_reporter = formatter.get_diagnostic_reporter();
-        let first_result = diagnostic_reporter.render_error(error);
+        let first_result = diagnostic_reporter.render_error(Arc::new(error));
 
         // reporter keeps it in memory
         assert!(first_result.is_none());

--- a/apps/oxlint/src/output_formatter/junit.rs
+++ b/apps/oxlint/src/output_formatter/junit.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use oxc_diagnostics::{
     Error, Severity,
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -17,7 +19,7 @@ impl InternalFormatter for JUnitOutputFormatter {
 
 #[derive(Default)]
 struct JUnitReporter {
-    diagnostics: Vec<Error>,
+    diagnostics: Vec<Arc<Error>>,
 }
 
 impl DiagnosticReporter for JUnitReporter {
@@ -25,16 +27,17 @@ impl DiagnosticReporter for JUnitReporter {
         Some(format_junit(&self.diagnostics))
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.diagnostics.push(error);
         None
     }
 }
 
-fn format_junit(diagnostics: &[Error]) -> String {
+fn format_junit(diagnostics: &[Arc<Error>]) -> String {
     let mut grouped: FxHashMap<String, Vec<&Error>> = FxHashMap::default();
 
     for diagnostic in diagnostics {
+        let diagnostic = diagnostic.as_ref();
         let info = Info::new(diagnostic);
         grouped.entry(info.filename).or_default().push(diagnostic);
     }
@@ -129,8 +132,8 @@ mod test {
             .with_label(Span::new(0, 9))
             .with_source_code(NamedSource::new("file.js", "debugger;"));
 
-        reporter.render_error(error);
-        reporter.render_error(warning);
+        reporter.render_error(Arc::new(error));
+        reporter.render_error(Arc::new(warning));
 
         let output = reporter.finish(&DiagnosticResult::default()).unwrap();
         assert_eq!(output, EXPECTED_REPORT);
@@ -163,8 +166,8 @@ mod test {
             .with_label(Span::new(0, 9))
             .with_source_code(NamedSource::new("b.js", "debugger;"));
 
-        reporter.render_error(error);
-        reporter.render_error(warning);
+        reporter.render_error(Arc::new(error));
+        reporter.render_error(Arc::new(warning));
 
         let output = reporter.finish(&DiagnosticResult::default()).unwrap();
         assert_eq!(output, EXPECTED_REPORT);

--- a/apps/oxlint/src/output_formatter/sarif.rs
+++ b/apps/oxlint/src/output_formatter/sarif.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use cow_utils::CowUtils;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
@@ -28,7 +30,7 @@ impl InternalFormatter for SarifOutputFormatter {
 
 #[derive(Debug, Default)]
 struct SarifReporter {
-    diagnostics: Vec<Error>,
+    diagnostics: Vec<Arc<Error>>,
 }
 
 impl DiagnosticReporter for SarifReporter {
@@ -40,7 +42,7 @@ impl DiagnosticReporter for SarifReporter {
         false
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.diagnostics.push(error);
         None
     }
@@ -452,7 +454,7 @@ fn nonzero(value: usize) -> Option<usize> {
     (value != 0).then_some(value)
 }
 
-fn format_sarif(diagnostics: &mut Vec<Error>) -> String {
+fn format_sarif(diagnostics: &mut Vec<Arc<Error>>) -> String {
     let mut builder = SarifBuilder::new();
     for diagnostic in diagnostics.drain(..) {
         builder.add_diagnostic(&diagnostic);
@@ -463,13 +465,15 @@ fn format_sarif(diagnostics: &mut Vec<Error>) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use oxc_diagnostics::{Error, NamedSource, OxcDiagnostic, Severity};
     use oxc_span::Span;
 
     use super::format_sarif;
 
     fn render(diagnostics: Vec<Error>) -> serde_json::Value {
-        let mut diagnostics = diagnostics;
+        let mut diagnostics = diagnostics.into_iter().map(Arc::new).collect();
         serde_json::from_str(&format_sarif(&mut diagnostics)).unwrap()
     }
 

--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::sync::Arc;
 
 use oxc_diagnostics::{
     Error, Severity,
@@ -18,7 +19,7 @@ impl InternalFormatter for StylishOutputFormatter {
 }
 
 struct StylishReporter {
-    diagnostics: Vec<Error>,
+    diagnostics: Vec<Arc<Error>>,
     no_color: bool,
 }
 
@@ -33,7 +34,7 @@ impl DiagnosticReporter for StylishReporter {
         Some(self.format_stylish())
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.diagnostics.push(error);
         None
     }
@@ -58,7 +59,7 @@ impl StylishReporter {
         let mut total_warnings = 0;
 
         let mut grouped: FxHashMap<String, Vec<&Error>> = FxHashMap::default();
-        let mut sorted = self.diagnostics.iter().collect::<Vec<_>>();
+        let mut sorted = self.diagnostics.iter().map(Arc::as_ref).collect::<Vec<_>>();
 
         sorted.sort_by_key(|diagnostic| Info::new(diagnostic).start.line);
 
@@ -165,8 +166,8 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file.js", "code"));
 
-        reporter.render_error(error);
-        reporter.render_error(warning);
+        reporter.render_error(Arc::new(error));
+        reporter.render_error(Arc::new(warning));
 
         let output = reporter.finish(&DiagnosticResult::default()).unwrap();
 
@@ -190,7 +191,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file.js", "code"));
 
-        reporter.render_error(error);
+        reporter.render_error(Arc::new(error));
 
         let output = reporter.finish(&DiagnosticResult::default()).unwrap();
 

--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -25,7 +25,13 @@ struct StylishReporter {
 
 impl Default for StylishReporter {
     fn default() -> Self {
-        Self { diagnostics: Vec::new(), no_color: std::env::var("NO_COLOR").is_ok() }
+        Self {
+            diagnostics: Vec::new(),
+            #[cfg(test)]
+            no_color: false,
+            #[cfg(not(test))]
+            no_color: std::env::var("NO_COLOR").is_ok(),
+        }
     }
 }
 

--- a/apps/oxlint/src/output_formatter/unix.rs
+++ b/apps/oxlint/src/output_formatter/unix.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use oxc_diagnostics::{
     Error, Severity,
@@ -37,9 +37,9 @@ impl DiagnosticReporter for UnixReporter {
         false
     }
 
-    fn render_error(&mut self, error: Error) -> Option<String> {
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
         self.total += 1;
-        Some(format_unix(&error))
+        Some(format_unix(error.as_ref()))
     }
 }
 
@@ -57,6 +57,8 @@ fn format_unix(diagnostic: &Error) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use oxc_diagnostics::{
         NamedSource, OxcDiagnostic,
         reporter::{DiagnosticReporter, DiagnosticResult},
@@ -82,7 +84,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
-        let _ = reporter.render_error(error);
+        let _ = reporter.render_error(Arc::new(error));
         let result = reporter.finish(&DiagnosticResult::default());
 
         assert!(result.is_some());
@@ -96,7 +98,7 @@ mod test {
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
-        let result = reporter.render_error(error);
+        let result = reporter.render_error(Arc::new(error));
 
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "file://test.ts:1:1: error message [Warning]\n");
@@ -111,7 +113,7 @@ mod test {
             .with_label(Span::new(0, 1))
             .with_source_code(NamedSource::new("file://test.js", ":"));
 
-        let result = reporter.render_error(error);
+        let result = reporter.render_error(Arc::new(error));
 
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "file://test.js:1:1: Expected `;` but found `:` [Error]\n");

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -21,6 +21,8 @@ pub enum CliRunResult {
     ConfigFileInitFailed,
     ConfigFileInitSucceeded,
     TsGoLintError,
+    /// Failed to create or open the path passed to `--output-file`.
+    OutputFileError,
 }
 
 impl Termination for CliRunResult {
@@ -45,6 +47,8 @@ impl Termination for CliRunResult {
             | Self::InvalidOptionSeverityWithoutRuleName
             | Self::LintUnprunedSuppressions
             | Self::TsGoLintError => ExitCode::FAILURE,
+            // Exit code 2 distinguishes `--output-file` I/O failures from lint errors (1).
+            Self::OutputFileError => ExitCode::from(2),
         }
     }
 }

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -56,7 +56,7 @@ use std::{
 
 pub mod reporter;
 
-pub use crate::service::{DiagnosticSender, DiagnosticService};
+pub use crate::service::{DiagnosticReceiver, DiagnosticSender, DiagnosticService};
 
 pub type Error = miette::Error;
 pub type Severity = miette::Severity;

--- a/crates/oxc_diagnostics/src/reporter.rs
+++ b/crates/oxc_diagnostics/src/reporter.rs
@@ -1,5 +1,7 @@
 //! [Reporters](DiagnosticReporter) for rendering and writing diagnostics.
 
+use std::sync::Arc;
+
 use miette::SourceSpan;
 
 use crate::{Error, Severity};
@@ -12,6 +14,7 @@ use crate::{Error, Severity};
 ///
 /// ## Example
 /// ```rust,ignore
+/// use std::sync::Arc;
 /// use oxc_diagnostics::{DiagnosticReporter, Error, Severity};
 ///
 /// #[derive(Default)]
@@ -25,7 +28,7 @@ use crate::{Error, Severity};
 ///     }
 ///
 ///     // render diagnostics to a simple Apache-like log format
-///     fn render_error(&mut self, error: Error) -> Option<String> {
+///     fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
 ///         let level = match error.severity().unwrap_or_default() {
 ///             Severity::Error => "ERROR",
 ///             Severity::Warning => "WARN",
@@ -61,7 +64,11 @@ pub trait DiagnosticReporter {
     /// of this diagnostic.
     ///
     /// Reporters should use this method to write diagnostics to their output stream.
-    fn render_error(&mut self, error: Error) -> Option<String>;
+    ///
+    /// The diagnostic is wrapped in an [`Arc`] so the same diagnostic can be cheaply fanned
+    /// out to multiple reporters. Streaming reporters can read it via `error.as_ref()`;
+    /// buffering reporters can clone the [`Arc`] to retain it until [`finish`](Self::finish).
+    fn render_error(&mut self, error: Arc<Error>) -> Option<String>;
 }
 
 /// DiagnosticResult will be submitted to the Reporter when the [`DiagnosticService`](crate::service::DiagnosticService)

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -185,7 +185,7 @@ impl DiagnosticService {
                     .and_then(|source| source.name())
                     .map(ToString::to_string);
 
-                if let Some(err_str) = self.reporter.render_error(diagnostic) {
+                if let Some(err_str) = self.reporter.render_error(Arc::new(diagnostic)) {
                     // Skip large output and print only once.
                     // Setting to 1200 because graphical output may contain ansi escape codes and other decorations.
                     if supports_minified_file_fallback
@@ -198,7 +198,7 @@ impl DiagnosticService {
                                 diagnostic.with_help(format!("{path} seems like a minified file"));
                         }
 
-                        let minified_diagnostic = Error::new(diagnostic);
+                        let minified_diagnostic = Arc::new(Error::new(diagnostic));
 
                         if let Some(err_str) = self.reporter.render_error(minified_diagnostic) {
                             writer
@@ -342,7 +342,7 @@ fn strict_canonicalize<P: AsRef<Path>>(path: P) -> std::io::Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, sync::Arc};
 
     use crate::{
         Error, OxcDiagnostic,
@@ -434,7 +434,7 @@ mod tests {
                 self.fallback_enabled
             }
 
-            fn render_error(&mut self, error: Error) -> Option<String> {
+            fn render_error(&mut self, error: Arc<Error>) -> Option<String> {
                 let message = error.to_string();
                 if message == "original diagnostic" {
                     Some(format!("{}\n", "x".repeat(1200)))

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -120,7 +120,11 @@ Arguments:
 
 ## Output
 - **`-f`**, **`--format`**=_`ARG`_ &mdash; 
-  Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+  Use a specific output format for stdout. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+- **`-o`**, **`--output-file`**=_`PATH`_ &mdash; 
+  Write the lint report to PATH (in addition to stdout). Parent directories are created if they do not exist; existing files are truncated. Use `--output-file-format` to control the format (defaults to `json`).
+- **`    --output-file-format`**=_`FORMAT`_ &mdash; 
+  Output format used for `--output-file`. Defaults to `json` when `--output-file` is set. Errors when used without `--output-file`. Possible values are the same as `--format`.
 
 
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -73,8 +73,8 @@ Handle Warnings
 
 Output
     -f, --format=ARG          Use a specific output format for stdout. Possible values:
-                              `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`,
-                              `junit`, `sarif`, `stylish`, `unix`
+                              `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`,
+                              `sarif`, `stylish`, `unix`
     -o, --output-file=PATH    Write the lint report to PATH (in addition to stdout). Parent
                               directories are created if they do not exist; existing files are
                               truncated. Use `--output-file-format` to control the format (defaults

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -72,9 +72,16 @@ Handle Warnings
                               your project
 
 Output
-    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
-                              `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`,
-                              `stylish`, `unix`
+    -f, --format=ARG          Use a specific output format for stdout. Possible values:
+                              `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`,
+                              `junit`, `sarif`, `stylish`, `unix`
+    -o, --output-file=PATH    Write the lint report to PATH (in addition to stdout). Parent
+                              directories are created if they do not exist; existing files are
+                              truncated. Use `--output-file-format` to control the format (defaults
+                              to `json`).
+        --output-file-format=FORMAT  Output format used for `--output-file`. Defaults to `json` when
+                              `--output-file` is set. Errors when used without `--output-file`.
+                              Possible values are the same as `--format`.
 
 Miscellaneous
         --silent              Do not display any diagnostics


### PR DESCRIPTION
### Summary
Adds an ESLint-style `--output-file` (`-o`) flag to oxlint, plus a companion `--output-file-format` flag that lets the file sink and stdout use **different formatters in a single run** (e.g. human-readable on stdout, machine-readable JSON in the file).
This is a deliberate UX improvement over ESLint's `--output-file`, which silences stdout when a file is provided and forces users to pick one format for everything. With oxlint you no longer have to choose.
### Why
Today, anyone wanting both a readable terminal report *and* a machine-readable artifact (CI annotations, IDE plugins, custom dashboards) has to either:
- run oxlint twice (slow, not always idempotent), or
- post-process the JSON to render something human-friendly themselves (extra tooling).
This PR removes that friction by writing both outputs natively in one pass.
### Related discussions
- Closes / addresses [#21574](https://github.com/oxc-project/oxc/issues/21574) — request for `--output-file`
- Related: [#2899](https://github.com/oxc-project/oxc/issues/2899), [#3178](https://github.com/oxc-project/oxc/issues/3178), and earlier exploration in [#2925](https://github.com/oxc-project/oxc/pull/2925)
### What's new
**CLI**
- `--output-file <PATH>` / `-o <PATH>` — write the lint report to a file in addition to stdout. Parent directories are created if missing; existing files are truncated **only** on a successful run.
- `--output-file-format <FORMAT>` — pick the format used for the file (defaults to `json`). Accepts the same values as `--format`. Errors at parse time if used without `--output-file`.
- `--format` documentation updated to clarify it controls **stdout only**.
**Behavior contract**
- `--silent` is treated as a stdout-only concern. When combined with `--output-file`, stdout stays quiet but the file still receives the full report.
- Early-exit conditions (invalid `--tsconfig`, no files matched, `--print-config`, etc.) do **not** create or truncate the destination file. Existing reports are preserved.
- Failure to open the destination returns a new dedicated exit code so CI can distinguish I/O failures from lint failures.
### Compatibility
- Adds one small breaking change to `oxc_diagnostics::DiagnosticReporter::render_error`: it now takes `Arc<Error>` instead of `Error` so the same diagnostic can be cheaply fanned out to multiple sinks. All in-tree reporters (oxlint + oxfmt) are updated; external implementors will need a one-line signature change.
- No behavior change for users who don't pass `--output-file`.
### Test plan
- Unit tests for the new CLI flag parsing and validation.
- Unit tests for the multi-sink dispatcher (single sink, dual sink fan-out, quiet, per-sink silent, command-info emission).
- CLI integration tests covering: dual-format runs, clean runs, nested path creation, unwritable destinations, `--print-config`, `--silent` + `--output-file`, and "destination file is preserved on every early-exit path".
- Generated CLI doc snapshots (`tasks/website_linter`) updated for the new flags.