### PR TITLE
refactor(oxfmt): Intro `FormatStrategyBuilder`

### DIFF
--- a/apps/oxfmt/src/api/format_api.rs
+++ b/apps/oxfmt/src/api/format_api.rs
@@ -5,9 +5,9 @@ use serde_json::Value;
 use oxc_napi::OxcError;
 
 use crate::core::{
-    ExternalFormatter, FormatFileStrategy, FormatResult, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb,
-    JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb, SourceFormatter,
-    resolve_options_from_value,
+    ExternalFormatter, FormatResult, FormatStrategyBuilder, JsFormatEmbeddedCb,
+    JsFormatEmbeddedDocCb, JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb,
+    SourceFormatter, resolve_options_from_value,
 };
 
 pub struct ApiFormatResult {
@@ -57,7 +57,8 @@ pub fn run(
     }
 
     // Determine format strategy from file path
-    let Ok(strategy) = FormatFileStrategy::try_from(PathBuf::from(filename))
+    let Ok(strategy) = FormatStrategyBuilder::default()
+        .build(PathBuf::from(filename))
         .map(|s| s.resolve_relative_path(&cwd))
     else {
         external_formatter.cleanup();

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -14,7 +14,7 @@ use oxc_span::SourceType;
 
 use crate::{
     core::{
-        ExternalFormatter, FormatFileStrategy, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb,
+        ExternalFormatter, FormatStrategy, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb,
         JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb, ResolvedOptions,
         resolve_options_from_value,
     },
@@ -137,10 +137,8 @@ fn run_full(
             .expect("source_ext should be a valid JS/TS extension"),
     );
 
-    let strategy = FormatFileStrategy::OxcFormatter {
-        path: format!("embedded.{source_ext}").into(),
-        source_type,
-    };
+    let strategy =
+        FormatStrategy::OxcFormatter { path: format!("embedded.{source_ext}").into(), source_type };
     let resolved_options = resolve_options_from_value(options, &strategy, None)
         .expect("`_oxfmtPluginOptionsJson` should contain valid config");
     let ResolvedOptions::OxcFormatter {
@@ -212,10 +210,8 @@ fn run_fragment(
     // And `run_fragment()` does not support external formatting, so no need to use `parent_filepath`.
     let (options, _parent_filepath) = parse_options_and_filepath(oxfmt_plugin_options_json);
 
-    let strategy = FormatFileStrategy::OxcFormatter {
-        path: format!("embedded.{source_ext}").into(),
-        source_type,
-    };
+    let strategy =
+        FormatStrategy::OxcFormatter { path: format!("embedded.{source_ext}").into(), source_type };
 
     let resolved_options = resolve_options_from_value(options, &strategy, None)
         .expect("`_oxfmtPluginOptionsJson` should contain valid config");

--- a/apps/oxfmt/src/cli/stdin_runner.rs
+++ b/apps/oxfmt/src/cli/stdin_runner.rs
@@ -11,8 +11,8 @@ use super::{
     },
 };
 use crate::core::{
-    ConfigResolver, ExternalFormatter, FormatFileStrategy, FormatResult, JsConfigLoaderCb,
-    SourceFormatter, resolve_editorconfig_path, utils,
+    ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, SourceFormatter,
+    resolve_editorconfig_path, utils,
 };
 
 pub struct StdinRunner {
@@ -95,13 +95,8 @@ impl StdinRunner {
             }
         }
 
-        // Determine format strategy from filepath
-        let Ok(strategy) =
-            FormatFileStrategy::try_from(filepath).map(|s| s.resolve_relative_path(&cwd))
-        else {
-            utils::print_and_flush(stderr, "Unsupported file type for stdin-filepath\n");
-            return CliRunResult::InvalidOptionConfig;
-        };
+        // Resolve filepath to absolute for nested config resolution
+        let filepath = utils::normalize_relative_path(&cwd, &filepath);
 
         // Resolve nested config based on filepath's parent directory
         // (same as CLI direct file path behavior)
@@ -109,7 +104,7 @@ impl StdinRunner {
             config_options.config.is_none() && !config_options.disable_nested_config;
         if detect_nested {
             match resolve_file_scope_config(
-                strategy.path(),
+                &filepath,
                 config_resolver.config_dir(),
                 editorconfig_path.as_deref(),
                 Some(&self.js_config_loader),
@@ -125,6 +120,12 @@ impl StdinRunner {
                 }
             }
         }
+
+        // Determine format strategy using config-aware builder
+        let Ok(strategy) = config_resolver.strategy_builder().build(filepath) else {
+            utils::print_and_flush(stderr, "Unsupported file type for stdin-filepath\n");
+            return CliRunResult::InvalidOptionConfig;
+        };
 
         // Check if the file is ignored by global ignores or config's `ignorePatterns`
         let global_matchers = match resolve_ignore_paths(&cwd, &ignore_options.ignore_path)

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -12,11 +12,11 @@ use tracing::instrument;
 use super::resolve::{build_global_ignore_matchers, is_ignored, resolve_file_scope_config};
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
-use crate::core::{ConfigResolver, FormatFileStrategy, config_discovery};
+use crate::core::{ConfigResolver, FormatStrategy, config_discovery};
 
 /// A file entry paired with its scope's config resolver.
 pub struct FormatEntry {
-    pub strategy: FormatFileStrategy,
+    pub strategy: FormatStrategy,
     pub config_resolver: Arc<ConfigResolver>,
 }
 
@@ -217,7 +217,7 @@ impl ScopedWalker {
                 if file_config.is_path_ignored(file, false) {
                     continue;
                 }
-                let Ok(strategy) = FormatFileStrategy::try_from(file.clone()) else {
+                let Ok(strategy) = file_config.strategy_builder().build(file.clone()) else {
                     continue;
                 };
                 #[cfg(not(feature = "napi"))]
@@ -679,7 +679,7 @@ impl ignore::ParallelVisitor for WalkVisitor {
                     // Tier 3 = `.html`, `.json`, etc: Other files supported by Prettier
                     // (Tier 4 = `.astro`, `.svelte`, etc: Other files supported by Prettier plugins)
                     // Everything else: Ignored
-                    let Ok(strategy) = FormatFileStrategy::try_from(path) else {
+                    let Ok(strategy) = resolver.strategy_builder().build(path) else {
                         return ignore::WalkState::Continue;
                     };
                     #[cfg(not(feature = "napi"))]

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -18,7 +18,7 @@ use oxc_toml::Options as TomlFormatterOptions;
 #[cfg(feature = "napi")]
 use super::js_config::JsConfigLoaderCb;
 use super::{
-    FormatFileStrategy,
+    FormatStrategy, FormatStrategyBuilder,
     oxfmtrc::{
         EndOfLineConfig, FormatConfig, OxfmtOptions, OxfmtOverrideConfig, Oxfmtrc,
         finalize_external_options, sync_external_options, to_oxfmt_options,
@@ -54,7 +54,7 @@ pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
 #[cfg(feature = "napi")]
 pub fn resolve_options_from_value(
     raw_config: Value,
-    strategy: &FormatFileStrategy,
+    strategy: &FormatStrategy,
     cwd: Option<&Path>,
 ) -> Result<ResolvedOptions, String> {
     let mut format_config: FormatConfig =
@@ -84,7 +84,7 @@ pub enum ResolvedOptions {
         /// For embedded language (xxx-in-js) formatting
         external_options: Value,
         /// Optional filepath override for external callbacks (e.g., Tailwind sorter).
-        /// When set, this path is used instead of `FormatFileStrategy::path`
+        /// When set, this path is used instead of `FormatStrategy::path`
         /// as the `options.filepath` passed to external callbacks.
         /// Needed for js-in-xxx where the strategy path is a dummy,
         /// but callbacks need the parent file path to resolve their config.
@@ -106,13 +106,13 @@ pub enum ResolvedOptions {
 }
 
 impl ResolvedOptions {
-    /// Build `ResolvedOptions` from `OxfmtOptions`, `external_options`, and `FormatFileStrategy`.
+    /// Build `ResolvedOptions` from `OxfmtOptions`, `external_options`, and `FormatStrategy`.
     ///
     /// This also applies plugin-specific options (Tailwind, oxfmt plugin flags) based on strategy.
     fn from_oxfmt_options(
         oxfmt_options: OxfmtOptions,
         mut external_options: Value,
-        strategy: &FormatFileStrategy,
+        strategy: &FormatStrategy,
     ) -> Self {
         // Apply plugin-specific options based on strategy
         finalize_external_options(&mut external_options, strategy);
@@ -124,21 +124,21 @@ impl ResolvedOptions {
         let OxfmtOptions { format_options, toml_options, insert_final_newline, .. } = oxfmt_options;
 
         match strategy {
-            FormatFileStrategy::OxcFormatter { .. } => ResolvedOptions::OxcFormatter {
+            FormatStrategy::OxcFormatter { .. } => ResolvedOptions::OxcFormatter {
                 format_options: Box::new(format_options),
                 external_options,
                 filepath_override: None,
                 insert_final_newline,
             },
-            FormatFileStrategy::OxfmtToml { .. } => {
+            FormatStrategy::OxfmtToml { .. } => {
                 ResolvedOptions::OxfmtToml { toml_options, insert_final_newline }
             }
             #[cfg(feature = "napi")]
-            FormatFileStrategy::ExternalFormatter { .. } => {
+            FormatStrategy::ExternalFormatter { .. } => {
                 ResolvedOptions::ExternalFormatter { external_options, insert_final_newline }
             }
             #[cfg(feature = "napi")]
-            FormatFileStrategy::ExternalFormatterPackageJson { .. } => {
+            FormatStrategy::ExternalFormatterPackageJson { .. } => {
                 ResolvedOptions::ExternalFormatterPackageJson {
                     external_options,
                     sort_package_json,
@@ -178,6 +178,9 @@ pub struct ConfigResolver {
     ignore_glob: Option<Gitignore>,
     /// Parsed `.editorconfig`, if any.
     editorconfig: Option<EditorConfig>,
+    /// Builder for creating [`FormatStrategy`] from file paths.
+    /// Carries per-scope experimental flags (e.g. `experimentalSvelte`).
+    strategy_builder: FormatStrategyBuilder,
 }
 
 impl ConfigResolver {
@@ -195,12 +198,18 @@ impl ConfigResolver {
             oxfmtrc_overrides: None,
             ignore_glob: None,
             editorconfig,
+            strategy_builder: FormatStrategyBuilder::default(),
         }
     }
 
     /// Returns the directory containing the config file, if any was loaded.
     pub fn config_dir(&self) -> Option<&Path> {
         self.config_dir.as_deref()
+    }
+
+    /// Returns the [`FormatStrategyBuilder`] for this config scope.
+    pub fn strategy_builder(&self) -> &FormatStrategyBuilder {
+        &self.strategy_builder
     }
 
     /// Returns `true` if this config has any `ignorePatterns`.
@@ -466,7 +475,7 @@ impl ConfigResolver {
     /// # Errors
     /// Returns error if merged override options are invalid (e.g. conflicting settings).
     #[instrument(level = "debug", name = "oxfmt::config::resolve", skip_all, fields(path = %strategy.path().display()))]
-    pub fn resolve(&self, strategy: &FormatFileStrategy) -> Result<ResolvedOptions, String> {
+    pub fn resolve(&self, strategy: &FormatStrategy) -> Result<ResolvedOptions, String> {
         let (oxfmt_options, external_options) = self.resolve_options(strategy.path())?;
         Ok(ResolvedOptions::from_oxfmt_options(oxfmt_options, external_options, strategy))
     }

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -9,7 +9,7 @@ use oxc_formatter::{FormatOptions, Formatter, enable_jsx_source_type, get_parse_
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-use super::{FormatFileStrategy, ResolvedOptions};
+use super::{FormatStrategy, ResolvedOptions};
 
 pub enum FormatResult {
     Success { is_changed: bool, code: String },
@@ -35,13 +35,13 @@ impl SourceFormatter {
     #[instrument(level = "debug", name = "oxfmt::format", skip_all, fields(path = %entry.path().display()))]
     pub fn format(
         &self,
-        entry: &FormatFileStrategy,
+        entry: &FormatStrategy,
         source_text: &str,
         resolved_options: ResolvedOptions,
     ) -> FormatResult {
         let (result, insert_final_newline) = match (entry, resolved_options) {
             (
-                FormatFileStrategy::OxcFormatter { path, source_type },
+                FormatStrategy::OxcFormatter { path, source_type },
                 ResolvedOptions::OxcFormatter {
                     format_options,
                     external_options,
@@ -60,12 +60,12 @@ impl SourceFormatter {
                 insert_final_newline,
             ),
             (
-                FormatFileStrategy::OxfmtToml { .. },
+                FormatStrategy::OxfmtToml { .. },
                 ResolvedOptions::OxfmtToml { toml_options, insert_final_newline },
             ) => (Ok(Self::format_by_toml(source_text, toml_options)), insert_final_newline),
             #[cfg(feature = "napi")]
             (
-                FormatFileStrategy::ExternalFormatter { path, parser_name },
+                FormatStrategy::ExternalFormatter { path, parser_name },
                 ResolvedOptions::ExternalFormatter { external_options, insert_final_newline },
             ) => (
                 self.format_by_external_formatter(source_text, path, parser_name, external_options),
@@ -73,7 +73,7 @@ impl SourceFormatter {
             ),
             #[cfg(feature = "napi")]
             (
-                FormatFileStrategy::ExternalFormatterPackageJson { path, parser_name },
+                FormatStrategy::ExternalFormatterPackageJson { path, parser_name },
                 ResolvedOptions::ExternalFormatterPackageJson {
                     external_options,
                     sort_package_json,
@@ -89,7 +89,7 @@ impl SourceFormatter {
                 ),
                 insert_final_newline,
             ),
-            _ => unreachable!("FormatFileStrategy and ResolvedOptions variant mismatch"),
+            _ => unreachable!("FormatStrategy and ResolvedOptions variant mismatch"),
         };
 
         match result {

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -13,7 +13,7 @@ mod js_config;
 pub use config::resolve_options_from_value;
 pub use config::{ConfigResolver, ResolvedOptions, config_discovery, resolve_editorconfig_path};
 pub use format::{FormatResult, SourceFormatter};
-pub use support::FormatFileStrategy;
+pub use support::{FormatStrategy, FormatStrategyBuilder};
 
 #[cfg(feature = "napi")]
 pub use external_formatter::{

--- a/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use oxc_formatter::{FormatOptions, IndentStyle, LineEnding};
 
-use crate::core::FormatFileStrategy;
+use crate::core::FormatStrategy;
 
 /// Syncs resolved `FormatOptions` values into the raw config JSON.
 /// This ensures `external_formatter`(Prettier) receives the same options that `oxc_formatter` uses.
@@ -60,7 +60,7 @@ pub fn sync_external_options(options: &FormatOptions, config: &mut Value) {
 /// - `_oxfmtPluginOptionsJson`: Bundled options for `prettier-plugin-oxfmt`
 ///
 /// Also removes Prettier-unaware options to minimize payload size.
-pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrategy) {
+pub fn finalize_external_options(config: &mut Value, strategy: &FormatStrategy) {
     let Some(obj) = config.as_object_mut() else {
         return;
     };
@@ -87,7 +87,7 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
 
     // Build oxfmt plugin options JSON for js-in-xxx parsers
     #[cfg(feature = "napi")]
-    if let FormatFileStrategy::ExternalFormatter { path, .. } = strategy
+    if let FormatStrategy::ExternalFormatter { path, .. } = strategy
         && strategy.needs_oxfmt_plugin()
     {
         let mut oxfmt_plugin_options = serde_json::Map::new();
@@ -254,7 +254,7 @@ mod tests {
         }"#;
         let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
 
-        let strategy = FormatFileStrategy::OxcFormatter {
+        let strategy = FormatStrategy::OxcFormatter {
             path: PathBuf::from("test.js"),
             source_type: SourceType::mjs(),
         };
@@ -279,7 +279,7 @@ mod tests {
         }"#;
         let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
 
-        let strategy = FormatFileStrategy::ExternalFormatter {
+        let strategy = FormatStrategy::ExternalFormatter {
             path: PathBuf::from("/tmp/foo/bar/App.vue"),
             parser_name: "vue",
         };

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -6,7 +6,7 @@ use oxc_span::SourceType;
 
 use super::utils;
 
-pub enum FormatFileStrategy {
+pub enum FormatStrategy {
     OxcFormatter {
         path: PathBuf,
         source_type: SourceType,
@@ -26,13 +26,28 @@ pub enum FormatFileStrategy {
     },
 }
 
-impl TryFrom<PathBuf> for FormatFileStrategy {
-    type Error = ();
+/// Builder for creating [`FormatStrategy`] from file paths.
+///
+/// Carries per-scope configuration (e.g. experimental language flags)
+/// that influences which files are supported and how they are formatted.
+///
+/// Created from [`super::ConfigResolver::strategy_builder()`] for CLI/LSP paths,
+/// or via [`FormatStrategyBuilder::default()`] for the NAPI API path.
+#[derive(Debug, Default)]
+pub struct FormatStrategyBuilder {
+    // Future: experimental_svelte, experimental_astro, etc.
+    _private: (),
+}
 
-    fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
+impl FormatStrategyBuilder {
+    /// Build a [`FormatStrategy`] from a file path.
+    ///
+    /// Returns `Ok` if the file type is supported, `Err(())` otherwise.
+    #[expect(clippy::unused_self)] // Will use `self` when experimental flags are added
+    pub fn build(&self, path: PathBuf) -> Result<FormatStrategy, ()> {
         // Check JS/TS files first
         if let Some(source_type) = get_oxc_formatter_source_type(&path) {
-            return Ok(Self::OxcFormatter { path, source_type });
+            return Ok(FormatStrategy::OxcFormatter { path, source_type });
         }
 
         // Extract file_name and extension once for all subsequent checks
@@ -47,25 +62,28 @@ impl TryFrom<PathBuf> for FormatFileStrategy {
 
         // Then TOML files
         if is_toml_file(file_name) {
-            return Ok(Self::OxfmtToml { path });
+            return Ok(FormatStrategy::OxfmtToml { path });
         }
 
         // Then external formatter files
         // `package.json` is special: sorted then formatted
         if file_name == "package.json" {
-            return Ok(Self::ExternalFormatterPackageJson { path, parser_name: "json-stringify" });
+            return Ok(FormatStrategy::ExternalFormatterPackageJson {
+                path,
+                parser_name: "json-stringify",
+            });
         }
 
         let extension = path.extension().and_then(|ext| ext.to_str());
         if let Some(parser_name) = get_external_parser_name(file_name, extension) {
-            return Ok(Self::ExternalFormatter { path, parser_name });
+            return Ok(FormatStrategy::ExternalFormatter { path, parser_name });
         }
 
         Err(())
     }
 }
 
-impl FormatFileStrategy {
+impl FormatStrategy {
     #[cfg(not(feature = "napi"))]
     pub fn can_format_without_external(&self) -> bool {
         matches!(self, Self::OxcFormatter { .. } | Self::OxfmtToml { .. })
@@ -186,7 +204,7 @@ static TOML_FILENAMES: phf::Set<&'static str> = phf_set! {
 /// See also `prettier --support-info | jq '.languages[]'`
 fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
     // JSON and variants
-    // NOTE: `package.json` is handled separately in `FormatFileStrategy::try_from()`
+    // NOTE: `package.json` is handled separately in `FormatStrategyBuilder::build()`
     if file_name == "composer.json" || extension == Some("importmap") {
         return Some("json-stringify");
     }
@@ -492,7 +510,7 @@ mod tests {
     #[test]
     fn test_get_external_parser_name() {
         let test_cases = vec![
-            // JSON (NOTE: `package.json` is handled in TryFrom, not here)
+            // JSON (NOTE: `package.json` is handled in FormatStrategyBuilder::build, not here)
             ("config.importmap", Some("json-stringify")),
             ("data.json", Some("json")),
             ("schema.avsc", Some("json")),
@@ -549,11 +567,12 @@ mod tests {
 
     #[test]
     fn test_package_json_is_special() {
-        let source = FormatFileStrategy::try_from(PathBuf::from("package.json")).unwrap();
-        assert!(matches!(source, FormatFileStrategy::ExternalFormatterPackageJson { .. }));
+        let source = FormatStrategyBuilder::default().build(PathBuf::from("package.json")).unwrap();
+        assert!(matches!(source, FormatStrategy::ExternalFormatterPackageJson { .. }));
 
-        let source = FormatFileStrategy::try_from(PathBuf::from("composer.json")).unwrap();
-        assert!(matches!(source, FormatFileStrategy::ExternalFormatter { .. }));
+        let source =
+            FormatStrategyBuilder::default().build(PathBuf::from("composer.json")).unwrap();
+        assert!(matches!(source, FormatStrategy::ExternalFormatter { .. }));
     }
 
     #[test]
@@ -569,9 +588,9 @@ mod tests {
         ];
 
         for file_name in toml_files {
-            let result = FormatFileStrategy::try_from(PathBuf::from(file_name));
+            let result = FormatStrategyBuilder::default().build(PathBuf::from(file_name));
             assert!(
-                matches!(result, Ok(FormatFileStrategy::OxfmtToml { .. })),
+                matches!(result, Ok(FormatStrategy::OxfmtToml { .. })),
                 "`{file_name}` should be detected as TOML"
             );
         }
@@ -580,7 +599,7 @@ mod tests {
         let excluded_files = vec!["Cargo.lock", "poetry.lock", "pdm.lock", "uv.lock", "Gopkg.lock"];
 
         for file_name in excluded_files {
-            let result = FormatFileStrategy::try_from(PathBuf::from(file_name));
+            let result = FormatStrategyBuilder::default().build(PathBuf::from(file_name));
             assert!(result.is_err(), "`{file_name}` should be excluded (lock file)");
         }
     }

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -11,8 +11,8 @@ use oxc_language_server::{
 };
 
 use crate::core::{
-    ConfigResolver, ExternalFormatter, FormatFileStrategy, FormatResult, JsConfigLoaderCb,
-    SourceFormatter, config_discovery, resolve_editorconfig_path, utils,
+    ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, SourceFormatter,
+    config_discovery, resolve_editorconfig_path, utils,
 };
 use crate::lsp::create_fake_file_path_from_language_id;
 use crate::lsp::options::FormatOptions as LSPFormatOptions;
@@ -336,11 +336,6 @@ impl ServerFormatter {
     /// Resolve config and format a file at the given path.
     /// Returns `None` if the file is unsupported or ignored.
     fn resolve_and_format(&self, path: &Path, source_text: &str) -> Option<FormatResult> {
-        let Ok(strategy) = FormatFileStrategy::try_from(path.to_path_buf()) else {
-            debug!("Unsupported file type for formatting: {}", path.display());
-            return None;
-        };
-
         let config_scope = self.resolve_config_scope(path);
         let cache = self.config_cache.pin();
         let cached = cache.get_or_insert_with(config_scope.clone(), || {
@@ -355,6 +350,11 @@ impl ServerFormatter {
             debug!("File is ignored by config ignorePatterns: {}", path.display());
             return None;
         }
+
+        let Ok(strategy) = cached.strategy_builder().build(path.to_path_buf()) else {
+            debug!("Unsupported file type for formatting: {}", path.display());
+            return None;
+        };
 
         let resolved_options = match cached.resolve(&strategy) {
             Ok(options) => options,


### PR DESCRIPTION
Prepare for svelte+astro plugin support.

Now `FormatStrategy` can be built by config, and its experimental settings.
