### PR TITLE
refactor(oxfmt): Resolve absolute path in caller

### DIFF
--- a/apps/oxfmt/src/api/format_api.rs
+++ b/apps/oxfmt/src/api/format_api.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf};
+use std::{env, path::Path};
 
 use serde_json::Value;
 
@@ -7,7 +7,7 @@ use oxc_napi::OxcError;
 use crate::core::{
     ExternalFormatter, FormatResult, FormatStrategyBuilder, JsFormatEmbeddedCb,
     JsFormatEmbeddedDocCb, JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb,
-    SourceFormatter, resolve_options_from_value,
+    SourceFormatter, resolve_options_from_value, utils,
 };
 
 pub struct ApiFormatResult {
@@ -57,10 +57,8 @@ pub fn run(
     }
 
     // Determine format strategy from file path
-    let Ok(strategy) = FormatStrategyBuilder::default()
-        .build(PathBuf::from(filename))
-        .map(|s| s.resolve_relative_path(&cwd))
-    else {
+    let filepath = utils::normalize_relative_path(&cwd, Path::new(filename));
+    let Ok(strategy) = FormatStrategyBuilder::default().build(filepath) else {
         external_formatter.cleanup();
         return ApiFormatResult {
             code: source_text,

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -4,8 +4,6 @@ use phf::phf_set;
 
 use oxc_span::SourceType;
 
-use super::utils;
-
 pub enum FormatStrategy {
     OxcFormatter {
         path: PathBuf,
@@ -115,21 +113,6 @@ impl FormatStrategy {
             self,
             Self::ExternalFormatter { parser_name, .. } if OXFMT_PARSERS.contains(parser_name)
         )
-    }
-
-    /// Resolve the stored path to an absolute path using the given `cwd`.
-    /// CLI file walk already provides absolute paths,
-    /// but stdin and NAPI entry points may receive relative paths from user input.
-    pub fn resolve_relative_path(mut self, cwd: &Path) -> Self {
-        match &mut self {
-            Self::OxcFormatter { path, .. }
-            | Self::OxfmtToml { path }
-            | Self::ExternalFormatter { path, .. }
-            | Self::ExternalFormatterPackageJson { path, .. } => {
-                *path = utils::normalize_relative_path(cwd, path);
-            }
-        }
-        self
     }
 }
 


### PR DESCRIPTION
Remove `FormatStrategy.resolve_relative_path()`, only used by 1 place, and which was not consistent style.