### PR TITLE
test(allocator): reformat imports

### DIFF
--- a/crates/oxc_allocator/tests/arena/alloc_fill.rs
+++ b/crates/oxc_allocator/tests/arena/alloc_fill.rs
@@ -1,7 +1,6 @@
+use std::{alloc::Layout, cmp, mem};
+
 use oxc_allocator::arena::Arena;
-use std::alloc::Layout;
-use std::cmp;
-use std::mem;
 
 #[test]
 fn alloc_slice_fill_zero() {

--- a/crates/oxc_allocator/tests/arena/quickchecks.rs
+++ b/crates/oxc_allocator/tests/arena/quickchecks.rs
@@ -1,7 +1,10 @@
-use crate::quickcheck;
-use ::quickcheck::{Arbitrary, Gen};
-use oxc_allocator::arena::Arena;
 use std::mem;
+
+use ::quickcheck::{Arbitrary, Gen};
+
+use oxc_allocator::arena::Arena;
+
+use crate::quickcheck;
 
 #[derive(Clone, Debug, PartialEq)]
 struct BigValue {

--- a/crates/oxc_allocator/tests/arena/tests.rs
+++ b/crates/oxc_allocator/tests/arena/tests.rs
@@ -1,9 +1,6 @@
+use std::{alloc::Layout, fmt::Debug, mem, ptr};
+
 use oxc_allocator::arena::Arena;
-use std::alloc::Layout;
-use std::fmt::Debug;
-use std::mem;
-use std::ptr;
-use std::usize;
 
 #[test]
 fn can_iterate_over_allocated_things() {

--- a/crates/oxc_allocator/tests/arena_try_alloc.rs
+++ b/crates/oxc_allocator/tests/arena_try_alloc.rs
@@ -7,10 +7,14 @@
     clippy::uninlined_format_args
 )]
 
-use oxc_allocator::arena::Arena;
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicBool, Ordering},
+};
+
 use rand::RngExt as _;
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicBool, Ordering};
+
+use oxc_allocator::arena::Arena;
 
 /// A custom allocator that wraps the system allocator, but lets us force
 /// allocation failures for testing.


### PR DESCRIPTION
Style change only. Collapse imports from `std` into a single `use` statement, and re-order `use` statements in tests for `Arena`.