### PR TITLE
perf(ast): add `#[inline(always)]` to `node_id` methods on enums with all variants unboxed

### DIFF
--- a/crates/oxc_ast/src/generated/get_id.rs
+++ b/crates/oxc_ast/src/generated/get_id.rs
@@ -3992,6 +3992,8 @@ impl ImportDeclarationSpecifier<'_> {
 
 impl ImportAttributeKey<'_> {
     /// Get [`NodeId`] of [`ImportAttributeKey`].
+    // `#[inline(always)]` because this should boil down to a single instruction.
+    #[inline(always)]
     pub fn node_id(&self) -> NodeId {
         match self {
             Self::Identifier(it) => it.node_id(),
@@ -4058,6 +4060,8 @@ impl ExportDefaultDeclarationKind<'_> {
 
 impl ModuleExportName<'_> {
     /// Get [`NodeId`] of [`ModuleExportName`].
+    // `#[inline(always)]` because this should boil down to a single instruction.
+    #[inline(always)]
     pub fn node_id(&self) -> NodeId {
         match self {
             Self::IdentifierName(it) => it.node_id(),
@@ -4366,6 +4370,8 @@ impl TSTypePredicateName<'_> {
 
 impl TSModuleDeclarationName<'_> {
     /// Get [`NodeId`] of [`TSModuleDeclarationName`].
+    // `#[inline(always)]` because this should boil down to a single instruction.
+    #[inline(always)]
     pub fn node_id(&self) -> NodeId {
         match self {
             Self::Identifier(it) => it.node_id(),

--- a/tasks/ast_tools/src/generators/get_id.rs
+++ b/tasks/ast_tools/src/generators/get_id.rs
@@ -150,13 +150,15 @@ fn generate_for_struct(
 
 fn generate_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<TokenStream> {
     // Check all variants are structs with a `NodeId` field (`has_kind` is only `true` for structs that do).
-    // Also check if all variants are boxed.
+    // Also check if all variants are consistently boxed or consistently unboxed.
     let mut all_variants_boxed = true;
+    let mut all_variants_unboxed = true;
 
     for variant in enum_def.all_variants(schema) {
         let mut field_type = variant.field_type(schema)?;
         if let Some(box_def) = field_type.as_box() {
             field_type = box_def.inner_type(schema);
+            all_variants_unboxed = false;
         } else {
             all_variants_boxed = false;
         }
@@ -167,10 +169,10 @@ fn generate_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<TokenStream>
         }
     }
 
-    // If all variants are boxed, add `#[inline(always)]` to the method.
-    // `NodeId` field is in a consistent position in all AST structs, so if all variants are boxed,
+    // If all variants are consistently boxed or consistently unboxed, add `#[inline(always)]` to the method.
+    // `NodeId` field is in a consistent position in all AST structs, so if all variants have the same shape,
     // the method should boil down to a single instruction.
-    let maybe_inline = if all_variants_boxed {
+    let maybe_inline = if all_variants_boxed || all_variants_unboxed {
         quote! {
             ///@ `#[inline(always)]` because this should boil down to a single instruction.
             #[inline(always)]


### PR DESCRIPTION
Follow-on after #21653.

That PR revealed that some AST enums don't have all their variants boxed. Where all variants are boxed, `node_id` methods should boil down to a single instruction, so we mark the method `#[inline(always)]`.

`node_id` method will also boil down to a single instruction where all variants are _not_ boxed, so add `#[inline(always)]` to them too. It's only where there's a mix of boxed and unboxed where the method will retain branching logic and be larger.

Probably compiler will inline these methods anyway, but the attributes are a useful signal as to where we can improve the AST - all enums should consistently box _all_ their variants, or none of them.