### PR TITLE
perf(ast)!: reduce size of `TSTypePredicateName`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -4939,7 +4939,7 @@ function deserializeTSTypePredicate(pos) {
       parent,
     });
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
 }
@@ -4949,7 +4949,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1208,7 +1208,7 @@ pub struct TSTypePredicate<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub enum TSTypePredicateName<'a> {
     Identifier(Box<'a, IdentifierName<'a>>) = 0,
-    This(TSThisType) = 1,
+    This(Box<'a, TSThisType>) = 1,
 }
 
 /// TypeScript Module and Namespace Declarations

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1549,15 +1549,15 @@ const _: () = {
     assert!(offset_of!(TSInterfaceHeritage, type_arguments) == 32);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSTypePredicate>() == 48);
+    assert!(size_of::<TSTypePredicate>() == 40);
     assert!(align_of::<TSTypePredicate>() == 8);
     assert!(offset_of!(TSTypePredicate, span) == 0);
     assert!(offset_of!(TSTypePredicate, node_id) == 8);
     assert!(offset_of!(TSTypePredicate, asserts) == 12);
     assert!(offset_of!(TSTypePredicate, parameter_name) == 16);
-    assert!(offset_of!(TSTypePredicate, type_annotation) == 40);
+    assert!(offset_of!(TSTypePredicate, type_annotation) == 32);
 
-    assert!(size_of::<TSTypePredicateName>() == 24);
+    assert!(size_of::<TSTypePredicateName>() == 16);
     assert!(align_of::<TSTypePredicateName>() == 8);
 
     // Padding: 6 bytes
@@ -3360,15 +3360,15 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSInterfaceHeritage, type_arguments) == 20);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSTypePredicate>() == 36);
+    assert!(size_of::<TSTypePredicate>() == 28);
     assert!(align_of::<TSTypePredicate>() == 4);
     assert!(offset_of!(TSTypePredicate, span) == 0);
     assert!(offset_of!(TSTypePredicate, node_id) == 8);
     assert!(offset_of!(TSTypePredicate, asserts) == 12);
     assert!(offset_of!(TSTypePredicate, parameter_name) == 16);
-    assert!(offset_of!(TSTypePredicate, type_annotation) == 32);
+    assert!(offset_of!(TSTypePredicate, type_annotation) == 24);
 
-    assert!(size_of::<TSTypePredicateName>() == 16);
+    assert!(size_of::<TSTypePredicateName>() == 8);
     assert!(align_of::<TSTypePredicateName>() == 4);
 
     // Padding: 2 bytes

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -13793,11 +13793,13 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypePredicateName::This`].
     ///
+    /// This node contains a [`TSThisType`] that will be stored in the memory arena.
+    ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn ts_type_predicate_name_this(self, span: Span) -> TSTypePredicateName<'a> {
-        TSTypePredicateName::This(self.ts_this_type(span))
+        TSTypePredicateName::This(self.alloc_ts_this_type(span))
     }
 
     /// Build a [`TSModuleDeclaration`].

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2776,7 +2776,7 @@ impl<'a> Dummy<'a> for TSInterfaceHeritage<'a> {
 impl<'a> Dummy<'a> for TSTypePredicate<'a> {
     /// Create a dummy [`TSTypePredicate`].
     ///
-    /// Does not allocate any data into arena.
+    /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             node_id: Dummy::dummy(allocator),
@@ -2791,7 +2791,7 @@ impl<'a> Dummy<'a> for TSTypePredicate<'a> {
 impl<'a> Dummy<'a> for TSTypePredicateName<'a> {
     /// Create a dummy [`TSTypePredicateName`].
     ///
-    /// Does not allocate any data into arena.
+    /// Has cost of making 1 allocation (16 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self::This(Dummy::dummy(allocator))
     }

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -1952,7 +1952,7 @@ impl GetSpan for TSTypePredicateName<'_> {
     fn span(&self) -> Span {
         match self {
             Self::Identifier(it) => GetSpan::span(&**it),
-            Self::This(it) => GetSpan::span(it),
+            Self::This(it) => GetSpan::span(&**it),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -1952,7 +1952,7 @@ impl GetSpanMut for TSTypePredicateName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
             Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::This(it) => GetSpanMut::span_mut(it),
+            Self::This(it) => GetSpanMut::span_mut(&mut **it),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/get_id.rs
+++ b/crates/oxc_ast/src/generated/get_id.rs
@@ -4364,6 +4364,8 @@ impl TSSignature<'_> {
 
 impl TSTypePredicateName<'_> {
     /// Get [`NodeId`] of [`TSTypePredicateName`].
+    // `#[inline(always)]` because this should boil down to a single instruction.
+    #[inline(always)]
     pub fn node_id(&self) -> NodeId {
         match self {
             Self::Identifier(it) => it.node_id(),

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -9411,7 +9411,7 @@ impl<'a> AstNode<'a, TSTypePredicateName<'a>> {
                 }))
             }
             TSTypePredicateName::This(s) => AstNodes::TSThisType(self.allocator.alloc(AstNode {
-                inner: s,
+                inner: s.as_ref(),
                 parent,
                 allocator: self.allocator,
                 following_span_start: self.following_span_start,

--- a/crates/oxc_minifier/src/generated/walk.rs
+++ b/crates/oxc_minifier/src/generated/walk.rs
@@ -4998,7 +4998,9 @@ unsafe fn walk_ts_type_predicate_name<'a, Tr: Traverse<'a>>(
         TSTypePredicateName::Identifier(node) => {
             walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSTypePredicateName::This(node) => walk_ts_this_type(traverser, node as *mut _, ctx),
+        TSTypePredicateName::This(node) => {
+            walk_ts_this_type(traverser, (&mut **node) as *mut _, ctx)
+        }
     }
     traverser.exit_ts_type_predicate_name(&mut *node, ctx);
 }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -443,11 +443,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::This => {
                 let span = self.start_span();
                 self.bump_any(); // bump `this`
-                let this_type = self.ast.ts_this_type(self.end_span(span));
+                let this_type = self.ast.alloc_ts_this_type(self.end_span(span));
                 if self.at(Kind::Is) && !self.cur_token().is_on_new_line() {
                     self.parse_this_type_predicate(span, this_type)
                 } else {
-                    TSType::TSThisType(self.alloc(this_type))
+                    TSType::TSThisType(this_type)
                 }
             }
             Kind::Typeof => {
@@ -699,7 +699,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.ts_type_type_query(self.end_span(span), entity_name, type_arguments)
     }
 
-    fn parse_this_type_predicate(&mut self, span: u32, this_ty: TSThisType) -> TSType<'a> {
+    fn parse_this_type_predicate(&mut self, span: u32, this_ty: Box<'a, TSThisType>) -> TSType<'a> {
         self.bump_any(); // bump `is`
         let ty = self.parse_ts_type();
         let type_annotation = Some(self.ast.ts_type_annotation(ty.span(), ty));
@@ -711,10 +711,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         )
     }
 
-    fn parse_this_type_node(&mut self) -> TSThisType {
+    fn parse_this_type_node(&mut self) -> Box<'a, TSThisType> {
         let span = self.start_span();
         self.bump_any(); // bump `this`
-        self.ast.ts_this_type(self.end_span(span))
+        self.ast.alloc_ts_this_type(self.end_span(span))
     }
 
     fn parse_ts_type_constraint(&mut self) -> Option<TSType<'a>> {

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -4998,7 +4998,9 @@ unsafe fn walk_ts_type_predicate_name<'a, State, Tr: Traverse<'a, State>>(
         TSTypePredicateName::Identifier(node) => {
             walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSTypePredicateName::This(node) => walk_ts_this_type(traverser, node as *mut _, ctx),
+        TSTypePredicateName::This(node) => {
+            walk_ts_this_type(traverser, (&mut **node) as *mut _, ctx)
+        }
     }
     traverser.exit_ts_type_predicate_name(&mut *node, ctx);
 }

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -3604,7 +3604,7 @@ function deserializeTSTypePredicate(pos) {
     end: deserializeI32(pos + 4),
   };
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   return node;
 }
 
@@ -3613,7 +3613,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -4028,7 +4028,7 @@ function deserializeTSTypePredicate(pos) {
       parent,
     });
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
 }
@@ -4038,7 +4038,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -4039,7 +4039,7 @@ function deserializeTSTypePredicate(pos) {
       range: [start, end],
     };
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   return node;
 }
 
@@ -4048,7 +4048,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -4461,7 +4461,7 @@ function deserializeTSTypePredicate(pos) {
       parent,
     });
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
 }
@@ -4471,7 +4471,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -3877,7 +3877,7 @@ function deserializeTSTypePredicate(pos) {
     end: deserializeI32(pos + 4),
   };
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   return node;
 }
 
@@ -3886,7 +3886,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -4331,7 +4331,7 @@ function deserializeTSTypePredicate(pos) {
       parent,
     });
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
 }
@@ -4341,7 +4341,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -4340,7 +4340,7 @@ function deserializeTSTypePredicate(pos) {
       range: [start, end],
     };
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   return node;
 }
 
@@ -4349,7 +4349,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -4792,7 +4792,7 @@ function deserializeTSTypePredicate(pos) {
       parent,
     });
   node.parameterName = deserializeTSTypePredicateName(pos + 16);
-  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 40);
+  node.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 32);
   parent = previousParent;
   return node;
 }
@@ -4802,7 +4802,7 @@ function deserializeTSTypePredicateName(pos) {
     case 0:
       return deserializeBoxIdentifierName(pos + 8);
     case 1:
-      return deserializeTSThisType(pos + 8);
+      return deserializeBoxTSThisType(pos + 8);
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -10295,7 +10295,7 @@ export class TSTypePredicate {
 
   get typeAnnotation() {
     const internal = this.#internal;
-    return constructOptionBoxTSTypeAnnotation(internal.pos + 40, internal.ast);
+    return constructOptionBoxTSTypeAnnotation(internal.pos + 32, internal.ast);
   }
 
   toJSON() {
@@ -10321,7 +10321,7 @@ function constructTSTypePredicateName(pos, ast) {
     case 0:
       return constructBoxIdentifierName(pos + 8, ast);
     case 1:
-      return new TSThisType(pos + 8, ast);
+      return constructBoxTSThisType(pos + 8, ast);
     default:
       throw new Error(`Unexpected discriminant ${ast.buffer[pos]} for TSTypePredicateName`);
   }

--- a/napi/parser/src-js/generated/lazy/walk.js
+++ b/napi/parser/src-js/generated/lazy/walk.js
@@ -4219,7 +4219,7 @@ function walkTSTypePredicate(pos, ast, visitors) {
   }
 
   walkTSTypePredicateName(pos + 16, ast, visitors);
-  walkOptionBoxTSTypeAnnotation(pos + 40, ast, visitors);
+  walkOptionBoxTSTypeAnnotation(pos + 32, ast, visitors);
 
   if (exit !== null) exit(node);
 }
@@ -4230,7 +4230,7 @@ function walkTSTypePredicateName(pos, ast, visitors) {
       walkBoxIdentifierName(pos + 8, ast, visitors);
       return;
     case 1:
-      walkTSThisType(pos + 8, ast, visitors);
+      walkBoxTSThisType(pos + 8, ast, visitors);
       return;
     default:
       throw new Error(`Unexpected discriminant ${ast.buffer[pos]} for TSTypePredicateName`);


### PR DESCRIPTION
#21653 revealed that `TSTypePredicateName` has an unboxed variant `This`.

Before the introduction of `NodeId` fields, this was fine as `TSThisType` contained only a `Span` (8 bytes). But with `NodeId` field added, it's 16 bytes, which makes `TSTypePredicateName` larger too - 24 bytes.

Box `TSThisType` in this variant, bringing `TSTypePredicateName` back down to 16 bytes.

This also has the side-effect of making `TSTypePredicateName`'s `node_id`, `span`, and `span_mut` methods branchless.