### PR TITLE
feat(linter/vue): implement no-deprecated-dollar-listeners-api rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4550,6 +4550,14 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::vue::no_deprecated_dollar_listeners_api::NoDeprecatedDollarListenersApi
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -721,6 +721,7 @@ pub use crate::rules::vue::define_props_destructuring::DefinePropsDestructuring 
 pub use crate::rules::vue::max_props::MaxProps as VueMaxProps;
 pub use crate::rules::vue::no_arrow_functions_in_watch::NoArrowFunctionsInWatch as VueNoArrowFunctionsInWatch;
 pub use crate::rules::vue::no_deprecated_destroyed_lifecycle::NoDeprecatedDestroyedLifecycle as VueNoDeprecatedDestroyedLifecycle;
+pub use crate::rules::vue::no_deprecated_dollar_listeners_api::NoDeprecatedDollarListenersApi as VueNoDeprecatedDollarListenersApi;
 pub use crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup as VueNoExportInScriptSetup;
 pub use crate::rules::vue::no_import_compiler_macros::NoImportCompilerMacros as VueNoImportCompilerMacros;
 pub use crate::rules::vue::no_lifecycle_after_await::NoLifecycleAfterAwait as VueNoLifecycleAfterAwait;
@@ -1458,6 +1459,7 @@ pub enum RuleEnum {
     VueMaxProps(VueMaxProps),
     VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch),
     VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle),
+    VueNoDeprecatedDollarListenersApi(VueNoDeprecatedDollarListenersApi),
     VueNoExportInScriptSetup(VueNoExportInScriptSetup),
     VueNoImportCompilerMacros(VueNoImportCompilerMacros),
     VueNoLifecycleAfterAwait(VueNoLifecycleAfterAwait),
@@ -2273,7 +2275,9 @@ const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID
 const VUE_MAX_PROPS_ID: usize = VUE_DEFINE_PROPS_DESTRUCTURING_ID + 1usize;
 const VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID: usize = VUE_MAX_PROPS_ID + 1usize;
 const VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID: usize = VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID + 1usize;
-const VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID: usize = VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID + 1usize;
+const VUE_NO_DEPRECATED_DOLLAR_LISTENERS_API_ID: usize =
+    VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID + 1usize;
+const VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID: usize = VUE_NO_DEPRECATED_DOLLAR_LISTENERS_API_ID + 1usize;
 const VUE_NO_IMPORT_COMPILER_MACROS_ID: usize = VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID + 1usize;
 const VUE_NO_LIFECYCLE_AFTER_AWAIT_ID: usize = VUE_NO_IMPORT_COMPILER_MACROS_ID + 1usize;
 const VUE_NO_MULTIPLE_SLOT_ARGS_ID: usize = VUE_NO_LIFECYCLE_AFTER_AWAIT_ID + 1usize;
@@ -3114,6 +3118,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VUE_MAX_PROPS_ID,
             Self::VueNoArrowFunctionsInWatch(_) => VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID,
+            Self::VueNoDeprecatedDollarListenersApi(_) => VUE_NO_DEPRECATED_DOLLAR_LISTENERS_API_ID,
             Self::VueNoExportInScriptSetup(_) => VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID,
             Self::VueNoImportCompilerMacros(_) => VUE_NO_IMPORT_COMPILER_MACROS_ID,
             Self::VueNoLifecycleAfterAwait(_) => VUE_NO_LIFECYCLE_AFTER_AWAIT_ID,
@@ -3942,6 +3947,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::NAME,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::NAME,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::NAME,
+            Self::VueNoDeprecatedDollarListenersApi(_) => VueNoDeprecatedDollarListenersApi::NAME,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::NAME,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::NAME,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::NAME,
@@ -4824,6 +4830,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::CATEGORY
             }
+            Self::VueNoDeprecatedDollarListenersApi(_) => {
+                VueNoDeprecatedDollarListenersApi::CATEGORY
+            }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::CATEGORY,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::CATEGORY,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::CATEGORY,
@@ -5653,6 +5662,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::FIX,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::FIX,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::FIX,
+            Self::VueNoDeprecatedDollarListenersApi(_) => VueNoDeprecatedDollarListenersApi::FIX,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::FIX,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::FIX,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::FIX,
@@ -6699,6 +6709,9 @@ impl RuleEnum {
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::documentation(),
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::documentation()
+            }
+            Self::VueNoDeprecatedDollarListenersApi(_) => {
+                VueNoDeprecatedDollarListenersApi::documentation()
             }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::documentation(),
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::documentation(),
@@ -8756,6 +8769,10 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::config_schema(generator)
                     .or_else(|| VueNoDeprecatedDestroyedLifecycle::schema(generator))
             }
+            Self::VueNoDeprecatedDollarListenersApi(_) => {
+                VueNoDeprecatedDollarListenersApi::config_schema(generator)
+                    .or_else(|| VueNoDeprecatedDollarListenersApi::schema(generator))
+            }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::config_schema(generator)
                 .or_else(|| VueNoExportInScriptSetup::schema(generator)),
             Self::VueNoImportCompilerMacros(_) => {
@@ -9501,6 +9518,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => "vue",
             Self::VueNoArrowFunctionsInWatch(_) => "vue",
             Self::VueNoDeprecatedDestroyedLifecycle(_) => "vue",
+            Self::VueNoDeprecatedDollarListenersApi(_) => "vue",
             Self::VueNoExportInScriptSetup(_) => "vue",
             Self::VueNoImportCompilerMacros(_) => "vue",
             Self::VueNoLifecycleAfterAwait(_) => "vue",
@@ -11814,6 +11832,11 @@ impl RuleEnum {
                     VueNoDeprecatedDestroyedLifecycle::from_configuration(value)?,
                 ))
             }
+            Self::VueNoDeprecatedDollarListenersApi(_) => {
+                Ok(Self::VueNoDeprecatedDollarListenersApi(
+                    VueNoDeprecatedDollarListenersApi::from_configuration(value)?,
+                ))
+            }
             Self::VueNoExportInScriptSetup(_) => Ok(Self::VueNoExportInScriptSetup(
                 VueNoExportInScriptSetup::from_configuration(value)?,
             )),
@@ -12568,6 +12591,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.to_configuration(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.to_configuration(),
+            Self::VueNoDeprecatedDollarListenersApi(rule) => rule.to_configuration(),
             Self::VueNoExportInScriptSetup(rule) => rule.to_configuration(),
             Self::VueNoImportCompilerMacros(rule) => rule.to_configuration(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.to_configuration(),
@@ -13296,6 +13320,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.run(node, ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run(node, ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
+            Self::VueNoDeprecatedDollarListenersApi(rule) => rule.run(node, ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
             Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run(node, ctx),
@@ -14024,6 +14049,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.run_once(ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_once(ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
+            Self::VueNoDeprecatedDollarListenersApi(rule) => rule.run_once(ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
             Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run_once(ctx),
@@ -14856,6 +14882,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueNoDeprecatedDollarListenersApi(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoImportCompilerMacros(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15584,6 +15611,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.should_run(ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.should_run(ctx),
+            Self::VueNoDeprecatedDollarListenersApi(rule) => rule.should_run(ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.should_run(ctx),
             Self::VueNoImportCompilerMacros(rule) => rule.should_run(ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.should_run(ctx),
@@ -16630,6 +16658,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::IS_TSGOLINT_RULE
             }
+            Self::VueNoDeprecatedDollarListenersApi(_) => {
+                VueNoDeprecatedDollarListenersApi::IS_TSGOLINT_RULE
+            }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::IS_TSGOLINT_RULE,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::IS_TSGOLINT_RULE,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::IS_TSGOLINT_RULE,
@@ -17513,6 +17544,9 @@ impl RuleEnum {
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::VERSION,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::VERSION
+            }
+            Self::VueNoDeprecatedDollarListenersApi(_) => {
+                VueNoDeprecatedDollarListenersApi::VERSION
             }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::VERSION,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::VERSION,
@@ -18423,6 +18457,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::HAS_CONFIG
             }
+            Self::VueNoDeprecatedDollarListenersApi(_) => {
+                VueNoDeprecatedDollarListenersApi::HAS_CONFIG
+            }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::HAS_CONFIG,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::HAS_CONFIG,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::HAS_CONFIG,
@@ -19151,6 +19188,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.types_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.types_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.types_info(),
+            Self::VueNoDeprecatedDollarListenersApi(rule) => rule.types_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.types_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.types_info(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.types_info(),
@@ -19879,6 +19917,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.run_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_info(),
+            Self::VueNoDeprecatedDollarListenersApi(rule) => rule.run_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.run_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.run_info(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run_info(),
@@ -20729,6 +20768,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueMaxProps(VueMaxProps::default()),
         RuleEnum::VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch::default()),
         RuleEnum::VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle::default()),
+        RuleEnum::VueNoDeprecatedDollarListenersApi(VueNoDeprecatedDollarListenersApi::default()),
         RuleEnum::VueNoExportInScriptSetup(VueNoExportInScriptSetup::default()),
         RuleEnum::VueNoImportCompilerMacros(VueNoImportCompilerMacros::default()),
         RuleEnum::VueNoLifecycleAfterAwait(VueNoLifecycleAfterAwait::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -761,6 +761,7 @@ pub(crate) mod vue {
     pub mod max_props;
     pub mod no_arrow_functions_in_watch;
     pub mod no_deprecated_destroyed_lifecycle;
+    pub mod no_deprecated_dollar_listeners_api;
     pub mod no_export_in_script_setup;
     pub mod no_import_compiler_macros;
     pub mod no_lifecycle_after_await;

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_dollar_listeners_api.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_dollar_listeners_api.rs
@@ -1,0 +1,320 @@
+use oxc_ast::{
+    AstKind,
+    ast::{BindingPattern, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_deprecated_dollar_listeners_api_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("The `$listeners` is deprecated.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDeprecatedDollarListenersApi;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow using deprecated `$listeners` (in Vue.js 3.0.0+).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `$listeners` object was removed in Vue 3. Component v-on listeners
+    /// are now part of `$attrs`, so code that reads `this.$listeners` in a
+    /// Vue component will break when upgrading to Vue 3.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   computed: {
+    ///     foo () {
+    ///       return this.$listeners
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   methods: {
+    ///     click () {
+    ///       this.$emit('click')
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoDeprecatedDollarListenersApi,
+    vue,
+    correctness,
+    version = "next",
+);
+
+impl Rule for NoDeprecatedDollarListenersApi {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::StaticMemberExpression(outer) = node.kind() else {
+            return;
+        };
+        if outer.property.name != "$listeners" {
+            return;
+        }
+        let in_vue = ctx.nodes().ancestors(node.id()).any(|a| match a.kind() {
+            AstKind::ExportDefaultDeclaration(_) => true,
+            AstKind::CallExpression(call) => call
+                .callee
+                .get_identifier_reference()
+                .is_some_and(|ident| ident.name == "defineComponent"),
+            _ => false,
+        });
+        if !in_vue {
+            return;
+        }
+        match outer.object.get_inner_expression() {
+            Expression::ThisExpression(_) => {}
+            Expression::Identifier(ident) => {
+                let scoping = ctx.scoping();
+                let reference = scoping.get_reference(ident.reference_id());
+                let Some(symbol_id) = reference.symbol_id() else { return };
+
+                let declaration = ctx.symbol_declaration(symbol_id);
+                let AstKind::VariableDeclarator(decl) = declaration.kind() else { return };
+
+                let BindingPattern::BindingIdentifier(_) = &decl.id else { return };
+                let Some(init) = &decl.init else { return };
+                let Expression::ThisExpression(_) = init.get_inner_expression() else { return };
+            }
+            _ => return,
+        }
+
+        ctx.diagnostic(no_deprecated_dollar_listeners_api_diagnostic(outer.property.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            "
+                    <script>
+                    export default {
+                      mounted () {
+                        this.$emit('start')
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      methods: {
+                        click () {
+                          this.$emit('click')
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                    }
+                    const another = function () {
+                      console.log(this.$listeners)
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      methods: {
+                        click ($listeners) {
+                          foo.$listeners
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          const {vm} = this
+                          return vm.$listeners
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          return this.$listeners
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          fn(this.$listeners)
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          const vm = this
+                          return vm.$listeners
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          const vm = this
+                          function fn() {
+                            return vm.$listeners
+                          }
+                          return fn()
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          const vm = this
+                          const a = vm?.$listeners
+                          const b = this?.$listeners
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default defineComponent({
+                      computed: {
+                        foo () {
+                          return this.$listeners
+                        }
+                      }
+                    })
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    defineComponent({
+                      computed: {
+                        foo () {
+                          return this.$listeners
+                        }
+                      }
+                    })
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(
+        NoDeprecatedDollarListenersApi::NAME,
+        NoDeprecatedDollarListenersApi::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_dollar_listeners_api.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_dollar_listeners_api.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:6:39]
+ 5 │                         foo () {
+ 6 │                           return this.$listeners
+   ·                                       ──────────
+ 7 │                         }
+   ╰────
+
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:6:35]
+ 5 │                         foo () {
+ 6 │                           fn(this.$listeners)
+   ·                                   ──────────
+ 7 │                         }
+   ╰────
+
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:7:37]
+ 6 │                           const vm = this
+ 7 │                           return vm.$listeners
+   ·                                     ──────────
+ 8 │                         }
+   ╰────
+
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:8:39]
+ 7 │                           function fn() {
+ 8 │                             return vm.$listeners
+   ·                                       ──────────
+ 9 │                           }
+   ╰────
+
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:7:41]
+ 6 │                           const vm = this
+ 7 │                           const a = vm?.$listeners
+   ·                                         ──────────
+ 8 │                           const b = this?.$listeners
+   ╰────
+
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:8:43]
+ 7 │                           const a = vm?.$listeners
+ 8 │                           const b = this?.$listeners
+   ·                                           ──────────
+ 9 │                         }
+   ╰────
+
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:6:39]
+ 5 │                         foo () {
+ 6 │                           return this.$listeners
+   ·                                       ──────────
+ 7 │                         }
+   ╰────
+
+  ⚠ eslint-plugin-vue(no-deprecated-dollar-listeners-api): The `$listeners` is deprecated.
+   ╭─[no_deprecated_dollar_listeners_api.tsx:6:39]
+ 5 │                         foo () {
+ 6 │                           return this.$listeners
+   ·                                       ──────────
+ 7 │                         }
+   ╰────


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/no-deprecated-dollar-listeners-api.html

AI disclosure: I used Claude Code for scaffolding and test setup; I wrote the core rule logic myself and reviewed all changes manually.