### PR TITLE
fix(linter): iframe-has-title false positive for template literals 

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -86,9 +86,9 @@ impl Rule for IframeHasTitle {
                         return;
                     }
                     JSXExpression::TemplateLiteral(tmpl)
-                        if !tmpl.quasis.is_empty()
-                            & !tmpl.expressions.is_empty()
-                            & tmpl.quasis.iter().any(|q| !q.value.raw.as_str().is_empty()) =>
+                        if (!tmpl.quasis.is_empty()
+                            && tmpl.quasis.iter().any(|q| !q.value.raw.as_str().is_empty()))
+                            || !tmpl.expressions.is_empty() =>
                     {
                         return;
                     }
@@ -120,6 +120,8 @@ fn test() {
         (r"<div />;", None, None),
         (r"<iframe title='Unique title' />", None, None),
         (r"<iframe title={foo} />", None, None),
+        (r"<iframe title={`Title`} />", None, None),
+        (r"<iframe title={`${title}`} />", None, None),
         (r"<FooComponent />", None, None),
         (r"<iframe title={titleGenerator('hello')} />", None, None),
         // Member expression tests


### PR DESCRIPTION
Either require `quasis` to not be empty, or require `expressions` to not be empty, instead of both.

Fixes #21712 