### PR TITLE
docs(linter): improve function usage examples in doc comments

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -585,7 +585,7 @@ impl<'a> LintContext<'a> {
 ///
 /// Example:
 ///
-/// ```text
+/// ```ignore
 /// assert_eq!(plugin_name_to_prefix("react"), "eslint-plugin-react");
 /// ```
 #[inline]

--- a/crates/oxc_linter/src/utils/url.rs
+++ b/crates/oxc_linter/src/utils/url.rs
@@ -4,7 +4,7 @@
 ///
 /// # Example
 ///
-/// ```text
+/// ```ignore
 /// find_url_query_value("https://example.com/?foo=bar&baz=qux", "baz") // => Some("qux")
 /// ```
 pub fn find_url_query_value<'url>(url: &'url str, key: &str) -> Option<&'url str> {


### PR DESCRIPTION
Small comments-only change. It's more idiomatic to include Rust code examples in an `ignore` fence rather than `text`, to get syntax highlighting.