### PR TITLE
refactor(allocator): simplify `Arena` creation methods

### DIFF
--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -82,22 +82,9 @@ impl Arena<1> {
     /// # use oxc_allocator::arena::Arena;
     /// let arena = Arena::new();
     /// ```
+    #[inline] // Because it's very cheap
     pub fn new() -> Self {
-        Self::with_capacity(0)
-    }
-
-    /// Attempt to construct a new arena to allocate into.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use oxc_allocator::arena::Arena;
-    /// let arena = Arena::try_new();
-    /// # let _ = arena.unwrap();
-    /// ```
-    #[expect(clippy::missing_errors_doc, reason = "`try_with_capacity(0)` always returns `Ok`")]
-    pub fn try_new() -> Result<Self, AllocErr> {
-        Arena::try_with_capacity(0)
+        Self::with_min_align()
     }
 
     /// Construct a new arena with the specified byte capacity to allocate into.
@@ -112,8 +99,9 @@ impl Arena<1> {
     /// # Panics
     ///
     /// Panics if allocating the initial capacity fails.
+    #[inline] // Because it just delegates
     pub fn with_capacity(capacity: usize) -> Self {
-        Self::try_with_capacity(capacity).unwrap_or_else(|_| oom())
+        Self::with_min_align_and_capacity(capacity)
     }
 
     /// Attempt to construct a new arena with the specified byte capacity to allocate into.
@@ -140,6 +128,7 @@ impl Arena<1> {
     /// 3. The underlying global allocator fails to allocate the initial chunk.
     ///
     /// When `capacity` is `0`, no allocation is performed, and `Ok` is always returned.
+    #[inline] // Because it just delegates
     pub fn try_with_capacity(capacity: usize) -> Result<Self, AllocErr> {
         Self::try_with_min_align_and_capacity(capacity)
     }
@@ -171,6 +160,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     // the `impl Arena` block with no const `MIN_ALIGN` parameter), and because we don't want to force everyone
     // to specify a minimum alignment with `Arena::new()` et al, we have a separate constructor
     // for specifying the minimum alignment.
+    #[inline] // Because it's very cheap
     pub fn with_min_align() -> Self {
         Self::new_impl(EMPTY_CHUNK.get())
     }
@@ -246,7 +236,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// When `capacity` is 0, no allocation is performed, and `Ok` is always returned.
     pub fn try_with_min_align_and_capacity(capacity: usize) -> Result<Self, AllocErr> {
         if capacity == 0 {
-            return Ok(Self::new_impl(EMPTY_CHUNK.get()));
+            return Ok(Self::with_min_align());
         }
 
         let layout = layout_from_size_align(capacity, MIN_ALIGN)?;
@@ -385,6 +375,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 }
 
 impl<const MIN_ALIGN: usize> Default for Arena<MIN_ALIGN> {
+    #[inline] // Because it just delegates
     fn default() -> Self {
         Self::with_min_align()
     }

--- a/crates/oxc_allocator/tests/arena_try_alloc.rs
+++ b/crates/oxc_allocator/tests/arena_try_alloc.rs
@@ -113,7 +113,7 @@ fn main() {
                 // We can't query the remaining free space in the current chunk,
                 // so we have to create a new Arena for each test and fill it to
                 // the brink of a new allocation.
-                let arena = Arena::try_new().unwrap();
+                let arena = Arena::new();
 
                 // Arena preallocates space in the initial chunk, so we need to
                 // use up this block prior to the actual test
@@ -143,7 +143,7 @@ fn main() {
             const NUM_TESTS: usize = 5000;
             const MAX_BYTES_ALLOCATED: usize = 65536;
 
-            let mut arena = Arena::try_new().unwrap();
+            let mut arena = Arena::new();
             let mut bytes_allocated = arena.chunk_capacity();
 
             // Arena preallocates space in the initial chunk, so we need to
@@ -167,7 +167,7 @@ fn main() {
                 }
 
                 if bytes_allocated >= MAX_BYTES_ALLOCATED {
-                    arena = GLOBAL_ALLOCATOR.with_successful_allocs(|| Arena::try_new().unwrap());
+                    arena = GLOBAL_ALLOCATOR.with_successful_allocs(Arena::new);
                     bytes_allocated = arena.chunk_capacity();
                 }
             }


### PR DESCRIPTION
Refactor `Arena` creation methods to simplify and clarify them:

- All `Arena<1>` methods delegate directly to the corresponding generic `Arena<MIN_ALIGN>` methods.
- Remove `Arena::try_new`. It's pointless as it always returns `Ok`, so is equivalent to `Arena::new`.
- Add `#[inline]` to small methods, and ones which purely delegate to another method.