### PR TITLE
fix(minifier): track pure functions in DCE mode

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -151,9 +151,6 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
-            return;
-        }
         Self::keep_track_of_pure_functions(stmt, ctx);
     }
 

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -103,7 +103,7 @@ fn dce_if_statement() {
     // <https://github.com/rollup/rollup/blob/master/test/function/samples/allow-undefined-as-parameter/main.js>
     test_same("function foo(undefined) { if (!undefined) throw Error('') } foo()");
 
-    test("function foo() { if (undefined) { bar } } foo()", "function foo() { } foo()");
+    test("function foo() { if (undefined) { bar } } foo()", "");
     test("function foo() { { bar } } foo()", "function foo() { bar } foo()");
 
     test("if (true) { foo; } if (true) { foo; }", "foo; foo;");
@@ -195,6 +195,8 @@ fn dce_var_hoisting() {
           function KEEP() { FOO }
         } f()",
     );
+    // `KEEP` has an empty body (pure), so `f` is treated as pure too and the call
+    // to `f()` is removed; then `f` has no remaining references and is dropped.
     test(
         "function f() {
           KEEP();
@@ -205,11 +207,7 @@ fn dce_var_hoisting() {
           function KEEP() {}
           REMOVE;
         } f()",
-        "function f() {
-          KEEP();
-          return function g() {}
-          function KEEP() {}
-        } f()",
+        "",
     );
 }
 
@@ -433,4 +431,13 @@ fn preserve_annotation_comments_when_inlining_single_use_variable() {
         "import(/* @vite-ignore */ /* webpackIgnore: true */ 'some-url');",
         CompressOptions::dce(),
     );
+}
+
+#[test]
+fn remove_pure_function_calls() {
+    // https://github.com/rolldown/rolldown/issues/9211
+    test("function noop() {} noop()", "");
+    test("var foo = () => 1; foo(), foo()", "");
+    test("var foo = function() {}; foo()", "");
+    test_same("function foo() { bar() } foo()");
 }


### PR DESCRIPTION
## Summary

In DCE mode, `enter_statement` was skipping `keep_track_of_pure_functions` via an `if ctx.state.dce { return; }` guard, so user-defined functions with empty or side-effect-free bodies were never recorded as pure. The two consumers of that map — `remove_unused_call_expr` (via `try_fold_expression_stmt`) and `remove_dead_code_call_expression` — **already run in DCE mode**, so the data was needed; only the producer was gated off.

The guard was introduced during the consolidation refactor in #18128, which preserved pre-consolidation behavior rather than being an intentional choice. Eliminating calls to side-effect-free functions is classic DCE, not a full-minify extra, so the tracker now runs in both modes.

```js
// before (minify: "dce-only" / rolldown treeshake: true)
function noop() {}
noop();  // kept

// after
// (empty)
```

## Test plan

- New test case `remove_pure_function_calls` covering the issue repro
- Two existing expectations in `dce_if_statement` / `dce_var_hoisting` updated where DCE now produces strictly smaller output (pure function + its only call both collapse)
- All 484 minifier unit tests pass
- `just minsize` shows no size-snapshot changes (DCE mode isn't exercised by minsize benchmarks)

Closes rolldown/rolldown#9211
