### PR TITLE
refactor(formatter): remove unsafe parent transmute

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -1,9 +1,8 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/formatter/ast_nodes.rs`.
 
-use std::mem::transmute;
-
-use oxc_allocator::Vec;
+#![expect(clippy::match_same_arms)]
+use oxc_allocator::{Allocator, Vec};
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 use oxc_str::Ident;
@@ -15,207 +14,199 @@ use crate::formatter::{
     trivia::{format_leading_comments, format_trailing_comments},
 };
 
-#[inline]
-pub(super) fn transmute_self<'a, T>(s: &AstNode<'a, T>) -> &'a AstNode<'a, T> {
-    #[expect(clippy::undocumented_unsafe_blocks)]
-    unsafe {
-        transmute(s)
-    }
-}
-
 #[derive(Clone, Copy)]
-pub enum AstNodes<'a> {
+pub enum AstNodes<'a, 'b> {
     Dummy(),
-    Program(&'a AstNode<'a, Program<'a>>),
-    IdentifierName(&'a AstNode<'a, IdentifierName<'a>>),
-    IdentifierReference(&'a AstNode<'a, IdentifierReference<'a>>),
-    BindingIdentifier(&'a AstNode<'a, BindingIdentifier<'a>>),
-    LabelIdentifier(&'a AstNode<'a, LabelIdentifier<'a>>),
-    ThisExpression(&'a AstNode<'a, ThisExpression>),
-    ArrayExpression(&'a AstNode<'a, ArrayExpression<'a>>),
-    Elision(&'a AstNode<'a, Elision>),
-    ObjectExpression(&'a AstNode<'a, ObjectExpression<'a>>),
-    ObjectProperty(&'a AstNode<'a, ObjectProperty<'a>>),
-    TemplateLiteral(&'a AstNode<'a, TemplateLiteral<'a>>),
-    TaggedTemplateExpression(&'a AstNode<'a, TaggedTemplateExpression<'a>>),
-    TemplateElement(&'a AstNode<'a, TemplateElement<'a>>),
-    ComputedMemberExpression(&'a AstNode<'a, ComputedMemberExpression<'a>>),
-    StaticMemberExpression(&'a AstNode<'a, StaticMemberExpression<'a>>),
-    PrivateFieldExpression(&'a AstNode<'a, PrivateFieldExpression<'a>>),
-    CallExpression(&'a AstNode<'a, CallExpression<'a>>),
-    NewExpression(&'a AstNode<'a, NewExpression<'a>>),
-    MetaProperty(&'a AstNode<'a, MetaProperty<'a>>),
-    SpreadElement(&'a AstNode<'a, SpreadElement<'a>>),
-    UpdateExpression(&'a AstNode<'a, UpdateExpression<'a>>),
-    UnaryExpression(&'a AstNode<'a, UnaryExpression<'a>>),
-    BinaryExpression(&'a AstNode<'a, BinaryExpression<'a>>),
-    PrivateInExpression(&'a AstNode<'a, PrivateInExpression<'a>>),
-    LogicalExpression(&'a AstNode<'a, LogicalExpression<'a>>),
-    ConditionalExpression(&'a AstNode<'a, ConditionalExpression<'a>>),
-    AssignmentExpression(&'a AstNode<'a, AssignmentExpression<'a>>),
-    ArrayAssignmentTarget(&'a AstNode<'a, ArrayAssignmentTarget<'a>>),
-    ObjectAssignmentTarget(&'a AstNode<'a, ObjectAssignmentTarget<'a>>),
-    AssignmentTargetRest(&'a AstNode<'a, AssignmentTargetRest<'a>>),
-    AssignmentTargetWithDefault(&'a AstNode<'a, AssignmentTargetWithDefault<'a>>),
-    AssignmentTargetPropertyIdentifier(&'a AstNode<'a, AssignmentTargetPropertyIdentifier<'a>>),
-    AssignmentTargetPropertyProperty(&'a AstNode<'a, AssignmentTargetPropertyProperty<'a>>),
-    SequenceExpression(&'a AstNode<'a, SequenceExpression<'a>>),
-    Super(&'a AstNode<'a, Super>),
-    AwaitExpression(&'a AstNode<'a, AwaitExpression<'a>>),
-    ChainExpression(&'a AstNode<'a, ChainExpression<'a>>),
-    ParenthesizedExpression(&'a AstNode<'a, ParenthesizedExpression<'a>>),
-    Directive(&'a AstNode<'a, Directive<'a>>),
-    Hashbang(&'a AstNode<'a, Hashbang<'a>>),
-    BlockStatement(&'a AstNode<'a, BlockStatement<'a>>),
-    VariableDeclaration(&'a AstNode<'a, VariableDeclaration<'a>>),
-    VariableDeclarator(&'a AstNode<'a, VariableDeclarator<'a>>),
-    EmptyStatement(&'a AstNode<'a, EmptyStatement>),
-    ExpressionStatement(&'a AstNode<'a, ExpressionStatement<'a>>),
-    IfStatement(&'a AstNode<'a, IfStatement<'a>>),
-    DoWhileStatement(&'a AstNode<'a, DoWhileStatement<'a>>),
-    WhileStatement(&'a AstNode<'a, WhileStatement<'a>>),
-    ForStatement(&'a AstNode<'a, ForStatement<'a>>),
-    ForInStatement(&'a AstNode<'a, ForInStatement<'a>>),
-    ForOfStatement(&'a AstNode<'a, ForOfStatement<'a>>),
-    ContinueStatement(&'a AstNode<'a, ContinueStatement<'a>>),
-    BreakStatement(&'a AstNode<'a, BreakStatement<'a>>),
-    ReturnStatement(&'a AstNode<'a, ReturnStatement<'a>>),
-    WithStatement(&'a AstNode<'a, WithStatement<'a>>),
-    SwitchStatement(&'a AstNode<'a, SwitchStatement<'a>>),
-    SwitchCase(&'a AstNode<'a, SwitchCase<'a>>),
-    LabeledStatement(&'a AstNode<'a, LabeledStatement<'a>>),
-    ThrowStatement(&'a AstNode<'a, ThrowStatement<'a>>),
-    TryStatement(&'a AstNode<'a, TryStatement<'a>>),
-    CatchClause(&'a AstNode<'a, CatchClause<'a>>),
-    CatchParameter(&'a AstNode<'a, CatchParameter<'a>>),
-    DebuggerStatement(&'a AstNode<'a, DebuggerStatement>),
-    AssignmentPattern(&'a AstNode<'a, AssignmentPattern<'a>>),
-    ObjectPattern(&'a AstNode<'a, ObjectPattern<'a>>),
-    BindingProperty(&'a AstNode<'a, BindingProperty<'a>>),
-    ArrayPattern(&'a AstNode<'a, ArrayPattern<'a>>),
-    BindingRestElement(&'a AstNode<'a, BindingRestElement<'a>>),
-    Function(&'a AstNode<'a, Function<'a>>),
-    FormalParameters(&'a AstNode<'a, FormalParameters<'a>>),
-    FormalParameter(&'a AstNode<'a, FormalParameter<'a>>),
-    FormalParameterRest(&'a AstNode<'a, FormalParameterRest<'a>>),
-    FunctionBody(&'a AstNode<'a, FunctionBody<'a>>),
-    ArrowFunctionExpression(&'a AstNode<'a, ArrowFunctionExpression<'a>>),
-    YieldExpression(&'a AstNode<'a, YieldExpression<'a>>),
-    Class(&'a AstNode<'a, Class<'a>>),
-    ClassBody(&'a AstNode<'a, ClassBody<'a>>),
-    MethodDefinition(&'a AstNode<'a, MethodDefinition<'a>>),
-    PropertyDefinition(&'a AstNode<'a, PropertyDefinition<'a>>),
-    PrivateIdentifier(&'a AstNode<'a, PrivateIdentifier<'a>>),
-    StaticBlock(&'a AstNode<'a, StaticBlock<'a>>),
-    AccessorProperty(&'a AstNode<'a, AccessorProperty<'a>>),
-    ImportExpression(&'a AstNode<'a, ImportExpression<'a>>),
-    ImportDeclaration(&'a AstNode<'a, ImportDeclaration<'a>>),
-    ImportSpecifier(&'a AstNode<'a, ImportSpecifier<'a>>),
-    ImportDefaultSpecifier(&'a AstNode<'a, ImportDefaultSpecifier<'a>>),
-    ImportNamespaceSpecifier(&'a AstNode<'a, ImportNamespaceSpecifier<'a>>),
-    WithClause(&'a AstNode<'a, WithClause<'a>>),
-    ImportAttribute(&'a AstNode<'a, ImportAttribute<'a>>),
-    ExportNamedDeclaration(&'a AstNode<'a, ExportNamedDeclaration<'a>>),
-    ExportDefaultDeclaration(&'a AstNode<'a, ExportDefaultDeclaration<'a>>),
-    ExportAllDeclaration(&'a AstNode<'a, ExportAllDeclaration<'a>>),
-    ExportSpecifier(&'a AstNode<'a, ExportSpecifier<'a>>),
-    V8IntrinsicExpression(&'a AstNode<'a, V8IntrinsicExpression<'a>>),
-    BooleanLiteral(&'a AstNode<'a, BooleanLiteral>),
-    NullLiteral(&'a AstNode<'a, NullLiteral>),
-    NumericLiteral(&'a AstNode<'a, NumericLiteral<'a>>),
-    StringLiteral(&'a AstNode<'a, StringLiteral<'a>>),
-    BigIntLiteral(&'a AstNode<'a, BigIntLiteral<'a>>),
-    RegExpLiteral(&'a AstNode<'a, RegExpLiteral<'a>>),
-    JSXElement(&'a AstNode<'a, JSXElement<'a>>),
-    JSXOpeningElement(&'a AstNode<'a, JSXOpeningElement<'a>>),
-    JSXClosingElement(&'a AstNode<'a, JSXClosingElement<'a>>),
-    JSXFragment(&'a AstNode<'a, JSXFragment<'a>>),
-    JSXOpeningFragment(&'a AstNode<'a, JSXOpeningFragment>),
-    JSXClosingFragment(&'a AstNode<'a, JSXClosingFragment>),
-    JSXNamespacedName(&'a AstNode<'a, JSXNamespacedName<'a>>),
-    JSXMemberExpression(&'a AstNode<'a, JSXMemberExpression<'a>>),
-    JSXExpressionContainer(&'a AstNode<'a, JSXExpressionContainer<'a>>),
-    JSXEmptyExpression(&'a AstNode<'a, JSXEmptyExpression>),
-    JSXAttribute(&'a AstNode<'a, JSXAttribute<'a>>),
-    JSXSpreadAttribute(&'a AstNode<'a, JSXSpreadAttribute<'a>>),
-    JSXIdentifier(&'a AstNode<'a, JSXIdentifier<'a>>),
-    JSXSpreadChild(&'a AstNode<'a, JSXSpreadChild<'a>>),
-    JSXText(&'a AstNode<'a, JSXText<'a>>),
-    TSThisParameter(&'a AstNode<'a, TSThisParameter<'a>>),
-    TSEnumDeclaration(&'a AstNode<'a, TSEnumDeclaration<'a>>),
-    TSEnumBody(&'a AstNode<'a, TSEnumBody<'a>>),
-    TSEnumMember(&'a AstNode<'a, TSEnumMember<'a>>),
-    TSTypeAnnotation(&'a AstNode<'a, TSTypeAnnotation<'a>>),
-    TSLiteralType(&'a AstNode<'a, TSLiteralType<'a>>),
-    TSConditionalType(&'a AstNode<'a, TSConditionalType<'a>>),
-    TSUnionType(&'a AstNode<'a, TSUnionType<'a>>),
-    TSIntersectionType(&'a AstNode<'a, TSIntersectionType<'a>>),
-    TSParenthesizedType(&'a AstNode<'a, TSParenthesizedType<'a>>),
-    TSTypeOperator(&'a AstNode<'a, TSTypeOperator<'a>>),
-    TSArrayType(&'a AstNode<'a, TSArrayType<'a>>),
-    TSIndexedAccessType(&'a AstNode<'a, TSIndexedAccessType<'a>>),
-    TSTupleType(&'a AstNode<'a, TSTupleType<'a>>),
-    TSNamedTupleMember(&'a AstNode<'a, TSNamedTupleMember<'a>>),
-    TSOptionalType(&'a AstNode<'a, TSOptionalType<'a>>),
-    TSRestType(&'a AstNode<'a, TSRestType<'a>>),
-    TSAnyKeyword(&'a AstNode<'a, TSAnyKeyword>),
-    TSStringKeyword(&'a AstNode<'a, TSStringKeyword>),
-    TSBooleanKeyword(&'a AstNode<'a, TSBooleanKeyword>),
-    TSNumberKeyword(&'a AstNode<'a, TSNumberKeyword>),
-    TSNeverKeyword(&'a AstNode<'a, TSNeverKeyword>),
-    TSIntrinsicKeyword(&'a AstNode<'a, TSIntrinsicKeyword>),
-    TSUnknownKeyword(&'a AstNode<'a, TSUnknownKeyword>),
-    TSNullKeyword(&'a AstNode<'a, TSNullKeyword>),
-    TSUndefinedKeyword(&'a AstNode<'a, TSUndefinedKeyword>),
-    TSVoidKeyword(&'a AstNode<'a, TSVoidKeyword>),
-    TSSymbolKeyword(&'a AstNode<'a, TSSymbolKeyword>),
-    TSThisType(&'a AstNode<'a, TSThisType>),
-    TSObjectKeyword(&'a AstNode<'a, TSObjectKeyword>),
-    TSBigIntKeyword(&'a AstNode<'a, TSBigIntKeyword>),
-    TSTypeReference(&'a AstNode<'a, TSTypeReference<'a>>),
-    TSQualifiedName(&'a AstNode<'a, TSQualifiedName<'a>>),
-    TSTypeParameterInstantiation(&'a AstNode<'a, TSTypeParameterInstantiation<'a>>),
-    TSTypeParameter(&'a AstNode<'a, TSTypeParameter<'a>>),
-    TSTypeParameterDeclaration(&'a AstNode<'a, TSTypeParameterDeclaration<'a>>),
-    TSTypeAliasDeclaration(&'a AstNode<'a, TSTypeAliasDeclaration<'a>>),
-    TSClassImplements(&'a AstNode<'a, TSClassImplements<'a>>),
-    TSInterfaceDeclaration(&'a AstNode<'a, TSInterfaceDeclaration<'a>>),
-    TSInterfaceBody(&'a AstNode<'a, TSInterfaceBody<'a>>),
-    TSPropertySignature(&'a AstNode<'a, TSPropertySignature<'a>>),
-    TSIndexSignature(&'a AstNode<'a, TSIndexSignature<'a>>),
-    TSCallSignatureDeclaration(&'a AstNode<'a, TSCallSignatureDeclaration<'a>>),
-    TSMethodSignature(&'a AstNode<'a, TSMethodSignature<'a>>),
-    TSConstructSignatureDeclaration(&'a AstNode<'a, TSConstructSignatureDeclaration<'a>>),
-    TSIndexSignatureName(&'a AstNode<'a, TSIndexSignatureName<'a>>),
-    TSInterfaceHeritage(&'a AstNode<'a, TSInterfaceHeritage<'a>>),
-    TSTypePredicate(&'a AstNode<'a, TSTypePredicate<'a>>),
-    TSModuleDeclaration(&'a AstNode<'a, TSModuleDeclaration<'a>>),
-    TSGlobalDeclaration(&'a AstNode<'a, TSGlobalDeclaration<'a>>),
-    TSModuleBlock(&'a AstNode<'a, TSModuleBlock<'a>>),
-    TSTypeLiteral(&'a AstNode<'a, TSTypeLiteral<'a>>),
-    TSInferType(&'a AstNode<'a, TSInferType<'a>>),
-    TSTypeQuery(&'a AstNode<'a, TSTypeQuery<'a>>),
-    TSImportType(&'a AstNode<'a, TSImportType<'a>>),
-    TSImportTypeQualifiedName(&'a AstNode<'a, TSImportTypeQualifiedName<'a>>),
-    TSFunctionType(&'a AstNode<'a, TSFunctionType<'a>>),
-    TSConstructorType(&'a AstNode<'a, TSConstructorType<'a>>),
-    TSMappedType(&'a AstNode<'a, TSMappedType<'a>>),
-    TSTemplateLiteralType(&'a AstNode<'a, TSTemplateLiteralType<'a>>),
-    TSAsExpression(&'a AstNode<'a, TSAsExpression<'a>>),
-    TSSatisfiesExpression(&'a AstNode<'a, TSSatisfiesExpression<'a>>),
-    TSTypeAssertion(&'a AstNode<'a, TSTypeAssertion<'a>>),
-    TSImportEqualsDeclaration(&'a AstNode<'a, TSImportEqualsDeclaration<'a>>),
-    TSExternalModuleReference(&'a AstNode<'a, TSExternalModuleReference<'a>>),
-    TSNonNullExpression(&'a AstNode<'a, TSNonNullExpression<'a>>),
-    Decorator(&'a AstNode<'a, Decorator<'a>>),
-    TSExportAssignment(&'a AstNode<'a, TSExportAssignment<'a>>),
-    TSNamespaceExportDeclaration(&'a AstNode<'a, TSNamespaceExportDeclaration<'a>>),
-    TSInstantiationExpression(&'a AstNode<'a, TSInstantiationExpression<'a>>),
-    JSDocNullableType(&'a AstNode<'a, JSDocNullableType<'a>>),
-    JSDocNonNullableType(&'a AstNode<'a, JSDocNonNullableType<'a>>),
-    JSDocUnknownType(&'a AstNode<'a, JSDocUnknownType>),
+    Program(&'b AstNode<'a, 'b, Program<'a>>),
+    IdentifierName(&'b AstNode<'a, 'b, IdentifierName<'a>>),
+    IdentifierReference(&'b AstNode<'a, 'b, IdentifierReference<'a>>),
+    BindingIdentifier(&'b AstNode<'a, 'b, BindingIdentifier<'a>>),
+    LabelIdentifier(&'b AstNode<'a, 'b, LabelIdentifier<'a>>),
+    ThisExpression(&'b AstNode<'a, 'b, ThisExpression>),
+    ArrayExpression(&'b AstNode<'a, 'b, ArrayExpression<'a>>),
+    Elision(&'b AstNode<'a, 'b, Elision>),
+    ObjectExpression(&'b AstNode<'a, 'b, ObjectExpression<'a>>),
+    ObjectProperty(&'b AstNode<'a, 'b, ObjectProperty<'a>>),
+    TemplateLiteral(&'b AstNode<'a, 'b, TemplateLiteral<'a>>),
+    TaggedTemplateExpression(&'b AstNode<'a, 'b, TaggedTemplateExpression<'a>>),
+    TemplateElement(&'b AstNode<'a, 'b, TemplateElement<'a>>),
+    ComputedMemberExpression(&'b AstNode<'a, 'b, ComputedMemberExpression<'a>>),
+    StaticMemberExpression(&'b AstNode<'a, 'b, StaticMemberExpression<'a>>),
+    PrivateFieldExpression(&'b AstNode<'a, 'b, PrivateFieldExpression<'a>>),
+    CallExpression(&'b AstNode<'a, 'b, CallExpression<'a>>),
+    NewExpression(&'b AstNode<'a, 'b, NewExpression<'a>>),
+    MetaProperty(&'b AstNode<'a, 'b, MetaProperty<'a>>),
+    SpreadElement(&'b AstNode<'a, 'b, SpreadElement<'a>>),
+    UpdateExpression(&'b AstNode<'a, 'b, UpdateExpression<'a>>),
+    UnaryExpression(&'b AstNode<'a, 'b, UnaryExpression<'a>>),
+    BinaryExpression(&'b AstNode<'a, 'b, BinaryExpression<'a>>),
+    PrivateInExpression(&'b AstNode<'a, 'b, PrivateInExpression<'a>>),
+    LogicalExpression(&'b AstNode<'a, 'b, LogicalExpression<'a>>),
+    ConditionalExpression(&'b AstNode<'a, 'b, ConditionalExpression<'a>>),
+    AssignmentExpression(&'b AstNode<'a, 'b, AssignmentExpression<'a>>),
+    ArrayAssignmentTarget(&'b AstNode<'a, 'b, ArrayAssignmentTarget<'a>>),
+    ObjectAssignmentTarget(&'b AstNode<'a, 'b, ObjectAssignmentTarget<'a>>),
+    AssignmentTargetRest(&'b AstNode<'a, 'b, AssignmentTargetRest<'a>>),
+    AssignmentTargetWithDefault(&'b AstNode<'a, 'b, AssignmentTargetWithDefault<'a>>),
+    AssignmentTargetPropertyIdentifier(&'b AstNode<'a, 'b, AssignmentTargetPropertyIdentifier<'a>>),
+    AssignmentTargetPropertyProperty(&'b AstNode<'a, 'b, AssignmentTargetPropertyProperty<'a>>),
+    SequenceExpression(&'b AstNode<'a, 'b, SequenceExpression<'a>>),
+    Super(&'b AstNode<'a, 'b, Super>),
+    AwaitExpression(&'b AstNode<'a, 'b, AwaitExpression<'a>>),
+    ChainExpression(&'b AstNode<'a, 'b, ChainExpression<'a>>),
+    ParenthesizedExpression(&'b AstNode<'a, 'b, ParenthesizedExpression<'a>>),
+    Directive(&'b AstNode<'a, 'b, Directive<'a>>),
+    Hashbang(&'b AstNode<'a, 'b, Hashbang<'a>>),
+    BlockStatement(&'b AstNode<'a, 'b, BlockStatement<'a>>),
+    VariableDeclaration(&'b AstNode<'a, 'b, VariableDeclaration<'a>>),
+    VariableDeclarator(&'b AstNode<'a, 'b, VariableDeclarator<'a>>),
+    EmptyStatement(&'b AstNode<'a, 'b, EmptyStatement>),
+    ExpressionStatement(&'b AstNode<'a, 'b, ExpressionStatement<'a>>),
+    IfStatement(&'b AstNode<'a, 'b, IfStatement<'a>>),
+    DoWhileStatement(&'b AstNode<'a, 'b, DoWhileStatement<'a>>),
+    WhileStatement(&'b AstNode<'a, 'b, WhileStatement<'a>>),
+    ForStatement(&'b AstNode<'a, 'b, ForStatement<'a>>),
+    ForInStatement(&'b AstNode<'a, 'b, ForInStatement<'a>>),
+    ForOfStatement(&'b AstNode<'a, 'b, ForOfStatement<'a>>),
+    ContinueStatement(&'b AstNode<'a, 'b, ContinueStatement<'a>>),
+    BreakStatement(&'b AstNode<'a, 'b, BreakStatement<'a>>),
+    ReturnStatement(&'b AstNode<'a, 'b, ReturnStatement<'a>>),
+    WithStatement(&'b AstNode<'a, 'b, WithStatement<'a>>),
+    SwitchStatement(&'b AstNode<'a, 'b, SwitchStatement<'a>>),
+    SwitchCase(&'b AstNode<'a, 'b, SwitchCase<'a>>),
+    LabeledStatement(&'b AstNode<'a, 'b, LabeledStatement<'a>>),
+    ThrowStatement(&'b AstNode<'a, 'b, ThrowStatement<'a>>),
+    TryStatement(&'b AstNode<'a, 'b, TryStatement<'a>>),
+    CatchClause(&'b AstNode<'a, 'b, CatchClause<'a>>),
+    CatchParameter(&'b AstNode<'a, 'b, CatchParameter<'a>>),
+    DebuggerStatement(&'b AstNode<'a, 'b, DebuggerStatement>),
+    AssignmentPattern(&'b AstNode<'a, 'b, AssignmentPattern<'a>>),
+    ObjectPattern(&'b AstNode<'a, 'b, ObjectPattern<'a>>),
+    BindingProperty(&'b AstNode<'a, 'b, BindingProperty<'a>>),
+    ArrayPattern(&'b AstNode<'a, 'b, ArrayPattern<'a>>),
+    BindingRestElement(&'b AstNode<'a, 'b, BindingRestElement<'a>>),
+    Function(&'b AstNode<'a, 'b, Function<'a>>),
+    FormalParameters(&'b AstNode<'a, 'b, FormalParameters<'a>>),
+    FormalParameter(&'b AstNode<'a, 'b, FormalParameter<'a>>),
+    FormalParameterRest(&'b AstNode<'a, 'b, FormalParameterRest<'a>>),
+    FunctionBody(&'b AstNode<'a, 'b, FunctionBody<'a>>),
+    ArrowFunctionExpression(&'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>),
+    YieldExpression(&'b AstNode<'a, 'b, YieldExpression<'a>>),
+    Class(&'b AstNode<'a, 'b, Class<'a>>),
+    ClassBody(&'b AstNode<'a, 'b, ClassBody<'a>>),
+    MethodDefinition(&'b AstNode<'a, 'b, MethodDefinition<'a>>),
+    PropertyDefinition(&'b AstNode<'a, 'b, PropertyDefinition<'a>>),
+    PrivateIdentifier(&'b AstNode<'a, 'b, PrivateIdentifier<'a>>),
+    StaticBlock(&'b AstNode<'a, 'b, StaticBlock<'a>>),
+    AccessorProperty(&'b AstNode<'a, 'b, AccessorProperty<'a>>),
+    ImportExpression(&'b AstNode<'a, 'b, ImportExpression<'a>>),
+    ImportDeclaration(&'b AstNode<'a, 'b, ImportDeclaration<'a>>),
+    ImportSpecifier(&'b AstNode<'a, 'b, ImportSpecifier<'a>>),
+    ImportDefaultSpecifier(&'b AstNode<'a, 'b, ImportDefaultSpecifier<'a>>),
+    ImportNamespaceSpecifier(&'b AstNode<'a, 'b, ImportNamespaceSpecifier<'a>>),
+    WithClause(&'b AstNode<'a, 'b, WithClause<'a>>),
+    ImportAttribute(&'b AstNode<'a, 'b, ImportAttribute<'a>>),
+    ExportNamedDeclaration(&'b AstNode<'a, 'b, ExportNamedDeclaration<'a>>),
+    ExportDefaultDeclaration(&'b AstNode<'a, 'b, ExportDefaultDeclaration<'a>>),
+    ExportAllDeclaration(&'b AstNode<'a, 'b, ExportAllDeclaration<'a>>),
+    ExportSpecifier(&'b AstNode<'a, 'b, ExportSpecifier<'a>>),
+    V8IntrinsicExpression(&'b AstNode<'a, 'b, V8IntrinsicExpression<'a>>),
+    BooleanLiteral(&'b AstNode<'a, 'b, BooleanLiteral>),
+    NullLiteral(&'b AstNode<'a, 'b, NullLiteral>),
+    NumericLiteral(&'b AstNode<'a, 'b, NumericLiteral<'a>>),
+    StringLiteral(&'b AstNode<'a, 'b, StringLiteral<'a>>),
+    BigIntLiteral(&'b AstNode<'a, 'b, BigIntLiteral<'a>>),
+    RegExpLiteral(&'b AstNode<'a, 'b, RegExpLiteral<'a>>),
+    JSXElement(&'b AstNode<'a, 'b, JSXElement<'a>>),
+    JSXOpeningElement(&'b AstNode<'a, 'b, JSXOpeningElement<'a>>),
+    JSXClosingElement(&'b AstNode<'a, 'b, JSXClosingElement<'a>>),
+    JSXFragment(&'b AstNode<'a, 'b, JSXFragment<'a>>),
+    JSXOpeningFragment(&'b AstNode<'a, 'b, JSXOpeningFragment>),
+    JSXClosingFragment(&'b AstNode<'a, 'b, JSXClosingFragment>),
+    JSXNamespacedName(&'b AstNode<'a, 'b, JSXNamespacedName<'a>>),
+    JSXMemberExpression(&'b AstNode<'a, 'b, JSXMemberExpression<'a>>),
+    JSXExpressionContainer(&'b AstNode<'a, 'b, JSXExpressionContainer<'a>>),
+    JSXEmptyExpression(&'b AstNode<'a, 'b, JSXEmptyExpression>),
+    JSXAttribute(&'b AstNode<'a, 'b, JSXAttribute<'a>>),
+    JSXSpreadAttribute(&'b AstNode<'a, 'b, JSXSpreadAttribute<'a>>),
+    JSXIdentifier(&'b AstNode<'a, 'b, JSXIdentifier<'a>>),
+    JSXSpreadChild(&'b AstNode<'a, 'b, JSXSpreadChild<'a>>),
+    JSXText(&'b AstNode<'a, 'b, JSXText<'a>>),
+    TSThisParameter(&'b AstNode<'a, 'b, TSThisParameter<'a>>),
+    TSEnumDeclaration(&'b AstNode<'a, 'b, TSEnumDeclaration<'a>>),
+    TSEnumBody(&'b AstNode<'a, 'b, TSEnumBody<'a>>),
+    TSEnumMember(&'b AstNode<'a, 'b, TSEnumMember<'a>>),
+    TSTypeAnnotation(&'b AstNode<'a, 'b, TSTypeAnnotation<'a>>),
+    TSLiteralType(&'b AstNode<'a, 'b, TSLiteralType<'a>>),
+    TSConditionalType(&'b AstNode<'a, 'b, TSConditionalType<'a>>),
+    TSUnionType(&'b AstNode<'a, 'b, TSUnionType<'a>>),
+    TSIntersectionType(&'b AstNode<'a, 'b, TSIntersectionType<'a>>),
+    TSParenthesizedType(&'b AstNode<'a, 'b, TSParenthesizedType<'a>>),
+    TSTypeOperator(&'b AstNode<'a, 'b, TSTypeOperator<'a>>),
+    TSArrayType(&'b AstNode<'a, 'b, TSArrayType<'a>>),
+    TSIndexedAccessType(&'b AstNode<'a, 'b, TSIndexedAccessType<'a>>),
+    TSTupleType(&'b AstNode<'a, 'b, TSTupleType<'a>>),
+    TSNamedTupleMember(&'b AstNode<'a, 'b, TSNamedTupleMember<'a>>),
+    TSOptionalType(&'b AstNode<'a, 'b, TSOptionalType<'a>>),
+    TSRestType(&'b AstNode<'a, 'b, TSRestType<'a>>),
+    TSAnyKeyword(&'b AstNode<'a, 'b, TSAnyKeyword>),
+    TSStringKeyword(&'b AstNode<'a, 'b, TSStringKeyword>),
+    TSBooleanKeyword(&'b AstNode<'a, 'b, TSBooleanKeyword>),
+    TSNumberKeyword(&'b AstNode<'a, 'b, TSNumberKeyword>),
+    TSNeverKeyword(&'b AstNode<'a, 'b, TSNeverKeyword>),
+    TSIntrinsicKeyword(&'b AstNode<'a, 'b, TSIntrinsicKeyword>),
+    TSUnknownKeyword(&'b AstNode<'a, 'b, TSUnknownKeyword>),
+    TSNullKeyword(&'b AstNode<'a, 'b, TSNullKeyword>),
+    TSUndefinedKeyword(&'b AstNode<'a, 'b, TSUndefinedKeyword>),
+    TSVoidKeyword(&'b AstNode<'a, 'b, TSVoidKeyword>),
+    TSSymbolKeyword(&'b AstNode<'a, 'b, TSSymbolKeyword>),
+    TSThisType(&'b AstNode<'a, 'b, TSThisType>),
+    TSObjectKeyword(&'b AstNode<'a, 'b, TSObjectKeyword>),
+    TSBigIntKeyword(&'b AstNode<'a, 'b, TSBigIntKeyword>),
+    TSTypeReference(&'b AstNode<'a, 'b, TSTypeReference<'a>>),
+    TSQualifiedName(&'b AstNode<'a, 'b, TSQualifiedName<'a>>),
+    TSTypeParameterInstantiation(&'b AstNode<'a, 'b, TSTypeParameterInstantiation<'a>>),
+    TSTypeParameter(&'b AstNode<'a, 'b, TSTypeParameter<'a>>),
+    TSTypeParameterDeclaration(&'b AstNode<'a, 'b, TSTypeParameterDeclaration<'a>>),
+    TSTypeAliasDeclaration(&'b AstNode<'a, 'b, TSTypeAliasDeclaration<'a>>),
+    TSClassImplements(&'b AstNode<'a, 'b, TSClassImplements<'a>>),
+    TSInterfaceDeclaration(&'b AstNode<'a, 'b, TSInterfaceDeclaration<'a>>),
+    TSInterfaceBody(&'b AstNode<'a, 'b, TSInterfaceBody<'a>>),
+    TSPropertySignature(&'b AstNode<'a, 'b, TSPropertySignature<'a>>),
+    TSIndexSignature(&'b AstNode<'a, 'b, TSIndexSignature<'a>>),
+    TSCallSignatureDeclaration(&'b AstNode<'a, 'b, TSCallSignatureDeclaration<'a>>),
+    TSMethodSignature(&'b AstNode<'a, 'b, TSMethodSignature<'a>>),
+    TSConstructSignatureDeclaration(&'b AstNode<'a, 'b, TSConstructSignatureDeclaration<'a>>),
+    TSIndexSignatureName(&'b AstNode<'a, 'b, TSIndexSignatureName<'a>>),
+    TSInterfaceHeritage(&'b AstNode<'a, 'b, TSInterfaceHeritage<'a>>),
+    TSTypePredicate(&'b AstNode<'a, 'b, TSTypePredicate<'a>>),
+    TSModuleDeclaration(&'b AstNode<'a, 'b, TSModuleDeclaration<'a>>),
+    TSGlobalDeclaration(&'b AstNode<'a, 'b, TSGlobalDeclaration<'a>>),
+    TSModuleBlock(&'b AstNode<'a, 'b, TSModuleBlock<'a>>),
+    TSTypeLiteral(&'b AstNode<'a, 'b, TSTypeLiteral<'a>>),
+    TSInferType(&'b AstNode<'a, 'b, TSInferType<'a>>),
+    TSTypeQuery(&'b AstNode<'a, 'b, TSTypeQuery<'a>>),
+    TSImportType(&'b AstNode<'a, 'b, TSImportType<'a>>),
+    TSImportTypeQualifiedName(&'b AstNode<'a, 'b, TSImportTypeQualifiedName<'a>>),
+    TSFunctionType(&'b AstNode<'a, 'b, TSFunctionType<'a>>),
+    TSConstructorType(&'b AstNode<'a, 'b, TSConstructorType<'a>>),
+    TSMappedType(&'b AstNode<'a, 'b, TSMappedType<'a>>),
+    TSTemplateLiteralType(&'b AstNode<'a, 'b, TSTemplateLiteralType<'a>>),
+    TSAsExpression(&'b AstNode<'a, 'b, TSAsExpression<'a>>),
+    TSSatisfiesExpression(&'b AstNode<'a, 'b, TSSatisfiesExpression<'a>>),
+    TSTypeAssertion(&'b AstNode<'a, 'b, TSTypeAssertion<'a>>),
+    TSImportEqualsDeclaration(&'b AstNode<'a, 'b, TSImportEqualsDeclaration<'a>>),
+    TSExternalModuleReference(&'b AstNode<'a, 'b, TSExternalModuleReference<'a>>),
+    TSNonNullExpression(&'b AstNode<'a, 'b, TSNonNullExpression<'a>>),
+    Decorator(&'b AstNode<'a, 'b, Decorator<'a>>),
+    TSExportAssignment(&'b AstNode<'a, 'b, TSExportAssignment<'a>>),
+    TSNamespaceExportDeclaration(&'b AstNode<'a, 'b, TSNamespaceExportDeclaration<'a>>),
+    TSInstantiationExpression(&'b AstNode<'a, 'b, TSInstantiationExpression<'a>>),
+    JSDocNullableType(&'b AstNode<'a, 'b, JSDocNullableType<'a>>),
+    JSDocNonNullableType(&'b AstNode<'a, 'b, JSDocNonNullableType<'a>>),
+    JSDocUnknownType(&'b AstNode<'a, 'b, JSDocUnknownType>),
 }
-impl AstNodes<'_> {
+impl AstNodes<'_, '_> {
     #[inline]
     pub fn span(&self) -> Span {
         match self {
@@ -800,7 +791,7 @@ impl AstNodes<'_> {
     }
 }
 
-impl<'a> AstNode<'a, Program<'a>> {
+impl<'a> AstNode<'a, '_, Program<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -822,7 +813,7 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 
     #[inline]
-    pub fn hashbang(&self) -> Option<&AstNode<'a, Hashbang<'a>>> {
+    pub fn hashbang<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Hashbang<'a>>> {
         let following_span_start = self
             .inner
             .directives
@@ -831,18 +822,19 @@ impl<'a> AstNode<'a, Program<'a>> {
             .or_else(|| self.inner.body.first().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.hashbang.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::Program(transmute_self(self)),
+                parent: AstNodes::Program(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
+    pub fn directives<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Directive<'a>>> {
         let following_span_start = self
             .inner
             .body
@@ -850,21 +842,23 @@ impl<'a> AstNode<'a, Program<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
-            parent: AstNodes::Program(transmute_self(self)),
+            parent: AstNodes::Program(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::Program(transmute_self(self)),
+            parent: AstNodes::Program(self),
             following_span_start,
         })
     }
@@ -879,27 +873,32 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Expression<'a>> {
+impl<'a> AstNode<'a, '_, Expression<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             Expression::BooleanLiteral(s) => {
-                AstNodes::BooleanLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BooleanLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Expression::NullLiteral(s) => AstNodes::NullLiteral(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Expression::NullLiteral(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::NullLiteral(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             Expression::NumericLiteral(s) => {
-                AstNodes::NumericLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::NumericLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -907,7 +906,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::BigIntLiteral(s) => {
-                AstNodes::BigIntLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BigIntLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -915,7 +915,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::RegExpLiteral(s) => {
-                AstNodes::RegExpLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::RegExpLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -923,7 +924,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::StringLiteral(s) => {
-                AstNodes::StringLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -931,7 +933,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::TemplateLiteral(s) => {
-                AstNodes::TemplateLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TemplateLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -939,27 +942,35 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::Identifier(s) => {
-                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Expression::MetaProperty(s) => AstNodes::MetaProperty(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            Expression::Super(s) => AstNodes::Super(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Expression::MetaProperty(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::MetaProperty(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            Expression::Super(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Super(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             Expression::ArrayExpression(s) => {
-                AstNodes::ArrayExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ArrayExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -967,7 +978,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::ArrowFunctionExpression(s) => {
-                AstNodes::ArrowFunctionExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ArrowFunctionExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -975,7 +987,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::AssignmentExpression(s) => {
-                AstNodes::AssignmentExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::AssignmentExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -983,7 +996,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::AwaitExpression(s) => {
-                AstNodes::AwaitExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::AwaitExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -991,7 +1005,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::BinaryExpression(s) => {
-                AstNodes::BinaryExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BinaryExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -999,7 +1014,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::CallExpression(s) => {
-                AstNodes::CallExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::CallExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1007,21 +1023,26 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::ChainExpression(s) => {
-                AstNodes::ChainExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ChainExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Expression::ClassExpression(s) => AstNodes::Class(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Expression::ClassExpression(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Class(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             Expression::ConditionalExpression(s) => {
-                AstNodes::ConditionalExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ConditionalExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1029,7 +1050,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::FunctionExpression(s) => {
-                AstNodes::Function(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Function(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1037,7 +1059,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::ImportExpression(s) => {
-                AstNodes::ImportExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ImportExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1045,7 +1068,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::LogicalExpression(s) => {
-                AstNodes::LogicalExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::LogicalExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1053,7 +1077,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::NewExpression(s) => {
-                AstNodes::NewExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::NewExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1061,7 +1086,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::ObjectExpression(s) => {
-                AstNodes::ObjectExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ObjectExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1069,7 +1095,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::ParenthesizedExpression(s) => {
-                AstNodes::ParenthesizedExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ParenthesizedExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1077,7 +1104,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::SequenceExpression(s) => {
-                AstNodes::SequenceExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::SequenceExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1085,7 +1113,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::TaggedTemplateExpression(s) => {
-                AstNodes::TaggedTemplateExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TaggedTemplateExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1093,7 +1122,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::ThisExpression(s) => {
-                AstNodes::ThisExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ThisExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1101,7 +1131,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::UnaryExpression(s) => {
-                AstNodes::UnaryExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::UnaryExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1109,7 +1140,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::UpdateExpression(s) => {
-                AstNodes::UpdateExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::UpdateExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1117,7 +1149,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::YieldExpression(s) => {
-                AstNodes::YieldExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::YieldExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1125,27 +1158,35 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::PrivateInExpression(s) => {
-                AstNodes::PrivateInExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::PrivateInExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Expression::JSXElement(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            Expression::JSXFragment(s) => AstNodes::JSXFragment(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Expression::JSXElement(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXElement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            Expression::JSXFragment(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXFragment(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             Expression::TSAsExpression(s) => {
-                AstNodes::TSAsExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSAsExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1153,7 +1194,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::TSSatisfiesExpression(s) => {
-                AstNodes::TSSatisfiesExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSSatisfiesExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1161,7 +1203,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::TSTypeAssertion(s) => {
-                AstNodes::TSTypeAssertion(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypeAssertion(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1169,7 +1212,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::TSNonNullExpression(s) => {
-                AstNodes::TSNonNullExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNonNullExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1177,7 +1221,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::TSInstantiationExpression(s) => {
-                AstNodes::TSInstantiationExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSInstantiationExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1185,7 +1230,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             Expression::V8IntrinsicExpression(s) => {
-                AstNodes::V8IntrinsicExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::V8IntrinsicExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1193,8 +1239,8 @@ impl<'a> AstNode<'a, Expression<'a>> {
                 }))
             }
             it @ match_member_expression!(Expression) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_member_expression(),
                         parent,
@@ -1204,11 +1250,12 @@ impl<'a> AstNode<'a, Expression<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, IdentifierName<'a>> {
+impl<'a> AstNode<'a, '_, IdentifierName<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1229,7 +1276,7 @@ impl<'a> AstNode<'a, IdentifierName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, IdentifierReference<'a>> {
+impl<'a> AstNode<'a, '_, IdentifierReference<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1250,7 +1297,7 @@ impl<'a> AstNode<'a, IdentifierReference<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BindingIdentifier<'a>> {
+impl<'a> AstNode<'a, '_, BindingIdentifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1271,7 +1318,7 @@ impl<'a> AstNode<'a, BindingIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, LabelIdentifier<'a>> {
+impl<'a> AstNode<'a, '_, LabelIdentifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1292,7 +1339,7 @@ impl<'a> AstNode<'a, LabelIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ThisExpression> {
+impl<'a> AstNode<'a, '_, ThisExpression> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1308,19 +1355,20 @@ impl<'a> AstNode<'a, ThisExpression> {
     }
 }
 
-impl<'a> AstNode<'a, ArrayExpression<'a>> {
+impl<'a> AstNode<'a, '_, ArrayExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn elements(&self) -> &AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>> {
+    pub fn elements<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, ArrayExpressionElement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
-            parent: AstNodes::ArrayExpression(transmute_self(self)),
+            parent: AstNodes::ArrayExpression(self),
             following_span_start,
         })
     }
@@ -1335,13 +1383,14 @@ impl<'a> AstNode<'a, ArrayExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
+impl<'a> AstNode<'a, '_, ArrayExpressionElement<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ArrayExpressionElement::SpreadElement(s) => {
-                AstNodes::SpreadElement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::SpreadElement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1349,7 +1398,8 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                 }))
             }
             ArrayExpressionElement::Elision(s) => {
-                AstNodes::Elision(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Elision(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1357,8 +1407,8 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                 }))
             }
             it @ match_expression!(ArrayExpressionElement) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_expression(),
                         parent,
@@ -1368,11 +1418,12 @@ impl<'a> AstNode<'a, ArrayExpressionElement<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, Elision> {
+impl<'a> AstNode<'a, '_, Elision> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1388,19 +1439,20 @@ impl<'a> AstNode<'a, Elision> {
     }
 }
 
-impl<'a> AstNode<'a, ObjectExpression<'a>> {
+impl<'a> AstNode<'a, '_, ObjectExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn properties(&self) -> &AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
+    pub fn properties<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, ObjectPropertyKind<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
-            parent: AstNodes::ObjectExpression(transmute_self(self)),
+            parent: AstNodes::ObjectExpression(self),
             following_span_start,
         })
     }
@@ -1415,13 +1467,14 @@ impl<'a> AstNode<'a, ObjectExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ObjectPropertyKind<'a>> {
+impl<'a> AstNode<'a, '_, ObjectPropertyKind<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ObjectPropertyKind::ObjectProperty(s) => {
-                AstNodes::ObjectProperty(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ObjectProperty(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1429,7 +1482,8 @@ impl<'a> AstNode<'a, ObjectPropertyKind<'a>> {
                 }))
             }
             ObjectPropertyKind::SpreadProperty(s) => {
-                AstNodes::SpreadElement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::SpreadElement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1437,11 +1491,12 @@ impl<'a> AstNode<'a, ObjectPropertyKind<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ObjectProperty<'a>> {
+impl<'a> AstNode<'a, '_, ObjectProperty<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1453,23 +1508,25 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self.inner.value.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::ObjectProperty(transmute_self(self)),
+            parent: AstNodes::ObjectProperty(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn value(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn value<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
-            parent: AstNodes::ObjectProperty(transmute_self(self)),
+            parent: AstNodes::ObjectProperty(self),
             following_span_start,
         })
     }
@@ -1499,13 +1556,14 @@ impl<'a> AstNode<'a, ObjectProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PropertyKey<'a>> {
+impl<'a> AstNode<'a, '_, PropertyKey<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             PropertyKey::StaticIdentifier(s) => {
-                AstNodes::IdentifierName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1513,7 +1571,8 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                 }))
             }
             PropertyKey::PrivateIdentifier(s) => {
-                AstNodes::PrivateIdentifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::PrivateIdentifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1521,8 +1580,8 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                 }))
             }
             it @ match_expression!(PropertyKey) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_expression(),
                         parent,
@@ -1532,18 +1591,19 @@ impl<'a> AstNode<'a, PropertyKey<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TemplateLiteral<'a>> {
+impl<'a> AstNode<'a, '_, TemplateLiteral<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
+    pub fn quasis<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TemplateElement<'a>>> {
         let following_span_start = self
             .inner
             .expressions
@@ -1551,21 +1611,23 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.quasis,
             allocator: self.allocator,
-            parent: AstNodes::TemplateLiteral(transmute_self(self)),
+            parent: AstNodes::TemplateLiteral(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
+    pub fn expressions<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expressions,
             allocator: self.allocator,
-            parent: AstNodes::TemplateLiteral(transmute_self(self)),
+            parent: AstNodes::TemplateLiteral(self),
             following_span_start,
         })
     }
@@ -1580,14 +1642,14 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
+impl<'a> AstNode<'a, '_, TaggedTemplateExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn tag(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn tag<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -1595,34 +1657,39 @@ impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.quasi.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.tag,
             allocator: self.allocator,
-            parent: AstNodes::TaggedTemplateExpression(transmute_self(self)),
+            parent: AstNodes::TaggedTemplateExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self.inner.quasi.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TaggedTemplateExpression(transmute_self(self)),
+                parent: AstNodes::TaggedTemplateExpression(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn quasi(&self) -> &AstNode<'a, TemplateLiteral<'a>> {
+    pub fn quasi<'c>(&'c self) -> &'c AstNode<'a, 'c, TemplateLiteral<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.quasi,
             allocator: self.allocator,
-            parent: AstNodes::TaggedTemplateExpression(transmute_self(self)),
+            parent: AstNodes::TaggedTemplateExpression(self),
             following_span_start,
         })
     }
@@ -1637,7 +1704,7 @@ impl<'a> AstNode<'a, TaggedTemplateExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TemplateElement<'a>> {
+impl<'a> AstNode<'a, '_, TemplateElement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -1668,13 +1735,14 @@ impl<'a> AstNode<'a, TemplateElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, MemberExpression<'a>> {
+impl<'a> AstNode<'a, '_, MemberExpression<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             MemberExpression::ComputedMemberExpression(s) => {
-                AstNodes::ComputedMemberExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ComputedMemberExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1682,7 +1750,8 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                 }))
             }
             MemberExpression::StaticMemberExpression(s) => {
-                AstNodes::StaticMemberExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StaticMemberExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1690,7 +1759,8 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                 }))
             }
             MemberExpression::PrivateFieldExpression(s) => {
-                AstNodes::PrivateFieldExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::PrivateFieldExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -1698,34 +1768,37 @@ impl<'a> AstNode<'a, MemberExpression<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
+impl<'a> AstNode<'a, '_, ComputedMemberExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn object<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.expression.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
-            parent: AstNodes::ComputedMemberExpression(transmute_self(self)),
+            parent: AstNodes::ComputedMemberExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::ComputedMemberExpression(transmute_self(self)),
+            parent: AstNodes::ComputedMemberExpression(self),
             following_span_start,
         })
     }
@@ -1745,30 +1818,32 @@ impl<'a> AstNode<'a, ComputedMemberExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
+impl<'a> AstNode<'a, '_, StaticMemberExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn object<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.property.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
-            parent: AstNodes::StaticMemberExpression(transmute_self(self)),
+            parent: AstNodes::StaticMemberExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn property(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn property<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
-            parent: AstNodes::StaticMemberExpression(transmute_self(self)),
+            parent: AstNodes::StaticMemberExpression(self),
             following_span_start,
         })
     }
@@ -1788,30 +1863,32 @@ impl<'a> AstNode<'a, StaticMemberExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
+impl<'a> AstNode<'a, '_, PrivateFieldExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn object<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.field.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
-            parent: AstNodes::PrivateFieldExpression(transmute_self(self)),
+            parent: AstNodes::PrivateFieldExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn field(&self) -> &AstNode<'a, PrivateIdentifier<'a>> {
+    pub fn field<'c>(&'c self) -> &'c AstNode<'a, 'c, PrivateIdentifier<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.field,
             allocator: self.allocator,
-            parent: AstNodes::PrivateFieldExpression(transmute_self(self)),
+            parent: AstNodes::PrivateFieldExpression(self),
             following_span_start,
         })
     }
@@ -1831,14 +1908,14 @@ impl<'a> AstNode<'a, PrivateFieldExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, CallExpression<'a>> {
+impl<'a> AstNode<'a, '_, CallExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn callee<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -1847,16 +1924,19 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
             .or_else(|| self.inner.arguments.first().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.callee,
             allocator: self.allocator,
-            parent: AstNodes::CallExpression(transmute_self(self)),
+            parent: AstNodes::CallExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self
             .inner
             .arguments
@@ -1864,23 +1944,25 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::CallExpression(transmute_self(self)),
+                parent: AstNodes::CallExpression(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
+    pub fn arguments<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Argument<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
-            parent: AstNodes::CallExpression(transmute_self(self)),
+            parent: AstNodes::CallExpression(self),
             following_span_start,
         })
     }
@@ -1905,14 +1987,14 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, NewExpression<'a>> {
+impl<'a> AstNode<'a, '_, NewExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn callee(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn callee<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -1921,16 +2003,19 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
             .or_else(|| self.inner.arguments.first().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.callee,
             allocator: self.allocator,
-            parent: AstNodes::NewExpression(transmute_self(self)),
+            parent: AstNodes::NewExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self
             .inner
             .arguments
@@ -1938,23 +2023,25 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::NewExpression(transmute_self(self)),
+                parent: AstNodes::NewExpression(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
+    pub fn arguments<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Argument<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
-            parent: AstNodes::NewExpression(transmute_self(self)),
+            parent: AstNodes::NewExpression(self),
             following_span_start,
         })
     }
@@ -1974,30 +2061,32 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, MetaProperty<'a>> {
+impl<'a> AstNode<'a, '_, MetaProperty<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn meta(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn meta<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = self.inner.property.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.meta,
             allocator: self.allocator,
-            parent: AstNodes::MetaProperty(transmute_self(self)),
+            parent: AstNodes::MetaProperty(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn property(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn property<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
-            parent: AstNodes::MetaProperty(transmute_self(self)),
+            parent: AstNodes::MetaProperty(self),
             following_span_start,
         })
     }
@@ -2012,19 +2101,20 @@ impl<'a> AstNode<'a, MetaProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SpreadElement<'a>> {
+impl<'a> AstNode<'a, '_, SpreadElement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn argument<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
-            parent: AstNodes::SpreadElement(transmute_self(self)),
+            parent: AstNodes::SpreadElement(self),
             following_span_start,
         })
     }
@@ -2039,20 +2129,23 @@ impl<'a> AstNode<'a, SpreadElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Argument<'a>> {
+impl<'a> AstNode<'a, '_, Argument<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
-            Argument::SpreadElement(s) => AstNodes::SpreadElement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Argument::SpreadElement(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::SpreadElement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             it @ match_expression!(Argument) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_expression(),
                         parent,
@@ -2062,11 +2155,12 @@ impl<'a> AstNode<'a, Argument<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, UpdateExpression<'a>> {
+impl<'a> AstNode<'a, '_, UpdateExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -2083,12 +2177,13 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
     }
 
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, SimpleAssignmentTarget<'a>> {
+    pub fn argument<'c>(&'c self) -> &'c AstNode<'a, 'c, SimpleAssignmentTarget<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
-            parent: AstNodes::UpdateExpression(transmute_self(self)),
+            parent: AstNodes::UpdateExpression(self),
             following_span_start,
         })
     }
@@ -2103,7 +2198,7 @@ impl<'a> AstNode<'a, UpdateExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, UnaryExpression<'a>> {
+impl<'a> AstNode<'a, '_, UnaryExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -2115,12 +2210,13 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
     }
 
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn argument<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
-            parent: AstNodes::UnaryExpression(transmute_self(self)),
+            parent: AstNodes::UnaryExpression(self),
             following_span_start,
         })
     }
@@ -2135,19 +2231,20 @@ impl<'a> AstNode<'a, UnaryExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BinaryExpression<'a>> {
+impl<'a> AstNode<'a, '_, BinaryExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::BinaryExpression(transmute_self(self)),
+            parent: AstNodes::BinaryExpression(self),
             following_span_start,
         })
     }
@@ -2158,12 +2255,13 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::BinaryExpression(transmute_self(self)),
+            parent: AstNodes::BinaryExpression(self),
             following_span_start,
         })
     }
@@ -2178,30 +2276,32 @@ impl<'a> AstNode<'a, BinaryExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PrivateInExpression<'a>> {
+impl<'a> AstNode<'a, '_, PrivateInExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, PrivateIdentifier<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, PrivateIdentifier<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::PrivateInExpression(transmute_self(self)),
+            parent: AstNodes::PrivateInExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::PrivateInExpression(transmute_self(self)),
+            parent: AstNodes::PrivateInExpression(self),
             following_span_start,
         })
     }
@@ -2216,19 +2316,20 @@ impl<'a> AstNode<'a, PrivateInExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, LogicalExpression<'a>> {
+impl<'a> AstNode<'a, '_, LogicalExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::LogicalExpression(transmute_self(self)),
+            parent: AstNodes::LogicalExpression(self),
             following_span_start,
         })
     }
@@ -2239,12 +2340,13 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::LogicalExpression(transmute_self(self)),
+            parent: AstNodes::LogicalExpression(self),
             following_span_start,
         })
     }
@@ -2259,41 +2361,44 @@ impl<'a> AstNode<'a, LogicalExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ConditionalExpression<'a>> {
+impl<'a> AstNode<'a, '_, ConditionalExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn test<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.consequent.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
-            parent: AstNodes::ConditionalExpression(transmute_self(self)),
+            parent: AstNodes::ConditionalExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn consequent(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn consequent<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.alternate.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
-            parent: AstNodes::ConditionalExpression(transmute_self(self)),
+            parent: AstNodes::ConditionalExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn alternate(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn alternate<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.alternate,
             allocator: self.allocator,
-            parent: AstNodes::ConditionalExpression(transmute_self(self)),
+            parent: AstNodes::ConditionalExpression(self),
             following_span_start,
         })
     }
@@ -2308,7 +2413,7 @@ impl<'a> AstNode<'a, ConditionalExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentExpression<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -2320,23 +2425,25 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, AssignmentTarget<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentExpression(transmute_self(self)),
+            parent: AstNodes::AssignmentExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentExpression(transmute_self(self)),
+            parent: AstNodes::AssignmentExpression(self),
             following_span_start,
         })
     }
@@ -2351,15 +2458,15 @@ impl<'a> AstNode<'a, AssignmentExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTarget<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTarget<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         #[expect(clippy::needless_return)]
         match self.inner {
             it @ match_simple_assignment_target!(AssignmentTarget) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_simple_assignment_target(),
                         parent,
@@ -2369,8 +2476,8 @@ impl<'a> AstNode<'a, AssignmentTarget<'a>> {
                     .as_ast_nodes();
             }
             it @ match_assignment_target_pattern!(AssignmentTarget) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_assignment_target_pattern(),
                         parent,
@@ -2383,13 +2490,14 @@ impl<'a> AstNode<'a, AssignmentTarget<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
+impl<'a> AstNode<'a, '_, SimpleAssignmentTarget<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             SimpleAssignmentTarget::AssignmentTargetIdentifier(s) => {
-                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2397,7 +2505,8 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                 }))
             }
             SimpleAssignmentTarget::TSAsExpression(s) => {
-                AstNodes::TSAsExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSAsExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2405,7 +2514,8 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                 }))
             }
             SimpleAssignmentTarget::TSSatisfiesExpression(s) => {
-                AstNodes::TSSatisfiesExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSSatisfiesExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2413,7 +2523,8 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                 }))
             }
             SimpleAssignmentTarget::TSNonNullExpression(s) => {
-                AstNodes::TSNonNullExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNonNullExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2421,7 +2532,8 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                 }))
             }
             SimpleAssignmentTarget::TSTypeAssertion(s) => {
-                AstNodes::TSTypeAssertion(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypeAssertion(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2429,8 +2541,8 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                 }))
             }
             it @ match_member_expression!(SimpleAssignmentTarget) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_member_expression(),
                         parent,
@@ -2440,17 +2552,19 @@ impl<'a> AstNode<'a, SimpleAssignmentTarget<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTargetPattern<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             AssignmentTargetPattern::ArrayAssignmentTarget(s) => {
-                AstNodes::ArrayAssignmentTarget(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ArrayAssignmentTarget(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2458,7 +2572,8 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
                 }))
             }
             AssignmentTargetPattern::ObjectAssignmentTarget(s) => {
-                AstNodes::ObjectAssignmentTarget(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ObjectAssignmentTarget(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2466,35 +2581,40 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
+impl<'a> AstNode<'a, '_, ArrayAssignmentTarget<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
+    pub fn elements<'c>(
+        &'c self,
+    ) -> &'c AstNode<'a, 'c, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
-            parent: AstNodes::ArrayAssignmentTarget(transmute_self(self)),
+            parent: AstNodes::ArrayAssignmentTarget(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
+    pub fn rest<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, AssignmentTargetRest<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ArrayAssignmentTarget(transmute_self(self)),
+                parent: AstNodes::ArrayAssignmentTarget(self),
                 following_span_start,
             }))
             .as_ref()
@@ -2510,31 +2630,33 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
+impl<'a> AstNode<'a, '_, ObjectAssignmentTarget<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn properties(&self) -> &AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
+    pub fn properties<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, AssignmentTargetProperty<'a>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
-            parent: AstNodes::ObjectAssignmentTarget(transmute_self(self)),
+            parent: AstNodes::ObjectAssignmentTarget(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
+    pub fn rest<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, AssignmentTargetRest<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ObjectAssignmentTarget(transmute_self(self)),
+                parent: AstNodes::ObjectAssignmentTarget(self),
                 following_span_start,
             }))
             .as_ref()
@@ -2550,19 +2672,20 @@ impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTargetRest<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn target(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
+    pub fn target<'c>(&'c self) -> &'c AstNode<'a, 'c, AssignmentTarget<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.target,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentTargetRest(transmute_self(self)),
+            parent: AstNodes::AssignmentTargetRest(self),
             following_span_start,
         })
     }
@@ -2577,13 +2700,14 @@ impl<'a> AstNode<'a, AssignmentTargetRest<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTargetMaybeDefault<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(s) => {
-                AstNodes::AssignmentTargetWithDefault(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::AssignmentTargetWithDefault(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2591,8 +2715,8 @@ impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                 }))
             }
             it @ match_assignment_target!(AssignmentTargetMaybeDefault) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_assignment_target(),
                         parent,
@@ -2602,34 +2726,37 @@ impl<'a> AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTargetWithDefault<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn binding(&self) -> &AstNode<'a, AssignmentTarget<'a>> {
+    pub fn binding<'c>(&'c self) -> &'c AstNode<'a, 'c, AssignmentTarget<'a>> {
         let following_span_start = self.inner.init.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentTargetWithDefault(transmute_self(self)),
+            parent: AstNodes::AssignmentTargetWithDefault(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn init(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn init<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.init,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentTargetWithDefault(transmute_self(self)),
+            parent: AstNodes::AssignmentTargetWithDefault(self),
             following_span_start,
         })
     }
@@ -2644,13 +2771,14 @@ impl<'a> AstNode<'a, AssignmentTargetWithDefault<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTargetProperty<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(s) => {
-                AstNodes::AssignmentTargetPropertyIdentifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::AssignmentTargetPropertyIdentifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2658,7 +2786,8 @@ impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
                 }))
             }
             AssignmentTargetProperty::AssignmentTargetPropertyProperty(s) => {
-                AstNodes::AssignmentTargetPropertyProperty(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::AssignmentTargetPropertyProperty(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2666,18 +2795,19 @@ impl<'a> AstNode<'a, AssignmentTargetProperty<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTargetPropertyIdentifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn binding(&self) -> &AstNode<'a, IdentifierReference<'a>> {
+    pub fn binding<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierReference<'a>> {
         let following_span_start = self
             .inner
             .init
@@ -2685,22 +2815,24 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentTargetPropertyIdentifier(transmute_self(self)),
+            parent: AstNodes::AssignmentTargetPropertyIdentifier(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn init(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn init<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.init.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::AssignmentTargetPropertyIdentifier(transmute_self(self)),
+                parent: AstNodes::AssignmentTargetPropertyIdentifier(self),
                 following_span_start,
             }))
             .as_ref()
@@ -2716,30 +2848,32 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentTargetPropertyProperty<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn name(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn name<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self.inner.binding.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentTargetPropertyProperty(transmute_self(self)),
+            parent: AstNodes::AssignmentTargetPropertyProperty(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn binding(&self) -> &AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
+    pub fn binding<'c>(&'c self) -> &'c AstNode<'a, 'c, AssignmentTargetMaybeDefault<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.binding,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentTargetPropertyProperty(transmute_self(self)),
+            parent: AstNodes::AssignmentTargetPropertyProperty(self),
             following_span_start,
         })
     }
@@ -2759,19 +2893,20 @@ impl<'a> AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SequenceExpression<'a>> {
+impl<'a> AstNode<'a, '_, SequenceExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
+    pub fn expressions<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expressions,
             allocator: self.allocator,
-            parent: AstNodes::SequenceExpression(transmute_self(self)),
+            parent: AstNodes::SequenceExpression(self),
             following_span_start,
         })
     }
@@ -2786,7 +2921,7 @@ impl<'a> AstNode<'a, SequenceExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Super> {
+impl<'a> AstNode<'a, '_, Super> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -2802,19 +2937,20 @@ impl<'a> AstNode<'a, Super> {
     }
 }
 
-impl<'a> AstNode<'a, AwaitExpression<'a>> {
+impl<'a> AstNode<'a, '_, AwaitExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn argument<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
-            parent: AstNodes::AwaitExpression(transmute_self(self)),
+            parent: AstNodes::AwaitExpression(self),
             following_span_start,
         })
     }
@@ -2829,19 +2965,20 @@ impl<'a> AstNode<'a, AwaitExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ChainExpression<'a>> {
+impl<'a> AstNode<'a, '_, ChainExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, ChainElement<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, ChainElement<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::ChainExpression(transmute_self(self)),
+            parent: AstNodes::ChainExpression(self),
             following_span_start,
         })
     }
@@ -2856,13 +2993,14 @@ impl<'a> AstNode<'a, ChainExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ChainElement<'a>> {
+impl<'a> AstNode<'a, '_, ChainElement<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ChainElement::CallExpression(s) => {
-                AstNodes::CallExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::CallExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2870,7 +3008,8 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                 }))
             }
             ChainElement::TSNonNullExpression(s) => {
-                AstNodes::TSNonNullExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNonNullExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2878,8 +3017,8 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                 }))
             }
             it @ match_member_expression!(ChainElement) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_member_expression(),
                         parent,
@@ -2889,23 +3028,25 @@ impl<'a> AstNode<'a, ChainElement<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
+impl<'a> AstNode<'a, '_, ParenthesizedExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::ParenthesizedExpression(transmute_self(self)),
+            parent: AstNodes::ParenthesizedExpression(self),
             following_span_start,
         })
     }
@@ -2920,13 +3061,14 @@ impl<'a> AstNode<'a, ParenthesizedExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Statement<'a>> {
+impl<'a> AstNode<'a, '_, Statement<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             Statement::BlockStatement(s) => {
-                AstNodes::BlockStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BlockStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2934,7 +3076,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::BreakStatement(s) => {
-                AstNodes::BreakStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BreakStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2942,7 +3085,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::ContinueStatement(s) => {
-                AstNodes::ContinueStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ContinueStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2950,7 +3094,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::DebuggerStatement(s) => {
-                AstNodes::DebuggerStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::DebuggerStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2958,7 +3103,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::DoWhileStatement(s) => {
-                AstNodes::DoWhileStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::DoWhileStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2966,7 +3112,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::EmptyStatement(s) => {
-                AstNodes::EmptyStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::EmptyStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2974,7 +3121,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::ExpressionStatement(s) => {
-                AstNodes::ExpressionStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ExpressionStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2982,7 +3130,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::ForInStatement(s) => {
-                AstNodes::ForInStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ForInStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -2990,27 +3139,35 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::ForOfStatement(s) => {
-                AstNodes::ForOfStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ForOfStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Statement::ForStatement(s) => AstNodes::ForStatement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            Statement::IfStatement(s) => AstNodes::IfStatement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Statement::ForStatement(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ForStatement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            Statement::IfStatement(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IfStatement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             Statement::LabeledStatement(s) => {
-                AstNodes::LabeledStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::LabeledStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3018,7 +3175,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::ReturnStatement(s) => {
-                AstNodes::ReturnStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ReturnStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3026,7 +3184,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::SwitchStatement(s) => {
-                AstNodes::SwitchStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::SwitchStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3034,36 +3193,44 @@ impl<'a> AstNode<'a, Statement<'a>> {
                 }))
             }
             Statement::ThrowStatement(s) => {
-                AstNodes::ThrowStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ThrowStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Statement::TryStatement(s) => AstNodes::TryStatement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Statement::TryStatement(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TryStatement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             Statement::WhileStatement(s) => {
-                AstNodes::WhileStatement(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::WhileStatement(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Statement::WithStatement(s) => AstNodes::WithStatement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Statement::WithStatement(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::WithStatement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             it @ match_declaration!(Statement) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_declaration(),
                         parent,
@@ -3073,8 +3240,8 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     .as_ast_nodes();
             }
             it @ match_module_declaration!(Statement) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_module_declaration(),
                         parent,
@@ -3084,23 +3251,25 @@ impl<'a> AstNode<'a, Statement<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, Directive<'a>> {
+impl<'a> AstNode<'a, '_, Directive<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, StringLiteral<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::Directive(transmute_self(self)),
+            parent: AstNodes::Directive(self),
             following_span_start,
         })
     }
@@ -3120,7 +3289,7 @@ impl<'a> AstNode<'a, Directive<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Hashbang<'a>> {
+impl<'a> AstNode<'a, '_, Hashbang<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -3141,19 +3310,20 @@ impl<'a> AstNode<'a, Hashbang<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BlockStatement<'a>> {
+impl<'a> AstNode<'a, '_, BlockStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Statement<'a>>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::BlockStatement(transmute_self(self)),
+            parent: AstNodes::BlockStatement(self),
             following_span_start,
         })
     }
@@ -3168,13 +3338,14 @@ impl<'a> AstNode<'a, BlockStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Declaration<'a>> {
+impl<'a> AstNode<'a, '_, Declaration<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             Declaration::VariableDeclaration(s) => {
-                AstNodes::VariableDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::VariableDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3182,21 +3353,26 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                 }))
             }
             Declaration::FunctionDeclaration(s) => {
-                AstNodes::Function(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Function(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            Declaration::ClassDeclaration(s) => AstNodes::Class(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            Declaration::ClassDeclaration(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Class(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             Declaration::TSTypeAliasDeclaration(s) => {
-                AstNodes::TSTypeAliasDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypeAliasDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3204,7 +3380,8 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                 }))
             }
             Declaration::TSInterfaceDeclaration(s) => {
-                AstNodes::TSInterfaceDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSInterfaceDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3212,7 +3389,8 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                 }))
             }
             Declaration::TSEnumDeclaration(s) => {
-                AstNodes::TSEnumDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSEnumDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3220,7 +3398,8 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                 }))
             }
             Declaration::TSModuleDeclaration(s) => {
-                AstNodes::TSModuleDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSModuleDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3228,7 +3407,8 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                 }))
             }
             Declaration::TSGlobalDeclaration(s) => {
-                AstNodes::TSGlobalDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSGlobalDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3236,7 +3416,8 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                 }))
             }
             Declaration::TSImportEqualsDeclaration(s) => {
-                AstNodes::TSImportEqualsDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSImportEqualsDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3244,11 +3425,12 @@ impl<'a> AstNode<'a, Declaration<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, VariableDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, VariableDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -3260,12 +3442,13 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn declarations(&self) -> &AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
+    pub fn declarations<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, VariableDeclarator<'a>>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.declarations,
             allocator: self.allocator,
-            parent: AstNodes::VariableDeclaration(transmute_self(self)),
+            parent: AstNodes::VariableDeclaration(self),
             following_span_start,
         })
     }
@@ -3285,7 +3468,7 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, VariableDeclarator<'a>> {
+impl<'a> AstNode<'a, '_, VariableDeclarator<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -3297,7 +3480,7 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, BindingPattern<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingPattern<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -3306,16 +3489,17 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
             .or_else(|| self.inner.init.as_ref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::VariableDeclarator(transmute_self(self)),
+            parent: AstNodes::VariableDeclarator(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self
             .inner
             .init
@@ -3323,24 +3507,26 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::VariableDeclarator(transmute_self(self)),
+                parent: AstNodes::VariableDeclarator(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn init(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn init<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.init.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::VariableDeclarator(transmute_self(self)),
+                parent: AstNodes::VariableDeclarator(self),
                 following_span_start,
             }))
             .as_ref()
@@ -3361,7 +3547,7 @@ impl<'a> AstNode<'a, VariableDeclarator<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, EmptyStatement> {
+impl<'a> AstNode<'a, '_, EmptyStatement> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -3377,19 +3563,20 @@ impl<'a> AstNode<'a, EmptyStatement> {
     }
 }
 
-impl<'a> AstNode<'a, ExpressionStatement<'a>> {
+impl<'a> AstNode<'a, '_, ExpressionStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::ExpressionStatement(transmute_self(self)),
+            parent: AstNodes::ExpressionStatement(self),
             following_span_start,
         })
     }
@@ -3404,42 +3591,45 @@ impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, IfStatement<'a>> {
+impl<'a> AstNode<'a, '_, IfStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn test<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.consequent.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
-            parent: AstNodes::IfStatement(transmute_self(self)),
+            parent: AstNodes::IfStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn consequent(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn consequent<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = self.inner.alternate.as_ref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
-            parent: AstNodes::IfStatement(transmute_self(self)),
+            parent: AstNodes::IfStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn alternate(&self) -> Option<&AstNode<'a, Statement<'a>>> {
+    pub fn alternate<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Statement<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.alternate.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::IfStatement(transmute_self(self)),
+                parent: AstNodes::IfStatement(self),
                 following_span_start,
             }))
             .as_ref()
@@ -3455,30 +3645,32 @@ impl<'a> AstNode<'a, IfStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, DoWhileStatement<'a>> {
+impl<'a> AstNode<'a, '_, DoWhileStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = self.inner.test.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::DoWhileStatement(transmute_self(self)),
+            parent: AstNodes::DoWhileStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn test<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
-            parent: AstNodes::DoWhileStatement(transmute_self(self)),
+            parent: AstNodes::DoWhileStatement(self),
             following_span_start,
         })
     }
@@ -3493,30 +3685,32 @@ impl<'a> AstNode<'a, DoWhileStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, WhileStatement<'a>> {
+impl<'a> AstNode<'a, '_, WhileStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn test(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn test<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.test,
             allocator: self.allocator,
-            parent: AstNodes::WhileStatement(transmute_self(self)),
+            parent: AstNodes::WhileStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::WhileStatement(transmute_self(self)),
+            parent: AstNodes::WhileStatement(self),
             following_span_start,
         })
     }
@@ -3531,14 +3725,14 @@ impl<'a> AstNode<'a, WhileStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ForStatement<'a>> {
+impl<'a> AstNode<'a, '_, ForStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn init(&self) -> Option<&AstNode<'a, ForStatementInit<'a>>> {
+    pub fn init<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, ForStatementInit<'a>>> {
         let following_span_start = self
             .inner
             .test
@@ -3547,18 +3741,19 @@ impl<'a> AstNode<'a, ForStatement<'a>> {
             .or_else(|| self.inner.update.as_ref().map(|n| n.span().start))
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.init.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ForStatement(transmute_self(self)),
+                parent: AstNodes::ForStatement(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn test(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn test<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self
             .inner
             .update
@@ -3566,36 +3761,39 @@ impl<'a> AstNode<'a, ForStatement<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.test.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ForStatement(transmute_self(self)),
+                parent: AstNodes::ForStatement(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn update(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn update<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.update.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ForStatement(transmute_self(self)),
+                parent: AstNodes::ForStatement(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::ForStatement(transmute_self(self)),
+            parent: AstNodes::ForStatement(self),
             following_span_start,
         })
     }
@@ -3610,13 +3808,14 @@ impl<'a> AstNode<'a, ForStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ForStatementInit<'a>> {
+impl<'a> AstNode<'a, '_, ForStatementInit<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ForStatementInit::VariableDeclaration(s) => {
-                AstNodes::VariableDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::VariableDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3624,8 +3823,8 @@ impl<'a> AstNode<'a, ForStatementInit<'a>> {
                 }))
             }
             it @ match_expression!(ForStatementInit) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_expression(),
                         parent,
@@ -3635,45 +3834,49 @@ impl<'a> AstNode<'a, ForStatementInit<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ForInStatement<'a>> {
+impl<'a> AstNode<'a, '_, ForInStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, ForStatementLeft<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, ForStatementLeft<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::ForInStatement(transmute_self(self)),
+            parent: AstNodes::ForInStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::ForInStatement(transmute_self(self)),
+            parent: AstNodes::ForInStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::ForInStatement(transmute_self(self)),
+            parent: AstNodes::ForInStatement(self),
             following_span_start,
         })
     }
@@ -3688,13 +3891,14 @@ impl<'a> AstNode<'a, ForInStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ForStatementLeft<'a>> {
+impl<'a> AstNode<'a, '_, ForStatementLeft<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ForStatementLeft::VariableDeclaration(s) => {
-                AstNodes::VariableDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::VariableDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -3702,8 +3906,8 @@ impl<'a> AstNode<'a, ForStatementLeft<'a>> {
                 }))
             }
             it @ match_assignment_target!(ForStatementLeft) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_assignment_target(),
                         parent,
@@ -3713,11 +3917,12 @@ impl<'a> AstNode<'a, ForStatementLeft<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ForOfStatement<'a>> {
+impl<'a> AstNode<'a, '_, ForOfStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -3729,34 +3934,37 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, ForStatementLeft<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, ForStatementLeft<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::ForOfStatement(transmute_self(self)),
+            parent: AstNodes::ForOfStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::ForOfStatement(transmute_self(self)),
+            parent: AstNodes::ForOfStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::ForOfStatement(transmute_self(self)),
+            parent: AstNodes::ForOfStatement(self),
             following_span_start,
         })
     }
@@ -3771,20 +3979,21 @@ impl<'a> AstNode<'a, ForOfStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ContinueStatement<'a>> {
+impl<'a> AstNode<'a, '_, ContinueStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
+    pub fn label<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, LabelIdentifier<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.label.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ContinueStatement(transmute_self(self)),
+                parent: AstNodes::ContinueStatement(self),
                 following_span_start,
             }))
             .as_ref()
@@ -3800,20 +4009,21 @@ impl<'a> AstNode<'a, ContinueStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BreakStatement<'a>> {
+impl<'a> AstNode<'a, '_, BreakStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn label(&self) -> Option<&AstNode<'a, LabelIdentifier<'a>>> {
+    pub fn label<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, LabelIdentifier<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.label.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::BreakStatement(transmute_self(self)),
+                parent: AstNodes::BreakStatement(self),
                 following_span_start,
             }))
             .as_ref()
@@ -3829,20 +4039,21 @@ impl<'a> AstNode<'a, BreakStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ReturnStatement<'a>> {
+impl<'a> AstNode<'a, '_, ReturnStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn argument(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn argument<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.argument.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ReturnStatement(transmute_self(self)),
+                parent: AstNodes::ReturnStatement(self),
                 following_span_start,
             }))
             .as_ref()
@@ -3858,30 +4069,32 @@ impl<'a> AstNode<'a, ReturnStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, WithStatement<'a>> {
+impl<'a> AstNode<'a, '_, WithStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn object(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn object<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
-            parent: AstNodes::WithStatement(transmute_self(self)),
+            parent: AstNodes::WithStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::WithStatement(transmute_self(self)),
+            parent: AstNodes::WithStatement(self),
             following_span_start,
         })
     }
@@ -3896,30 +4109,32 @@ impl<'a> AstNode<'a, WithStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SwitchStatement<'a>> {
+impl<'a> AstNode<'a, '_, SwitchStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn discriminant(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn discriminant<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.cases.first().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.discriminant,
             allocator: self.allocator,
-            parent: AstNodes::SwitchStatement(transmute_self(self)),
+            parent: AstNodes::SwitchStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn cases(&self) -> &AstNode<'a, Vec<'a, SwitchCase<'a>>> {
+    pub fn cases<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, SwitchCase<'a>>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.cases,
             allocator: self.allocator,
-            parent: AstNodes::SwitchStatement(transmute_self(self)),
+            parent: AstNodes::SwitchStatement(self),
             following_span_start,
         })
     }
@@ -3934,14 +4149,14 @@ impl<'a> AstNode<'a, SwitchStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, SwitchCase<'a>> {
+impl<'a> AstNode<'a, '_, SwitchCase<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn test(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn test<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self
             .inner
             .consequent
@@ -3949,23 +4164,25 @@ impl<'a> AstNode<'a, SwitchCase<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.test.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::SwitchCase(transmute_self(self)),
+                parent: AstNodes::SwitchCase(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn consequent(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn consequent<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.consequent,
             allocator: self.allocator,
-            parent: AstNodes::SwitchCase(transmute_self(self)),
+            parent: AstNodes::SwitchCase(self),
             following_span_start,
         })
     }
@@ -3980,30 +4197,32 @@ impl<'a> AstNode<'a, SwitchCase<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, LabeledStatement<'a>> {
+impl<'a> AstNode<'a, '_, LabeledStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn label(&self) -> &AstNode<'a, LabelIdentifier<'a>> {
+    pub fn label<'c>(&'c self) -> &'c AstNode<'a, 'c, LabelIdentifier<'a>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.label,
             allocator: self.allocator,
-            parent: AstNodes::LabeledStatement(transmute_self(self)),
+            parent: AstNodes::LabeledStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Statement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Statement<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::LabeledStatement(transmute_self(self)),
+            parent: AstNodes::LabeledStatement(self),
             following_span_start,
         })
     }
@@ -4018,19 +4237,20 @@ impl<'a> AstNode<'a, LabeledStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ThrowStatement<'a>> {
+impl<'a> AstNode<'a, '_, ThrowStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn argument<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
-            parent: AstNodes::ThrowStatement(transmute_self(self)),
+            parent: AstNodes::ThrowStatement(self),
             following_span_start,
         })
     }
@@ -4045,14 +4265,14 @@ impl<'a> AstNode<'a, ThrowStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TryStatement<'a>> {
+impl<'a> AstNode<'a, '_, TryStatement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn block(&self) -> &AstNode<'a, BlockStatement<'a>> {
+    pub fn block<'c>(&'c self) -> &'c AstNode<'a, 'c, BlockStatement<'a>> {
         let following_span_start = self
             .inner
             .handler
@@ -4060,35 +4280,38 @@ impl<'a> AstNode<'a, TryStatement<'a>> {
             .map(|n| n.span().start)
             .or_else(|| self.inner.finalizer.as_deref().map(|n| n.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.block.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TryStatement(transmute_self(self)),
+            parent: AstNodes::TryStatement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn handler(&self) -> Option<&AstNode<'a, CatchClause<'a>>> {
+    pub fn handler<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, CatchClause<'a>>> {
         let following_span_start = self.inner.finalizer.as_deref().map_or(0, |n| n.span().start);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.handler.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TryStatement(transmute_self(self)),
+                parent: AstNodes::TryStatement(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn finalizer(&self) -> Option<&AstNode<'a, BlockStatement<'a>>> {
+    pub fn finalizer<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, BlockStatement<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.finalizer.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TryStatement(transmute_self(self)),
+                parent: AstNodes::TryStatement(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4104,32 +4327,34 @@ impl<'a> AstNode<'a, TryStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, CatchClause<'a>> {
+impl<'a> AstNode<'a, '_, CatchClause<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn param(&self) -> Option<&AstNode<'a, CatchParameter<'a>>> {
+    pub fn param<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, CatchParameter<'a>>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.param.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::CatchClause(transmute_self(self)),
+                parent: AstNodes::CatchClause(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, BlockStatement<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, BlockStatement<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::CatchClause(transmute_self(self)),
+            parent: AstNodes::CatchClause(self),
             following_span_start,
         })
     }
@@ -4144,14 +4369,14 @@ impl<'a> AstNode<'a, CatchClause<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, CatchParameter<'a>> {
+impl<'a> AstNode<'a, '_, CatchParameter<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn pattern(&self) -> &AstNode<'a, BindingPattern<'a>> {
+    pub fn pattern<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingPattern<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -4159,22 +4384,24 @@ impl<'a> AstNode<'a, CatchParameter<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.pattern,
             allocator: self.allocator,
-            parent: AstNodes::CatchParameter(transmute_self(self)),
+            parent: AstNodes::CatchParameter(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::CatchParameter(transmute_self(self)),
+                parent: AstNodes::CatchParameter(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4190,7 +4417,7 @@ impl<'a> AstNode<'a, CatchParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, DebuggerStatement> {
+impl<'a> AstNode<'a, '_, DebuggerStatement> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -4206,13 +4433,14 @@ impl<'a> AstNode<'a, DebuggerStatement> {
     }
 }
 
-impl<'a> AstNode<'a, BindingPattern<'a>> {
+impl<'a> AstNode<'a, '_, BindingPattern<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             BindingPattern::BindingIdentifier(s) => {
-                AstNodes::BindingIdentifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BindingIdentifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -4220,7 +4448,8 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                 }))
             }
             BindingPattern::ObjectPattern(s) => {
-                AstNodes::ObjectPattern(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ObjectPattern(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -4228,7 +4457,8 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                 }))
             }
             BindingPattern::ArrayPattern(s) => {
-                AstNodes::ArrayPattern(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ArrayPattern(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -4236,7 +4466,8 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                 }))
             }
             BindingPattern::AssignmentPattern(s) => {
-                AstNodes::AssignmentPattern(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::AssignmentPattern(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -4244,34 +4475,37 @@ impl<'a> AstNode<'a, BindingPattern<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, AssignmentPattern<'a>> {
+impl<'a> AstNode<'a, '_, AssignmentPattern<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, BindingPattern<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingPattern<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentPattern(transmute_self(self)),
+            parent: AstNodes::AssignmentPattern(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::AssignmentPattern(transmute_self(self)),
+            parent: AstNodes::AssignmentPattern(self),
             following_span_start,
         })
     }
@@ -4286,31 +4520,33 @@ impl<'a> AstNode<'a, AssignmentPattern<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ObjectPattern<'a>> {
+impl<'a> AstNode<'a, '_, ObjectPattern<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn properties(&self) -> &AstNode<'a, Vec<'a, BindingProperty<'a>>> {
+    pub fn properties<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, BindingProperty<'a>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
-            parent: AstNodes::ObjectPattern(transmute_self(self)),
+            parent: AstNodes::ObjectPattern(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
+    pub fn rest<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, BindingRestElement<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ObjectPattern(transmute_self(self)),
+                parent: AstNodes::ObjectPattern(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4326,30 +4562,32 @@ impl<'a> AstNode<'a, ObjectPattern<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BindingProperty<'a>> {
+impl<'a> AstNode<'a, '_, BindingProperty<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self.inner.value.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::BindingProperty(transmute_self(self)),
+            parent: AstNodes::BindingProperty(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn value(&self) -> &AstNode<'a, BindingPattern<'a>> {
+    pub fn value<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingPattern<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
-            parent: AstNodes::BindingProperty(transmute_self(self)),
+            parent: AstNodes::BindingProperty(self),
             following_span_start,
         })
     }
@@ -4374,31 +4612,33 @@ impl<'a> AstNode<'a, BindingProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ArrayPattern<'a>> {
+impl<'a> AstNode<'a, '_, ArrayPattern<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
+    pub fn elements<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Option<BindingPattern<'a>>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
-            parent: AstNodes::ArrayPattern(transmute_self(self)),
+            parent: AstNodes::ArrayPattern(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
+    pub fn rest<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, BindingRestElement<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ArrayPattern(transmute_self(self)),
+                parent: AstNodes::ArrayPattern(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4414,19 +4654,20 @@ impl<'a> AstNode<'a, ArrayPattern<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BindingRestElement<'a>> {
+impl<'a> AstNode<'a, '_, BindingRestElement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, BindingPattern<'a>> {
+    pub fn argument<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingPattern<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
-            parent: AstNodes::BindingRestElement(transmute_self(self)),
+            parent: AstNodes::BindingRestElement(self),
             following_span_start,
         })
     }
@@ -4441,7 +4682,7 @@ impl<'a> AstNode<'a, BindingRestElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Function<'a>> {
+impl<'a> AstNode<'a, '_, Function<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -4453,7 +4694,7 @@ impl<'a> AstNode<'a, Function<'a>> {
     }
 
     #[inline]
-    pub fn id(&self) -> Option<&AstNode<'a, BindingIdentifier<'a>>> {
+    pub fn id<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, BindingIdentifier<'a>>> {
         let following_span_start = self
             .inner
             .type_parameters
@@ -4462,11 +4703,12 @@ impl<'a> AstNode<'a, Function<'a>> {
             .or_else(|| self.inner.this_param.as_deref().map(|n| n.span().start))
             .or_else(|| Some(self.inner.params.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.id.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::Function(transmute_self(self)),
+                parent: AstNodes::Function(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4488,7 +4730,9 @@ impl<'a> AstNode<'a, Function<'a>> {
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self
             .inner
             .this_param
@@ -4496,31 +4740,33 @@ impl<'a> AstNode<'a, Function<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.params.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::Function(transmute_self(self)),
+                parent: AstNodes::Function(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
+    pub fn this_param<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSThisParameter<'a>>> {
         let following_span_start = self.inner.params.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::Function(transmute_self(self)),
+                parent: AstNodes::Function(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, FormalParameters<'a>> {
         let following_span_start = self
             .inner
             .return_type
@@ -4529,16 +4775,17 @@ impl<'a> AstNode<'a, Function<'a>> {
             .or_else(|| self.inner.body.as_deref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::Function(transmute_self(self)),
+            parent: AstNodes::Function(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self
             .inner
             .body
@@ -4546,24 +4793,26 @@ impl<'a> AstNode<'a, Function<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::Function(transmute_self(self)),
+                parent: AstNodes::Function(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn body(&self) -> Option<&AstNode<'a, FunctionBody<'a>>> {
+    pub fn body<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, FunctionBody<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.body.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::Function(transmute_self(self)),
+                parent: AstNodes::Function(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4589,7 +4838,7 @@ impl<'a> AstNode<'a, Function<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, FormalParameters<'a>> {
+impl<'a> AstNode<'a, '_, FormalParameters<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -4601,24 +4850,26 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
     }
 
     #[inline]
-    pub fn items(&self) -> &AstNode<'a, Vec<'a, FormalParameter<'a>>> {
+    pub fn items<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, FormalParameter<'a>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.items,
             allocator: self.allocator,
-            parent: AstNodes::FormalParameters(transmute_self(self)),
+            parent: AstNodes::FormalParameters(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn rest(&self) -> Option<&AstNode<'a, FormalParameterRest<'a>>> {
+    pub fn rest<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, FormalParameterRest<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::FormalParameters(transmute_self(self)),
+                parent: AstNodes::FormalParameters(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4634,25 +4885,26 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, FormalParameter<'a>> {
+impl<'a> AstNode<'a, '_, FormalParameter<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.pattern.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
-            parent: AstNodes::FormalParameter(transmute_self(self)),
+            parent: AstNodes::FormalParameter(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn pattern(&self) -> &AstNode<'a, BindingPattern<'a>> {
+    pub fn pattern<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingPattern<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -4661,16 +4913,17 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
             .or_else(|| self.inner.initializer.as_deref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.pattern,
             allocator: self.allocator,
-            parent: AstNodes::FormalParameter(transmute_self(self)),
+            parent: AstNodes::FormalParameter(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self
             .inner
             .initializer
@@ -4678,24 +4931,26 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::FormalParameter(transmute_self(self)),
+                parent: AstNodes::FormalParameter(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn initializer(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn initializer<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.initializer.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::FormalParameter(transmute_self(self)),
+                parent: AstNodes::FormalParameter(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4731,25 +4986,26 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, FormalParameterRest<'a>> {
+impl<'a> AstNode<'a, '_, FormalParameterRest<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.rest.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
-            parent: AstNodes::FormalParameterRest(transmute_self(self)),
+            parent: AstNodes::FormalParameterRest(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn rest(&self) -> &AstNode<'a, BindingRestElement<'a>> {
+    pub fn rest<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingRestElement<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -4757,22 +5013,24 @@ impl<'a> AstNode<'a, FormalParameterRest<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.rest,
             allocator: self.allocator,
-            parent: AstNodes::FormalParameterRest(transmute_self(self)),
+            parent: AstNodes::FormalParameterRest(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::FormalParameterRest(transmute_self(self)),
+                parent: AstNodes::FormalParameterRest(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4788,14 +5046,14 @@ impl<'a> AstNode<'a, FormalParameterRest<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, FunctionBody<'a>> {
+impl<'a> AstNode<'a, '_, FunctionBody<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
+    pub fn directives<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Directive<'a>>> {
         let following_span_start = self
             .inner
             .statements
@@ -4803,21 +5061,23 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
-            parent: AstNodes::FunctionBody(transmute_self(self)),
+            parent: AstNodes::FunctionBody(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn statements(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn statements<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.statements,
             allocator: self.allocator,
-            parent: AstNodes::FunctionBody(transmute_self(self)),
+            parent: AstNodes::FunctionBody(self),
             following_span_start,
         })
     }
@@ -4832,7 +5092,7 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
+impl<'a> AstNode<'a, '_, ArrowFunctionExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -4849,20 +5109,23 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self.inner.params.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ArrowFunctionExpression(transmute_self(self)),
+                parent: AstNodes::ArrowFunctionExpression(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, FormalParameters<'a>> {
         let following_span_start = self
             .inner
             .return_type
@@ -4870,34 +5133,37 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::ArrowFunctionExpression(transmute_self(self)),
+            parent: AstNodes::ArrowFunctionExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ArrowFunctionExpression(transmute_self(self)),
+                parent: AstNodes::ArrowFunctionExpression(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, FunctionBody<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, FunctionBody<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::ArrowFunctionExpression(transmute_self(self)),
+            parent: AstNodes::ArrowFunctionExpression(self),
             following_span_start,
         })
     }
@@ -4922,7 +5188,7 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, YieldExpression<'a>> {
+impl<'a> AstNode<'a, '_, YieldExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -4934,13 +5200,14 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
     }
 
     #[inline]
-    pub fn argument(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn argument<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.argument.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::YieldExpression(transmute_self(self)),
+                parent: AstNodes::YieldExpression(self),
                 following_span_start,
             }))
             .as_ref()
@@ -4956,7 +5223,7 @@ impl<'a> AstNode<'a, YieldExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Class<'a>> {
+impl<'a> AstNode<'a, '_, Class<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -4968,7 +5235,7 @@ impl<'a> AstNode<'a, Class<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Decorator<'a>>> {
         let following_span_start = self
             .inner
             .id
@@ -4980,16 +5247,17 @@ impl<'a> AstNode<'a, Class<'a>> {
             .or_else(|| self.inner.implements.first().map(|n| n.span().start))
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
-            parent: AstNodes::Class(transmute_self(self)),
+            parent: AstNodes::Class(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn id(&self) -> Option<&AstNode<'a, BindingIdentifier<'a>>> {
+    pub fn id<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, BindingIdentifier<'a>>> {
         let following_span_start = self
             .inner
             .type_parameters
@@ -5000,18 +5268,21 @@ impl<'a> AstNode<'a, Class<'a>> {
             .or_else(|| self.inner.implements.first().map(|n| n.span().start))
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.id.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::Class(transmute_self(self)),
+                parent: AstNodes::Class(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self
             .inner
             .super_class
@@ -5021,18 +5292,19 @@ impl<'a> AstNode<'a, Class<'a>> {
             .or_else(|| self.inner.implements.first().map(|n| n.span().start))
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::Class(transmute_self(self)),
+                parent: AstNodes::Class(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn super_class(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn super_class<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self
             .inner
             .super_type_arguments
@@ -5041,18 +5313,21 @@ impl<'a> AstNode<'a, Class<'a>> {
             .or_else(|| self.inner.implements.first().map(|n| n.span().start))
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.super_class.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::Class(transmute_self(self)),
+                parent: AstNodes::Class(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn super_type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self
             .inner
             .implements
@@ -5060,34 +5335,37 @@ impl<'a> AstNode<'a, Class<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.super_type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::Class(transmute_self(self)),
+                parent: AstNodes::Class(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn implements(&self) -> &AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
+    pub fn implements<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSClassImplements<'a>>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.implements,
             allocator: self.allocator,
-            parent: AstNodes::Class(transmute_self(self)),
+            parent: AstNodes::Class(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, ClassBody<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, ClassBody<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::Class(transmute_self(self)),
+            parent: AstNodes::Class(self),
             following_span_start,
         })
     }
@@ -5112,19 +5390,20 @@ impl<'a> AstNode<'a, Class<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ClassBody<'a>> {
+impl<'a> AstNode<'a, '_, ClassBody<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, ClassElement<'a>>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, ClassElement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::ClassBody(transmute_self(self)),
+            parent: AstNodes::ClassBody(self),
             following_span_start,
         })
     }
@@ -5139,19 +5418,23 @@ impl<'a> AstNode<'a, ClassBody<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ClassElement<'a>> {
+impl<'a> AstNode<'a, '_, ClassElement<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
-            ClassElement::StaticBlock(s) => AstNodes::StaticBlock(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            ClassElement::StaticBlock(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StaticBlock(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             ClassElement::MethodDefinition(s) => {
-                AstNodes::MethodDefinition(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::MethodDefinition(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5159,7 +5442,8 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                 }))
             }
             ClassElement::PropertyDefinition(s) => {
-                AstNodes::PropertyDefinition(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::PropertyDefinition(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5167,7 +5451,8 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                 }))
             }
             ClassElement::AccessorProperty(s) => {
-                AstNodes::AccessorProperty(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::AccessorProperty(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5175,7 +5460,8 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                 }))
             }
             ClassElement::TSIndexSignature(s) => {
-                AstNodes::TSIndexSignature(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSIndexSignature(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5183,11 +5469,12 @@ impl<'a> AstNode<'a, ClassElement<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, MethodDefinition<'a>> {
+impl<'a> AstNode<'a, '_, MethodDefinition<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -5199,34 +5486,37 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.key.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
-            parent: AstNodes::MethodDefinition(transmute_self(self)),
+            parent: AstNodes::MethodDefinition(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self.inner.value.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::MethodDefinition(transmute_self(self)),
+            parent: AstNodes::MethodDefinition(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn value(&self) -> &AstNode<'a, Function<'a>> {
+    pub fn value<'c>(&'c self) -> &'c AstNode<'a, 'c, Function<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.value.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::MethodDefinition(transmute_self(self)),
+            parent: AstNodes::MethodDefinition(self),
             following_span_start,
         })
     }
@@ -5271,7 +5561,7 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PropertyDefinition<'a>> {
+impl<'a> AstNode<'a, '_, PropertyDefinition<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -5283,18 +5573,19 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.key.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
-            parent: AstNodes::PropertyDefinition(transmute_self(self)),
+            parent: AstNodes::PropertyDefinition(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -5303,16 +5594,17 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
             .or_else(|| self.inner.value.as_ref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::PropertyDefinition(transmute_self(self)),
+            parent: AstNodes::PropertyDefinition(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self
             .inner
             .value
@@ -5320,24 +5612,26 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::PropertyDefinition(transmute_self(self)),
+                parent: AstNodes::PropertyDefinition(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn value(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn value<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::PropertyDefinition(transmute_self(self)),
+                parent: AstNodes::PropertyDefinition(self),
                 following_span_start,
             }))
             .as_ref()
@@ -5393,7 +5687,7 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
+impl<'a> AstNode<'a, '_, PrivateIdentifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -5414,19 +5708,20 @@ impl<'a> AstNode<'a, PrivateIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, StaticBlock<'a>> {
+impl<'a> AstNode<'a, '_, StaticBlock<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::StaticBlock(transmute_self(self)),
+            parent: AstNodes::StaticBlock(self),
             following_span_start,
         })
     }
@@ -5441,13 +5736,14 @@ impl<'a> AstNode<'a, StaticBlock<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, ModuleDeclaration<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ModuleDeclaration::ImportDeclaration(s) => {
-                AstNodes::ImportDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ImportDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5455,7 +5751,8 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                 }))
             }
             ModuleDeclaration::ExportAllDeclaration(s) => {
-                AstNodes::ExportAllDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ExportAllDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5463,7 +5760,8 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                 }))
             }
             ModuleDeclaration::ExportDefaultDeclaration(s) => {
-                AstNodes::ExportDefaultDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ExportDefaultDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5471,7 +5769,8 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                 }))
             }
             ModuleDeclaration::ExportNamedDeclaration(s) => {
-                AstNodes::ExportNamedDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ExportNamedDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5479,7 +5778,8 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                 }))
             }
             ModuleDeclaration::TSExportAssignment(s) => {
-                AstNodes::TSExportAssignment(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSExportAssignment(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5487,7 +5787,8 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                 }))
             }
             ModuleDeclaration::TSNamespaceExportDeclaration(s) => {
-                AstNodes::TSNamespaceExportDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNamespaceExportDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5495,11 +5796,12 @@ impl<'a> AstNode<'a, ModuleDeclaration<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, AccessorProperty<'a>> {
+impl<'a> AstNode<'a, '_, AccessorProperty<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -5511,18 +5813,19 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.key.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.decorators,
             allocator: self.allocator,
-            parent: AstNodes::AccessorProperty(transmute_self(self)),
+            parent: AstNodes::AccessorProperty(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -5531,16 +5834,17 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
             .or_else(|| self.inner.value.as_ref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::AccessorProperty(transmute_self(self)),
+            parent: AstNodes::AccessorProperty(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self
             .inner
             .value
@@ -5548,24 +5852,26 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::AccessorProperty(transmute_self(self)),
+                parent: AstNodes::AccessorProperty(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn value(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn value<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::AccessorProperty(transmute_self(self)),
+                parent: AstNodes::AccessorProperty(self),
                 following_span_start,
             }))
             .as_ref()
@@ -5606,14 +5912,14 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportExpression<'a>> {
+impl<'a> AstNode<'a, '_, ImportExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn source(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn source<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self
             .inner
             .options
@@ -5621,22 +5927,24 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
-            parent: AstNodes::ImportExpression(transmute_self(self)),
+            parent: AstNodes::ImportExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn options(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn options<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.options.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ImportExpression(transmute_self(self)),
+                parent: AstNodes::ImportExpression(self),
                 following_span_start,
             }))
             .as_ref()
@@ -5657,32 +5965,36 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, ImportDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn specifiers(&self) -> Option<&AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>>> {
+    pub fn specifiers<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, Vec<'a, ImportDeclarationSpecifier<'a>>>> {
         let following_span_start = self.inner.source.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.specifiers.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ImportDeclaration(transmute_self(self)),
+                parent: AstNodes::ImportDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
+    pub fn source<'c>(&'c self) -> &'c AstNode<'a, 'c, StringLiteral<'a>> {
         let following_span_start = self.inner.with_clause.as_deref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
-            parent: AstNodes::ImportDeclaration(transmute_self(self)),
+            parent: AstNodes::ImportDeclaration(self),
             following_span_start,
         })
     }
@@ -5693,13 +6005,14 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
+    pub fn with_clause<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, WithClause<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ImportDeclaration(transmute_self(self)),
+                parent: AstNodes::ImportDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
@@ -5720,13 +6033,14 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
+impl<'a> AstNode<'a, '_, ImportDeclarationSpecifier<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ImportDeclarationSpecifier::ImportSpecifier(s) => {
-                AstNodes::ImportSpecifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ImportSpecifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5734,7 +6048,8 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                 }))
             }
             ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
-                AstNodes::ImportDefaultSpecifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ImportDefaultSpecifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5742,7 +6057,8 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                 }))
             }
             ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
-                AstNodes::ImportNamespaceSpecifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ImportNamespaceSpecifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -5750,34 +6066,37 @@ impl<'a> AstNode<'a, ImportDeclarationSpecifier<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ImportSpecifier<'a>> {
+impl<'a> AstNode<'a, '_, ImportSpecifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn imported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
+    pub fn imported<'c>(&'c self) -> &'c AstNode<'a, 'c, ModuleExportName<'a>> {
         let following_span_start = self.inner.local.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.imported,
             allocator: self.allocator,
-            parent: AstNodes::ImportSpecifier(transmute_self(self)),
+            parent: AstNodes::ImportSpecifier(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn local<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
-            parent: AstNodes::ImportSpecifier(transmute_self(self)),
+            parent: AstNodes::ImportSpecifier(self),
             following_span_start,
         })
     }
@@ -5797,19 +6116,20 @@ impl<'a> AstNode<'a, ImportSpecifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
+impl<'a> AstNode<'a, '_, ImportDefaultSpecifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn local<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
-            parent: AstNodes::ImportDefaultSpecifier(transmute_self(self)),
+            parent: AstNodes::ImportDefaultSpecifier(self),
             following_span_start,
         })
     }
@@ -5824,19 +6144,20 @@ impl<'a> AstNode<'a, ImportDefaultSpecifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
+impl<'a> AstNode<'a, '_, ImportNamespaceSpecifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn local(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn local<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
-            parent: AstNodes::ImportNamespaceSpecifier(transmute_self(self)),
+            parent: AstNodes::ImportNamespaceSpecifier(self),
             following_span_start,
         })
     }
@@ -5851,7 +6172,7 @@ impl<'a> AstNode<'a, ImportNamespaceSpecifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, WithClause<'a>> {
+impl<'a> AstNode<'a, '_, WithClause<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -5863,12 +6184,13 @@ impl<'a> AstNode<'a, WithClause<'a>> {
     }
 
     #[inline]
-    pub fn with_entries(&self) -> &AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
+    pub fn with_entries<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, ImportAttribute<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.with_entries,
             allocator: self.allocator,
-            parent: AstNodes::WithClause(transmute_self(self)),
+            parent: AstNodes::WithClause(self),
             following_span_start,
         })
     }
@@ -5883,30 +6205,32 @@ impl<'a> AstNode<'a, WithClause<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportAttribute<'a>> {
+impl<'a> AstNode<'a, '_, ImportAttribute<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, ImportAttributeKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, ImportAttributeKey<'a>> {
         let following_span_start = self.inner.value.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::ImportAttribute(transmute_self(self)),
+            parent: AstNodes::ImportAttribute(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn value(&self) -> &AstNode<'a, StringLiteral<'a>> {
+    pub fn value<'c>(&'c self) -> &'c AstNode<'a, 'c, StringLiteral<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.value,
             allocator: self.allocator,
-            parent: AstNodes::ImportAttribute(transmute_self(self)),
+            parent: AstNodes::ImportAttribute(self),
             following_span_start,
         })
     }
@@ -5921,13 +6245,14 @@ impl<'a> AstNode<'a, ImportAttribute<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
+impl<'a> AstNode<'a, '_, ImportAttributeKey<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ImportAttributeKey::Identifier(s) => {
-                AstNodes::IdentifierName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierName(allocator.alloc(AstNode {
                     inner: s,
                     parent,
                     allocator: self.allocator,
@@ -5935,7 +6260,8 @@ impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
                 }))
             }
             ImportAttributeKey::StringLiteral(s) => {
-                AstNodes::StringLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
                     inner: s,
                     parent,
                     allocator: self.allocator,
@@ -5943,18 +6269,19 @@ impl<'a> AstNode<'a, ImportAttributeKey<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, ExportNamedDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn declaration(&self) -> Option<&AstNode<'a, Declaration<'a>>> {
+    pub fn declaration<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Declaration<'a>>> {
         let following_span_start = self
             .inner
             .specifiers
@@ -5963,18 +6290,19 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
             .or_else(|| self.inner.source.as_ref().map(|n| n.span().start))
             .or_else(|| self.inner.with_clause.as_deref().map(|n| n.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.declaration.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ExportNamedDeclaration(transmute_self(self)),
+                parent: AstNodes::ExportNamedDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn specifiers(&self) -> &AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
+    pub fn specifiers<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, ExportSpecifier<'a>>> {
         let following_span_start = self
             .inner
             .source
@@ -5982,22 +6310,24 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
             .map(|n| n.span().start)
             .or_else(|| self.inner.with_clause.as_deref().map(|n| n.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.specifiers,
             allocator: self.allocator,
-            parent: AstNodes::ExportNamedDeclaration(transmute_self(self)),
+            parent: AstNodes::ExportNamedDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn source(&self) -> Option<&AstNode<'a, StringLiteral<'a>>> {
+    pub fn source<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, StringLiteral<'a>>> {
         let following_span_start = self.inner.with_clause.as_deref().map_or(0, |n| n.span().start);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.source.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ExportNamedDeclaration(transmute_self(self)),
+                parent: AstNodes::ExportNamedDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
@@ -6009,13 +6339,14 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
+    pub fn with_clause<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, WithClause<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ExportNamedDeclaration(transmute_self(self)),
+                parent: AstNodes::ExportNamedDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
@@ -6031,19 +6362,20 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, ExportDefaultDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn declaration(&self) -> &AstNode<'a, ExportDefaultDeclarationKind<'a>> {
+    pub fn declaration<'c>(&'c self) -> &'c AstNode<'a, 'c, ExportDefaultDeclarationKind<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.declaration,
             allocator: self.allocator,
-            parent: AstNodes::ExportDefaultDeclaration(transmute_self(self)),
+            parent: AstNodes::ExportDefaultDeclaration(self),
             following_span_start,
         })
     }
@@ -6058,44 +6390,47 @@ impl<'a> AstNode<'a, ExportDefaultDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, ExportAllDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn exported(&self) -> Option<&AstNode<'a, ModuleExportName<'a>>> {
+    pub fn exported<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, ModuleExportName<'a>>> {
         let following_span_start = self.inner.source.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.exported.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::ExportAllDeclaration(transmute_self(self)),
+                parent: AstNodes::ExportAllDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
+    pub fn source<'c>(&'c self) -> &'c AstNode<'a, 'c, StringLiteral<'a>> {
         let following_span_start = self.inner.with_clause.as_deref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
-            parent: AstNodes::ExportAllDeclaration(transmute_self(self)),
+            parent: AstNodes::ExportAllDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn with_clause(&self) -> Option<&AstNode<'a, WithClause<'a>>> {
+    pub fn with_clause<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, WithClause<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.with_clause.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::ExportAllDeclaration(transmute_self(self)),
+                parent: AstNodes::ExportAllDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
@@ -6116,30 +6451,32 @@ impl<'a> AstNode<'a, ExportAllDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ExportSpecifier<'a>> {
+impl<'a> AstNode<'a, '_, ExportSpecifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn local(&self) -> &AstNode<'a, ModuleExportName<'a>> {
+    pub fn local<'c>(&'c self) -> &'c AstNode<'a, 'c, ModuleExportName<'a>> {
         let following_span_start = self.inner.exported.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.local,
             allocator: self.allocator,
-            parent: AstNodes::ExportSpecifier(transmute_self(self)),
+            parent: AstNodes::ExportSpecifier(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn exported(&self) -> &AstNode<'a, ModuleExportName<'a>> {
+    pub fn exported<'c>(&'c self) -> &'c AstNode<'a, 'c, ModuleExportName<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.exported,
             allocator: self.allocator,
-            parent: AstNodes::ExportSpecifier(transmute_self(self)),
+            parent: AstNodes::ExportSpecifier(self),
             following_span_start,
         })
     }
@@ -6159,13 +6496,14 @@ impl<'a> AstNode<'a, ExportSpecifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
+impl<'a> AstNode<'a, '_, ExportDefaultDeclarationKind<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ExportDefaultDeclarationKind::FunctionDeclaration(s) => {
-                AstNodes::Function(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Function(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6173,7 +6511,8 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                 }))
             }
             ExportDefaultDeclarationKind::ClassDeclaration(s) => {
-                AstNodes::Class(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::Class(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6181,7 +6520,8 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                 }))
             }
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(s) => {
-                AstNodes::TSInterfaceDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSInterfaceDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6189,8 +6529,8 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                 }))
             }
             it @ match_expression!(ExportDefaultDeclarationKind) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_expression(),
                         parent,
@@ -6200,17 +6540,19 @@ impl<'a> AstNode<'a, ExportDefaultDeclarationKind<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, ModuleExportName<'a>> {
+impl<'a> AstNode<'a, '_, ModuleExportName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             ModuleExportName::IdentifierName(s) => {
-                AstNodes::IdentifierName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierName(allocator.alloc(AstNode {
                     inner: s,
                     parent,
                     allocator: self.allocator,
@@ -6218,7 +6560,8 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                 }))
             }
             ModuleExportName::IdentifierReference(s) => {
-                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierReference(allocator.alloc(AstNode {
                     inner: s,
                     parent,
                     allocator: self.allocator,
@@ -6226,7 +6569,8 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                 }))
             }
             ModuleExportName::StringLiteral(s) => {
-                AstNodes::StringLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
                     inner: s,
                     parent,
                     allocator: self.allocator,
@@ -6234,18 +6578,19 @@ impl<'a> AstNode<'a, ModuleExportName<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
+impl<'a> AstNode<'a, '_, V8IntrinsicExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn name(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn name<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = self
             .inner
             .arguments
@@ -6253,21 +6598,23 @@ impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
-            parent: AstNodes::V8IntrinsicExpression(transmute_self(self)),
+            parent: AstNodes::V8IntrinsicExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
+    pub fn arguments<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Argument<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.arguments,
             allocator: self.allocator,
-            parent: AstNodes::V8IntrinsicExpression(transmute_self(self)),
+            parent: AstNodes::V8IntrinsicExpression(self),
             following_span_start,
         })
     }
@@ -6282,7 +6629,7 @@ impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BooleanLiteral> {
+impl<'a> AstNode<'a, '_, BooleanLiteral> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6303,7 +6650,7 @@ impl<'a> AstNode<'a, BooleanLiteral> {
     }
 }
 
-impl<'a> AstNode<'a, NullLiteral> {
+impl<'a> AstNode<'a, '_, NullLiteral> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6319,7 +6666,7 @@ impl<'a> AstNode<'a, NullLiteral> {
     }
 }
 
-impl<'a> AstNode<'a, NumericLiteral<'a>> {
+impl<'a> AstNode<'a, '_, NumericLiteral<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6350,7 +6697,7 @@ impl<'a> AstNode<'a, NumericLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, StringLiteral<'a>> {
+impl<'a> AstNode<'a, '_, StringLiteral<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6381,7 +6728,7 @@ impl<'a> AstNode<'a, StringLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, BigIntLiteral<'a>> {
+impl<'a> AstNode<'a, '_, BigIntLiteral<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6412,7 +6759,7 @@ impl<'a> AstNode<'a, BigIntLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, RegExpLiteral<'a>> {
+impl<'a> AstNode<'a, '_, RegExpLiteral<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6438,14 +6785,14 @@ impl<'a> AstNode<'a, RegExpLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXElement<'a>> {
+impl<'a> AstNode<'a, '_, JSXElement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn opening_element(&self) -> &AstNode<'a, JSXOpeningElement<'a>> {
+    pub fn opening_element<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXOpeningElement<'a>> {
         let following_span_start = self
             .inner
             .children
@@ -6454,16 +6801,17 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
             .or_else(|| self.inner.closing_element.as_deref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.opening_element.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::JSXElement(transmute_self(self)),
+            parent: AstNodes::JSXElement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
+    pub fn children<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, JSXChild<'a>>> {
         let following_span_start = self
             .inner
             .closing_element
@@ -6471,22 +6819,24 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.children,
             allocator: self.allocator,
-            parent: AstNodes::JSXElement(transmute_self(self)),
+            parent: AstNodes::JSXElement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn closing_element(&self) -> Option<&AstNode<'a, JSXClosingElement<'a>>> {
+    pub fn closing_element<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, JSXClosingElement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.closing_element.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::JSXElement(transmute_self(self)),
+                parent: AstNodes::JSXElement(self),
                 following_span_start,
             }))
             .as_ref()
@@ -6502,14 +6852,14 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
+impl<'a> AstNode<'a, '_, JSXOpeningElement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
+    pub fn name<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXElementName<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -6518,16 +6868,19 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
             .or_else(|| self.inner.attributes.first().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
-            parent: AstNodes::JSXOpeningElement(transmute_self(self)),
+            parent: AstNodes::JSXOpeningElement(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self
             .inner
             .attributes
@@ -6535,23 +6888,25 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::JSXOpeningElement(transmute_self(self)),
+                parent: AstNodes::JSXOpeningElement(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn attributes(&self) -> &AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
+    pub fn attributes<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, JSXAttributeItem<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.attributes,
             allocator: self.allocator,
-            parent: AstNodes::JSXOpeningElement(transmute_self(self)),
+            parent: AstNodes::JSXOpeningElement(self),
             following_span_start,
         })
     }
@@ -6566,19 +6921,20 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXClosingElement<'a>> {
+impl<'a> AstNode<'a, '_, JSXClosingElement<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn name(&self) -> &AstNode<'a, JSXElementName<'a>> {
+    pub fn name<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXElementName<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
-            parent: AstNodes::JSXClosingElement(transmute_self(self)),
+            parent: AstNodes::JSXClosingElement(self),
             following_span_start,
         })
     }
@@ -6593,14 +6949,14 @@ impl<'a> AstNode<'a, JSXClosingElement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXFragment<'a>> {
+impl<'a> AstNode<'a, '_, JSXFragment<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn opening_fragment(&self) -> &AstNode<'a, JSXOpeningFragment> {
+    pub fn opening_fragment<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXOpeningFragment> {
         let following_span_start = self
             .inner
             .children
@@ -6608,32 +6964,35 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.closing_fragment.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.opening_fragment,
             allocator: self.allocator,
-            parent: AstNodes::JSXFragment(transmute_self(self)),
+            parent: AstNodes::JSXFragment(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
+    pub fn children<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, JSXChild<'a>>> {
         let following_span_start = self.inner.closing_fragment.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.children,
             allocator: self.allocator,
-            parent: AstNodes::JSXFragment(transmute_self(self)),
+            parent: AstNodes::JSXFragment(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn closing_fragment(&self) -> &AstNode<'a, JSXClosingFragment> {
+    pub fn closing_fragment<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXClosingFragment> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.closing_fragment,
             allocator: self.allocator,
-            parent: AstNodes::JSXFragment(transmute_self(self)),
+            parent: AstNodes::JSXFragment(self),
             following_span_start,
         })
     }
@@ -6648,7 +7007,7 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXOpeningFragment> {
+impl<'a> AstNode<'a, '_, JSXOpeningFragment> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6664,7 +7023,7 @@ impl<'a> AstNode<'a, JSXOpeningFragment> {
     }
 }
 
-impl<'a> AstNode<'a, JSXClosingFragment> {
+impl<'a> AstNode<'a, '_, JSXClosingFragment> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6680,13 +7039,14 @@ impl<'a> AstNode<'a, JSXClosingFragment> {
     }
 }
 
-impl<'a> AstNode<'a, JSXElementName<'a>> {
+impl<'a> AstNode<'a, '_, JSXElementName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             JSXElementName::Identifier(s) => {
-                AstNodes::JSXIdentifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXIdentifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6694,7 +7054,8 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                 }))
             }
             JSXElementName::IdentifierReference(s) => {
-                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6702,7 +7063,8 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                 }))
             }
             JSXElementName::NamespacedName(s) => {
-                AstNodes::JSXNamespacedName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXNamespacedName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6710,7 +7072,8 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                 }))
             }
             JSXElementName::MemberExpression(s) => {
-                AstNodes::JSXMemberExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXMemberExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6718,7 +7081,8 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                 }))
             }
             JSXElementName::ThisExpression(s) => {
-                AstNodes::ThisExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ThisExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6726,34 +7090,37 @@ impl<'a> AstNode<'a, JSXElementName<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
+impl<'a> AstNode<'a, '_, JSXNamespacedName<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn namespace(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
+    pub fn namespace<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXIdentifier<'a>> {
         let following_span_start = self.inner.name.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.namespace,
             allocator: self.allocator,
-            parent: AstNodes::JSXNamespacedName(transmute_self(self)),
+            parent: AstNodes::JSXNamespacedName(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn name(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
+    pub fn name<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXIdentifier<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
-            parent: AstNodes::JSXNamespacedName(transmute_self(self)),
+            parent: AstNodes::JSXNamespacedName(self),
             following_span_start,
         })
     }
@@ -6768,30 +7135,32 @@ impl<'a> AstNode<'a, JSXNamespacedName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
+impl<'a> AstNode<'a, '_, JSXMemberExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn object(&self) -> &AstNode<'a, JSXMemberExpressionObject<'a>> {
+    pub fn object<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXMemberExpressionObject<'a>> {
         let following_span_start = self.inner.property.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.object,
             allocator: self.allocator,
-            parent: AstNodes::JSXMemberExpression(transmute_self(self)),
+            parent: AstNodes::JSXMemberExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn property(&self) -> &AstNode<'a, JSXIdentifier<'a>> {
+    pub fn property<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXIdentifier<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.property,
             allocator: self.allocator,
-            parent: AstNodes::JSXMemberExpression(transmute_self(self)),
+            parent: AstNodes::JSXMemberExpression(self),
             following_span_start,
         })
     }
@@ -6806,13 +7175,14 @@ impl<'a> AstNode<'a, JSXMemberExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
+impl<'a> AstNode<'a, '_, JSXMemberExpressionObject<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             JSXMemberExpressionObject::IdentifierReference(s) => {
-                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6820,7 +7190,8 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                 }))
             }
             JSXMemberExpressionObject::MemberExpression(s) => {
-                AstNodes::JSXMemberExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXMemberExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6828,7 +7199,8 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                 }))
             }
             JSXMemberExpressionObject::ThisExpression(s) => {
-                AstNodes::ThisExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ThisExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6836,23 +7208,25 @@ impl<'a> AstNode<'a, JSXMemberExpressionObject<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
+impl<'a> AstNode<'a, '_, JSXExpressionContainer<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, JSXExpression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXExpression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::JSXExpressionContainer(transmute_self(self)),
+            parent: AstNodes::JSXExpressionContainer(self),
             following_span_start,
         })
     }
@@ -6867,13 +7241,14 @@ impl<'a> AstNode<'a, JSXExpressionContainer<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXExpression<'a>> {
+impl<'a> AstNode<'a, '_, JSXExpression<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             JSXExpression::EmptyExpression(s) => {
-                AstNodes::JSXEmptyExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXEmptyExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6881,8 +7256,8 @@ impl<'a> AstNode<'a, JSXExpression<'a>> {
                 }))
             }
             it @ match_expression!(JSXExpression) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_expression(),
                         parent,
@@ -6892,11 +7267,12 @@ impl<'a> AstNode<'a, JSXExpression<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, JSXEmptyExpression> {
+impl<'a> AstNode<'a, '_, JSXEmptyExpression> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -6912,13 +7288,14 @@ impl<'a> AstNode<'a, JSXEmptyExpression> {
     }
 }
 
-impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
+impl<'a> AstNode<'a, '_, JSXAttributeItem<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             JSXAttributeItem::Attribute(s) => {
-                AstNodes::JSXAttribute(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXAttribute(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6926,7 +7303,8 @@ impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
                 }))
             }
             JSXAttributeItem::SpreadAttribute(s) => {
-                AstNodes::JSXSpreadAttribute(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXSpreadAttribute(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -6934,18 +7312,19 @@ impl<'a> AstNode<'a, JSXAttributeItem<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, JSXAttribute<'a>> {
+impl<'a> AstNode<'a, '_, JSXAttribute<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn name(&self) -> &AstNode<'a, JSXAttributeName<'a>> {
+    pub fn name<'c>(&'c self) -> &'c AstNode<'a, 'c, JSXAttributeName<'a>> {
         let following_span_start = self
             .inner
             .value
@@ -6953,22 +7332,24 @@ impl<'a> AstNode<'a, JSXAttribute<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
-            parent: AstNodes::JSXAttribute(transmute_self(self)),
+            parent: AstNodes::JSXAttribute(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn value(&self) -> Option<&AstNode<'a, JSXAttributeValue<'a>>> {
+    pub fn value<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, JSXAttributeValue<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.value.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::JSXAttribute(transmute_self(self)),
+                parent: AstNodes::JSXAttribute(self),
                 following_span_start,
             }))
             .as_ref()
@@ -6984,19 +7365,20 @@ impl<'a> AstNode<'a, JSXAttribute<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
+impl<'a> AstNode<'a, '_, JSXSpreadAttribute<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn argument(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn argument<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.argument,
             allocator: self.allocator,
-            parent: AstNodes::JSXSpreadAttribute(transmute_self(self)),
+            parent: AstNodes::JSXSpreadAttribute(self),
             following_span_start,
         })
     }
@@ -7011,13 +7393,14 @@ impl<'a> AstNode<'a, JSXSpreadAttribute<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXAttributeName<'a>> {
+impl<'a> AstNode<'a, '_, JSXAttributeName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             JSXAttributeName::Identifier(s) => {
-                AstNodes::JSXIdentifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXIdentifier(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7025,7 +7408,8 @@ impl<'a> AstNode<'a, JSXAttributeName<'a>> {
                 }))
             }
             JSXAttributeName::NamespacedName(s) => {
-                AstNodes::JSXNamespacedName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXNamespacedName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7033,17 +7417,19 @@ impl<'a> AstNode<'a, JSXAttributeName<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, JSXAttributeValue<'a>> {
+impl<'a> AstNode<'a, '_, JSXAttributeValue<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             JSXAttributeValue::StringLiteral(s) => {
-                AstNodes::StringLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7051,21 +7437,26 @@ impl<'a> AstNode<'a, JSXAttributeValue<'a>> {
                 }))
             }
             JSXAttributeValue::ExpressionContainer(s) => {
-                AstNodes::JSXExpressionContainer(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXExpressionContainer(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            JSXAttributeValue::Element(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            JSXAttributeValue::Element(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXElement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             JSXAttributeValue::Fragment(s) => {
-                AstNodes::JSXFragment(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXFragment(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7073,11 +7464,12 @@ impl<'a> AstNode<'a, JSXAttributeValue<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, JSXIdentifier<'a>> {
+impl<'a> AstNode<'a, '_, JSXIdentifier<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -7098,61 +7490,76 @@ impl<'a> AstNode<'a, JSXIdentifier<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXChild<'a>> {
+impl<'a> AstNode<'a, '_, JSXChild<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
-            JSXChild::Text(s) => AstNodes::JSXText(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            JSXChild::Element(s) => AstNodes::JSXElement(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            JSXChild::Fragment(s) => AstNodes::JSXFragment(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            JSXChild::ExpressionContainer(s) => {
-                AstNodes::JSXExpressionContainer(self.allocator.alloc(AstNode {
+            JSXChild::Text(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXText(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            JSXChild::Spread(s) => AstNodes::JSXSpreadChild(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            JSXChild::Element(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXElement(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            JSXChild::Fragment(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXFragment(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            JSXChild::ExpressionContainer(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXExpressionContainer(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            JSXChild::Spread(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSXSpreadChild(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
+impl<'a> AstNode<'a, '_, JSXSpreadChild<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::JSXSpreadChild(transmute_self(self)),
+            parent: AstNodes::JSXSpreadChild(self),
             following_span_start,
         })
     }
@@ -7167,7 +7574,7 @@ impl<'a> AstNode<'a, JSXSpreadChild<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSXText<'a>> {
+impl<'a> AstNode<'a, '_, JSXText<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -7193,7 +7600,7 @@ impl<'a> AstNode<'a, JSXText<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSThisParameter<'a>> {
+impl<'a> AstNode<'a, '_, TSThisParameter<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -7205,13 +7612,14 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSThisParameter(transmute_self(self)),
+                parent: AstNodes::TSThisParameter(self),
                 following_span_start,
             }))
             .as_ref()
@@ -7227,30 +7635,32 @@ impl<'a> AstNode<'a, TSThisParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSEnumDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::TSEnumDeclaration(transmute_self(self)),
+            parent: AstNodes::TSEnumDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, TSEnumBody<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, TSEnumBody<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::TSEnumDeclaration(transmute_self(self)),
+            parent: AstNodes::TSEnumDeclaration(self),
             following_span_start,
         })
     }
@@ -7275,19 +7685,20 @@ impl<'a> AstNode<'a, TSEnumDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSEnumBody<'a>> {
+impl<'a> AstNode<'a, '_, TSEnumBody<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn members(&self) -> &AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
+    pub fn members<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSEnumMember<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.members,
             allocator: self.allocator,
-            parent: AstNodes::TSEnumBody(transmute_self(self)),
+            parent: AstNodes::TSEnumBody(self),
             following_span_start,
         })
     }
@@ -7302,14 +7713,14 @@ impl<'a> AstNode<'a, TSEnumBody<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSEnumMember<'a>> {
+impl<'a> AstNode<'a, '_, TSEnumMember<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, TSEnumMemberName<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, TSEnumMemberName<'a>> {
         let following_span_start = self
             .inner
             .initializer
@@ -7317,22 +7728,24 @@ impl<'a> AstNode<'a, TSEnumMember<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::TSEnumMember(transmute_self(self)),
+            parent: AstNodes::TSEnumMember(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn initializer(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    pub fn initializer<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, Expression<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.initializer.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::TSEnumMember(transmute_self(self)),
+                parent: AstNodes::TSEnumMember(self),
                 following_span_start,
             }))
             .as_ref()
@@ -7348,27 +7761,32 @@ impl<'a> AstNode<'a, TSEnumMember<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
+impl<'a> AstNode<'a, '_, TSEnumMemberName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSEnumMemberName::Identifier(s) => {
-                AstNodes::IdentifierName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSEnumMemberName::String(s) => AstNodes::StringLiteral(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSEnumMemberName::String(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSEnumMemberName::ComputedString(s) => {
-                AstNodes::StringLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7376,7 +7794,8 @@ impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
                 }))
             }
             TSEnumMemberName::ComputedTemplateString(s) => {
-                AstNodes::TemplateLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TemplateLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7384,23 +7803,25 @@ impl<'a> AstNode<'a, TSEnumMemberName<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeAnnotation<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeAnnotation(transmute_self(self)),
+            parent: AstNodes::TSTypeAnnotation(self),
             following_span_start,
         })
     }
@@ -7415,19 +7836,20 @@ impl<'a> AstNode<'a, TSTypeAnnotation<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSLiteralType<'a>> {
+impl<'a> AstNode<'a, '_, TSLiteralType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn literal(&self) -> &AstNode<'a, TSLiteral<'a>> {
+    pub fn literal<'c>(&'c self) -> &'c AstNode<'a, 'c, TSLiteral<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.literal,
             allocator: self.allocator,
-            parent: AstNodes::TSLiteralType(transmute_self(self)),
+            parent: AstNodes::TSLiteralType(self),
             following_span_start,
         })
     }
@@ -7442,13 +7864,14 @@ impl<'a> AstNode<'a, TSLiteralType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSLiteral<'a>> {
+impl<'a> AstNode<'a, '_, TSLiteral<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSLiteral::BooleanLiteral(s) => {
-                AstNodes::BooleanLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BooleanLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7456,27 +7879,35 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                 }))
             }
             TSLiteral::NumericLiteral(s) => {
-                AstNodes::NumericLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::NumericLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSLiteral::BigIntLiteral(s) => AstNodes::BigIntLiteral(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            TSLiteral::StringLiteral(s) => AstNodes::StringLiteral(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSLiteral::BigIntLiteral(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BigIntLiteral(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSLiteral::StringLiteral(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSLiteral::TemplateLiteral(s) => {
-                AstNodes::TemplateLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TemplateLiteral(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7484,7 +7915,8 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                 }))
             }
             TSLiteral::UnaryExpression(s) => {
-                AstNodes::UnaryExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::UnaryExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7492,23 +7924,28 @@ impl<'a> AstNode<'a, TSLiteral<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSType<'a>> {
+impl<'a> AstNode<'a, '_, TSType<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
-            TSType::TSAnyKeyword(s) => AstNodes::TSAnyKeyword(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSAnyKeyword(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSAnyKeyword(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSBigIntKeyword(s) => {
-                AstNodes::TSBigIntKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSBigIntKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7516,7 +7953,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSBooleanKeyword(s) => {
-                AstNodes::TSBooleanKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSBooleanKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7524,27 +7962,35 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSIntrinsicKeyword(s) => {
-                AstNodes::TSIntrinsicKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSIntrinsicKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSNeverKeyword(s) => AstNodes::TSNeverKeyword(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            TSType::TSNullKeyword(s) => AstNodes::TSNullKeyword(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSNeverKeyword(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNeverKeyword(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSType::TSNullKeyword(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNullKeyword(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSNumberKeyword(s) => {
-                AstNodes::TSNumberKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNumberKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7552,7 +7998,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSObjectKeyword(s) => {
-                AstNodes::TSObjectKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSObjectKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7560,7 +8007,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSStringKeyword(s) => {
-                AstNodes::TSStringKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSStringKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7568,7 +8016,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSSymbolKeyword(s) => {
-                AstNodes::TSSymbolKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSSymbolKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7576,7 +8025,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSUndefinedKeyword(s) => {
-                AstNodes::TSUndefinedKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSUndefinedKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7584,27 +8034,35 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSUnknownKeyword(s) => {
-                AstNodes::TSUnknownKeyword(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSUnknownKeyword(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSVoidKeyword(s) => AstNodes::TSVoidKeyword(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            TSType::TSArrayType(s) => AstNodes::TSArrayType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSVoidKeyword(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSVoidKeyword(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSType::TSArrayType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSArrayType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSConditionalType(s) => {
-                AstNodes::TSConditionalType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSConditionalType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7612,61 +8070,80 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSConstructorType(s) => {
-                AstNodes::TSConstructorType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSConstructorType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSFunctionType(s) => AstNodes::TSFunctionType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            TSType::TSImportType(s) => AstNodes::TSImportType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSFunctionType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSFunctionType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSType::TSImportType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSImportType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSIndexedAccessType(s) => {
-                AstNodes::TSIndexedAccessType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSIndexedAccessType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSInferType(s) => AstNodes::TSInferType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSInferType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSInferType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSIntersectionType(s) => {
-                AstNodes::TSIntersectionType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSIntersectionType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSLiteralType(s) => AstNodes::TSLiteralType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            TSType::TSMappedType(s) => AstNodes::TSMappedType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSLiteralType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSLiteralType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSType::TSMappedType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSMappedType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSNamedTupleMember(s) => {
-                AstNodes::TSNamedTupleMember(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSNamedTupleMember(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7674,33 +8151,44 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSTemplateLiteralType(s) => {
-                AstNodes::TSTemplateLiteralType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTemplateLiteralType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSThisType(s) => AstNodes::TSThisType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            TSType::TSTupleType(s) => AstNodes::TSTupleType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
-            TSType::TSTypeLiteral(s) => AstNodes::TSTypeLiteral(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSThisType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSThisType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSType::TSTupleType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTupleType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
+            TSType::TSTypeLiteral(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypeLiteral(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSTypeOperatorType(s) => {
-                AstNodes::TSTypeOperator(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypeOperator(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7708,35 +8196,44 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::TSTypePredicate(s) => {
-                AstNodes::TSTypePredicate(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypePredicate(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSTypeQuery(s) => AstNodes::TSTypeQuery(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSTypeQuery(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypeQuery(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSTypeReference(s) => {
-                AstNodes::TSTypeReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSTypeReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSType::TSUnionType(s) => AstNodes::TSUnionType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSType::TSUnionType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSUnionType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             TSType::TSParenthesizedType(s) => {
-                AstNodes::TSParenthesizedType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSParenthesizedType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7744,7 +8241,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::JSDocNullableType(s) => {
-                AstNodes::JSDocNullableType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSDocNullableType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7752,7 +8250,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::JSDocNonNullableType(s) => {
-                AstNodes::JSDocNonNullableType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSDocNonNullableType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7760,7 +8259,8 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
             TSType::JSDocUnknownType(s) => {
-                AstNodes::JSDocUnknownType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::JSDocUnknownType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -7768,56 +8268,61 @@ impl<'a> AstNode<'a, TSType<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSConditionalType<'a>> {
+impl<'a> AstNode<'a, '_, TSConditionalType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn check_type(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn check_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.inner.extends_type.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.check_type,
             allocator: self.allocator,
-            parent: AstNodes::TSConditionalType(transmute_self(self)),
+            parent: AstNodes::TSConditionalType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn extends_type(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn extends_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.inner.true_type.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.extends_type,
             allocator: self.allocator,
-            parent: AstNodes::TSConditionalType(transmute_self(self)),
+            parent: AstNodes::TSConditionalType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn true_type(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn true_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.inner.false_type.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.true_type,
             allocator: self.allocator,
-            parent: AstNodes::TSConditionalType(transmute_self(self)),
+            parent: AstNodes::TSConditionalType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn false_type(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn false_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.false_type,
             allocator: self.allocator,
-            parent: AstNodes::TSConditionalType(transmute_self(self)),
+            parent: AstNodes::TSConditionalType(self),
             following_span_start,
         })
     }
@@ -7832,19 +8337,20 @@ impl<'a> AstNode<'a, TSConditionalType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSUnionType<'a>> {
+impl<'a> AstNode<'a, '_, TSUnionType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn types<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
-            parent: AstNodes::TSUnionType(transmute_self(self)),
+            parent: AstNodes::TSUnionType(self),
             following_span_start,
         })
     }
@@ -7859,19 +8365,20 @@ impl<'a> AstNode<'a, TSUnionType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSIntersectionType<'a>> {
+impl<'a> AstNode<'a, '_, TSIntersectionType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn types<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
-            parent: AstNodes::TSIntersectionType(transmute_self(self)),
+            parent: AstNodes::TSIntersectionType(self),
             following_span_start,
         })
     }
@@ -7886,19 +8393,20 @@ impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
+impl<'a> AstNode<'a, '_, TSParenthesizedType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSParenthesizedType(transmute_self(self)),
+            parent: AstNodes::TSParenthesizedType(self),
             following_span_start,
         })
     }
@@ -7913,7 +8421,7 @@ impl<'a> AstNode<'a, TSParenthesizedType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeOperator<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeOperator<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -7925,12 +8433,13 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeOperator(transmute_self(self)),
+            parent: AstNodes::TSTypeOperator(self),
             following_span_start,
         })
     }
@@ -7945,19 +8454,20 @@ impl<'a> AstNode<'a, TSTypeOperator<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSArrayType<'a>> {
+impl<'a> AstNode<'a, '_, TSArrayType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn element_type(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn element_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.element_type,
             allocator: self.allocator,
-            parent: AstNodes::TSArrayType(transmute_self(self)),
+            parent: AstNodes::TSArrayType(self),
             following_span_start,
         })
     }
@@ -7972,30 +8482,32 @@ impl<'a> AstNode<'a, TSArrayType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
+impl<'a> AstNode<'a, '_, TSIndexedAccessType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn object_type(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn object_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.inner.index_type.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.object_type,
             allocator: self.allocator,
-            parent: AstNodes::TSIndexedAccessType(transmute_self(self)),
+            parent: AstNodes::TSIndexedAccessType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn index_type(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn index_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.index_type,
             allocator: self.allocator,
-            parent: AstNodes::TSIndexedAccessType(transmute_self(self)),
+            parent: AstNodes::TSIndexedAccessType(self),
             following_span_start,
         })
     }
@@ -8010,19 +8522,20 @@ impl<'a> AstNode<'a, TSIndexedAccessType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTupleType<'a>> {
+impl<'a> AstNode<'a, '_, TSTupleType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn element_types(&self) -> &AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
+    pub fn element_types<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSTupleElement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.element_types,
             allocator: self.allocator,
-            parent: AstNodes::TSTupleType(transmute_self(self)),
+            parent: AstNodes::TSTupleType(self),
             following_span_start,
         })
     }
@@ -8037,30 +8550,32 @@ impl<'a> AstNode<'a, TSTupleType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
+impl<'a> AstNode<'a, '_, TSNamedTupleMember<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn label(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn label<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = self.inner.element_type.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.label,
             allocator: self.allocator,
-            parent: AstNodes::TSNamedTupleMember(transmute_self(self)),
+            parent: AstNodes::TSNamedTupleMember(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn element_type(&self) -> &AstNode<'a, TSTupleElement<'a>> {
+    pub fn element_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTupleElement<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.element_type,
             allocator: self.allocator,
-            parent: AstNodes::TSNamedTupleMember(transmute_self(self)),
+            parent: AstNodes::TSNamedTupleMember(self),
             following_span_start,
         })
     }
@@ -8080,19 +8595,20 @@ impl<'a> AstNode<'a, TSNamedTupleMember<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSOptionalType<'a>> {
+impl<'a> AstNode<'a, '_, TSOptionalType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSOptionalType(transmute_self(self)),
+            parent: AstNodes::TSOptionalType(self),
             following_span_start,
         })
     }
@@ -8107,19 +8623,20 @@ impl<'a> AstNode<'a, TSOptionalType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSRestType<'a>> {
+impl<'a> AstNode<'a, '_, TSRestType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSRestType(transmute_self(self)),
+            parent: AstNodes::TSRestType(self),
             following_span_start,
         })
     }
@@ -8134,28 +8651,32 @@ impl<'a> AstNode<'a, TSRestType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTupleElement<'a>> {
+impl<'a> AstNode<'a, '_, TSTupleElement<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSTupleElement::TSOptionalType(s) => {
-                AstNodes::TSOptionalType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSOptionalType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSTupleElement::TSRestType(s) => AstNodes::TSRestType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSTupleElement::TSRestType(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSRestType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
             it @ match_ts_type!(TSTupleElement) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_ts_type(),
                         parent,
@@ -8165,11 +8686,12 @@ impl<'a> AstNode<'a, TSTupleElement<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSAnyKeyword> {
+impl<'a> AstNode<'a, '_, TSAnyKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8185,7 +8707,7 @@ impl<'a> AstNode<'a, TSAnyKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSStringKeyword> {
+impl<'a> AstNode<'a, '_, TSStringKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8201,7 +8723,7 @@ impl<'a> AstNode<'a, TSStringKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSBooleanKeyword> {
+impl<'a> AstNode<'a, '_, TSBooleanKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8217,7 +8739,7 @@ impl<'a> AstNode<'a, TSBooleanKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSNumberKeyword> {
+impl<'a> AstNode<'a, '_, TSNumberKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8233,7 +8755,7 @@ impl<'a> AstNode<'a, TSNumberKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSNeverKeyword> {
+impl<'a> AstNode<'a, '_, TSNeverKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8249,7 +8771,7 @@ impl<'a> AstNode<'a, TSNeverKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSIntrinsicKeyword> {
+impl<'a> AstNode<'a, '_, TSIntrinsicKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8265,7 +8787,7 @@ impl<'a> AstNode<'a, TSIntrinsicKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSUnknownKeyword> {
+impl<'a> AstNode<'a, '_, TSUnknownKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8281,7 +8803,7 @@ impl<'a> AstNode<'a, TSUnknownKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSNullKeyword> {
+impl<'a> AstNode<'a, '_, TSNullKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8297,7 +8819,7 @@ impl<'a> AstNode<'a, TSNullKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSUndefinedKeyword> {
+impl<'a> AstNode<'a, '_, TSUndefinedKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8313,7 +8835,7 @@ impl<'a> AstNode<'a, TSUndefinedKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSVoidKeyword> {
+impl<'a> AstNode<'a, '_, TSVoidKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8329,7 +8851,7 @@ impl<'a> AstNode<'a, TSVoidKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSSymbolKeyword> {
+impl<'a> AstNode<'a, '_, TSSymbolKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8345,7 +8867,7 @@ impl<'a> AstNode<'a, TSSymbolKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSThisType> {
+impl<'a> AstNode<'a, '_, TSThisType> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8361,7 +8883,7 @@ impl<'a> AstNode<'a, TSThisType> {
     }
 }
 
-impl<'a> AstNode<'a, TSObjectKeyword> {
+impl<'a> AstNode<'a, '_, TSObjectKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8377,7 +8899,7 @@ impl<'a> AstNode<'a, TSObjectKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSBigIntKeyword> {
+impl<'a> AstNode<'a, '_, TSBigIntKeyword> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8393,14 +8915,14 @@ impl<'a> AstNode<'a, TSBigIntKeyword> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeReference<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeReference<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_name(&self) -> &AstNode<'a, TSTypeName<'a>> {
+    pub fn type_name<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeName<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -8408,22 +8930,26 @@ impl<'a> AstNode<'a, TSTypeReference<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_name,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeReference(transmute_self(self)),
+            parent: AstNodes::TSTypeReference(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSTypeReference(transmute_self(self)),
+                parent: AstNodes::TSTypeReference(self),
                 following_span_start,
             }))
             .as_ref()
@@ -8439,13 +8965,14 @@ impl<'a> AstNode<'a, TSTypeReference<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeName<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSTypeName::IdentifierReference(s) => {
-                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8453,7 +8980,8 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                 }))
             }
             TSTypeName::QualifiedName(s) => {
-                AstNodes::TSQualifiedName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSQualifiedName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8461,7 +8989,8 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                 }))
             }
             TSTypeName::ThisExpression(s) => {
-                AstNodes::ThisExpression(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::ThisExpression(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8469,34 +8998,37 @@ impl<'a> AstNode<'a, TSTypeName<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSQualifiedName<'a>> {
+impl<'a> AstNode<'a, '_, TSQualifiedName<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, TSTypeName<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeName<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::TSQualifiedName(transmute_self(self)),
+            parent: AstNodes::TSQualifiedName(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::TSQualifiedName(transmute_self(self)),
+            parent: AstNodes::TSQualifiedName(self),
             following_span_start,
         })
     }
@@ -8511,19 +9043,20 @@ impl<'a> AstNode<'a, TSQualifiedName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeParameterInstantiation<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.params,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeParameterInstantiation(transmute_self(self)),
+            parent: AstNodes::TSTypeParameterInstantiation(self),
             following_span_start,
         })
     }
@@ -8538,14 +9071,14 @@ impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeParameter<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeParameter<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn name(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn name<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self
             .inner
             .constraint
@@ -8554,16 +9087,17 @@ impl<'a> AstNode<'a, TSTypeParameter<'a>> {
             .or_else(|| self.inner.default.as_ref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.name,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeParameter(transmute_self(self)),
+            parent: AstNodes::TSTypeParameter(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn constraint(&self) -> Option<&AstNode<'a, TSType<'a>>> {
+    pub fn constraint<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSType<'a>>> {
         let following_span_start = self
             .inner
             .default
@@ -8571,24 +9105,26 @@ impl<'a> AstNode<'a, TSTypeParameter<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.constraint.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::TSTypeParameter(transmute_self(self)),
+                parent: AstNodes::TSTypeParameter(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn default(&self) -> Option<&AstNode<'a, TSType<'a>>> {
+    pub fn default<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSType<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.default.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::TSTypeParameter(transmute_self(self)),
+                parent: AstNodes::TSTypeParameter(self),
                 following_span_start,
             }))
             .as_ref()
@@ -8619,19 +9155,20 @@ impl<'a> AstNode<'a, TSTypeParameter<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeParameterDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSTypeParameter<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.params,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeParameterDeclaration(transmute_self(self)),
+            parent: AstNodes::TSTypeParameterDeclaration(self),
             following_span_start,
         })
     }
@@ -8646,14 +9183,14 @@ impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeAliasDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self
             .inner
             .type_parameters
@@ -8661,34 +9198,39 @@ impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.type_annotation.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeAliasDeclaration(transmute_self(self)),
+            parent: AstNodes::TSTypeAliasDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self.inner.type_annotation.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSTypeAliasDeclaration(transmute_self(self)),
+                parent: AstNodes::TSTypeAliasDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeAliasDeclaration(transmute_self(self)),
+            parent: AstNodes::TSTypeAliasDeclaration(self),
             following_span_start,
         })
     }
@@ -8708,14 +9250,14 @@ impl<'a> AstNode<'a, TSTypeAliasDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSClassImplements<'a>> {
+impl<'a> AstNode<'a, '_, TSClassImplements<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, TSTypeName<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeName<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -8723,22 +9265,26 @@ impl<'a> AstNode<'a, TSClassImplements<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSClassImplements(transmute_self(self)),
+            parent: AstNodes::TSClassImplements(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSClassImplements(transmute_self(self)),
+                parent: AstNodes::TSClassImplements(self),
                 following_span_start,
             }))
             .as_ref()
@@ -8754,14 +9300,14 @@ impl<'a> AstNode<'a, TSClassImplements<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSInterfaceDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self
             .inner
             .type_parameters
@@ -8770,16 +9316,19 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
             .or_else(|| self.inner.extends.first().map(|n| n.span().start))
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::TSInterfaceDeclaration(transmute_self(self)),
+            parent: AstNodes::TSInterfaceDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self
             .inner
             .extends
@@ -8787,34 +9336,37 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.body.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSInterfaceDeclaration(transmute_self(self)),
+                parent: AstNodes::TSInterfaceDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn extends(&self) -> &AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
+    pub fn extends<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSInterfaceHeritage<'a>>> {
         let following_span_start = self.inner.body.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.extends,
             allocator: self.allocator,
-            parent: AstNodes::TSInterfaceDeclaration(transmute_self(self)),
+            parent: AstNodes::TSInterfaceDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, TSInterfaceBody<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, TSInterfaceBody<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.body.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSInterfaceDeclaration(transmute_self(self)),
+            parent: AstNodes::TSInterfaceDeclaration(self),
             following_span_start,
         })
     }
@@ -8834,19 +9386,20 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
+impl<'a> AstNode<'a, '_, TSInterfaceBody<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSSignature<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::TSInterfaceBody(transmute_self(self)),
+            parent: AstNodes::TSInterfaceBody(self),
             following_span_start,
         })
     }
@@ -8861,7 +9414,7 @@ impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSPropertySignature<'a>> {
+impl<'a> AstNode<'a, '_, TSPropertySignature<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -8883,7 +9436,7 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -8891,22 +9444,24 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::TSPropertySignature(transmute_self(self)),
+            parent: AstNodes::TSPropertySignature(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSPropertySignature(transmute_self(self)),
+                parent: AstNodes::TSPropertySignature(self),
                 following_span_start,
             }))
             .as_ref()
@@ -8922,13 +9477,14 @@ impl<'a> AstNode<'a, TSPropertySignature<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSSignature<'a>> {
+impl<'a> AstNode<'a, '_, TSSignature<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSSignature::TSIndexSignature(s) => {
-                AstNodes::TSIndexSignature(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSIndexSignature(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8936,7 +9492,8 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                 }))
             }
             TSSignature::TSPropertySignature(s) => {
-                AstNodes::TSPropertySignature(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSPropertySignature(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8944,7 +9501,8 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                 }))
             }
             TSSignature::TSCallSignatureDeclaration(s) => {
-                AstNodes::TSCallSignatureDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSCallSignatureDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8952,7 +9510,8 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                 }))
             }
             TSSignature::TSConstructSignatureDeclaration(s) => {
-                AstNodes::TSConstructSignatureDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSConstructSignatureDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8960,7 +9519,8 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                 }))
             }
             TSSignature::TSMethodSignature(s) => {
-                AstNodes::TSMethodSignature(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSMethodSignature(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -8968,34 +9528,37 @@ impl<'a> AstNode<'a, TSSignature<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSIndexSignature<'a>> {
+impl<'a> AstNode<'a, '_, TSIndexSignature<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn parameters(&self) -> &AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
+    pub fn parameters<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSIndexSignatureName<'a>>> {
         let following_span_start = self.inner.type_annotation.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.parameters,
             allocator: self.allocator,
-            parent: AstNodes::TSIndexSignature(transmute_self(self)),
+            parent: AstNodes::TSIndexSignature(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeAnnotation<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.type_annotation.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSIndexSignature(transmute_self(self)),
+            parent: AstNodes::TSIndexSignature(self),
             following_span_start,
         })
     }
@@ -9020,14 +9583,16 @@ impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSCallSignatureDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self
             .inner
             .this_param
@@ -9035,31 +9600,33 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.params.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSCallSignatureDeclaration(transmute_self(self)),
+                parent: AstNodes::TSCallSignatureDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
+    pub fn this_param<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSThisParameter<'a>>> {
         let following_span_start = self.inner.params.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSCallSignatureDeclaration(transmute_self(self)),
+                parent: AstNodes::TSCallSignatureDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, FormalParameters<'a>> {
         let following_span_start = self
             .inner
             .return_type
@@ -9067,22 +9634,24 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSCallSignatureDeclaration(transmute_self(self)),
+            parent: AstNodes::TSCallSignatureDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSCallSignatureDeclaration(transmute_self(self)),
+                parent: AstNodes::TSCallSignatureDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9098,14 +9667,14 @@ impl<'a> AstNode<'a, TSCallSignatureDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSMethodSignature<'a>> {
+impl<'a> AstNode<'a, '_, TSMethodSignature<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, PropertyKey<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, PropertyKey<'a>> {
         let following_span_start = self
             .inner
             .type_parameters
@@ -9114,10 +9683,11 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
             .or_else(|| self.inner.this_param.as_deref().map(|n| n.span().start))
             .or_else(|| Some(self.inner.params.span().start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::TSMethodSignature(transmute_self(self)),
+            parent: AstNodes::TSMethodSignature(self),
             following_span_start,
         })
     }
@@ -9138,7 +9708,9 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self
             .inner
             .this_param
@@ -9146,31 +9718,33 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.params.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSMethodSignature(transmute_self(self)),
+                parent: AstNodes::TSMethodSignature(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
+    pub fn this_param<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSThisParameter<'a>>> {
         let following_span_start = self.inner.params.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSMethodSignature(transmute_self(self)),
+                parent: AstNodes::TSMethodSignature(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, FormalParameters<'a>> {
         let following_span_start = self
             .inner
             .return_type
@@ -9178,22 +9752,24 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSMethodSignature(transmute_self(self)),
+            parent: AstNodes::TSMethodSignature(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSMethodSignature(transmute_self(self)),
+                parent: AstNodes::TSMethodSignature(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9209,27 +9785,30 @@ impl<'a> AstNode<'a, TSMethodSignature<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSConstructSignatureDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self.inner.params.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSConstructSignatureDeclaration(transmute_self(self)),
+                parent: AstNodes::TSConstructSignatureDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, FormalParameters<'a>> {
         let following_span_start = self
             .inner
             .return_type
@@ -9237,22 +9816,24 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSConstructSignatureDeclaration(transmute_self(self)),
+            parent: AstNodes::TSConstructSignatureDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn return_type(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.return_type.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSConstructSignatureDeclaration(transmute_self(self)),
+                parent: AstNodes::TSConstructSignatureDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9268,7 +9849,7 @@ impl<'a> AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
+impl<'a> AstNode<'a, '_, TSIndexSignatureName<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -9280,12 +9861,13 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeAnnotation<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.type_annotation.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSIndexSignatureName(transmute_self(self)),
+            parent: AstNodes::TSIndexSignatureName(self),
             following_span_start,
         })
     }
@@ -9300,14 +9882,14 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
+impl<'a> AstNode<'a, '_, TSInterfaceHeritage<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -9315,22 +9897,26 @@ impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSInterfaceHeritage(transmute_self(self)),
+            parent: AstNodes::TSInterfaceHeritage(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSInterfaceHeritage(transmute_self(self)),
+                parent: AstNodes::TSInterfaceHeritage(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9346,14 +9932,14 @@ impl<'a> AstNode<'a, TSInterfaceHeritage<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypePredicate<'a>> {
+impl<'a> AstNode<'a, '_, TSTypePredicate<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn parameter_name(&self) -> &AstNode<'a, TSTypePredicateName<'a>> {
+    pub fn parameter_name<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypePredicateName<'a>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -9361,10 +9947,11 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.parameter_name,
             allocator: self.allocator,
-            parent: AstNodes::TSTypePredicate(transmute_self(self)),
+            parent: AstNodes::TSTypePredicate(self),
             following_span_start,
         })
     }
@@ -9375,13 +9962,14 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSTypeAnnotation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSTypePredicate(transmute_self(self)),
+                parent: AstNodes::TSTypePredicate(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9397,55 +9985,62 @@ impl<'a> AstNode<'a, TSTypePredicate<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypePredicateName<'a>> {
+impl<'a> AstNode<'a, '_, TSTypePredicateName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSTypePredicateName::Identifier(s) => {
-                AstNodes::IdentifierName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
                     following_span_start: self.following_span_start,
                 }))
             }
-            TSTypePredicateName::This(s) => AstNodes::TSThisType(self.allocator.alloc(AstNode {
-                inner: s.as_ref(),
-                parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            })),
+            TSTypePredicateName::This(s) => {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSThisType(allocator.alloc(AstNode {
+                    inner: s.as_ref(),
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }))
+            }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSModuleDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, TSModuleDeclarationName<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, TSModuleDeclarationName<'a>> {
         let following_span_start = self.inner.body.as_ref().map_or(0, |n| n.span().start);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::TSModuleDeclaration(transmute_self(self)),
+            parent: AstNodes::TSModuleDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> Option<&AstNode<'a, TSModuleDeclarationBody<'a>>> {
+    pub fn body<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSModuleDeclarationBody<'a>>> {
         let following_span_start = 0;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.body.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::TSModuleDeclaration(transmute_self(self)),
+                parent: AstNodes::TSModuleDeclaration(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9471,13 +10066,14 @@ impl<'a> AstNode<'a, TSModuleDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSModuleDeclarationName<'a>> {
+impl<'a> AstNode<'a, '_, TSModuleDeclarationName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSModuleDeclarationName::Identifier(s) => {
-                AstNodes::BindingIdentifier(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::BindingIdentifier(allocator.alloc(AstNode {
                     inner: s,
                     parent,
                     allocator: self.allocator,
@@ -9485,7 +10081,8 @@ impl<'a> AstNode<'a, TSModuleDeclarationName<'a>> {
                 }))
             }
             TSModuleDeclarationName::StringLiteral(s) => {
-                AstNodes::StringLiteral(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::StringLiteral(allocator.alloc(AstNode {
                     inner: s,
                     parent,
                     allocator: self.allocator,
@@ -9493,17 +10090,19 @@ impl<'a> AstNode<'a, TSModuleDeclarationName<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSModuleDeclarationBody<'a>> {
+impl<'a> AstNode<'a, '_, TSModuleDeclarationBody<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSModuleDeclarationBody::TSModuleDeclaration(s) => {
-                AstNodes::TSModuleDeclaration(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSModuleDeclaration(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -9511,7 +10110,8 @@ impl<'a> AstNode<'a, TSModuleDeclarationBody<'a>> {
                 }))
             }
             TSModuleDeclarationBody::TSModuleBlock(s) => {
-                AstNodes::TSModuleBlock(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSModuleBlock(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -9519,11 +10119,12 @@ impl<'a> AstNode<'a, TSModuleDeclarationBody<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSGlobalDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSGlobalDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -9535,12 +10136,13 @@ impl<'a> AstNode<'a, TSGlobalDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, TSModuleBlock<'a>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, TSModuleBlock<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::TSGlobalDeclaration(transmute_self(self)),
+            parent: AstNodes::TSGlobalDeclaration(self),
             following_span_start,
         })
     }
@@ -9560,14 +10162,14 @@ impl<'a> AstNode<'a, TSGlobalDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSModuleBlock<'a>> {
+impl<'a> AstNode<'a, '_, TSModuleBlock<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
+    pub fn directives<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Directive<'a>>> {
         let following_span_start = self
             .inner
             .body
@@ -9575,21 +10177,23 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.directives,
             allocator: self.allocator,
-            parent: AstNodes::TSModuleBlock(transmute_self(self)),
+            parent: AstNodes::TSModuleBlock(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.body,
             allocator: self.allocator,
-            parent: AstNodes::TSModuleBlock(transmute_self(self)),
+            parent: AstNodes::TSModuleBlock(self),
             following_span_start,
         })
     }
@@ -9604,19 +10208,20 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeLiteral<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn members(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
+    pub fn members<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSSignature<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.members,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeLiteral(transmute_self(self)),
+            parent: AstNodes::TSTypeLiteral(self),
             following_span_start,
         })
     }
@@ -9631,19 +10236,20 @@ impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInferType<'a>> {
+impl<'a> AstNode<'a, '_, TSInferType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_parameter(&self) -> &AstNode<'a, TSTypeParameter<'a>> {
+    pub fn type_parameter<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeParameter<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.type_parameter.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSInferType(transmute_self(self)),
+            parent: AstNodes::TSInferType(self),
             following_span_start,
         })
     }
@@ -9658,14 +10264,14 @@ impl<'a> AstNode<'a, TSInferType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeQuery<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeQuery<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expr_name(&self) -> &AstNode<'a, TSTypeQueryExprName<'a>> {
+    pub fn expr_name<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeQueryExprName<'a>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -9673,22 +10279,26 @@ impl<'a> AstNode<'a, TSTypeQuery<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expr_name,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeQuery(transmute_self(self)),
+            parent: AstNodes::TSTypeQuery(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSTypeQuery(transmute_self(self)),
+                parent: AstNodes::TSTypeQuery(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9704,13 +10314,14 @@ impl<'a> AstNode<'a, TSTypeQuery<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeQueryExprName<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSTypeQueryExprName::TSImportType(s) => {
-                AstNodes::TSImportType(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSImportType(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -9718,8 +10329,8 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
                 }))
             }
             it @ match_ts_type_name!(TSTypeQueryExprName) => {
-                return self
-                    .allocator
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                return allocator
                     .alloc(AstNode {
                         inner: it.to_ts_type_name(),
                         parent,
@@ -9729,18 +10340,19 @@ impl<'a> AstNode<'a, TSTypeQueryExprName<'a>> {
                     .as_ast_nodes();
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSImportType<'a>> {
+impl<'a> AstNode<'a, '_, TSImportType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn source(&self) -> &AstNode<'a, StringLiteral<'a>> {
+    pub fn source<'c>(&'c self) -> &'c AstNode<'a, 'c, StringLiteral<'a>> {
         let following_span_start = self
             .inner
             .options
@@ -9750,16 +10362,17 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
             .or_else(|| self.inner.type_arguments.as_deref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.source,
             allocator: self.allocator,
-            parent: AstNodes::TSImportType(transmute_self(self)),
+            parent: AstNodes::TSImportType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn options(&self) -> Option<&AstNode<'a, ObjectExpression<'a>>> {
+    pub fn options<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, ObjectExpression<'a>>> {
         let following_span_start = self
             .inner
             .qualifier
@@ -9768,18 +10381,19 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
             .or_else(|| self.inner.type_arguments.as_deref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.options.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSImportType(transmute_self(self)),
+                parent: AstNodes::TSImportType(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn qualifier(&self) -> Option<&AstNode<'a, TSImportTypeQualifier<'a>>> {
+    pub fn qualifier<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSImportTypeQualifier<'a>>> {
         let following_span_start = self
             .inner
             .type_arguments
@@ -9787,24 +10401,28 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.qualifier.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::TSImportType(transmute_self(self)),
+                parent: AstNodes::TSImportType(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> Option<&AstNode<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_arguments.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSImportType(transmute_self(self)),
+                parent: AstNodes::TSImportType(self),
                 following_span_start,
             }))
             .as_ref()
@@ -9820,13 +10438,14 @@ impl<'a> AstNode<'a, TSImportType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
+impl<'a> AstNode<'a, '_, TSImportTypeQualifier<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSImportTypeQualifier::Identifier(s) => {
-                AstNodes::IdentifierName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -9834,7 +10453,8 @@ impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
                 }))
             }
             TSImportTypeQualifier::QualifiedName(s) => {
-                AstNodes::TSImportTypeQualifiedName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSImportTypeQualifiedName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -9842,34 +10462,37 @@ impl<'a> AstNode<'a, TSImportTypeQualifier<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSImportTypeQualifiedName<'a>> {
+impl<'a> AstNode<'a, '_, TSImportTypeQualifiedName<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn left(&self) -> &AstNode<'a, TSImportTypeQualifier<'a>> {
+    pub fn left<'c>(&'c self) -> &'c AstNode<'a, 'c, TSImportTypeQualifier<'a>> {
         let following_span_start = self.inner.right.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.left,
             allocator: self.allocator,
-            parent: AstNodes::TSImportTypeQualifiedName(transmute_self(self)),
+            parent: AstNodes::TSImportTypeQualifiedName(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn right(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn right<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.right,
             allocator: self.allocator,
-            parent: AstNodes::TSImportTypeQualifiedName(transmute_self(self)),
+            parent: AstNodes::TSImportTypeQualifiedName(self),
             following_span_start,
         })
     }
@@ -9884,14 +10507,16 @@ impl<'a> AstNode<'a, TSImportTypeQualifiedName<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSFunctionType<'a>> {
+impl<'a> AstNode<'a, '_, TSFunctionType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self
             .inner
             .this_param
@@ -9899,47 +10524,51 @@ impl<'a> AstNode<'a, TSFunctionType<'a>> {
             .map(|n| n.span().start)
             .or_else(|| Some(self.inner.params.span().start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSFunctionType(transmute_self(self)),
+                parent: AstNodes::TSFunctionType(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn this_param(&self) -> Option<&AstNode<'a, TSThisParameter<'a>>> {
+    pub fn this_param<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSThisParameter<'a>>> {
         let following_span_start = self.inner.params.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.this_param.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSFunctionType(transmute_self(self)),
+                parent: AstNodes::TSFunctionType(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, FormalParameters<'a>> {
         let following_span_start = self.inner.return_type.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSFunctionType(transmute_self(self)),
+            parent: AstNodes::TSFunctionType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn return_type(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeAnnotation<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.return_type.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSFunctionType(transmute_self(self)),
+            parent: AstNodes::TSFunctionType(self),
             following_span_start,
         })
     }
@@ -9954,7 +10583,7 @@ impl<'a> AstNode<'a, TSFunctionType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSConstructorType<'a>> {
+impl<'a> AstNode<'a, '_, TSConstructorType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
@@ -9966,36 +10595,41 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
     }
 
     #[inline]
-    pub fn type_parameters(&self) -> Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters<'c>(
+        &'c self,
+    ) -> Option<&'c AstNode<'a, 'c, TSTypeParameterDeclaration<'a>>> {
         let following_span_start = self.inner.params.span().start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_parameters.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
                 allocator: self.allocator,
-                parent: AstNodes::TSConstructorType(transmute_self(self)),
+                parent: AstNodes::TSConstructorType(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, FormalParameters<'a>> {
+    pub fn params<'c>(&'c self) -> &'c AstNode<'a, 'c, FormalParameters<'a>> {
         let following_span_start = self.inner.return_type.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.params.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSConstructorType(transmute_self(self)),
+            parent: AstNodes::TSConstructorType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn return_type(&self) -> &AstNode<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeAnnotation<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.return_type.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSConstructorType(transmute_self(self)),
+            parent: AstNodes::TSConstructorType(self),
             following_span_start,
         })
     }
@@ -10010,25 +10644,26 @@ impl<'a> AstNode<'a, TSConstructorType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSMappedType<'a>> {
+impl<'a> AstNode<'a, '_, TSMappedType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn key(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn key<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self.inner.constraint.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.key,
             allocator: self.allocator,
-            parent: AstNodes::TSMappedType(transmute_self(self)),
+            parent: AstNodes::TSMappedType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn constraint(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn constraint<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self
             .inner
             .name_type
@@ -10037,16 +10672,17 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
             .or_else(|| self.inner.type_annotation.as_ref().map(|n| n.span().start))
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.constraint,
             allocator: self.allocator,
-            parent: AstNodes::TSMappedType(transmute_self(self)),
+            parent: AstNodes::TSMappedType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn name_type(&self) -> Option<&AstNode<'a, TSType<'a>>> {
+    pub fn name_type<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSType<'a>>> {
         let following_span_start = self
             .inner
             .type_annotation
@@ -10054,24 +10690,26 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.name_type.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::TSMappedType(transmute_self(self)),
+                parent: AstNodes::TSMappedType(self),
                 following_span_start,
             }))
             .as_ref()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> Option<&AstNode<'a, TSType<'a>>> {
+    pub fn type_annotation<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, TSType<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.type_annotation.as_ref().map(|inner| AstNode {
                 inner,
                 allocator: self.allocator,
-                parent: AstNodes::TSMappedType(transmute_self(self)),
+                parent: AstNodes::TSMappedType(self),
                 following_span_start,
             }))
             .as_ref()
@@ -10097,14 +10735,14 @@ impl<'a> AstNode<'a, TSMappedType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
+impl<'a> AstNode<'a, '_, TSTemplateLiteralType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
+    pub fn quasis<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TemplateElement<'a>>> {
         let following_span_start = self
             .inner
             .types
@@ -10112,21 +10750,23 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
             .map(|n| n.span().start)
             .or(Some(self.following_span_start))
             .unwrap_or(0);
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.quasis,
             allocator: self.allocator,
-            parent: AstNodes::TSTemplateLiteralType(transmute_self(self)),
+            parent: AstNodes::TSTemplateLiteralType(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn types<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.types,
             allocator: self.allocator,
-            parent: AstNodes::TSTemplateLiteralType(transmute_self(self)),
+            parent: AstNodes::TSTemplateLiteralType(self),
             following_span_start,
         })
     }
@@ -10141,30 +10781,32 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSAsExpression<'a>> {
+impl<'a> AstNode<'a, '_, TSAsExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.type_annotation.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSAsExpression(transmute_self(self)),
+            parent: AstNodes::TSAsExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSAsExpression(transmute_self(self)),
+            parent: AstNodes::TSAsExpression(self),
             following_span_start,
         })
     }
@@ -10179,30 +10821,32 @@ impl<'a> AstNode<'a, TSAsExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
+impl<'a> AstNode<'a, '_, TSSatisfiesExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.type_annotation.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSSatisfiesExpression(transmute_self(self)),
+            parent: AstNodes::TSSatisfiesExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSSatisfiesExpression(transmute_self(self)),
+            parent: AstNodes::TSSatisfiesExpression(self),
             following_span_start,
         })
     }
@@ -10217,30 +10861,32 @@ impl<'a> AstNode<'a, TSSatisfiesExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
+impl<'a> AstNode<'a, '_, TSTypeAssertion<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.inner.expression.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeAssertion(transmute_self(self)),
+            parent: AstNodes::TSTypeAssertion(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSTypeAssertion(transmute_self(self)),
+            parent: AstNodes::TSTypeAssertion(self),
             following_span_start,
         })
     }
@@ -10255,30 +10901,32 @@ impl<'a> AstNode<'a, TSTypeAssertion<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSImportEqualsDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, BindingIdentifier<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, BindingIdentifier<'a>> {
         let following_span_start = self.inner.module_reference.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::TSImportEqualsDeclaration(transmute_self(self)),
+            parent: AstNodes::TSImportEqualsDeclaration(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn module_reference(&self) -> &AstNode<'a, TSModuleReference<'a>> {
+    pub fn module_reference<'c>(&'c self) -> &'c AstNode<'a, 'c, TSModuleReference<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.module_reference,
             allocator: self.allocator,
-            parent: AstNodes::TSImportEqualsDeclaration(transmute_self(self)),
+            parent: AstNodes::TSImportEqualsDeclaration(self),
             following_span_start,
         })
     }
@@ -10298,13 +10946,14 @@ impl<'a> AstNode<'a, TSImportEqualsDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSModuleReference<'a>> {
+impl<'a> AstNode<'a, '_, TSModuleReference<'a>> {
     #[inline]
-    pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+    pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
         let parent = self.parent;
         let node = match self.inner {
             TSModuleReference::ExternalModuleReference(s) => {
-                AstNodes::TSExternalModuleReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSExternalModuleReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -10312,7 +10961,8 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                 }))
             }
             TSModuleReference::IdentifierReference(s) => {
-                AstNodes::IdentifierReference(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::IdentifierReference(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -10320,7 +10970,8 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                 }))
             }
             TSModuleReference::QualifiedName(s) => {
-                AstNodes::TSQualifiedName(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::TSQualifiedName(allocator.alloc(AstNode {
                     inner: s.as_ref(),
                     parent,
                     allocator: self.allocator,
@@ -10328,23 +10979,25 @@ impl<'a> AstNode<'a, TSModuleReference<'a>> {
                 }))
             }
         };
-        self.allocator.alloc(node)
+        let allocator: &'c oxc_allocator::Allocator = self.allocator;
+        allocator.alloc(node)
     }
 }
 
-impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
+impl<'a> AstNode<'a, '_, TSExternalModuleReference<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, StringLiteral<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, StringLiteral<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSExternalModuleReference(transmute_self(self)),
+            parent: AstNodes::TSExternalModuleReference(self),
             following_span_start,
         })
     }
@@ -10359,19 +11012,20 @@ impl<'a> AstNode<'a, TSExternalModuleReference<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
+impl<'a> AstNode<'a, '_, TSNonNullExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSNonNullExpression(transmute_self(self)),
+            parent: AstNodes::TSNonNullExpression(self),
             following_span_start,
         })
     }
@@ -10386,19 +11040,20 @@ impl<'a> AstNode<'a, TSNonNullExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Decorator<'a>> {
+impl<'a> AstNode<'a, '_, Decorator<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::Decorator(transmute_self(self)),
+            parent: AstNodes::Decorator(self),
             following_span_start,
         })
     }
@@ -10413,19 +11068,20 @@ impl<'a> AstNode<'a, Decorator<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSExportAssignment<'a>> {
+impl<'a> AstNode<'a, '_, TSExportAssignment<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSExportAssignment(transmute_self(self)),
+            parent: AstNodes::TSExportAssignment(self),
             following_span_start,
         })
     }
@@ -10440,19 +11096,20 @@ impl<'a> AstNode<'a, TSExportAssignment<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
+impl<'a> AstNode<'a, '_, TSNamespaceExportDeclaration<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn id(&self) -> &AstNode<'a, IdentifierName<'a>> {
+    pub fn id<'c>(&'c self) -> &'c AstNode<'a, 'c, IdentifierName<'a>> {
         let following_span_start = 0;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.id,
             allocator: self.allocator,
-            parent: AstNodes::TSNamespaceExportDeclaration(transmute_self(self)),
+            parent: AstNodes::TSNamespaceExportDeclaration(self),
             following_span_start,
         })
     }
@@ -10467,30 +11124,32 @@ impl<'a> AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
+impl<'a> AstNode<'a, '_, TSInstantiationExpression<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn expression(&self) -> &AstNode<'a, Expression<'a>> {
+    pub fn expression<'c>(&'c self) -> &'c AstNode<'a, 'c, Expression<'a>> {
         let following_span_start = self.inner.type_arguments.span().start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.expression,
             allocator: self.allocator,
-            parent: AstNodes::TSInstantiationExpression(transmute_self(self)),
+            parent: AstNodes::TSInstantiationExpression(self),
             following_span_start,
         })
     }
 
     #[inline]
-    pub fn type_arguments(&self) -> &AstNode<'a, TSTypeParameterInstantiation<'a>> {
+    pub fn type_arguments<'c>(&'c self) -> &'c AstNode<'a, 'c, TSTypeParameterInstantiation<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: self.inner.type_arguments.as_ref(),
             allocator: self.allocator,
-            parent: AstNodes::TSInstantiationExpression(transmute_self(self)),
+            parent: AstNodes::TSInstantiationExpression(self),
             following_span_start,
         })
     }
@@ -10505,19 +11164,20 @@ impl<'a> AstNode<'a, TSInstantiationExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSDocNullableType<'a>> {
+impl<'a> AstNode<'a, '_, JSDocNullableType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::JSDocNullableType(transmute_self(self)),
+            parent: AstNodes::JSDocNullableType(self),
             following_span_start,
         })
     }
@@ -10537,19 +11197,20 @@ impl<'a> AstNode<'a, JSDocNullableType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
+impl<'a> AstNode<'a, '_, JSDocNonNullableType<'a>> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()
     }
 
     #[inline]
-    pub fn type_annotation(&self) -> &AstNode<'a, TSType<'a>> {
+    pub fn type_annotation<'c>(&'c self) -> &'c AstNode<'a, 'c, TSType<'a>> {
         let following_span_start = self.following_span_start;
-        self.allocator.alloc(AstNode {
+        let allocator: &'c Allocator = self.allocator;
+        allocator.alloc(AstNode {
             inner: &self.inner.type_annotation,
             allocator: self.allocator,
-            parent: AstNodes::JSDocNonNullableType(transmute_self(self)),
+            parent: AstNodes::JSDocNonNullableType(self),
             following_span_start,
         })
     }
@@ -10569,7 +11230,7 @@ impl<'a> AstNode<'a, JSDocNonNullableType<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, JSDocUnknownType> {
+impl<'a> AstNode<'a, '_, JSDocUnknownType> {
     #[inline]
     pub fn node_id(&self) -> NodeId {
         self.inner.node_id()

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -16,13 +16,13 @@ use crate::{
     utils::{suppressed::FormatSuppressedNode, typecast::format_type_cast_comment_node},
 };
 
-impl<'a> Format<'a> for AstNode<'a, Program<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Program<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         self.write(f);
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Expression<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if f.comments().has_trailing_suppression_comment(self.span().end) {
@@ -36,425 +36,383 @@ impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
             .fmt(f);
             return;
         }
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             Expression::BooleanLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<BooleanLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BooleanLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::NullLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<NullLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<NullLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::NumericLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<NumericLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<NumericLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::BigIntLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<BigIntLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BigIntLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::RegExpLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<RegExpLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<RegExpLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::StringLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::TemplateLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<TemplateLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TemplateLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::MetaProperty(inner) => {
-                allocator
-                    .alloc(AstNode::<MetaProperty> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<MetaProperty> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::Super(inner) => {
-                allocator
-                    .alloc(AstNode::<Super> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Super> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ArrayExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ArrayExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ArrayExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ArrowFunctionExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ArrowFunctionExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ArrowFunctionExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::AssignmentExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<AssignmentExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<AssignmentExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::AwaitExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<AwaitExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<AwaitExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::BinaryExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<BinaryExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BinaryExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::CallExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<CallExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<CallExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ChainExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ChainExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ChainExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ClassExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<Class> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Class> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ConditionalExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ConditionalExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ConditionalExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::FunctionExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<Function> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Function> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ImportExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ImportExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ImportExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::LogicalExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<LogicalExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<LogicalExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::NewExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<NewExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<NewExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ObjectExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ObjectExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ObjectExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ParenthesizedExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ParenthesizedExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ParenthesizedExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::SequenceExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<SequenceExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<SequenceExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::TaggedTemplateExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TaggedTemplateExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TaggedTemplateExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::ThisExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ThisExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ThisExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::UnaryExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<UnaryExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<UnaryExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::UpdateExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<UpdateExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<UpdateExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::YieldExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<YieldExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<YieldExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::PrivateInExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<PrivateInExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<PrivateInExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::JSXElement(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXElement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXElement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::JSXFragment(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXFragment> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXFragment> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::TSAsExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSAsExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSAsExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::TSSatisfiesExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSSatisfiesExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSSatisfiesExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::TSTypeAssertion(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypeAssertion> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypeAssertion> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::TSNonNullExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNonNullExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNonNullExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::TSInstantiationExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSInstantiationExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSInstantiationExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Expression::V8IntrinsicExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<V8IntrinsicExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<V8IntrinsicExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_member_expression!(Expression) => {
                 let inner = it.to_member_expression();
-                allocator
-                    .alloc(AstNode::<'a, MemberExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, MemberExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, IdentifierName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, IdentifierName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -467,56 +425,7 @@ impl<'a> Format<'a> for AstNode<'a, IdentifierName<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, IdentifierReference<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        self.format_leading_comments(f);
-        let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, BindingIdentifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, LabelIdentifier<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, ThisExpression> {
+impl<'a> Format<'a> for AstNode<'a, '_, IdentifierReference<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -539,7 +448,56 @@ impl<'a> Format<'a> for AstNode<'a, ThisExpression> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ArrayExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BindingIdentifier<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, LabelIdentifier<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, ThisExpression> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
+        }
+        self.format_leading_comments(f);
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f);
+        }
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, ArrayExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, true, f) {
@@ -562,48 +520,44 @@ impl<'a> Format<'a> for AstNode<'a, ArrayExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ArrayExpressionElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ArrayExpressionElement<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ArrayExpressionElement::SpreadElement(inner) => {
-                allocator
-                    .alloc(AstNode::<SpreadElement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<SpreadElement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ArrayExpressionElement::Elision(inner) => {
-                allocator
-                    .alloc(AstNode::<Elision> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Elision> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_expression!(ArrayExpressionElement) => {
                 let inner = it.to_expression();
-                allocator
-                    .alloc(AstNode::<'a, Expression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, Expression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Elision> {
+impl<'a> Format<'a> for AstNode<'a, '_, Elision> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -616,7 +570,7 @@ impl<'a> Format<'a> for AstNode<'a, Elision> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ObjectExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ObjectExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, true, f) {
@@ -639,37 +593,34 @@ impl<'a> Format<'a> for AstNode<'a, ObjectExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ObjectPropertyKind<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ObjectPropertyKind<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ObjectPropertyKind::ObjectProperty(inner) => {
-                allocator
-                    .alloc(AstNode::<ObjectProperty> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ObjectProperty> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ObjectPropertyKind::SpreadProperty(inner) => {
-                allocator
-                    .alloc(AstNode::<SpreadElement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<SpreadElement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ObjectProperty<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ObjectProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -682,48 +633,44 @@ impl<'a> Format<'a> for AstNode<'a, ObjectProperty<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, PropertyKey<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, PropertyKey<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             PropertyKey::StaticIdentifier(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             PropertyKey::PrivateIdentifier(inner) => {
-                allocator
-                    .alloc(AstNode::<PrivateIdentifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<PrivateIdentifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_expression!(PropertyKey) => {
                 let inner = it.to_expression();
-                allocator
-                    .alloc(AstNode::<'a, Expression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, Expression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TemplateLiteral<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TemplateLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -746,7 +693,7 @@ impl<'a> Format<'a> for AstNode<'a, TemplateLiteral<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TaggedTemplateExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -769,7 +716,7 @@ impl<'a> Format<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TemplateElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TemplateElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -782,47 +729,43 @@ impl<'a> Format<'a> for AstNode<'a, TemplateElement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, MemberExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, MemberExpression<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             MemberExpression::ComputedMemberExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ComputedMemberExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ComputedMemberExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             MemberExpression::StaticMemberExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<StaticMemberExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StaticMemberExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             MemberExpression::PrivateFieldExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<PrivateFieldExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<PrivateFieldExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ComputedMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -845,7 +788,7 @@ impl<'a> Format<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, StaticMemberExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, StaticMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -868,7 +811,7 @@ impl<'a> Format<'a> for AstNode<'a, StaticMemberExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, PrivateFieldExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -891,7 +834,7 @@ impl<'a> Format<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, CallExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, CallExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -914,7 +857,7 @@ impl<'a> Format<'a> for AstNode<'a, CallExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, NewExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, NewExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -937,7 +880,7 @@ impl<'a> Format<'a> for AstNode<'a, NewExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, MetaProperty<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, MetaProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -960,7 +903,7 @@ impl<'a> Format<'a> for AstNode<'a, MetaProperty<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, SpreadElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, SpreadElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -973,38 +916,35 @@ impl<'a> Format<'a> for AstNode<'a, SpreadElement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Argument<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Argument<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             Argument::SpreadElement(inner) => {
-                allocator
-                    .alloc(AstNode::<SpreadElement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<SpreadElement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_expression!(Argument) => {
                 let inner = it.to_expression();
-                allocator
-                    .alloc(AstNode::<'a, Expression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, Expression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, UpdateExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, UpdateExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1027,7 +967,7 @@ impl<'a> Format<'a> for AstNode<'a, UpdateExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, UnaryExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, UnaryExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1050,7 +990,7 @@ impl<'a> Format<'a> for AstNode<'a, UnaryExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BinaryExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BinaryExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1073,7 +1013,7 @@ impl<'a> Format<'a> for AstNode<'a, BinaryExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, PrivateInExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, PrivateInExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1096,7 +1036,7 @@ impl<'a> Format<'a> for AstNode<'a, PrivateInExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, LogicalExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, LogicalExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1119,7 +1059,7 @@ impl<'a> Format<'a> for AstNode<'a, LogicalExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ConditionalExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ConditionalExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1142,7 +1082,7 @@ impl<'a> Format<'a> for AstNode<'a, ConditionalExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1165,140 +1105,127 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTarget<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTarget<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             it @ match_simple_assignment_target!(AssignmentTarget) => {
                 let inner = it.to_simple_assignment_target();
-                allocator
-                    .alloc(AstNode::<'a, SimpleAssignmentTarget> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, SimpleAssignmentTarget> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_assignment_target_pattern!(AssignmentTarget) => {
                 let inner = it.to_assignment_target_pattern();
-                allocator
-                    .alloc(AstNode::<'a, AssignmentTargetPattern> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, AssignmentTargetPattern> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, SimpleAssignmentTarget<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, SimpleAssignmentTarget<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             SimpleAssignmentTarget::AssignmentTargetIdentifier(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             SimpleAssignmentTarget::TSAsExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSAsExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSAsExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             SimpleAssignmentTarget::TSSatisfiesExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSSatisfiesExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSSatisfiesExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             SimpleAssignmentTarget::TSNonNullExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNonNullExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNonNullExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             SimpleAssignmentTarget::TSTypeAssertion(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypeAssertion> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypeAssertion> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_member_expression!(SimpleAssignmentTarget) => {
                 let inner = it.to_member_expression();
-                allocator
-                    .alloc(AstNode::<'a, MemberExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, MemberExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPattern<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTargetPattern<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             AssignmentTargetPattern::ArrayAssignmentTarget(inner) => {
-                allocator
-                    .alloc(AstNode::<ArrayAssignmentTarget> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ArrayAssignmentTarget> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             AssignmentTargetPattern::ObjectAssignmentTarget(inner) => {
-                allocator
-                    .alloc(AstNode::<ObjectAssignmentTarget> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ObjectAssignmentTarget> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ArrayAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1311,7 +1238,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ObjectAssignmentTarget<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ObjectAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1324,7 +1251,7 @@ impl<'a> Format<'a> for AstNode<'a, ObjectAssignmentTarget<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTargetRest<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTargetRest<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1337,38 +1264,35 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetRest<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTargetMaybeDefault<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTargetMaybeDefault<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(inner) => {
-                allocator
-                    .alloc(AstNode::<AssignmentTargetWithDefault> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<AssignmentTargetWithDefault> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_assignment_target!(AssignmentTargetMaybeDefault) => {
                 let inner = it.to_assignment_target();
-                allocator
-                    .alloc(AstNode::<'a, AssignmentTarget> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, AssignmentTarget> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTargetWithDefault<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1381,37 +1305,34 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTargetProperty<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTargetProperty<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(inner) => {
-                allocator
-                    .alloc(AstNode::<AssignmentTargetPropertyIdentifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<AssignmentTargetPropertyIdentifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             AssignmentTargetProperty::AssignmentTargetPropertyProperty(inner) => {
-                allocator
-                    .alloc(AstNode::<AssignmentTargetPropertyProperty> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<AssignmentTargetPropertyProperty> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTargetPropertyIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1424,7 +1345,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentTargetPropertyProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1437,30 +1358,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, SequenceExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        self.format_leading_comments(f);
-        let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, Super> {
+impl<'a> Format<'a> for AstNode<'a, '_, SequenceExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1483,7 +1381,7 @@ impl<'a> Format<'a> for AstNode<'a, Super> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AwaitExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Super> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1506,7 +1404,7 @@ impl<'a> Format<'a> for AstNode<'a, AwaitExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ChainExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AwaitExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1529,48 +1427,67 @@ impl<'a> Format<'a> for AstNode<'a, ChainExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ChainElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ChainExpression<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
+        }
+        self.format_leading_comments(f);
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f);
+        }
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, ChainElement<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ChainElement::CallExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<CallExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<CallExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ChainElement::TSNonNullExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNonNullExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNonNullExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_member_expression!(ChainElement) => {
                 let inner = it.to_member_expression();
-                allocator
-                    .alloc(AstNode::<'a, MemberExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, MemberExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ParenthesizedExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ParenthesizedExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -1593,7 +1510,7 @@ impl<'a> Format<'a> for AstNode<'a, ParenthesizedExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Statement<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if !matches!(self.inner, Statement::ExpressionStatement(_))
@@ -1609,216 +1526,195 @@ impl<'a> Format<'a> for AstNode<'a, Statement<'a>> {
             .fmt(f);
             return;
         }
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             Statement::BlockStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<BlockStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BlockStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::BreakStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<BreakStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BreakStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::ContinueStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<ContinueStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ContinueStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::DebuggerStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<DebuggerStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<DebuggerStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::DoWhileStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<DoWhileStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<DoWhileStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::EmptyStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<EmptyStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<EmptyStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::ExpressionStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<ExpressionStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ExpressionStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::ForInStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<ForInStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ForInStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::ForOfStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<ForOfStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ForOfStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::ForStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<ForStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ForStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::IfStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<IfStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IfStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::LabeledStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<LabeledStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<LabeledStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::ReturnStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<ReturnStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ReturnStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::SwitchStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<SwitchStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<SwitchStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::ThrowStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<ThrowStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ThrowStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::TryStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<TryStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TryStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::WhileStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<WhileStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<WhileStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Statement::WithStatement(inner) => {
-                allocator
-                    .alloc(AstNode::<WithStatement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<WithStatement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_declaration!(Statement) => {
                 let inner = it.to_declaration();
-                allocator
-                    .alloc(AstNode::<'a, Declaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, Declaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_module_declaration!(Statement) => {
                 let inner = it.to_module_declaration();
-                allocator
-                    .alloc(AstNode::<'a, ModuleDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, ModuleDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Directive<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Directive<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1831,7 +1727,7 @@ impl<'a> Format<'a> for AstNode<'a, Directive<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Hashbang<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Hashbang<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1844,7 +1740,7 @@ impl<'a> Format<'a> for AstNode<'a, Hashbang<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BlockStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BlockStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1857,107 +1753,97 @@ impl<'a> Format<'a> for AstNode<'a, BlockStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Declaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Declaration<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             Declaration::VariableDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<VariableDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<VariableDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::FunctionDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<Function> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Function> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::ClassDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<Class> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Class> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::TSTypeAliasDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypeAliasDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypeAliasDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::TSInterfaceDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSInterfaceDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSInterfaceDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::TSEnumDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSEnumDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSEnumDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::TSModuleDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSModuleDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSModuleDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::TSGlobalDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSGlobalDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSGlobalDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             Declaration::TSImportEqualsDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSImportEqualsDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSImportEqualsDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, VariableDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, VariableDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1970,7 +1856,7 @@ impl<'a> Format<'a> for AstNode<'a, VariableDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, VariableDeclarator<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, VariableDeclarator<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1983,7 +1869,7 @@ impl<'a> Format<'a> for AstNode<'a, VariableDeclarator<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, EmptyStatement> {
+impl<'a> Format<'a> for AstNode<'a, '_, EmptyStatement> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -1996,7 +1882,7 @@ impl<'a> Format<'a> for AstNode<'a, EmptyStatement> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ExpressionStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2009,7 +1895,7 @@ impl<'a> Format<'a> for AstNode<'a, ExpressionStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, IfStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, IfStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2022,7 +1908,7 @@ impl<'a> Format<'a> for AstNode<'a, IfStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, DoWhileStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, DoWhileStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2035,7 +1921,7 @@ impl<'a> Format<'a> for AstNode<'a, DoWhileStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, WhileStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, WhileStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2048,7 +1934,7 @@ impl<'a> Format<'a> for AstNode<'a, WhileStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ForStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ForStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2061,38 +1947,35 @@ impl<'a> Format<'a> for AstNode<'a, ForStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ForStatementInit<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ForStatementInit<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ForStatementInit::VariableDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<VariableDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<VariableDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_expression!(ForStatementInit) => {
                 let inner = it.to_expression();
-                allocator
-                    .alloc(AstNode::<'a, Expression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, Expression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ForInStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ForInStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2105,38 +1988,35 @@ impl<'a> Format<'a> for AstNode<'a, ForInStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ForStatementLeft<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ForStatementLeft<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ForStatementLeft::VariableDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<VariableDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<VariableDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_assignment_target!(ForStatementLeft) => {
                 let inner = it.to_assignment_target();
-                allocator
-                    .alloc(AstNode::<'a, AssignmentTarget> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, AssignmentTarget> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ForOfStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ForOfStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2149,7 +2029,7 @@ impl<'a> Format<'a> for AstNode<'a, ForOfStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ContinueStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ContinueStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2162,7 +2042,7 @@ impl<'a> Format<'a> for AstNode<'a, ContinueStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BreakStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BreakStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2175,7 +2055,7 @@ impl<'a> Format<'a> for AstNode<'a, BreakStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ReturnStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ReturnStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2188,7 +2068,7 @@ impl<'a> Format<'a> for AstNode<'a, ReturnStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, WithStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, WithStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2201,7 +2081,7 @@ impl<'a> Format<'a> for AstNode<'a, WithStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, SwitchStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, SwitchStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2214,7 +2094,7 @@ impl<'a> Format<'a> for AstNode<'a, SwitchStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, SwitchCase<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, SwitchCase<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2227,7 +2107,7 @@ impl<'a> Format<'a> for AstNode<'a, SwitchCase<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, LabeledStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, LabeledStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2240,7 +2120,7 @@ impl<'a> Format<'a> for AstNode<'a, LabeledStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ThrowStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ThrowStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2253,7 +2133,7 @@ impl<'a> Format<'a> for AstNode<'a, ThrowStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TryStatement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TryStatement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2266,7 +2146,7 @@ impl<'a> Format<'a> for AstNode<'a, TryStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, CatchClause<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, CatchClause<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -2279,7 +2159,7 @@ impl<'a> Format<'a> for AstNode<'a, CatchClause<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, CatchParameter<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, CatchParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -2292,7 +2172,7 @@ impl<'a> Format<'a> for AstNode<'a, CatchParameter<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, DebuggerStatement> {
+impl<'a> Format<'a> for AstNode<'a, '_, DebuggerStatement> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2305,57 +2185,52 @@ impl<'a> Format<'a> for AstNode<'a, DebuggerStatement> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BindingPattern<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BindingPattern<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             BindingPattern::BindingIdentifier(inner) => {
-                allocator
-                    .alloc(AstNode::<BindingIdentifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BindingIdentifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             BindingPattern::ObjectPattern(inner) => {
-                allocator
-                    .alloc(AstNode::<ObjectPattern> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ObjectPattern> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             BindingPattern::ArrayPattern(inner) => {
-                allocator
-                    .alloc(AstNode::<ArrayPattern> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ArrayPattern> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             BindingPattern::AssignmentPattern(inner) => {
-                allocator
-                    .alloc(AstNode::<AssignmentPattern> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<AssignmentPattern> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AssignmentPattern<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AssignmentPattern<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2368,7 +2243,7 @@ impl<'a> Format<'a> for AstNode<'a, AssignmentPattern<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ObjectPattern<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ObjectPattern<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2381,7 +2256,7 @@ impl<'a> Format<'a> for AstNode<'a, ObjectPattern<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BindingProperty<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BindingProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2394,7 +2269,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingProperty<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ArrayPattern<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ArrayPattern<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2407,7 +2282,7 @@ impl<'a> Format<'a> for AstNode<'a, ArrayPattern<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BindingRestElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BindingRestElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2420,7 +2295,7 @@ impl<'a> Format<'a> for AstNode<'a, BindingRestElement<'a>> {
     }
 }
 
-impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
+impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, '_, Function<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -2464,7 +2339,7 @@ impl<'a> Format<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, FormalParameters<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, FormalParameters<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -2477,7 +2352,7 @@ impl<'a> Format<'a> for AstNode<'a, FormalParameters<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, FormalParameter<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, FormalParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2490,7 +2365,7 @@ impl<'a> Format<'a> for AstNode<'a, FormalParameter<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, FormalParameterRest<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, FormalParameterRest<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2503,7 +2378,7 @@ impl<'a> Format<'a> for AstNode<'a, FormalParameterRest<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, FunctionBody<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, FunctionBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -2517,7 +2392,7 @@ impl<'a> Format<'a> for AstNode<'a, FunctionBody<'a>> {
 }
 
 impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
-    for AstNode<'a, ArrowFunctionExpression<'a>>
+    for AstNode<'a, '_, ArrowFunctionExpression<'a>>
 {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
@@ -2566,7 +2441,7 @@ impl<'a> Format<'a, FormatJsArrowFunctionExpressionOptions>
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, YieldExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, YieldExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -2589,7 +2464,7 @@ impl<'a> Format<'a> for AstNode<'a, YieldExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Class<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Class<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -2612,7 +2487,7 @@ impl<'a> Format<'a> for AstNode<'a, Class<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ClassBody<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ClassBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -2625,67 +2500,61 @@ impl<'a> Format<'a> for AstNode<'a, ClassBody<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ClassElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ClassElement<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ClassElement::StaticBlock(inner) => {
-                allocator
-                    .alloc(AstNode::<StaticBlock> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StaticBlock> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ClassElement::MethodDefinition(inner) => {
-                allocator
-                    .alloc(AstNode::<MethodDefinition> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<MethodDefinition> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ClassElement::PropertyDefinition(inner) => {
-                allocator
-                    .alloc(AstNode::<PropertyDefinition> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<PropertyDefinition> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ClassElement::AccessorProperty(inner) => {
-                allocator
-                    .alloc(AstNode::<AccessorProperty> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<AccessorProperty> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ClassElement::TSIndexSignature(inner) => {
-                allocator
-                    .alloc(AstNode::<TSIndexSignature> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSIndexSignature> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, MethodDefinition<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, MethodDefinition<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2698,7 +2567,7 @@ impl<'a> Format<'a> for AstNode<'a, MethodDefinition<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, PropertyDefinition<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, PropertyDefinition<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2711,7 +2580,7 @@ impl<'a> Format<'a> for AstNode<'a, PropertyDefinition<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, PrivateIdentifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, PrivateIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2724,7 +2593,7 @@ impl<'a> Format<'a> for AstNode<'a, PrivateIdentifier<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, StaticBlock<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, StaticBlock<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2737,77 +2606,70 @@ impl<'a> Format<'a> for AstNode<'a, StaticBlock<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ModuleDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ModuleDeclaration<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ModuleDeclaration::ImportDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<ImportDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ImportDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ModuleDeclaration::ExportAllDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<ExportAllDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ExportAllDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ModuleDeclaration::ExportDefaultDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<ExportDefaultDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ExportDefaultDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ModuleDeclaration::ExportNamedDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<ExportNamedDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ExportNamedDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ModuleDeclaration::TSExportAssignment(inner) => {
-                allocator
-                    .alloc(AstNode::<TSExportAssignment> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSExportAssignment> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ModuleDeclaration::TSNamespaceExportDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNamespaceExportDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNamespaceExportDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, AccessorProperty<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, AccessorProperty<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2820,7 +2682,7 @@ impl<'a> Format<'a> for AstNode<'a, AccessorProperty<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -2843,7 +2705,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2856,47 +2718,43 @@ impl<'a> Format<'a> for AstNode<'a, ImportDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportDeclarationSpecifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportDeclarationSpecifier<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ImportDeclarationSpecifier::ImportSpecifier(inner) => {
-                allocator
-                    .alloc(AstNode::<ImportSpecifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ImportSpecifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ImportDeclarationSpecifier::ImportDefaultSpecifier(inner) => {
-                allocator
-                    .alloc(AstNode::<ImportDefaultSpecifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ImportDefaultSpecifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ImportDeclarationSpecifier::ImportNamespaceSpecifier(inner) => {
-                allocator
-                    .alloc(AstNode::<ImportNamespaceSpecifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ImportNamespaceSpecifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportSpecifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2909,7 +2767,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportSpecifier<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportDefaultSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2922,7 +2780,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportNamespaceSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2935,7 +2793,7 @@ impl<'a> Format<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, WithClause<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, WithClause<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2948,7 +2806,7 @@ impl<'a> Format<'a> for AstNode<'a, WithClause<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportAttribute<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportAttribute<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -2961,37 +2819,34 @@ impl<'a> Format<'a> for AstNode<'a, ImportAttribute<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ImportAttributeKey<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ImportAttributeKey<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ImportAttributeKey::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ImportAttributeKey::StringLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ExportNamedDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -3004,7 +2859,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ExportDefaultDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if is_suppressed {
@@ -3017,7 +2872,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ExportAllDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3030,7 +2885,7 @@ impl<'a> Format<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ExportSpecifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ExportSpecifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3043,98 +2898,89 @@ impl<'a> Format<'a> for AstNode<'a, ExportSpecifier<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ExportDefaultDeclarationKind<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ExportDefaultDeclarationKind<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ExportDefaultDeclarationKind::FunctionDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<Function> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Function> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ExportDefaultDeclarationKind::ClassDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<Class> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<Class> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSInterfaceDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSInterfaceDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_expression!(ExportDefaultDeclarationKind) => {
                 let inner = it.to_expression();
-                allocator
-                    .alloc(AstNode::<'a, Expression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, Expression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, ModuleExportName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ModuleExportName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             ModuleExportName::IdentifierName(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ModuleExportName::IdentifierReference(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             ModuleExportName::StringLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, V8IntrinsicExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -3157,7 +3003,7 @@ impl<'a> Format<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BooleanLiteral> {
+impl<'a> Format<'a> for AstNode<'a, '_, BooleanLiteral> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -3180,7 +3026,7 @@ impl<'a> Format<'a> for AstNode<'a, BooleanLiteral> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, NullLiteral> {
+impl<'a> Format<'a> for AstNode<'a, '_, NullLiteral> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -3203,7 +3049,7 @@ impl<'a> Format<'a> for AstNode<'a, NullLiteral> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, NumericLiteral<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, NumericLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -3226,7 +3072,7 @@ impl<'a> Format<'a> for AstNode<'a, NumericLiteral<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, StringLiteral<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, StringLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -3249,7 +3095,7 @@ impl<'a> Format<'a> for AstNode<'a, StringLiteral<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, BigIntLiteral<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, BigIntLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -3272,7 +3118,7 @@ impl<'a> Format<'a> for AstNode<'a, BigIntLiteral<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, RegExpLiteral<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, RegExpLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -3295,7 +3141,7 @@ impl<'a> Format<'a> for AstNode<'a, RegExpLiteral<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if format_type_cast_comment_node(self, false, f) {
             return;
@@ -3311,7 +3157,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXElement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXOpeningElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXOpeningElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3324,7 +3170,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXOpeningElement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXClosingElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXClosingElement<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3337,7 +3183,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXClosingElement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXFragment<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXFragment<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if format_type_cast_comment_node(self, false, f) {
             return;
@@ -3353,7 +3199,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXFragment<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXOpeningFragment> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXOpeningFragment> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3366,7 +3212,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXOpeningFragment> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXClosingFragment> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXClosingFragment> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3379,67 +3225,61 @@ impl<'a> Format<'a> for AstNode<'a, JSXClosingFragment> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXElementName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXElementName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             JSXElementName::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXIdentifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXIdentifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXElementName::IdentifierReference(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXElementName::NamespacedName(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXNamespacedName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXNamespacedName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXElementName::MemberExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXMemberExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXMemberExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXElementName::ThisExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ThisExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ThisExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXNamespacedName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXNamespacedName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3452,7 +3292,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXNamespacedName<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXMemberExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXMemberExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3465,47 +3305,43 @@ impl<'a> Format<'a> for AstNode<'a, JSXMemberExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXMemberExpressionObject<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXMemberExpressionObject<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             JSXMemberExpressionObject::IdentifierReference(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXMemberExpressionObject::MemberExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXMemberExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXMemberExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXMemberExpressionObject::ThisExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ThisExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ThisExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXExpressionContainer<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3518,38 +3354,35 @@ impl<'a> Format<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXExpression<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             JSXExpression::EmptyExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXEmptyExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXEmptyExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_expression!(JSXExpression) => {
                 let inner = it.to_expression();
-                allocator
-                    .alloc(AstNode::<'a, Expression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, Expression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXEmptyExpression> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXEmptyExpression> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3562,37 +3395,34 @@ impl<'a> Format<'a> for AstNode<'a, JSXEmptyExpression> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXAttributeItem<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXAttributeItem<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             JSXAttributeItem::Attribute(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXAttribute> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXAttribute> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXAttributeItem::SpreadAttribute(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXSpreadAttribute> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXSpreadAttribute> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXAttribute<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXAttribute<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3605,7 +3435,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXAttribute<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXSpreadAttribute<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3618,87 +3448,79 @@ impl<'a> Format<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXAttributeName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXAttributeName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             JSXAttributeName::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXIdentifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXIdentifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXAttributeName::NamespacedName(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXNamespacedName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXNamespacedName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXAttributeValue<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXAttributeValue<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             JSXAttributeValue::StringLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXAttributeValue::ExpressionContainer(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXExpressionContainer> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXExpressionContainer> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXAttributeValue::Element(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXElement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXElement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXAttributeValue::Fragment(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXFragment> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXFragment> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXIdentifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXIdentifier<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3711,67 +3533,61 @@ impl<'a> Format<'a> for AstNode<'a, JSXIdentifier<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXChild<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXChild<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             JSXChild::Text(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXText> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXText> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXChild::Element(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXElement> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXElement> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXChild::Fragment(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXFragment> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXFragment> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXChild::ExpressionContainer(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXExpressionContainer> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXExpressionContainer> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             JSXChild::Spread(inner) => {
-                allocator
-                    .alloc(AstNode::<JSXSpreadChild> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSXSpreadChild> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXSpreadChild<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXSpreadChild<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3784,7 +3600,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXSpreadChild<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSXText<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, JSXText<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3797,7 +3613,7 @@ impl<'a> Format<'a> for AstNode<'a, JSXText<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSThisParameter<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSThisParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3810,7 +3626,7 @@ impl<'a> Format<'a> for AstNode<'a, TSThisParameter<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSEnumDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3823,7 +3639,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSEnumBody<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSEnumBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3836,7 +3652,7 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumBody<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSEnumMember<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSEnumMember<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3849,57 +3665,52 @@ impl<'a> Format<'a> for AstNode<'a, TSEnumMember<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSEnumMemberName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSEnumMemberName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSEnumMemberName::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSEnumMemberName::String(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSEnumMemberName::ComputedString(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSEnumMemberName::ComputedTemplateString(inner) => {
-                allocator
-                    .alloc(AstNode::<TemplateLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TemplateLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeAnnotation<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3912,7 +3723,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSLiteralType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSLiteralType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -3925,457 +3736,412 @@ impl<'a> Format<'a> for AstNode<'a, TSLiteralType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSLiteral<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSLiteral<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSLiteral::BooleanLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<BooleanLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BooleanLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSLiteral::NumericLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<NumericLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<NumericLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSLiteral::BigIntLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<BigIntLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BigIntLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSLiteral::StringLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSLiteral::TemplateLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<TemplateLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TemplateLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSLiteral::UnaryExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<UnaryExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<UnaryExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSType<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSType::TSAnyKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSAnyKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSAnyKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSBigIntKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSBigIntKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSBigIntKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSBooleanKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSBooleanKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSBooleanKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSIntrinsicKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSIntrinsicKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSIntrinsicKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSNeverKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNeverKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNeverKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSNullKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNullKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNullKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSNumberKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNumberKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNumberKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSObjectKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSObjectKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSObjectKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSStringKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSStringKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSStringKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSSymbolKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSSymbolKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSSymbolKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSUndefinedKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSUndefinedKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSUndefinedKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSUnknownKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSUnknownKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSUnknownKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSVoidKeyword(inner) => {
-                allocator
-                    .alloc(AstNode::<TSVoidKeyword> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSVoidKeyword> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSArrayType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSArrayType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSArrayType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSConditionalType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSConditionalType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSConditionalType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSConstructorType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSConstructorType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSConstructorType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSFunctionType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSFunctionType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSFunctionType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSImportType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSImportType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSImportType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSIndexedAccessType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSIndexedAccessType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSIndexedAccessType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSInferType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSInferType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSInferType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSIntersectionType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSIntersectionType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSIntersectionType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSLiteralType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSLiteralType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSLiteralType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSMappedType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSMappedType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSMappedType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSNamedTupleMember(inner) => {
-                allocator
-                    .alloc(AstNode::<TSNamedTupleMember> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSNamedTupleMember> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSTemplateLiteralType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTemplateLiteralType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTemplateLiteralType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSThisType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSThisType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSThisType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSTupleType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTupleType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTupleType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSTypeLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypeLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypeLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSTypeOperatorType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypeOperator> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypeOperator> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSTypePredicate(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypePredicate> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypePredicate> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSTypeQuery(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypeQuery> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypeQuery> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSTypeReference(inner) => {
-                allocator
-                    .alloc(AstNode::<TSTypeReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSTypeReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSUnionType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSUnionType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSUnionType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::TSParenthesizedType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSParenthesizedType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSParenthesizedType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::JSDocNullableType(inner) => {
-                allocator
-                    .alloc(AstNode::<JSDocNullableType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSDocNullableType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::JSDocNonNullableType(inner) => {
-                allocator
-                    .alloc(AstNode::<JSDocNonNullableType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSDocNonNullableType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSType::JSDocUnknownType(inner) => {
-                allocator
-                    .alloc(AstNode::<JSDocUnknownType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<JSDocUnknownType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSConditionalType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSConditionalType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -4398,7 +4164,7 @@ impl<'a> Format<'a> for AstNode<'a, TSConditionalType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSUnionType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSUnionType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -4420,43 +4186,7 @@ impl<'a> Format<'a> for AstNode<'a, TSUnionType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSIntersectionType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        self.format_leading_comments(f);
-        let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSParenthesizedType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSTypeOperator<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSIntersectionType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -4479,7 +4209,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeOperator<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSArrayType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSParenthesizedType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4492,7 +4222,30 @@ impl<'a> Format<'a> for AstNode<'a, TSArrayType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSIndexedAccessType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeOperator<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
+        }
+        self.format_leading_comments(f);
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f);
+        }
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, TSArrayType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4505,7 +4258,7 @@ impl<'a> Format<'a> for AstNode<'a, TSIndexedAccessType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTupleType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSIndexedAccessType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4518,7 +4271,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTupleType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTupleType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4531,7 +4284,7 @@ impl<'a> Format<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSOptionalType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSNamedTupleMember<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4544,7 +4297,7 @@ impl<'a> Format<'a> for AstNode<'a, TSOptionalType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSRestType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSOptionalType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4557,48 +4310,57 @@ impl<'a> Format<'a> for AstNode<'a, TSRestType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTupleElement<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSRestType<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, TSTupleElement<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSTupleElement::TSOptionalType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSOptionalType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSOptionalType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSTupleElement::TSRestType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSRestType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSRestType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_ts_type!(TSTupleElement) => {
                 let inner = it.to_ts_type();
-                allocator
-                    .alloc(AstNode::<'a, TSType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, TSType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSAnyKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSAnyKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4611,7 +4373,7 @@ impl<'a> Format<'a> for AstNode<'a, TSAnyKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSStringKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSStringKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4624,7 +4386,7 @@ impl<'a> Format<'a> for AstNode<'a, TSStringKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSBooleanKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSBooleanKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4637,7 +4399,7 @@ impl<'a> Format<'a> for AstNode<'a, TSBooleanKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSNumberKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSNumberKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4650,7 +4412,7 @@ impl<'a> Format<'a> for AstNode<'a, TSNumberKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSNeverKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSNeverKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4663,7 +4425,7 @@ impl<'a> Format<'a> for AstNode<'a, TSNeverKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSIntrinsicKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSIntrinsicKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4676,7 +4438,7 @@ impl<'a> Format<'a> for AstNode<'a, TSIntrinsicKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSUnknownKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSUnknownKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4689,7 +4451,7 @@ impl<'a> Format<'a> for AstNode<'a, TSUnknownKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSNullKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSNullKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4702,7 +4464,7 @@ impl<'a> Format<'a> for AstNode<'a, TSNullKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSUndefinedKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSUndefinedKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4715,7 +4477,7 @@ impl<'a> Format<'a> for AstNode<'a, TSUndefinedKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSVoidKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSVoidKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4728,7 +4490,7 @@ impl<'a> Format<'a> for AstNode<'a, TSVoidKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSSymbolKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSSymbolKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4741,7 +4503,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSymbolKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSThisType> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSThisType> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4754,7 +4516,7 @@ impl<'a> Format<'a> for AstNode<'a, TSThisType> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSObjectKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSObjectKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4767,7 +4529,7 @@ impl<'a> Format<'a> for AstNode<'a, TSObjectKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSBigIntKeyword> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSBigIntKeyword> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4780,7 +4542,7 @@ impl<'a> Format<'a> for AstNode<'a, TSBigIntKeyword> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeReference<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeReference<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4793,47 +4555,43 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeReference<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSTypeName::IdentifierReference(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSTypeName::QualifiedName(inner) => {
-                allocator
-                    .alloc(AstNode::<TSQualifiedName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSQualifiedName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSTypeName::ThisExpression(inner) => {
-                allocator
-                    .alloc(AstNode::<ThisExpression> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<ThisExpression> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSQualifiedName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSQualifiedName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4846,7 +4604,7 @@ impl<'a> Format<'a> for AstNode<'a, TSQualifiedName<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeParameterInstantiation<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4859,7 +4617,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeParameter<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeParameter<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4872,7 +4630,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeParameter<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeParameterDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4885,7 +4643,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeAliasDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4898,7 +4656,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSClassImplements<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSClassImplements<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4911,7 +4669,7 @@ impl<'a> Format<'a> for AstNode<'a, TSClassImplements<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSInterfaceDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4924,7 +4682,7 @@ impl<'a> Format<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSInterfaceBody<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSInterfaceBody<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4937,7 +4695,7 @@ impl<'a> Format<'a> for AstNode<'a, TSInterfaceBody<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSPropertySignature<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSPropertySignature<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -4950,67 +4708,61 @@ impl<'a> Format<'a> for AstNode<'a, TSPropertySignature<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSSignature<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSSignature<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSSignature::TSIndexSignature(inner) => {
-                allocator
-                    .alloc(AstNode::<TSIndexSignature> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSIndexSignature> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSSignature::TSPropertySignature(inner) => {
-                allocator
-                    .alloc(AstNode::<TSPropertySignature> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSPropertySignature> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSSignature::TSCallSignatureDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSCallSignatureDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSCallSignatureDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSSignature::TSConstructSignatureDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSConstructSignatureDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSConstructSignatureDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSSignature::TSMethodSignature(inner) => {
-                allocator
-                    .alloc(AstNode::<TSMethodSignature> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSMethodSignature> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSIndexSignature<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSIndexSignature<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5023,7 +4775,7 @@ impl<'a> Format<'a> for AstNode<'a, TSIndexSignature<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSCallSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5036,7 +4788,7 @@ impl<'a> Format<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSMethodSignature<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSMethodSignature<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5049,7 +4801,7 @@ impl<'a> Format<'a> for AstNode<'a, TSMethodSignature<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSConstructSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5062,7 +4814,7 @@ impl<'a> Format<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSIndexSignatureName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5075,7 +4827,7 @@ impl<'a> Format<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSInterfaceHeritage<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5088,7 +4840,7 @@ impl<'a> Format<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypePredicate<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypePredicate<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5101,37 +4853,34 @@ impl<'a> Format<'a> for AstNode<'a, TSTypePredicate<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypePredicateName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypePredicateName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSTypePredicateName::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSTypePredicateName::This(inner) => {
-                allocator
-                    .alloc(AstNode::<TSThisType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSThisType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSModuleDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5144,67 +4893,61 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSModuleDeclarationName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSModuleDeclarationName::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<BindingIdentifier> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<BindingIdentifier> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSModuleDeclarationName::StringLiteral(inner) => {
-                allocator
-                    .alloc(AstNode::<StringLiteral> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<StringLiteral> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSModuleDeclarationBody<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSModuleDeclarationBody<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSModuleDeclarationBody::TSModuleDeclaration(inner) => {
-                allocator
-                    .alloc(AstNode::<TSModuleDeclaration> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSModuleDeclaration> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSModuleDeclarationBody::TSModuleBlock(inner) => {
-                allocator
-                    .alloc(AstNode::<TSModuleBlock> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSModuleBlock> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSGlobalDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSGlobalDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5217,7 +4960,7 @@ impl<'a> Format<'a> for AstNode<'a, TSGlobalDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSModuleBlock<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSModuleBlock<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5230,7 +4973,7 @@ impl<'a> Format<'a> for AstNode<'a, TSModuleBlock<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeLiteral<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeLiteral<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5243,30 +4986,7 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeLiteral<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSInferType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        self.format_leading_comments(f);
-        let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSTypeQuery<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSInferType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -5289,38 +5009,58 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeQuery<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeQueryExprName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeQuery<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
+        }
+        self.format_leading_comments(f);
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f);
+        }
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeQueryExprName<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSTypeQueryExprName::TSImportType(inner) => {
-                allocator
-                    .alloc(AstNode::<TSImportType> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSImportType> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             it @ match_ts_type_name!(TSTypeQueryExprName) => {
                 let inner = it.to_ts_type_name();
-                allocator
-                    .alloc(AstNode::<'a, TSTypeName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<'a, '_, TSTypeName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSImportType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSImportType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5333,37 +5073,34 @@ impl<'a> Format<'a> for AstNode<'a, TSImportType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifier<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSImportTypeQualifier<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSImportTypeQualifier::Identifier(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSImportTypeQualifier::QualifiedName(inner) => {
-                allocator
-                    .alloc(AstNode::<TSImportTypeQualifiedName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSImportTypeQualifiedName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSImportTypeQualifiedName<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5376,30 +5113,7 @@ impl<'a> Format<'a> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSFunctionType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        self.format_leading_comments(f);
-        let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSConstructorType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSFunctionType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -5422,33 +5136,7 @@ impl<'a> Format<'a> for AstNode<'a, TSConstructorType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSMappedType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSTemplateLiteralType<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSAsExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSConstructorType<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -5471,7 +5159,33 @@ impl<'a> Format<'a> for AstNode<'a, TSAsExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSMappedType<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, TSTemplateLiteralType<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, TSAsExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -5494,7 +5208,7 @@ impl<'a> Format<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSTypeAssertion<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSSatisfiesExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -5517,7 +5231,30 @@ impl<'a> Format<'a> for AstNode<'a, TSTypeAssertion<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSTypeAssertion<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
+        }
+        self.format_leading_comments(f);
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f);
+        }
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, TSImportEqualsDeclaration<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5530,47 +5267,43 @@ impl<'a> Format<'a> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSModuleReference<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSModuleReference<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {
             TSModuleReference::ExternalModuleReference(inner) => {
-                allocator
-                    .alloc(AstNode::<TSExternalModuleReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSExternalModuleReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSModuleReference::IdentifierReference(inner) => {
-                allocator
-                    .alloc(AstNode::<IdentifierReference> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<IdentifierReference> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
             TSModuleReference::QualifiedName(inner) => {
-                allocator
-                    .alloc(AstNode::<TSQualifiedName> {
-                        inner,
-                        parent,
-                        allocator,
-                        following_span_start: self.following_span_start,
-                    })
-                    .fmt(f);
+                AstNode::<TSQualifiedName> {
+                    inner,
+                    parent,
+                    allocator: self.allocator,
+                    following_span_start: self.following_span_start,
+                }
+                .fmt(f);
             }
         }
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSExternalModuleReference<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5583,69 +5316,7 @@ impl<'a> Format<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, TSNonNullExpression<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        self.format_leading_comments(f);
-        let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, Decorator<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSExportAssignment<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
-    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
-        self.format_leading_comments(f);
-        if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
-        } else {
-            self.write(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> Format<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSNonNullExpression<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
@@ -5668,7 +5339,7 @@ impl<'a> Format<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSDocNullableType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Decorator<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5681,7 +5352,7 @@ impl<'a> Format<'a> for AstNode<'a, JSDocNullableType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSExportAssignment<'a>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);
@@ -5694,7 +5365,69 @@ impl<'a> Format<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, JSDocUnknownType> {
+impl<'a> Format<'a> for AstNode<'a, '_, TSNamespaceExportDeclaration<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, TSInstantiationExpression<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
+            return;
+        }
+        self.format_leading_comments(f);
+        let needs_parentheses = self.needs_parentheses(f);
+        if needs_parentheses {
+            "(".fmt(f);
+        }
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        if needs_parentheses {
+            ")".fmt(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, JSDocNullableType<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, JSDocNonNullableType<'a>> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        self.format_leading_comments(f);
+        if is_suppressed {
+            FormatSuppressedNode(self.span()).fmt(f);
+        } else {
+            self.write(f);
+        }
+        self.format_trailing_comments(f);
+    }
+}
+
+impl<'a> Format<'a> for AstNode<'a, '_, JSDocUnknownType> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.span().start);
         self.format_leading_comments(f);

--- a/crates/oxc_formatter/src/ast_nodes/impls/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/impls/ast_nodes.rs
@@ -4,7 +4,7 @@ use oxc_span::{GetSpan, Span};
 
 use crate::ast_nodes::AstNodes;
 
-impl<'a> AstNodes<'a> {
+impl<'a, 'b> AstNodes<'a, 'b> {
     /// Returns an iterator over all ancestor nodes in the AST, starting from self.
     ///
     /// The iteration includes the current node and proceeds upward through the tree,
@@ -17,7 +17,7 @@ impl<'a> AstNodes<'a> {
     ///       └─ ExpressionStatement  <- self
     /// ```
     /// For `self` as ExpressionStatement, this yields: [ExpressionStatement, BlockStatement, Program]
-    pub fn ancestors(&self) -> impl Iterator<Item = &AstNodes<'a>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = &AstNodes<'a, 'b>> {
         // Start with the current node and walk up the tree, including Program
         std::iter::successors(Some(self), |node| {
             // Continue iteration until we've yielded Program (root node)
@@ -28,7 +28,7 @@ impl<'a> AstNodes<'a> {
 
     /// If the node is a ChainExpression, recursively skip to its parent until a non-ChainExpression node is found.
     /// This is useful for analyses that want to ignore the presence of ChainExpressions in the AST.
-    pub fn without_chain_expression(&self) -> &AstNodes<'a> {
+    pub fn without_chain_expression(&self) -> &AstNodes<'a, 'b> {
         match self {
             AstNodes::ChainExpression(chain_expression) => {
                 chain_expression.parent.without_chain_expression()

--- a/crates/oxc_formatter/src/ast_nodes/iterator.rs
+++ b/crates/oxc_formatter/src/ast_nodes/iterator.rs
@@ -13,9 +13,9 @@ use oxc_span::GetSpan;
 use super::{AstNode, AstNodes};
 
 /// Iterator for `AstNode<Vec<T>>`.
-pub struct AstNodeIterator<'a, T> {
+pub struct AstNodeIterator<'a, 'b, T> {
     inner: std::iter::Peekable<std::slice::Iter<'a, T>>,
-    parent: AstNodes<'a>,
+    parent: AstNodes<'a, 'b>,
     allocator: &'a Allocator,
     /// The `following_span_start` for the last element when there's no next element in this iterator.
     ///
@@ -72,8 +72,8 @@ macro_rules! impl_ast_node_vec {
         impl_ast_node_vec!($type, true, |n: &$type| n.span().start);
     };
     ($type:ty, $has_following_span_in_the_last_item:tt, $get_span:expr) => {
-        impl<'a> AstNode<'a, Vec<'a, $type>> {
-            pub fn iter(&self) -> AstNodeIterator<'a, $type> {
+        impl<'a, 'parent> AstNode<'a, 'parent, Vec<'a, $type>> {
+            pub fn iter<'b>(&'b self) -> AstNodeIterator<'a, 'b, $type> {
                 AstNodeIterator {
                     inner: self.inner.iter().peekable(),
                     parent: self.parent,
@@ -87,7 +87,7 @@ macro_rules! impl_ast_node_vec {
                 }
             }
 
-            pub fn first(&self) -> Option<&'a AstNode<'a, $type>> {
+            pub fn first<'b>(&'b self) -> Option<&'b AstNode<'a, 'b, $type>> {
                 let following = if $has_following_span_in_the_last_item {
                     self.following_span_start
                 } else {
@@ -95,7 +95,8 @@ macro_rules! impl_ast_node_vec {
                 };
                 let get_span: fn(&$type) -> u32 = $get_span;
                 let mut inner_iter = self.inner.iter();
-                self.allocator
+                let allocator: &'b Allocator = self.allocator;
+                allocator
                     .alloc(inner_iter.next().map(|inner| AstNode {
                         inner,
                         parent: self.parent,
@@ -105,13 +106,14 @@ macro_rules! impl_ast_node_vec {
                     .as_ref()
             }
 
-            pub fn last(&self) -> Option<&'a AstNode<'a, $type>> {
+            pub fn last<'b>(&'b self) -> Option<&'b AstNode<'a, 'b, $type>> {
                 let following = if $has_following_span_in_the_last_item {
                     self.following_span_start
                 } else {
                     0
                 };
-                self.allocator
+                let allocator: &'b Allocator = self.allocator;
+                allocator
                     .alloc(self.inner.last().map(|inner| AstNode {
                         inner,
                         parent: self.parent,
@@ -122,26 +124,26 @@ macro_rules! impl_ast_node_vec {
             }
         }
 
-        impl<'a> Iterator for AstNodeIterator<'a, $type> {
-            type Item = &'a AstNode<'a, $type>;
+        impl<'a: 'b, 'b> Iterator for AstNodeIterator<'a, 'b, $type> {
+            type Item = &'b AstNode<'a, 'b, $type>;
             fn next(&mut self) -> Option<Self::Item> {
-                let allocator = self.allocator;
+                let allocator: &'b Allocator = self.allocator;
                 let following = self.following_span_start;
                 let get_span = self.get_following_span_start;
                 allocator
                     .alloc(self.inner.next().map(|inner| AstNode {
                         parent: self.parent,
                         inner,
-                        allocator,
+                        allocator: self.allocator,
                         following_span_start: self.inner.peek().map_or(following, |n| get_span(*n)),
                     }))
                     .as_ref()
             }
         }
 
-        impl<'a> IntoIterator for &AstNode<'a, Vec<'a, $type>> {
-            type Item = &'a AstNode<'a, $type>;
-            type IntoIter = AstNodeIterator<'a, $type>;
+        impl<'a, 'b, 'parent> IntoIterator for &'b AstNode<'a, 'parent, Vec<'a, $type>> {
+            type Item = &'b AstNode<'a, 'b, $type>;
+            type IntoIter = AstNodeIterator<'a, 'b, $type>;
             fn into_iter(self) -> Self::IntoIter {
                 AstNodeIterator {
                     inner: self.inner.iter().peekable(),
@@ -167,8 +169,8 @@ macro_rules! impl_ast_node_vec_for_option {
         impl_ast_node_vec_for_option!($type, true);
     };
     ($type:ty, $has_following_span_in_the_last_item:tt) => {
-        impl<'a> AstNode<'a, Vec<'a, $type>> {
-            pub fn iter(&self) -> AstNodeIterator<'a, $type> {
+        impl<'a, 'parent> AstNode<'a, 'parent, Vec<'a, $type>> {
+            pub fn iter<'b>(&'b self) -> AstNodeIterator<'a, 'b, $type> {
                 AstNodeIterator {
                     inner: self.inner.iter().peekable(),
                     parent: self.parent,
@@ -182,14 +184,15 @@ macro_rules! impl_ast_node_vec_for_option {
                 }
             }
 
-            pub fn first(&self) -> Option<&'a AstNode<'a, $type>> {
+            pub fn first<'b>(&'b self) -> Option<&'b AstNode<'a, 'b, $type>> {
                 let following = if $has_following_span_in_the_last_item {
                     self.following_span_start
                 } else {
                     0
                 };
                 let mut inner_iter = self.inner.iter();
-                self.allocator
+                let allocator: &'b Allocator = self.allocator;
+                allocator
                     .alloc(inner_iter.next().map(|inner| {
                         AstNode {
                             inner,
@@ -204,13 +207,14 @@ macro_rules! impl_ast_node_vec_for_option {
                     .as_ref()
             }
 
-            pub fn last(&self) -> Option<&'a AstNode<'a, $type>> {
+            pub fn last<'b>(&'b self) -> Option<&'b AstNode<'a, 'b, $type>> {
                 let following = if $has_following_span_in_the_last_item {
                     self.following_span_start
                 } else {
                     0
                 };
-                self.allocator
+                let allocator: &'b Allocator = self.allocator;
+                allocator
                     .alloc(self.inner.last().map(|inner| AstNode {
                         inner,
                         parent: self.parent,
@@ -221,10 +225,10 @@ macro_rules! impl_ast_node_vec_for_option {
             }
         }
 
-        impl<'a> Iterator for AstNodeIterator<'a, $type> {
-            type Item = &'a AstNode<'a, $type>;
+        impl<'a: 'b, 'b> Iterator for AstNodeIterator<'a, 'b, $type> {
+            type Item = &'b AstNode<'a, 'b, $type>;
             fn next(&mut self) -> Option<Self::Item> {
-                let allocator = self.allocator;
+                let allocator: &'b Allocator = self.allocator;
                 let following = self.following_span_start;
                 let get_span = self.get_following_span_start;
                 allocator
@@ -232,7 +236,7 @@ macro_rules! impl_ast_node_vec_for_option {
                         AstNode {
                             parent: self.parent,
                             inner,
-                            allocator,
+                            allocator: self.allocator,
                             following_span_start: match self.inner.peek().map(|n| get_span(n)) {
                                 Some(span) if span != 0 => span,
                                 // Skip over `None` (elision) to find the next real element's span
@@ -252,9 +256,9 @@ macro_rules! impl_ast_node_vec_for_option {
             }
         }
 
-        impl<'a> IntoIterator for &AstNode<'a, Vec<'a, $type>> {
-            type Item = &'a AstNode<'a, $type>;
-            type IntoIter = AstNodeIterator<'a, $type>;
+        impl<'a, 'b, 'parent> IntoIterator for &'b AstNode<'a, 'parent, Vec<'a, $type>> {
+            type Item = &'b AstNode<'a, 'b, $type>;
+            type IntoIter = AstNodeIterator<'a, 'b, $type>;
             fn into_iter(self) -> Self::IntoIter {
                 AstNodeIterator {
                     inner: self.inner.iter().peekable(),

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt,
-    mem::{transmute, transmute_copy},
-    ops::Deref,
-};
+use std::{fmt, mem::transmute_copy, ops::Deref};
 
 use oxc_allocator::{Allocator, Vec};
 use oxc_ast::ast::*;
@@ -10,15 +6,15 @@ use oxc_span::{GetSpan, Span};
 
 use super::AstNodes;
 
-pub struct AstNode<'a, T> {
+pub struct AstNode<'a, 'b, T> {
     pub(super) inner: &'a T,
-    pub(super) parent: AstNodes<'a>,
+    pub(super) parent: AstNodes<'a, 'b>,
     pub(super) allocator: &'a Allocator,
     /// The start position of the following sibling node, or 0 if none.
     pub(super) following_span_start: u32,
 }
 
-impl<T: fmt::Debug> fmt::Debug for AstNode<'_, T> {
+impl<T: fmt::Debug> fmt::Debug for AstNode<'_, '_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AstNode")
             .field("inner", &self.inner)
@@ -28,7 +24,7 @@ impl<T: fmt::Debug> fmt::Debug for AstNode<'_, T> {
     }
 }
 
-impl<'a, T> Deref for AstNode<'a, T> {
+impl<'a, T> Deref for AstNode<'a, '_, T> {
     type Target = T;
 
     fn deref(&self) -> &'a Self::Target {
@@ -36,15 +32,16 @@ impl<'a, T> Deref for AstNode<'a, T> {
     }
 }
 
-impl<'a, T> AsRef<T> for AstNode<'a, T> {
+impl<'a, T> AsRef<T> for AstNode<'a, '_, T> {
     fn as_ref(&self) -> &'a T {
         self.inner
     }
 }
 
-impl<'a, T> AstNode<'a, Option<T>> {
-    pub fn as_ref(&self) -> Option<&'a AstNode<'a, T>> {
-        self.allocator
+impl<'a, T> AstNode<'a, '_, Option<T>> {
+    pub fn as_ref<'c>(&'c self) -> Option<&'c AstNode<'a, 'c, T>> {
+        let allocator: &'c Allocator = self.allocator;
+        allocator
             .alloc(self.inner.as_ref().map(|inner| AstNode {
                 inner,
                 parent: self.parent,
@@ -55,19 +52,19 @@ impl<'a, T> AstNode<'a, Option<T>> {
     }
 }
 
-impl<T: GetSpan> GetSpan for AstNode<'_, T> {
+impl<T: GetSpan> GetSpan for AstNode<'_, '_, T> {
     fn span(&self) -> Span {
         self.inner.span()
     }
 }
 
-impl<T: GetSpan> GetSpan for &AstNode<'_, T> {
+impl<T: GetSpan> GetSpan for &AstNode<'_, '_, T> {
     fn span(&self) -> Span {
         self.inner.span()
     }
 }
 
-impl<'a, T> AstNode<'a, T> {
+impl<'a, 'b, T> AstNode<'a, 'b, T> {
     /// Returns an iterator over all ancestor nodes in the AST, starting from self.
     ///
     /// The iteration includes the current node and proceeds upward through the tree,
@@ -97,31 +94,31 @@ impl<'a, T> AstNode<'a, T> {
     /// let in_arrow_fn = self.ancestors()
     ///     .any(|p| matches!(p, AstNodes::ArrowFunctionExpression(_)));
     /// ```
-    pub fn ancestors(&self) -> impl Iterator<Item = &AstNodes<'a>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = &AstNodes<'a, 'b>> {
         self.parent().ancestors()
     }
 
     /// Returns the parent node.
     #[inline]
-    pub fn parent(&self) -> &AstNodes<'a> {
+    pub fn parent(&self) -> &AstNodes<'a, 'b> {
         &self.parent
     }
 
     /// Returns the grandparent node (parent's parent).
     ///
     /// This is a convenience method equivalent to `self.parent().parent()`.
-    pub fn grand_parent(&self) -> &AstNodes<'a> {
+    pub fn grand_parent(&self) -> &AstNodes<'a, 'b> {
         self.parent().parent()
     }
 }
 
-impl<'a, T> AstNode<'a, T> {
-    pub fn new(inner: &'a T, parent: AstNodes<'a>, allocator: &'a Allocator) -> Self {
+impl<'a, 'b, T> AstNode<'a, 'b, T> {
+    pub fn new(inner: &'a T, parent: AstNodes<'a, 'b>, allocator: &'a Allocator) -> Self {
         AstNode { inner, parent, allocator, following_span_start: 0 }
     }
 }
 
-impl<T: GetSpan> AstNode<'_, T> {
+impl<T: GetSpan> AstNode<'_, '_, T> {
     /// Check if this node is the callee of a CallExpression or NewExpression
     pub fn is_call_like_callee(&self) -> bool {
         let callee = match self.parent() {
@@ -139,7 +136,7 @@ impl<T: GetSpan> AstNode<'_, T> {
     }
 }
 
-impl<'a> AstNode<'a, ExpressionStatement<'a>> {
+impl<'a> AstNode<'a, '_, ExpressionStatement<'a>> {
     /// Check if this ExpressionStatement is the body of an arrow function expression
     ///
     /// Example:
@@ -153,10 +150,10 @@ impl<'a> AstNode<'a, ExpressionStatement<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, ImportExpression<'a>> {
+impl<'a> AstNode<'a, '_, ImportExpression<'a>> {
     /// Converts the arguments of the ImportExpression into an `AstNode` representing a `Vec` of `Argument`.
     #[inline]
-    pub fn to_arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
+    pub fn to_arguments<'c>(&'c self) -> &'c AstNode<'a, 'c, Vec<'a, Argument<'a>>> {
         // Convert ImportExpression's source and options to Vec<'a, Argument<'a>>.
         // This allows us to reuse CallExpression's argument formatting logic when printing
         // import expressions, since import(source, options) has the same structure as
@@ -178,25 +175,18 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
 
         let arguments_ref = self.allocator.alloc(arguments);
         let following_span_start = self.following_span_start;
+        let allocator: &'c Allocator = self.allocator;
 
-        self.allocator.alloc(AstNode {
+        allocator.alloc(AstNode {
             inner: arguments_ref,
             allocator: self.allocator,
-            parent: AstNodes::ImportExpression({
-                // SAFETY: `self` is already allocated in Arena, so transmute from `&` to `&'a` is safe.
-                unsafe {
-                    transmute::<
-                        &AstNode<'_, ImportExpression<'_>>,
-                        &'a AstNode<'a, ImportExpression<'a>>,
-                    >(self)
-                }
-            }),
+            parent: AstNodes::ImportExpression(self),
             following_span_start,
         })
     }
 }
 
-impl<'a> AstNode<'a, CallExpression<'a>> {
+impl<'a> AstNode<'a, '_, CallExpression<'a>> {
     /// Check if the passing span is the callee of this CallExpression
     pub fn is_callee_span(&self, span: Span) -> bool {
         self.inner.callee.span() == span
@@ -208,7 +198,7 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, NewExpression<'a>> {
+impl<'a> AstNode<'a, '_, NewExpression<'a>> {
     /// Check if the passing span is the callee of this NewExpression
     pub fn is_callee_span(&self, span: Span) -> bool {
         self.inner.callee.span() == span

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::NeedsParentheses;
 
-impl NeedsParentheses<'_> for AstNode<'_, Expression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, Expression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         match self.as_ast_nodes() {
             AstNodes::BooleanLiteral(it) => it.needs_parentheses(f),
@@ -66,7 +66,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Expression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, IdentifierReference<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, IdentifierReference<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -164,56 +164,56 @@ impl NeedsParentheses<'_> for AstNode<'_, IdentifierReference<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, BooleanLiteral> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, BooleanLiteral> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, NullLiteral> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, NullLiteral> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, BigIntLiteral<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, BigIntLiteral<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, RegExpLiteral<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, RegExpLiteral<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TemplateLiteral<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TemplateLiteral<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, MetaProperty<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, MetaProperty<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, Super> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, Super> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, NumericLiteral<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, NumericLiteral<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -226,7 +226,7 @@ impl NeedsParentheses<'_> for AstNode<'_, NumericLiteral<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, StringLiteral<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, StringLiteral<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -253,14 +253,14 @@ impl NeedsParentheses<'_> for AstNode<'_, StringLiteral<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ThisExpression> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ThisExpression> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ArrayExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ArrayExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         // Wrap array expressions in for-in initializers
         // e.g., `for (var a = ([b in c]) in {})`
@@ -268,7 +268,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ArrayExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ObjectExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ObjectExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -291,27 +291,27 @@ impl NeedsParentheses<'_> for AstNode<'_, ObjectExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TaggedTemplateExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TaggedTemplateExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, MemberExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, MemberExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ComputedMemberExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ComputedMemberExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         self.is_new_callee() && (self.optional || member_chain_callee_needs_parens(&self.object))
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, StaticMemberExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, StaticMemberExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -321,14 +321,14 @@ impl NeedsParentheses<'_> for AstNode<'_, StaticMemberExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, PrivateFieldExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, PrivateFieldExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         self.is_new_callee() && (self.optional || member_chain_callee_needs_parens(&self.object))
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, CallExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, CallExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -352,7 +352,7 @@ impl NeedsParentheses<'_> for AstNode<'_, CallExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, NewExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, NewExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -362,7 +362,7 @@ impl NeedsParentheses<'_> for AstNode<'_, NewExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, UpdateExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, UpdateExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -383,7 +383,7 @@ impl NeedsParentheses<'_> for AstNode<'_, UpdateExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, UnaryExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, UnaryExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -407,7 +407,7 @@ impl NeedsParentheses<'_> for AstNode<'_, UnaryExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, BinaryExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, BinaryExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -437,7 +437,7 @@ impl NeedsParentheses<'_> for AstNode<'_, BinaryExpression<'_>> {
 /// separately at the VariableDeclarator level (see `is_for_in_statement_init`).
 ///
 /// <https://github.com/prettier/prettier/issues/907#issuecomment-284304321>
-fn is_in_for_initializer(expr: &AstNode<'_, BinaryExpression<'_>>) -> bool {
+fn is_in_for_initializer(expr: &AstNode<'_, '_, BinaryExpression<'_>>) -> bool {
     let mut ancestors = expr.ancestors();
 
     while let Some(parent) = ancestors.next() {
@@ -481,7 +481,7 @@ fn is_in_for_initializer(expr: &AstNode<'_, BinaryExpression<'_>>) -> bool {
 ///
 /// Legacy syntax: `for (var a = 1 in b);`
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_for-in_initializer>
-fn is_for_in_statement_init<T: GetSpan>(node: &T, parent: &AstNodes<'_>) -> bool {
+fn is_for_in_statement_init<T: GetSpan>(node: &T, parent: &AstNodes<'_, '_>) -> bool {
     let AstNodes::VariableDeclarator(declarator) = parent else { return false };
     let Some(init) = &declarator.init else { return false };
     if init.span() != node.span() {
@@ -494,7 +494,7 @@ fn is_for_in_statement_init<T: GetSpan>(node: &T, parent: &AstNodes<'_>) -> bool
         if matches!(&stmt.left, ForStatementLeft::VariableDeclaration(d) if ptr::eq(d.as_ref(), decl.as_ref())))
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, PrivateInExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, PrivateInExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
@@ -506,7 +506,7 @@ impl NeedsParentheses<'_> for AstNode<'_, PrivateInExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, LogicalExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, LogicalExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -532,7 +532,7 @@ impl NeedsParentheses<'_> for AstNode<'_, LogicalExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ConditionalExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ConditionalExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -561,7 +561,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ConditionalExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, Function<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, Function<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if self.r#type() != FunctionType::FunctionExpression {
             return false;
@@ -589,7 +589,7 @@ impl NeedsParentheses<'_> for AstNode<'_, Function<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, AssignmentExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -668,7 +668,7 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, SequenceExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, SequenceExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -685,7 +685,7 @@ impl NeedsParentheses<'_> for AstNode<'_, SequenceExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, AwaitExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, AwaitExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -695,7 +695,7 @@ impl NeedsParentheses<'_> for AstNode<'_, AwaitExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ChainExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ChainExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -721,7 +721,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ChainExpression<'_>> {
 /// - The tag of a tagged template expression
 ///
 /// For `(a?.b)!.c`, the parent is TSNonNullExpression, so we check the grandparent.
-pub fn chain_expression_needs_parens(span: Span, parent: &AstNodes<'_>) -> bool {
+pub fn chain_expression_needs_parens(span: Span, parent: &AstNodes<'_, '_>) -> bool {
     match parent {
         AstNodes::NewExpression(new) => new.is_callee_span(span),
         AstNodes::CallExpression(call) => call.is_callee_span(span) && !call.optional,
@@ -739,7 +739,7 @@ pub fn chain_expression_needs_parens(span: Span, parent: &AstNodes<'_>) -> bool 
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, Class<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, Class<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if self.r#type() != ClassType::ClassExpression {
             return false;
@@ -768,13 +768,13 @@ impl NeedsParentheses<'_> for AstNode<'_, Class<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ParenthesizedExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ParenthesizedExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         unreachable!("Already disabled `preserveParens` option in the parser")
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ArrowFunctionExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ArrowFunctionExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -809,7 +809,7 @@ impl NeedsParentheses<'_> for AstNode<'_, ArrowFunctionExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, YieldExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, YieldExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -821,7 +821,7 @@ impl NeedsParentheses<'_> for AstNode<'_, YieldExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, ImportExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, ImportExpression<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -831,47 +831,47 @@ impl NeedsParentheses<'_> for AstNode<'_, ImportExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, V8IntrinsicExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, V8IntrinsicExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, JSXMemberExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, JSXMemberExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, JSXExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, JSXExpression<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, JSXEmptyExpression> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, JSXEmptyExpression> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         false
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSAsExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSAsExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent())
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSSatisfiesExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSSatisfiesExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent())
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSTypeAssertion<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSTypeAssertion<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         match self.parent() {
             AstNodes::TSAsExpression(_) | AstNodes::TSSatisfiesExpression(_) => true,
@@ -883,7 +883,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSTypeAssertion<'_>> {
     }
 }
 
-fn type_cast_like_needs_parens(span: Span, parent: &AstNodes<'_>) -> bool {
+fn type_cast_like_needs_parens(span: Span, parent: &AstNodes<'_, '_>) -> bool {
     #[expect(clippy::match_same_arms)] // for better readability
     match parent {
         AstNodes::TSTypeAssertion(_)
@@ -912,7 +912,7 @@ fn type_cast_like_needs_parens(span: Span, parent: &AstNodes<'_>) -> bool {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSNonNullExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSNonNullExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         let parent = self.parent();
         is_class_extends(self.span, parent)
@@ -920,7 +920,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSNonNullExpression<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSInstantiationExpression<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSInstantiationExpression<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         let expr = match self.parent() {
             AstNodes::StaticMemberExpression(expr) => &expr.object,
@@ -1005,12 +1005,12 @@ fn member_chain_callee_needs_parens(e: &Expression) -> bool {
 
 #[derive(Clone, Copy)]
 enum UnaryLike<'a, 'b> {
-    UpdateExpression(&'b AstNode<'a, UpdateExpression<'a>>),
-    UnaryExpression(&'b AstNode<'a, UnaryExpression<'a>>),
+    UpdateExpression(&'b AstNode<'a, 'b, UpdateExpression<'a>>),
+    UnaryExpression(&'b AstNode<'a, 'b, UnaryExpression<'a>>),
 }
 
 impl UnaryLike<'_, '_> {
-    fn parent(&self) -> &AstNodes<'_> {
+    fn parent(&self) -> &AstNodes<'_, '_> {
         match self {
             Self::UpdateExpression(e) => e.parent(),
             Self::UnaryExpression(e) => e.parent(),
@@ -1039,7 +1039,7 @@ fn unary_like_expression_needs_parens(node: UnaryLike<'_, '_>) -> bool {
 /// Returns `true` if an expression with lower precedence than an update expression needs parentheses.
 ///
 /// This is generally the case if the expression is used in a left hand side, or primary expression context.
-fn update_or_lower_expression_needs_parens(span: Span, parent: &AstNodes<'_>) -> bool {
+fn update_or_lower_expression_needs_parens(span: Span, parent: &AstNodes<'_, '_>) -> bool {
     match parent {
         AstNodes::TSNonNullExpression(_)
         | AstNodes::StaticMemberExpression(_)
@@ -1070,7 +1070,7 @@ pub enum FirstInStatementMode {
 /// the left most node or reached a statement.
 fn is_first_in_statement(
     mut current_span: Span,
-    parent: &AstNodes<'_>,
+    parent: &AstNodes<'_, '_>,
     mode: FirstInStatementMode,
 ) -> bool {
     for (index, ancestor) in parent.ancestors().enumerate() {
@@ -1148,7 +1148,7 @@ fn is_first_in_statement(
     false
 }
 
-fn await_or_yield_needs_parens(span: Span, node: &AstNodes<'_>) -> bool {
+fn await_or_yield_needs_parens(span: Span, node: &AstNodes<'_, '_>) -> bool {
     if matches!(
         node,
         AstNodes::UnaryExpression(_)
@@ -1171,7 +1171,7 @@ fn await_or_yield_needs_parens(span: Span, node: &AstNodes<'_>) -> bool {
 fn ts_as_or_satisfies_needs_parens(
     span: Span,
     inner: &Expression<'_>,
-    parent: &AstNodes<'_>,
+    parent: &AstNodes<'_, '_>,
 ) -> bool {
     match parent {
         AstNodes::ConditionalExpression(_)
@@ -1187,14 +1187,14 @@ fn ts_as_or_satisfies_needs_parens(
     }
 }
 
-fn is_class_extends(span: Span, parent: &AstNodes<'_>) -> bool {
+fn is_class_extends(span: Span, parent: &AstNodes<'_, '_>) -> bool {
     if let AstNodes::Class(c) = parent {
         return c.super_class.as_ref().is_some_and(|c| c.span() == span);
     }
     false
 }
 
-fn jsx_element_or_fragment_needs_paren(span: Span, parent: &AstNodes<'_>) -> bool {
+fn jsx_element_or_fragment_needs_paren(span: Span, parent: &AstNodes<'_, '_>) -> bool {
     if is_class_extends(span, parent) {
         return true;
     }
@@ -1221,7 +1221,7 @@ fn jsx_element_or_fragment_needs_paren(span: Span, parent: &AstNodes<'_>) -> boo
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, JSXElement<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, JSXElement<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;
@@ -1231,7 +1231,7 @@ impl NeedsParentheses<'_> for AstNode<'_, JSXElement<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, JSXFragment<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, JSXFragment<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         if f.comments().is_type_cast_node(self) {
             return false;

--- a/crates/oxc_formatter/src/parentheses/ts_type.rs
+++ b/crates/oxc_formatter/src/parentheses/ts_type.rs
@@ -13,7 +13,7 @@ use crate::{
 /// `(| number)[]`) don't exist — the parser unwraps them. In oxc's AST, they do exist, so inner
 /// types need to "see through" them when checking `needs_parentheses` to get the correct parent
 /// context.
-fn effective_parent<'a>(parent: &'a AstNodes<'a>) -> &'a AstNodes<'a> {
+fn effective_parent<'a, 'b>(parent: &'b AstNodes<'a, 'b>) -> &'b AstNodes<'a, 'b> {
     match parent {
         AstNodes::TSUnionType(union) if union.types.len() <= 1 => effective_parent(union.parent()),
         AstNodes::TSIntersectionType(intersection) if intersection.types.len() <= 1 => {
@@ -23,7 +23,7 @@ fn effective_parent<'a>(parent: &'a AstNodes<'a>) -> &'a AstNodes<'a> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSType<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSType<'_>> {
     fn needs_parentheses(&self, f: &Formatter<'_, '_>) -> bool {
         match self.as_ast_nodes() {
             AstNodes::TSFunctionType(it) => it.needs_parentheses(f),
@@ -42,7 +42,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSType<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSFunctionType<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSFunctionType<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         let parent = effective_parent(self.parent());
@@ -62,7 +62,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSFunctionType<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSInferType<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSInferType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         let parent = effective_parent(self.parent());
         match parent {
@@ -73,7 +73,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSInferType<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSConstructorType<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSConstructorType<'_>> {
     #[inline]
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         function_like_type_needs_parentheses(
@@ -84,7 +84,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSConstructorType<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSUnionType<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSUnionType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         // Single-member unions are transparent (formatted as just the member).
         // In Prettier/Babel, these don't exist in the AST.
@@ -109,7 +109,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSUnionType<'_>> {
 /// Ported from Biome's function_like_type_needs_parentheses
 fn function_like_type_needs_parentheses<'a>(
     span: Span,
-    parent: &'a AstNodes<'a>,
+    parent: &'a AstNodes<'a, '_>,
     return_type: Option<&'a TSTypeAnnotation<'a>>,
 ) -> bool {
     match parent {
@@ -159,7 +159,7 @@ fn operator_type_or_higher_needs_parens(span: Span, parent: &AstNodes) -> bool {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSIntersectionType<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSIntersectionType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         // Single-member intersections are transparent (formatted as just the member).
         if self.types.len() <= 1 {
@@ -173,7 +173,7 @@ impl NeedsParentheses<'_> for AstNode<'_, TSIntersectionType<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSConditionalType<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSConditionalType<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         let parent = effective_parent(self.parent());
         match parent {
@@ -187,13 +187,13 @@ impl NeedsParentheses<'_> for AstNode<'_, TSConditionalType<'_>> {
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSTypeOperator<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSTypeOperator<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         operator_type_or_higher_needs_parens(self.span(), effective_parent(self.parent()))
     }
 }
 
-impl NeedsParentheses<'_> for AstNode<'_, TSTypeQuery<'_>> {
+impl NeedsParentheses<'_> for AstNode<'_, '_, TSTypeQuery<'_>> {
     fn needs_parentheses(&self, _f: &Formatter<'_, '_>) -> bool {
         match effective_parent(self.parent()) {
             AstNodes::TSArrayType(_) => true,

--- a/crates/oxc_formatter/src/print/array_element_list.rs
+++ b/crates/oxc_formatter/src/print/array_element_list.rs
@@ -11,13 +11,13 @@ use crate::{
 };
 
 pub struct ArrayElementList<'a, 'b> {
-    elements: &'b AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>>,
+    elements: &'b AstNode<'a, 'b, Vec<'a, ArrayExpressionElement<'a>>>,
     group_id: Option<GroupId>,
 }
 
 impl<'a, 'b> ArrayElementList<'a, 'b> {
     pub fn new(
-        elements: &'b AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>>,
+        elements: &'b AstNode<'a, 'b, Vec<'a, ArrayExpressionElement<'a>>>,
         group_id: GroupId,
     ) -> Self {
         Self { elements, group_id: Some(group_id) }

--- a/crates/oxc_formatter/src/print/array_expression.rs
+++ b/crates/oxc_formatter/src/print/array_expression.rs
@@ -14,12 +14,12 @@ pub struct FormatArrayExpressionOptions {
 }
 
 pub struct FormatArrayExpression<'a, 'b> {
-    array: &'b AstNode<'a, ArrayExpression<'a>>,
+    array: &'b AstNode<'a, 'b, ArrayExpression<'a>>,
     options: FormatArrayExpressionOptions,
 }
 
 impl<'a, 'b> FormatArrayExpression<'a, 'b> {
-    pub fn new(array: &'b AstNode<'a, ArrayExpression<'a>>) -> Self {
+    pub fn new(array: &'b AstNode<'a, 'b, ArrayExpression<'a>>) -> Self {
         Self { array, options: FormatArrayExpressionOptions::default() }
     }
 }

--- a/crates/oxc_formatter/src/print/array_pattern.rs
+++ b/crates/oxc_formatter/src/print/array_pattern.rs
@@ -13,10 +13,10 @@ use crate::{
 
 use super::FormatWrite;
 
-struct FormatArrayPattern<'a, 'b>(&'b AstNode<'a, ArrayPattern<'a>>);
+struct FormatArrayPattern<'a, 'b>(&'b AstNode<'a, 'b, ArrayPattern<'a>>);
 
-impl<'a> Deref for FormatArrayPattern<'a, '_> {
-    type Target = AstNode<'a, ArrayPattern<'a>>;
+impl<'a, 'b> Deref for FormatArrayPattern<'a, 'b> {
+    type Target = AstNode<'a, 'b, ArrayPattern<'a>>;
 
     fn deref(&self) -> &Self::Target {
         self.0
@@ -52,7 +52,7 @@ impl<'a> Format<'a> for FormatArrayPattern<'a, '_> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ArrayPattern<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ArrayPattern<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         FormatArrayPattern(self).fmt(f);
     }

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -21,7 +21,7 @@ use crate::{
 use super::{FormatWrite, parameters::has_only_simple_parameters};
 
 impl<'a> FormatWrite<'a, FormatJsArrowFunctionExpressionOptions>
-    for AstNode<'a, ArrowFunctionExpression<'a>>
+    for AstNode<'a, '_, ArrowFunctionExpression<'a>>
 {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         FormatJsArrowFunctionExpression::new(self).fmt(f);
@@ -38,7 +38,7 @@ impl<'a> FormatWrite<'a, FormatJsArrowFunctionExpressionOptions>
 
 #[derive(Clone, Copy)]
 pub struct FormatJsArrowFunctionExpression<'a, 'b> {
-    arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
+    arrow: &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>,
     options: FormatJsArrowFunctionExpressionOptions,
 }
 
@@ -80,12 +80,12 @@ pub enum FunctionCacheMode {
 }
 
 impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
-    pub fn new(arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>) -> Self {
+    pub fn new(arrow: &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>) -> Self {
         Self { arrow, options: FormatJsArrowFunctionExpressionOptions::default() }
     }
 
     pub fn new_with_options(
-        arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
+        arrow: &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>,
         options: FormatJsArrowFunctionExpressionOptions,
     ) -> Self {
         Self { arrow, options }
@@ -227,7 +227,7 @@ impl<'a> Format<'a> for FormatJsArrowFunctionExpression<'a, '_> {
 
 enum ArrowFunctionLayout<'a, 'b> {
     /// Arrow function with a non-arrow function body
-    Single(&'b AstNode<'a, ArrowFunctionExpression<'a>>),
+    Single(&'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>),
 
     /// A chain of at least two arrow functions.
     ///
@@ -251,7 +251,7 @@ impl<'a, 'b> ArrowFunctionLayout<'a, 'b> {
     /// Determines the layout for the passed arrow function. See [ArrowFunctionLayout] for a description
     /// of the different layouts.
     fn for_arrow(
-        arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
+        arrow: &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>,
         options: FormatJsArrowFunctionExpressionOptions,
     ) -> ArrowFunctionLayout<'a, 'b> {
         let mut head = None;
@@ -434,14 +434,14 @@ pub fn is_huggable_html_embed(expression: &Expression<'_>, f: &Formatter<'_, '_>
 
 struct ArrowChain<'a, 'b> {
     /// The top most arrow function in the chain
-    head: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
+    head: &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>,
 
     /// The arrow functions in the chain that are neither the first nor the last.
     /// Empty for chains consisting only of two arrow functions.
-    middle: Vec<&'b AstNode<'a, ArrowFunctionExpression<'a>>>,
+    middle: Vec<&'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>>,
 
     /// The last arrow function in the chain
-    tail: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
+    tail: &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>,
 
     options: FormatJsArrowFunctionExpressionOptions,
 
@@ -451,7 +451,7 @@ struct ArrowChain<'a, 'b> {
 
 impl<'a, 'b> ArrowChain<'a, 'b> {
     /// Returns an iterator over all arrow functions in this chain
-    fn arrows(&self) -> impl Iterator<Item = &'b AstNode<'a, ArrowFunctionExpression<'a>>> {
+    fn arrows(&self) -> impl Iterator<Item = &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>> {
         use std::iter::once;
         once(self.head).chain(self.middle.iter().copied()).chain(once(self.tail))
     }
@@ -705,7 +705,7 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
     }
 }
 
-fn should_add_parens(body: &AstNode<'_, FunctionBody<'_>>) -> bool {
+fn should_add_parens(body: &AstNode<'_, '_, FunctionBody<'_>>) -> bool {
     let AstNodes::ExpressionStatement(stmt) = body.statements().first().unwrap().as_ast_nodes()
     else {
         unreachable!()
@@ -736,7 +736,7 @@ fn has_rest_object_or_array_parameter(params: &FormalParameters) -> bool {
 /// Formats the parameters and return type annotation without any soft line breaks if `is_grouped_call_argument` is `true`
 /// so that the parameters and return type are kept on the same line.
 fn format_signature<'a, 'b>(
-    arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
+    arrow: &'b AstNode<'a, 'b, ArrowFunctionExpression<'a>>,
     is_grouped_call_argument: bool,
     is_first_in_chain: bool,
     cache_mode: FunctionCacheMode,
@@ -787,7 +787,7 @@ fn format_signature<'a, 'b>(
 /// Formats a function body with additional caching depending on [`mode`](Self::mode).
 pub struct FormatMaybeCachedFunctionBody<'a, 'b> {
     /// The body to format.
-    pub body: &'b AstNode<'a, FunctionBody<'a>>,
+    pub body: &'b AstNode<'a, 'b, FunctionBody<'a>>,
 
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
     pub expression: bool,

--- a/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
@@ -8,7 +8,7 @@ use crate::{
     write,
 };
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSAsExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSAsExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent());
         format_as_or_satisfies_expression(
@@ -21,7 +21,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSAsExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSSatisfiesExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_callee_or_object = is_callee_or_object_context(self.span(), self.parent());
         format_as_or_satisfies_expression(
@@ -35,8 +35,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSSatisfiesExpression<'a>> {
 }
 
 fn format_as_or_satisfies_expression<'a>(
-    expression: &AstNode<'a, Expression>,
-    type_annotation: &AstNode<'a, TSType>,
+    expression: &AstNode<'a, '_, Expression>,
+    type_annotation: &AstNode<'a, '_, TSType>,
     is_callee_or_object: bool,
     operation: &'static str,
     f: &mut Formatter<'_, 'a>,
@@ -75,7 +75,7 @@ fn format_as_or_satisfies_expression<'a>(
     }
 }
 
-fn is_callee_or_object_context(span: Span, parent: &AstNodes<'_>) -> bool {
+fn is_callee_or_object_context(span: Span, parent: &AstNodes<'_, '_>) -> bool {
     match parent {
         // Static member
         AstNodes::StaticMemberExpression(_) => true,

--- a/crates/oxc_formatter/src/print/assignment_pattern_property_list.rs
+++ b/crates/oxc_formatter/src/print/assignment_pattern_property_list.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 enum AssignmentTargetPropertyListNode<'a, 'b> {
-    Property(&'b AstNode<'a, AssignmentTargetProperty<'a>>),
-    Rest(&'b AstNode<'a, AssignmentTargetRest<'a>>),
+    Property(&'b AstNode<'a, 'b, AssignmentTargetProperty<'a>>),
+    Rest(&'b AstNode<'a, 'b, AssignmentTargetRest<'a>>),
 }
 
 impl GetSpan for AssignmentTargetPropertyListNode<'_, '_> {
@@ -32,8 +32,8 @@ impl<'a> Format<'a> for AssignmentTargetPropertyListNode<'a, '_> {
 }
 
 struct AssignmentTargetPropertyListIter<'a, 'b> {
-    properties: AstNodeIterator<'a, AssignmentTargetProperty<'a>>,
-    rest: Option<&'b AstNode<'a, AssignmentTargetRest<'a>>>,
+    properties: AstNodeIterator<'a, 'b, AssignmentTargetProperty<'a>>,
+    rest: Option<&'b AstNode<'a, 'b, AssignmentTargetRest<'a>>>,
 }
 
 impl<'a, 'b> Iterator for AssignmentTargetPropertyListIter<'a, 'b> {
@@ -49,14 +49,14 @@ impl<'a, 'b> Iterator for AssignmentTargetPropertyListIter<'a, 'b> {
 }
 
 pub struct AssignmentTargetPropertyList<'a, 'b> {
-    properties: &'b AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>>,
-    rest: Option<&'b AstNode<'a, AssignmentTargetRest<'a>>>,
+    properties: &'b AstNode<'a, 'b, Vec<'a, AssignmentTargetProperty<'a>>>,
+    rest: Option<&'b AstNode<'a, 'b, AssignmentTargetRest<'a>>>,
 }
 
 impl<'a, 'b> AssignmentTargetPropertyList<'a, 'b> {
     pub fn new(
-        properties: &'b AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>>,
-        rest: Option<&'b AstNode<'a, AssignmentTargetRest<'a>>>,
+        properties: &'b AstNode<'a, 'b, Vec<'a, AssignmentTargetProperty<'a>>>,
+        rest: Option<&'b AstNode<'a, 'b, AssignmentTargetRest<'a>>>,
     ) -> Self {
         Self { properties, rest }
     }

--- a/crates/oxc_formatter/src/print/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/print/binary_like_expression.rs
@@ -54,13 +54,13 @@ impl BinaryLikeOperator {
 
 #[derive(Debug, Clone, Copy)]
 pub enum BinaryLikeExpression<'a, 'b> {
-    LogicalExpression(&'b AstNode<'a, LogicalExpression<'a>>),
-    BinaryExpression(&'b AstNode<'a, BinaryExpression<'a>>),
+    LogicalExpression(&'b AstNode<'a, 'b, LogicalExpression<'a>>),
+    BinaryExpression(&'b AstNode<'a, 'b, BinaryExpression<'a>>),
 }
 
 impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
     /// Returns the left hand side of the binary expression.
-    fn left(&self) -> &'b AstNode<'a, Expression<'a>> {
+    fn left(&self) -> &'b AstNode<'a, 'b, Expression<'a>> {
         match self {
             Self::LogicalExpression(expr) => expr.left(),
             Self::BinaryExpression(expr) => expr.left(),
@@ -68,14 +68,14 @@ impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
     }
 
     /// Returns the right hand side of the binary expression.
-    pub fn right(&self) -> &'b AstNode<'a, Expression<'a>> {
+    pub fn right(&self) -> &'b AstNode<'a, 'b, Expression<'a>> {
         match self {
             Self::LogicalExpression(expr) => expr.right(),
             Self::BinaryExpression(expr) => expr.right(),
         }
     }
 
-    pub fn parent(&self) -> &AstNodes<'a> {
+    pub fn parent(&self) -> &AstNodes<'a, '_> {
         match self {
             Self::LogicalExpression(expr) => expr.parent(),
             Self::BinaryExpression(expr) => expr.parent(),
@@ -91,7 +91,7 @@ impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
     /// if (true) { a + b } // false
     /// switch (a + b) {} // true
     /// ```
-    fn is_inside_condition(&self, parent: &AstNodes<'_>) -> bool {
+    fn is_inside_condition(&self, parent: &AstNodes<'_, '_>) -> bool {
         match parent {
             AstNodes::IfStatement(stmt) => stmt.test().span() == self.span(),
             AstNodes::DoWhileStatement(stmt) => stmt.test().span() == self.span(),
@@ -141,7 +141,7 @@ impl<'a, 'b> BinaryLikeExpression<'a, 'b> {
     /// There are some cases where the indentation is done by the parent, so if the parent is already doing
     /// the indentation, then there's no need to do a second indentation.
     /// [Prettier applies]: <https://github.com/prettier/prettier/blob/b0201e01ef99db799eb3716f15b7dfedb0a2e62b/src/language-js/print/binaryish.js#L122-L125>
-    pub fn should_not_indent_if_parent_indents(&self, parent: &AstNodes<'a>) -> bool {
+    pub fn should_not_indent_if_parent_indents(&self, parent: &AstNodes<'a, '_>) -> bool {
         match parent {
             AstNodes::ReturnStatement(_)
             | AstNodes::ThrowStatement(_)
@@ -180,10 +180,10 @@ impl GetSpan for BinaryLikeExpression<'_, '_> {
     }
 }
 
-impl<'a, 'b> TryFrom<&'b AstNode<'a, Expression<'a>>> for BinaryLikeExpression<'a, 'b> {
+impl<'a, 'b> TryFrom<&'b AstNode<'a, 'b, Expression<'a>>> for BinaryLikeExpression<'a, 'b> {
     type Error = ();
 
-    fn try_from(value: &'b AstNode<'a, Expression<'a>>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'b AstNode<'a, 'b, Expression<'a>>) -> Result<Self, Self::Error> {
         match value.as_ast_nodes() {
             AstNodes::LogicalExpression(expr) => Ok(Self::LogicalExpression(expr)),
             AstNodes::BinaryExpression(expr) => Ok(Self::BinaryExpression(expr)),
@@ -568,7 +568,7 @@ fn split_into_left_and_right_sides<'a, 'b>(
 /// these cases the decide to actually break on a new line and indent it.
 ///
 /// This function checks what the parents adheres to this behaviour
-fn should_indent_if_parent_inlines(parent: &AstNodes<'_>) -> bool {
+fn should_indent_if_parent_inlines(parent: &AstNodes<'_, '_>) -> bool {
     matches!(
         parent,
         AstNodes::AssignmentExpression(_)
@@ -580,7 +580,7 @@ fn should_indent_if_parent_inlines(parent: &AstNodes<'_>) -> bool {
 
 fn is_same_binary_expression_kind(
     binary: BinaryLikeExpression<'_, '_>,
-    other: &AstNodes<'_>,
+    other: &AstNodes<'_, '_>,
 ) -> bool {
     match binary {
         BinaryLikeExpression::LogicalExpression(_) => {

--- a/crates/oxc_formatter/src/print/binding_property_list.rs
+++ b/crates/oxc_formatter/src/print/binding_property_list.rs
@@ -9,13 +9,13 @@ use crate::{
 };
 
 pub struct BindingPropertyList<'a, 'b> {
-    properties: &'b AstNode<'a, Vec<'a, BindingProperty<'a>>>,
-    rest: Option<&'b AstNode<'a, BindingRestElement<'a>>>,
+    properties: &'b AstNode<'a, 'b, Vec<'a, BindingProperty<'a>>>,
+    rest: Option<&'b AstNode<'a, 'b, BindingRestElement<'a>>>,
 }
 
 enum BindingPropertyListNode<'a, 'b> {
-    Property(&'b AstNode<'a, BindingProperty<'a>>),
-    Rest(&'b AstNode<'a, BindingRestElement<'a>>),
+    Property(&'b AstNode<'a, 'b, BindingProperty<'a>>),
+    Rest(&'b AstNode<'a, 'b, BindingRestElement<'a>>),
 }
 
 impl GetSpan for BindingPropertyListNode<'_, '_> {
@@ -37,8 +37,8 @@ impl<'a> Format<'a> for BindingPropertyListNode<'a, '_> {
 }
 
 struct BindingPropertyListIter<'a, 'b> {
-    properties: AstNodeIterator<'a, BindingProperty<'a>>,
-    rest: Option<&'b AstNode<'a, BindingRestElement<'a>>>,
+    properties: AstNodeIterator<'a, 'b, BindingProperty<'a>>,
+    rest: Option<&'b AstNode<'a, 'b, BindingRestElement<'a>>>,
 }
 
 impl<'a, 'b> Iterator for BindingPropertyListIter<'a, 'b> {
@@ -55,8 +55,8 @@ impl<'a, 'b> Iterator for BindingPropertyListIter<'a, 'b> {
 
 impl<'a, 'b> BindingPropertyList<'a, 'b> {
     pub fn new(
-        properties: &'b AstNode<'a, Vec<'a, BindingProperty<'a>>>,
-        rest: Option<&'b AstNode<'a, BindingRestElement<'a>>>,
+        properties: &'b AstNode<'a, 'b, Vec<'a, BindingProperty<'a>>>,
+        rest: Option<&'b AstNode<'a, 'b, BindingRestElement<'a>>>,
     ) -> Self {
         Self { properties, rest }
     }

--- a/crates/oxc_formatter/src/print/block_statement.rs
+++ b/crates/oxc_formatter/src/print/block_statement.rs
@@ -9,7 +9,7 @@ use crate::{
     write,
 };
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, Statement<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, Statement<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         f.join_nodes_with_hardline().entries(
             self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_))),
@@ -17,7 +17,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Statement<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BlockStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "{");
 
@@ -28,7 +28,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
         };
 
         let has_comment_before_catch_clause = comments_before_catch_clause.is_some();
-        // See reason in `[AstNode<'a, CatchClause<'a>>::write]`
+        // See reason in `[AstNode<'a, '_, CatchClause<'a>>::write]`
         let formatted_comments_before_catch_clause = format_once(|f| {
             if let Some(comments) = comments_before_catch_clause {
                 f.write_element(comments);
@@ -73,7 +73,7 @@ pub fn is_empty_block(block: &[Statement<'_>]) -> bool {
 /// * empty block that is the 'bons' or 'alt' of an if statement: two lines `{\n}`
 /// * non empty block: put each stmt on its own line: `{\nstmt1;\nstmt2;\n}`
 /// * non empty block with comments (trailing comments on {, or leading comments on })
-fn is_non_collapsible(parent: &AstNodes<'_>) -> bool {
+fn is_non_collapsible(parent: &AstNodes<'_, '_>) -> bool {
     match parent {
         AstNodes::FunctionBody(_)
         | AstNodes::ForStatement(_)

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -34,7 +34,7 @@ use crate::{
     write,
 };
 
-impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, ArenaVec<'a, Argument<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let l_paren_token = "(";
         let r_paren_token = ")";
@@ -211,7 +211,7 @@ pub fn is_function_composition_args(args: &[Argument<'_>]) -> bool {
 }
 
 fn format_all_elements_broken_out<'a, 'b>(
-    node: &'b AstNode<'a, ArenaVec<'a, Argument<'a>>>,
+    node: &'b AstNode<'a, 'b, ArenaVec<'a, Argument<'a>>>,
     elements: impl Iterator<Item = (Option<FormatElement<'a>>, usize)>,
     expand: bool,
     mut buffer: impl Buffer<'a>,
@@ -247,7 +247,7 @@ fn format_all_elements_broken_out<'a, 'b>(
 }
 
 fn format_all_args_broken_out<'a, 'b>(
-    node: &'b AstNode<'a, ArenaVec<'a, Argument<'a>>>,
+    node: &'b AstNode<'a, 'b, ArenaVec<'a, Argument<'a>>>,
     expand: bool,
     mut buffer: impl Buffer<'a>,
 ) {
@@ -647,7 +647,7 @@ fn can_group_arrow_function_expression_argument(
 }
 
 fn write_grouped_arguments<'a>(
-    node: &AstNode<'a, ArenaVec<'a, Argument<'a>>>,
+    node: &AstNode<'a, '_, ArenaVec<'a, Argument<'a>>>,
     group_layout: GroupedCallArgumentLayout,
     f: &mut Formatter<'_, 'a>,
 ) {
@@ -914,7 +914,7 @@ fn write_grouped_arguments<'a>(
 
 /// Helper for formatting the first grouped argument (see [should_group_first_argument]).
 struct FormatGroupedFirstArgument<'a, 'b> {
-    argument: &'b AstNode<'a, Argument<'a>>,
+    argument: &'b AstNode<'a, 'b, Argument<'a>>,
 }
 
 impl<'a> Format<'a> for FormatGroupedFirstArgument<'a, '_> {
@@ -943,7 +943,7 @@ impl<'a> Format<'a> for FormatGroupedFirstArgument<'a, '_> {
 /// Helper for formatting the last grouped argument (see [should_group_last_argument]).
 struct FormatGroupedLastArgument<'a, 'b> {
     /// The argument to format
-    argument: &'b AstNode<'a, Argument<'a>>,
+    argument: &'b AstNode<'a, 'b, Argument<'a>>,
     /// Is this the only argument in the arguments list
     is_only: bool,
 }
@@ -988,7 +988,7 @@ fn function_has_only_simple_parameters(params: &FormalParameters<'_>) -> bool {
 
 /// Tests if this a simple module import like `import("module-name")` or `require("module-name")`.
 pub fn is_simple_module_import(
-    arguments: &AstNode<'_, ArenaVec<'_, Argument<'_>>>,
+    arguments: &AstNode<'_, '_, ArenaVec<'_, Argument<'_>>>,
     comments: &Comments,
 ) -> bool {
     if arguments.len() != 1 {
@@ -1037,7 +1037,7 @@ pub fn is_simple_module_import(
 /// Tests if amd's [`define`](https://github.com/amdjs/amdjs-api/wiki/AMD#define-function-) function.
 fn is_commonjs_or_amd_call(
     arguments: &[Argument<'_>],
-    call: &AstNode<'_, CallExpression<'_>>,
+    call: &AstNode<'_, '_, CallExpression<'_>>,
     f: &Formatter<'_, '_>,
 ) -> bool {
     let Expression::Identifier(ident) = &call.callee else {
@@ -1112,7 +1112,7 @@ fn is_multiline_template_only_args(arguments: &[Argument], source_text: SourceTe
 /// This triggers the "hugging" layout where the backtick is adjacent to `(`.
 fn is_graphql_call_with_single_template_arg<'a>(
     arguments: &[Argument],
-    call: Option<&&AstNode<'a, CallExpression<'a>>>,
+    call: Option<&&AstNode<'a, '_, CallExpression<'a>>>,
 ) -> bool {
     arguments.len() == 1
         && matches!(arguments.first(), Some(Argument::TemplateLiteral(_)))
@@ -1189,7 +1189,7 @@ fn is_react_hook_with_deps_array(
 /// ```
 ///
 /// <https://github.com/prettier/prettier/blob/0273e33fc691e28e4ab3f3c8ee86918b65cf823d/src/language-js/print/function-parameters.js#L240-L291>
-fn is_decorated_function(argument: &AstNode<'_, Argument<'_>>) -> bool {
+fn is_decorated_function(argument: &AstNode<'_, '_, Argument<'_>>) -> bool {
     // Check if the argument is an arrow function with a block body
     let AstNodes::ArrowFunctionExpression(arrow) = argument.as_ast_nodes() else {
         return false;

--- a/crates/oxc_formatter/src/print/call_like_expression/mod.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/mod.rs
@@ -18,7 +18,7 @@ use arguments::is_simple_module_import;
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, CallExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let callee = self.callee();
         let type_arguments = self.type_arguments();
@@ -129,13 +129,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, NewExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, NewExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["new", space(), self.callee(), self.type_arguments(), self.arguments()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ImportExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ImportExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["import"]);
         if let Some(phase) = &self.phase() {

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -29,7 +29,7 @@ use super::{
     type_parameters::{FormatTSTypeParameters, FormatTSTypeParametersOptions},
 };
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ClassBody<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ClassBody<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if f.options().quote_properties.is_consistent() {
             let quote_needed = self.body.iter().any(|signature| {
@@ -53,7 +53,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ClassBody<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, ClassElement<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, ClassElement<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         // Join class elements with hard line breaks between them
         let mut join = f.join_nodes_with_hardline();
@@ -66,13 +66,15 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ClassElement<'a>>> {
     }
 }
 
-impl<'a> Format<'a> for (&AstNode<'a, ClassElement<'a>>, Option<&AstNode<'a, ClassElement<'a>>>) {
+impl<'a> Format<'a>
+    for (&AstNode<'a, '_, ClassElement<'a>>, Option<&AstNode<'a, '_, ClassElement<'a>>>)
+{
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         FormatClassElementWithSemicolon::new(self.0, self.1).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, MethodDefinition<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, MethodDefinition<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.decorators()]);
 
@@ -138,19 +140,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, MethodDefinition<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, PropertyDefinition<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, PropertyDefinition<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         AssignmentLike::PropertyDefinition(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, PrivateIdentifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, PrivateIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["#", text_without_whitespace(self.name().as_str())]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, StaticBlock<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, StaticBlock<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["static", space(), "{"]);
 
@@ -164,13 +166,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StaticBlock<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AccessorProperty<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AccessorProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         AssignmentLike::AccessorProperty(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignature<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSIndexSignature<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.r#static {
             write!(f, ["static", space()]);
@@ -192,7 +194,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignature<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, TSIndexSignatureName<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         f.join_with(&soft_line_break_or_space()).entries_with_trailing_separator(
             self.iter(),
@@ -202,13 +204,13 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSIndexSignatureName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [text_without_whitespace(self.name().as_str()), self.type_annotation()]);
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, TSClassImplements<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let last_index = self.len().saturating_sub(1);
         let mut joiner = f.join_with(soft_line_break_or_space());
@@ -227,13 +229,13 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSClassImplements<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSClassImplements<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.expression(), self.type_arguments()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, Class<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, Class<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.r#type == ClassType::ClassExpression
             && (!self.decorators.is_empty() && self.needs_parentheses(f))
@@ -245,10 +247,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Class<'a>> {
     }
 }
 
-struct FormatClass<'a, 'b>(pub &'b AstNode<'a, Class<'a>>);
+struct FormatClass<'a, 'b>(pub &'b AstNode<'a, 'b, Class<'a>>);
 
-impl<'a> Deref for FormatClass<'a, '_> {
-    type Target = AstNode<'a, Class<'a>>;
+impl<'a, 'b> Deref for FormatClass<'a, 'b> {
+    type Target = AstNode<'a, 'b, Class<'a>>;
 
     fn deref(&self) -> &Self::Target {
         self.0
@@ -523,14 +525,14 @@ fn should_group<'a>(class: &AstNode<Class<'a>>, f: &Formatter<'_, 'a>) -> bool {
 }
 
 pub struct FormatClassElementWithSemicolon<'a, 'b> {
-    element: &'b AstNode<'a, ClassElement<'a>>,
-    next_element: Option<&'b AstNode<'a, ClassElement<'a>>>,
+    element: &'b AstNode<'a, 'b, ClassElement<'a>>,
+    next_element: Option<&'b AstNode<'a, 'b, ClassElement<'a>>>,
 }
 
 impl<'a, 'b> FormatClassElementWithSemicolon<'a, 'b> {
     pub fn new(
-        element: &'b AstNode<'a, ClassElement<'a>>,
-        next_element: Option<&'b AstNode<'a, ClassElement<'a>>>,
+        element: &'b AstNode<'a, 'b, ClassElement<'a>>,
+        next_element: Option<&'b AstNode<'a, 'b, ClassElement<'a>>>,
     ) -> Self {
         Self { element, next_element }
     }
@@ -613,10 +615,10 @@ impl<'a> Format<'a> for FormatClassElementWithSemicolon<'a, '_> {
 
 /// Based on <https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/function.js#L160-L176>
 pub fn format_grouped_parameters_with_return_type_for_method<'a>(
-    type_parameters: Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>>,
+    type_parameters: Option<&AstNode<'a, '_, TSTypeParameterDeclaration<'a>>>,
     this_param: Option<&TSThisParameter<'a>>,
-    params: &AstNode<'a, FormalParameters<'a>>,
-    return_type: Option<&AstNode<'a, TSTypeAnnotation<'a>>>,
+    params: &AstNode<'a, '_, FormalParameters<'a>>,
+    return_type: Option<&AstNode<'a, '_, TSTypeAnnotation<'a>>>,
     f: &mut Formatter<'_, 'a>,
 ) {
     write!(f, type_parameters);
@@ -677,6 +679,6 @@ pub fn format_grouped_parameters_with_return_type_for_method<'a>(
 /// ```ts
 /// constructor(private id: string) {}
 /// ```
-fn should_break_function_parameters<'a>(params: &AstNode<'a, FormalParameters<'a>>) -> bool {
+fn should_break_function_parameters<'a>(params: &AstNode<'a, '_, FormalParameters<'a>>) -> bool {
     params.parameters_count() > 1 && params.items().iter().any(|param| param.has_modifier())
 }

--- a/crates/oxc_formatter/src/print/decorators.rs
+++ b/crates/oxc_formatter/src/print/decorators.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, Decorator<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, Decorator<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if self.is_empty() {
             return;
@@ -67,7 +67,7 @@ fn is_identifier_or_static_member_only(callee: &Expression) -> bool {
     false
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, Decorator<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, Decorator<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["@"]);
 
@@ -98,7 +98,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Decorator<'a>> {
 /// Check if decorators should expand (have newlines between them)
 #[inline]
 fn should_expand_decorators<'a>(
-    decorators: &AstNode<'a, Vec<'a, Decorator<'a>>>,
+    decorators: &AstNode<'a, '_, Vec<'a, Decorator<'a>>>,
     f: &Formatter<'_, 'a>,
 ) -> bool {
     decorators.iter().any(|decorator| f.source_text().has_newline_after(decorator.span().end))

--- a/crates/oxc_formatter/src/print/export_declarations.rs
+++ b/crates/oxc_formatter/src/print/export_declarations.rs
@@ -23,7 +23,7 @@ use super::FormatWrite;
 fn format_export_keyword_with_class_decorators<'a>(
     span: Span,
     keyword: &'static str,
-    declaration: &AstNodes<'a>,
+    declaration: &AstNodes<'a, '_>,
     f: &mut Formatter<'_, 'a>,
 ) {
     // `@decorator export class Cls {}`
@@ -63,7 +63,7 @@ fn format_export_keyword_with_class_decorators<'a>(
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ExportDefaultDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         format_export_keyword_with_class_decorators(
             self.span,
@@ -81,7 +81,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ExportAllDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["export", space(), self.export_kind(), "*", space()]);
         if let Some(name) = &self.exported() {
@@ -94,7 +94,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ExportNamedDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let declaration = self.declaration();
         let export_kind = self.export_kind();
@@ -173,7 +173,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, ExportSpecifier<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_with(soft_line_break_or_space()).entries(
@@ -196,7 +196,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ExportSpecifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ExportSpecifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().line_comments_before(self.exported.span().end);
         write!(f, [FormatLeadingComments::Comments(comments)]);
@@ -210,13 +210,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportSpecifier<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSExportAssignment<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSExportAssignment<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["export = ", self.expression(), OptionalSemicolon]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSNamespaceExportDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["export as namespace ", self.id(), OptionalSemicolon]);
     }

--- a/crates/oxc_formatter/src/print/fragment.rs
+++ b/crates/oxc_formatter/src/print/fragment.rs
@@ -26,12 +26,12 @@ use super::parameters::{ParameterLayout, ParameterList};
 ///
 /// For `v-slot` bindings (e.g., `{ item }`), use the default (no parens).
 pub struct FormatVueBindingParams<'a, 'b> {
-    node: &'b AstNode<'a, FormalParameters<'a>>,
+    node: &'b AstNode<'a, 'b, FormalParameters<'a>>,
     with_parens: bool,
 }
 
 impl<'a, 'b> FormatVueBindingParams<'a, 'b> {
-    pub fn new(node: &'b AstNode<'a, FormalParameters<'a>>, with_parens: bool) -> Self {
+    pub fn new(node: &'b AstNode<'a, 'b, FormalParameters<'a>>, with_parens: bool) -> Self {
         Self { node, with_parens }
     }
 }
@@ -66,11 +66,11 @@ impl<'a> Format<'a> for FormatVueBindingParams<'a, '_> {
 /// Does NOT include angle bracket delimiters `<`/`>` or group wrapping.
 /// And trailing commas are suppressed.
 pub struct FormatVueScriptGeneric<'a, 'b> {
-    decl: &'b AstNode<'a, TSTypeParameterDeclaration<'a>>,
+    decl: &'b AstNode<'a, 'b, TSTypeParameterDeclaration<'a>>,
 }
 
 impl<'a, 'b> FormatVueScriptGeneric<'a, 'b> {
-    pub fn new(decl: &'b AstNode<'a, TSTypeParameterDeclaration<'a>>) -> Self {
+    pub fn new(decl: &'b AstNode<'a, 'b, TSTypeParameterDeclaration<'a>>) -> Self {
         Self { decl }
     }
 }

--- a/crates/oxc_formatter/src/print/function.rs
+++ b/crates/oxc_formatter/src/print/function.rs
@@ -17,7 +17,7 @@ use crate::{
     write,
 };
 
-impl<'a> FormatWrite<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
+impl<'a> FormatWrite<'a, FormatFunctionOptions> for AstNode<'a, '_, Function<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         FormatFunction::new(self).fmt(f);
     }
@@ -35,12 +35,12 @@ pub struct FormatFunctionOptions {
 }
 
 pub struct FormatFunction<'a, 'b> {
-    pub function: &'b AstNode<'a, Function<'a>>,
+    pub function: &'b AstNode<'a, 'b, Function<'a>>,
     pub options: FormatFunctionOptions,
 }
 
-impl<'a> Deref for FormatFunction<'a, '_> {
-    type Target = AstNode<'a, Function<'a>>;
+impl<'a, 'b> Deref for FormatFunction<'a, 'b> {
+    type Target = AstNode<'a, 'b, Function<'a>>;
 
     fn deref(&self) -> &Self::Target {
         self.function
@@ -48,12 +48,12 @@ impl<'a> Deref for FormatFunction<'a, '_> {
 }
 
 impl<'a, 'b> FormatFunction<'a, 'b> {
-    pub fn new(function: &'b AstNode<'a, Function<'a>>) -> Self {
+    pub fn new(function: &'b AstNode<'a, 'b, Function<'a>>) -> Self {
         Self { function, options: FormatFunctionOptions::default() }
     }
 
     pub fn new_with_options(
-        function: &'b AstNode<'a, Function<'a>>,
+        function: &'b AstNode<'a, 'b, Function<'a>>,
         options: FormatFunctionOptions,
     ) -> Self {
         Self { function, options }
@@ -148,7 +148,7 @@ impl<'a> Format<'a> for FormatFunction<'a, '_> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, FunctionBody<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, FunctionBody<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().block_comments_before(self.span.start);
         write!(f, [space(), FormatLeadingComments::Comments(comments)]);

--- a/crates/oxc_formatter/src/print/function_type.rs
+++ b/crates/oxc_formatter/src/print/function_type.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSFunctionType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSFunctionType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         format_grouped_parameters_with_return_type(
             self.type_parameters(),
@@ -24,7 +24,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSFunctionType<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructorType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSConstructorType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let r#abstract = self.r#abstract();
 
@@ -49,7 +49,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructorType<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSCallSignatureDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         format_grouped_parameters_with_return_type(
             self.type_parameters(),
@@ -62,7 +62,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSMethodSignature<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSMethodSignature<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_inner = format_with(|f| {
             match self.kind() {
@@ -113,7 +113,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMethodSignature<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSConstructSignatureDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
@@ -137,10 +137,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
 
 /// Based on <https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/print/type-annotation.js#L274-L331>
 pub fn format_grouped_parameters_with_return_type<'a>(
-    type_parameters: Option<&AstNode<'a, TSTypeParameterDeclaration<'a>>>,
+    type_parameters: Option<&AstNode<'a, '_, TSTypeParameterDeclaration<'a>>>,
     this_param: Option<&TSThisParameter<'a>>,
-    params: &AstNode<'a, FormalParameters<'a>>,
-    return_type: Option<&AstNode<'a, TSTypeAnnotation<'a>>>,
+    params: &AstNode<'a, '_, FormalParameters<'a>>,
+    return_type: Option<&AstNode<'a, '_, TSTypeAnnotation<'a>>>,
     is_function_or_constructor_type: bool,
     f: &mut Formatter<'_, 'a>,
 ) {

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -26,8 +26,8 @@ impl<'a> Format<'a> for ImportOrExportKind {
 }
 
 pub fn format_import_and_export_source_with_clause<'a>(
-    source: &AstNode<'a, StringLiteral>,
-    with_clause: Option<&AstNode<'a, WithClause>>,
+    source: &AstNode<'a, '_, StringLiteral>,
+    with_clause: Option<&AstNode<'a, '_, WithClause>>,
     f: &mut Formatter<'_, 'a>,
 ) {
     source.fmt(f);
@@ -41,7 +41,7 @@ pub fn format_import_and_export_source_with_clause<'a>(
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ImportDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let decl = &format_with(|f| {
             write!(f, ["import", space(), self.import_kind]);
@@ -63,7 +63,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, ImportDeclarationSpecifier<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let mut specifiers_iter = self.iter().peekable();
 
@@ -144,7 +144,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ImportSpecifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ImportSpecifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().line_comments_before(self.local.span.end);
         write!(f, [FormatLeadingComments::Comments(comments), self.import_kind()]);
@@ -156,19 +156,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportSpecifier<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ImportDefaultSpecifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ImportDefaultSpecifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.local()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ImportNamespaceSpecifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["*", space(), "as", space(), self.local()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, WithClause<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, WithClause<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if f.options().quote_properties.is_consistent() {
             let quote_needed = self.with_entries.iter().any(|attribute| {
@@ -207,7 +207,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithClause<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, ImportAttribute<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if self.is_empty() {
             return write!(f, "{}");
@@ -271,7 +271,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ImportAttribute<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ImportAttribute<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if let AstNodes::StringLiteral(string) = self.key().as_ast_nodes() {
             let format = FormatLiteralStringToken::new(
@@ -300,7 +300,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportAttribute<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSImportEqualsDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
@@ -319,7 +319,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSExternalModuleReference<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSExternalModuleReference<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["require("]);
 

--- a/crates/oxc_formatter/src/print/intersection_type.rs
+++ b/crates/oxc_formatter/src/print/intersection_type.rs
@@ -11,7 +11,7 @@ use crate::{
     write,
 };
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSIntersectionType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let content = format_with(|f| format_intersection_types(self.types(), f));
         write!(f, [group(&content)]);
@@ -20,7 +20,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
 
 // [Prettier applies]: https://github.com/prettier/prettier/blob/cd3e530c2e51fb8296c0fb7738a9afdd3a3a4410/src/language-js/print/type-annotation.js#L93-L120
 fn format_intersection_types<'a>(
-    node: &AstNode<'a, Vec<'a, TSType<'a>>>,
+    node: &AstNode<'a, '_, Vec<'a, TSType<'a>>>,
     f: &mut Formatter<'_, 'a>,
 ) {
     let last_index = node.len().saturating_sub(1);

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -33,7 +33,7 @@ impl FormatJsxChildList {
 
     pub fn fmt_children<'a, 'b>(
         &self,
-        children: &'b AstNode<'a, ArenaVec<'a, JSXChild<'a>>>,
+        children: &'b AstNode<'a, 'b, ArenaVec<'a, JSXChild<'a>>>,
         f: &mut Formatter<'_, 'a>,
     ) -> FormatChildrenResult<'a, 'b> {
         // Use Biome's exact approach - no need for jsx_split_children at this stage
@@ -366,7 +366,7 @@ impl FormatJsxChildList {
     }
 
     fn children_meta(
-        children: &AstNode<'_, ArenaVec<'_, JSXChild<'_>>>,
+        children: &AstNode<'_, '_, ArenaVec<'_, JSXChild<'_>>>,
         comments: &Comments<'_>,
     ) -> ChildrenMeta {
         let mut meta = ChildrenMeta::default();

--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -20,8 +20,8 @@ use super::{FormatJsxChildList, JsxChildListLayout};
 /// Union type for JSX elements and fragments that have children
 #[derive(Debug, Clone)]
 pub enum AnyJsxTagWithChildren<'a, 'b> {
-    Element(&'b AstNode<'a, JSXElement<'a>>),
-    Fragment(&'b AstNode<'a, JSXFragment<'a>>),
+    Element(&'b AstNode<'a, 'b, JSXElement<'a>>),
+    Fragment(&'b AstNode<'a, 'b, JSXFragment<'a>>),
 }
 
 impl<'a> AnyJsxTagWithChildren<'a, '_> {
@@ -242,7 +242,7 @@ impl<'a> Format<'a> for AnyJsxTagWithChildren<'a, '_> {
 /// // As JSX attribute:
 /// <Tooltip title={[].map(name => (<Foo>{name}</Foo>))} />;
 /// ```
-pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
+pub fn should_expand(mut parent: &AstNodes<'_, '_>) -> bool {
     if let AstNodes::ExpressionStatement(stmt) = parent {
         // If the parent is a JSXExpressionContainer, we need to check its parent
         // to determine if it should expand.
@@ -287,14 +287,14 @@ impl<'a, 'b> AnyJsxTagWithChildren<'a, 'b> {
         }
     }
 
-    fn children(&self) -> &'b AstNode<'a, Vec<'a, JSXChild<'a>>> {
+    fn children(&self) -> &'b AstNode<'a, 'b, Vec<'a, JSXChild<'a>>> {
         match self {
             Self::Element(element) => element.children(),
             Self::Fragment(fragment) => fragment.children(),
         }
     }
 
-    fn parent(&self) -> &'b AstNodes<'a> {
+    fn parent(&self) -> &'b AstNodes<'a, 'b> {
         match self {
             Self::Element(element) => element.parent(),
             Self::Fragment(fragment) => fragment.parent(),
@@ -361,7 +361,7 @@ pub enum ElementLayout<'a, 'b> {
     ///   } that will eventually break across multiple lines ${(40 / 3) * 45}`}
     /// </div>;
     /// ```
-    Template(&'b AstNode<'a, JSXExpressionContainer<'a>>),
+    Template(&'b AstNode<'a, 'b, JSXExpressionContainer<'a>>),
 
     /// Default layout used for all elements that have children and [ElementLayout::Template] does not apply.
     ///

--- a/crates/oxc_formatter/src/print/jsx/mod.rs
+++ b/crates/oxc_formatter/src/print/jsx/mod.rs
@@ -25,19 +25,19 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXElement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXElement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         AnyJsxTagWithChildren::Element(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXOpeningElement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXOpeningElement<'a>> {
     fn write(&self, _f: &mut Formatter<'_, 'a>) {
         unreachable!("`AnyJsxTagWithChildren` will print it.")
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingElement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXClosingElement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let name = self.name();
         let mut name_has_leading_comment = false;
@@ -65,13 +65,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingElement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXFragment<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXFragment<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         AnyJsxTagWithChildren::Fragment(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXOpeningFragment> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXOpeningFragment> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().comments_before(self.span.end);
 
@@ -100,7 +100,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXOpeningFragment> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingFragment> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXClosingFragment> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().comments_before(self.span.end);
 
@@ -136,19 +136,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXClosingFragment> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXNamespacedName<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXNamespacedName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.namespace(), ":", self.name()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXMemberExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXMemberExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.object(), ".", self.property()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXExpressionContainer<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXExpressionContainer<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let has_comment = |f: &mut Formatter<'_, '_>| {
             let expression_span = self.expression.span();
@@ -304,11 +304,11 @@ pub fn should_inline_jsx_expression(container: &JSXExpressionContainer<'_>) -> b
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXEmptyExpression> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXEmptyExpression> {
     fn write(&self, _f: &mut Formatter<'_, 'a>) {}
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, JSXAttributeItem<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let line_break = if f.options().attribute_position == AttributePosition::Multiline {
             hard_line_break()
@@ -320,7 +320,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXAttribute<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXAttribute<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, self.name());
 
@@ -347,7 +347,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXAttribute<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXSpreadAttribute<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments();
         let has_comment = comments.has_comment_before(self.argument.span().start)
@@ -369,13 +369,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadAttribute<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXIdentifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadChild<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXSpreadChild<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments();
         let has_comment = comments.has_comment_before(self.expression.span().start)
@@ -397,7 +397,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadChild<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSXText<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSXText<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, text(self.value().as_str()));
     }

--- a/crates/oxc_formatter/src/print/jsx/opening_element.rs
+++ b/crates/oxc_formatter/src/print/jsx/opening_element.rs
@@ -10,12 +10,12 @@ use crate::{
 };
 
 pub struct FormatOpeningElement<'a, 'b> {
-    element: &'b AstNode<'a, JSXOpeningElement<'a>>,
+    element: &'b AstNode<'a, 'b, JSXOpeningElement<'a>>,
     is_self_closing: bool,
 }
 
-impl<'a> Deref for FormatOpeningElement<'a, '_> {
-    type Target = AstNode<'a, JSXOpeningElement<'a>>;
+impl<'a, 'b> Deref for FormatOpeningElement<'a, 'b> {
+    type Target = AstNode<'a, 'b, JSXOpeningElement<'a>>;
 
     fn deref(&self) -> &Self::Target {
         self.element
@@ -23,7 +23,7 @@ impl<'a> Deref for FormatOpeningElement<'a, '_> {
 }
 
 impl<'a, 'b> FormatOpeningElement<'a, 'b> {
-    pub fn new(element: &'b AstNode<'a, JSXOpeningElement<'a>>, is_self_closing: bool) -> Self {
+    pub fn new(element: &'b AstNode<'a, 'b, JSXOpeningElement<'a>>, is_self_closing: bool) -> Self {
         Self { element, is_self_closing }
     }
 

--- a/crates/oxc_formatter/src/print/mapped_type.rs
+++ b/crates/oxc_formatter/src/print/mapped_type.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSMappedType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if f.comments().is_suppressed(self.key.span.start) {
             return write!(f, FormatSuppressedNode(self.span));

--- a/crates/oxc_formatter/src/print/member_expression.rs
+++ b/crates/oxc_formatter/src/print/member_expression.rs
@@ -12,14 +12,14 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ComputedMemberExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ComputedMemberExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, self.object());
         FormatComputedMemberExpressionWithoutObject(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, StaticMemberExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, StaticMemberExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_member_chain = {
             let mut recording = f.start_recording();
@@ -78,7 +78,7 @@ fn operator_token(optional: bool) -> &'static str {
 }
 
 fn layout<'a>(
-    node: &AstNode<'a, StaticMemberExpression<'a>>,
+    node: &AstNode<'a, '_, StaticMemberExpression<'a>>,
     is_member_chain: bool,
     f: &Formatter<'_, 'a>,
 ) -> StaticMemberLayout {
@@ -152,7 +152,7 @@ fn layout<'a>(
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, PrivateFieldExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, PrivateFieldExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.object(), self.optional().then_some("?"), ".", self.field()]);
     }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -98,7 +98,7 @@ pub trait FormatWrite<'ast, T = ()> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierName<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, IdentifierName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let text = text_without_whitespace(self.name().as_str());
         let is_property_key_parent = matches!(
@@ -120,41 +120,41 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierName<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, IdentifierReference<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, IdentifierReference<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BindingIdentifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BindingIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, LabelIdentifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, LabelIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, text_without_whitespace(self.name().as_str()));
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ThisExpression> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ThisExpression> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "this");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ArrayExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ArrayExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         FormatArrayExpression::new(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, Elision> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, Elision> {
     fn write(&self, _f: &mut Formatter<'_, 'a>) {}
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ObjectExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ObjectExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if f.options().quote_properties.is_consistent() {
             let quote_needed = self.properties.iter().any(|kind| {
@@ -171,7 +171,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ObjectExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, ObjectPropertyKind<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line().entries_with_trailing_separator(
@@ -182,7 +182,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ObjectProperty<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ObjectProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if f.comments().has_trailing_suppression_comment(self.span().end) {
             write!(f, [FormatSuppressedNode(self.span())]);
@@ -237,19 +237,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ObjectProperty<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, MetaProperty<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, MetaProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.meta(), ".", self.property()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, SpreadElement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, SpreadElement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["...", self.argument()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, UpdateExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, UpdateExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.prefix() {
             write!(f, self.operator().as_str());
@@ -261,7 +261,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, UpdateExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, UnaryExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, UnaryExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, self.operator().as_str());
         if self.operator().is_keyword() {
@@ -281,37 +281,37 @@ impl<'a> FormatWrite<'a> for AstNode<'a, UnaryExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BinaryExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BinaryExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         BinaryLikeExpression::BinaryExpression(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, PrivateInExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, PrivateInExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.left(), space(), "in", space(), self.right()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, LogicalExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, LogicalExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         BinaryLikeExpression::LogicalExpression(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ConditionalExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ConditionalExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         ConditionalLike::ConditionalExpression(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AssignmentExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         AssignmentLike::AssignmentExpression(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ArrayAssignmentTarget<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "[");
 
@@ -340,25 +340,25 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ArrayAssignmentTarget<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ObjectAssignmentTarget<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ObjectAssignmentTarget<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         ObjectPatternLike::ObjectAssignmentTarget(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetRest<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AssignmentTargetRest<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["...", self.target()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AssignmentTargetWithDefault<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.binding(), space(), "=", space(), self.init()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AssignmentTargetPropertyIdentifier<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, self.binding());
         if let Some(expr) = &self.init() {
@@ -367,7 +367,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>>
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AssignmentTargetPropertyProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.computed() {
             write!(f, "[");
@@ -380,13 +380,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, Super> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, Super> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "super");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AwaitExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AwaitExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_inner = format_with(|f| write!(f, ["await", space(), self.argument()]));
 
@@ -429,7 +429,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AwaitExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ChainExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ChainExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         // When ChainExpression contains TSNonNullExpression, we print `(a?.b)!` instead of `(a?.b!)`
         // This normalizes `(a?.b!).c` to `(a?.b)!.c` to match Prettier's output.
@@ -451,13 +451,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ChainExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ParenthesizedExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ParenthesizedExpression<'a>> {
     fn write(&self, _f: &mut Formatter<'_, 'a>) {
         unreachable!("No `ParenthesizedExpression` as we disabled `preserve_parens` in the parser")
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, EmptyStatement> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, EmptyStatement> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if matches!(
             self.parent(),
@@ -476,7 +476,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, EmptyStatement> {
 
 /// Returns `true` if the expression needs a leading semicolon to prevent ASI issues
 fn expression_statement_needs_semicolon<'a>(
-    stmt: &AstNode<'a, ExpressionStatement<'a>>,
+    stmt: &AstNode<'a, '_, ExpressionStatement<'a>>,
     f: &Formatter<'_, 'a>,
 ) -> bool {
     if matches!(
@@ -560,7 +560,7 @@ fn expression_statement_needs_semicolon<'a>(
     })
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ExpressionStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let span = self.span();
         // Check if we need a leading semicolon to prevent ASI issues
@@ -581,7 +581,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, DoWhileStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let body = self.body();
         write!(f, group(&format_args!("do", FormatStatementBody::new(body))));
@@ -626,7 +626,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
 /// ```
 ///
 /// This ensures compatibility with [Prettier's comment handling for empty statements](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/printer-methods.js#L15).
-struct FormatCommentForEmptyStatement<'a, 'b>(&'b AstNode<'a, Statement<'a>>);
+struct FormatCommentForEmptyStatement<'a, 'b>(&'b AstNode<'a, 'b, Statement<'a>>);
 impl<'a> Format<'a> for FormatCommentForEmptyStatement<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if let AstNodes::EmptyStatement(empty) = self.0.as_ast_nodes() {
@@ -637,7 +637,7 @@ impl<'a> Format<'a> for FormatCommentForEmptyStatement<'a, '_> {
     }
 }
 
-struct FormatTestOfIfAndWhileStatement<'a, 'b>(&'b AstNode<'a, Expression<'a>>);
+struct FormatTestOfIfAndWhileStatement<'a, 'b>(&'b AstNode<'a, 'b, Expression<'a>>);
 impl<'a> Format<'a> for FormatTestOfIfAndWhileStatement<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         // FormatNodeWithoutTrailingComments already handles suppression comments internally,
@@ -649,7 +649,7 @@ impl<'a> Format<'a> for FormatTestOfIfAndWhileStatement<'a, '_> {
         }
     }
 }
-impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, WhileStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let body = self.body();
         write!(
@@ -669,7 +669,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ForStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let init = self.init();
         let test = self.test();
@@ -709,7 +709,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ForInStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
         let body = self.body();
@@ -735,7 +735,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ForOfStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
 
@@ -767,7 +767,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, IfStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let test = self.test();
         let consequent = self.consequent();
@@ -837,7 +837,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ContinueStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "continue");
         if let Some(label) = self.label() {
@@ -847,7 +847,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ContinueStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BreakStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "break");
         if let Some(label) = self.label() {
@@ -857,7 +857,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BreakStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, WithStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
@@ -873,7 +873,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, LabeledStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().line_comments_before(self.body.span().start);
         FormatLeadingComments::Comments(comments).fmt(f);
@@ -898,13 +898,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, DebuggerStatement> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, DebuggerStatement> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["debugger", OptionalSemicolon]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BindingPattern<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BindingPattern<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         Format::fmt(self, f);
         if let AstNodes::VariableDeclarator(declarator) = self.parent() {
@@ -913,14 +913,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BindingPattern<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameterRest<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, FormalParameterRest<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.rest()]);
         write!(f, self.type_annotation());
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentPattern<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, AssignmentPattern<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let left = self.left().memoized();
         // Format `left` early before writing leading comments, so that comments
@@ -941,25 +941,25 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AssignmentPattern<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ObjectPattern<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ObjectPattern<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         ObjectPatternLike::ObjectPattern(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BindingProperty<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BindingProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         AssignmentLike::BindingProperty(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BindingRestElement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BindingRestElement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["...", self.argument()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, YieldExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, YieldExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["yield", self.delegate().then_some("*")]);
         if let Some(argument) = &self.argument() {
@@ -968,25 +968,25 @@ impl<'a> FormatWrite<'a> for AstNode<'a, YieldExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, V8IntrinsicExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, V8IntrinsicExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["%", self.name(), self.arguments()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BooleanLiteral> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BooleanLiteral> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, if self.value() { "true" } else { "false" });
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, NullLiteral> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, NullLiteral> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "null");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, NumericLiteral<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, NumericLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let source_text = f.source_text().text_for(self);
         let options = NumberFormatOptions::keep_one_trailing_decimal_zero();
@@ -1043,7 +1043,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, NumericLiteral<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, StringLiteral<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, StringLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         // Check if we're in a Tailwind context via stack (O(1) lookup)
         // This handles nested string literals inside JSXAttribute/CallExpression values
@@ -1063,7 +1063,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StringLiteral<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, BigIntLiteral<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, BigIntLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
@@ -1072,7 +1072,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BigIntLiteral<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, RegExpLiteral<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, RegExpLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let raw = self.raw().unwrap().as_str();
 
@@ -1092,7 +1092,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, RegExpLiteral<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSEnumDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.declare() {
             write!(f, ["declare", space()]);
@@ -1104,7 +1104,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumBody<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSEnumBody<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.members().is_empty() {
             write!(f, format_dangling_comments(self.span()).with_block_indent());
@@ -1114,7 +1114,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumBody<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, TSEnumMember<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line().entries_with_trailing_separator(
@@ -1125,7 +1125,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumMember<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSEnumMember<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let id = self.id();
         let is_computed = matches!(id.as_ref(), TSEnumMemberName::ComputedTemplateString(_));
@@ -1146,7 +1146,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumMember<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeAnnotation<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         match self.parent() {
             AstNodes::TSFunctionType(_) | AstNodes::TSConstructorType(_) => {
@@ -1162,43 +1162,43 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAnnotation<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSLiteralType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSLiteralType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         self.literal().fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSConditionalType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSConditionalType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         ConditionalLike::TSConditionalType(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSParenthesizedType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSParenthesizedType<'a>> {
     fn write(&self, _f: &mut Formatter<'_, 'a>) {
         unreachable!("No `TSParenthesizedType` as we disabled `preserve_parens` in the parser")
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeOperator<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeOperator<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.operator().to_str(), space(), self.type_annotation()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSArrayType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSArrayType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.element_type(), "[]"]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexedAccessType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSIndexedAccessType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.object_type(), "[", self.index_type(), "]"]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSNamedTupleMember<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, self.label());
         if self.optional() {
@@ -1208,103 +1208,103 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSNamedTupleMember<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSOptionalType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSOptionalType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.type_annotation(), "?"]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSRestType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSRestType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["...", self.type_annotation()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSAnyKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSAnyKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "any");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSStringKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSStringKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "string");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSBooleanKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSBooleanKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "boolean");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSNumberKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSNumberKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "number");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSNeverKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSNeverKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "never");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSIntrinsicKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSIntrinsicKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "intrinsic");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSUnknownKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSUnknownKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "unknown");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSNullKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSNullKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "null");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSUndefinedKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSUndefinedKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "undefined");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSVoidKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSVoidKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "void");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSSymbolKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSSymbolKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "symbol");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSThisType> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSThisType> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "this");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSObjectKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSObjectKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "object");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSBigIntKeyword> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSBigIntKeyword> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "bigint");
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeReference<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeReference<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let wrap = is_leftmost_intrinsic_in_type_alias(self);
         write!(
@@ -1321,7 +1321,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeReference<'a>> {
 /// (or fails to parse when followed by `|`/`&`)
 ///
 /// See: <https://github.com/oxc-project/oxc/issues/20205>
-fn is_leftmost_intrinsic_in_type_alias(reference: &AstNode<'_, TSTypeReference<'_>>) -> bool {
+fn is_leftmost_intrinsic_in_type_alias(reference: &AstNode<'_, '_, TSTypeReference<'_>>) -> bool {
     let TSTypeName::IdentifierReference(ident) = &reference.type_name else {
         return false;
     };
@@ -1359,25 +1359,25 @@ fn is_leftmost_intrinsic_in_type_alias(reference: &AstNode<'_, TSTypeReference<'
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSQualifiedName<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSQualifiedName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.left(), ".", self.right()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeParameterDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         FormatTSTypeParameters::new(self, FormatTSTypeParametersOptions::default()).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeAliasDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [AssignmentLike::TSTypeAliasDeclaration(self), OptionalSemicolon]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSInterfaceDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let id = self.id();
         let type_parameters = self.type_parameters();
@@ -1488,7 +1488,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceBody<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSInterfaceBody<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [space(), "{"]);
 
@@ -1502,7 +1502,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceBody<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSPropertySignature<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSPropertySignature<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.readonly() {
             write!(f, ["readonly", space()]);
@@ -1522,8 +1522,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSPropertySignature<'a>> {
 }
 
 struct FormatTSSignature<'a, 'b> {
-    signature: &'b AstNode<'a, TSSignature<'a>>,
-    next_signature: Option<&'b AstNode<'a, TSSignature<'a>>>,
+    signature: &'b AstNode<'a, 'b, TSSignature<'a>>,
+    next_signature: Option<&'b AstNode<'a, 'b, TSSignature<'a>>>,
 }
 
 impl GetSpan for FormatTSSignature<'_, '_> {
@@ -1585,7 +1585,7 @@ impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, TSSignature<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         if f.options().quote_properties.is_consistent() {
             let quote_needed = self.as_ref().iter().any(|signature| {
@@ -1615,7 +1615,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, TSInterfaceHeritage<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let last_index = self.len().saturating_sub(1);
         let mut joiner = f.join_with(soft_line_break_or_space());
@@ -1634,13 +1634,13 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceHeritage<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSInterfaceHeritage<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.expression(), self.type_arguments()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypePredicate<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypePredicate<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.asserts() {
             write!(f, ["asserts", space()]);
@@ -1652,7 +1652,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypePredicate<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSModuleDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.declare() {
             write!(f, ["declare", space()]);
@@ -1689,7 +1689,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSGlobalDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSGlobalDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.declare {
             write!(f, ["declare", space()]);
@@ -1700,7 +1700,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSGlobalDeclaration<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleBlock<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSModuleBlock<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let directives = self.directives();
         let body = self.body();
@@ -1716,25 +1716,25 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleBlock<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeLiteral<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         ObjectLike::TSTypeLiteral(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSInferType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSInferType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["infer ", self.type_parameter()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeQuery<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeQuery<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["typeof ", self.expr_name(), self.type_arguments()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSImportType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSImportType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["import("]);
 
@@ -1776,13 +1776,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSImportType<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSImportTypeQualifiedName<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.left(), ".", self.right()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAssertion<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeAssertion<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let break_after_cast = !matches!(
             self.expression,
@@ -1818,19 +1818,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeAssertion<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSNonNullExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSNonNullExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.expression(), "!"]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSInstantiationExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSInstantiationExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, [self.expression(), self.type_arguments()]);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSDocNullableType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSDocNullableType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.postfix() {
             write!(f, [self.type_annotation(), "?"]);
@@ -1840,7 +1840,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSDocNullableType<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSDocNonNullableType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.postfix() {
             write!(f, [self.type_annotation(), "!"]);
@@ -1850,6 +1850,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSDocNonNullableType<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, JSDocUnknownType> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, JSDocUnknownType> {
     fn write(&self, _f: &mut Formatter<'_, 'a>) {}
 }

--- a/crates/oxc_formatter/src/print/object_like.rs
+++ b/crates/oxc_formatter/src/print/object_like.rs
@@ -15,8 +15,8 @@ use crate::{
 
 #[derive(Clone, Copy)]
 pub enum ObjectLike<'a, 'b> {
-    ObjectExpression(&'b AstNode<'a, ObjectExpression<'a>>),
-    TSTypeLiteral(&'b AstNode<'a, TSTypeLiteral<'a>>),
+    ObjectExpression(&'b AstNode<'a, 'b, ObjectExpression<'a>>),
+    TSTypeLiteral(&'b AstNode<'a, 'b, TSTypeLiteral<'a>>),
 }
 
 impl<'a> ObjectLike<'a, '_> {

--- a/crates/oxc_formatter/src/print/object_pattern_like.rs
+++ b/crates/oxc_formatter/src/print/object_pattern_like.rs
@@ -17,8 +17,8 @@ use super::{
 };
 
 pub enum ObjectPatternLike<'a, 'b> {
-    ObjectPattern(&'b AstNode<'a, ObjectPattern<'a>>),
-    ObjectAssignmentTarget(&'b AstNode<'a, ObjectAssignmentTarget<'a>>),
+    ObjectPattern(&'b AstNode<'a, 'b, ObjectPattern<'a>>),
+    ObjectAssignmentTarget(&'b AstNode<'a, 'b, ObjectAssignmentTarget<'a>>),
 }
 
 impl GetSpan for ObjectPatternLike<'_, '_> {

--- a/crates/oxc_formatter/src/print/parameters.rs
+++ b/crates/oxc_formatter/src/print/parameters.rs
@@ -16,7 +16,9 @@ use crate::{
 
 use super::FormatWrite;
 
-pub fn get_this_param<'a>(parent: &AstNodes<'a>) -> Option<&'a AstNode<'a, TSThisParameter<'a>>> {
+pub fn get_this_param<'a, 'b>(
+    parent: &AstNodes<'a, 'b>,
+) -> Option<&'b AstNode<'a, 'b, TSThisParameter<'a>>> {
     match parent {
         AstNodes::Function(func) => func.this_param(),
         AstNodes::TSFunctionType(func) => func.this_param(),
@@ -26,7 +28,7 @@ pub fn get_this_param<'a>(parent: &AstNodes<'a>) -> Option<&'a AstNode<'a, TSThi
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, FormalParameters<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         // `function foo /**/ () {}`
         //               ^^^ keep comments printed before parameters
@@ -97,7 +99,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameter<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, FormalParameter<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let content = format_with(|f| {
             let left = format_with(|f| {
@@ -159,16 +161,16 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameter<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSThisParameter<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSThisParameter<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["this", self.type_annotation()]);
     }
 }
 
 enum Parameter<'a, 'b> {
-    This(&'b AstNode<'a, TSThisParameter<'a>>),
-    Formal(&'b AstNode<'a, FormalParameter<'a>>),
-    Rest(&'b AstNode<'a, FormalParameterRest<'a>>),
+    This(&'b AstNode<'a, 'b, TSThisParameter<'a>>),
+    Formal(&'b AstNode<'a, 'b, FormalParameter<'a>>),
+    Rest(&'b AstNode<'a, 'b, FormalParameterRest<'a>>),
 }
 
 impl GetSpan for Parameter<'_, '_> {
@@ -192,9 +194,9 @@ impl<'a> Format<'a> for Parameter<'a, '_> {
 }
 
 struct FormalParametersIter<'a, 'b> {
-    this: Option<&'b AstNode<'a, TSThisParameter<'a>>>,
-    params: AstNodeIterator<'a, FormalParameter<'a>>,
-    rest: Option<&'b AstNode<'a, FormalParameterRest<'a>>>,
+    this: Option<&'b AstNode<'a, 'b, TSThisParameter<'a>>>,
+    params: AstNodeIterator<'a, 'b, FormalParameter<'a>>,
+    rest: Option<&'b AstNode<'a, 'b, FormalParameterRest<'a>>>,
 }
 
 impl<'a, 'b> From<&'b ParameterList<'a, 'b>> for FormalParametersIter<'a, 'b> {
@@ -217,8 +219,8 @@ impl<'a, 'b> Iterator for FormalParametersIter<'a, 'b> {
 }
 
 pub struct ParameterList<'a, 'b> {
-    list: &'b AstNode<'a, FormalParameters<'a>>,
-    this: Option<&'b AstNode<'a, TSThisParameter<'a>>>,
+    list: &'b AstNode<'a, 'b, FormalParameters<'a>>,
+    this: Option<&'b AstNode<'a, 'b, TSThisParameter<'a>>>,
     layout: Option<ParameterLayout>,
     trailing_separator_override: Option<TrailingSeparator>,
 }
@@ -258,8 +260,8 @@ pub enum ParameterLayout {
 
 impl<'a, 'b> ParameterList<'a, 'b> {
     pub fn with_layout(
-        list: &'b AstNode<'a, FormalParameters<'a>>,
-        this: Option<&'b AstNode<'a, TSThisParameter<'a>>>,
+        list: &'b AstNode<'a, 'b, FormalParameters<'a>>,
+        this: Option<&'b AstNode<'a, 'b, TSThisParameter<'a>>>,
         layout: ParameterLayout,
     ) -> Self {
         Self { list, this, layout: Some(layout), trailing_separator_override: None }
@@ -334,8 +336,8 @@ pub fn can_avoid_parentheses(arrow: &ArrowFunctionExpression<'_>, f: &Formatter<
 }
 
 pub fn should_hug_function_parameters<'a>(
-    parameters: &AstNode<'a, FormalParameters<'a>>,
-    this_param: Option<&AstNode<'a, TSThisParameter<'a>>>,
+    parameters: &AstNode<'a, '_, FormalParameters<'a>>,
+    this_param: Option<&AstNode<'a, '_, TSThisParameter<'a>>>,
     parentheses_not_needed: bool,
     f: &Formatter<'_, 'a>,
 ) -> bool {

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -16,7 +16,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, Program<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_trailing_comments = format_with(|f| {
             write!(
@@ -44,10 +44,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
     }
 }
 
-struct FormatProgramBody<'a, 'b>(&'b AstNode<'a, Vec<'a, Statement<'a>>>);
+struct FormatProgramBody<'a, 'b>(&'b AstNode<'a, 'b, Vec<'a, Statement<'a>>>);
 
-impl<'a> Deref for FormatProgramBody<'a, '_> {
-    type Target = AstNode<'a, Vec<'a, Statement<'a>>>;
+impl<'a, 'b> Deref for FormatProgramBody<'a, 'b> {
+    type Target = AstNode<'a, 'b, Vec<'a, Statement<'a>>>;
     fn deref(&self) -> &Self::Target {
         self.0
     }
@@ -93,7 +93,7 @@ impl<'a> Format<'a> for FormatProgramBody<'a, '_> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, Directive<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let Some(last_directive) = self.last() else {
             // No directives, no extra new line
@@ -118,7 +118,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, Directive<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, Directive<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(
             f,
@@ -135,7 +135,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Directive<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, Hashbang<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, Hashbang<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, ["#!", text(self.value().as_str().trim_end())]);
 

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -12,13 +12,13 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ReturnStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ReturnStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         ReturnAndThrowStatement::ReturnStatement(self).fmt(f);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, ThrowStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, ThrowStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         ReturnAndThrowStatement::ThrowStatement(self).fmt(f);
     }
@@ -26,8 +26,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ThrowStatement<'a>> {
 
 /// Unified enum for statements that have an optional argument (return/throw)
 pub enum ReturnAndThrowStatement<'a, 'b> {
-    ReturnStatement(&'b AstNode<'a, ReturnStatement<'a>>),
-    ThrowStatement(&'b AstNode<'a, ThrowStatement<'a>>),
+    ReturnStatement(&'b AstNode<'a, 'b, ReturnStatement<'a>>),
+    ThrowStatement(&'b AstNode<'a, 'b, ThrowStatement<'a>>),
 }
 
 impl<'a, 'b> ReturnAndThrowStatement<'a, 'b> {
@@ -40,7 +40,7 @@ impl<'a, 'b> ReturnAndThrowStatement<'a, 'b> {
     }
 
     /// Get the argument expression if present
-    fn argument(&self) -> Option<&'b AstNode<'a, Expression<'a>>> {
+    fn argument(&self) -> Option<&'b AstNode<'a, 'b, Expression<'a>>> {
         match self {
             Self::ReturnStatement(node) => node.argument(),
             Self::ThrowStatement(node) => Some(node.argument()),
@@ -82,7 +82,7 @@ impl<'a> Format<'a> for ReturnAndThrowStatement<'a, '_> {
     }
 }
 
-pub struct FormatAdjacentArgument<'a, 'b>(pub &'b AstNode<'a, Expression<'a>>);
+pub struct FormatAdjacentArgument<'a, 'b>(pub &'b AstNode<'a, 'b, Expression<'a>>);
 
 impl<'a> Format<'a> for FormatAdjacentArgument<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {

--- a/crates/oxc_formatter/src/print/sequence_expression.rs
+++ b/crates/oxc_formatter/src/print/sequence_expression.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, SequenceExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let format_inner = format_with(|f| {
             let mut expressions = self.expressions().iter();

--- a/crates/oxc_formatter/src/print/switch_statement.rs
+++ b/crates/oxc_formatter/src/print/switch_statement.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, SwitchStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, SwitchStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let discriminant = self.discriminant();
         let cases = self.cases();
@@ -40,13 +40,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, SwitchCase<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, SwitchCase<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         f.join_nodes_with_hardline().entries(self);
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, SwitchCase<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let is_default = if let Some(test) = self.test() {
             write!(f, ["case", space(), test, ":"]);

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -20,7 +20,7 @@ const PLACEHOLDER_SUFFIX: &str = "-id";
 /// Joins quasis with special `@prettier-placeholder-N-id` markers, formats as SCSS,
 /// then replaces placeholder occurrences in the resulting IR with `${expr}` Docs.
 pub(super) fn format_css_doc<'a>(
-    quasi: &AstNode<'a, TemplateLiteral<'a>>,
+    quasi: &AstNode<'a, '_, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let quasis = &quasi.quasis;

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -21,7 +21,7 @@ use crate::{
 /// - tagged template (gql`...`)
 /// - and function call (`graphql(schema, `...`)`)
 pub(super) fn format_graphql_doc<'a>(
-    quasi: &AstNode<'a, TemplateLiteral<'a>>,
+    quasi: &AstNode<'a, '_, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let quasis = &quasi.quasis;

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -31,7 +31,7 @@ const COUNTER: &str = "0";
 ///
 /// Supports both html-in-js and angular-in-js (`@Component({ template })`).
 pub(super) fn format_html_doc<'a>(
-    quasi: &AstNode<'a, TemplateLiteral<'a>>,
+    quasi: &AstNode<'a, '_, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
     is_angular: bool,
 ) -> bool {
@@ -326,7 +326,7 @@ fn write_html_template<'a>(
 /// Prettier's HTML formatting returns unsupported IR (e.g. with `conditionalGroup`).
 fn format_js_in_html_as_fallback<'a>(
     joined: &str,
-    expressions: &[&AstNode<'a, Expression<'a>>],
+    expressions: &[&AstNode<'a, '_, Expression<'a>>],
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let Some(Ok(formatted)) = f.context().external_callbacks().format_embedded("html", joined)

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Unescapes backticks in `.raw`, strips common indentation, formats as markdown,
 /// then re-escapes backticks and applies indented or dedent-to-root layout.
 pub(super) fn try_embed_markdown<'a>(
-    tagged: &AstNode<'a, TaggedTemplateExpression<'a>>,
+    tagged: &AstNode<'a, '_, TaggedTemplateExpression<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let raw = tagged.quasi.quasis[0].value.raw.as_str();

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Try to format a tagged template with the embedded formatter if supported.
 /// Returns `true` if formatting was performed, `false` if not applicable.
 pub(super) fn try_format_embedded_template<'a>(
-    tagged: &AstNode<'a, TaggedTemplateExpression<'a>>,
+    tagged: &AstNode<'a, '_, TaggedTemplateExpression<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     match get_tag_name(&tagged.tag) {
@@ -48,7 +48,7 @@ fn get_tag_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
 /// `arguments.rs` also applies a "hugging" layout (`graphql(`…`)` with no trailing comma).
 /// See `is_graphql_call_with_single_template_arg()` in `arguments.rs`.
 pub(super) fn try_format_graphql_call<'a>(
-    template: &AstNode<'a, TemplateLiteral<'a>>,
+    template: &AstNode<'a, '_, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let AstNodes::CallExpression(call) = template.parent() else { return false };
@@ -66,7 +66,7 @@ pub(super) fn try_format_graphql_call<'a>(
 /// - HTML
 /// - GraphQL
 pub(super) fn try_format_comment_embedded<'a>(
-    template: &AstNode<'a, TemplateLiteral<'a>>,
+    template: &AstNode<'a, '_, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     // By the time `TemplateLiteral::write()` runs, parent nodes have already printed
@@ -98,7 +98,7 @@ pub(super) fn try_format_comment_embedded<'a>(
 /// Try to format a template literal inside css prop or styled-jsx with the embedded formatter.
 /// Returns `true` if formatting was attempted, `false` if not applicable.
 pub(super) fn try_format_css_template<'a>(
-    template_literal: &AstNode<'a, TemplateLiteral<'a>>,
+    template_literal: &AstNode<'a, '_, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     if !is_in_css_jsx(template_literal) {
@@ -108,7 +108,7 @@ pub(super) fn try_format_css_template<'a>(
 }
 
 /// Check if the template literal is inside a `css` prop or `<style jsx>` element.
-fn is_in_css_jsx<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> bool {
+fn is_in_css_jsx<'a>(node: &AstNode<'a, '_, TemplateLiteral<'a>>) -> bool {
     let AstNodes::JSXExpressionContainer(container) = node.parent() else {
         return false;
     };
@@ -139,7 +139,7 @@ fn is_in_css_jsx<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> bool {
 /// Try to format a template literal inside Angular @Component's template/styles property.
 /// Returns `true` if formatting was performed, `false` if not applicable.
 pub(super) fn try_format_angular_component<'a>(
-    template_literal: &AstNode<'a, TemplateLiteral<'a>>,
+    template_literal: &AstNode<'a, '_, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     match get_angular_component_property(template_literal) {
@@ -150,7 +150,9 @@ pub(super) fn try_format_angular_component<'a>(
 }
 
 /// Detect Angular `@Component({ template: \`...\`, styles: \`...\` })`.
-fn get_angular_component_property<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> Option<&'a str> {
+fn get_angular_component_property<'a>(
+    node: &AstNode<'a, '_, TemplateLiteral<'a>>,
+) -> Option<&'a str> {
     let prop = match node.parent() {
         AstNodes::ObjectProperty(prop) => prop,
         AstNodes::ArrayExpression(arr) => {

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TemplateLiteral<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TemplateLiteral<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         // Angular `@Component({ template, styles })`
         if embed::try_format_angular_component(self, f) {
@@ -52,7 +52,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TemplateLiteral<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TaggedTemplateExpression<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         // Format the tag and type arguments
         write!(f, [self.tag(), self.type_arguments()]);
@@ -101,7 +101,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TemplateElement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TemplateElement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let source = f.source_text().text_for(self);
 
@@ -120,7 +120,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TemplateElement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTemplateLiteralType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTemplateLiteralType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let template = TemplateLike::TSTemplateLiteralType(self);
         write!(f, template);
@@ -194,13 +194,13 @@ impl TemplateElementIndention {
 
 /// Unified enum for handling both JS template literals and TS template literal types
 pub enum TemplateLike<'a, 'b> {
-    TemplateLiteral(&'b AstNode<'a, TemplateLiteral<'a>>),
-    TSTemplateLiteralType(&'b AstNode<'a, TSTemplateLiteralType<'a>>),
+    TemplateLiteral(&'b AstNode<'a, 'b, TemplateLiteral<'a>>),
+    TSTemplateLiteralType(&'b AstNode<'a, 'b, TSTemplateLiteralType<'a>>),
 }
 
 impl<'a> TemplateLike<'a, '_> {
     #[inline]
-    pub fn quasis(&self) -> &AstNode<'a, ArenaVec<'a, TemplateElement<'a>>> {
+    pub fn quasis(&self) -> &AstNode<'a, '_, ArenaVec<'a, TemplateElement<'a>>> {
         match self {
             Self::TemplateLiteral(t) => t.quasis(),
             Self::TSTemplateLiteralType(t) => t.quasis(),
@@ -209,13 +209,13 @@ impl<'a> TemplateLike<'a, '_> {
 }
 
 /// Iterator that yields template expressions without allocation
-enum TemplateExpressionIterator<'a> {
-    Expression(AstNodeIterator<'a, Expression<'a>>),
-    TSType(AstNodeIterator<'a, TSType<'a>>),
+enum TemplateExpressionIterator<'a, 'b> {
+    Expression(AstNodeIterator<'a, 'b, Expression<'a>>),
+    TSType(AstNodeIterator<'a, 'b, TSType<'a>>),
 }
 
-impl<'a> Iterator for TemplateExpressionIterator<'a> {
-    type Item = TemplateExpression<'a, 'a>;
+impl<'a, 'b> Iterator for TemplateExpressionIterator<'a, 'b> {
+    type Item = TemplateExpression<'a, 'b>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -316,12 +316,12 @@ pub struct FormatTemplateExpressionOptions {
 }
 
 pub enum TemplateExpression<'a, 'b> {
-    Expression(&'b AstNode<'a, Expression<'a>>),
-    TSType(&'b AstNode<'a, TSType<'a>>),
+    Expression(&'b AstNode<'a, 'b, Expression<'a>>),
+    TSType(&'b AstNode<'a, 'b, TSType<'a>>),
 }
 
 impl TemplateExpression<'_, '_> {
-    pub fn as_expression(&self) -> Option<&AstNode<'_, Expression<'_>>> {
+    pub fn as_expression(&self) -> Option<&AstNode<'_, '_, Expression<'_>>> {
         match self {
             Self::Expression(e) => Some(e),
             Self::TSType(_) => None,
@@ -641,7 +641,7 @@ impl<'a> Format<'a> for EachTemplateSeparator {
 
 impl<'a> EachTemplateTable<'a> {
     pub(crate) fn from_template(
-        quasi: &AstNode<'a, TemplateLiteral<'a>>,
+        quasi: &AstNode<'a, '_, TemplateLiteral<'a>>,
         f: &mut Formatter<'_, 'a>,
     ) -> Self {
         let mut builder = EachTemplateTableBuilder::new();

--- a/crates/oxc_formatter/src/print/try_statement.rs
+++ b/crates/oxc_formatter/src/print/try_statement.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TryStatement<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TryStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let block = self.block();
         let handler = self.handler();
@@ -42,7 +42,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TryStatement<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, CatchClause<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, CatchClause<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments();
         let leading_comments = comments.comments_before(self.span.start);
@@ -76,7 +76,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CatchClause<'a>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, CatchParameter<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, CatchParameter<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "(");
 

--- a/crates/oxc_formatter/src/print/tuple_type.rs
+++ b/crates/oxc_formatter/src/print/tuple_type.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, TSTupleElement<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line().entries_with_trailing_separator(
@@ -21,7 +21,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTupleType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTupleType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         write!(f, "[");
 

--- a/crates/oxc_formatter/src/print/type_parameters.rs
+++ b/crates/oxc_formatter/src/print/type_parameters.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameter<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeParameter<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         if self.r#const() {
             write!(f, ["const", space()]);
@@ -66,7 +66,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameter<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, TSTypeParameter<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         // Type parameter lists of arrow function expressions have to include at least one comma
         // to avoid any ambiguity with JSX elements, and in `.mts`/`.cts` sources.
@@ -91,7 +91,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
 ///
 /// <https://github.com/prettier/prettier/blob/070c89bba46235f4948560ed612a11e89ccd2da9/src/language-js/print/type-parameters.js#L33-L42>
 fn should_force_trailing_comma_for_arrow_function(
-    params: &AstNode<'_, Vec<'_, TSTypeParameter<'_>>>,
+    params: &AstNode<'_, '_, Vec<'_, TSTypeParameter<'_>>>,
     f: &Formatter<'_, '_>,
 ) -> bool {
     if params.len() != 1 {
@@ -122,13 +122,13 @@ pub struct FormatTSTypeParametersOptions {
 }
 
 pub struct FormatTSTypeParameters<'a, 'b> {
-    decl: &'b AstNode<'a, TSTypeParameterDeclaration<'a>>,
+    decl: &'b AstNode<'a, 'b, TSTypeParameterDeclaration<'a>>,
     options: FormatTSTypeParametersOptions,
 }
 
 impl<'a, 'b> FormatTSTypeParameters<'a, 'b> {
     pub fn new(
-        decl: &'b AstNode<'a, TSTypeParameterDeclaration<'a>>,
+        decl: &'b AstNode<'a, 'b, TSTypeParameterDeclaration<'a>>,
         options: FormatTSTypeParametersOptions,
     ) -> Self {
         Self { decl, options }
@@ -159,7 +159,7 @@ impl<'a> Format<'a> for FormatTSTypeParameters<'a, '_> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSTypeParameterInstantiation<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let params = self.params();
 
@@ -226,7 +226,7 @@ fn should_hug_single_type(ty: &TSType, f: &Formatter<'_, '_>) -> bool {
 /// const foo: SomeThing<{ [P in "x" | "y"]: number }> = () => {};
 /// ```
 fn is_arrow_function_variable_type_argument<'a>(
-    node: &AstNode<'a, TSTypeParameterInstantiation<'a>>,
+    node: &AstNode<'a, '_, TSTypeParameterInstantiation<'a>>,
 ) -> bool {
     let Some(first) = node.params().first() else { unreachable!() };
 

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -16,7 +16,7 @@ use crate::{
     write,
 };
 
-impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, TSUnionType<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let types = self.types();
 
@@ -225,7 +225,7 @@ impl LeadingCommentsInfo {
 }
 
 fn should_indent_alias_union<'a>(
-    alias: &AstNode<'a, TSTypeAliasDeclaration<'a>>,
+    alias: &AstNode<'a, '_, TSTypeAliasDeclaration<'a>>,
     comment_info: LeadingCommentsInfo,
     f: &Formatter<'_, 'a>,
 ) -> bool {
@@ -246,7 +246,7 @@ fn should_indent_alias_union<'a>(
 }
 
 fn format_union_types<'a>(
-    node: &AstNode<'a, Vec<'a, TSType<'a>>>,
+    node: &AstNode<'a, '_, Vec<'a, TSType<'a>>>,
     mut suppressed_node_span: Span,
     should_hug: bool,
     f: &mut Formatter<'_, 'a>,
@@ -318,7 +318,7 @@ fn format_union_types<'a>(
             //            ^^^^^^^^^^^ the following logic is to print comment2,
             // )[]; // comment 3
             //```
-            // TODO: We may need to tweak `AstNode<'a, Vec<'a, T>>` iterator as some of Vec's last elements should have the following span.
+            // TODO: We may need to tweak `AstNode<'a, '_, Vec<'a, T>>` iterator as some of Vec's last elements should have the following span.
             let comments = f.context().comments().end_of_line_comments_after(element_span.end);
             write!(f, FormatTrailingComments::Comments(comments));
         }

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, VariableDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let semicolon = match self.parent() {
             AstNodes::ExportNamedDeclaration(_) => false,
@@ -42,7 +42,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
+impl<'a> Format<'a> for AstNode<'a, '_, Vec<'a, VariableDeclarator<'a>>> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let length = self.len();
 
@@ -93,7 +93,7 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
     }
 }
 
-impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclarator<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, '_, VariableDeclarator<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         AssignmentLike::VariableDeclarator(self).fmt(f);
     }

--- a/crates/oxc_formatter/src/utils/array.rs
+++ b/crates/oxc_formatter/src/utils/array.rs
@@ -9,10 +9,10 @@ use crate::{
 /// Utility function to print array-like nodes (array expressions, array bindings and assignment patterns)
 pub fn write_array_node<'a, 'b, N>(
     len: usize,
-    array: impl IntoIterator<Item = Option<&'a N>> + 'b,
+    array: impl IntoIterator<Item = Option<&'b N>> + 'b,
     f: &mut Formatter<'_, 'a>,
 ) where
-    N: Format<'a> + GetSpan + std::fmt::Debug + 'a,
+    N: Format<'a> + GetSpan + std::fmt::Debug + 'b,
 {
     // Specifically do not use format_separated as arrays need separators
     // inserted after holes regardless of the formatting since this makes a

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -21,13 +21,13 @@ use super::string::{FormatLiteralStringToken, StringLiteralParentKind};
 
 #[derive(Clone, Copy)]
 pub enum AssignmentLike<'a, 'b> {
-    VariableDeclarator(&'b AstNode<'a, VariableDeclarator<'a>>),
-    AssignmentExpression(&'b AstNode<'a, AssignmentExpression<'a>>),
-    ObjectProperty(&'b AstNode<'a, ObjectProperty<'a>>),
-    BindingProperty(&'b AstNode<'a, BindingProperty<'a>>),
-    PropertyDefinition(&'b AstNode<'a, PropertyDefinition<'a>>),
-    AccessorProperty(&'b AstNode<'a, AccessorProperty<'a>>),
-    TSTypeAliasDeclaration(&'b AstNode<'a, TSTypeAliasDeclaration<'a>>),
+    VariableDeclarator(&'b AstNode<'a, 'b, VariableDeclarator<'a>>),
+    AssignmentExpression(&'b AstNode<'a, 'b, AssignmentExpression<'a>>),
+    ObjectProperty(&'b AstNode<'a, 'b, ObjectProperty<'a>>),
+    BindingProperty(&'b AstNode<'a, 'b, BindingProperty<'a>>),
+    PropertyDefinition(&'b AstNode<'a, 'b, PropertyDefinition<'a>>),
+    AccessorProperty(&'b AstNode<'a, 'b, AccessorProperty<'a>>),
+    TSTypeAliasDeclaration(&'b AstNode<'a, 'b, TSTypeAliasDeclaration<'a>>),
 }
 
 /// Determines how a assignment like be formatted
@@ -499,7 +499,7 @@ impl<'a> AssignmentLike<'a, '_> {
         AssignmentLikeLayout::Fluid
     }
 
-    fn get_right_expression(&self) -> Option<&AstNode<'a, Expression<'a>>> {
+    fn get_right_expression(&self) -> Option<&AstNode<'a, '_, Expression<'a>>> {
         match self {
             AssignmentLike::VariableDeclarator(variable_decorator) => variable_decorator.init(),
             AssignmentLike::AssignmentExpression(assignment) => Some(assignment.right()),
@@ -611,7 +611,7 @@ impl<'a> AssignmentLike<'a, '_> {
     /// for nodes that belong to TypeScript too.
     fn should_break_after_operator(
         &self,
-        right_expression: Option<&AstNode<'a, Expression<'a>>>,
+        right_expression: Option<&AstNode<'a, '_, Expression<'a>>>,
         is_left_short: bool,
         f: &mut Formatter<'_, 'a>,
     ) -> bool {
@@ -708,7 +708,7 @@ impl<'a> AssignmentLike<'a, '_> {
 ///
 /// Based on <https://github.com/prettier/prettier/blob/0273e33fc691e28e4ab3f3c8ee86918b65cf823d/src/language-js/print/assignment.js#L196-L264>
 fn should_break_after_operator<'a>(
-    right: &AstNode<'a, Expression<'a>>,
+    right: &AstNode<'a, '_, Expression<'a>>,
     is_left_short: bool,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
@@ -759,8 +759,8 @@ fn should_break_after_operator<'a>(
 ///
 /// Example: `void !!(await test())` returns the `await test()` expression.
 fn get_innermost_expression<'a, 'b>(
-    mut current: &'b AstNode<'a, Expression<'a>>,
-) -> &'b AstNode<'a, Expression<'a>> {
+    mut current: &'b AstNode<'a, 'b, Expression<'a>>,
+) -> &'b AstNode<'a, 'b, Expression<'a>> {
     loop {
         match current.as_ast_nodes() {
             AstNodes::UnaryExpression(unary) => {
@@ -891,12 +891,12 @@ impl<'a> Format<'a> for AssignmentLike<'a, '_> {
 /// Formats an expression and passes the assignment layout to its formatting function if the expressions
 /// formatting rule takes the layout as an option.
 pub struct WithAssignmentLayout<'a, 'b> {
-    expression: &'b AstNode<'a, Expression<'a>>,
+    expression: &'b AstNode<'a, 'b, Expression<'a>>,
     layout: Option<AssignmentLikeLayout>,
 }
 
 pub fn with_assignment_layout<'a, 'b>(
-    expression: &'b AstNode<'a, Expression<'a>>,
+    expression: &'b AstNode<'a, 'b, Expression<'a>>,
     layout: Option<AssignmentLikeLayout>,
 ) -> WithAssignmentLayout<'a, 'b> {
     WithAssignmentLayout { expression, layout }
@@ -921,7 +921,7 @@ impl<'a> Format<'a> for WithAssignmentLayout<'a, '_> {
 /// or have only one which [is_short_argument], except for member call chains
 /// [Prettier applies]: <https://github.com/prettier/prettier/blob/a043ac0d733c4d53f980aa73807a63fc914f23bd/src/language-js/print/assignment.js#L329>
 fn is_poorly_breakable_member_or_call_chain<'a>(
-    expression: &AstNode<'a, Expression<'a>>,
+    expression: &AstNode<'a, '_, Expression<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let threshold = f.options().line_width.value() / 4;
@@ -1065,7 +1065,7 @@ fn is_short_argument(argument: &Expression, threshold: u16, f: &Formatter) -> bo
 ///
 /// <https://github.com/prettier/prettier/blob/a043ac0d733c4d53f980aa73807a63fc914f23bd/src/language-js/print/assignment.js#L432-L459>
 fn is_complex_type_arguments<'a>(
-    type_arguments: &AstNode<'a, TSTypeParameterInstantiation<'a>>,
+    type_arguments: &AstNode<'a, '_, TSTypeParameterInstantiation<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     let params = &type_arguments.params;

--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 
 pub enum ConditionalLike<'a, 'b> {
-    ConditionalExpression(&'b AstNode<'a, ConditionalExpression<'a>>),
-    TSConditionalType(&'b AstNode<'a, TSConditionalType<'a>>),
+    ConditionalExpression(&'b AstNode<'a, 'b, ConditionalExpression<'a>>),
+    TSConditionalType(&'b AstNode<'a, 'b, TSConditionalType<'a>>),
 }
 
 impl<'a> ConditionalLike<'a, '_> {
@@ -30,7 +30,7 @@ impl<'a> ConditionalLike<'a, '_> {
     }
 
     #[inline]
-    fn parent(&self) -> &AstNodes<'a> {
+    fn parent(&self) -> &AstNodes<'a, '_> {
         match self {
             ConditionalLike::ConditionalExpression(expr) => expr.parent(),
             ConditionalLike::TSConditionalType(ty) => ty.parent(),
@@ -590,14 +590,14 @@ impl<'a> Format<'a> for FormatConditionalLike<'a, '_> {
 
 /// Formats JSX consequent with conditional wrapping
 fn format_jsx_chain_consequent<'a, 'b>(
-    expression: &'b AstNode<'a, Expression<'a>>,
+    expression: &'b AstNode<'a, 'b, Expression<'a>>,
 ) -> impl Format<'a> + 'b {
     FormatJsxChainExpression { expression, alternate: false }
 }
 
 /// Formats JSX alternate with conditional wrapping
 fn format_jsx_chain_alternate<'a, 'b>(
-    expression: &'b AstNode<'a, Expression<'a>>,
+    expression: &'b AstNode<'a, 'b, Expression<'a>>,
 ) -> impl Format<'a> + 'b {
     FormatJsxChainExpression { expression, alternate: true }
 }
@@ -624,7 +624,7 @@ fn format_jsx_chain_alternate<'a, 'b>(
 /// );
 /// ```
 struct FormatJsxChainExpression<'a, 'b> {
-    expression: &'b AstNode<'a, Expression<'a>>,
+    expression: &'b AstNode<'a, 'b, Expression<'a>>,
     alternate: bool,
 }
 

--- a/crates/oxc_formatter/src/utils/expression.rs
+++ b/crates/oxc_formatter/src/utils/expression.rs
@@ -7,33 +7,33 @@ use crate::ast_nodes::{AstNode, AstNodes};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ExpressionLeftSide<'a, 'b> {
-    Expression(&'b AstNode<'a, Expression<'a>>),
-    AssignmentTarget(&'b AstNode<'a, AssignmentTarget<'a>>),
-    SimpleAssignmentTarget(&'b AstNode<'a, SimpleAssignmentTarget<'a>>),
+    Expression(&'b AstNode<'a, 'b, Expression<'a>>),
+    AssignmentTarget(&'b AstNode<'a, 'b, AssignmentTarget<'a>>),
+    SimpleAssignmentTarget(&'b AstNode<'a, 'b, SimpleAssignmentTarget<'a>>),
 }
 
-impl<'a, 'b> From<&'b AstNode<'a, Expression<'a>>> for ExpressionLeftSide<'a, 'b> {
-    fn from(value: &'b AstNode<'a, Expression<'a>>) -> Self {
+impl<'a, 'b> From<&'b AstNode<'a, 'b, Expression<'a>>> for ExpressionLeftSide<'a, 'b> {
+    fn from(value: &'b AstNode<'a, 'b, Expression<'a>>) -> Self {
         Self::Expression(value)
     }
 }
 
-impl<'a, 'b> From<&'b AstNode<'a, AssignmentTarget<'a>>> for ExpressionLeftSide<'a, 'b> {
-    fn from(value: &'b AstNode<'a, AssignmentTarget<'a>>) -> Self {
+impl<'a, 'b> From<&'b AstNode<'a, 'b, AssignmentTarget<'a>>> for ExpressionLeftSide<'a, 'b> {
+    fn from(value: &'b AstNode<'a, 'b, AssignmentTarget<'a>>) -> Self {
         Self::AssignmentTarget(value)
     }
 }
 
-impl<'a, 'b> From<&'b AstNode<'a, SimpleAssignmentTarget<'a>>> for ExpressionLeftSide<'a, 'b> {
-    fn from(value: &'b AstNode<'a, SimpleAssignmentTarget<'a>>) -> Self {
+impl<'a, 'b> From<&'b AstNode<'a, 'b, SimpleAssignmentTarget<'a>>> for ExpressionLeftSide<'a, 'b> {
+    fn from(value: &'b AstNode<'a, 'b, SimpleAssignmentTarget<'a>>) -> Self {
         Self::SimpleAssignmentTarget(value)
     }
 }
 
 impl<'a, 'b> ExpressionLeftSide<'a, 'b> {
     pub fn leftmost(
-        expression: &'b AstNode<'a, Expression<'a>>,
-    ) -> &'b AstNode<'a, Expression<'a>> {
+        expression: &'b AstNode<'a, 'b, Expression<'a>>,
+    ) -> &'b AstNode<'a, 'b, Expression<'a>> {
         let current: Self = expression.into();
 
         current.iter_expression().last().unwrap()
@@ -96,7 +96,7 @@ impl<'a, 'b> ExpressionLeftSide<'a, 'b> {
         })
     }
 
-    pub fn iter_expression(&self) -> impl Iterator<Item = &'b AstNode<'a, Expression<'a>>> {
+    pub fn iter_expression(&self) -> impl Iterator<Item = &'b AstNode<'a, 'b, Expression<'a>>> {
         self.iter().filter_map(|left| match left {
             ExpressionLeftSide::Expression(expression) => Some(expression),
             _ => None,
@@ -111,7 +111,9 @@ impl<'a, 'b> ExpressionLeftSide<'a, 'b> {
         }
     }
 
-    fn get_left_side_of_assignment(node: &'b AstNodes<'a>) -> Option<ExpressionLeftSide<'a, 'b>> {
+    fn get_left_side_of_assignment(
+        node: &'b AstNodes<'a, 'b>,
+    ) -> Option<ExpressionLeftSide<'a, 'b>> {
         match node {
             AstNodes::TSAsExpression(expr) => Some(expr.expression().into()),
             AstNodes::TSSatisfiesExpression(expr) => Some(expr.expression().into()),

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -171,7 +171,7 @@ pub enum JsxChild<'a, 'b> {
     EmptyLine,
 
     /// Any other content that isn't a text. Should be formatted as is.
-    NonText(&'b AstNode<'a, JSXChild<'a>>),
+    NonText(&'b AstNode<'a, 'b, JSXChild<'a>>),
 }
 
 impl PartialEq for JsxChild<'_, '_> {
@@ -268,7 +268,7 @@ impl<'a> Iterator for JsxSplitChunksIterator<'a> {
 impl FusedIterator for JsxSplitChunksIterator<'_> {}
 
 pub fn jsx_split_children<'a, 'b>(
-    children: &'b AstNode<'a, ArenaVec<'a, JSXChild<'a>>>,
+    children: &'b AstNode<'a, 'b, ArenaVec<'a, JSXChild<'a>>>,
     comments: &Comments<'a>,
 ) -> Vec<JsxChild<'a, 'b>> {
     let mut builder = JsxSplitChildrenBuilder::new();
@@ -279,7 +279,7 @@ pub fn jsx_split_children<'a, 'b>(
                 // Split the text into words
                 // Keep track if there's any leading/trailing empty line, new line or whitespace
 
-                let text_value = &text.value;
+                let text_value = text.value.as_str();
                 let mut chunks = JsxSplitChunksIterator::new(text_value).peekable();
 
                 // Text starting with a whitespace

--- a/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
@@ -29,22 +29,22 @@ pub enum CallExpressionPosition {
 #[derive(Clone, Debug)]
 pub enum ChainMember<'a, 'b> {
     /// Holds onto a [oxc_ast::ast::StaticMemberExpression]
-    StaticMember(&'b AstNode<'a, StaticMemberExpression<'a>>),
+    StaticMember(&'b AstNode<'a, 'b, StaticMemberExpression<'a>>),
 
     /// Holds onto a [oxc_ast::ast::CallExpression]
     CallExpression {
-        expression: &'b AstNode<'a, CallExpression<'a>>,
+        expression: &'b AstNode<'a, 'b, CallExpression<'a>>,
         position: CallExpressionPosition,
     },
 
     /// Holds onto a [oxc_ast::ast::ComputedMemberExpression]
-    ComputedMember(&'b AstNode<'a, ComputedMemberExpression<'a>>),
+    ComputedMember(&'b AstNode<'a, 'b, ComputedMemberExpression<'a>>),
 
-    TSNonNullExpression(&'b AstNode<'a, TSNonNullExpression<'a>>),
+    TSNonNullExpression(&'b AstNode<'a, 'b, TSNonNullExpression<'a>>),
 
     /// Any other node that are not [oxc_ast::ast::CallExpression] or [oxc_ast::ast::StaticMemberExpression]
     /// Are tracked using this variant
-    Node(&'b AstNode<'a, Expression<'a>>),
+    Node(&'b AstNode<'a, 'b, Expression<'a>>),
 }
 
 impl ChainMember<'_, '_> {
@@ -131,11 +131,11 @@ impl<'a> Format<'a> for ChainMember<'a, '_> {
 }
 
 pub struct FormatComputedMemberExpressionWithoutObject<'a, 'b>(
-    pub &'b AstNode<'a, ComputedMemberExpression<'a>>,
+    pub &'b AstNode<'a, 'b, ComputedMemberExpression<'a>>,
 );
 
-impl<'a> Deref for FormatComputedMemberExpressionWithoutObject<'a, '_> {
-    type Target = AstNode<'a, ComputedMemberExpression<'a>>;
+impl<'a, 'b> Deref for FormatComputedMemberExpressionWithoutObject<'a, 'b> {
+    type Target = AstNode<'a, 'b, ComputedMemberExpression<'a>>;
 
     fn deref(&self) -> &Self::Target {
         self.0

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -26,14 +26,14 @@ use super::typecast::is_type_cast_node;
 
 #[derive(Debug)]
 pub struct MemberChain<'a, 'b> {
-    root: &'b AstNode<'a, CallExpression<'a>>,
+    root: &'b AstNode<'a, 'b, CallExpression<'a>>,
     head: MemberChainGroup<'a, 'b>,
     tail: TailChainGroups<'a, 'b>,
 }
 
 impl<'a, 'b> MemberChain<'a, 'b> {
     pub(crate) fn from_call_expression(
-        call_expression: &'b AstNode<'a, CallExpression<'a>>,
+        call_expression: &'b AstNode<'a, 'b, CallExpression<'a>>,
         f: &Formatter<'_, 'a>,
     ) -> Self {
         let mut chain_members = chain_members_iter(call_expression, f).collect::<Vec<_>>();
@@ -59,7 +59,7 @@ impl<'a, 'b> MemberChain<'a, 'b> {
 
     /// Here we check if the first group can be merged to the head. If so, then
     /// we move out the first group out of the groups
-    fn maybe_merge_with_first_group(&mut self, parent: &AstNodes<'a>, f: &Formatter<'_, 'a>) {
+    fn maybe_merge_with_first_group(&mut self, parent: &AstNodes<'a, '_>, f: &Formatter<'_, 'a>) {
         if self.should_merge_tail_with_head(parent, f) {
             let group = self.tail.pop_first().unwrap();
             self.head.extend_members(group.into_members());
@@ -67,7 +67,11 @@ impl<'a, 'b> MemberChain<'a, 'b> {
     }
 
     /// This function checks if the current grouping should be merged with the first group.
-    fn should_merge_tail_with_head(&self, parent: &AstNodes<'a>, f: &Formatter<'_, 'a>) -> bool {
+    fn should_merge_tail_with_head(
+        &self,
+        parent: &AstNodes<'a, '_>,
+        f: &Formatter<'_, 'a>,
+    ) -> bool {
         let Some(first_group) = self.tail.first() else {
             return false;
         };
@@ -357,13 +361,13 @@ fn is_computed_array_member_access(member: &ChainMember<'_, '_>) -> bool {
     )
 }
 
-fn has_arrow_or_function_expression_arg(call: &AstNode<'_, CallExpression<'_>>) -> bool {
+fn has_arrow_or_function_expression_arg(call: &AstNode<'_, '_, CallExpression<'_>>) -> bool {
     call.as_ref().arguments.iter().any(|argument| {
         matches!(&argument, Argument::ArrowFunctionExpression(_) | Argument::FunctionExpression(_))
     })
 }
 
-fn has_simple_arguments<'a>(call: &AstNode<'a, CallExpression<'a>>) -> bool {
+fn has_simple_arguments<'a>(call: &AstNode<'a, '_, CallExpression<'a>>) -> bool {
     call.arguments().iter().all(|argument| SimpleArgument::new(argument).is_simple())
 }
 
@@ -386,7 +390,7 @@ fn is_factory(token: &str) -> bool {
 /// This function is the inverse of the prettier function
 /// [Prettier applies]: <https://github.com/prettier/prettier/blob/a043ac0d733c4d53f980aa73807a63fc914f23bd/src/language-js/print/member-chain.js#L342>
 pub fn is_member_call_chain<'a>(
-    expression: &AstNode<'a, CallExpression<'a>>,
+    expression: &AstNode<'a, '_, CallExpression<'a>>,
     f: &Formatter<'_, 'a>,
 ) -> bool {
     MemberChain::from_call_expression(expression, f).tail.is_member_call_chain()
@@ -397,17 +401,17 @@ fn has_short_name(name: &str, tab_width: u8) -> bool {
 }
 
 fn chain_members_iter<'a, 'b>(
-    root: &'b AstNode<'a, CallExpression<'a>>,
+    root: &'b AstNode<'a, 'b, CallExpression<'a>>,
     f: &Formatter<'_, 'a>,
 ) -> impl Iterator<Item = ChainMember<'a, 'b>> {
     let mut is_root = true;
-    let mut next: Option<&'b AstNode<'a, Expression<'a>>> = None;
+    let mut next: Option<&'b AstNode<'a, 'b, Expression<'a>>> = None;
 
     iter::from_fn(move || {
         let handle_call_expression =
             |position: CallExpressionPosition,
-             expr: &'b AstNode<'a, CallExpression<'a>>,
-             next: &mut Option<&'b AstNode<'a, Expression<'a>>>| {
+             expr: &'b AstNode<'a, 'b, CallExpression<'a>>,
+             next: &mut Option<&'b AstNode<'a, 'b, Expression<'a>>>| {
                 let callee = expr.callee();
 
                 let is_chain = matches!(

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -23,7 +23,7 @@ use crate::ast_nodes::{AstNode, AstNodes};
 /// ```javascript
 /// `connect(a, b, c)(d)`
 /// ```
-pub fn is_long_curried_call(call: &AstNode<'_, CallExpression<'_>>) -> bool {
+pub fn is_long_curried_call(call: &AstNode<'_, '_, CallExpression<'_>>) -> bool {
     if let AstNodes::CallExpression(parent_call) = call.parent()
         && parent_call.is_callee_span(call.span)
     {

--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -13,7 +13,7 @@ use crate::{
     write,
 };
 
-pub fn format_property_key<'a>(key: &AstNode<'a, PropertyKey<'a>>, f: &mut Formatter<'_, 'a>) {
+pub fn format_property_key<'a>(key: &AstNode<'a, '_, PropertyKey<'a>>, f: &mut Formatter<'_, 'a>) {
     // Check if we're in a Tailwind context and the key is a string literal with multiple classes
     if let AstNodes::StringLiteral(string) = key.as_ast_nodes() {
         if let Some(ctx) = tailwind_context_for_string_literal(string, f) {
@@ -40,7 +40,7 @@ pub fn format_property_key<'a>(key: &AstNode<'a, PropertyKey<'a>>, f: &mut Forma
 }
 
 pub fn write_member_name<'a>(
-    key: &AstNode<'a, PropertyKey<'a>>,
+    key: &AstNode<'a, '_, PropertyKey<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> usize {
     if let AstNodes::StringLiteral(string) = key.as_ast_nodes() {

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -15,12 +15,12 @@ use crate::{
 };
 
 pub struct FormatStatementBody<'a, 'b> {
-    body: &'b AstNode<'a, Statement<'a>>,
+    body: &'b AstNode<'a, 'b, Statement<'a>>,
     force_space: bool,
 }
 
 impl<'a, 'b> FormatStatementBody<'a, 'b> {
-    pub fn new(body: &'b AstNode<'a, Statement<'a>>) -> Self {
+    pub fn new(body: &'b AstNode<'a, 'b, Statement<'a>>) -> Self {
         Self { body, force_space: false }
     }
 

--- a/crates/oxc_formatter/src/utils/tailwindcss.rs
+++ b/crates/oxc_formatter/src/utils/tailwindcss.rs
@@ -30,7 +30,7 @@ use super::string::{FormatLiteralStringToken, StringLiteralParentKind};
 /// - The context is not disabled (e.g., not inside a nested non-Tailwind call)
 /// - The string contains whitespace (indicating multiple classes to sort)
 pub fn tailwind_context_for_string_literal<'a>(
-    string: &AstNode<'a, StringLiteral<'a>>,
+    string: &AstNode<'a, '_, StringLiteral<'a>>,
     f: &Formatter<'_, 'a>,
 ) -> Option<TailwindContextEntry> {
     f.context().tailwind_context().copied().filter(|ctx| {
@@ -166,7 +166,7 @@ impl CollapseWhitespace {
 /// ```
 pub fn can_collapse_whitespace<'a, 'b>(
     span: Span,
-    ancestors: impl Iterator<Item = &'b AstNodes<'a>>,
+    ancestors: impl Iterator<Item = &'b AstNodes<'a, 'b>>,
     f: &Formatter<'_, 'a>,
 ) -> CollapseWhitespace
 where
@@ -232,7 +232,7 @@ where
 /// - Preserves boundary spaces when required by concat/template context
 /// - With `preserve_whitespace`, outputs content unchanged
 pub fn write_tailwind_string_literal<'a>(
-    string_literal: &AstNode<'a, StringLiteral<'a>>,
+    string_literal: &AstNode<'a, '_, StringLiteral<'a>>,
     ctx: TailwindContextEntry,
     f: &mut Formatter<'_, 'a>,
 ) {
@@ -320,7 +320,7 @@ pub fn write_tailwind_string_literal<'a>(
 ///
 /// Based on [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/28beb4e008b913414562addec4abb8ab261f3828/src/index.ts#L511-L566).
 pub fn write_tailwind_template_element<'a>(
-    element: &AstNode<'a, TemplateElement<'a>>,
+    element: &AstNode<'a, '_, TemplateElement<'a>>,
     ctx: TailwindContextEntry,
     f: &mut Formatter<'_, 'a>,
 ) {
@@ -383,7 +383,7 @@ pub fn write_tailwind_template_element<'a>(
 
 /// Determines whitespace collapse rules for a template element based on binary expression context.
 fn can_collapse_whitespace_template<'a>(
-    element: &AstNode<'a, TemplateElement<'a>>,
+    element: &AstNode<'a, '_, TemplateElement<'a>>,
     is_first: bool,
     is_last: bool,
     f: &Formatter<'_, 'a>,

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -17,10 +17,6 @@ pub fn formatter_output_path(file_name: &str) -> String {
     format!("{FORMATTER_CRATE_PATH}/src/ast_nodes/generated/{file_name}.rs")
 }
 
-pub fn get_node_type(ty: &TokenStream) -> TokenStream {
-    quote! { AstNode<'a, #ty> }
-}
-
 /// AST nodes whose last child should have `following_span_start = 0`.
 ///
 /// This ensures trailing comments are correctly attributed to the last child itself,
@@ -71,7 +67,7 @@ impl Generator for FormatterAstNodesGenerator {
 
         let ast_nodes_variants = ast_nodes_names.iter().map(|(name, lifetime)| {
             quote! {
-                #name(&'a AstNode<'a, #name #lifetime>),
+                #name(&'b AstNode<'a, 'b, #name #lifetime>),
             }
         });
 
@@ -92,19 +88,9 @@ impl Generator for FormatterAstNodesGenerator {
             quote! { Self::#name(_) => #debug_name, }
         });
 
-        let transmute_self = quote! {
-            #[inline]
-            pub(super) fn transmute_self<'a, T>(s: &AstNode<'a, T>) -> &'a AstNode<'a, T> {
-                // SAFETY: `s` is already allocated in Arena, so transmute from `&` to `&'a` is safe.
-                #[expect(clippy::undocumented_unsafe_blocks)]
-                unsafe { transmute(s) }
-            }
-        };
-
         let output = quote! {
-            use std::mem::transmute;
-            ///@@line_break
-            use oxc_allocator::Vec;
+            #![expect(clippy::match_same_arms)]
+            use oxc_allocator::{Allocator, Vec};
             use oxc_ast::ast::*;
             use oxc_span::GetSpan;
             use oxc_str::Ident;
@@ -115,20 +101,14 @@ impl Generator for FormatterAstNodesGenerator {
                 Format, Formatter,
                 trivia::{format_leading_comments, format_trailing_comments},
             };
-
-
-
-            ///@@line_break
-            #transmute_self
-
             ///@@line_break
             #[derive(Clone, Copy)]
-            pub enum AstNodes<'a> {
+            pub enum AstNodes<'a, 'b> {
                 Dummy(),
                 #(#ast_nodes_variants)*
             }
 
-            impl AstNodes<'_> {
+            impl AstNodes<'_, '_> {
                 #[inline]
                 pub fn span(&self) -> Span {
                     match self {
@@ -246,7 +226,7 @@ fn generate_struct_impls(
         };
 
         let parent_expr = if has_kind {
-            quote! { AstNodes::#struct_name(transmute_self(self)) }
+            quote! { AstNodes::#struct_name(self) }
         } else {
             quote! { self.parent }
         };
@@ -344,7 +324,8 @@ fn generate_struct_impls(
             if is_option {
                 quote! {
                     #following_span_start_expr
-                    self.allocator.alloc(self.inner.#field_name.as_ref().map(|inner| AstNode {
+                    let allocator: &'c Allocator = self.allocator;
+                    allocator.alloc(self.inner.#field_name.as_ref().map(|inner| AstNode {
                         inner: #inner_access,
                         allocator: self.allocator,
                         parent: #parent_expr,
@@ -354,7 +335,8 @@ fn generate_struct_impls(
             } else {
                 quote! {
                     #following_span_start_expr
-                    self.allocator.alloc(AstNode {
+                    let allocator: &'c Allocator = self.allocator;
+                    allocator.alloc(AstNode {
                         inner: #field_access,
                         allocator: self.allocator,
                         parent: #parent_expr,
@@ -364,30 +346,44 @@ fn generate_struct_impls(
             }
         };
 
-        let return_type_final = if is_not_ast_node {
-            quote! { #reference_prefix #field_inner_ty }
-        } else {
-            quote! { &AstNode<'a, #field_inner_ty> }
-        };
-
-        let return_type_final = if is_option {
-            quote! { Option<#return_type_final> }
-        } else {
-            return_type_final
-        };
-
-        Some(quote! {
-            ///@@line_break
-            #[inline]
-            pub fn #field_name(&self) -> #return_type_final {
-                #body
+        let return_type = if is_not_ast_node {
+            if is_copyable {
+                quote! { #field_inner_ty }
+            } else {
+                quote! { &#field_inner_ty }
             }
-        })
+        } else {
+            quote! { &'c AstNode<'a, 'c, #field_inner_ty> }
+        };
+
+        let return_type = if is_option {
+            quote! { Option<#return_type> }
+        } else {
+            return_type
+        };
+
+        if is_not_ast_node {
+            Some(quote! {
+                ///@@line_break
+                #[inline]
+                pub fn #field_name(&self) -> #return_type {
+                    #body
+                }
+            })
+        } else {
+            Some(quote! {
+                ///@@line_break
+                #[inline]
+                pub fn #field_name<'c>(&'c self) -> #return_type {
+                    #body
+                }
+            })
+        }
     });
 
     quote! {
         ///@@line_break
-        impl<'a> AstNode<'a, #type_ty> {
+        impl<'a> AstNode<'a, '_, #type_ty> {
             #(#methods)*
 
             ///@@line_break
@@ -541,7 +537,8 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
 
         let implementation = if has_kind(field_type, schema) {
             quote! {
-                AstNodes::#node_type_ident(self.allocator.alloc(AstNode {
+                let allocator: &'c oxc_allocator::Allocator = self.allocator;
+                AstNodes::#node_type_ident(allocator.alloc(AstNode {
                     inner: #inner_expr,
                     parent,
                     allocator: self.allocator,
@@ -564,7 +561,8 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
         let to_fn_ident = format_ident!("to_{inherits_snake_name}");
 
         let implementation = quote! {
-            return self.allocator.alloc(AstNode {
+            let allocator: &'c oxc_allocator::Allocator = self.allocator;
+            return allocator.alloc(AstNode {
                 inner: it.#to_fn_ident(),
                 parent,
                 allocator: self.allocator,
@@ -574,7 +572,6 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
         quote! { it @ #match_ident!(#enum_ident) => { #implementation }, }
     });
 
-    let node_type = get_node_type(&type_ty);
     let implementation = if variant_match_arms.len() == 0 {
         quote! {
             #[expect(clippy::needless_return)]
@@ -588,14 +585,15 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
                 #(#variant_match_arms)*
                 #(#inherits_match_arms)*
             };
-            self.allocator.alloc(node)
+            let allocator: &'c oxc_allocator::Allocator = self.allocator;
+            allocator.alloc(node)
         }
     };
     quote! {
         ///@@line_break
-        impl<'a> #node_type {
+        impl<'a> AstNode<'a, '_, #type_ty> {
             #[inline]
-            pub fn as_ast_nodes(&self) -> &AstNodes<'a> {
+            pub fn as_ast_nodes<'c>(&'c self) -> &'c AstNodes<'a, 'c> {
                 let parent = self.parent;
                 #implementation
             }

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -6,7 +6,7 @@ use quote::{format_ident, quote};
 
 use crate::{
     Codegen, Generator,
-    generators::{define_generator, formatter::ast_nodes::get_node_type},
+    generators::define_generator,
     output::Output,
     schema::{Def, EnumDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId},
 };
@@ -106,7 +106,7 @@ fn generate_struct_implementation(
 ) -> TokenStream {
     let type_ty = struct_def.ty(schema);
     let type_ty = quote! {
-        AstNode::<'a, #type_ty>
+        AstNode::<'a, '_, #type_ty>
     };
 
     let struct_name = struct_def.name();
@@ -273,12 +273,12 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
 
         Some(quote! {
             #enum_ident::#variant_name(inner) => {
-                allocator.alloc(AstNode::<#node_type> {
+                AstNode::<#node_type> {
                     inner,
                     parent,
-                    allocator,
+                    allocator: self.allocator,
                     following_span_start: self.following_span_start,
-                }).fmt(f);
+                }.fmt(f);
             },
         })
     });
@@ -296,19 +296,21 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
         let match_arm = quote! {
             it @ #match_ident!(#enum_ident) => {
                 let inner = it.#to_fn_ident();
-                allocator.alloc(AstNode::<'a, #inherits_inner_type> {
+                AstNode::<'a, '_, #inherits_inner_type> {
                     inner,
                     parent,
-                    allocator,
+                    allocator: self.allocator,
                     following_span_start: self.following_span_start,
-                }).fmt(f);
+                }.fmt(f);
             },
         };
 
         match_arm
     });
 
-    let node_type = get_node_type(&enum_ty);
+    let node_type = quote! {
+        AstNode::<'a, '_, #enum_ty>
+    };
 
     let inline_trailing_suppression = match enum_def.name() {
         "Statement" => {
@@ -346,7 +348,6 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_, 'a>) {
                 #inline_trailing_suppression
-                let allocator = self.allocator;
                 let parent = self.parent;
                 match self.inner {
                     #(#variant_match_arms)*


### PR DESCRIPTION
Remove the generated `transmute_self` helper from formatter AST nodes by separating the AST lifetime from the parent-link borrow lifetime.

Previously, generated child accessors needed to set their parent to `self`, but `AstNodes<'a>` required a parent reference with the full AST lifetime. The generator worked around that by transmuting `&self` to `&'a self`. This PR changes the formatter wrapper shape to carry two lifetimes instead:

```rust
AstNode<'ast, 'parent, T>
AstNodes<'ast, 'parent>
```

Child accessors now return wrappers tied to the accessor borrow:

```rust
pub fn child<'c>(&'c self) -> &'c AstNode<'a, 'c, Child<'a>>
```

and can safely store the parent as `AstNodes::Parent(self)`. The returned child wrapper cannot outlive the borrow of `self`, so Rust enforces the parent-link validity without any lifetime extension or `unsafe`.

The arena allocator is reborrowed for the shorter accessor lifetime when allocating wrapper nodes:

```rust
let allocator: &'c Allocator = self.allocator;
```

This keeps the allocated wrapper memory valid while only exposing it through the safe, shorter borrow.

Performance/memory notes:
- no `alloc_self()` parent-wrapper allocation is introduced
- lifetimes are compile-time only, so the wrapper representation stays runtime-neutral
- enum formatting now uses stack temporary wrappers instead of arena-allocating those dispatch wrappers
- formatter behavior is intended to be unchanged

Cleanup in the latest revision:
- removed the now-unused `get_node_type` generator helper
- generated `ast_nodes.rs` imports `Allocator` once instead of fully qualifying it at every reborrow site
- reverted the unrelated `oxc_allocator` and `oxc_parser` clippy cleanups so this PR stays formatter-scoped

Scope note: the existing `transmute_copy` in `ImportExpression::to_arguments` is unrelated and intentionally left as-is. This PR removes the generated parent-lifetime transmute path.

AI-assisted.

Checks:
- `just fmt`
- `cargo check -p oxc_formatter`
- `cargo check -p oxc_ast_tools --no-default-features`
- `cargo test -p oxc_formatter`
- `cargo test -p oxc_jsdoc`
- `cargo run -p oxc_prettier_conformance` — js 746/753, ts 591/601
- `cargo run -p oxc_prettier_conformance -- --jsdoc` — jsdoc 145/145
- `cargo clippy -p oxc_formatter -p oxc_ast_tools --no-deps -- -D warnings`
- `cargo clippy -p oxc_formatter --no-deps -- -D warnings`

Note: I did not keep unrelated allocator/parser edits just to make a broader dependency clippy invocation clean.
