### PR TITLE
feat(linter): Update `no-console` auto-fixer to "dangerous suggestion"

### DIFF
--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_deny_no_console@hello_world.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_deny_no_console@hello_world.js.snap
@@ -20,24 +20,6 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
-Title: Delete this code.
-Is Preferred: Some(true)
-TextEdit: TextEdit {
-    range: Range {
-        start: Position {
-            line: 0,
-            character: 0,
-        },
-        end: Position {
-            line: 0,
-            character: 29,
-        },
-    },
-    new_text: "",
-}
-
-
-CodeAction: 
 Title: Disable no-console for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
@@ -74,19 +56,4 @@ TextEdit: TextEdit {
 
 
 ########### Fix All Action
-CodeAction: 
-Title: fix all safe fixable oxlint issues
-Is Preferred: Some(true)
-TextEdit: TextEdit {
-    range: Range {
-        start: Position {
-            line: 0,
-            character: 0,
-        },
-        end: Position {
-            line: 0,
-            character: 29,
-        },
-    },
-    new_text: "",
-}
+None

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
@@ -58,24 +58,6 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
-Title: Delete this code.
-Is Preferred: Some(true)
-TextEdit: TextEdit {
-    range: Range {
-        start: Position {
-            line: 9,
-            character: 0,
-        },
-        end: Position {
-            line: 9,
-            character: 29,
-        },
-    },
-    new_text: "",
-}
-
-
-CodeAction: 
 Title: Disable no-console for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
     NoConsole,
     eslint,
     restriction,
-    conditional_suggestion,
+    conditional_dangerous_suggestion,
     config = NoConsoleConfig,
     version = "0.0.13",
 );
@@ -129,7 +129,7 @@ impl Rule for NoConsole {
 
         let diagnostic_span = ident.span().merge(mem_span);
 
-        ctx.diagnostic_with_suggestion(
+        ctx.diagnostic_with_dangerous_suggestion(
             no_console_diagnostic(diagnostic_span, &self.allow),
             |fixer| {
                 let parent = ctx.nodes().parent_node(node.id());


### PR DESCRIPTION
This switches `no-console` to emit "dangerous suggestion" diagnostics, rather than "(safe) suggestion".

It aligns better with expectations that auto-fixing `no-console` by removing the line should be considered "dangerous". As a user, it was unexpected to see that removal was considered "safe", and with these changes, it would align with ESlint's behavior for this rule.