### PR TITLE
fix(linter/role-supports-aria-props): false positive with `combobox` and `haspopup`

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -399,6 +399,7 @@ const COMBOBOX_PROPS: &[AriaProperty] = &[
     AriaProperty::Expanded,
     AriaProperty::FlowTo,
     AriaProperty::Grabbed,
+    AriaProperty::HasPopup,
     AriaProperty::Hidden,
     AriaProperty::Invalid,
     AriaProperty::KeyShortcuts,
@@ -1642,6 +1643,7 @@ fn test() {
         (r#"<div role="heading" aria-level />"#, None, None),
         (r#"<div role="heading" aria-level="1" />"#, None, None),
         (r#"<option aria-posinset="1" />"#, None, None),
+        (r#"<input role="combobox" aria-haspopup="listbox" />"#, None, None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
As @jackstevenson mentioned in https://github.com/oxc-project/oxc/issues/21719#issuecomment-4315048656, `AriaProperty::HasPopup` is missing from `COMBOBOX_PROPS`, making oxlint report `aria-haspopup` as an unsupported attribute, even though it's supported: https://github.com/A11yance/aria-query/blob/main/src/etc/roles/literal/comboboxRole.js#L21

Fixes #21719