### PR TITLE
refactor(allocator): remove pointless `debug_assert!`s

### DIFF
--- a/crates/oxc_allocator/src/arena/utils.rs
+++ b/crates/oxc_allocator/src/arena/utils.rs
@@ -15,7 +15,6 @@ pub fn is_pointer_aligned_to<T>(ptr: *mut T, align: usize) -> bool {
 
 #[inline]
 pub const fn round_up_to(n: usize, divisor: usize) -> Option<usize> {
-    debug_assert!(divisor > 0);
     debug_assert!(divisor.is_power_of_two());
     match n.checked_add(divisor - 1) {
         Some(x) => Some(x & !(divisor - 1)),
@@ -37,7 +36,6 @@ pub unsafe fn round_up_to_unchecked(n: usize, divisor: usize) -> usize {
 
 #[inline]
 pub fn round_down_to(n: usize, divisor: usize) -> usize {
-    debug_assert!(divisor > 0);
     debug_assert!(divisor.is_power_of_two());
     n & !(divisor - 1)
 }
@@ -54,14 +52,12 @@ pub fn round_down_to(n: usize, divisor: usize) -> usize {
 /// See comment in that method for more details.
 #[inline]
 pub fn round_mut_ptr_down_to(ptr: *mut u8, divisor: usize) -> *mut u8 {
-    debug_assert!(divisor > 0);
     debug_assert!(divisor.is_power_of_two());
     ptr.wrapping_sub(ptr as usize & (divisor - 1))
 }
 
 #[inline]
 pub unsafe fn round_mut_ptr_up_to_unchecked(ptr: *mut u8, divisor: usize) -> *mut u8 {
-    debug_assert!(divisor > 0);
     debug_assert!(divisor.is_power_of_two());
     unsafe {
         let aligned = round_up_to_unchecked(ptr as usize, divisor);


### PR DESCRIPTION
`usize::is_power_of_two` already returns `false` for `0`, so this is pointless duplication:

```rust
debug_assert!(n > 0);
debug_assert!(n.is_power_of_two());
```

Remove the first `debug_assert!` in these cases, to reduce code size and improve perf in debug builds.