### PR TITLE
refactor(allocator): get pointer address with `.addr()` not `as usize`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -221,7 +221,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         //
         // For statically-known `layout.size()` (e.g. in `Arena::alloc`):
         // We inform compiler that `cursor_ptr` is always aligned to `MIN_ALIGN` with an unchecked assertion.
-        // Combined with `round_mut_ptr_down_to`'s implementation as `p.wrapping_sub(p as usize & (divisor - 1))`,
+        // Combined with `round_mut_ptr_down_to`'s implementation as `ptr.wrapping_sub(ptr.addr() & (divisor - 1))`,
         // LLVM's known-bits analysis can:
         //
         // * compute the `& (divisor - 1)` term as a constant, and
@@ -279,7 +279,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         let align = max(layout.align(), MIN_ALIGN);
         let new_ptr = round_mut_ptr_down_to(new_ptr, align);
 
-        if new_ptr.addr().wrapping_sub(start_ptr.addr()) > (isize::MAX as usize) {
+        if new_ptr.addr().wrapping_sub(start_ptr.addr()) > isize::MAX as usize {
             return None;
         }
 
@@ -357,10 +357,10 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 Self::new_chunk(new_chunk_memory_details, layout, current_footer_ptr)
             })?;
 
-            debug_assert_eq!(
-                new_footer_ptr.as_ref().start_ptr.as_ptr() as usize % layout.align(),
-                0
-            );
+            debug_assert!(is_pointer_aligned_to(
+                new_footer_ptr.as_ref().start_ptr.as_ptr(),
+                layout.align()
+            ));
 
             // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
             // can read its final cursor position later.

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -24,7 +24,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// assert!(capacity >= 100);
     /// ```
     pub fn chunk_capacity(&self) -> usize {
-        self.cursor_ptr.get().as_ptr() as usize - self.start_ptr.get().as_ptr() as usize
+        self.cursor_ptr.get().as_ptr().addr() - self.start_ptr.get().as_ptr().addr()
     }
 
     /// Get an iterator over each chunk of allocated memory that this arena has allocated into.

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -13,7 +13,7 @@ use crate::tracking::AllocationStats;
 
 use super::{
     Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK,
-    utils::{layout_from_size_align, oom, round_up_to},
+    utils::{is_pointer_aligned_to, layout_from_size_align, oom, round_up_to},
 };
 
 /// The typical page size these days.
@@ -152,7 +152,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// let arena = ArenaAlign8::with_min_align();
     /// for x in 0..u8::MAX {
     ///     let x = arena.alloc(x);
-    ///     assert_eq!((x as *mut _ as usize) % 8, 0, "x is aligned to 8");
+    ///     assert!(std::ptr::from_ref(x).addr().is_multiple_of(8), "x is aligned to 8");
     /// }
     /// ```
     //
@@ -182,7 +182,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// let mut arena = ArenaAlign8::with_min_align_and_capacity(8 * 100);
     /// for x in 0..100_u64 {
     ///     let x = arena.alloc(x);
-    ///     assert_eq!((x as *mut _ as usize) % 8, 0, "x is aligned to 8");
+    ///     assert!(std::ptr::from_ref(x).addr().is_multiple_of(8), "x is aligned to 8");
     /// }
     /// assert_eq!(
     ///     arena.iter_allocated_chunks().count(), 1,
@@ -214,7 +214,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// let mut arena = ArenaAlign8::try_with_min_align_and_capacity(8 * 100)?;
     /// for x in 0..100_u64 {
     ///     let x = arena.alloc(x);
-    ///     assert_eq!((x as *mut _ as usize) % 8, 0, "x is aligned to 8");
+    ///     assert!(std::ptr::from_ref(x).addr().is_multiple_of(8), "x is aligned to 8");
     /// }
     /// assert_eq!(
     ///     arena.iter_allocated_chunks().count(), 1,
@@ -318,8 +318,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 round_up_to(new_size_without_footer + OVERHEAD, TYPICAL_PAGE_SIZE)? - OVERHEAD;
         }
 
-        debug_assert_eq!(align % CHUNK_ALIGN, 0);
-        debug_assert_eq!(new_size_without_footer % CHUNK_ALIGN, 0);
+        debug_assert!(align.is_multiple_of(CHUNK_ALIGN));
+        debug_assert!(new_size_without_footer.is_multiple_of(CHUNK_ALIGN));
         let size = new_size_without_footer
             .checked_add(CHUNK_FOOTER_SIZE)
             .unwrap_or_else(allocation_size_overflow);
@@ -346,8 +346,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
             // The `ChunkFooter` is at the end of the chunk
             let footer_ptr = start_ptr.as_ptr().add(new_size_without_footer);
-            debug_assert_eq!((start_ptr.as_ptr() as usize) % align, 0);
-            debug_assert_eq!(footer_ptr as usize % CHUNK_ALIGN, 0);
+            debug_assert!(is_pointer_aligned_to(start_ptr.as_ptr(), align));
+            debug_assert!(is_pointer_aligned_to(footer_ptr, CHUNK_ALIGN));
             #[expect(
                 clippy::cast_ptr_alignment,
                 reason = "footer_ptr is aligned to CHUNK_ALIGN, which is == align_of::<ChunkFooter>()"
@@ -357,7 +357,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // Initial cursor sits at the footer, which is the end of the allocatable region.
             // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
             let cursor_ptr = NonNull::new_unchecked(footer_ptr.cast::<u8>());
-            debug_assert_eq!(cursor_ptr.as_ptr() as usize % MIN_ALIGN, 0);
+            debug_assert!(is_pointer_aligned_to(cursor_ptr.as_ptr(), MIN_ALIGN));
 
             ptr::write(
                 footer_ptr,

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -3,7 +3,9 @@
 
 use std::{alloc::Layout, cell::Cell, ptr::NonNull};
 
-use super::{Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK};
+use super::{
+    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK, utils::is_pointer_aligned_to,
+};
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Construct a static-sized [`Arena`] from an existing memory allocation.
@@ -26,7 +28,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// * `start_ptr` must have permission for writes.
     pub unsafe fn from_raw_parts(start_ptr: NonNull<u8>, size: usize) -> Self {
         // Debug assert that `start_ptr` and `size` fulfill size and alignment requirements
-        debug_assert!((start_ptr.as_ptr() as usize).is_multiple_of(CHUNK_ALIGN));
+        debug_assert!(is_pointer_aligned_to(start_ptr.as_ptr(), CHUNK_ALIGN));
         debug_assert!(size.is_multiple_of(CHUNK_ALIGN));
         debug_assert!(size >= CHUNK_FOOTER_SIZE);
 

--- a/crates/oxc_allocator/src/arena/tests.rs
+++ b/crates/oxc_allocator/src/arena/tests.rs
@@ -75,14 +75,14 @@ fn test_realloc() {
         let layout = Layout::from_size_align(10, 1).unwrap();
         let p = b.alloc_layout(layout);
         let q = (&b).realloc(p, layout, 11).unwrap();
-        assert_eq!(q.as_ptr() as usize, p.as_ptr() as usize - 1);
+        assert_eq!(q.as_ptr().addr(), p.as_ptr().addr() - 1);
         b.reset();
 
         // `realloc` will allocate a new chunk when growing the last allocation, if need be
         let layout = Layout::from_size_align(1, 1).unwrap();
         let p = b.alloc_layout(layout);
         let q = (&b).realloc(p, layout, CAPACITY + 1).unwrap();
-        assert_ne!(q.as_ptr() as usize, p.as_ptr() as usize - CAPACITY);
+        assert_ne!(q.as_ptr().addr(), p.as_ptr().addr() - CAPACITY);
         b.reset();
 
         // `realloc` will allocate and copy when reallocating anything that wasn't the last allocation
@@ -90,7 +90,7 @@ fn test_realloc() {
         let p = b.alloc_layout(layout);
         let _ = b.alloc_layout(layout);
         let q = (&b).realloc(p, layout, 2).unwrap();
-        assert!(q.as_ptr() as usize != p.as_ptr() as usize - 1);
+        assert!(q.as_ptr().addr() != p.as_ptr().addr() - 1);
         b.reset();
     }
 }

--- a/crates/oxc_allocator/src/arena/tests_alloc.rs
+++ b/crates/oxc_allocator/src/arena/tests_alloc.rs
@@ -66,7 +66,7 @@ fn bottom_half_enough_room() {
     let layout = Layout::from_size_align(32, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x2000 - 32);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x2000 - 32);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn bottom_half_exact_fit() {
     let layout = Layout::from_size_align(32, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1000);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1000);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn top_half_enough_room() {
     let layout = Layout::from_size_align(32, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 32);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 32);
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn top_half_exact_fit() {
     let layout = Layout::from_size_align(32, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, start);
+    assert_eq!(result.unwrap().as_ptr().addr(), start);
 }
 
 #[test]
@@ -160,7 +160,7 @@ fn zst_zero_capacity() {
     let layout = Layout::from_size_align(0, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1000);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1000);
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn zst_top_half() {
     let layout = Layout::from_size_align(0, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, addr);
+    assert_eq!(result.unwrap().as_ptr().addr(), addr);
 }
 
 // --- Greater path: align > MIN_ALIGN ---
@@ -182,8 +182,8 @@ fn greater_enough_room() {
     let layout = Layout::from_size_align(16, 8).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1030 - 16);
-    assert_eq!(result.unwrap().as_ptr() as usize % 8, 0);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1030 - 16);
+    assert!(result.unwrap().as_ptr().addr().is_multiple_of(8));
 }
 
 #[test]
@@ -212,8 +212,8 @@ fn greater_top_half() {
     let layout = Layout::from_size_align(32, 8).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 32);
-    assert_eq!(result.unwrap().as_ptr() as usize % 8, 0);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 32);
+    assert!(result.unwrap().as_ptr().addr().is_multiple_of(8));
 }
 
 #[test]
@@ -352,13 +352,13 @@ fn consecutive_allocations() {
     let layout = Layout::from_size_align(32, 1).unwrap();
 
     let p1 = arena.try_alloc_layout_fast(layout).unwrap();
-    assert_eq!(p1.as_ptr() as usize, 0x1100 - 32);
+    assert_eq!(p1.as_ptr().addr(), 0x1100 - 32);
 
     let p2 = arena.try_alloc_layout_fast(layout).unwrap();
-    assert_eq!(p2.as_ptr() as usize, 0x1100 - 64);
+    assert_eq!(p2.as_ptr().addr(), 0x1100 - 64);
 
     let p3 = arena.try_alloc_layout_fast(layout).unwrap();
-    assert_eq!(p3.as_ptr() as usize, 0x1100 - 96);
+    assert_eq!(p3.as_ptr().addr(), 0x1100 - 96);
 }
 
 /// Multiple allocations in top half.
@@ -370,10 +370,10 @@ fn consecutive_allocations_top_half() {
     let layout = Layout::from_size_align(32, 8).unwrap();
 
     let p1 = arena.try_alloc_layout_fast(layout).unwrap();
-    assert_eq!(p1.as_ptr() as usize, cursor - 32);
+    assert_eq!(p1.as_ptr().addr(), cursor - 32);
 
     let p2 = arena.try_alloc_layout_fast(layout).unwrap();
-    assert_eq!(p2.as_ptr() as usize, cursor - 64);
+    assert_eq!(p2.as_ptr().addr(), cursor - 64);
 }
 
 /// Fill chunk to exact capacity, then fail.
@@ -441,7 +441,7 @@ fn chunk_spans_midpoint() {
     let layout = Layout::from_size_align(16, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 16);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 16);
 }
 
 /// Same as above but allocation is too big.
@@ -469,7 +469,7 @@ fn near_usize_max() {
     let layout = Layout::from_size_align(16, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 16);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 16);
 }
 
 /// Near usize::MAX, allocation too big.
@@ -491,7 +491,7 @@ fn size_one_bottom_half() {
     let layout = Layout::from_size_align(1, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1000);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1000);
 }
 
 #[test]
@@ -501,7 +501,7 @@ fn size_one_top_half() {
     let layout = Layout::from_size_align(1, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, start);
+    assert_eq!(result.unwrap().as_ptr().addr(), start);
 }
 
 // --- ZST with large alignment (Greater path) ---
@@ -516,7 +516,7 @@ fn zst_greater_path() {
     let layout = Layout::from_size_align(0, 8).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1030);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1030);
 }
 
 /// ZST with align > MIN_ALIGN where rounding cursor down lands exactly on start.
@@ -527,7 +527,7 @@ fn zst_greater_path_exact_start() {
     let layout = Layout::from_size_align(0, 16).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1000);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1000);
 }
 
 // --- Greater path: cursor already aligned ---
@@ -540,7 +540,7 @@ fn greater_cursor_already_aligned() {
     let layout = Layout::from_size_align(16, 8).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1040 - 16);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1040 - 16);
 }
 
 // --- Arena<16> (maximum MIN_ALIGN) ---
@@ -551,8 +551,8 @@ fn arena16_equal_path() {
     let layout = Layout::from_size_align(48, 16).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1100 - 48);
-    assert_eq!(result.unwrap().as_ptr() as usize % 16, 0);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1100 - 48);
+    assert!(result.unwrap().as_ptr().addr().is_multiple_of(16));
 }
 
 #[test]
@@ -562,7 +562,7 @@ fn arena16_less_path() {
     let layout = Layout::from_size_align(5, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1100 - 16);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1100 - 16);
 }
 
 #[test]
@@ -573,8 +573,8 @@ fn arena16_top_half() {
     let layout = Layout::from_size_align(32, 16).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 32);
-    assert_eq!(result.unwrap().as_ptr() as usize % 16, 0);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 32);
+    assert!(result.unwrap().as_ptr().addr().is_multiple_of(16));
 }
 
 // --- Lowest valid start address ---
@@ -587,7 +587,7 @@ fn lowest_valid_start() {
     let layout = Layout::from_size_align(32, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 32);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 32);
 }
 
 #[test]
@@ -608,7 +608,7 @@ fn less_rounds_size_up() {
     let layout = Layout::from_size_align(3, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, 0x1100 - 8);
+    assert_eq!(result.unwrap().as_ptr().addr(), 0x1100 - 8);
 }
 
 #[test]
@@ -619,7 +619,7 @@ fn less_top_half() {
     let layout = Layout::from_size_align(3, 1).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 8);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 8);
 }
 
 // --- Equal path: align == MIN_ALIGN ---
@@ -632,7 +632,7 @@ fn equal_top_half() {
     let layout = Layout::from_size_align(32, 8).unwrap();
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 32);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 32);
 }
 
 #[test]
@@ -656,11 +656,11 @@ fn over_aligned() {
 
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 8);
-    assert_eq!(result.unwrap().as_ptr() as usize % 16, 0);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 8);
+    assert!(result.unwrap().as_ptr().addr().is_multiple_of(16));
 
     let result = arena.try_alloc_layout_fast(layout);
     assert!(result.is_some());
-    assert_eq!(result.unwrap().as_ptr() as usize, cursor - 24);
-    assert_eq!(result.unwrap().as_ptr() as usize % 16, 0);
+    assert_eq!(result.unwrap().as_ptr().addr(), cursor - 24);
+    assert!(result.unwrap().as_ptr().addr().is_multiple_of(16));
 }

--- a/crates/oxc_allocator/src/arena/utils.rs
+++ b/crates/oxc_allocator/src/arena/utils.rs
@@ -8,7 +8,7 @@ pub use super::bumpalo_alloc::AllocErr;
 pub fn is_pointer_aligned_to<T>(ptr: *mut T, align: usize) -> bool {
     debug_assert!(align.is_power_of_two());
 
-    let addr = ptr as usize;
+    let addr = ptr.addr();
     let aligned_addr = round_down_to(addr, align);
     addr == aligned_addr
 }
@@ -53,15 +53,15 @@ pub fn round_down_to(n: usize, divisor: usize) -> usize {
 #[inline]
 pub fn round_mut_ptr_down_to(ptr: *mut u8, divisor: usize) -> *mut u8 {
     debug_assert!(divisor.is_power_of_two());
-    ptr.wrapping_sub(ptr as usize & (divisor - 1))
+    ptr.wrapping_sub(ptr.addr() & (divisor - 1))
 }
 
 #[inline]
 pub unsafe fn round_mut_ptr_up_to_unchecked(ptr: *mut u8, divisor: usize) -> *mut u8 {
     debug_assert!(divisor.is_power_of_two());
     unsafe {
-        let aligned = round_up_to_unchecked(ptr as usize, divisor);
-        let delta = aligned - (ptr as usize);
+        let aligned = round_up_to_unchecked(ptr.addr(), divisor);
+        let delta = aligned - ptr.addr();
         ptr.add(delta)
     }
 }


### PR DESCRIPTION
Avoid conversion of pointers to `usize` addresses using `ptr as usize`. `ptr.addr()` is more idiomatic.

Also, use the existing `is_pointer_aligned_to` helper function for alignment checks instead of `ptr.addr() % align == 0`. The former is clearer, and also checks in debug builds that `align` is a valid power of 2.