### PR TITLE
perf(allocator): use `NonNull::offset_from_unsigned` in `Arena::chunk_capacity`

### DIFF
--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -24,7 +24,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// assert!(capacity >= 100);
     /// ```
     pub fn chunk_capacity(&self) -> usize {
-        self.cursor_ptr.get().as_ptr().addr() - self.start_ptr.get().as_ptr().addr()
+        // SAFETY: `cursor_ptr` is always equal to or after `start_ptr`.
+        // Both pointers point to within the same allocation.
+        unsafe { self.cursor_ptr.get().offset_from_unsigned(self.start_ptr.get()) }
     }
 
     /// Get an iterator over each chunk of allocated memory that this arena has allocated into.


### PR DESCRIPTION
`Arena::chunk_capacity` use `cursor_ptr.offset_from_unsigned(start_ptr)` instead of converting the 2 pointers to `usize`s and comparing. `NonNull::offset_from_unsigned` can be more performant, as it gives the compiler certain guarantees (notably that the distance between the 2 pointers cannot exceed `isize::MAX`).