### PR TITLE
perf(allocator): remove unnecessary check from `Arena::try_alloc_layout_slow_impl`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -335,14 +335,17 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
             // Get a new chunk from the global allocator
             let current_footer_ptr = self.current_chunk_footer_ptr.get();
+
             let current_layout = current_footer_ptr.as_ref().layout;
+            let current_size_without_footer = current_layout.size() - CHUNK_FOOTER_SIZE;
 
             // By default, we want our new chunk to be about twice as big as the previous chunk.
             // If the global allocator refuses it, we try to divide it by half until it works
             // or the requested size is smaller than the default footer size.
             let min_new_chunk_size = layout.size().max(DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
-            let mut base_size =
-                (current_layout.size() - CHUNK_FOOTER_SIZE).checked_mul(2)?.max(min_new_chunk_size);
+            // `current_size_without_footer * 2` cannot overflow because `Layout::size()` is always `<= isize::MAX`
+            let mut base_size = (current_size_without_footer * 2).max(min_new_chunk_size);
+
             let mut chunk_memory_details = iter::from_fn(|| {
                 if base_size >= min_new_chunk_size {
                     let size = base_size;


### PR DESCRIPTION
`Arena::try_alloc_layout_slow_impl` was calculating target size for the new chunk with `old_size.checked_mul(2)`.

This check is unnecessary because `old_size` comes from a `Layout`, and so cannot exceed `isize::MAX`, so doubling it cannot overflow `usize`. Remove the check and just use `old_size * 2` instead.