### PR TITLE
refactor(allocator): rename `EMPTY_CHUNK` to `EMPTY_CHUNK_FOOTER`

### DIFF
--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -12,7 +12,7 @@ use super::bumpalo_alloc::AllocErr;
 use crate::tracking::AllocationStats;
 
 use super::{
-    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK,
+    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK_FOOTER,
     utils::{is_pointer_aligned_to, layout_from_size_align, oom, round_up_to},
 };
 
@@ -162,7 +162,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     // for specifying the minimum alignment.
     #[inline] // Because it's very cheap
     pub fn with_min_align() -> Self {
-        Self::new_impl(EMPTY_CHUNK.get())
+        Self::new_impl(EMPTY_CHUNK_FOOTER.get())
     }
 
     /// Create a new `Arena` that enforces a minimum alignment, and starts with room for at least `capacity` bytes.
@@ -248,7 +248,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 // to avoid `Arena::with_capacity` allocating 16 KiB even when requested `capacity` is much smaller.
                 Self::new_chunk_memory_details(Some(capacity), layout).ok_or(AllocErr)?,
                 layout,
-                EMPTY_CHUNK.get(),
+                EMPTY_CHUNK_FOOTER.get(),
             )
             .ok_or(AllocErr)?
         };

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -2,7 +2,7 @@
 
 use std::{alloc, ptr::NonNull};
 
-use super::{Arena, ChunkFooter, EMPTY_CHUNK, utils::is_pointer_aligned_to};
+use super::{Arena, ChunkFooter, EMPTY_CHUNK_FOOTER, utils::is_pointer_aligned_to};
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Reset this arena.
@@ -53,8 +53,10 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             let current_footer_ptr = self.current_chunk_footer_ptr.get();
 
             // Deallocate all chunks except the current one
-            let prev_footer_ptr =
-                current_footer_ptr.as_ref().previous_chunk_footer_ptr.replace(EMPTY_CHUNK.get());
+            let prev_footer_ptr = current_footer_ptr
+                .as_ref()
+                .previous_chunk_footer_ptr
+                .replace(EMPTY_CHUNK_FOOTER.get());
             dealloc_chunk_list(prev_footer_ptr);
 
             // Reset the bump cursor to the end of the chunk.

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -4,7 +4,8 @@
 use std::{alloc::Layout, cell::Cell, ptr::NonNull};
 
 use super::{
-    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK, utils::is_pointer_aligned_to,
+    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK_FOOTER,
+    utils::is_pointer_aligned_to,
 };
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
@@ -46,7 +47,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         let chunk_footer = ChunkFooter {
             start_ptr,
             layout,
-            previous_chunk_footer_ptr: Cell::new(EMPTY_CHUNK.get()),
+            previous_chunk_footer_ptr: Cell::new(EMPTY_CHUNK_FOOTER.get()),
             cursor_ptr: Cell::new(chunk_footer_ptr.cast::<u8>()),
         };
 

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -248,10 +248,11 @@ unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 ///
 /// Chunks form a linked list with `Arena::current_chunk_footer_ptr` pointing to current chunk's footer,
 /// and each chunk's `ChunkFooter::previous_chunk_footer_ptr` pointing to the previous chunk's footer.
-/// The list ends with the canonical empty chunk `EMPTY_CHUNK`, whose `previous_chunk_footer_ptr` points to itself.
+/// The list ends with the canonical empty chunk footer `EMPTY_CHUNK_FOOTER`, whose `previous_chunk_footer_ptr`
+/// points to itself.
 ///
 /// An empty `Arena`, which does not own any memory, has `Arena::current_chunk_footer_ptr` pointing to
-/// the canonical empty chunk footer `EMPTY_CHUNK`.
+/// the canonical empty chunk footer `EMPTY_CHUNK_FOOTER`.
 #[repr(C, align(16))]
 #[derive(Debug)]
 struct ChunkFooter {
@@ -266,7 +267,7 @@ struct ChunkFooter {
 
     /// Link to the previous chunk.
     ///
-    /// The last node in the chunks linked list is the canonical empty chunk footer `EMPTY_CHUNK`,
+    /// The last node in the chunks linked list is the canonical empty chunk footer `EMPTY_CHUNK_FOOTER`,
     /// whose `previous_chunk_footer_ptr` link points to itself.
     previous_chunk_footer_ptr: Cell<NonNull<ChunkFooter>>,
 
@@ -293,18 +294,18 @@ struct EmptyChunkFooter(ChunkFooter);
 
 unsafe impl Sync for EmptyChunkFooter {}
 
-static EMPTY_CHUNK: EmptyChunkFooter = EmptyChunkFooter(ChunkFooter {
+static EMPTY_CHUNK_FOOTER: EmptyChunkFooter = EmptyChunkFooter(ChunkFooter {
     // The start of the (empty) allocatable region for this chunk is itself
-    start_ptr: NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>(),
+    start_ptr: NonNull::from_ref(&EMPTY_CHUNK_FOOTER).cast::<u8>(),
 
     // This chunk is empty (except the footer itself)
     layout: Layout::new::<ChunkFooter>(),
 
     // Points to itself as the previous chunk
-    previous_chunk_footer_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK.0)),
+    previous_chunk_footer_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK_FOOTER.0)),
 
     // The end of the (empty) allocatable region for this chunk is also itself
-    cursor_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK).cast::<u8>()),
+    cursor_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK_FOOTER).cast::<u8>()),
 });
 
 impl EmptyChunkFooter {
@@ -316,6 +317,6 @@ impl EmptyChunkFooter {
 impl ChunkFooter {
     /// Returns `true` if this chunk is the empty chunk (end of the linked list).
     fn is_empty(&self) -> bool {
-        ptr::eq(self, EMPTY_CHUNK.get().as_ptr())
+        ptr::eq(self, EMPTY_CHUNK_FOOTER.get().as_ptr())
     }
 }


### PR DESCRIPTION
Pure refactor. Rename this var to better reflect what it is.