### PR TITLE
fix(minifier,ecmascript): bail out of string folds that would drop lone-surrogate flag

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -664,15 +664,7 @@ fn get_side_free_uri_input<'a>(
     if expr_may_have_lone_surrogates(expr, ctx) {
         return None;
     }
-    let value = expr.get_side_free_string_value(ctx)?;
-    // Tripwire: a future `to_js_string` impl that isn't mirrored in `expr_may_have_lone_surrogates`
-    // would silently produce a flagless literal here.
-    debug_assert!(
-        !str_has_lone_surrogate_encoding(&value),
-        "expr_may_have_lone_surrogates missed a case; value bytes: {:?}",
-        value.as_bytes()
-    );
-    Some(value)
+    expr.get_side_free_string_value(ctx)
 }
 
 fn try_fold_decode_uri<'a>(

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -28,6 +28,21 @@ use super::{
     str_has_lone_surrogate_encoding,
 };
 
+/// Unwrap `expr` to its `StringLiteral` only when it doesn't carry the lone-surrogate encoding.
+///
+/// String-method folds that read the literal's bytes (index, slice, compare, emit) would read
+/// escape bytes rather than runtime code units when the flag is set, and any literal they
+/// produce would drop the flag via `value_to_expr`. Each caller's comment explains the
+/// site-specific bail reason; this helper just collapses the repeated pattern.
+fn string_literal_without_lone_surrogates<'a, 'b>(
+    expr: &'b Expression<'a>,
+) -> Option<&'b StringLiteral<'a>> {
+    match expr {
+        Expression::StringLiteral(s) if !s.lone_surrogates => Some(s),
+        _ => None,
+    }
+}
+
 fn try_fold_global_functions<'a>(
     ident: &IdentifierReference<'a>,
     arguments: &Vec<'a, Argument<'a>>,
@@ -150,11 +165,8 @@ fn try_fold_string_index_of<'a>(
     if args.len() >= 3 {
         return None;
     }
-    let Expression::StringLiteral(s) = object else { return None };
     // `indexOf`/`lastIndexOf` index by JS code unit, not bytes of the encoded form.
-    if s.lone_surrogates {
-        return None;
-    }
+    let s = string_literal_without_lone_surrogates(object)?;
     let search_value = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -192,12 +204,9 @@ fn try_fold_string_substring_or_slice<'a>(
     if args.len() > 2 {
         return None;
     }
-    let Expression::StringLiteral(s) = object else { return None };
     // Slicing by JS code unit against the encoding (5 chars per surrogate) would split a
     // `�XXXX` run, yielding bytes codegen can't re-encode.
-    if s.lone_surrogates {
-        return None;
-    }
+    let s = string_literal_without_lone_surrogates(object)?;
     let start_idx = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -234,12 +243,9 @@ fn try_fold_string_char_at<'a>(
     if args.len() > 1 {
         return None;
     }
-    let Expression::StringLiteral(s) = object else { return None };
     // `charAt` indexes by JS code unit; against the 5-chars-per-surrogate encoding it would return
     // a fragment of the escape (e.g. `�`) rather than the single code unit the source represents.
-    if s.lone_surrogates {
-        return None;
-    }
+    let s = string_literal_without_lone_surrogates(object)?;
     let char_at_index = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -261,12 +267,9 @@ fn try_fold_string_char_code_at<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
-    let Expression::StringLiteral(s) = object else { return None };
     // Indexing into the encoded form would return the code of an escape char, not the runtime
     // code unit.
-    if s.lone_surrogates {
-        return None;
-    }
+    let s = string_literal_without_lone_surrogates(object)?;
     let char_at_index = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -288,11 +291,11 @@ fn try_fold_starts_with<'a>(
         return None;
     }
     let Argument::StringLiteral(arg) = args.first().unwrap() else { return None };
-    let Expression::StringLiteral(s) = object else { return None };
     // Either side carrying the encoding would make this a compare of escape bytes.
-    if s.lone_surrogates || arg.lone_surrogates {
+    if arg.lone_surrogates {
         return None;
     }
+    let s = string_literal_without_lone_surrogates(object)?;
     Some(ConstantValue::Boolean(s.value.starts_with(arg.value.as_str())))
 }
 
@@ -305,12 +308,9 @@ fn try_fold_string_replace<'a>(
     if args.len() != 2 {
         return None;
     }
-    let Expression::StringLiteral(s) = object else { return None };
     // Any operand carrying the encoding could split a `�XXXX` run or splice escape bytes into
     // a result that gets emitted without the flag.
-    if s.lone_surrogates {
-        return None;
-    }
+    let s = string_literal_without_lone_surrogates(object)?;
     let search_value = args.first().unwrap();
     let search_value = match search_value {
         Argument::SpreadElement(_) => return None,

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -677,11 +677,18 @@ fn get_side_free_uri_input<'a>(
         return None;
     }
     let value = expr.get_side_free_string_value(ctx)?;
-    // Guard against an identifier whose resolved constant bytes match
-    // the encoding without us catching it via the AST check above.
-    if str_has_lone_surrogate_encoding(&value) {
-        return None;
-    }
+    // `expr_may_have_lone_surrogates` already byte-scans identifier-
+    // resolved constants and recursively covers every expression kind
+    // with a `to_js_string` impl, so the resulting string value can't
+    // carry the encoding here. Keep the scan as a debug assertion so a
+    // future `to_js_string` impl that isn't mirrored in the helper
+    // fails loudly in tests rather than silently producing a flagless
+    // literal.
+    debug_assert!(
+        !str_has_lone_surrogate_encoding(&value),
+        "expr_may_have_lone_surrogates missed a case; value bytes: {:?}",
+        value.as_bytes()
+    );
     Some(value)
 }
 

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use super::{
     ConstantEvaluation, ConstantEvaluationCtx, ConstantValue, expr_may_have_lone_surrogates,
-    get_side_free_string_value_safe, str_has_lone_surrogate_encoding,
+    get_side_free_string_value_without_lone_surrogates, str_has_lone_surrogate_encoding,
 };
 
 /// Unwrap `expr` to its `StringLiteral` only when it doesn't carry the lone-surrogate encoding.
@@ -170,7 +170,7 @@ fn try_fold_string_index_of<'a>(
     let search_value = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
-            Some(get_side_free_string_value_safe(arg.to_expression(), ctx)?)
+            Some(get_side_free_string_value_without_lone_surrogates(arg.to_expression(), ctx)?)
         }
         None => None,
     };
@@ -327,7 +327,7 @@ fn try_fold_string_replace<'a>(
     let replace_value = match replace_value {
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
-            get_side_free_string_value_safe(replace_value.to_expression(), ctx)?
+            get_side_free_string_value_without_lone_surrogates(replace_value.to_expression(), ctx)?
         }
     };
     if replace_value.contains('$') {
@@ -605,7 +605,7 @@ fn try_fold_encode_uri<'a>(
     // `encodeURI('\uD800')` throws `URIError` at runtime; our stored value is the encoded form,
     // which the `%`-encoder would happily turn into `%EF%BF%BDd800`. Bail via the safe helper
     // rather than diverge. The same reasoning applies to the other three URI folds below.
-    let string_value = get_side_free_string_value_safe(expr, ctx)?;
+    let string_value = get_side_free_string_value_without_lone_surrogates(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -634,7 +634,7 @@ fn try_fold_encode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = get_side_free_string_value_safe(expr, ctx)?;
+    let string_value = get_side_free_string_value_without_lone_surrogates(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -659,7 +659,7 @@ fn try_fold_decode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = get_side_free_string_value_safe(expr, ctx)?;
+    let string_value = get_side_free_string_value_without_lone_surrogates(expr, ctx)?;
 
     let decoded = decode_uri_chars(
         string_value,
@@ -681,7 +681,7 @@ fn try_fold_decode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = get_side_free_string_value_safe(expr, ctx)?;
+    let string_value = get_side_free_string_value_without_lone_surrogates(expr, ctx)?;
 
     // decodeURIComponent decodes all percent-encoded sequences
     let decoded = decode_uri_chars(

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use super::{
     ConstantEvaluation, ConstantEvaluationCtx, ConstantValue, expr_may_have_lone_surrogates,
-    str_has_lone_surrogate_encoding,
+    get_side_free_string_value_safe, str_has_lone_surrogate_encoding,
 };
 
 /// Unwrap `expr` to its `StringLiteral` only when it doesn't carry the lone-surrogate encoding.
@@ -170,11 +170,7 @@ fn try_fold_string_index_of<'a>(
     let search_value = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
-            let expr = arg.to_expression();
-            if expr_may_have_lone_surrogates(expr, ctx) {
-                return None;
-            }
-            Some(expr.get_side_free_string_value(ctx)?)
+            Some(get_side_free_string_value_safe(arg.to_expression(), ctx)?)
         }
         None => None,
     };
@@ -331,11 +327,7 @@ fn try_fold_string_replace<'a>(
     let replace_value = match replace_value {
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
-            let value = replace_value.to_expression();
-            if expr_may_have_lone_surrogates(value, ctx) {
-                return None;
-            }
-            value.get_side_free_string_value(ctx)?
+            get_side_free_string_value_safe(replace_value.to_expression(), ctx)?
         }
     };
     if replace_value.contains('$') {
@@ -610,7 +602,10 @@ fn try_fold_encode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = get_side_free_uri_input(expr, ctx)?;
+    // `encodeURI('\uD800')` throws `URIError` at runtime; our stored value is the encoded form,
+    // which the `%`-encoder would happily turn into `%EF%BF%BDd800`. Bail via the safe helper
+    // rather than diverge. The same reasoning applies to the other three URI folds below.
+    let string_value = get_side_free_string_value_safe(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -639,7 +634,7 @@ fn try_fold_encode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = get_side_free_uri_input(expr, ctx)?;
+    let string_value = get_side_free_string_value_safe(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -650,21 +645,6 @@ fn try_fold_encode_uri_component<'a>(
         )
     };
     Some(ConstantValue::String(encoded))
-}
-
-/// Extract an `encodeURI*`/`decodeURI*` input as a side-free string, rejecting values that carry
-/// the lone-surrogate encoding.
-///
-/// `encodeURI('\uD800')` throws a `URIError` at runtime; our value for that input is the encoded
-/// form, which the `%`-encoder would happily turn into `%EF%BF%BDd800`. Bail rather than diverge.
-fn get_side_free_uri_input<'a>(
-    expr: &Expression<'a>,
-    ctx: &impl ConstantEvaluationCtx<'a>,
-) -> Option<Cow<'a, str>> {
-    if expr_may_have_lone_surrogates(expr, ctx) {
-        return None;
-    }
-    expr.get_side_free_string_value(ctx)
 }
 
 fn try_fold_decode_uri<'a>(
@@ -679,7 +659,7 @@ fn try_fold_decode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = get_side_free_uri_input(expr, ctx)?;
+    let string_value = get_side_free_string_value_safe(expr, ctx)?;
 
     let decoded = decode_uri_chars(
         string_value,
@@ -701,7 +681,7 @@ fn try_fold_decode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = get_side_free_uri_input(expr, ctx)?;
+    let string_value = get_side_free_string_value_safe(expr, ctx)?;
 
     // decodeURIComponent decodes all percent-encoded sequences
     let decoded = decode_uri_chars(

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -23,7 +23,10 @@ use crate::{
     side_effects::MayHaveSideEffects,
 };
 
-use super::{ConstantEvaluation, ConstantEvaluationCtx, ConstantValue};
+use super::{
+    ConstantEvaluation, ConstantEvaluationCtx, ConstantValue, expr_may_have_lone_surrogates,
+    str_has_lone_surrogate_encoding,
+};
 
 fn try_fold_global_functions<'a>(
     ident: &IdentifierReference<'a>,
@@ -107,6 +110,12 @@ fn try_fold_string_casing<'a>(
         return None;
     }
 
+    // Bail if the source carries the lone-surrogate encoding — the
+    // folded result would be a bare `StringLiteral` with
+    // `lone_surrogates: false`, silently corrupting the value.
+    if expr_may_have_lone_surrogates(object, ctx) {
+        return None;
+    }
     let value = match object {
         Expression::StringLiteral(s) => Cow::Borrowed(s.value.as_str()),
         Expression::Identifier(ident) => ident
@@ -138,10 +147,20 @@ fn try_fold_string_index_of<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
+    // `indexOf`/`lastIndexOf` operate on JS code units, so searching
+    // the encoded form would return an index into the encoding rather
+    // than the runtime string.
+    if s.lone_surrogates {
+        return None;
+    }
     let search_value = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
-            Some(arg.to_expression().get_side_free_string_value(ctx)?)
+            let expr = arg.to_expression();
+            if expr_may_have_lone_surrogates(expr, ctx) {
+                return None;
+            }
+            Some(expr.get_side_free_string_value(ctx)?)
         }
         None => None,
     };
@@ -172,6 +191,14 @@ fn try_fold_string_substring_or_slice<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
+    // `substring`/`slice` operate on JS code units, but the source's
+    // bytes are the lone-surrogate encoding (each surrogate expands to
+    // 5 JS chars / 7 UTF-8 bytes). Slicing against those bytes would
+    // split the encoding at a non-char boundary — panicking codegen if
+    // it tries to decode a partial sequence.
+    if s.lone_surrogates {
+        return None;
+    }
     let start_idx = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -209,6 +236,13 @@ fn try_fold_string_char_at<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
+    // `charAt` operates on JS code units; a lone-surrogate-encoded
+    // source has 5 chars per surrogate, so indexing would yield a
+    // fragment of the encoding (e.g. `�`) rather than the single
+    // JS char the source represents.
+    if s.lone_surrogates {
+        return None;
+    }
     let char_at_index = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -231,6 +265,11 @@ fn try_fold_string_char_code_at<'a>(
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     let Expression::StringLiteral(s) = object else { return None };
+    // Indexing into the encoded form would return the char code of an
+    // escape byte rather than the runtime code unit.
+    if s.lone_surrogates {
+        return None;
+    }
     let char_at_index = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,
         Some(arg @ match_expression!(Argument)) => {
@@ -253,6 +292,11 @@ fn try_fold_starts_with<'a>(
     }
     let Argument::StringLiteral(arg) = args.first().unwrap() else { return None };
     let Expression::StringLiteral(s) = object else { return None };
+    // Either side using the encoding would make `starts_with` compare
+    // escape bytes instead of runtime code units.
+    if s.lone_surrogates || arg.lone_surrogates {
+        return None;
+    }
     Some(ConstantValue::Boolean(s.value.starts_with(arg.value.as_str())))
 }
 
@@ -266,12 +310,21 @@ fn try_fold_string_replace<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
+    // Any operand using the lone-surrogate encoding could cause the
+    // replacement to split at a boundary inside a `�XXXX` run, or
+    // splice encoded bytes into a result with no flag to decode them.
+    if s.lone_surrogates {
+        return None;
+    }
     let search_value = args.first().unwrap();
     let search_value = match search_value {
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
             let value = search_value.to_expression();
             if value.may_have_side_effects(ctx) {
+                return None;
+            }
+            if expr_may_have_lone_surrogates(value, ctx) {
                 return None;
             }
             value.evaluate_value(ctx)?.into_string()?
@@ -281,7 +334,11 @@ fn try_fold_string_replace<'a>(
     let replace_value = match replace_value {
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
-            replace_value.to_expression().get_side_free_string_value(ctx)?
+            let value = replace_value.to_expression();
+            if expr_may_have_lone_surrogates(value, ctx) {
+                return None;
+            }
+            value.get_side_free_string_value(ctx)?
         }
     };
     if replace_value.contains('$') {
@@ -363,11 +420,18 @@ fn try_fold_to_string<'a>(
         Expression::RegExpLiteral(lit) if args.is_empty() => {
             lit.to_js_string(ctx).map(ConstantValue::String)
         }
-        e if args.is_empty() => e
-            .evaluate_value(ctx)
-            // `null` and `undefined` returns type errors
-            .filter(|v| !v.is_undefined() && !v.is_null())
-            .and_then(|v| v.to_js_string(ctx).map(ConstantValue::String)),
+        e if args.is_empty() => {
+            // Folding e.g. `'\uDC00'.toString()` would route the
+            // encoded bytes through `value_to_expr` as a bare
+            // `StringLiteral` without `lone_surrogates: true`.
+            if expr_may_have_lone_surrogates(e, ctx) {
+                return None;
+            }
+            e.evaluate_value(ctx)
+                // `null` and `undefined` returns type errors
+                .filter(|v| !v.is_undefined() && !v.is_null())
+                .and_then(|v| v.to_js_string(ctx).map(ConstantValue::String))
+        }
         _ => None,
     }
 }
@@ -550,7 +614,7 @@ fn try_fold_encode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -579,7 +643,7 @@ fn try_fold_encode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -590,6 +654,29 @@ fn try_fold_encode_uri_component<'a>(
         )
     };
     Some(ConstantValue::String(encoded))
+}
+
+/// Return `expr`'s value as a side-free string, but only when it does
+/// not use the lone-surrogate encoding.
+///
+/// `encodeURI('\uD800')` throws a `URIError` at runtime. Our value for
+/// that input is the `�d800` encoded form — passing it through the
+/// `%`-encoder would yield `%EF%BF%BDd800`, which doesn't match the
+/// runtime's exception behaviour. Bail rather than fold.
+fn side_free_non_lone_surrogate_string<'a>(
+    expr: &Expression<'a>,
+    ctx: &impl ConstantEvaluationCtx<'a>,
+) -> Option<Cow<'a, str>> {
+    if expr_may_have_lone_surrogates(expr, ctx) {
+        return None;
+    }
+    let value = expr.get_side_free_string_value(ctx)?;
+    // Guard against an identifier whose resolved constant bytes match
+    // the encoding without us catching it via the AST check above.
+    if str_has_lone_surrogate_encoding(&value) {
+        return None;
+    }
+    Some(value)
 }
 
 fn try_fold_decode_uri<'a>(
@@ -604,7 +691,7 @@ fn try_fold_decode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     let decoded = decode_uri_chars(
         string_value,
@@ -626,7 +713,7 @@ fn try_fold_decode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = expr.get_side_free_string_value(ctx)?;
+    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
 
     // decodeURIComponent decodes all percent-encoded sequences
     let decoded = decode_uri_chars(

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -110,19 +110,26 @@ fn try_fold_string_casing<'a>(
         return None;
     }
 
-    // Bail if the source carries the lone-surrogate encoding — the
-    // folded result would be a bare `StringLiteral` with
-    // `lone_surrogates: false`, silently corrupting the value.
-    if expr_may_have_lone_surrogates(object, ctx) {
-        return None;
-    }
+    // Each branch bails if the source carries the lone-surrogate
+    // encoding: the folded result would otherwise be a bare
+    // `StringLiteral` with `lone_surrogates: false`, silently
+    // corrupting the value. The flag / byte scan lives alongside the
+    // value extraction to avoid a second `get_constant_value_for_reference_id`
+    // lookup for identifiers.
     let value = match object {
+        Expression::StringLiteral(s) if s.lone_surrogates => return None,
         Expression::StringLiteral(s) => Cow::Borrowed(s.value.as_str()),
-        Expression::Identifier(ident) => ident
-            .reference_id
-            .get()
-            .and_then(|reference_id| ctx.get_constant_value_for_reference_id(reference_id))
-            .and_then(ConstantValue::into_string)?,
+        Expression::Identifier(ident) => {
+            let cow = ident
+                .reference_id
+                .get()
+                .and_then(|reference_id| ctx.get_constant_value_for_reference_id(reference_id))
+                .and_then(ConstantValue::into_string)?;
+            if str_has_lone_surrogate_encoding(&cow) {
+                return None;
+            }
+            cow
+        }
         _ => return None,
     };
 

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -110,11 +110,8 @@ fn try_fold_string_casing<'a>(
         return None;
     }
 
-    // Each branch bails if the source carries the lone-surrogate
-    // encoding: the folded result would otherwise be a bare
-    // `StringLiteral` with `lone_surrogates: false`, silently
-    // corrupting the value. The flag / byte scan lives alongside the
-    // value extraction to avoid a second `get_constant_value_for_reference_id`
+    // Bail on lone-surrogate inputs; the folded literal would default to `lone_surrogates: false`.
+    // The flag / byte scan lives inline to avoid a second `get_constant_value_for_reference_id`
     // lookup for identifiers.
     let value = match object {
         Expression::StringLiteral(s) if s.lone_surrogates => return None,
@@ -154,9 +151,7 @@ fn try_fold_string_index_of<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
-    // `indexOf`/`lastIndexOf` operate on JS code units, so searching
-    // the encoded form would return an index into the encoding rather
-    // than the runtime string.
+    // `indexOf`/`lastIndexOf` index by JS code unit, not bytes of the encoded form.
     if s.lone_surrogates {
         return None;
     }
@@ -198,11 +193,8 @@ fn try_fold_string_substring_or_slice<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
-    // `substring`/`slice` operate on JS code units, but the source's
-    // bytes are the lone-surrogate encoding (each surrogate expands to
-    // 5 JS chars / 7 UTF-8 bytes). Slicing against those bytes would
-    // split the encoding at a non-char boundary — panicking codegen if
-    // it tries to decode a partial sequence.
+    // Slicing by JS code unit against the encoding (5 chars per surrogate) would split a
+    // `�XXXX` run, yielding bytes codegen can't re-encode.
     if s.lone_surrogates {
         return None;
     }
@@ -243,10 +235,8 @@ fn try_fold_string_char_at<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
-    // `charAt` operates on JS code units; a lone-surrogate-encoded
-    // source has 5 chars per surrogate, so indexing would yield a
-    // fragment of the encoding (e.g. `�`) rather than the single
-    // JS char the source represents.
+    // `charAt` indexes by JS code unit; against the 5-chars-per-surrogate encoding it would return
+    // a fragment of the escape (e.g. `�`) rather than the single code unit the source represents.
     if s.lone_surrogates {
         return None;
     }
@@ -272,8 +262,8 @@ fn try_fold_string_char_code_at<'a>(
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     let Expression::StringLiteral(s) = object else { return None };
-    // Indexing into the encoded form would return the char code of an
-    // escape byte rather than the runtime code unit.
+    // Indexing into the encoded form would return the code of an escape char, not the runtime
+    // code unit.
     if s.lone_surrogates {
         return None;
     }
@@ -299,8 +289,7 @@ fn try_fold_starts_with<'a>(
     }
     let Argument::StringLiteral(arg) = args.first().unwrap() else { return None };
     let Expression::StringLiteral(s) = object else { return None };
-    // Either side using the encoding would make `starts_with` compare
-    // escape bytes instead of runtime code units.
+    // Either side carrying the encoding would make this a compare of escape bytes.
     if s.lone_surrogates || arg.lone_surrogates {
         return None;
     }
@@ -317,9 +306,8 @@ fn try_fold_string_replace<'a>(
         return None;
     }
     let Expression::StringLiteral(s) = object else { return None };
-    // Any operand using the lone-surrogate encoding could cause the
-    // replacement to split at a boundary inside a `�XXXX` run, or
-    // splice encoded bytes into a result with no flag to decode them.
+    // Any operand carrying the encoding could split a `�XXXX` run or splice escape bytes into
+    // a result that gets emitted without the flag.
     if s.lone_surrogates {
         return None;
     }
@@ -331,10 +319,8 @@ fn try_fold_string_replace<'a>(
             if value.may_have_side_effects(ctx) {
                 return None;
             }
-            // Catches string literals, templates with flagged quasis,
-            // and — via byte scan on the resolved `ConstantValue::String` —
-            // identifiers bound to lone-surrogate constants, which the
-            // `evaluate_value` call below would otherwise silently flatten.
+            // Pre-filter: `evaluate_value` below resolves identifiers to the encoded bytes of
+            // their `ConstantValue::String` but discards the flag.
             if expr_may_have_lone_surrogates(value, ctx) {
                 return None;
             }
@@ -346,8 +332,6 @@ fn try_fold_string_replace<'a>(
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
             let value = replace_value.to_expression();
-            // Same story: `get_side_free_string_value` below would
-            // drop any `lone_surrogates` flag, so pre-filter.
             if expr_may_have_lone_surrogates(value, ctx) {
                 return None;
             }
@@ -434,9 +418,8 @@ fn try_fold_to_string<'a>(
             lit.to_js_string(ctx).map(ConstantValue::String)
         }
         e if args.is_empty() => {
-            // Folding e.g. `'\uDC00'.toString()` would route the
-            // encoded bytes through `value_to_expr` as a bare
-            // `StringLiteral` without `lone_surrogates: true`.
+            // `'\uDC00'.toString()` would otherwise route the encoded bytes through
+            // `value_to_expr` without the flag.
             if expr_may_have_lone_surrogates(e, ctx) {
                 return None;
             }
@@ -669,13 +652,11 @@ fn try_fold_encode_uri_component<'a>(
     Some(ConstantValue::String(encoded))
 }
 
-/// Extract an `encodeURI*`/`decodeURI*` input as a side-free string,
-/// rejecting values that carry the lone-surrogate encoding.
+/// Extract an `encodeURI*`/`decodeURI*` input as a side-free string, rejecting values that carry
+/// the lone-surrogate encoding.
 ///
-/// `encodeURI('\uD800')` throws a `URIError` at runtime. Our value for
-/// that input is the `�d800` encoded form — passing it through the
-/// `%`-encoder would yield `%EF%BF%BDd800`, which doesn't match the
-/// runtime's exception behaviour. Bail rather than fold.
+/// `encodeURI('\uD800')` throws a `URIError` at runtime; our value for that input is the encoded
+/// form, which the `%`-encoder would happily turn into `%EF%BF%BDd800`. Bail rather than diverge.
 fn get_side_free_uri_input<'a>(
     expr: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -684,13 +665,8 @@ fn get_side_free_uri_input<'a>(
         return None;
     }
     let value = expr.get_side_free_string_value(ctx)?;
-    // `expr_may_have_lone_surrogates` already byte-scans identifier-
-    // resolved constants and recursively covers every expression kind
-    // with a `to_js_string` impl, so the resulting string value can't
-    // carry the encoding here. Keep the scan as a debug assertion so a
-    // future `to_js_string` impl that isn't mirrored in the helper
-    // fails loudly in tests rather than silently producing a flagless
-    // literal.
+    // Tripwire: a future `to_js_string` impl that isn't mirrored in `expr_may_have_lone_surrogates`
+    // would silently produce a flagless literal here.
     debug_assert!(
         !str_has_lone_surrogate_encoding(&value),
         "expr_may_have_lone_surrogates missed a case; value bytes: {:?}",

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -620,7 +620,7 @@ fn try_fold_encode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
+    let string_value = get_side_free_uri_input(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -649,7 +649,7 @@ fn try_fold_encode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
+    let string_value = get_side_free_uri_input(expr, ctx)?;
 
     // SAFETY: should_encode only returns false for ascii chars
     let encoded = unsafe {
@@ -662,14 +662,14 @@ fn try_fold_encode_uri_component<'a>(
     Some(ConstantValue::String(encoded))
 }
 
-/// Return `expr`'s value as a side-free string, but only when it does
-/// not use the lone-surrogate encoding.
+/// Extract an `encodeURI*`/`decodeURI*` input as a side-free string,
+/// rejecting values that carry the lone-surrogate encoding.
 ///
 /// `encodeURI('\uD800')` throws a `URIError` at runtime. Our value for
 /// that input is the `�d800` encoded form — passing it through the
 /// `%`-encoder would yield `%EF%BF%BDd800`, which doesn't match the
 /// runtime's exception behaviour. Bail rather than fold.
-fn side_free_non_lone_surrogate_string<'a>(
+fn get_side_free_uri_input<'a>(
     expr: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<Cow<'a, str>> {
@@ -697,7 +697,7 @@ fn try_fold_decode_uri<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
+    let string_value = get_side_free_uri_input(expr, ctx)?;
 
     let decoded = decode_uri_chars(
         string_value,
@@ -719,7 +719,7 @@ fn try_fold_decode_uri_component<'a>(
     }
     let arg = args.first()?;
     let expr = arg.as_expression()?;
-    let string_value = side_free_non_lone_surrogate_string(expr, ctx)?;
+    let string_value = get_side_free_uri_input(expr, ctx)?;
 
     // decodeURIComponent decodes all percent-encoded sequences
     let decoded = decode_uri_chars(

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -324,6 +324,10 @@ fn try_fold_string_replace<'a>(
             if value.may_have_side_effects(ctx) {
                 return None;
             }
+            // Catches string literals, templates with flagged quasis,
+            // and — via byte scan on the resolved `ConstantValue::String` —
+            // identifiers bound to lone-surrogate constants, which the
+            // `evaluate_value` call below would otherwise silently flatten.
             if expr_may_have_lone_surrogates(value, ctx) {
                 return None;
             }
@@ -335,6 +339,8 @@ fn try_fold_string_replace<'a>(
         Argument::SpreadElement(_) => return None,
         match_expression!(Argument) => {
             let value = replace_value.to_expression();
+            // Same story: `get_side_free_string_value` below would
+            // drop any `lone_surrogates` flag, so pre-filter.
             if expr_may_have_lone_surrogates(value, ctx) {
                 return None;
             }

--- a/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
@@ -1,6 +1,9 @@
 use oxc_ast::ast::{Expression, NumberBase};
 
-use super::{ConstantEvaluation, ConstantEvaluationCtx, DetermineValueType, ValueType};
+use super::{
+    ConstantEvaluation, ConstantEvaluationCtx, DetermineValueType, ValueType,
+    expr_may_have_lone_surrogates,
+};
 
 /// <https://tc39.es/ecma262/#sec-abstract-equality-comparison>
 pub(super) fn abstract_equality_comparison<'a>(
@@ -100,6 +103,17 @@ pub(super) fn strict_equality_comparison<'a>(
                 Some(lnum == rnum)
             }
             ValueType::String => {
+                // The stored `value` bytes coincide for a real U+FFFD
+                // followed by four ASCII hex characters and the
+                // lone-surrogate encoding of the same hex. Two strings
+                // with identical bytes but different `lone_surrogates`
+                // flags are different runtime values, so a byte compare
+                // here would give the wrong answer.
+                if expr_may_have_lone_surrogates(left_expr, ctx)
+                    || expr_may_have_lone_surrogates(right_expr, ctx)
+                {
+                    return None;
+                }
                 let left = left_expr.get_side_free_string_value(ctx)?;
                 let right = right_expr.get_side_free_string_value(ctx)?;
                 Some(left == right)

--- a/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
@@ -103,12 +103,9 @@ pub(super) fn strict_equality_comparison<'a>(
                 Some(lnum == rnum)
             }
             ValueType::String => {
-                // The stored `value` bytes coincide for a real U+FFFD
-                // followed by four ASCII hex characters and the
-                // lone-surrogate encoding of the same hex. Two strings
-                // with identical bytes but different `lone_surrogates`
-                // flags are different runtime values, so a byte compare
-                // here would give the wrong answer.
+                // A real U+FFFD + four ASCII hex chars has the same bytes as the lone-surrogate
+                // encoding of the same hex, but they're different runtime values — so a byte
+                // compare here would lie when one side carries the flag and the other doesn't.
                 if expr_may_have_lone_surrogates(left_expr, ctx)
                     || expr_may_have_lone_surrogates(right_expr, ctx)
                 {

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -60,6 +60,21 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
         || b == b"fffd"
 }
 
+/// Returns `true` if any quasi or interpolation in `t` may carry the
+/// lone-surrogate encoding.
+///
+/// Split out from [`expr_may_have_lone_surrogates`]'s `TemplateLiteral`
+/// arm so minifier sites that hold a `&TemplateLiteral` directly (not
+/// wrapped in an `Expression`) can use the same check without an
+/// `Expression::TemplateLiteral(...)` round-trip.
+pub fn template_may_have_lone_surrogates<'a>(
+    t: &TemplateLiteral<'a>,
+    ctx: &impl GlobalContext<'a>,
+) -> bool {
+    t.quasis.iter().any(|q| q.lone_surrogates)
+        || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
+}
+
 /// Returns `true` if the expression, when stringified, may carry the
 /// lone-surrogate encoding.
 ///
@@ -84,10 +99,7 @@ pub fn expr_may_have_lone_surrogates<'a>(
 ) -> bool {
     match expr {
         Expression::StringLiteral(s) => s.lone_surrogates,
-        Expression::TemplateLiteral(t) => {
-            t.quasis.iter().any(|q| q.lone_surrogates)
-                || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
-        }
+        Expression::TemplateLiteral(t) => template_may_have_lone_surrogates(t, ctx),
         Expression::BinaryExpression(e) if e.operator == BinaryOperator::Addition => {
             expr_may_have_lone_surrogates(&e.left, ctx)
                 || expr_may_have_lone_surrogates(&e.right, ctx)

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -145,9 +145,9 @@ pub fn expr_may_have_lone_surrogates<'a>(
         // - `CallExpression` / `NewExpression` / `TaggedTemplateExpression`:
         //   side-effecting and either fold to a literal elsewhere
         //   (caught by the literal arm above) or don't fold at all.
-        // - `MemberExpression` / `ChainExpression`: string-typed member
-        //   access (only `.length` today) produces a number, not a
-        //   string.
+        // - `MemberExpression` / `ChainExpression`: only `.length` folds
+        //   today, and that yields a number, so no string-valued result
+        //   can flow through.
         // - `AssignmentExpression` / `UpdateExpression`: side effects,
         //   so fold paths bail via `may_have_side_effects` first.
         //

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -17,6 +17,15 @@
 //!
 //! Detection is conservative: false positives only skip a fold that could have been performed,
 //! never produce wrong output.
+//!
+//! Invariant (load-bearing for the `_ => false` arm of [`expr_may_have_lone_surrogates`]): every
+//! fold that produces a `ConstantValue::String` from possibly-flagged bytes either rewrites the
+//! result into a `StringLiteral` / `TemplateLiteral` in place (which the typed arms above catch)
+//! or bails itself. Under bottom-up evaluation, a parent that inspects a `CallExpression` /
+//! `NewExpression` / `TaggedTemplateExpression` subexpression therefore sees either an
+//! already-rewritten literal or a still-unfolded call — never a raw flagless string value. When
+//! adding a new string-producing fold, either add a typed arm here for the kind it produces, or
+//! gate the fold site with [`expr_may_have_lone_surrogates`] before emitting a literal.
 
 use std::borrow::Cow;
 

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -126,11 +126,6 @@ pub fn expr_may_have_lone_surrogates<'a>(
                 ConstantValue::String(s) => str_has_lone_surrogate_encoding(&s),
                 _ => false,
             }),
-        // Every `UnaryExpression` kind that `to_js_string` handles
-        // (`void x` → `"undefined"`, `!x` → `"true"`/`"false"`) produces
-        // a fixed ASCII string regardless of the operand, so the
-        // operand's contents can't flow into a lone-surrogate result.
-        Expression::UnaryExpression(_) => false,
         Expression::LogicalExpression(e) => {
             expr_may_have_lone_surrogates(&e.left, ctx)
                 || expr_may_have_lone_surrogates(&e.right, ctx)
@@ -143,6 +138,23 @@ pub fn expr_may_have_lone_surrogates<'a>(
             e.expressions.last().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))
         }
         Expression::ParenthesizedExpression(e) => expr_may_have_lone_surrogates(&e.expression, ctx),
+        // The catch-all covers every other kind, notably:
+        // - `UnaryExpression`: `void x` → `"undefined"` and `!x` →
+        //   `"true"`/`"false"` produce fixed ASCII regardless of the
+        //   operand, so a lone-surrogate operand can't flow through.
+        // - `CallExpression` / `NewExpression` / `TaggedTemplateExpression`:
+        //   side-effecting and either fold to a literal elsewhere
+        //   (caught by the literal arm above) or don't fold at all.
+        // - `MemberExpression` / `ChainExpression`: string-typed member
+        //   access (only `.length` today) produces a number, not a
+        //   string.
+        // - `AssignmentExpression` / `UpdateExpression`: side effects,
+        //   so fold paths bail via `may_have_side_effects` first.
+        //
+        // If a new `to_js_string` impl adds a string-producing kind
+        // that could carry lone surrogates, add a dedicated arm for it
+        // above — the catch-all is not a license to silently skip a
+        // string producer.
         _ => false,
     }
 }

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -102,6 +102,12 @@ pub fn expr_may_have_lone_surrogates<'a>(
                 || expr_may_have_lone_surrogates(&e.right, ctx)
         }
         Expression::ArrayExpression(arr) => array_may_have_lone_surrogates(arr, ctx),
+        // TODO: when the caller follows this up with `get_side_free_string_value` /
+        // `evaluate_value` on the same identifier, the resolution happens twice — once here
+        // and once at the fold site. `try_fold_string_casing` inlines its own resolution to
+        // avoid that; every other fold site pays the double lookup. A helper that returns
+        // `Option<Cow<str>>` directly from this check (instead of just `bool`) could thread
+        // the resolved value through and kill the second lookup everywhere.
         Expression::Identifier(ident) => ident
             .reference_id
             .get()

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -32,7 +32,7 @@ use std::borrow::Cow;
 use oxc_ast::ast::*;
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{GlobalContext, side_effects::MayHaveSideEffects};
+use crate::{GlobalContext, ToJsString, side_effects::MayHaveSideEffects};
 
 use super::{ConstantEvaluation, ConstantEvaluationCtx, ConstantValue};
 
@@ -216,7 +216,10 @@ pub fn get_side_free_string_value_without_lone_surrogates<'a>(
         if expr.may_have_side_effects(ctx) {
             return None;
         }
-        let s = cv.into_string()?;
+        // `to_js_string` — not `into_string` — so non-`String` constants (`Number`, `Boolean`,
+        // `BigInt`, `Null`, `Undefined`) stringify through `ToJsString` the same way the generic
+        // fall-through would via `evaluate_value_to_string`. `into_string` would drop the fold.
+        let s = cv.to_js_string(ctx)?;
         return (!str_has_lone_surrogate_encoding(&s)).then_some(s);
     }
     if expr_may_have_lone_surrogates(expr, ctx) {

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -51,31 +51,46 @@ pub fn str_has_lone_surrogate_encoding(s: &str) -> bool {
     bytes.windows(7).any(|w| w[..3] == [0xEF, 0xBF, 0xBD] && is_lone_surrogate_suffix(&w[3..]))
 }
 
-/// Counts non-overlapping `\u{FFFD}XXXX` encoded runs in `s`.
+/// Returns the runtime UTF-16 length of a flagged string.
 ///
-/// Each run represents a single UTF-16 code unit at runtime — a lone surrogate, or U+FFFD itself
-/// via the `fffd` self-escape — while occupying 5 stored code units. For a flagged string the
-/// runtime length is therefore `s.encode_utf16().count() - 4 * count_lone_surrogate_runs(s)`.
+/// A single byte-level walk: each `\u{FFFD}XXXX` encoded run (7 bytes / 5 stored UTF-16 code
+/// units) contributes 1 runtime code unit — either a lone surrogate, or U+FFFD itself via the
+/// `fffd` self-escape — and any other codepoint contributes its normal UTF-16 length. Fuses
+/// what used to be a two-pass `encode_utf16().count() - 4 * run_count`.
 ///
-/// The scan is purely on bytes, so in an unflagged string with coincidentally matching bytes (a
-/// real U+FFFD followed by four hex characters) this also counts a run; callers must have
-/// established the literal is flagged before using the count for a length calculation.
-pub fn count_lone_surrogate_runs(s: &str) -> usize {
+/// Only meaningful when the caller has already established `lone_surrogates: true`: the scan
+/// can't distinguish an encoded run from a coincidentally-matching U+FFFD followed by four hex
+/// characters, so on an unflagged string this would under-count.
+pub fn flagged_str_runtime_utf16_length(s: &str) -> usize {
     let bytes = s.as_bytes();
-    if !bytes.contains(&0xEF) {
-        return 0;
-    }
-    let mut count = 0;
+    let mut len = 0;
     let mut i = 0;
-    while i + 7 <= bytes.len() {
-        if bytes[i..i + 3] == [0xEF, 0xBF, 0xBD] && is_lone_surrogate_suffix(&bytes[i + 3..i + 7]) {
-            count += 1;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Encoded run: U+FFFD (EF BF BD) + 4 ASCII hex digits = 7 bytes, 1 runtime UTF-16 unit.
+        if b == 0xEF
+            && i + 7 <= bytes.len()
+            && bytes[i + 1] == 0xBF
+            && bytes[i + 2] == 0xBD
+            && is_lone_surrogate_suffix(&bytes[i + 3..i + 7])
+        {
+            len += 1;
             i += 7;
-        } else {
-            i += 1;
+            continue;
         }
+        // Otherwise advance by one UTF-8 codepoint and add its UTF-16 length. `&str` guarantees
+        // valid UTF-8, so `b` is always a lead byte here.
+        let (step, units) = match b {
+            0x00..=0x7F => (1, 1), // ASCII
+            0xC2..=0xDF => (2, 1), // 2-byte sequence (U+0080..=U+07FF)
+            0xE0..=0xEF => (3, 1), // 3-byte sequence (U+0800..=U+FFFF, BMP)
+            0xF0..=0xF4 => (4, 2), // 4-byte sequence (supplementary → UTF-16 surrogate pair)
+            _ => unreachable!("invalid UTF-8 lead byte {b:#x}"),
+        };
+        len += units;
+        i += step;
     }
-    count
+    len
 }
 
 fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
@@ -239,7 +254,7 @@ pub fn get_side_free_string_value_without_lone_surrogates<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::{count_lone_surrogate_runs, str_has_lone_surrogate_encoding};
+    use super::{flagged_str_runtime_utf16_length, str_has_lone_surrogate_encoding};
 
     #[test]
     fn empty_and_short_inputs() {
@@ -302,15 +317,31 @@ mod tests {
     }
 
     #[test]
-    fn counts_non_overlapping_runs() {
-        assert_eq!(count_lone_surrogate_runs(""), 0);
-        assert_eq!(count_lone_surrogate_runs("plain"), 0);
-        assert_eq!(count_lone_surrogate_runs("\u{FFFD}d800"), 1);
-        assert_eq!(count_lone_surrogate_runs("\u{FFFD}d800\u{FFFD}dc00"), 2);
+    fn runtime_length_empty_and_ascii() {
+        assert_eq!(flagged_str_runtime_utf16_length(""), 0);
+        assert_eq!(flagged_str_runtime_utf16_length("plain"), 5);
+    }
+
+    #[test]
+    fn runtime_length_counts_encoded_runs_as_one() {
+        // One encoded lone surrogate: 5 stored UTF-16 units → 1 runtime unit.
+        assert_eq!(flagged_str_runtime_utf16_length("\u{FFFD}d800"), 1);
+        // Two back-to-back runs.
+        assert_eq!(flagged_str_runtime_utf16_length("\u{FFFD}d800\u{FFFD}dc00"), 2);
         // Self-escape counts as a run (one U+FFFD at runtime).
-        assert_eq!(count_lone_surrogate_runs("\u{FFFD}fffd\u{FFFD}d800"), 2);
-        // Non-matching U+FFFD occurrences aren't counted.
-        assert_eq!(count_lone_surrogate_runs("\u{FFFD}\u{FFFD}d800"), 1);
-        assert_eq!(count_lone_surrogate_runs("a\u{FFFD}dc00b\u{FFFD}dfffc"), 2);
+        assert_eq!(flagged_str_runtime_utf16_length("\u{FFFD}fffd\u{FFFD}d800"), 2);
+    }
+
+    #[test]
+    fn runtime_length_mixes_encoded_and_plain_codepoints() {
+        // ASCII around a run: 'a' + run + 'b' + run + 'c' = 5 runtime units.
+        assert_eq!(flagged_str_runtime_utf16_length("a\u{FFFD}dc00b\u{FFFD}dfffc"), 5);
+        // Non-matching U+FFFD followed by a matching run: 1 (plain U+FFFD) + 1 (run) = 2.
+        assert_eq!(flagged_str_runtime_utf16_length("\u{FFFD}\u{FFFD}d800"), 2);
+        // A non-hex suffix defeats the run match, so each of the 5 stored chars counts normally
+        // (U+FFFD + 4 ASCII = 5 UTF-16 units).
+        assert_eq!(flagged_str_runtime_utf16_length("\u{FFFD}d7ff"), 5);
+        // Supplementary-plane codepoint (U+1F600 😀) encodes as a UTF-16 surrogate pair → 2 units.
+        assert_eq!(flagged_str_runtime_utf16_length("a\u{1F600}b"), 4);
     }
 }

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -6,6 +6,10 @@
 //! `TemplateElement` `lone_surrogates` flag tells codegen to decode those escapes back into
 //! `\uXXXX`; when the flag is clear, codegen emits the bytes as-is.
 //!
+//! The encoding is produced by `oxc_parser::lexer::unicode` (string literals) and
+//! `oxc_parser::lexer::template` (template elements) at the point they first see a lone
+//! surrogate; both write `\u{FFFD}{code_point:04x}` and set `lone_surrogates: true` on the token.
+//!
 //! Two strings with the same bytes but different flags are different runtime values. Folds that
 //! produce a new `ConstantValue::String` drop the flag, and `value_to_expr` then builds a literal
 //! defaulting to `lone_surrogates: false` — so any fold consuming a `lone_surrogates: true` input

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -87,7 +87,9 @@ pub fn array_may_have_lone_surrogates<'a>(
 /// Identifiers are resolved through `ctx.get_constant_value_for_reference_id` and the resulting
 /// `ConstantValue::String` bytes are byte-scanned. That loses the AST flag but is sound for
 /// bail-out: a lone-surrogate literal's bytes always contain the encoding, and a byte-identical
-/// non-surrogate string only causes a missed fold.
+/// non-surrogate string only causes a missed fold. One source of such byte-identical constants
+/// is a prior concat like `'�' + 'dc00'` — neither operand is flagged, the concat folds
+/// legitimately, and the resulting `ConstantValue::String` bytes match the encoding pattern.
 pub fn expr_may_have_lone_surrogates<'a>(
     expr: &Expression<'a>,
     ctx: &impl GlobalContext<'a>,

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -103,10 +103,19 @@ pub fn template_may_have_lone_surrogates<'a>(
 
 /// Returns `true` if any element in `arr` may carry the lone-surrogate encoding.
 ///
-/// `as_expression` skips `SpreadElement` and `Elision`. Sound for the array-join / array-split
-/// folds that call this: `ArrayJoin::array_join` bails on any element whose `to_js_string` fails,
-/// and `SpreadElement::to_js_string` always fails — so an array with a spread never produces a
-/// `ConstantValue::String` for these folds. Elisions stringify to `""`.
+/// `as_expression` skips `SpreadElement` and `Elision`. Sound for every current caller because
+/// each one establishes, by its own precondition, that spreads can't reach a string-producing
+/// fold:
+///
+/// - [`expr_may_have_lone_surrogates`]'s `ArrayExpression` arm reflects `ArrayJoin::array_join`,
+///   which bails on any element whose `to_js_string` fails; `SpreadElement::to_js_string` always
+///   fails, so an array with a spread never produces a `ConstantValue::String` — we can't
+///   mislead a parent that wouldn't itself be misled.
+/// - The minifier's `.split(',')` rewrite in `substitute_array_expression` gates on
+///   `is_all_string` (every element is a `StringLiteral`), ruling out spreads before this check.
+///
+/// Elisions stringify to `""`, so skipping them is also sound. If a future caller doesn't
+/// satisfy one of these preconditions, it has to justify spread-skip on its own terms.
 ///
 /// Split out from [`expr_may_have_lone_surrogates`]'s `ArrayExpression` arm so sites that hold an
 /// `&ArrayExpression` directly can reuse the check.

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -134,27 +134,23 @@ pub fn expr_may_have_lone_surrogates<'a>(
             e.expressions.last().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))
         }
         Expression::ParenthesizedExpression(e) => expr_may_have_lone_surrogates(&e.expression, ctx),
-        // The catch-all rests on two separate arguments, one per group of remaining kinds:
+        // Catch-all: two groups of remaining kinds, same result.
         //
-        // (1) `UnaryExpression` (`typeof`/`void`/`!` etc.) yields fixed ASCII strings,
-        //     `MemberExpression` / `ChainExpression` only fold `.length` → number, and
-        //     `AssignmentExpression` / `UpdateExpression` are rejected upstream by
-        //     `may_have_side_effects`. None of these can surface a lone-surrogate string value
-        //     for a parent fold to consume.
+        // (1) Kinds that can't surface a lone-surrogate string for a parent to consume:
+        //     `UnaryExpression` (`typeof`/`void`/`!`) yields fixed ASCII; `MemberExpression` /
+        //     `ChainExpression` only fold `.length` → number; `AssignmentExpression` /
+        //     `UpdateExpression` are gated out upstream by `may_have_side_effects`.
         //
         // (2) `CallExpression` / `NewExpression` / `TaggedTemplateExpression` *can* produce a
-        //     string (via `CallExpression::evaluate_value_to` → `try_fold_known_global_methods`,
-        //     plus the `.concat` path in `replace_known_methods.rs`). We do not analyse them
-        //     here; instead, each string-producing fold carries its own lone-surrogate bailout
-        //     at the point it would emit a literal. Because children fold before parents, by
-        //     the time a parent checks this function on a call, either the call has already
-        //     been rewritten to a `StringLiteral` (caught by the first arm of this match) or
-        //     it didn't fold. Returning `false` here is therefore safe *as long as* every
-        //     string-producing fold preserves that invariant.
+        //     string (via `try_fold_known_global_methods` and the `.concat` path in
+        //     `replace_known_methods`). We don't analyse them; each string-producing fold
+        //     bails itself. Bottom-up evaluation then guarantees a parent sees either an
+        //     already-rewritten `StringLiteral` (caught by the first arm above) or a
+        //     still-un-folded call — returning `false` is safe while that invariant holds.
         //
-        // When adding a new string-producing fold, either add its corresponding `Expression`
-        // kind as a dedicated arm above, or add an explicit `expr_may_have_lone_surrogates`
-        // check at the fold site before emitting a literal.
+        // When adding a new string-producing fold: either add a dedicated arm above for its
+        // `Expression` kind, or guard the fold site with `expr_may_have_lone_surrogates`
+        // before emitting a literal.
         _ => false,
     }
 }

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -59,6 +59,24 @@ pub fn template_may_have_lone_surrogates<'a>(
         || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
 }
 
+/// Returns `true` if any element in `arr` may carry the lone-surrogate encoding.
+///
+/// `as_expression` skips `SpreadElement` and `Elision`. Sound for the array-join / array-split
+/// folds that call this: `ArrayJoin::array_join` bails on any element whose `to_js_string` fails,
+/// and `SpreadElement::to_js_string` always fails — so an array with a spread never produces a
+/// `ConstantValue::String` for these folds. Elisions stringify to `""`.
+///
+/// Split out from [`expr_may_have_lone_surrogates`]'s `ArrayExpression` arm so sites that hold an
+/// `&ArrayExpression` directly can reuse the check.
+pub fn array_may_have_lone_surrogates<'a>(
+    arr: &ArrayExpression<'a>,
+    ctx: &impl GlobalContext<'a>,
+) -> bool {
+    arr.elements
+        .iter()
+        .any(|el| el.as_expression().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx)))
+}
+
 /// Returns `true` if the expression, when stringified, may carry the lone-surrogate encoding.
 ///
 /// Fold sites call this before consuming an operand's string value; when it returns `true`, the
@@ -81,14 +99,7 @@ pub fn expr_may_have_lone_surrogates<'a>(
             expr_may_have_lone_surrogates(&e.left, ctx)
                 || expr_may_have_lone_surrogates(&e.right, ctx)
         }
-        Expression::ArrayExpression(arr) => arr
-            .elements
-            .iter()
-            // `as_expression` skips `SpreadElement` and `Elision`. Sound because
-            // `ArrayJoin::array_join` bails on any element whose `to_js_string` fails, and
-            // `SpreadElement::to_js_string` always fails — so an array with a spread never
-            // produces a `ConstantValue::String` for these folds. Elisions stringify to `""`.
-            .any(|el| el.as_expression().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))),
+        Expression::ArrayExpression(arr) => array_may_have_lone_surrogates(arr, ctx),
         Expression::Identifier(ident) => ident
             .reference_id
             .get()

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -51,6 +51,33 @@ pub fn str_has_lone_surrogate_encoding(s: &str) -> bool {
     bytes.windows(7).any(|w| w[..3] == [0xEF, 0xBF, 0xBD] && is_lone_surrogate_suffix(&w[3..]))
 }
 
+/// Counts non-overlapping `\u{FFFD}XXXX` encoded runs in `s`.
+///
+/// Each run represents a single UTF-16 code unit at runtime — a lone surrogate, or U+FFFD itself
+/// via the `fffd` self-escape — while occupying 5 stored code units. For a flagged string the
+/// runtime length is therefore `s.encode_utf16().count() - 4 * count_lone_surrogate_runs(s)`.
+///
+/// The scan is purely on bytes, so in an unflagged string with coincidentally matching bytes (a
+/// real U+FFFD followed by four hex characters) this also counts a run; callers must have
+/// established the literal is flagged before using the count for a length calculation.
+pub fn count_lone_surrogate_runs(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    if !bytes.contains(&0xEF) {
+        return 0;
+    }
+    let mut count = 0;
+    let mut i = 0;
+    while i + 7 <= bytes.len() {
+        if bytes[i..i + 3] == [0xEF, 0xBF, 0xBD] && is_lone_surrogate_suffix(&bytes[i + 3..i + 7]) {
+            count += 1;
+            i += 7;
+        } else {
+            i += 1;
+        }
+    }
+    count
+}
+
 fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
     debug_assert_eq!(b.len(), 4);
     // Surrogate range d800–dfff, lowercase hex.
@@ -200,7 +227,7 @@ pub fn get_side_free_string_value_without_lone_surrogates<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::str_has_lone_surrogate_encoding;
+    use super::{count_lone_surrogate_runs, str_has_lone_surrogate_encoding};
 
     #[test]
     fn empty_and_short_inputs() {
@@ -260,5 +287,18 @@ mod tests {
     fn lone_u_fffd_alone_is_not_the_encoding() {
         assert!(!str_has_lone_surrogate_encoding("\u{FFFD}"));
         assert!(!str_has_lone_surrogate_encoding("hello \u{FFFD} world"));
+    }
+
+    #[test]
+    fn counts_non_overlapping_runs() {
+        assert_eq!(count_lone_surrogate_runs(""), 0);
+        assert_eq!(count_lone_surrogate_runs("plain"), 0);
+        assert_eq!(count_lone_surrogate_runs("\u{FFFD}d800"), 1);
+        assert_eq!(count_lone_surrogate_runs("\u{FFFD}d800\u{FFFD}dc00"), 2);
+        // Self-escape counts as a run (one U+FFFD at runtime).
+        assert_eq!(count_lone_surrogate_runs("\u{FFFD}fffd\u{FFFD}d800"), 2);
+        // Non-matching U+FFFD occurrences aren't counted.
+        assert_eq!(count_lone_surrogate_runs("\u{FFFD}\u{FFFD}d800"), 1);
+        assert_eq!(count_lone_surrogate_runs("a\u{FFFD}dc00b\u{FFFD}dfffc"), 2);
     }
 }

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -162,7 +162,7 @@ pub fn expr_may_have_lone_surrogates<'a>(
 /// at every fold site that reads an operand's string and emits a new `StringLiteral` from the
 /// bytes. Collapsing it into one call keeps the invariant ("consume only flag-safe bytes") in
 /// one place and avoids drift between sites.
-pub fn get_side_free_string_value_safe<'a>(
+pub fn get_side_free_string_value_without_lone_surrogates<'a>(
     expr: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<Cow<'a, str>> {

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -126,7 +126,11 @@ pub fn expr_may_have_lone_surrogates<'a>(
                 ConstantValue::String(s) => str_has_lone_surrogate_encoding(&s),
                 _ => false,
             }),
-        Expression::UnaryExpression(e) => expr_may_have_lone_surrogates(&e.argument, ctx),
+        // Every `UnaryExpression` kind that `to_js_string` handles
+        // (`void x` → `"undefined"`, `!x` → `"true"`/`"false"`) produces
+        // a fixed ASCII string regardless of the operand, so the
+        // operand's contents can't flow into a lone-surrogate result.
+        Expression::UnaryExpression(_) => false,
         Expression::LogicalExpression(e) => {
             expr_may_have_lone_surrogates(&e.left, ctx)
                 || expr_may_have_lone_surrogates(&e.right, ctx)

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -23,7 +23,7 @@ use std::borrow::Cow;
 use oxc_ast::ast::*;
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::GlobalContext;
+use crate::{GlobalContext, side_effects::MayHaveSideEffects};
 
 use super::{ConstantEvaluation, ConstantEvaluationCtx, ConstantValue};
 
@@ -108,12 +108,14 @@ pub fn expr_may_have_lone_surrogates<'a>(
                 || expr_may_have_lone_surrogates(&e.right, ctx)
         }
         Expression::ArrayExpression(arr) => array_may_have_lone_surrogates(arr, ctx),
-        // TODO: when the caller follows this up with `get_side_free_string_value` /
-        // `evaluate_value` on the same identifier, the resolution happens twice — once here
-        // and once at the fold site. `try_fold_string_casing` inlines its own resolution to
-        // avoid that; every other fold site pays the double lookup. A helper that returns
-        // `Option<Cow<str>>` directly from this check (instead of just `bool`) could thread
-        // the resolved value through and kill the second lookup everywhere.
+        // The Identifier arm pays a `get_constant_value_for_reference_id` lookup; fold sites that
+        // pair a gate check with `get_side_free_string_value` / `evaluate_value_to_string` on the
+        // same identifier then pay a second one. `get_side_free_string_value_without_lone_surrogates`
+        // collapses the two into one lookup for its callers. `try_fold_string_casing` inlines its
+        // own resolution; the remaining standalone call sites in `equality_comparison`,
+        // `is_less_than`, binary-`+` in `mod.rs`, the `a + 'b' + 'c'` reshape, and `String()` in
+        // `substitute_alternate_syntax` still pay the double lookup — each uses a different
+        // string-fetching method, so a single shared helper doesn't fit them all.
         Expression::Identifier(ident) => ident
             .reference_id
             .get()
@@ -162,10 +164,25 @@ pub fn expr_may_have_lone_surrogates<'a>(
 /// at every fold site that reads an operand's string and emits a new `StringLiteral` from the
 /// bytes. Collapsing it into one call keeps the invariant ("consume only flag-safe bytes") in
 /// one place and avoids drift between sites.
+///
+/// For a constant-bound `Identifier`, resolves the binding once rather than looking it up twice
+/// (in `expr_may_have_lone_surrogates` and again in `get_side_free_string_value`). Globals like
+/// `undefined`/`Infinity`/`NaN` — which `get_side_free_string_value` stringifies via
+/// `ToJsString` without a constant lookup — go through the generic fall-through below.
 pub fn get_side_free_string_value_without_lone_surrogates<'a>(
     expr: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<Cow<'a, str>> {
+    if let Expression::Identifier(ident) = expr
+        && let Some(rid) = ident.reference_id.get()
+        && let Some(cv) = ctx.get_constant_value_for_reference_id(rid)
+    {
+        if expr.may_have_side_effects(ctx) {
+            return None;
+        }
+        let s = cv.into_string()?;
+        return (!str_has_lone_surrogate_encoding(&s)).then_some(s);
+    }
     if expr_may_have_lone_surrogates(expr, ctx) {
         return None;
     }

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -197,33 +197,32 @@ pub fn expr_may_have_lone_surrogates<'a>(
         }
         Expression::ParenthesizedExpression(e) => expr_may_have_lone_surrogates(&e.expression, ctx),
 
-        // `Call` / `New` / `TaggedTemplate` *can* fold to a string (via `try_fold_known_global_methods`
-        // and the `.concat` path in `replace_known_methods`), but every string-producing fold
-        // self-bails on flagged inputs. Under bottom-up evaluation, a parent therefore sees either
-        // an already-rewritten `StringLiteral` (caught by the first arm above) or a still-unfolded
-        // call whose `evaluate_value` will return `None` at the same bail — in neither case does a
-        // flagged string reach the parent through this arm.
+        // All remaining kinds return `false`. Two groups, same result:
         //
-        // Invariant, load-bearing: when adding a new string-producing fold, either add a dedicated
-        // arm above for its `Expression` kind, or guard the fold site with
-        // `expr_may_have_lone_surrogates` before emitting a literal.
-        Expression::CallExpression(_)
-        | Expression::NewExpression(_)
-        | Expression::TaggedTemplateExpression(_) => false,
-
-        // Everything else can't surface a flagged string here:
-        // - Non-string producers: numeric/boolean/null/bigint/regexp literals; object/function/class
-        //   expressions; `MetaProperty`, `Super`, `ThisExpression`, `PrivateInExpression`.
-        // - `BinaryExpression` non-Addition folds to number/boolean/bigint.
-        // - `UnaryExpression` (`typeof`/`void`/`!`/...) yields fixed ASCII or number.
-        // - Member/chain expressions only fold `.length` → number.
-        // - Side-effecting kinds (`Assignment`, `Update`, `Await`, `Yield`, `Import`) are gated out
-        //   upstream by `may_have_side_effects` before any fold emit.
-        // - JSX / TS / V8 intrinsics don't participate in constant-string folding.
+        // (1) `Call` / `New` / `TaggedTemplate` *can* fold to a string (via
+        //     `try_fold_known_global_methods` and the `.concat` path in `replace_known_methods`).
+        //     Load-bearing invariant: every string-producing fold self-bails on flagged inputs, so
+        //     under bottom-up evaluation a parent sees either an already-rewritten `StringLiteral`
+        //     (caught by the first arm above) or a still-unfolded call whose `evaluate_value` will
+        //     return `None` at the same bail — flagged bytes never reach the parent through this
+        //     arm. When adding a new string-producing fold, either add a dedicated arm above for
+        //     its `Expression` kind, or guard the fold site with `expr_may_have_lone_surrogates`
+        //     before emitting a literal.
+        //
+        // (2) Kinds that can't surface a flagged string here at all: numeric/boolean/null/bigint
+        //     /regexp literals; object/function/class expressions; `MetaProperty`, `Super`,
+        //     `ThisExpression`, `PrivateInExpression`; non-Addition `BinaryExpression` (number/
+        //     boolean/bigint); `UnaryExpression` (`typeof`/`void`/`!`/…, fixed ASCII or number);
+        //     member/chain expressions (only fold `.length` → number); side-effecting kinds
+        //     (`Assignment`, `Update`, `Await`, `Yield`, `Import`) gated out upstream by
+        //     `may_have_side_effects`; JSX / TS / V8 intrinsics (not folded to strings).
         //
         // Listed exhaustively (rather than `_ => false`) so a future `Expression` variant yields a
         // compile error here, forcing an explicit decision.
-        Expression::BooleanLiteral(_)
+        Expression::CallExpression(_)
+        | Expression::NewExpression(_)
+        | Expression::TaggedTemplateExpression(_)
+        | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::NumericLiteral(_)
         | Expression::BigIntLiteral(_)

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -14,12 +14,14 @@
 //! Detection is conservative: false positives only skip a fold that could have been performed,
 //! never produce wrong output.
 
+use std::borrow::Cow;
+
 use oxc_ast::ast::*;
 use oxc_syntax::operator::BinaryOperator;
 
 use crate::GlobalContext;
 
-use super::ConstantValue;
+use super::{ConstantEvaluation, ConstantEvaluationCtx, ConstantValue};
 
 /// Returns `true` if `s` contains the lone-surrogate encoding pattern `\u{FFFD}XXXX` — surrogate
 /// range `d800`..=`dfff`, or the self-escape `fffd`.
@@ -151,6 +153,23 @@ pub fn expr_may_have_lone_surrogates<'a>(
         // check at the fold site before emitting a literal.
         _ => false,
     }
+}
+
+/// Extract `expr`'s side-free string value, unless [`expr_may_have_lone_surrogates`] says the
+/// bytes might carry the encoding.
+///
+/// The bail pattern — check the flag/byte-scan, then pull `get_side_free_string_value` — recurs
+/// at every fold site that reads an operand's string and emits a new `StringLiteral` from the
+/// bytes. Collapsing it into one call keeps the invariant ("consume only flag-safe bytes") in
+/// one place and avoids drift between sites.
+pub fn get_side_free_string_value_safe<'a>(
+    expr: &Expression<'a>,
+    ctx: &impl ConstantEvaluationCtx<'a>,
+) -> Option<Cow<'a, str>> {
+    if expr_may_have_lone_surrogates(expr, ctx) {
+        return None;
+    }
+    expr.get_side_free_string_value(ctx)
 }
 
 #[cfg(test)]

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -142,3 +142,68 @@ pub fn expr_may_have_lone_surrogates<'a>(
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::str_has_lone_surrogate_encoding;
+
+    #[test]
+    fn empty_and_short_inputs() {
+        assert!(!str_has_lone_surrogate_encoding(""));
+        assert!(!str_has_lone_surrogate_encoding("abc"));
+        // 6 bytes: one short of the 7-byte window.
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}dc0"));
+    }
+
+    #[test]
+    fn no_u_fffd_short_circuits() {
+        assert!(!str_has_lone_surrogate_encoding("plain ascii text"));
+        assert!(!str_has_lone_surrogate_encoding(&"a".repeat(1024)));
+    }
+
+    #[test]
+    fn surrogate_range_boundaries() {
+        // Low and high surrogate boundaries match.
+        assert!(str_has_lone_surrogate_encoding("\u{FFFD}d800"));
+        assert!(str_has_lone_surrogate_encoding("\u{FFFD}dbff"));
+        assert!(str_has_lone_surrogate_encoding("\u{FFFD}dc00"));
+        assert!(str_has_lone_surrogate_encoding("\u{FFFD}dfff"));
+        // Just outside the surrogate range.
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}d7ff"));
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}e000"));
+    }
+
+    #[test]
+    fn self_escape_for_literal_u_fffd() {
+        assert!(str_has_lone_surrogate_encoding("\u{FFFD}fffd"));
+    }
+
+    #[test]
+    fn uppercase_hex_is_not_the_encoding() {
+        // The encoding uses lowercase hex; `�D800` is real U+FFFD
+        // followed by the ASCII text "D800".
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}D800"));
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}FFFD"));
+    }
+
+    #[test]
+    fn non_hex_suffix_is_rejected() {
+        // `�dz00` — "dz00" isn't a valid hex run, and isn't
+        // "fffd", so no match.
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}dz00"));
+        // `�d80g` — trailing non-hex.
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}d80g"));
+    }
+
+    #[test]
+    fn matches_anywhere_in_string() {
+        assert!(str_has_lone_surrogate_encoding("prefix\u{FFFD}d800suffix"));
+        assert!(str_has_lone_surrogate_encoding("a\u{FFFD}dc00b\u{FFFD}dfffc"));
+    }
+
+    #[test]
+    fn lone_u_fffd_alone_is_not_the_encoding() {
+        assert!(!str_has_lone_surrogate_encoding("\u{FFFD}"));
+        assert!(!str_has_lone_surrogate_encoding("hello \u{FFFD} world"));
+    }
+}

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -95,6 +95,16 @@ pub fn expr_may_have_lone_surrogates<'a>(
         Expression::ArrayExpression(arr) => arr
             .elements
             .iter()
+            // `as_expression` skips `SpreadElement` and `Elision`. That is
+            // sound here because `ArrayJoin::array_join` (the only path
+            // that stringifies an array for the folds we guard) returns
+            // `None` as soon as any element fails to stringify, and
+            // `SpreadElement::to_js_string` always fails — so an array
+            // containing a spread never produces a `ConstantValue::String`
+            // in the first place. Elisions stringify to `""` and can't
+            // contribute lone surrogates. If either of those invariants
+            // changes, this branch would need to recurse into the spread's
+            // argument.
             .any(|el| el.as_expression().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))),
         Expression::Identifier(ident) => ident
             .reference_id

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -196,24 +196,65 @@ pub fn expr_may_have_lone_surrogates<'a>(
             e.expressions.last().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))
         }
         Expression::ParenthesizedExpression(e) => expr_may_have_lone_surrogates(&e.expression, ctx),
-        // Catch-all: two groups of remaining kinds, same result.
+
+        // `Call` / `New` / `TaggedTemplate` *can* fold to a string (via `try_fold_known_global_methods`
+        // and the `.concat` path in `replace_known_methods`), but every string-producing fold
+        // self-bails on flagged inputs. Under bottom-up evaluation, a parent therefore sees either
+        // an already-rewritten `StringLiteral` (caught by the first arm above) or a still-unfolded
+        // call whose `evaluate_value` will return `None` at the same bail — in neither case does a
+        // flagged string reach the parent through this arm.
         //
-        // (1) Kinds that can't surface a lone-surrogate string for a parent to consume:
-        //     `UnaryExpression` (`typeof`/`void`/`!`) yields fixed ASCII; `MemberExpression` /
-        //     `ChainExpression` only fold `.length` → number; `AssignmentExpression` /
-        //     `UpdateExpression` are gated out upstream by `may_have_side_effects`.
+        // Invariant, load-bearing: when adding a new string-producing fold, either add a dedicated
+        // arm above for its `Expression` kind, or guard the fold site with
+        // `expr_may_have_lone_surrogates` before emitting a literal.
+        Expression::CallExpression(_)
+        | Expression::NewExpression(_)
+        | Expression::TaggedTemplateExpression(_) => false,
+
+        // Everything else can't surface a flagged string here:
+        // - Non-string producers: numeric/boolean/null/bigint/regexp literals; object/function/class
+        //   expressions; `MetaProperty`, `Super`, `ThisExpression`, `PrivateInExpression`.
+        // - `BinaryExpression` non-Addition folds to number/boolean/bigint.
+        // - `UnaryExpression` (`typeof`/`void`/`!`/...) yields fixed ASCII or number.
+        // - Member/chain expressions only fold `.length` → number.
+        // - Side-effecting kinds (`Assignment`, `Update`, `Await`, `Yield`, `Import`) are gated out
+        //   upstream by `may_have_side_effects` before any fold emit.
+        // - JSX / TS / V8 intrinsics don't participate in constant-string folding.
         //
-        // (2) `CallExpression` / `NewExpression` / `TaggedTemplateExpression` *can* produce a
-        //     string (via `try_fold_known_global_methods` and the `.concat` path in
-        //     `replace_known_methods`). We don't analyse them; each string-producing fold
-        //     bails itself. Bottom-up evaluation then guarantees a parent sees either an
-        //     already-rewritten `StringLiteral` (caught by the first arm above) or a
-        //     still-un-folded call — returning `false` is safe while that invariant holds.
-        //
-        // When adding a new string-producing fold: either add a dedicated arm above for its
-        // `Expression` kind, or guard the fold site with `expr_may_have_lone_surrogates`
-        // before emitting a literal.
-        _ => false,
+        // Listed exhaustively (rather than `_ => false`) so a future `Expression` variant yields a
+        // compile error here, forcing an explicit decision.
+        Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::MetaProperty(_)
+        | Expression::Super(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::AssignmentExpression(_)
+        | Expression::AwaitExpression(_)
+        | Expression::BinaryExpression(_)
+        | Expression::ChainExpression(_)
+        | Expression::ClassExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::ImportExpression(_)
+        | Expression::ObjectExpression(_)
+        | Expression::ThisExpression(_)
+        | Expression::UnaryExpression(_)
+        | Expression::UpdateExpression(_)
+        | Expression::YieldExpression(_)
+        | Expression::PrivateInExpression(_)
+        | Expression::JSXElement(_)
+        | Expression::JSXFragment(_)
+        | Expression::TSAsExpression(_)
+        | Expression::TSSatisfiesExpression(_)
+        | Expression::TSTypeAssertion(_)
+        | Expression::TSNonNullExpression(_)
+        | Expression::TSInstantiationExpression(_)
+        | Expression::V8IntrinsicExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => false,
     }
 }
 

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -1,0 +1,122 @@
+//! Detection helpers for bailing out of folds that would drop the
+//! `lone_surrogates` flag.
+//!
+//! Some JS strings contain unpaired UTF-16 surrogates that are not
+//! representable in UTF-8. `oxc_ast` stores them in a special encoding:
+//! the string's bytes use `\u{FFFD}XXXX` (U+FFFD followed by four
+//! lowercase hex digits) as an escape sequence — surrogate code points
+//! as `\u{FFFD}d800..\u{FFFD}dfff`, and literal U+FFFD as
+//! `\u{FFFD}fffd`. The `StringLiteral::lone_surrogates` /
+//! `TemplateElement::lone_surrogates` flag tells codegen to decode the
+//! escape back into `\uXXXX` sequences; when the flag is clear, codegen
+//! emits the bytes as-is.
+//!
+//! The flag and the bytes are equally load-bearing. Two strings with
+//! the same bytes but different flags are different strings at runtime.
+//! Folds that produce a new `ConstantValue::String` discard the flag
+//! (and the surrounding `value_to_expr` defaults the new literal's flag
+//! to `false`), so any fold consuming a `lone_surrogates: true` input
+//! would silently corrupt the value. The helpers here let callers
+//! detect that and bail out rather than fold.
+//!
+//! The detection is conservative — callers over-approximate rather than
+//! risk a missed bailout. A false positive only skips a fold that could
+//! have been performed; it never produces incorrect output.
+
+use oxc_ast::ast::*;
+use oxc_syntax::operator::BinaryOperator;
+
+use crate::GlobalContext;
+
+use super::ConstantValue;
+
+/// Returns `true` if `s` contains the lone-surrogate encoding pattern
+/// `\u{FFFD}XXXX` where `XXXX` is a surrogate-range hex value
+/// (`d800`..=`dfff`) or the self-escape `fffd`.
+///
+/// Scans the raw bytes without consulting any AST flag, so it also
+/// matches a genuine U+FFFD that happens to precede four matching hex
+/// characters. That false-positive case only causes callers to skip a
+/// fold — it cannot produce wrong output.
+pub fn str_has_lone_surrogate_encoding(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    // U+FFFD is `EF BF BD` in UTF-8; bail early if the leading byte is
+    // absent (the common case for ASCII-heavy code).
+    if !bytes.contains(&0xEF) {
+        return false;
+    }
+    // 3 bytes for U+FFFD + 4 bytes for the hex suffix.
+    bytes.windows(7).any(|w| w[..3] == [0xEF, 0xBF, 0xBD] && is_lone_surrogate_suffix(&w[3..]))
+}
+
+fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
+    debug_assert_eq!(b.len(), 4);
+    // Surrogate range d800–dfff, lowercase hex.
+    (b[0] == b'd'
+        && matches!(b[1], b'8'..=b'9' | b'a'..=b'f')
+        && matches!(b[2], b'0'..=b'9' | b'a'..=b'f')
+        && matches!(b[3], b'0'..=b'9' | b'a'..=b'f'))
+        // Self-escape for a real U+FFFD inside a lone-surrogate string.
+        || b == b"fffd"
+}
+
+/// Returns `true` if the expression, when stringified, may carry the
+/// lone-surrogate encoding.
+///
+/// Used at fold sites that would otherwise consume the expression's
+/// string value. When this returns `true`, the caller must skip the
+/// fold — otherwise the fold would produce a new string literal with
+/// `lone_surrogates: false`, silently corrupting the value.
+///
+/// Conservatively over-approximates: for kinds it can't analyse
+/// precisely (e.g. an identifier whose initializer uses the encoding),
+/// it returns `true`. False positives only cause a missed fold.
+///
+/// Identifiers are resolved through `ctx.get_constant_value_for_reference_id`
+/// and the resulting `ConstantValue::String` bytes are byte-scanned. That
+/// loses the AST flag but is sound for bail-out purposes: if the source
+/// was a lone-surrogate literal, its bytes contain the encoding; if it
+/// wasn't but the bytes happen to match, the false positive only skips a
+/// fold.
+pub fn expr_may_have_lone_surrogates<'a>(
+    expr: &Expression<'a>,
+    ctx: &impl GlobalContext<'a>,
+) -> bool {
+    match expr {
+        Expression::StringLiteral(s) => s.lone_surrogates,
+        Expression::TemplateLiteral(t) => {
+            t.quasis.iter().any(|q| q.lone_surrogates)
+                || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
+        }
+        Expression::BinaryExpression(e) if e.operator == BinaryOperator::Addition => {
+            expr_may_have_lone_surrogates(&e.left, ctx)
+                || expr_may_have_lone_surrogates(&e.right, ctx)
+        }
+        Expression::ArrayExpression(arr) => arr
+            .elements
+            .iter()
+            .any(|el| el.as_expression().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))),
+        Expression::Identifier(ident) => ident
+            .reference_id
+            .get()
+            .and_then(|rid| ctx.get_constant_value_for_reference_id(rid))
+            .is_some_and(|cv| match cv {
+                ConstantValue::String(s) => str_has_lone_surrogate_encoding(&s),
+                _ => false,
+            }),
+        Expression::UnaryExpression(e) => expr_may_have_lone_surrogates(&e.argument, ctx),
+        Expression::LogicalExpression(e) => {
+            expr_may_have_lone_surrogates(&e.left, ctx)
+                || expr_may_have_lone_surrogates(&e.right, ctx)
+        }
+        Expression::ConditionalExpression(e) => {
+            expr_may_have_lone_surrogates(&e.consequent, ctx)
+                || expr_may_have_lone_surrogates(&e.alternate, ctx)
+        }
+        Expression::SequenceExpression(e) => {
+            e.expressions.last().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))
+        }
+        Expression::ParenthesizedExpression(e) => expr_may_have_lone_surrogates(&e.expression, ctx),
+        _ => false,
+    }
+}

--- a/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs
@@ -1,27 +1,18 @@
-//! Detection helpers for bailing out of folds that would drop the
-//! `lone_surrogates` flag.
+//! Detection helpers for bailing out of folds that would drop the `lone_surrogates` flag.
 //!
-//! Some JS strings contain unpaired UTF-16 surrogates that are not
-//! representable in UTF-8. `oxc_ast` stores them in a special encoding:
-//! the string's bytes use `\u{FFFD}XXXX` (U+FFFD followed by four
-//! lowercase hex digits) as an escape sequence — surrogate code points
-//! as `\u{FFFD}d800..\u{FFFD}dfff`, and literal U+FFFD as
-//! `\u{FFFD}fffd`. The `StringLiteral::lone_surrogates` /
-//! `TemplateElement::lone_surrogates` flag tells codegen to decode the
-//! escape back into `\uXXXX` sequences; when the flag is clear, codegen
-//! emits the bytes as-is.
+//! `oxc_ast` stores strings with unpaired UTF-16 surrogates in a special encoding: each surrogate
+//! code point is spelled `\u{FFFD}XXXX` (U+FFFD followed by four lowercase hex digits), with
+//! `\u{FFFD}fffd` reserved as the self-escape for a real U+FFFD. The `StringLiteral` /
+//! `TemplateElement` `lone_surrogates` flag tells codegen to decode those escapes back into
+//! `\uXXXX`; when the flag is clear, codegen emits the bytes as-is.
 //!
-//! The flag and the bytes are equally load-bearing. Two strings with
-//! the same bytes but different flags are different strings at runtime.
-//! Folds that produce a new `ConstantValue::String` discard the flag
-//! (and the surrounding `value_to_expr` defaults the new literal's flag
-//! to `false`), so any fold consuming a `lone_surrogates: true` input
-//! would silently corrupt the value. The helpers here let callers
-//! detect that and bail out rather than fold.
+//! Two strings with the same bytes but different flags are different runtime values. Folds that
+//! produce a new `ConstantValue::String` drop the flag, and `value_to_expr` then builds a literal
+//! defaulting to `lone_surrogates: false` — so any fold consuming a `lone_surrogates: true` input
+//! would silently corrupt the value. The helpers here let callers detect that and bail.
 //!
-//! The detection is conservative — callers over-approximate rather than
-//! risk a missed bailout. A false positive only skips a fold that could
-//! have been performed; it never produces incorrect output.
+//! Detection is conservative: false positives only skip a fold that could have been performed,
+//! never produce wrong output.
 
 use oxc_ast::ast::*;
 use oxc_syntax::operator::BinaryOperator;
@@ -30,18 +21,14 @@ use crate::GlobalContext;
 
 use super::ConstantValue;
 
-/// Returns `true` if `s` contains the lone-surrogate encoding pattern
-/// `\u{FFFD}XXXX` where `XXXX` is a surrogate-range hex value
-/// (`d800`..=`dfff`) or the self-escape `fffd`.
+/// Returns `true` if `s` contains the lone-surrogate encoding pattern `\u{FFFD}XXXX` — surrogate
+/// range `d800`..=`dfff`, or the self-escape `fffd`.
 ///
-/// Scans the raw bytes without consulting any AST flag, so it also
-/// matches a genuine U+FFFD that happens to precede four matching hex
-/// characters. That false-positive case only causes callers to skip a
-/// fold — it cannot produce wrong output.
+/// Scans raw bytes without consulting any AST flag, so a genuine U+FFFD followed by four matching
+/// hex characters also matches. That false positive only skips a fold.
 pub fn str_has_lone_surrogate_encoding(s: &str) -> bool {
     let bytes = s.as_bytes();
-    // U+FFFD is `EF BF BD` in UTF-8; bail early if the leading byte is
-    // absent (the common case for ASCII-heavy code).
+    // U+FFFD is `EF BF BD` in UTF-8; short-circuit when absent (the common case).
     if !bytes.contains(&0xEF) {
         return false;
     }
@@ -60,13 +47,10 @@ fn is_lone_surrogate_suffix(b: &[u8]) -> bool {
         || b == b"fffd"
 }
 
-/// Returns `true` if any quasi or interpolation in `t` may carry the
-/// lone-surrogate encoding.
+/// Returns `true` if any quasi or interpolation in `t` may carry the lone-surrogate encoding.
 ///
-/// Split out from [`expr_may_have_lone_surrogates`]'s `TemplateLiteral`
-/// arm so minifier sites that hold a `&TemplateLiteral` directly (not
-/// wrapped in an `Expression`) can use the same check without an
-/// `Expression::TemplateLiteral(...)` round-trip.
+/// Split out from [`expr_may_have_lone_surrogates`]'s `TemplateLiteral` arm so sites that hold a
+/// `&TemplateLiteral` directly can reuse the check.
 pub fn template_may_have_lone_surrogates<'a>(
     t: &TemplateLiteral<'a>,
     ctx: &impl GlobalContext<'a>,
@@ -75,24 +59,17 @@ pub fn template_may_have_lone_surrogates<'a>(
         || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
 }
 
-/// Returns `true` if the expression, when stringified, may carry the
-/// lone-surrogate encoding.
+/// Returns `true` if the expression, when stringified, may carry the lone-surrogate encoding.
 ///
-/// Used at fold sites that would otherwise consume the expression's
-/// string value. When this returns `true`, the caller must skip the
-/// fold — otherwise the fold would produce a new string literal with
-/// `lone_surrogates: false`, silently corrupting the value.
+/// Fold sites call this before consuming an operand's string value; when it returns `true`, the
+/// caller must skip the fold or the result would be a new string literal with `lone_surrogates:
+/// false`, silently corrupting the value. Conservatively over-approximates — false positives only
+/// cost a missed fold.
 ///
-/// Conservatively over-approximates: for kinds it can't analyse
-/// precisely (e.g. an identifier whose initializer uses the encoding),
-/// it returns `true`. False positives only cause a missed fold.
-///
-/// Identifiers are resolved through `ctx.get_constant_value_for_reference_id`
-/// and the resulting `ConstantValue::String` bytes are byte-scanned. That
-/// loses the AST flag but is sound for bail-out purposes: if the source
-/// was a lone-surrogate literal, its bytes contain the encoding; if it
-/// wasn't but the bytes happen to match, the false positive only skips a
-/// fold.
+/// Identifiers are resolved through `ctx.get_constant_value_for_reference_id` and the resulting
+/// `ConstantValue::String` bytes are byte-scanned. That loses the AST flag but is sound for
+/// bail-out: a lone-surrogate literal's bytes always contain the encoding, and a byte-identical
+/// non-surrogate string only causes a missed fold.
 pub fn expr_may_have_lone_surrogates<'a>(
     expr: &Expression<'a>,
     ctx: &impl GlobalContext<'a>,
@@ -107,16 +84,10 @@ pub fn expr_may_have_lone_surrogates<'a>(
         Expression::ArrayExpression(arr) => arr
             .elements
             .iter()
-            // `as_expression` skips `SpreadElement` and `Elision`. That is
-            // sound here because `ArrayJoin::array_join` (the only path
-            // that stringifies an array for the folds we guard) returns
-            // `None` as soon as any element fails to stringify, and
-            // `SpreadElement::to_js_string` always fails — so an array
-            // containing a spread never produces a `ConstantValue::String`
-            // in the first place. Elisions stringify to `""` and can't
-            // contribute lone surrogates. If either of those invariants
-            // changes, this branch would need to recurse into the spread's
-            // argument.
+            // `as_expression` skips `SpreadElement` and `Elision`. Sound because
+            // `ArrayJoin::array_join` bails on any element whose `to_js_string` fails, and
+            // `SpreadElement::to_js_string` always fails — so an array with a spread never
+            // produces a `ConstantValue::String` for these folds. Elisions stringify to `""`.
             .any(|el| el.as_expression().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))),
         Expression::Identifier(ident) => ident
             .reference_id
@@ -138,23 +109,27 @@ pub fn expr_may_have_lone_surrogates<'a>(
             e.expressions.last().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx))
         }
         Expression::ParenthesizedExpression(e) => expr_may_have_lone_surrogates(&e.expression, ctx),
-        // The catch-all covers every other kind, notably:
-        // - `UnaryExpression`: `void x` → `"undefined"` and `!x` →
-        //   `"true"`/`"false"` produce fixed ASCII regardless of the
-        //   operand, so a lone-surrogate operand can't flow through.
-        // - `CallExpression` / `NewExpression` / `TaggedTemplateExpression`:
-        //   side-effecting and either fold to a literal elsewhere
-        //   (caught by the literal arm above) or don't fold at all.
-        // - `MemberExpression` / `ChainExpression`: only `.length` folds
-        //   today, and that yields a number, so no string-valued result
-        //   can flow through.
-        // - `AssignmentExpression` / `UpdateExpression`: side effects,
-        //   so fold paths bail via `may_have_side_effects` first.
+        // The catch-all rests on two separate arguments, one per group of remaining kinds:
         //
-        // If a new `to_js_string` impl adds a string-producing kind
-        // that could carry lone surrogates, add a dedicated arm for it
-        // above — the catch-all is not a license to silently skip a
-        // string producer.
+        // (1) `UnaryExpression` (`typeof`/`void`/`!` etc.) yields fixed ASCII strings,
+        //     `MemberExpression` / `ChainExpression` only fold `.length` → number, and
+        //     `AssignmentExpression` / `UpdateExpression` are rejected upstream by
+        //     `may_have_side_effects`. None of these can surface a lone-surrogate string value
+        //     for a parent fold to consume.
+        //
+        // (2) `CallExpression` / `NewExpression` / `TaggedTemplateExpression` *can* produce a
+        //     string (via `CallExpression::evaluate_value_to` → `try_fold_known_global_methods`,
+        //     plus the `.concat` path in `replace_known_methods.rs`). We do not analyse them
+        //     here; instead, each string-producing fold carries its own lone-surrogate bailout
+        //     at the point it would emit a literal. Because children fold before parents, by
+        //     the time a parent checks this function on a call, either the call has already
+        //     been rewritten to a `StringLiteral` (caught by the first arm of this match) or
+        //     it didn't fold. Returning `false` here is therefore safe *as long as* every
+        //     string-producing fold preserves that invariant.
+        //
+        // When adding a new string-producing fold, either add its corresponding `Expression`
+        // kind as a dedicated arm above, or add an explicit `expr_may_have_lone_surrogates`
+        // check at the fold site before emitting a literal.
         _ => false,
     }
 }

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -561,7 +561,16 @@ fn evaluate_value_length<'a>(
         && s.lone_surrogates
     {
         let stored = s.value.encode_utf16().count();
-        let runtime = stored - 4 * count_lone_surrogate_runs(&s.value);
+        let runs = count_lone_surrogate_runs(&s.value);
+        // A well-formed flagged literal (parser-produced) satisfies `stored >= 5 * runs >= 4 * runs`,
+        // so the subtraction is exact. `saturating_sub` defends against a synthetic AST where the
+        // flag is set without a matching encoded run: better to miss a fold than to wrap.
+        debug_assert!(
+            stored >= 4 * runs,
+            "flagged literal without matching encoding: {:?}",
+            s.value
+        );
+        let runtime = stored.saturating_sub(4 * runs);
         return Some(ConstantValue::Number(runtime.to_f64().unwrap()));
     }
     if let Some(ConstantValue::String(s)) = object.evaluate_value(ctx) {

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -2,12 +2,14 @@ mod call_expr;
 mod equality_comparison;
 mod is_int32_or_uint32;
 mod is_literal_value;
+mod lone_surrogates;
 mod url_encoding;
 mod value;
 mod value_type;
 
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
+pub use lone_surrogates::{expr_may_have_lone_surrogates, str_has_lone_surrogate_encoding};
 pub use value::ConstantValue;
 pub use value_type::{DetermineValueType, ValueType};
 
@@ -216,6 +218,16 @@ fn binary_operation_evaluate_value_to<'a>(
             if left_to_primitive.is_string() == Some(true)
                 || right_to_primitive.is_string() == Some(true)
             {
+                // A concatenated result materialized via `value_to_expr`
+                // would be a bare `StringLiteral` with
+                // `lone_surrogates: false`, losing the flag that
+                // distinguishes a real U+FFFD from an encoded surrogate.
+                // Bail out and let codegen emit the two operands as-is.
+                if expr_may_have_lone_surrogates(left, ctx)
+                    || expr_may_have_lone_surrogates(right, ctx)
+                {
+                    return None;
+                }
                 let lval = left.evaluate_value_to_string(ctx)?;
                 let rval = right.evaluate_value_to_string(ctx)?;
                 return Some(ConstantValue::String(lval + rval));
@@ -534,6 +546,14 @@ fn evaluate_value_length<'a>(
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if let Some(ConstantValue::String(s)) = object.evaluate_value(ctx) {
+        // `s` holds the lone-surrogate-encoded bytes for strings whose
+        // source flagged `lone_surrogates: true`. Counting its UTF-16
+        // units would report the length of the encoding, not the
+        // runtime string (each surrogate is 1 code unit but 5 chars
+        // here).
+        if expr_may_have_lone_surrogates(object, ctx) {
+            return None;
+        }
         Some(ConstantValue::Number(s.encode_utf16().count().to_f64().unwrap()))
     } else if let Expression::ArrayExpression(arr) = object {
         if arr.elements.iter().any(|e| matches!(e, ArrayExpressionElement::SpreadElement(_))) {

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -10,9 +10,9 @@ mod value_type;
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
 pub use lone_surrogates::{
-    array_may_have_lone_surrogates, count_lone_surrogate_runs, expr_may_have_lone_surrogates,
-    get_side_free_string_value_without_lone_surrogates, str_has_lone_surrogate_encoding,
-    template_may_have_lone_surrogates,
+    array_may_have_lone_surrogates, expr_may_have_lone_surrogates,
+    flagged_str_runtime_utf16_length, get_side_free_string_value_without_lone_surrogates,
+    str_has_lone_surrogate_encoding, template_may_have_lone_surrogates,
 };
 pub use value::ConstantValue;
 pub use value_type::{DetermineValueType, ValueType};
@@ -560,17 +560,7 @@ fn evaluate_value_length<'a>(
     if let Expression::StringLiteral(s) = object
         && s.lone_surrogates
     {
-        let stored = s.value.encode_utf16().count();
-        let runs = count_lone_surrogate_runs(&s.value);
-        // A well-formed flagged literal (parser-produced) satisfies `stored >= 5 * runs >= 4 * runs`,
-        // so the subtraction is exact. `saturating_sub` defends against a synthetic AST where the
-        // flag is set without a matching encoded run: better to miss a fold than to wrap.
-        debug_assert!(
-            stored >= 4 * runs,
-            "flagged literal without matching encoding: {:?}",
-            s.value
-        );
-        let runtime = stored.saturating_sub(4 * runs);
+        let runtime = flagged_str_runtime_utf16_length(&s.value);
         return Some(ConstantValue::Number(runtime.to_f64().unwrap()));
     }
     if let Some(ConstantValue::String(s)) = object.evaluate_value(ctx) {

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -10,8 +10,9 @@ mod value_type;
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
 pub use lone_surrogates::{
-    array_may_have_lone_surrogates, expr_may_have_lone_surrogates, get_side_free_string_value_safe,
-    str_has_lone_surrogate_encoding, template_may_have_lone_surrogates,
+    array_may_have_lone_surrogates, expr_may_have_lone_surrogates,
+    get_side_free_string_value_without_lone_surrogates, str_has_lone_surrogate_encoding,
+    template_may_have_lone_surrogates,
 };
 pub use value::ConstantValue;
 pub use value_type::{DetermineValueType, ValueType};

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -72,6 +72,12 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects<'a> {
     }
 
     /// Evaluate the expression to a constant value and convert it to a string.
+    ///
+    /// The returned `Cow` is the stored byte form and does not carry the `lone_surrogates` flag.
+    /// Any caller that would produce a `StringLiteral` (directly or via `value_to_expr`) from the
+    /// result must first reject flagged operands with [`expr_may_have_lone_surrogates`], or the
+    /// emitted literal will default to `lone_surrogates: false` and silently corrupt the runtime
+    /// value. See `crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs`.
     fn evaluate_value_to_string(
         &self,
         ctx: &impl ConstantEvaluationCtx<'a>,

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -10,7 +10,7 @@ mod value_type;
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
 pub use lone_surrogates::{
-    expr_may_have_lone_surrogates, str_has_lone_surrogate_encoding,
+    array_may_have_lone_surrogates, expr_may_have_lone_surrogates, str_has_lone_surrogate_encoding,
     template_may_have_lone_surrogates,
 };
 pub use value::ConstantValue;

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -77,7 +77,7 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects<'a> {
     /// Any caller that would produce a `StringLiteral` (directly or via `value_to_expr`) from the
     /// result must first reject flagged operands with [`expr_may_have_lone_surrogates`], or the
     /// emitted literal will default to `lone_surrogates: false` and silently corrupt the runtime
-    /// value. See `crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs`.
+    /// value.
     fn evaluate_value_to_string(
         &self,
         ctx: &impl ConstantEvaluationCtx<'a>,

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -221,11 +221,8 @@ fn binary_operation_evaluate_value_to<'a>(
             if left_to_primitive.is_string() == Some(true)
                 || right_to_primitive.is_string() == Some(true)
             {
-                // A concatenated result materialized via `value_to_expr`
-                // would be a bare `StringLiteral` with
-                // `lone_surrogates: false`, losing the flag that
-                // distinguishes a real U+FFFD from an encoded surrogate.
-                // Bail out and let codegen emit the two operands as-is.
+                // A merged literal via `value_to_expr` would lose the flag distinguishing a real
+                // U+FFFD from an encoded surrogate. Leave the two operands for codegen.
                 if expr_may_have_lone_surrogates(left, ctx)
                     || expr_may_have_lone_surrogates(right, ctx)
                 {
@@ -549,11 +546,8 @@ fn evaluate_value_length<'a>(
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if let Some(ConstantValue::String(s)) = object.evaluate_value(ctx) {
-        // `s` holds the lone-surrogate-encoded bytes for strings whose
-        // source flagged `lone_surrogates: true`. Counting its UTF-16
-        // units would report the length of the encoding, not the
-        // runtime string (each surrogate is 1 code unit but 5 chars
-        // here).
+        // Counting UTF-16 units of the encoded bytes reports the encoding's length (5 chars per
+        // surrogate), not the runtime string's.
         if expr_may_have_lone_surrogates(object, ctx) {
             return None;
         }

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -9,7 +9,10 @@ mod value_type;
 
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
-pub use lone_surrogates::{expr_may_have_lone_surrogates, str_has_lone_surrogate_encoding};
+pub use lone_surrogates::{
+    expr_may_have_lone_surrogates, str_has_lone_surrogate_encoding,
+    template_may_have_lone_surrogates,
+};
 pub use value::ConstantValue;
 pub use value_type::{DetermineValueType, ValueType};
 

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -10,8 +10,8 @@ mod value_type;
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
 pub use lone_surrogates::{
-    array_may_have_lone_surrogates, expr_may_have_lone_surrogates, str_has_lone_surrogate_encoding,
-    template_may_have_lone_surrogates,
+    array_may_have_lone_surrogates, expr_may_have_lone_surrogates, get_side_free_string_value_safe,
+    str_has_lone_surrogate_encoding, template_may_have_lone_surrogates,
 };
 pub use value::ConstantValue;
 pub use value_type::{DetermineValueType, ValueType};

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -10,7 +10,7 @@ mod value_type;
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
 pub use lone_surrogates::{
-    array_may_have_lone_surrogates, expr_may_have_lone_surrogates,
+    array_may_have_lone_surrogates, count_lone_surrogate_runs, expr_may_have_lone_surrogates,
     get_side_free_string_value_without_lone_surrogates, str_has_lone_surrogate_encoding,
     template_may_have_lone_surrogates,
 };
@@ -552,6 +552,18 @@ fn evaluate_value_length<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
+    // Flagged string literal: the runtime length is the stored UTF-16 length minus 4 for each
+    // encoded `\u{FFFD}XXXX` run (5 stored units collapse to 1 runtime unit). Only the direct
+    // literal case — where we can read `lone_surrogates` — can fold; identifiers and concat
+    // results drop the flag at the `ConstantValue::String` boundary and are left to the
+    // bail-out below.
+    if let Expression::StringLiteral(s) = object
+        && s.lone_surrogates
+    {
+        let stored = s.value.encode_utf16().count();
+        let runtime = stored - 4 * count_lone_surrogate_runs(&s.value);
+        return Some(ConstantValue::Number(runtime.to_f64().unwrap()));
+    }
     if let Some(ConstantValue::String(s)) = object.evaluate_value(ctx) {
         // Counting UTF-16 units of the encoded bytes reports the encoding's length (5 chars per
         // surrogate), not the runtime string's.

--- a/crates/oxc_ecmascript/src/is_less_than.rs
+++ b/crates/oxc_ecmascript/src/is_less_than.rs
@@ -29,10 +29,8 @@ pub fn is_less_than<'a>(
 
     // 3. If px is a String and py is a String, then
     if px.is_string() && py.is_string() {
-        // `to_js_string` returns the stored `value` bytes for string
-        // literals, so ordering them by UTF-16 units compares the
-        // encoded form rather than the runtime code-unit sequence —
-        // wrong for inputs where the `lone_surrogates` flag is set.
+        // `to_js_string` returns the stored bytes, so UTF-16 ordering compares the encoding
+        // rather than the runtime code-unit sequence when `lone_surrogates` is set.
         if expr_may_have_lone_surrogates(x, ctx) || expr_may_have_lone_surrogates(y, ctx) {
             return None;
         }

--- a/crates/oxc_ecmascript/src/is_less_than.rs
+++ b/crates/oxc_ecmascript/src/is_less_than.rs
@@ -8,6 +8,7 @@ use crate::{
     ToBigInt, ToJsString,
     constant_evaluation::{
         ConstantEvaluation, ConstantEvaluationCtx, ConstantValue, DetermineValueType,
+        expr_may_have_lone_surrogates,
     },
 };
 
@@ -28,6 +29,13 @@ pub fn is_less_than<'a>(
 
     // 3. If px is a String and py is a String, then
     if px.is_string() && py.is_string() {
+        // `to_js_string` returns the stored `value` bytes for string
+        // literals, so ordering them by UTF-16 units compares the
+        // encoded form rather than the runtime code-unit sequence —
+        // wrong for inputs where the `lone_surrogates` flag is set.
+        if expr_may_have_lone_surrogates(x, ctx) || expr_may_have_lone_surrogates(y, ctx) {
+            return None;
+        }
         let left_string = x.to_js_string(ctx)?;
         let right_string = y.to_js_string(ctx)?;
         return Some(ConstantValue::Boolean(

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -4,7 +4,7 @@ use oxc_ecmascript::{
     GlobalContext, ToJsString,
     constant_evaluation::{
         ConstantEvaluation, ConstantValue, DetermineValueType, ValueType,
-        expr_may_have_lone_surrogates,
+        expr_may_have_lone_surrogates, template_may_have_lone_surrogates,
     },
     side_effects::MayHaveSideEffects,
 };
@@ -747,9 +747,7 @@ impl<'a> PeepholeOptimizations {
         // literals can't represent lone surrogates as escapes, so any
         // lone-surrogate content — in an existing quasi or in a
         // candidate expression — would corrupt the merged string.
-        if t.quasis.iter().any(|q| q.lone_surrogates)
-            || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
-        {
+        if template_may_have_lone_surrogates(t, ctx) {
             return;
         }
         let has_expr_to_inline = t

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -410,6 +410,16 @@ impl<'a> PeepholeOptimizations {
         parent_span: Span,
         ctx: &TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
+        // Remove useless `+ ""` (e.g. `typeof foo + ""` -> `typeof foo`). Safe for lone-surrogate
+        // operands: the surviving operand is moved via `take_in`, preserving its flag.
+        if Self::evaluates_to_empty_string(left_expr) && right_expr.value_type(ctx).is_string() {
+            return Some(right_expr.take_in(ctx.ast));
+        } else if Self::evaluates_to_empty_string(right_expr)
+            && left_expr.value_type(ctx).is_string()
+        {
+            return Some(left_expr.take_in(ctx.ast));
+        }
+
         // Template quasis can't escape lone surrogates, so splicing either operand's value into
         // a quasi would corrupt the merged string.
         if expr_may_have_lone_surrogates(left_expr, ctx)
@@ -480,15 +490,6 @@ impl<'a> PeepholeOptimizations {
                 first_quasi.value.cooked = new_cooked;
                 return Some(right_expr.take_in(ctx.ast));
             }
-        }
-
-        // remove useless `+ ""` (e.g. `typeof foo + ""` -> `typeof foo`)
-        if Self::evaluates_to_empty_string(left_expr) && right_expr.value_type(ctx).is_string() {
-            return Some(right_expr.take_in(ctx.ast));
-        } else if Self::evaluates_to_empty_string(right_expr)
-            && left_expr.value_type(ctx).is_string()
-        {
-            return Some(left_expr.take_in(ctx.ast));
         }
 
         None

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -2,7 +2,10 @@ use oxc_allocator::TakeIn;
 use oxc_ast::ast::*;
 use oxc_ecmascript::{
     GlobalContext, ToJsString,
-    constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType, ValueType},
+    constant_evaluation::{
+        ConstantEvaluation, ConstantValue, DetermineValueType, ValueType,
+        expr_may_have_lone_surrogates,
+    },
     side_effects::MayHaveSideEffects,
 };
 use oxc_span::{GetSpan, SPAN};
@@ -369,10 +372,18 @@ impl<'a> PeepholeOptimizations {
         if let Expression::BinaryExpression(left_binary_expr) = &mut e.left
             && left_binary_expr.right.value_type(ctx).is_string()
         {
-            if let (Some(left_str), Some(right_str)) = (
-                left_binary_expr.right.get_side_free_string_value(ctx),
-                e.right.get_side_free_string_value(ctx),
-            ) {
+            // Skip this reshape when either piece might carry the
+            // lone-surrogate encoding: the combined literal would be
+            // emitted with `lone_surrogates: false`, corrupting it.
+            let skip_for_lone_surrogates =
+                expr_may_have_lone_surrogates(&left_binary_expr.right, ctx)
+                    || expr_may_have_lone_surrogates(&e.right, ctx);
+            if !skip_for_lone_surrogates
+                && let (Some(left_str), Some(right_str)) = (
+                    left_binary_expr.right.get_side_free_string_value(ctx),
+                    e.right.get_side_free_string_value(ctx),
+                )
+            {
                 let span = left_binary_expr
                     .right
                     .span()
@@ -401,6 +412,14 @@ impl<'a> PeepholeOptimizations {
         parent_span: Span,
         ctx: &TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
+        // Template merges splice strings into quasi raw/cooked values.
+        // Template literals can't represent lone surrogates as escapes,
+        // so any lone-surrogate input makes the merged result invalid.
+        if expr_may_have_lone_surrogates(left_expr, ctx)
+            || expr_may_have_lone_surrogates(right_expr, ctx)
+        {
+            return None;
+        }
         if let Expression::TemplateLiteral(left) = left_expr {
             // "`${a}b` + `x${y}`" => "`${a}bx${y}`"
             if let Expression::TemplateLiteral(right) = right_expr {
@@ -550,7 +569,12 @@ impl<'a> PeepholeOptimizations {
                     *expr = ctx.ast.expression_unary(
                         e.span,
                         UnaryOperator::UnaryPlus,
-                        ctx.ast.expression_string_literal(n.span, n.value, n.raw),
+                        ctx.ast.expression_string_literal_with_lone_surrogates(
+                            n.span,
+                            n.value,
+                            n.raw,
+                            n.lone_surrogates,
+                        ),
                     );
                     ctx.state.changed = true;
                     return;
@@ -718,6 +742,16 @@ impl<'a> PeepholeOptimizations {
     ///
     /// - `foo${1}bar${i}` => `foo1bar${i}`
     pub fn inline_template_literal(t: &mut TemplateLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Inlining splices a foldable expression's stringified value
+        // into the neighbouring quasi's raw/cooked text. Template
+        // literals can't represent lone surrogates as escapes, so any
+        // lone-surrogate content — in an existing quasi or in a
+        // candidate expression — would corrupt the merged string.
+        if t.quasis.iter().any(|q| q.lone_surrogates)
+            || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
+        {
+            return;
+        }
         let has_expr_to_inline = t
             .expressions
             .iter()

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -372,9 +372,7 @@ impl<'a> PeepholeOptimizations {
         if let Expression::BinaryExpression(left_binary_expr) = &mut e.left
             && left_binary_expr.right.value_type(ctx).is_string()
         {
-            // Skip this reshape when either piece might carry the
-            // lone-surrogate encoding: the combined literal would be
-            // emitted with `lone_surrogates: false`, corrupting it.
+            // A merged right-hand literal would be emitted without the flag.
             let skip_for_lone_surrogates =
                 expr_may_have_lone_surrogates(&left_binary_expr.right, ctx)
                     || expr_may_have_lone_surrogates(&e.right, ctx);
@@ -412,9 +410,8 @@ impl<'a> PeepholeOptimizations {
         parent_span: Span,
         ctx: &TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
-        // Template merges splice strings into quasi raw/cooked values.
-        // Template literals can't represent lone surrogates as escapes,
-        // so any lone-surrogate input makes the merged result invalid.
+        // Template quasis can't escape lone surrogates, so splicing either operand's value into
+        // a quasi would corrupt the merged string.
         if expr_may_have_lone_surrogates(left_expr, ctx)
             || expr_may_have_lone_surrogates(right_expr, ctx)
         {
@@ -742,11 +739,8 @@ impl<'a> PeepholeOptimizations {
     ///
     /// - `foo${1}bar${i}` => `foo1bar${i}`
     pub fn inline_template_literal(t: &mut TemplateLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Inlining splices a foldable expression's stringified value
-        // into the neighbouring quasi's raw/cooked text. Template
-        // literals can't represent lone surrogates as escapes, so any
-        // lone-surrogate content — in an existing quasi or in a
-        // candidate expression — would corrupt the merged string.
+        // Inlining splices values into quasi raw/cooked text, which can't represent lone
+        // surrogates as escapes.
         if template_may_have_lone_surrogates(t, ctx) {
             return;
         }

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -138,7 +138,9 @@ impl<'a> PeepholeOptimizations {
         }
         let Some(cv) = &symbol_value.initialized_constant else { return };
         // `ConstantValue::String` holds the encoded bytes but not the flag, so materializing
-        // a lone-surrogate initializer via `value_to_expr` would emit a flagless literal.
+        // a lone-surrogate initializer via `value_to_expr` would emit a flagless literal. Only
+        // the single-use branch below can reach a flagged string: the multi-reference branch is
+        // gated on `s.len() <= 3`, well under the 7-byte minimum encoded form.
         if let ConstantValue::String(s) = cv
             && str_has_lone_surrogate_encoding(s)
         {

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -137,11 +137,8 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         let Some(cv) = &symbol_value.initialized_constant else { return };
-        // An initializer like `const x = '\uDC00'` stores its
-        // lone-surrogate encoding in the `ConstantValue::String` bytes
-        // but not the flag. Materializing it via `value_to_expr` would
-        // yield a new `StringLiteral` with `lone_surrogates: false`,
-        // silently corrupting the value at the use site.
+        // `ConstantValue::String` holds the encoded bytes but not the flag, so materializing
+        // a lone-surrogate initializer via `value_to_expr` would emit a flagless literal.
         if let ConstantValue::String(s) = cv
             && str_has_lone_surrogate_encoding(s)
         {

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -1,6 +1,8 @@
 use crate::generated::ancestor::Ancestor;
 use oxc_ast::ast::*;
-use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue};
+use oxc_ecmascript::constant_evaluation::{
+    ConstantEvaluation, ConstantValue, str_has_lone_surrogate_encoding,
+};
 use oxc_span::GetSpan;
 
 use crate::TraverseCtx;
@@ -135,6 +137,16 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         let Some(cv) = &symbol_value.initialized_constant else { return };
+        // An initializer like `const x = '\uDC00'` stores its
+        // lone-surrogate encoding in the `ConstantValue::String` bytes
+        // but not the flag. Materializing it via `value_to_expr` would
+        // yield a new `StringLiteral` with `lone_surrogates: false`,
+        // silently corrupting the value at the use site.
+        if let ConstantValue::String(s) = cv
+            && str_has_lone_surrogate_encoding(s)
+        {
+            return;
+        }
         if symbol_value.read_references_count == 1
             || match cv {
                 ConstantValue::Number(n) => n.fract() == 0.0 && *n >= -99.0 && *n <= 999.0,

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1265,7 +1265,14 @@ impl<'a> PeepholeOptimizations {
         changed
     }
 
-    /// Returns new length
+    /// Returns new length.
+    ///
+    /// This path moves the declarator's init AST node verbatim into the use site
+    /// (via `take_in`), so lone-surrogate `StringLiteral`s and `TemplateElement`s
+    /// ride along with their flags intact. Unlike `inline_identifier_reference`,
+    /// which has to bail on flagged strings because it reconstructs a literal
+    /// from a flagless `ConstantValue::String`, this inliner is structurally safe
+    /// without a dedicated guard.
     fn substitute_single_use_symbol_in_expression_from_declarators(
         target_expr: &mut Expression<'a>,
         declarators: &mut [VariableDeclarator<'a>],

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -279,15 +279,10 @@ impl<'a> PeepholeOptimizations {
                     args.iter().filter(|arg| !matches!(arg, Argument::StringLiteral(_))).count();
                 let string_count = args.len() - expression_count;
 
-                // Lone-surrogate content can't ride through this fold:
-                //   - with only string args, the result is one merged
-                //     `StringLiteral` whose flag would default to false;
-                //   - with expression args, the result is a template
-                //     literal whose quasis can't escape lone surrogates.
-                // Bail out whenever the base or any string arg carries
-                // the encoding. Non-string args stay as `${}`
-                // expressions and don't enter the quasis, so they
-                // don't force a bailout here.
+                // Lone surrogates can't ride through: string args merge into quasi text (which
+                // can't escape them), and with all-string args the result is one flagless
+                // literal. Non-string args stay as `${}` substitutions and preserve the flag
+                // at runtime, so they don't force a bailout.
                 if base_str.lone_surrogates
                     || args
                         .iter()

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -279,6 +279,23 @@ impl<'a> PeepholeOptimizations {
                     args.iter().filter(|arg| !matches!(arg, Argument::StringLiteral(_))).count();
                 let string_count = args.len() - expression_count;
 
+                // Lone-surrogate content can't ride through this fold:
+                //   - with only string args, the result is one merged
+                //     `StringLiteral` whose flag would default to false;
+                //   - with expression args, the result is a template
+                //     literal whose quasis can't escape lone surrogates.
+                // Bail out whenever the base or any string arg carries
+                // the encoding. Non-string args stay as `${}`
+                // expressions and don't enter the quasis, so they
+                // don't force a bailout here.
+                if base_str.lone_surrogates
+                    || args
+                        .iter()
+                        .any(|arg| matches!(arg, Argument::StringLiteral(s) if s.lone_surrogates))
+                {
+                    return None;
+                }
+
                 // whether it is shorter to use `String::concat`
                 if ".concat()".len() + args.len() + "''".len() * string_count
                     < "${}".len() * expression_count

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -4,7 +4,9 @@ use crate::generated::ancestor::Ancestor;
 use oxc_allocator::{CloneIn, TakeIn, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
-use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType};
+use oxc_ecmascript::constant_evaluation::{
+    ConstantEvaluation, ConstantValue, DetermineValueType, expr_may_have_lone_surrogates,
+};
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
 use oxc_semantic::ReferenceFlags;
@@ -1023,10 +1025,19 @@ impl<'a> PeepholeOptimizations {
                 match arg {
                     // `String()` -> `''`
                     None => Some(ctx.ast.expression_string_literal(span, "", None)),
-                    Some(arg) => arg
-                        .evaluate_value_to_string(ctx)
-                        .filter(|_| !arg.may_have_side_effects(ctx))
-                        .map(|s| ctx.value_to_expr(e.span, ConstantValue::String(s))),
+                    Some(arg) => {
+                        // Folding `String('\uDC00')` would route the
+                        // encoded bytes through `value_to_expr`, which
+                        // builds a `StringLiteral` defaulting to
+                        // `lone_surrogates: false`.
+                        if expr_may_have_lone_surrogates(arg, ctx) {
+                            None
+                        } else {
+                            arg.evaluate_value_to_string(ctx)
+                                .filter(|_| !arg.may_have_side_effects(ctx))
+                                .map(|s| ctx.value_to_expr(e.span, ConstantValue::String(s)))
+                        }
+                    }
                 }
             }
             "Number" => Some(ctx.ast.expression_numeric_literal(
@@ -1261,6 +1272,13 @@ impl<'a> PeepholeOptimizations {
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
+        // Folding `\`\uDC00\`` → `'\uDC00'` would drop the quasi's
+        // `lone_surrogates` flag on the new string literal.
+        if t.quasis.iter().any(|q| q.lone_surrogates)
+            || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
+        {
+            return;
+        }
         let Some(val) = t.to_js_string(ctx) else { return };
         *expr = ctx.ast.expression_string_literal(t.span(), ctx.ast.str_from_cow(&val), None);
         ctx.state.changed = true;
@@ -1587,6 +1605,19 @@ impl<'a> PeepholeOptimizations {
             element.as_expression().is_some_and(|expr| matches!(expr, Expression::StringLiteral(_)))
         });
         if !is_all_string {
+            return;
+        }
+
+        // Joining the element bytes into one `"str".split(",")` would
+        // produce a single `StringLiteral` with `lone_surrogates:
+        // false`, even though the concatenated bytes contain the
+        // encoding. Runtime would then evaluate `split` on a
+        // 5-chars-per-surrogate string and return mis-sliced code
+        // units instead of the original elements.
+        if array.elements.iter().any(|element| {
+            let Expression::StringLiteral(str) = element.to_expression() else { unreachable!() };
+            str.lone_surrogates
+        }) {
             return;
         }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -5,8 +5,8 @@ use oxc_allocator::{CloneIn, TakeIn, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::constant_evaluation::{
-    ConstantEvaluation, ConstantValue, DetermineValueType, expr_may_have_lone_surrogates,
-    template_may_have_lone_surrogates,
+    ConstantEvaluation, ConstantValue, DetermineValueType, array_may_have_lone_surrogates,
+    expr_may_have_lone_surrogates, template_may_have_lone_surrogates,
 };
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
@@ -1606,11 +1606,7 @@ impl<'a> PeepholeOptimizations {
 
         // Joining the bytes into one flagless literal and calling `split(',')` on the encoded
         // form at runtime would return mis-sliced code units rather than the original elements.
-        if array
-            .elements
-            .iter()
-            .any(|el| el.as_expression().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx)))
-        {
+        if array_may_have_lone_surrogates(array, ctx) {
             return;
         }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1613,10 +1613,11 @@ impl<'a> PeepholeOptimizations {
         // encoding. Runtime would then evaluate `split` on a
         // 5-chars-per-surrogate string and return mis-sliced code
         // units instead of the original elements.
-        if array.elements.iter().any(|element| {
-            let Expression::StringLiteral(str) = element.to_expression() else { unreachable!() };
-            str.lone_surrogates
-        }) {
+        if array
+            .elements
+            .iter()
+            .any(|el| el.as_expression().is_some_and(|e| expr_may_have_lone_surrogates(e, ctx)))
+        {
             return;
         }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -6,6 +6,7 @@ use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::constant_evaluation::{
     ConstantEvaluation, ConstantValue, DetermineValueType, expr_may_have_lone_surrogates,
+    template_may_have_lone_surrogates,
 };
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
@@ -1274,9 +1275,7 @@ impl<'a> PeepholeOptimizations {
         let Expression::TemplateLiteral(t) = expr else { return };
         // Folding `\`\uDC00\`` → `'\uDC00'` would drop the quasi's
         // `lone_surrogates` flag on the new string literal.
-        if t.quasis.iter().any(|q| q.lone_surrogates)
-            || t.expressions.iter().any(|e| expr_may_have_lone_surrogates(e, ctx))
-        {
+        if template_may_have_lone_surrogates(t, ctx) {
             return;
         }
         let Some(val) = t.to_js_string(ctx) else { return };

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1027,10 +1027,8 @@ impl<'a> PeepholeOptimizations {
                     // `String()` -> `''`
                     None => Some(ctx.ast.expression_string_literal(span, "", None)),
                     Some(arg) => {
-                        // Folding `String('\uDC00')` would route the
-                        // encoded bytes through `value_to_expr`, which
-                        // builds a `StringLiteral` defaulting to
-                        // `lone_surrogates: false`.
+                        // `String('\uDC00')` would route the encoded bytes through
+                        // `value_to_expr` without the flag.
                         if expr_may_have_lone_surrogates(arg, ctx) {
                             None
                         } else {
@@ -1273,8 +1271,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
-        // Folding `\`\uDC00\`` → `'\uDC00'` would drop the quasi's
-        // `lone_surrogates` flag on the new string literal.
+        // Collapsing to a string literal would drop the quasi's flag.
         if template_may_have_lone_surrogates(t, ctx) {
             return;
         }
@@ -1607,12 +1604,8 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        // Joining the element bytes into one `"str".split(",")` would
-        // produce a single `StringLiteral` with `lone_surrogates:
-        // false`, even though the concatenated bytes contain the
-        // encoding. Runtime would then evaluate `split` on a
-        // 5-chars-per-surrogate string and return mis-sliced code
-        // units instead of the original elements.
+        // Joining the bytes into one flagless literal and calling `split(',')` on the encoded
+        // form at runtime would return mis-sliced code units rather than the original elements.
         if array
             .elements
             .iter()

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1605,7 +1605,8 @@ impl<'a> PeepholeOptimizations {
         }
 
         // Joining the bytes into one flagless literal and calling `split(',')` on the encoded
-        // form at runtime would return mis-sliced code units rather than the original elements.
+        // form at runtime would slice into the encoded runs and return fragments of the escape
+        // bytes rather than the original elements.
         if array_may_have_lone_surrogates(array, ctx) {
             return;
         }

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1289,6 +1289,13 @@ fn test_lone_surrogate_bailouts() {
     test("x = 'a' + (true ? '\\uDC00' : '')", "x = 'a' + '\\uDC00'");
     test("x = 'a' + (0, '\\uDC00')", "x = 'a' + '\\uDC00'");
     test("x = 'a' + ('' || '\\uDC00')", "x = 'a' + '\\uDC00'");
+
+    // `"" + x → x` and `x + "" → x` (with `x` string-typed) remain safe to fold even when `x`
+    // carries the encoding: `take_in` moves the operand verbatim so its flag rides along.
+    test("x = '' + '\\uDC00'", "x = '\\uDC00'");
+    test("x = '\\uDC00' + ''", "x = '\\uDC00'");
+    test("x = [] + '\\uDC00'", "x = '\\uDC00'");
+    test("x = '\\uDC00' + []", "x = '\\uDC00'");
 }
 
 /// String equality and ordering fold by byte comparison on the stored `value`. When either side

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1275,6 +1275,12 @@ fn test_lone_surrogate_bailouts() {
     // covers the byte-identical-to-encoding case an AST flag check
     // would miss).
     test_same("const a = '\\uDC00'; log(a, a)");
+    // Same check via a template-literal initializer: `init_symbol_value`
+    // stores `ConstantValue::String` of the template's encoded cooked
+    // bytes, and the inline byte-scan catches it. (Also exercises
+    // `substitute_template_literal`'s bail-out leaving the init as a
+    // template for codegen.)
+    test_same("const a = `\\uDC00`; log(a, a)");
 
     // U+FFFD on its own is a real character, not the encoding — these
     // must still fold.

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1024,12 +1024,21 @@ fn test_fold_string_length() {
     // Test Unicode escapes are accounted for.
     fold("x = '123\\u01dc'.length", "x = 4");
 
-    // Lone-surrogate strings bail out — UTF-16 units of the encoded bytes would report 5 per
-    // surrogate instead of 1. (TODO: the runtime length *is* computable; a future pass could
-    // still fold these.) `['length']` first rewrites to `.length`, then bails the same way.
-    fold_same("x = '\\uDC00'.length");
-    fold_same("x = '[\\uDC00]'.length");
-    fold("x = '\\uDC00'['length']", "x = '\\uDC00'.length");
+    // Lone-surrogate literals fold by subtracting 4 per encoded `\u{FFFD}XXXX` run from the
+    // stored UTF-16 length — each run is one runtime code unit (a surrogate, or U+FFFD itself
+    // via the `fffd` self-escape). `['length']` first rewrites to `.length`, then runs the
+    // same fold.
+    fold("x = '\\uDC00'.length", "x = 1");
+    fold("x = '[\\uDC00]'.length", "x = 3");
+    fold("x = '\\uDC00\\uDC00'.length", "x = 2");
+    fold("x = '\\uFFFD\\uDC00'.length", "x = 2");
+    fold("x = '\\uDC00'['length']", "x = 1");
+
+    // Identifier- and concat-bound flagged strings still bail: the flag doesn't survive the
+    // `ConstantValue::String` boundary, and a byte-scan can't tell an encoded run from a real
+    // U+FFFD followed by four hex characters. Pinning the current conservative miss.
+    test_same("const a = '\\uDC00'; x = a.length, y = a");
+    test_same("x = ('\\uDC00' + 'a').length");
 
     // `\u{FFFD}` + non-surrogate hex is a real replacement character, not the encoding.
     fold("x = '\\uFFFD0000'.length", "x = 5");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1024,21 +1024,14 @@ fn test_fold_string_length() {
     // Test Unicode escapes are accounted for.
     fold("x = '123\\u01dc'.length", "x = 4");
 
-    // Lone-surrogate strings bail out: the `ConstantValue::String` holds
-    // the `\u{FFFD}XXXX` encoding (5 chars per surrogate), so counting
-    // its UTF-16 units would report the encoding's length rather than
-    // the runtime string's. (TODO: the runtime length is computable —
-    // each `\u{FFFD}XXXX` escape counts as 1 code unit — so a future
-    // pass could still fold these if the optimization matters.)
+    // Lone-surrogate strings bail out — UTF-16 units of the encoded bytes would report 5 per
+    // surrogate instead of 1. (TODO: the runtime length *is* computable; a future pass could
+    // still fold these.) `['length']` first rewrites to `.length`, then bails the same way.
     fold_same("x = '\\uDC00'.length");
     fold_same("x = '[\\uDC00]'.length");
-    // `['length']` folds to `.length` via a separate rewrite, then the
-    // length fold bails — so the computed form normalizes to the same
-    // unfolded `.length` shape.
     fold("x = '\\uDC00'['length']", "x = '\\uDC00'.length");
 
-    // `\u{FFFD}` + non-surrogate hex is a real replacement character,
-    // not the encoding — still folds (6 chars = 6 UTF-16 units).
+    // `\u{FFFD}` + non-surrogate hex is a real replacement character, not the encoding.
     fold("x = '\\uFFFD0000'.length", "x = 5");
 }
 
@@ -1207,117 +1200,73 @@ fn test_inline_values_in_template_literal() {
     fold_same("foo`foo${1}bar`");
 }
 
-/// String folds that would otherwise merge bytes and emit a new
-/// `StringLiteral` must skip when any input carries the lone-surrogate
-/// encoding. Without the bail-out the folded literal would default to
-/// `lone_surrogates: false`, so codegen would either emit the escape
-/// bytes literally (corrupting the value) or — in the adversarial case
-/// `"�dc00" + "\uDC00"` — wrongly decode the first operand's real
-/// U+FFFD as a surrogate escape. Lone surrogates are rare in practice;
-/// leaving these expressions unfolded trades a negligible optimization
-/// loss for correctness.
+/// String folds that merge bytes into a new `StringLiteral` must skip when any input carries the
+/// lone-surrogate encoding — the merged literal would default to `lone_surrogates: false`, so
+/// codegen would emit the escape bytes literally, or (adversarial case `"�dc00" + "\uDC00"`)
+/// misread the real U+FFFD as a surrogate escape.
 #[test]
 fn test_lone_surrogate_bailouts() {
-    // Two helper forms in use below:
-    //   - `test_same(src)` / `test(src, expected)` run the minifier on
-    //     an `x = …` assignment; the assignment keeps the RHS alive
-    //     against DCE.
-    //   - `fold(src, expected)` / `fold_same(src)` wrap the source in
-    //     `NOOP(…)` for expressions that would otherwise be dropped as
-    //     unused (e.g. the `'�' + 'x'` control cases at the
-    //     bottom of this test).
-    // Both forms run full minify → codegen, so the comparisons are
-    // equivalent up to the wrapping.
-
-    // The original bug from https://github.com/oxc-project/oxc/issues/15524
+    // https://github.com/oxc-project/oxc/issues/15524
     test_same("console.log(':' + `[\\uDC00-\\uDFFF]`)");
 
-    // String + string concat: any operand with lone surrogates bails.
+    // String + string concat.
     test_same("x = '[\\uDC00]' + '[\\uDFFF]'");
     test_same("x = 'a' + '[\\uDC00]'");
     test_same("x = '[\\uDC00]' + 'a'");
 
-    // The reviewer's adversarial case: left has the same internal bytes
-    // (`�` + `dc00` text) as a lone-surrogate encoding, but with
-    // `lone_surrogates: false`. Concatenating would merge them into a
-    // single `lone_surrogates`-less literal whose first `�dc00`
-    // would then be misread as the escape. The AST flag check catches it.
+    // Adversarial: left has real-U+FFFD-followed-by-ASCII bytes identical to the encoding of
+    // the right's lone low surrogate. A flagless merge would misread the result as an escape.
     test_same("x = '\\uFFFDdc00' + '\\uDC00'");
 
-    // Triple concat: any position containing a lone surrogate bails.
+    // Triple concat and the `a + 'b' + 'c' → a + 'bc'` reshape.
     test_same("x = 'a' + '[\\uDC00]' + 'b'");
     test_same("x = '[\\uDC00]' + 'a' + '[\\uDFFF]'");
-
-    // `a + 'b' + 'c' → a + 'bc'` reshape bails on either right-side piece.
     test_same("x = a + '[\\uDC00]' + 'b'");
     test_same("x = a + 'b' + '[\\uDC00]'");
 
-    // Template merges, in every direction.
+    // Template merges, both directions and both kinds.
     test_same("x = `[\\uDC00]` + ':'");
     test_same("x = ':' + `[\\uDC00]`");
     test_same("x = `[\\uDC00]` + `[\\uDFFF]`");
     test_same("x = `a${b}[\\uDC00]` + `[\\uDFFF]${c}d`");
 
-    // `substitute_template_literal`: a single-quasi template with lone
-    // surrogates stays a template rather than collapsing into a string
-    // literal that would default to `lone_surrogates: false`.
+    // Template → string-literal collapse stays a template.
     test_same("x = `[\\uDC00]`");
     test_same("x = `a[\\uDC00]b`");
 
-    // `inline_template_literal` bails when any quasi or foldable
-    // expression contains the encoding.
+    // Template inlining bails when any quasi or foldable expression carries the encoding.
     test_same("x = `foo${1}[\\uDC00]`");
     test_same("x = `foo${'[\\uDC00]'}bar`");
 
-    // Identifiers resolving to a lone-surrogate constant: multi-use
-    // bindings keep the identifier around (the inline path bails when
-    // the resolved `ConstantValue::String` byte-scan matches, which
-    // covers the byte-identical-to-encoding case an AST flag check
-    // would miss).
+    // Multi-use identifier bindings: the inline path's byte-scan on the resolved constant value
+    // catches the case an AST-flag check would miss. Template-initialized form also exercises
+    // `substitute_template_literal`'s bail-out leaving the init as a template for codegen.
     test_same("const a = '\\uDC00'; log(a, a)");
-    // Same check via a template-literal initializer: `init_symbol_value`
-    // stores `ConstantValue::String` of the template's encoded cooked
-    // bytes, and the inline byte-scan catches it. (Also exercises
-    // `substitute_template_literal`'s bail-out leaving the init as a
-    // template for codegen.)
     test_same("const a = `\\uDC00`; log(a, a)");
 
-    // U+FFFD on its own is a real character, not the encoding — these
-    // must still fold.
+    // Control cases: plain U+FFFD (not the encoding) still folds.
     fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");
     fold("'\\uFFFD' + '0000'", "'\\uFFFD0000'");
-    // Even the suffixes `dc00`/`dfff`/`fffd` are fine when they come
-    // from real text, not the encoding.
     fold("'\\uFFFD' + 'dc00'", "'\\uFFFDdc00'");
     fold("'\\uFFFD' + 'fffd'", "'\\uFFFDfffd'");
 
-    // Non-literal subexpressions (logical/ternary/sequence) fold in
-    // exit order and yield a plain lone-surrogate StringLiteral before
-    // the parent Addition sees them; the Addition itself then bails,
-    // leaving the `+ literal` intact with its flag preserved.
+    // Non-literal subexpressions fold in exit order to a plain lone-surrogate literal; the
+    // parent Addition then bails, leaving the literal with its flag preserved.
     test("x = 'a' + (true ? '\\uDC00' : '')", "x = 'a' + '\\uDC00'");
     test("x = 'a' + (0, '\\uDC00')", "x = 'a' + '\\uDC00'");
     test("x = 'a' + ('' || '\\uDC00')", "x = 'a' + '\\uDC00'");
 }
 
-/// Equality and ordering comparisons between strings fold by byte
-/// comparison of the stored `value` field. When either operand uses the
-/// lone-surrogate encoding, the bytes no longer correspond to the
-/// runtime code-unit sequence, so the byte compare gives the wrong
-/// answer. The adversarial case is a `lone_surrogates: false` literal
-/// whose bytes happen to match a `lone_surrogates: true` literal's
-/// encoded form — same bytes, different runtime strings. Bail out
-/// whenever either side might carry the encoding.
+/// String equality and ordering fold by byte comparison on the stored `value`. When either side
+/// carries the encoding those bytes don't correspond to the runtime code-unit sequence, so the
+/// compare lies — most sharply when a `lone_surrogates: false` literal has the same bytes as the
+/// encoded form of a `lone_surrogates: true` literal.
 #[test]
 fn test_lone_surrogate_comparison_bailouts() {
-    // Adversarial case: left is a real `�` followed by the ASCII
-    // text `dc00` (5 code units at runtime); right is a lone low
-    // surrogate (1 code unit at runtime). Same stored bytes, different
-    // runtime values. Each of the following has a different truth
-    // value at runtime than a byte compare would yield — so none of
-    // them fold to a boolean. (`===`/`!==` still normalize to `==`/`!=`
-    // when both types are known string — that is a separate rewrite
-    // and doesn't change the comparison's value.)
+    // Adversarial case: left is a real `�` + ASCII `dc00` (5 code units at runtime); right is a
+    // lone low surrogate (1 code unit). Same stored bytes, different runtime values. (`===`/`!==`
+    // still normalize to `==`/`!=` when both types are string — a separate rewrite that doesn't
+    // change the comparison's value.)
     fold("'\\uFFFDdc00' === '\\uDC00'", "'\\uFFFDdc00' == '\\uDC00'"); // runtime: false;  byte compare: true
     fold("'\\uFFFDdc00' !== '\\uDC00'", "'\\uFFFDdc00' != '\\uDC00'"); // runtime: true;   byte compare: false
     fold_same("'\\uFFFDdc00' == '\\uDC00'"); // runtime: false;  byte compare: true
@@ -1325,20 +1274,16 @@ fn test_lone_surrogate_comparison_bailouts() {
     fold_same("'\\uFFFDdc00' > '\\uDC00'"); //  runtime: true;   byte compare: false
     fold_same("'\\uFFFDdc00' <= '\\uDC00'"); // runtime: false;  byte compare: true
 
-    // Even when either side carries the encoding, any comparison
-    // involving it bails — we don't inspect whether the byte compare
-    // would coincidentally agree with the runtime answer.
+    // Any comparison involving a surrogate-flagged operand bails, without checking whether the
+    // byte compare would coincidentally agree.
     fold_same("'\\uFFFDdc00' < '\\uDC00'");
     fold_same("'\\uFFFDdc00' >= '\\uDC00'");
     fold("'\\uDC00' === '\\uDC00'", "'\\uDC00' == '\\uDC00'");
     fold_same("'\\uDC00' < '\\uDC00'");
-
-    // Reversed operand order exercises the same code path for symmetry.
     fold("'\\uDC00' === '\\uFFFDdc00'", "'\\uDC00' == '\\uFFFDdc00'");
     fold_same("'\\uDC00' > '\\uFFFDdc00'");
 
-    // Control cases: plain U+FFFD (not the encoding) still folds
-    // normally — these are real text comparisons.
+    // Control cases: plain U+FFFD (not the encoding) still folds.
     fold("'\\uFFFD' === '\\uFFFD'", "!0");
     fold("'\\uFFFD' !== 'x'", "!0");
     fold("'\\uFFFD' > 'z'", "!0");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1263,10 +1263,20 @@ fn test_lone_surrogate_bailouts() {
     // `.replace()` fold calls `expr_may_have_lone_surrogates` on the replacement arg, hitting
     // the Identifier arm's byte-scan.
     test_same("const a = '\\uDC00'; log('foo'.replace('f', a), a)");
+    // Same guard, search-arg position (distinct call site). Adversarial receiver: bytes of
+    // `'�dc00'` are real-U+FFFD + ASCII at runtime (5 code units, no match for a lone
+    // surrogate) but match the encoded form of `a`. Without the guard the fold locates
+    // `a` by byte equality and replaces, emitting `log('x', ...)`.
+    test_same("const a = '\\uDC00'; log('\\uFFFDdc00'.replace(a, 'x'), a)");
     // The `a + 'b' + 'c' → a + 'bc'` reshape with a flagged-via-identifier trailing operand:
     // `(a + 'b') + c` checks `expr_may_have_lone_surrogates(c)` through the Identifier arm
     // before merging `'b'` and `c` into a flagless literal.
     test_same("const c = '\\uDC00'; log(a + 'b' + c, c)");
+    // Move-then-fold-bail: the single-use inliner in `minimize_statements.rs` substitutes
+    // `a`'s init verbatim via `take_in`, producing `log('\uDC00' + 'b')` with the flag
+    // intact; the next iteration's `+` fold then bails on its StringLiteral arm. Pins down
+    // that the move preserves `lone_surrogates` so the downstream guard still sees the flag.
+    test("const a = '\\uDC00'; log(a + 'b')", "log('\\uDC00' + 'b')");
 
     // Control cases: plain U+FFFD (not the encoding) still folds.
     fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1190,6 +1190,82 @@ fn test_inline_values_in_template_literal() {
     fold_same("foo`foo${1}bar`");
 }
 
+/// String folds that would otherwise merge bytes and emit a new
+/// `StringLiteral` must skip when any input carries the lone-surrogate
+/// encoding. Without the bail-out the folded literal would default to
+/// `lone_surrogates: false`, so codegen would either emit the escape
+/// bytes literally (corrupting the value) or — in the adversarial case
+/// `"�dc00" + "\uDC00"` — wrongly decode the first operand's real
+/// U+FFFD as a surrogate escape. Lone surrogates are rare in practice;
+/// leaving these expressions unfolded trades a negligible optimization
+/// loss for correctness.
+#[test]
+fn test_lone_surrogate_bailouts() {
+    // The original bug from https://github.com/oxc-project/oxc/issues/15524
+    test_same("console.log(':' + `[\\uDC00-\\uDFFF]`)");
+
+    // String + string concat: any operand with lone surrogates bails.
+    test_same("x = '[\\uDC00]' + '[\\uDFFF]'");
+    test_same("x = 'a' + '[\\uDC00]'");
+    test_same("x = '[\\uDC00]' + 'a'");
+
+    // The reviewer's adversarial case: left has the same internal bytes
+    // (`�` + `dc00` text) as a lone-surrogate encoding, but with
+    // `lone_surrogates: false`. Concatenating would merge them into a
+    // single `lone_surrogates`-less literal whose first `�dc00`
+    // would then be misread as the escape. The AST flag check catches it.
+    test_same("x = '\\uFFFDdc00' + '\\uDC00'");
+
+    // Triple concat: any position containing a lone surrogate bails.
+    test_same("x = 'a' + '[\\uDC00]' + 'b'");
+    test_same("x = '[\\uDC00]' + 'a' + '[\\uDFFF]'");
+
+    // `a + 'b' + 'c' → a + 'bc'` reshape bails on either right-side piece.
+    test_same("x = a + '[\\uDC00]' + 'b'");
+    test_same("x = a + 'b' + '[\\uDC00]'");
+
+    // Template merges, in every direction.
+    test_same("x = `[\\uDC00]` + ':'");
+    test_same("x = ':' + `[\\uDC00]`");
+    test_same("x = `[\\uDC00]` + `[\\uDFFF]`");
+    test_same("x = `a${b}[\\uDC00]` + `[\\uDFFF]${c}d`");
+
+    // `substitute_template_literal`: a single-quasi template with lone
+    // surrogates stays a template rather than collapsing into a string
+    // literal that would default to `lone_surrogates: false`.
+    test_same("x = `[\\uDC00]`");
+    test_same("x = `a[\\uDC00]b`");
+
+    // `inline_template_literal` bails when any quasi or foldable
+    // expression contains the encoding.
+    test_same("x = `foo${1}[\\uDC00]`");
+    test_same("x = `foo${'[\\uDC00]'}bar`");
+
+    // Identifiers resolving to a lone-surrogate constant: multi-use
+    // bindings keep the identifier around (the inline path bails when
+    // the resolved `ConstantValue::String` byte-scan matches, which
+    // covers the byte-identical-to-encoding case an AST flag check
+    // would miss).
+    test_same("const a = '\\uDC00'; log(a, a)");
+
+    // U+FFFD (U+FFFD) is a real character, not the encoding — these
+    // must still fold.
+    fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");
+    fold("'\\uFFFD' + '0000'", "'\\uFFFD0000'");
+    // Even the suffixes `dc00`/`dfff`/`fffd` are fine when they come
+    // from real text, not the encoding.
+    fold("'\\uFFFD' + 'dc00'", "'\\uFFFDdc00'");
+    fold("'\\uFFFD' + 'fffd'", "'\\uFFFDfffd'");
+
+    // Non-literal subexpressions (logical/ternary/sequence) fold in
+    // exit order and yield a plain lone-surrogate StringLiteral before
+    // the parent Addition sees them; the Addition itself then bails,
+    // leaving the `+ literal` intact with its flag preserved.
+    test("x = 'a' + (true ? '\\uDC00' : '')", "x = 'a' + '\\uDC00'");
+    test("x = 'a' + (0, '\\uDC00')", "x = 'a' + '\\uDC00'");
+    test("x = 'a' + ('' || '\\uDC00')", "x = 'a' + '\\uDC00'");
+}
+
 mod bigint {
     use super::{
         MAX_SAFE_FLOAT, MAX_SAFE_INT, NEG_MAX_SAFE_FLOAT, NEG_MAX_SAFE_INT, fold, fold_same,

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1300,6 +1300,50 @@ fn test_lone_surrogate_bailouts() {
     test("x = 'a' + ('' || '\\uDC00')", "x = 'a' + '\\uDC00'");
 }
 
+/// Equality and ordering comparisons between strings fold by byte
+/// comparison of the stored `value` field. When either operand uses the
+/// lone-surrogate encoding, the bytes no longer correspond to the
+/// runtime code-unit sequence, so the byte compare gives the wrong
+/// answer. The adversarial case is a `lone_surrogates: false` literal
+/// whose bytes happen to match a `lone_surrogates: true` literal's
+/// encoded form — same bytes, different runtime strings. Bail out
+/// whenever either side might carry the encoding.
+#[test]
+fn test_lone_surrogate_comparison_bailouts() {
+    // Adversarial case: left is a real `�` followed by the ASCII
+    // text `dc00` (5 code units at runtime); right is a lone low
+    // surrogate (1 code unit at runtime). Same stored bytes, different
+    // runtime values. Each of the following has a different truth
+    // value at runtime than a byte compare would yield — so none of
+    // them fold to a boolean. (`===`/`!==` still normalize to `==`/`!=`
+    // when both types are known string — that is a separate rewrite
+    // and doesn't change the comparison's value.)
+    fold("'\\uFFFDdc00' === '\\uDC00'", "'\\uFFFDdc00' == '\\uDC00'"); // runtime: false;  byte compare: true
+    fold("'\\uFFFDdc00' !== '\\uDC00'", "'\\uFFFDdc00' != '\\uDC00'"); // runtime: true;   byte compare: false
+    fold_same("'\\uFFFDdc00' == '\\uDC00'"); // runtime: false;  byte compare: true
+    fold_same("'\\uFFFDdc00' != '\\uDC00'"); // runtime: true;   byte compare: false
+    fold_same("'\\uFFFDdc00' > '\\uDC00'"); //  runtime: true;   byte compare: false
+    fold_same("'\\uFFFDdc00' <= '\\uDC00'"); // runtime: false;  byte compare: true
+
+    // Even when either side carries the encoding, any comparison
+    // involving it bails — we don't inspect whether the byte compare
+    // would coincidentally agree with the runtime answer.
+    fold_same("'\\uFFFDdc00' < '\\uDC00'");
+    fold_same("'\\uFFFDdc00' >= '\\uDC00'");
+    fold("'\\uDC00' === '\\uDC00'", "'\\uDC00' == '\\uDC00'");
+    fold_same("'\\uDC00' < '\\uDC00'");
+
+    // Reversed operand order exercises the same code path for symmetry.
+    fold("'\\uDC00' === '\\uFFFDdc00'", "'\\uDC00' == '\\uFFFDdc00'");
+    fold_same("'\\uDC00' > '\\uFFFDdc00'");
+
+    // Control cases: plain U+FFFD (not the encoding) still folds
+    // normally — these are real text comparisons.
+    fold("'\\uFFFD' === '\\uFFFD'", "!0");
+    fold("'\\uFFFD' !== 'x'", "!0");
+    fold("'\\uFFFD' > 'z'", "!0");
+}
+
 mod bigint {
     use super::{
         MAX_SAFE_FLOAT, MAX_SAFE_INT, NEG_MAX_SAFE_FLOAT, NEG_MAX_SAFE_INT, fold, fold_same,

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1265,7 +1265,7 @@ fn test_lone_surrogate_bailouts() {
     // would miss).
     test_same("const a = '\\uDC00'; log(a, a)");
 
-    // U+FFFD (U+FFFD) is a real character, not the encoding — these
+    // U+FFFD on its own is a real character, not the encoding — these
     // must still fold.
     fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");
     fold("'\\uFFFD' + '0000'", "'\\uFFFD0000'");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1218,6 +1218,17 @@ fn test_inline_values_in_template_literal() {
 /// loss for correctness.
 #[test]
 fn test_lone_surrogate_bailouts() {
+    // Two helper forms in use below:
+    //   - `test_same(src)` / `test(src, expected)` run the minifier on
+    //     an `x = …` assignment; the assignment keeps the RHS alive
+    //     against DCE.
+    //   - `fold(src, expected)` / `fold_same(src)` wrap the source in
+    //     `NOOP(…)` for expressions that would otherwise be dropped as
+    //     unused (e.g. the `'�' + 'x'` control cases at the
+    //     bottom of this test).
+    // Both forms run full minify → codegen, so the comparisons are
+    // equivalent up to the wrapping.
+
     // The original bug from https://github.com/oxc-project/oxc/issues/15524
     test_same("console.log(':' + `[\\uDC00-\\uDFFF]`)");
 

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1339,6 +1339,17 @@ fn test_lone_surrogate_comparison_bailouts() {
     fold("'\\uDC00' === '\\uFFFDdc00'", "'\\uDC00' == '\\uFFFDdc00'");
     fold_same("'\\uDC00' > '\\uFFFDdc00'");
 
+    // Abstract equality (`==`/`!=`) on same-type strings routes through
+    // `strict_equality_comparison` just like `===`/`!==`, so the guard fires identically.
+    // Both-flagged with the same bytes is a conservative miss — runtime-equal, but we bail
+    // rather than return a byte-compare result that would happen to coincide.
+    fold_same("'\\uDC00' == '\\uDC00'");
+    fold_same("'\\uDC00' != '\\uDC00'");
+    // Both-unflagged with bytes that match the encoding pattern: neither side has the flag, so
+    // the byte compare *is* the runtime compare and folding is safe.
+    fold("'\\uFFFDdc00' == '\\uFFFDdc00'", "!0");
+    fold("'\\uFFFDdc00' != '\\uFFFDdc00'", "!1");
+
     // Control cases: plain U+FFFD (not the encoding) still folds.
     fold("'\\uFFFD' === '\\uFFFD'", "!0");
     fold("'\\uFFFD' !== 'x'", "!0");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1263,6 +1263,10 @@ fn test_lone_surrogate_bailouts() {
     // `.replace()` fold calls `expr_may_have_lone_surrogates` on the replacement arg, hitting
     // the Identifier arm's byte-scan.
     test_same("const a = '\\uDC00'; log('foo'.replace('f', a), a)");
+    // The `a + 'b' + 'c' → a + 'bc'` reshape with a flagged-via-identifier trailing operand:
+    // `(a + 'b') + c` checks `expr_may_have_lone_surrogates(c)` through the Identifier arm
+    // before merging `'b'` and `c` into a flagless literal.
+    test_same("const c = '\\uDC00'; log(a + 'b' + c, c)");
 
     // Control cases: plain U+FFFD (not the encoding) still folds.
     fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1145,6 +1145,12 @@ fn test_number_constructor() {
     fold("Number('a')", "NaN");
     fold("Number('1')", "1");
     test_same("var Number; NOOP(Number(1))");
+    // `Number('\uDC00')` routes through `evaluate_value_to_number` and folds to `NaN` —
+    // the `+'\uDC00'` else-branch in `fold_call_expression` is unreachable for string
+    // literals (they always produce `Some(f64)`), but is kept as defensive coverage.
+    // Pinning this direction here; the defensive branch's flag-preservation is
+    // visually audited only.
+    fold("Number('\\uDC00')", "NaN");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1253,6 +1253,17 @@ fn test_lone_surrogate_bailouts() {
     test_same("const a = '\\uDC00'; log(a, a)");
     test_same("const a = `\\uDC00`; log(a, a)");
 
+    // Flagged-via-identifier operands at specific fold sites. The trailing `a` pins the
+    // binding against the single-reference inline path (strings only multi-ref-inline when
+    // `s.len() <= 3`, well below the 7-byte encoded lone surrogate), so `a` stays as an
+    // Identifier at the fold site and exercises the Identifier arm of the bail-out.
+    //
+    // `try_fold_string_casing`'s own inlined byte-scan on the resolved constant.
+    test_same("const a = '\\uDC00'; log(a.toLowerCase(), a)");
+    // `.replace()` fold calls `expr_may_have_lone_surrogates` on the replacement arg, hitting
+    // the Identifier arm's byte-scan.
+    test_same("const a = '\\uDC00'; log('foo'.replace('f', a), a)");
+
     // Control cases: plain U+FFFD (not the encoding) still folds.
     fold("'\\uFFFD' + 'x'", "'\\uFFFDx'");
     fold("'\\uFFFD' + '0000'", "'\\uFFFD0000'");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1023,6 +1023,23 @@ fn test_fold_string_length() {
 
     // Test Unicode escapes are accounted for.
     fold("x = '123\\u01dc'.length", "x = 4");
+
+    // Lone-surrogate strings bail out: the `ConstantValue::String` holds
+    // the `\u{FFFD}XXXX` encoding (5 chars per surrogate), so counting
+    // its UTF-16 units would report the encoding's length rather than
+    // the runtime string's. (TODO: the runtime length is computable —
+    // each `\u{FFFD}XXXX` escape counts as 1 code unit — so a future
+    // pass could still fold these if the optimization matters.)
+    fold_same("x = '\\uDC00'.length");
+    fold_same("x = '[\\uDC00]'.length");
+    // `['length']` folds to `.length` via a separate rewrite, then the
+    // length fold bails — so the computed form normalizes to the same
+    // unfolded `.length` shape.
+    fold("x = '\\uDC00'['length']", "x = '\\uDC00'.length");
+
+    // `\u{FFFD}` + non-surrogate hex is a real replacement character,
+    // not the encoding — still folds (6 chars = 6 UTF-16 units).
+    fold("x = '\\uFFFD0000'.length", "x = 5");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1238,8 +1238,17 @@ fn test_lone_surrogate_bailouts() {
     test_same("x = `foo${1}[\\uDC00]`");
     test_same("x = `foo${'[\\uDC00]'}bar`");
 
-    // Multi-use identifier bindings: the inline path's byte-scan on the resolved constant value
-    // catches the case an AST-flag check would miss. Template-initialized form also exercises
+    // Single-use identifier bindings exercise `inline.rs`'s byte-scan guard. Without it, the
+    // initializer gets materialized at the reference site via `value_to_expr` as a flagless
+    // literal, i.e. `log('�dc00')` (real-U+FFFD + ASCII, a 5-code-unit runtime string
+    // instead of the 1-unit lone surrogate). With the guard, an identifier-substitution path
+    // preserves the flag and the output is `log('\uDC00')`. (The multi-reference analogue
+    // won't hit the inline path at all — the only string case that inlines at multi-ref is
+    // `s.len() <= 3`, and the shortest encoded lone surrogate is 7 bytes.)
+    test("const a = '\\uDC00'; log(a)", "log('\\uDC00')");
+    test("const a = `\\uDC00`; log(a)", "log(`\\uDC00`)");
+
+    // Multi-use identifier bindings. Template-initialized form exercises
     // `substitute_template_literal`'s bail-out leaving the init as a template for codegen.
     test_same("const a = '\\uDC00'; log(a, a)");
     test_same("const a = `\\uDC00`; log(a, a)");

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -33,6 +33,15 @@ fn test_string_index_of() {
     test("x = 'abcnulldef'.indexOf(null)", "x = 3");
     test("x = 'abctruedef'.indexOf(true)", "x = 3");
 
+    // Identifier bound to a non-string constant stringifies the same as the literal does.
+    // Using a large integer keeps `n` out of the multi-ref integer inliner (`-99..=999`) so the
+    // fold site sees an Identifier rather than a pre-inlined numeric literal; once the fold
+    // consumes that reference, the trailing `y = n` single-ref-inlines to `y = 12345`.
+    test(
+        "const n = 12345; x = 'abc12345def'.indexOf(n), y = n",
+        "const n = 12345; x = 3, y = 12345",
+    );
+
     test_same("x = 1 .indexOf('bcd');");
     test_same("x = NaN.indexOf('bcd')");
     test("x = undefined.indexOf('bcd')", "x = (void 0).indexOf('bcd')");
@@ -161,6 +170,14 @@ fn test_fold_string_replace() {
     test_same("'PreXyzPost'.replace('Xyz', '$\\'')"); // would fold to  'PrePostPost'
     test_same("'PreXyzPostXyz'.replace('Xyz', '$\\'')"); // would fold to 'PrePostXyzPostXyz'
     test_same("'123'.replace('2', '$`')"); // would fold to '113'
+
+    // Identifier bound to a non-string constant stringifies for the replace arg. A large
+    // integer keeps `n` out of the multi-ref integer inliner (`-99..=999`) so the fold site
+    // sees an Identifier; the trailing `y = n` single-ref-inlines after the fold.
+    test(
+        "const n = 12345; x = 'xtail'.replace('x', n), y = n",
+        "const n = 12345; x = '12345tail', y = 12345",
+    );
 }
 
 #[test]
@@ -1190,6 +1207,11 @@ fn test_fold_encode_uri() {
 
     test_same("x = encodeURI('a', 'b')");
     test_same("x = encodeURI(x)");
+
+    // Identifier bound to a non-string constant stringifies for the encoder input. A large
+    // integer keeps `n` out of the multi-ref integer inliner (`-99..=999`) so the fold site
+    // sees an Identifier; the trailing `y = n` single-ref-inlines after the fold.
+    test("const n = 12345; x = encodeURI(n), y = n", "const n = 12345; x = '12345', y = 12345");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -494,6 +494,20 @@ fn test_lone_surrogate_bailouts() {
     // the ambiguous bytes. (`\u{FFFD}` self-escape is `�fffd`, so `'�fffd'` is
     // excluded from this class — that one is genuinely indistinguishable from the encoding.)
     test("x = encodeURI('\\uFFFDdc00')", "x = '%EF%BF%BDdc00'");
+
+    // `parseFloat` / `parseInt` need no dedicated bail: they produce `Number`, and the non-
+    // numeric prefix handling behaves the same on the runtime string and on the stored
+    // encoded bytes (neither `\uDC00` nor `�dc00` starts with a numeric prefix). Pin
+    // that convergence so a future "conservative bail on any lone-surrogate input" doesn't
+    // regress a legitimate fold.
+    test("x = parseFloat('\\uDC00')", "x = NaN");
+    test("x = parseInt('\\uDC00')", "x = NaN");
+    test("x = parseInt('\\uDC00', 16)", "x = NaN");
+    // Numeric prefix before a lone surrogate still folds, on both the flagged operand and
+    // its real-U+FFFD byte-twin.
+    test("x = parseFloat('42\\uDC00')", "x = 42");
+    test("x = parseInt('a\\uDC00', 16)", "x = 10");
+    test("x = parseFloat('42\\uFFFDdc00')", "x = 42");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -437,6 +437,74 @@ fn test_fold_string_trim() {
     test_same("x = 'abc'.trimEnd(1)");
 }
 
+/// Folds that walk the string by JS code unit (`substring`/`slice`/
+/// `charAt`/`charCodeAt`/`indexOf`/`startsWith`/`replace*`/`toLowerCase`/
+/// `toUpperCase`/`trim*`) or re-encode its value (`encodeURI*`,
+/// `decodeURI*`, `String`, `toString()`) would produce a new string
+/// without the `lone_surrogates` flag and either run against the
+/// encoded form (returning fragments of escape bytes) or panic codegen
+/// on a partial sequence. Each fold bails out on a lone-surrogate
+/// input; locking that in.
+#[test]
+fn test_lone_surrogate_bailouts() {
+    // Char-unit operations against the encoded form would cut through
+    // a `�XXXX` sequence.
+    test_same("x = '[\\uDC00]'.substring(0, 1)");
+    test_same("x = '[\\uDC00]'.substring(1)");
+    test_same("x = '[\\uDC00]'.slice(0, 1)");
+    test_same("x = '[\\uDC00]'.slice(1)");
+    test_same("x = '[\\uDC00]'.charAt(0)");
+    test_same("x = '\\uDC00'.charAt(0)");
+    test_same("x = '\\uDC00'.charCodeAt(0)");
+    test_same("x = '[\\uDC00]'.indexOf('[')");
+    test_same("x = 'abc'.indexOf('\\uDC00')");
+    test_same("x = '\\uDC00'.startsWith('a')");
+    test_same("x = 'abc'.startsWith('\\uDC00')");
+
+    // `replace`/`replaceAll`: any operand's encoding could split or
+    // splice escape bytes into the result.
+    test_same("x = '[\\uDC00]'.replace('[', '(')");
+    test_same("x = '[\\uDC00]'.replaceAll('[', '(')");
+    test_same("x = 'abc'.replace('\\uDC00', 'x')");
+    test_same("x = 'abc'.replace('b', '\\uDC00')");
+
+    // Case-folding and trimming: even paths that would preserve the
+    // encoding (trim, toLowerCase) bail for uniformity — the fold
+    // produces a bare `StringLiteral` with `lone_surrogates: false`,
+    // which codegen would emit as raw bytes, not as `\uXXXX`.
+    test_same("x = '\\uDC00'.toLowerCase()");
+    test_same("x = '\\uDC00'.toUpperCase()");
+    test_same("x = '[\\uDC00]'.toUpperCase()");
+    test_same("x = '\\uDC00'.trim()");
+    test_same("x = '  \\uDC00  '.trim()");
+
+    // URL encode/decode: `encodeURI('\uD800')` throws at runtime; our
+    // value is the encoded form, so running the `%`-encoder would
+    // diverge from runtime behaviour.
+    test_same("x = encodeURI('\\uDC00')");
+    test_same("x = encodeURIComponent('\\uDC00')");
+    test_same("x = decodeURI('\\uDC00')");
+    test_same("x = decodeURIComponent('\\uDC00')");
+
+    // `String()` and `.toString()` would route the encoded bytes
+    // through `value_to_expr`.
+    test_same("x = String('\\uDC00')");
+    test_same("x = '\\uDC00'.toString()");
+
+    // `concat`: with all-string args, the result is one merged literal
+    // without the flag; with expression args, the template literal's
+    // quasis can't represent lone surrogates. Both bail.
+    test_same("x = ''.concat('[\\uDC00]')");
+    test_same("x = '[\\uDC00]'.concat(a)");
+    test_same("x = 'a'.concat(b, '[\\uDC00]')");
+
+    // `�` not followed by matching hex is *not* the encoding —
+    // it's the real replacement character, and folds fine.
+    test("x = '\\uFFFD'.toLowerCase()", "x = '\\uFFFD'");
+    test("x = '\\uFFFD'.trim()", "x = '\\uFFFD'");
+    test("x = ''.concat('\\uFFFD')", "x = '\\uFFFD'");
+}
+
 #[test]
 fn test_fold_math_functions_bug() {
     test_same("Math[0]()");

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -483,6 +483,13 @@ fn test_lone_surrogate_bailouts() {
     test_same("x = '[\\uDC00]'.concat(a)");
     test_same("x = 'a'.concat(b, '[\\uDC00]')");
 
+    // Identifier arg resolving to a lone-surrogate constant survives the concat → template rewrite
+    // as `${a}`; downstream template-level folds then bail via template_may_have_lone_surrogates.
+    test(
+        "const a = '\\uDC00'; x = ''.concat(a, b); y = a",
+        "const a = '\\uDC00'; x = `${a}${b}`, y = a",
+    );
+
     // Control cases: plain U+FFFD (not the encoding) still folds.
     test("x = '\\uFFFD'.toLowerCase()", "x = '\\uFFFD'");
     test("x = '\\uFFFD'.trim()", "x = '\\uFFFD'");

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -494,6 +494,11 @@ fn test_lone_surrogate_bailouts() {
     // `String()` / `.toString()` would route encoded bytes through `value_to_expr`.
     test_same("x = String('\\uDC00')");
     test_same("x = '\\uDC00'.toString()");
+    // `String(identifier)` / `identifier.toString()` exercise the Identifier arm of
+    // `expr_may_have_lone_surrogates`'s byte-scan. Trailing `y = a` keeps `a` out of the
+    // single-reference inliner so the fold site actually sees an Identifier.
+    test_same("const a = '\\uDC00'; x = String(a), y = a");
+    test_same("const a = '\\uDC00'; x = a.toString(), y = a");
 
     // `.concat`: both the all-string merge and the template-literal rewrite bail.
     test_same("x = ''.concat('[\\uDC00]')");

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -487,6 +487,13 @@ fn test_lone_surrogate_bailouts() {
     test("x = '\\uFFFD'.toLowerCase()", "x = '\\uFFFD'");
     test("x = '\\uFFFD'.trim()", "x = '\\uFFFD'");
     test("x = ''.concat('\\uFFFD')", "x = '\\uFFFD'");
+
+    // Real U+FFFD followed by ASCII `dc00` has the same bytes as the lone-surrogate encoding
+    // of `\uDC00`, but at runtime it's a 5-code-unit string; `encodeURI` %-encodes the U+FFFD
+    // and leaves the ASCII alone. The fold must handle this without a byte-scan tripping up on
+    // the ambiguous bytes. (`\u{FFFD}` self-escape is `�fffd`, so `'�fffd'` is
+    // excluded from this class — that one is genuinely indistinguishable from the encoding.)
+    test("x = encodeURI('\\uFFFDdc00')", "x = '%EF%BF%BDdc00'");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -437,18 +437,12 @@ fn test_fold_string_trim() {
     test_same("x = 'abc'.trimEnd(1)");
 }
 
-/// Folds that walk the string by JS code unit (`substring`/`slice`/
-/// `charAt`/`charCodeAt`/`indexOf`/`startsWith`/`replace*`/`toLowerCase`/
-/// `toUpperCase`/`trim*`) or re-encode its value (`encodeURI*`,
-/// `decodeURI*`, `String`, `toString()`) would produce a new string
-/// without the `lone_surrogates` flag and either run against the
-/// encoded form (returning fragments of escape bytes) or panic codegen
-/// on a partial sequence. Each fold bails out on a lone-surrogate
-/// input; locking that in.
+/// Every string-method fold (`substring`/`slice`/`charAt`/`charCodeAt`/`indexOf`/`startsWith`/
+/// `replace*`/`toLowerCase`/`toUpperCase`/`trim*`/`encodeURI*`/`decodeURI*`/`String`/`toString`/
+/// `concat`) must bail on lone-surrogate inputs; locking that in.
 #[test]
 fn test_lone_surrogate_bailouts() {
-    // Char-unit operations against the encoded form would cut through
-    // a `�XXXX` sequence.
+    // Code-unit indexing would cut through a `�XXXX` run.
     test_same("x = '[\\uDC00]'.substring(0, 1)");
     test_same("x = '[\\uDC00]'.substring(1)");
     test_same("x = '[\\uDC00]'.slice(0, 1)");
@@ -461,45 +455,35 @@ fn test_lone_surrogate_bailouts() {
     test_same("x = '\\uDC00'.startsWith('a')");
     test_same("x = 'abc'.startsWith('\\uDC00')");
 
-    // `replace`/`replaceAll`: any operand's encoding could split or
-    // splice escape bytes into the result.
+    // `replace`/`replaceAll`: any operand could split or splice escape bytes.
     test_same("x = '[\\uDC00]'.replace('[', '(')");
     test_same("x = '[\\uDC00]'.replaceAll('[', '(')");
     test_same("x = 'abc'.replace('\\uDC00', 'x')");
     test_same("x = 'abc'.replace('b', '\\uDC00')");
 
-    // Case-folding and trimming: even paths that would preserve the
-    // encoding (trim, toLowerCase) bail for uniformity — the fold
-    // produces a bare `StringLiteral` with `lone_surrogates: false`,
-    // which codegen would emit as raw bytes, not as `\uXXXX`.
+    // Case-folding and trimming bail for uniformity — the result would lack the flag.
     test_same("x = '\\uDC00'.toLowerCase()");
     test_same("x = '\\uDC00'.toUpperCase()");
     test_same("x = '[\\uDC00]'.toUpperCase()");
     test_same("x = '\\uDC00'.trim()");
     test_same("x = '  \\uDC00  '.trim()");
 
-    // URL encode/decode: `encodeURI('\uD800')` throws at runtime; our
-    // value is the encoded form, so running the `%`-encoder would
-    // diverge from runtime behaviour.
+    // `encodeURI('\uD800')` throws at runtime; folding the encoded form would diverge.
     test_same("x = encodeURI('\\uDC00')");
     test_same("x = encodeURIComponent('\\uDC00')");
     test_same("x = decodeURI('\\uDC00')");
     test_same("x = decodeURIComponent('\\uDC00')");
 
-    // `String()` and `.toString()` would route the encoded bytes
-    // through `value_to_expr`.
+    // `String()` / `.toString()` would route encoded bytes through `value_to_expr`.
     test_same("x = String('\\uDC00')");
     test_same("x = '\\uDC00'.toString()");
 
-    // `concat`: with all-string args, the result is one merged literal
-    // without the flag; with expression args, the template literal's
-    // quasis can't represent lone surrogates. Both bail.
+    // `.concat`: both the all-string merge and the template-literal rewrite bail.
     test_same("x = ''.concat('[\\uDC00]')");
     test_same("x = '[\\uDC00]'.concat(a)");
     test_same("x = 'a'.concat(b, '[\\uDC00]')");
 
-    // `�` not followed by matching hex is *not* the encoding —
-    // it's the real replacement character, and folds fine.
+    // Control cases: plain U+FFFD (not the encoding) still folds.
     test("x = '\\uFFFD'.toLowerCase()", "x = '\\uFFFD'");
     test("x = '\\uFFFD'.trim()", "x = '\\uFFFD'");
     test("x = ''.concat('\\uFFFD')", "x = '\\uFFFD'");

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -295,6 +295,12 @@ fn test_string_array_splitting() {
     // all possible delimiters used, leave it alone
     test_same_with_longer_args("'.', ',', '(', ')', ' '");
 
+    // Lone surrogates anywhere in the element set: joining the bytes
+    // would produce one `StringLiteral` with `lone_surrogates: false`,
+    // and runtime `.split(',')` against the encoded form would return
+    // mis-sliced code units instead of the original elements. Bail.
+    test_same_with_longer_args("'[\\uDC00]','2','3','4','5','6'");
+
     test_options(
         &format!("var x=['1','2','3','4','5','6'{additional_args}]"),
         "",

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -296,7 +296,7 @@ fn test_string_array_splitting() {
     test_same_with_longer_args("'.', ',', '(', ')', ' '");
 
     // Any lone-surrogate element bails: the merged literal would be flagless, and `.split(',')`
-    // at runtime would mis-slice the encoded bytes.
+    // at runtime would slice into the encoded bytes instead of returning the original elements.
     test_same_with_longer_args("'[\\uDC00]','2','3','4','5','6'");
 
     test_options(

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -295,10 +295,8 @@ fn test_string_array_splitting() {
     // all possible delimiters used, leave it alone
     test_same_with_longer_args("'.', ',', '(', ')', ' '");
 
-    // Lone surrogates anywhere in the element set: joining the bytes
-    // would produce one `StringLiteral` with `lone_surrogates: false`,
-    // and runtime `.split(',')` against the encoded form would return
-    // mis-sliced code units instead of the original elements. Bail.
+    // Any lone-surrogate element bails: the merged literal would be flagless, and `.split(',')`
+    // at runtime would mis-slice the encoded bytes.
     test_same_with_longer_args("'[\\uDC00]','2','3','4','5','6'");
 
     test_options(


### PR DESCRIPTION
What
---

Stop the minifier from corrupting strings that carry `lone_surrogates: true` by routing them through folds that emit a new `StringLiteral` via `value_to_expr`. That constructs the literal with `lone_surrogates: false` and so writes the stored escape bytes verbatim at codegen.

Closes #15524. Supersedes #13229 with a narrower approach: detect at operand level, bail per fold site, keep `ConstantValue::String` unchanged.

Why
---

`oxc_ast` stores a string with unpaired UTF-16 surrogates in a special 5-code-unit-per-surrogate encoding (`\u{FFFD}XXXX`, with `\u{FFFD}fffd` reserved as the self-escape for a real U+FFFD). The flag on `StringLiteral` / `TemplateElement` tells codegen to decode those runs back into `\uXXXX`; when the flag is clear, codegen emits the bytes as-is.

Two strings with the same stored bytes but different flags are different runtime values. `ConstantValue::String` only holds bytes. Any fold that reads an operand's string, threads it through `ConstantValue::String`, and rebuilds a literal therefore silently converts a flagged input into a 5-code-unit ASCII-plus-U+FFFD runtime value.

The concrete example from #15524:

```
console.log(':' + `[\uDC00-\uDFFF]`)
```

was minified to

```
console.log(':[�dc00-�dfff]');
```

instead of preserving the lone surrogates.

How
---

New module `crates/oxc_ecmascript/src/constant_evaluation/lone_surrogates.rs` centralises detection:

- `expr_may_have_lone_surrogates` — the main gate. Recurses through composing kinds (add / array / logical / conditional / sequence / parenthesized / template), resolves `Identifier` via a byte scan over its constant value, and returns `false` for `Call` / `New` / `TaggedTemplate` on the documented bottom-up invariant that every string-producing fold self-bails. Exhaustive `Expression` match, so a new variant yields a compile error here.
- `str_has_lone_surrogate_encoding` / `flagged_str_runtime_utf16_length` — byte-level primitives used where only a `ConstantValue::String` is in hand, and for the new `.length` fold on flagged literals.
- `template_may_have_lone_surrogates` / `array_may_have_lone_surrogates` / `get_side_free_string_value_without_lone_surrogates` — small helpers for specific call-site shapes.

Callers gate every fold that would emit a new `StringLiteral`: string methods, URI encoders/decoders, `String(arg)`, `toString`, `.concat`, template merges/inlining, the array-split rewrite, the single-use constant inliner, `+` concat and the `a + 'b' + 'c'` reshape, string equality, string ordering. Paths that move the AST node verbatim via `take_in` ride the flag along for free — the declarator-level single-use inliner and `'' + x → x` need no gate; each carries a one-line comment explaining why.

Detection is conservative: false positives skip an optimisation, never emit a corrupted value. The byte scan can't distinguish an encoded run from a real U+FFFD followed by four hex characters, so identifier- and concat-bound flagged strings currently don't fold through `.length` — pinned in tests.

Left for later
---

- `.length` folding for template literals with all quasis and no expressions, if minsize shows it matters.
- Plumb the `lone_surrogates` flag through constant propagation — either by extending `ConstantValue::String` to carry it, or by stashing the binding's initialiser AST node on `SymbolValue`. Every identifier-bound fold then consults the flag directly instead of byte-scanning; the helper's Identifier arm and the inline byte-scans in `inline_identifier_reference`, `try_fold_string_casing`, and `get_side_free_string_value_without_lone_surrogates` collapse into flag lookups. As a bonus, the conservative bail on byte-twin operands (a real `�` followed by four hex chars) goes away — `.length` of an identifier-bound flagged string starts folding, and other folds stop missing legitimate opportunities.
