### PR TITLE
refactor(allocator): remove conversions to/from `NonNull` pointers

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc.rs
+++ b/crates/oxc_allocator/src/arena/alloc.rs
@@ -4,8 +4,8 @@
 
 use std::{
     alloc::Layout,
-    ptr::{self},
-    slice, str,
+    ptr::{self, NonNull},
+    str,
 };
 
 use super::{Arena, bumpalo_alloc::AllocErr, utils::oom};
@@ -78,7 +78,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         F: FnOnce() -> T,
     {
         #[inline(always)]
-        unsafe fn inner_writer<T, F>(ptr: *mut T, f: F)
+        unsafe fn inner_writer<T, F>(ptr: NonNull<T>, f: F)
         where
             F: FnOnce() -> T,
         {
@@ -91,16 +91,15 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // the code so it writes directly into the heap instead. It seems we get it to realize this most
             // consistently if we put this critical line into it's own function instead of inlining it into the
             // surrounding code.
-            unsafe { ptr::write(ptr, f()) };
+            unsafe { ptr.write(f()) };
         }
 
         let layout = Layout::new::<T>();
+        let mut ptr = self.alloc_layout(layout).cast::<T>();
 
         unsafe {
-            let ptr = self.alloc_layout(layout);
-            let ptr = ptr.as_ptr().cast::<T>();
             inner_writer(ptr, f);
-            &mut *ptr
+            ptr.as_mut()
         }
     }
 
@@ -131,7 +130,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         F: FnOnce() -> T,
     {
         #[inline(always)]
-        unsafe fn inner_writer<T, F>(ptr: *mut T, f: F)
+        unsafe fn inner_writer<T, F>(ptr: NonNull<T>, f: F)
         where
             F: FnOnce() -> T,
         {
@@ -144,17 +143,16 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // the code so it writes directly into the heap instead. It seems we get it to realize this most
             // consistently if we put this critical line into it's own function instead of inlining it into the
             // surrounding code.
-            unsafe { ptr::write(ptr, f()) };
+            unsafe { ptr.write(f()) };
         }
 
         // Self-contained: `ptr` is allocated for `T` and then a `T` is written.
         let layout = Layout::new::<T>();
-        let ptr = self.try_alloc_layout(layout)?;
-        let ptr = ptr.as_ptr().cast::<T>();
+        let mut ptr = self.try_alloc_layout(layout)?.cast::<T>();
 
         unsafe {
             inner_writer(ptr, f);
-            Ok(&mut *ptr)
+            Ok(ptr.as_mut())
         }
     }
 
@@ -184,7 +182,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         unsafe {
             ptr::copy_nonoverlapping(src.as_ptr(), dst_ptr.as_ptr(), src.len());
-            slice::from_raw_parts_mut(dst_ptr.as_ptr(), src.len())
+            NonNull::slice_from_raw_parts(dst_ptr, src.len()).as_mut()
         }
     }
 
@@ -226,10 +224,10 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         unsafe {
             for (i, val) in src.iter().cloned().enumerate() {
-                ptr::write(dst_ptr.as_ptr().add(i), val);
+                dst_ptr.add(i).write(val);
             }
 
-            slice::from_raw_parts_mut(dst_ptr.as_ptr(), src.len())
+            NonNull::slice_from_raw_parts(dst_ptr, src.len()).as_mut()
         }
     }
 
@@ -287,10 +285,10 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         unsafe {
             for i in 0..len {
-                ptr::write(dst_ptr.as_ptr().add(i), f(i));
+                dst_ptr.add(i).write(f(i));
             }
 
-            let result = slice::from_raw_parts_mut(dst_ptr.as_ptr(), len);
+            let result = NonNull::slice_from_raw_parts(dst_ptr, len).as_mut();
             debug_assert_eq!(Layout::for_value(result), layout);
             result
         }

--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -4,12 +4,7 @@
 //! They all ultimately call into `alloc_layout` or `try_alloc_layout`, defined in this module.
 //! (`alloc_layout` and `try_alloc_layout` are also public methods)
 
-use std::{
-    alloc::Layout,
-    cmp::max,
-    iter,
-    ptr::{self, NonNull},
-};
+use std::{alloc::Layout, cmp::max, iter, ptr::NonNull};
 
 use allocator_api2::alloc::{AllocError, Allocator};
 
@@ -20,7 +15,7 @@ use super::{
     bumpalo_alloc::{Alloc as BumpaloAlloc, AllocErr},
     utils::{
         is_pointer_aligned_to, layout_from_size_align, oom, round_down_to, round_mut_ptr_down_to,
-        round_mut_ptr_up_to_unchecked, round_up_to,
+        round_nonnull_ptr_up_to_unchecked, round_up_to,
     },
 };
 
@@ -397,14 +392,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // otherwise they are simply leaked - at least until somebody calls `reset()`
         unsafe {
             if self.is_last_allocation(ptr) {
-                let cursor_ptr = self.cursor_ptr.get().as_ptr().add(layout.size());
-
-                let cursor_ptr = round_mut_ptr_up_to_unchecked(cursor_ptr, MIN_ALIGN);
+                let cursor_ptr = self.cursor_ptr.get().add(layout.size());
+                let cursor_ptr = round_nonnull_ptr_up_to_unchecked(cursor_ptr, MIN_ALIGN);
                 debug_assert!(
-                    is_pointer_aligned_to(cursor_ptr, MIN_ALIGN),
+                    is_pointer_aligned_to(cursor_ptr.as_ptr(), MIN_ALIGN),
                     "bump pointer {cursor_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
                 );
-                let cursor_ptr = NonNull::new_unchecked(cursor_ptr);
                 self.cursor_ptr.set(cursor_ptr);
             }
         }
@@ -439,9 +432,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 self.stats.record_reallocation_after_allocation();
 
                 // We know that these regions are nonoverlapping because `new_ptr` is a fresh allocation
-                unsafe {
-                    ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_layout.size());
-                }
+                unsafe { new_ptr.copy_from_nonoverlapping(ptr, new_layout.size()) };
 
                 Ok(new_ptr)
             };
@@ -484,7 +475,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         {
             unsafe {
                 // Note: `new_ptr` is aligned, because ptr *has to* be aligned, and we made sure delta is aligned
-                let new_ptr = NonNull::new_unchecked(self.cursor_ptr.get().as_ptr().add(delta));
+                let new_ptr = self.cursor_ptr.get().add(delta);
                 debug_assert!(
                     is_pointer_aligned_to(new_ptr.as_ptr(), MIN_ALIGN),
                     "bump pointer {new_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
@@ -492,7 +483,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 self.cursor_ptr.set(new_ptr);
 
                 // Note: We know it is non-overlapping because of the size check in the `if` condition
-                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
+                new_ptr.copy_from_nonoverlapping(ptr, new_size);
 
                 #[cfg(all(
                     feature = "track_allocations",
@@ -528,7 +519,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             if let Some(new_ptr) =
                 self.try_alloc_layout_fast(layout_from_size_align(delta, old_layout.align())?)
             {
-                unsafe { ptr::copy(ptr.as_ptr(), new_ptr.as_ptr(), old_size) };
+                unsafe { new_ptr.copy_from(ptr, old_size) };
 
                 #[cfg(all(
                     feature = "track_allocations",
@@ -542,7 +533,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         // Fallback: Do a fresh allocation and copy the existing data into it
         let new_ptr = self.try_alloc_layout(new_layout)?;
-        unsafe { ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_size) };
+        unsafe { new_ptr.copy_from_nonoverlapping(ptr, old_size) };
 
         #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
         self.stats.record_reallocation_after_allocation();
@@ -594,9 +585,7 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Arena<MIN_ALIGN> {
     #[inline]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.try_alloc_layout(layout)
-            .map(|p| unsafe {
-                NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), layout.size()))
-            })
+            .map(|new_ptr| NonNull::slice_from_raw_parts(new_ptr, layout.size()))
             .map_err(|_| AllocError)
     }
 
@@ -613,9 +602,7 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Arena<MIN_ALIGN> {
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
         unsafe { Arena::<MIN_ALIGN>::shrink(self, ptr, old_layout, new_layout) }
-            .map(|p| unsafe {
-                NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), new_layout.size()))
-            })
+            .map(|new_ptr| NonNull::slice_from_raw_parts(new_ptr, new_layout.size()))
             .map_err(|_| AllocError)
     }
 
@@ -627,9 +614,7 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Arena<MIN_ALIGN> {
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
         unsafe { Arena::<MIN_ALIGN>::grow(self, ptr, old_layout, new_layout) }
-            .map(|p| unsafe {
-                NonNull::new_unchecked(ptr::slice_from_raw_parts_mut(p.as_ptr(), new_layout.size()))
-            })
+            .map(|new_ptr| NonNull::slice_from_raw_parts(new_ptr, new_layout.size()))
             .map_err(|_| AllocError)
     }
 
@@ -640,8 +625,8 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Arena<MIN_ALIGN> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        let mut ptr = unsafe { self.grow(ptr, old_layout, new_layout) }?;
-        (unsafe { ptr.as_mut() })[old_layout.size()..].fill(0);
-        Ok(ptr)
+        let mut new_ptr = unsafe { self.grow(ptr, old_layout, new_layout) }?;
+        (unsafe { new_ptr.as_mut() })[old_layout.size()..].fill(0);
+        Ok(new_ptr)
     }
 }

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -1,12 +1,6 @@
 //! Methods to get info about the chunks of memory allocated by an `Arena`, and associated iterator types.
 
-use std::{
-    iter::FusedIterator,
-    marker::PhantomData,
-    mem,
-    ptr::{self, NonNull},
-    slice,
-};
+use std::{iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull, slice};
 
 use super::{Arena, CHUNK_FOOTER_SIZE, ChunkFooter};
 
@@ -224,27 +218,24 @@ impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
 
     fn next(&mut self) -> Option<(*mut u8, usize)> {
         unsafe {
-            let footer = self.footer_ptr.as_ref();
+            let footer_ptr = self.footer_ptr;
+            let footer = footer_ptr.as_ref();
             if footer.is_empty() {
                 return None;
             }
 
-            let start_ptr = footer.start_ptr.as_ptr();
-            let cursor_ptr = self
-                .current_chunk_cursor_ptr
-                .take()
-                .unwrap_or_else(|| footer.cursor_ptr.get())
-                .as_ptr();
-            let end_ptr = ptr::from_ref(footer).cast::<u8>();
+            let cursor_ptr =
+                self.current_chunk_cursor_ptr.take().unwrap_or_else(|| footer.cursor_ptr.get());
+            let end_ptr = footer_ptr.cast::<u8>();
 
-            debug_assert!(start_ptr <= cursor_ptr);
-            debug_assert!(cursor_ptr.cast_const() <= end_ptr);
+            debug_assert!(footer.start_ptr <= cursor_ptr);
+            debug_assert!(cursor_ptr <= end_ptr);
 
             // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`
-            let len = end_ptr.offset_from_unsigned(cursor_ptr.cast_const());
+            let len = end_ptr.offset_from_unsigned(cursor_ptr);
             self.footer_ptr = footer.previous_chunk_footer_ptr.get();
 
-            Some((cursor_ptr, len))
+            Some((cursor_ptr.as_ptr(), len))
         }
     }
 }

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -3,7 +3,7 @@
 use std::{
     alloc::{self, Layout},
     cell::Cell,
-    ptr::{self, NonNull},
+    ptr::NonNull,
 };
 
 use super::bumpalo_alloc::AllocErr;
@@ -345,31 +345,23 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             let start_ptr = NonNull::new(start_ptr)?;
 
             // The `ChunkFooter` is at the end of the chunk
-            let footer_ptr = start_ptr.as_ptr().add(new_size_without_footer);
+            let footer_ptr = start_ptr.add(new_size_without_footer).cast::<ChunkFooter>();
             debug_assert!(is_pointer_aligned_to(start_ptr.as_ptr(), align));
-            debug_assert!(is_pointer_aligned_to(footer_ptr, CHUNK_ALIGN));
-            #[expect(
-                clippy::cast_ptr_alignment,
-                reason = "footer_ptr is aligned to CHUNK_ALIGN, which is == align_of::<ChunkFooter>()"
-            )]
-            let footer_ptr = footer_ptr.cast::<ChunkFooter>();
+            debug_assert!(is_pointer_aligned_to(footer_ptr.as_ptr(), CHUNK_ALIGN));
 
             // Initial cursor sits at the footer, which is the end of the allocatable region.
             // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
-            let cursor_ptr = NonNull::new_unchecked(footer_ptr.cast::<u8>());
+            let cursor_ptr = footer_ptr.cast::<u8>();
             debug_assert!(is_pointer_aligned_to(cursor_ptr.as_ptr(), MIN_ALIGN));
 
-            ptr::write(
-                footer_ptr,
-                ChunkFooter {
-                    start_ptr,
-                    layout,
-                    previous_chunk_footer_ptr: Cell::new(previous_chunk_footer_ptr),
-                    cursor_ptr: Cell::new(cursor_ptr),
-                },
-            );
+            footer_ptr.write(ChunkFooter {
+                start_ptr,
+                layout,
+                previous_chunk_footer_ptr: Cell::new(previous_chunk_footer_ptr),
+                cursor_ptr: Cell::new(cursor_ptr),
+            });
 
-            Some(NonNull::new_unchecked(footer_ptr))
+            Some(footer_ptr)
         }
     }
 }

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -79,11 +79,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// * `cursor_ptr` must be aligned to `MIN_ALIGN`.
     /// * No live references to data in the current chunk before `cursor_ptr` can exist.
     pub unsafe fn set_cursor_ptr(&self, cursor_ptr: NonNull<u8>) {
-        debug_assert!(cursor_ptr.as_ptr() >= self.start_ptr.get().as_ptr());
-        debug_assert!(
-            cursor_ptr.as_ptr() <= self.current_chunk_footer_ptr.get().as_ptr().cast::<u8>()
-        );
-        debug_assert!(cursor_ptr.addr().get().is_multiple_of(MIN_ALIGN));
+        debug_assert!(cursor_ptr >= self.start_ptr.get());
+        debug_assert!(cursor_ptr <= self.current_chunk_footer_ptr.get().cast::<u8>());
+        debug_assert!(is_pointer_aligned_to(cursor_ptr.as_ptr(), MIN_ALIGN));
 
         // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `cursor_ptr` is valid
         #[expect(clippy::unnecessary_safety_comment)]

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -6,11 +6,7 @@
 
 #![expect(clippy::inline_always, clippy::undocumented_unsafe_blocks)]
 
-use std::{
-    alloc::Layout,
-    cell::Cell,
-    ptr::{self, NonNull},
-};
+use std::{alloc::Layout, cell::Cell, ptr::NonNull};
 
 #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
 use crate::tracking::AllocationStats;
@@ -317,6 +313,6 @@ impl EmptyChunkFooter {
 impl ChunkFooter {
     /// Returns `true` if this chunk is the empty chunk (end of the linked list).
     fn is_empty(&self) -> bool {
-        ptr::eq(self, EMPTY_CHUNK_FOOTER.get().as_ptr())
+        NonNull::from_ref(self) == EMPTY_CHUNK_FOOTER.get()
     }
 }

--- a/crates/oxc_allocator/src/arena/utils.rs
+++ b/crates/oxc_allocator/src/arena/utils.rs
@@ -1,6 +1,6 @@
 //! Utility functions for `Arena`.
 
-use std::{alloc::Layout, hint::unreachable_unchecked};
+use std::{alloc::Layout, hint::unreachable_unchecked, ptr::NonNull};
 
 pub use super::bumpalo_alloc::AllocErr;
 
@@ -57,11 +57,12 @@ pub fn round_mut_ptr_down_to(ptr: *mut u8, divisor: usize) -> *mut u8 {
 }
 
 #[inline]
-pub unsafe fn round_mut_ptr_up_to_unchecked(ptr: *mut u8, divisor: usize) -> *mut u8 {
+pub unsafe fn round_nonnull_ptr_up_to_unchecked(ptr: NonNull<u8>, divisor: usize) -> NonNull<u8> {
     debug_assert!(divisor.is_power_of_two());
     unsafe {
-        let aligned = round_up_to_unchecked(ptr.addr(), divisor);
-        let delta = aligned - ptr.addr();
+        let addr = ptr.addr().get();
+        let aligned = round_up_to_unchecked(addr, divisor);
+        let delta = aligned - addr;
         ptr.add(delta)
     }
 }


### PR DESCRIPTION
Refactor to `Arena`. Simplify code and reduce unsafe by avoiding round-trip conversions between `NonNull` and `*mut` pointers.