### PR TITLE
refactor(allocator): `ChunkRawIter` yield `NonNull` pointers

### DIFF
--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -1,6 +1,6 @@
 //! Methods to get info about the chunks of memory allocated by an `Arena`, and associated iterator types.
 
-use std::{iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull, slice};
+use std::{iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull};
 
 use super::{Arena, CHUNK_FOOTER_SIZE, ChunkFooter};
 
@@ -188,8 +188,7 @@ impl<'a, const MIN_ALIGN: usize> Iterator for ChunkIter<'a, MIN_ALIGN> {
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
             let (ptr, len) = self.raw.next()?;
-            let slice = slice::from_raw_parts(ptr as *const mem::MaybeUninit<u8>, len);
-            Some(slice)
+            Some(NonNull::slice_from_raw_parts(ptr.cast::<mem::MaybeUninit<u8>>(), len).as_ref())
         }
     }
 }
@@ -214,9 +213,9 @@ pub struct ChunkRawIter<'a, const MIN_ALIGN: usize = 1> {
 }
 
 impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
-    type Item = (*mut u8, usize);
+    type Item = (NonNull<u8>, usize);
 
-    fn next(&mut self) -> Option<(*mut u8, usize)> {
+    fn next(&mut self) -> Option<(NonNull<u8>, usize)> {
         unsafe {
             let footer_ptr = self.footer_ptr;
             let footer = footer_ptr.as_ref();
@@ -235,7 +234,7 @@ impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
             let len = end_ptr.offset_from_unsigned(cursor_ptr);
             self.footer_ptr = footer.previous_chunk_footer_ptr.get();
 
-            Some((cursor_ptr.as_ptr(), len))
+            Some((cursor_ptr, len))
         }
     }
 }

--- a/crates/oxc_allocator/tests/arena/main.rs
+++ b/crates/oxc_allocator/tests/arena/main.rs
@@ -12,7 +12,6 @@
     clippy::needless_pass_by_value,
     clippy::print_stderr,
     clippy::print_stdout,
-    clippy::ptr_as_ptr,
     clippy::ptr_cast_constness,
     clippy::ptr_offset_by_literal,
     clippy::ref_as_ptr,

--- a/crates/oxc_allocator/tests/arena/quickchecks.rs
+++ b/crates/oxc_allocator/tests/arena/quickchecks.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use std::{mem, ptr::NonNull};
 
 use ::quickcheck::{Arbitrary, Gen};
 
@@ -232,10 +232,10 @@ quickcheck! {
     fn all_allocations_in_a_chunk(values: Vec<BigValue>) -> () {
         let b = Arena::new();
         let allocated: Vec<&BigValue> = values.into_iter().map(|val| b.alloc(val) as &_).collect();
-        let chunks: Vec<(*mut u8, usize)> = unsafe { b.iter_allocated_chunks_raw() }.collect();
+        let chunks: Vec<(NonNull<u8>, usize)> = unsafe { b.iter_allocated_chunks_raw() }.collect();
         for alloc in allocated.into_iter() {
             assert!(chunks.iter().any(|&(ptr, size)| {
-                let ptr = ptr as usize;
+                let ptr = ptr.addr().get();
                 let chunk = (ptr, ptr + size);
                 contains(chunk, range(alloc))
             }));
@@ -247,11 +247,11 @@ quickcheck! {
         for val in values {
             b.alloc(val);
         }
-        let raw_chunks: Vec<(_, _)> = unsafe { b.iter_allocated_chunks_raw() }.collect();
+        let raw_chunks: Vec<(NonNull<u8>, usize)> = unsafe { b.iter_allocated_chunks_raw() }.collect();
         let chunks: Vec<&[_]> = b.iter_allocated_chunks().collect();
         assert_eq!(raw_chunks.len(), chunks.len());
         for ((ptr, size), chunk) in raw_chunks.into_iter().zip(chunks) {
-            assert_eq!(ptr as *const _, chunk.as_ptr() as *const _);
+            assert_eq!(ptr.as_ptr().cast_const(), chunk.as_ptr().cast::<u8>());
             assert_eq!(size, chunk.len());
         }
     }


### PR DESCRIPTION
`ChunkRawIter` is an iterator over pointer & length pairs for an `Arena`'s chunks. Alter it to return `NonNull<u8>` pointers instead of `*mut u8` pointers.

This is not a breaking change, as we do not expose the `Arena` type externally.