### PR TITLE
fix(allocator): fix UB in `Arena::grow_zeroed`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -625,8 +625,19 @@ unsafe impl<const MIN_ALIGN: usize> Allocator for &Arena<MIN_ALIGN> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        let mut new_ptr = unsafe { self.grow(ptr, old_layout, new_layout) }?;
-        (unsafe { new_ptr.as_mut() })[old_layout.size()..].fill(0);
+        let new_ptr = unsafe { self.grow(ptr, old_layout, new_layout) }?;
+
+        // Zero the tail of the new allocation (the bytes past the copied old contents).
+        // Write through a raw pointer rather than constructing a `&mut [u8]` over the full range,
+        // because the tail is uninitialized and `&mut [u8]` spanning uninit bytes is UB.
+        // `old_layout.size() <= new_layout.size()` (invariant of `Allocator` trait), so this cannot underflow.
+        let tail_len = new_layout.size() - old_layout.size();
+
+        // SAFETY: `new_ptr` covers `new_layout.size()` bytes.
+        // `old_layout.size() <= new_layout.size()` (invariant of `Allocator` trait).
+        // So `tail_len` bytes starting at offset `old_layout.size()` are in bounds.
+        unsafe { new_ptr.cast::<u8>().add(old_layout.size()).write_bytes(0, tail_len) };
+
         Ok(new_ptr)
     }
 }


### PR DESCRIPTION
Implementation of `grow_zeroed` method of `allocator_api2::alloc::Allocator` trait for `Arena` created a `&mut [u8]` covering the tail end of a new allocation which may contain uninitialized bytes. This is UB.

Fix this by using `NonNull::write_bytes` to zero the bytes instead.

Same fix submitted to `bumpalo`: https://github.com/fitzgen/bumpalo/pull/321