### PR TITLE
refactor(allocator): `is_pointer_aligned_to` take any pointer

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -355,10 +355,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 Self::new_chunk(new_chunk_memory_details, layout, current_footer_ptr)
             })?;
 
-            debug_assert!(is_pointer_aligned_to(
-                new_footer_ptr.as_ref().start_ptr.as_ptr(),
-                layout.align()
-            ));
+            debug_assert!(is_pointer_aligned_to(new_footer_ptr.as_ref().start_ptr, layout.align()));
 
             // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
             // can read its final cursor position later.
@@ -395,7 +392,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 let cursor_ptr = self.cursor_ptr.get().add(layout.size());
                 let cursor_ptr = round_nonnull_ptr_up_to_unchecked(cursor_ptr, MIN_ALIGN);
                 debug_assert!(
-                    is_pointer_aligned_to(cursor_ptr.as_ptr(), MIN_ALIGN),
+                    is_pointer_aligned_to(cursor_ptr, MIN_ALIGN),
                     "bump pointer {cursor_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
                 );
                 self.cursor_ptr.set(cursor_ptr);
@@ -420,7 +417,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // In the case of (2), to successfully "shrink" the allocation, we have to allocate a whole new region
         // for the new layout.
         if old_layout.align() < new_layout.align() {
-            return if is_pointer_aligned_to(ptr.as_ptr(), new_layout.align()) {
+            return if is_pointer_aligned_to(ptr, new_layout.align()) {
                 Ok(ptr)
             } else {
                 let new_ptr = self.try_alloc_layout(new_layout)?;
@@ -438,7 +435,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             };
         }
 
-        debug_assert!(is_pointer_aligned_to(ptr.as_ptr(), new_layout.align()));
+        debug_assert!(is_pointer_aligned_to(ptr, new_layout.align()));
 
         let old_size = old_layout.size();
         let new_size = new_layout.size();
@@ -477,7 +474,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 // Note: `new_ptr` is aligned, because ptr *has to* be aligned, and we made sure delta is aligned
                 let new_ptr = self.cursor_ptr.get().add(delta);
                 debug_assert!(
-                    is_pointer_aligned_to(new_ptr.as_ptr(), MIN_ALIGN),
+                    is_pointer_aligned_to(new_ptr, MIN_ALIGN),
                     "bump pointer {new_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
                 );
                 self.cursor_ptr.set(new_ptr);

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -346,13 +346,13 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
             // The `ChunkFooter` is at the end of the chunk
             let footer_ptr = start_ptr.add(new_size_without_footer).cast::<ChunkFooter>();
-            debug_assert!(is_pointer_aligned_to(start_ptr.as_ptr(), align));
-            debug_assert!(is_pointer_aligned_to(footer_ptr.as_ptr(), CHUNK_ALIGN));
+            debug_assert!(is_pointer_aligned_to(start_ptr, align));
+            debug_assert!(is_pointer_aligned_to(footer_ptr, CHUNK_ALIGN));
 
             // Initial cursor sits at the footer, which is the end of the allocatable region.
             // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
             let cursor_ptr = footer_ptr.cast::<u8>();
-            debug_assert!(is_pointer_aligned_to(cursor_ptr.as_ptr(), MIN_ALIGN));
+            debug_assert!(is_pointer_aligned_to(cursor_ptr, MIN_ALIGN));
 
             footer_ptr.write(ChunkFooter {
                 start_ptr,

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -63,7 +63,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // We don't need to reset `cursor_ptr` in `ChunkFooter`, as it'll be set if the chunk is retired later on.
             // `iter_allocated_chunks_raw` ignores `cursor_ptr` of the current chunk.
             debug_assert!(
-                is_pointer_aligned_to(current_footer_ptr.as_ptr(), MIN_ALIGN),
+                is_pointer_aligned_to(current_footer_ptr, MIN_ALIGN),
                 "bump pointer {current_footer_ptr:#p} should be aligned to the minimum alignment of {MIN_ALIGN:#x}"
             );
             self.cursor_ptr.set(current_footer_ptr.cast::<u8>());

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -29,7 +29,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// * `start_ptr` must have permission for writes.
     pub unsafe fn from_raw_parts(start_ptr: NonNull<u8>, size: usize) -> Self {
         // Debug assert that `start_ptr` and `size` fulfill size and alignment requirements
-        debug_assert!(is_pointer_aligned_to(start_ptr.as_ptr(), CHUNK_ALIGN));
+        debug_assert!(is_pointer_aligned_to(start_ptr, CHUNK_ALIGN));
         debug_assert!(size.is_multiple_of(CHUNK_ALIGN));
         debug_assert!(size >= CHUNK_FOOTER_SIZE);
 
@@ -81,7 +81,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     pub unsafe fn set_cursor_ptr(&self, cursor_ptr: NonNull<u8>) {
         debug_assert!(cursor_ptr >= self.start_ptr.get());
         debug_assert!(cursor_ptr <= self.current_chunk_footer_ptr.get().cast::<u8>());
-        debug_assert!(is_pointer_aligned_to(cursor_ptr.as_ptr(), MIN_ALIGN));
+        debug_assert!(is_pointer_aligned_to(cursor_ptr, MIN_ALIGN));
 
         // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `cursor_ptr` is valid
         #[expect(clippy::unnecessary_safety_comment)]

--- a/crates/oxc_allocator/src/arena/utils.rs
+++ b/crates/oxc_allocator/src/arena/utils.rs
@@ -4,8 +4,37 @@ use std::{alloc::Layout, hint::unreachable_unchecked, ptr::NonNull};
 
 pub use super::bumpalo_alloc::AllocErr;
 
+/// Types that expose a pointer address.
+///
+/// Implemented for `*const T`, `*mut T`, and `NonNull<T>` so `is_pointer_aligned_to`
+/// can take any of them without forcing callers to pre-convert.
+pub trait Pointer {
+    fn addr(self) -> usize;
+}
+
+impl<T: ?Sized> Pointer for *const T {
+    #[inline]
+    fn addr(self) -> usize {
+        self.addr()
+    }
+}
+
+impl<T: ?Sized> Pointer for *mut T {
+    #[inline]
+    fn addr(self) -> usize {
+        self.addr()
+    }
+}
+
+impl<T: ?Sized> Pointer for NonNull<T> {
+    #[inline]
+    fn addr(self) -> usize {
+        self.addr().get()
+    }
+}
+
 #[inline]
-pub fn is_pointer_aligned_to<T>(ptr: *mut T, align: usize) -> bool {
+pub fn is_pointer_aligned_to<P: Pointer>(ptr: P, align: usize) -> bool {
     debug_assert!(align.is_power_of_two());
 
     let addr = ptr.addr();


### PR DESCRIPTION
Make `is_pointer_aligned_to` helper function take any pointer (`*const`, `*mut`, `NonNull`). This shortens code at call sites, making it easier to see what's being checked.