### PR TITLE
refactor(linter): allow `config` in `declare_oxc_lint` to be a path to a config struct

### DIFF
--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -3,6 +3,13 @@ use oxc_macros::declare_oxc_lint_test;
 
 struct TestRule;
 
+mod shared_config {
+    #[derive(schemars::JsonSchema)]
+    pub struct Config;
+}
+
+struct TestRuleWithSharedConfig;
+
 declare_oxc_lint_test!(
     /// Dummy description
     /// # which is multiline
@@ -25,6 +32,15 @@ declare_oxc_lint_test!(
     version = "next"
 );
 
+declare_oxc_lint_test!(
+    /// Dummy description3
+    TestRuleWithSharedConfig,
+    eslint,
+    correctness,
+    version = "next",
+    config = shared_config::Config,
+);
+
 #[test]
 fn test_declare_oxc_lint() {
     // Simple, multiline documentation
@@ -40,4 +56,12 @@ fn test_declare_oxc_lint() {
 
     // plugin name is passed to const
     assert_eq!(TestRule::PLUGIN, "eslint");
+
+    // Shared config paths can be used as config schema sources.
+    let has_config = TestRuleWithSharedConfig::HAS_CONFIG;
+    assert!(has_config);
+
+    let mut generator =
+        schemars::r#gen::SchemaGenerator::new(schemars::r#gen::SchemaSettings::default());
+    assert!(TestRuleWithSharedConfig::config_schema(&mut generator).is_some());
 }

--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -3,7 +3,7 @@ use itertools::Itertools as _;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    Attribute, Error, Expr, Ident, Lit, LitStr, Meta, Result, Token,
+    Attribute, Error, Expr, Ident, Lit, LitStr, Meta, Path, Result, Token,
     parse::{Parse, ParseStream},
 };
 
@@ -28,9 +28,9 @@ pub struct LintRuleMeta {
     documentation: DocumentationSource,
     pub used_in_test: bool,
     /// Rule configuration
-    /// This is the name of a struct/enum/whatever implementing
+    /// This is the path to a struct/enum/whatever implementing
     /// schemars::JsonSchema
-    config: Option<Ident>,
+    config: Option<Path>,
     /// The version of oxlint in which this rule was first available.
     version: LitStr,
 }
@@ -104,7 +104,7 @@ impl Parse for LintRuleMeta {
         // the RuleMeta impl, falling back on default set by RuleMeta itself.
         // Do not provide a default value here so that it can be set there instead.
         let mut fix: Option<Ident> = None;
-        let mut config: Option<Ident> = None;
+        let mut config: Option<Path> = None;
         let mut version: Option<LitStr> = None;
 
         // remaining options are `key = value` pairs, with the exception of
@@ -126,7 +126,7 @@ impl Parse for LintRuleMeta {
                         fix.replace(key);
                     }
                 }
-                // config = StructImplementingJsonSchemaTrait
+                // config = path::to::StructImplementingJsonSchemaTrait
                 "config" => {
                     input.parse::<Token!(=)>()?;
                     config.replace(input.parse()?);

--- a/crates/oxc_macros/src/lib.rs
+++ b/crates/oxc_macros/src/lib.rs
@@ -14,6 +14,7 @@ mod declare_oxc_lint;
 /// 4. What kind of auto-fixes the lint supports, if any
 ///
 /// And optionally, a 5th part for defining configuration if there are any config options.
+/// The config value may be a local type or a type path such as `shared::rule::RuleConfig`.
 ///
 /// ## Documentation
 /// Lint rule documentation added here will be used to build documentation pages


### PR DESCRIPTION
In order to support shared config structs like in https://github.com/oxc-project/oxc/pull/18467, we need to allow defining `config` as a path to a struct in a different module, like `config = shared::SomeConfig`