### PR TITLE
docs(linter): Improve the docs for the `vitest/hoisted-apis-on-top` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
+++ b/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
@@ -14,8 +14,9 @@ use crate::{
 };
 
 fn hoisted_apis_on_top_diagnostic(span: Span) -> OxcDiagnostic {
+    // TODO: Only mention the doMock alternative if the API in question is `vi.mock()`.
     OxcDiagnostic::warn("Hoisted API cannot be used in a runtime location in this file.")
-        .with_help("Move this hoisted API to the top of the file to better reflect its behavior.\nIf possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.")
+        .with_help("Move this hoisted API to the top of the file to better reflect its behavior.\nYou may alternatively replace `vi.mock()` with `vi.doMock`, which is not hoisted.")
         .with_label(span)
 }
 
@@ -27,14 +28,21 @@ pub struct HoistedApisOnTop;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce hoisted APIs to be on top of the file.
+    /// Requires [hoisted](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting) Vitest APIs
+    /// (`vi.mock`, `vi.unmock`, and `vi.hoisted`) to appear in the top-level of the file.
     ///
     /// ### Why is this bad?
     ///
-    /// Some Vitest APIs are hoisted automatically during the transform process. Using this APIs
-    /// in look like runtime code can lead to unexpected results running tests.
+    /// Vitest hoists certain APIs to the top of the file during transformation, so they always
+    /// run before any imports — regardless of where they appear in the source. Writing them
+    /// inside conditionals, test bodies, or other runtime locations can be misleading and confusing.
+    ///
+    /// The code looks like it executes at runtime, but it actually runs first. This rule ensures
+    /// that these hoisted APIs are not allowed in confusing contexts.
     ///
     /// ### Examples
+    ///
+    /// <!-- TODO: Add comments to these example code snippets explaining what their problems are. -->
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js

--- a/crates/oxc_linter/src/snapshots/vitest_hoisted_apis_on_top.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_hoisted_apis_on_top.snap
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        You may alternatively replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
   ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.mjs:5:6]
@@ -20,7 +20,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        You may alternatively replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
   ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.mjs:5:6]
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        You may alternatively replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
   ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.mjs:5:6]
@@ -40,7 +40,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        You may alternatively replace `vi.mock()` with `vi.doMock`, which is not hoisted.
 
   ⚠ eslint-plugin-vitest(hoisted-apis-on-top): Hoisted API cannot be used in a runtime location in this file.
    ╭─[hoisted_apis_on_top.mjs:3:6]
@@ -50,4 +50,4 @@ source: crates/oxc_linter/src/tester.rs
  4 │             }
    ╰────
   help: Move this hoisted API to the top of the file to better reflect its behavior.
-        If possible, replace `vi.mock()` with `vi.doMock`, which is not hoisted.
+        You may alternatively replace `vi.mock()` with `vi.doMock`, which is not hoisted.


### PR DESCRIPTION
The docs for this rule were a bit hard to understand, so this rewrites them.

Also add two TODO comments for future improvements.