### PR TITLE
docs(linter): Improve docs for `vitest/require-mock-type-parameters` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/require_mock_type_parameters.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_mock_type_parameters.rs
@@ -48,21 +48,22 @@ impl std::ops::Deref for RequireMockTypeParameters {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforces the use of type parameters on vi.fn(), and optionally on vi.importActual() and vi.importMock().
+    /// Enforces the use of type parameters on `vi.fn()`, and optionally on `vi.importActual()` and `vi.importMock()`.
     ///
-    /// By default, only vi.fn() is checked. Set checkImportFunctions to true to also check vi.importActual() and vi.importMock().
+    /// By default, only `vi.fn()` is checked. Set `checkImportFunctions` to `true` to also check `vi.importActual()` and `vi.importMock()`.
     ///
     /// ### Why is this bad?
     ///
-    /// Without explicit type parameters, vi.fn() creates a mock typed as (...args: any[]) => any.
+    /// Without explicit type parameters, `vi.fn()` creates a mock typed as `(...args: any[]) => any`.
     /// This disables type checking between the mock and the real implementation, which can lead to two problems:
     ///
-    /// - tests that fail due to incorrect mock usage when they should pass, or worse, tests that pass while the mock silently diverges from the actual runtime behavior.
+    /// - tests that fail due to incorrect mock usage when they should pass
+    /// - or worse, tests that pass while the mock silently diverges from the actual runtime behavior.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule configured as `{ "checkImportFunctions": false }`:
-    /// ```js
+    /// ```ts
     /// import { vi } from 'vitest'
     ///
     /// test('foo', () => {
@@ -71,7 +72,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **incorrect** code for this rule configured as `{ "checkImportFunctions": true }`:
-    /// ```js
+    /// ```ts
     /// import { vi } from 'vitest'
     ///
     /// vi.mock('./example.js', async () => {
@@ -83,18 +84,18 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule configured as `{ "checkImportFunctions": false }`:
-    /// ```js
+    /// ```ts
     /// import { vi } from 'vitest'
     ///
-    ///  test('foo', () => {
-    ///    const myMockedFnOne = vi.fn<(arg1: string, arg2: boolean) => number>()
-    ///    const myMockedFnTwo = vi.fn<() => void>()
-    ///    const myMockedFnThree = vi.fn<any>()
-    ///  })
+    /// test('foo', () => {
+    ///   const myMockedFnOne = vi.fn<(arg1: string, arg2: boolean) => number>()
+    ///   const myMockedFnTwo = vi.fn<() => void>()
+    ///   const myMockedFnThree = vi.fn<any>()
+    /// })
     /// ```
     ///
     /// Examples of **correct** code for this rule configured as `{ "checkImportFunctions": true }`:
-    /// ```js
+    /// ```ts
     /// import { vi } from 'vitest'
     ///
     /// vi.mock('./example.js', async () => {


### PR DESCRIPTION
The code examples were marked as `js` but contained TypeScript syntax, so oxfmt was messing them up. Also added some missing backticks around method names.