### PR TITLE
docs(linter): Misc grammar cleanup for Vitest rules.

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
@@ -129,13 +129,13 @@ impl ConsistentEachForJson {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule ensure consistency on which method used to create parameterized test.
-    /// This configuration affects to different test function types (`test`, `it`, `describe`, `suite`).
+    /// This rule enforces consistency in which method is used to create parameterized tests.
+    /// This configuration affects different test function types (`test`, `it`, `describe`, `suite`).
     ///
     /// ### Why is this bad?
     ///
-    /// Not having a consistent way to create parametrized tests, we rely on the developer to remember that
-    /// `.for` spread the values as different arguments and `.each` pass the array as an unique argument.
+    /// Without a consistent way to create parameterized tests, we rely on the developer to remember that
+    /// `.for` spreads the values as different arguments while `.each` passes the array as a single argument.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
@@ -157,12 +157,12 @@ impl TrackingExpectPair {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// It checks when a target is expected with `toHaveBeenCalledOnce` and `toHaveBeenCalledWith` instead of
+    /// It checks when a target is asserted with both `toHaveBeenCalledOnce` and `toHaveBeenCalledWith` instead of
     /// `toHaveBeenCalledExactlyOnceWith`.
     ///
     /// ### Why is this bad?
     ///
-    /// The user must deduct from both expects that the spy function is called once and with a specific arguments.
+    /// The reader must deduce from both expectations that the spy function is called once and with specific arguments.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_once.rs
@@ -28,9 +28,9 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// The *Times method required to read the arguments to know how many times
-    /// is expected a spy to be called. Most of the times you expecting a method is called
-    /// once.
+    /// The `*Times` matchers require reading the argument to know how many
+    /// times a spy is expected to be called. Most of the time, you expect a
+    /// method to be called once.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
@@ -29,9 +29,9 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Tests that are related to a specific function, if the function being tested is renamed,
-    /// the describe title will be not match anymore and can make confusion in the future. Using the function
-    /// ensure a consistency even if the function is renamed.
+    /// For tests that are related to a specific function, if the function being tested is renamed,
+    /// the describe title will no longer match and can cause confusion in the future. Using the function
+    /// directly ensures consistency even if the function is renamed.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/prefer_expect_type_of.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_expect_type_of.rs
@@ -16,6 +16,7 @@ fn prefer_expect_type_of_diagnostic(span: Span, help: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn("Type assertions should be done using `expectTypeOf`.")
         .with_help(format!("Substitute the assertion with `{help}`."))
         .with_label(span)
+        .with_note("https://vitest.dev/api/expect-typeof")
 }
 
 #[derive(Debug, Default, Clone)]
@@ -24,11 +25,11 @@ pub struct PreferExpectTypeOf;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce using `expectTypeOf` instead of `expect(typeof ...)`
+    /// Enforce using [`expectTypeOf`](https://vitest.dev/api/expect-typeof) instead of `expect(typeof ...)`.
     ///
     /// ### Why is this bad?
     ///
-    /// Vitest provide a more expressive type-safe way to test type than using `expect(typeof ...)`
+    /// Vitest provides a more expressive, type-safe way to test types than using `expect(typeof ...)`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// A lack of type information and IntelliSense increase the risk of mismatches between the real module and it's mock.
+    /// A lack of type information and IntelliSense increases the risk of mismatches between the real module and its mock.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/warn_todo.rs
+++ b/crates/oxc_linter/src/rules/vitest/warn_todo.rs
@@ -24,12 +24,11 @@ pub struct WarnTodo;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule triggers warnings when `.todo` is used in `describe`, `it`, or `test` functions.
-    /// It is recommended to use this with your CI pipeline to annotate PR diffs.
+    /// This rule warns about usage of `.todo` in `describe`, `it`, or `test` functions.
     ///
     /// ### Why is this bad?
     ///
-    /// The test that you push should be completed, any pending/"TODO" code should not be committed.
+    /// The tests you push should be complete. Any pending/`TODO` code should not be committed.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(12).toBeNumber()`.
+  note: https://vitest.dev/api/expect-typeof
 
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf("name").toBeString()`.
+  note: https://vitest.dev/api/expect-typeof
 
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(true).toBeBoolean()`.
+  note: https://vitest.dev/api/expect-typeof
 
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(variable).toBeObject()`.
+  note: https://vitest.dev/api/expect-typeof
 
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
@@ -36,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(fn).toBeFunction()`.
+  note: https://vitest.dev/api/expect-typeof
 
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(value).toBeString()`.
+  note: https://vitest.dev/api/expect-typeof
 
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
@@ -50,6 +56,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(value).not.toBeString()`.
+  note: https://vitest.dev/api/expect-typeof
 
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
@@ -57,3 +64,4 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(value)["not"].toBeString()`.
+  note: https://vitest.dev/api/expect-typeof


### PR DESCRIPTION
Just some minor grammar cleanup for Vitest rules and other minor docs improvements, including a Vitest docs URL on one rule's diagnostics.

Had Claude look through and ensure correct grammar across the rules and then tweaked what it found.