### PR TITLE
chore(oxlint/lsp): define `rulesCustomization`

### DIFF
--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize, de::Error};
 use serde_json::Value;
 
 use oxc_linter::FixKind;
+use tracing::error;
 
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -89,6 +90,70 @@ pub struct LintOptions {
     /// What kind of fixes to generate for code actions.
     #[schemars(with = "Option<LintFixKindFlag>")]
     pub fix_kind: LintFixKindFlag,
+    /// Customization for individual rules, allows to override the linter's diagnostics and autofix.
+    /// Example of lowering the severity of "no-unused-vars" rule to "hint" and disabling autofix for it:
+    /// ```json
+    /// {
+    ///   "rulesCustomization": {
+    ///     "no-unused-vars": {
+    ///       "severity": "hint",
+    ///       "autofix": false
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules_customization: Option<RulesCustomization>,
+}
+
+#[derive(Debug, Default, Serialize, PartialEq, Eq, JsonSchema)]
+#[serde(transparent)]
+pub struct RulesCustomization {
+    #[serde(flatten)]
+    pub rules: FxHashMap<String, RuleCustomization>,
+}
+
+impl<'de> Deserialize<'de> for RulesCustomization {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let Some(object) = value.as_object() else {
+            return Err(D::Error::custom("rulesCustomization must be an object"));
+        };
+
+        let mut rules = FxHashMap::with_capacity_and_hasher(object.len(), FxBuildHasher);
+        for (rule_name, rule_config) in object {
+            let Ok(customization) = RuleCustomization::deserialize(rule_config) else {
+                error!("failed to deserialize customization for rule {rule_name}, skipping.");
+                continue;
+            };
+            rules.insert(rule_name.clone(), customization);
+        }
+
+        Ok(Self { rules })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum RuleCustomizationSeverity {
+    Error,
+    Warn,
+    Info,
+    Hint,
+    Off,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleCustomization {
+    // note: this will not enable "off" rules; it only customizes active rules
+    // it only modifies the severity of returned diagnostics, not the linter configuration
+    pub severity: Option<RuleCustomizationSeverity>,
+    // some editors support "fix all" code action, this flag indicates whether to include this rule in "fix all" code action
+    pub autofix: Option<bool>,
 }
 
 #[derive(Debug, Default, Serialize, PartialEq, Eq, Deserialize, JsonSchema)]
@@ -158,7 +223,6 @@ impl TryFrom<Value> for LintOptions {
                 flags.insert("fix_kind".to_string(), fix_kind);
             }
         }
-
         Ok(Self {
             run: object.get("run").and_then(|run| Run::deserialize(run).ok()).unwrap_or_default(),
             unused_disable_directives: object
@@ -185,6 +249,12 @@ impl TryFrom<Value> for LintOptions {
                     Some(&"all") => LintFixKindFlag::All,
                     _ => LintFixKindFlag::default(),
                 }),
+            #[cfg(not(test))]
+            rules_customization: None,
+            #[cfg(test)]
+            rules_customization: object
+                .get("rulesCustomization")
+                .and_then(|key| RulesCustomization::deserialize(key).ok()),
         })
     }
 }
@@ -193,7 +263,7 @@ impl TryFrom<Value> for LintOptions {
 mod test {
     use serde_json::json;
 
-    use super::{LintOptions, Run, UnusedDisableDirectives};
+    use super::{LintOptions, RuleCustomizationSeverity, Run, UnusedDisableDirectives};
 
     #[test]
     fn test_valid_options_json() {
@@ -203,7 +273,16 @@ mod test {
             "unusedDisableDirectives": "warn",
             "typeAware": true,
             "disableNestedConfig": true,
-            "fixKind": "dangerous_fix"
+            "fixKind": "dangerous_fix",
+            "rulesCustomization": {
+                "no-unused-vars": {
+                    "severity": "error",
+                    "autofix": true
+                },
+                "eqeqeq": {
+                    "severity": "warn"
+                }
+            }
         });
 
         let options = LintOptions::try_from(json).unwrap();
@@ -213,6 +292,16 @@ mod test {
         assert_eq!(options.type_aware, Some(true));
         assert!(options.disable_nested_config);
         assert_eq!(options.fix_kind, super::LintFixKindFlag::DangerousFix);
+
+        assert!(options.rules_customization.is_some());
+        let rules_customization = options.rules_customization.unwrap();
+        assert_eq!(rules_customization.rules.len(), 2);
+        let no_unused_vars = &rules_customization.rules["no-unused-vars"];
+        assert_eq!(no_unused_vars.severity, Some(RuleCustomizationSeverity::Error));
+        assert_eq!(no_unused_vars.autofix, Some(true));
+        let eqeqeq = &rules_customization.rules["eqeqeq"];
+        assert_eq!(eqeqeq.severity, Some(RuleCustomizationSeverity::Warn));
+        assert_eq!(eqeqeq.autofix, None);
     }
 
     #[test]
@@ -226,6 +315,7 @@ mod test {
         assert_eq!(options.type_aware, None);
         assert!(!options.disable_nested_config);
         assert_eq!(options.fix_kind, super::LintFixKindFlag::SafeFixOrSuggestion);
+        assert!(options.rules_customization.is_none());
     }
 
     #[test]
@@ -245,6 +335,29 @@ mod test {
         let options = LintOptions::try_from(json).unwrap();
         assert_eq!(options.run, Run::OnType); // fallback
         assert_eq!(options.config_path, Some("./custom.json".into()));
+    }
+
+    #[test]
+    fn test_invalid_rule_customization_json() {
+        let json = json!({
+            "rulesCustomization": {
+                "valid-rule": {
+                    "severity": "error",
+                },
+                "invalid-rule": {
+                    "severity": "invalid_severity",
+                }
+            }
+        });
+
+        let options = LintOptions::try_from(json).unwrap();
+        assert!(options.rules_customization.is_some());
+        let rules_customization = options.rules_customization.unwrap();
+        assert_eq!(rules_customization.rules.len(), 1);
+        // rule settings are valid
+        assert!(rules_customization.rules.contains_key("valid-rule"));
+        // rule settings are invalid, should be skipped without affecting the deserialization of other rules
+        assert!(!rules_customization.rules.contains_key("invalid-rule"));
     }
 
     #[test]

--- a/tasks/website_linter/src/snapshots/schema_markdown_lsp.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown_lsp.snap
@@ -74,6 +74,25 @@ type: `"safe_fix" | "safe_fix_or_suggestion" | "dangerous_fix" | "dangerous_fix_
 What kind of fixes to generate for code actions.
 
 
+## rulesCustomization
+
+type: `Record<string, object>`
+
+
+Customization for individual rules, allows to override the linter's diagnostics and autofix.
+Example of lowering the severity of "no-unused-vars" rule to "hint" and disabling autofix for it:
+```json
+{
+  "rulesCustomization": {
+    "no-unused-vars": {
+      "severity": "hint",
+      "autofix": false
+    }
+  }
+}
+```
+
+
 ## run
 
 type: `"onSave" | "onType"`


### PR DESCRIPTION
Related https://github.com/oxc-project/oxc-vscode/issues/22

Created a POC form a new LSP configuration `ruleCustomization`, which allows users to override the **output** of the linter. It will not change the behavior, because the integration with nested config and Co. would to too much for it.
This aligns how VS Code ESLint does it: https://github.com/microsoft/vscode-eslint/issues/1541

VS Code ESLint supports with `eslint.rules.customizations` another structure with "glob" support (see related issue). 
For simplicity, I created a normal map. I am not sure, if glob features are really needed.

Because of this, the struct is different from `eslint.rules.customizations`.
- `severity` will change the output diagnostic, or remove it completely with "off", I think that what VS Code does too
- `autofix` is new and has nothing to do with `fixable` from ESLint. It will disable the fix for the code actions on save. Allowing users to avoid unexpected remove of code described by https://github.com/oxc-project/oxc/issues/21538