### PR TITLE
chore(oxlint/lsp): respect `RuleCustomization.severity` for lsp diagnostics

### DIFF
--- a/apps/oxlint/fixtures/lsp/rules_customization/severity/.oxlintrc.json
+++ b/apps/oxlint/fixtures/lsp/rules_customization/severity/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-debugger": "error",
+    "no-console": "error"
+  }
+}

--- a/apps/oxlint/fixtures/lsp/rules_customization/severity/test.ts
+++ b/apps/oxlint/fixtures/lsp/rules_customization/severity/test.ts
@@ -1,0 +1,2 @@
+debugger;
+console.log('Hello, world!');

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -12,6 +12,8 @@ use oxc_linter::{
     AllowWarnDeny, DisableDirectives, Fix, FixKind, Message, PossibleFixes, RuleCommentType,
 };
 
+use crate::lsp::options::{RuleCustomizationSeverity, RulesCustomization};
+
 #[derive(Debug, Clone, Default)]
 pub struct DiagnosticReport {
     pub diagnostic: Diagnostic,
@@ -41,6 +43,38 @@ pub enum FixedContentKind {
     UnusedDirective,
 }
 
+impl RulesCustomization {
+    fn get_severity_for_rule(&self, code: &OxcCode) -> Option<RuleCustomizationSeverity> {
+        let rule_name = code.number.as_ref()?;
+        let scope = code.scope.as_ref()?;
+
+        if scope == "eslint" {
+            self.rules
+                .get(rule_name.as_ref())
+                .and_then(|customization| customization.severity.clone())
+        } else {
+            let lookup = format!("{scope}/{rule_name}");
+            self.rules.get(lookup.as_str()).and_then(|customization| customization.severity.clone())
+        }
+    }
+}
+
+impl TryFrom<RuleCustomizationSeverity> for DiagnosticSeverity {
+    type Error = &'static str;
+
+    fn try_from(value: RuleCustomizationSeverity) -> Result<Self, Self::Error> {
+        match value {
+            RuleCustomizationSeverity::Error => Ok(DiagnosticSeverity::ERROR),
+            RuleCustomizationSeverity::Warn => Ok(DiagnosticSeverity::WARNING),
+            RuleCustomizationSeverity::Hint => Ok(DiagnosticSeverity::HINT),
+            RuleCustomizationSeverity::Info => Ok(DiagnosticSeverity::INFORMATION),
+            RuleCustomizationSeverity::Off => Err(
+                "Off severity should not be converted to DiagnosticSeverity as it means the rule is disabled and should not produce diagnostics.",
+            ),
+        }
+    }
+}
+
 fn miette_severity_to_lsp_severity(value: Severity) -> DiagnosticSeverity {
     match value {
         Severity::Error => DiagnosticSeverity::ERROR,
@@ -56,8 +90,18 @@ pub fn message_to_lsp_diagnostic(
     uri: &Uri,
     source_text: &str,
     rope: &Rope,
-) -> DiagnosticReport {
-    let severity = miette_severity_to_lsp_severity(message.error.severity);
+    rules_customization: Option<&RulesCustomization>,
+) -> Option<DiagnosticReport> {
+    let severity = if let Some(rules_customization) = rules_customization {
+        if let Some(severity) = rules_customization.get_severity_for_rule(&message.error.code) {
+            // filter off rules early
+            DiagnosticSeverity::try_from(severity).ok()?
+        } else {
+            miette_severity_to_lsp_severity(message.error.severity)
+        }
+    } else {
+        miette_severity_to_lsp_severity(message.error.severity)
+    };
 
     let related_information = message.error.labels.as_ref().map(|spans| {
         spans
@@ -165,10 +209,10 @@ pub fn message_to_lsp_diagnostic(
     // and attaching a ignore comment would not ignore the error.
     // This is because the ignore comment would need to be placed before the error offset, which is not possible.
     if error_offset == section_offset && message.span.end == section_offset {
-        return DiagnosticReport {
+        return Some(DiagnosticReport {
             diagnostic,
             code_action: Some(LinterCodeAction { range, fixed_content }),
-        };
+        });
     }
 
     add_ignore_fixes(
@@ -186,7 +230,7 @@ pub fn message_to_lsp_diagnostic(
         Some(LinterCodeAction { range, fixed_content })
     };
 
-    DiagnosticReport { diagnostic, code_action }
+    Some(DiagnosticReport { diagnostic, code_action })
 }
 
 fn fix_to_fixed_content(

--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -136,7 +136,7 @@ impl<'de> Deserialize<'de> for RulesCustomization {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum RuleCustomizationSeverity {
     Error,

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -44,7 +44,9 @@ use crate::{
             generate_inverted_diagnostics, message_to_lsp_diagnostic,
         },
         lsp_file_system::LspFileSystem,
-        options::{LintOptions as LSPLintOptions, Run, UnusedDisableDirectives},
+        options::{
+            LintOptions as LSPLintOptions, RulesCustomization, Run, UnusedDisableDirectives,
+        },
         utils::{normalize_path, range_overlaps},
     },
 };
@@ -232,6 +234,7 @@ impl ServerLinterBuilder {
             runner,
             fix_kind,
             lint_options.report_unused_directive,
+            options.rules_customization,
         )
     }
 }
@@ -387,6 +390,7 @@ pub struct ServerLinter {
     runner: LintRunner,
     fix_kind: FixKind,
     unused_directives_severity: Option<AllowWarnDeny>,
+    rules_customization: Option<RulesCustomization>,
 }
 
 impl Tool for ServerLinter {
@@ -668,6 +672,7 @@ impl ServerLinter {
         runner: LintRunner,
         fix_kind: FixKind,
         unused_directives_severity: Option<AllowWarnDeny>,
+        rules_customization: Option<RulesCustomization>,
     ) -> Self {
         Self {
             run,
@@ -679,6 +684,7 @@ impl ServerLinter {
             runner,
             fix_kind,
             unused_directives_severity,
+            rules_customization,
         }
     }
 
@@ -788,7 +794,15 @@ impl ServerLinter {
             match self.runner.run_source(&[Arc::from(path.as_os_str())], &fs) {
                 Ok(results) => results
                     .into_iter()
-                    .map(|message| message_to_lsp_diagnostic(message, uri, source_text, rope))
+                    .filter_map(|message| {
+                        message_to_lsp_diagnostic(
+                            message,
+                            uri,
+                            source_text,
+                            rope,
+                            self.rules_customization.as_ref(),
+                        )
+                    })
                     .collect(),
                 Err(e) => {
                     // clear disable directives on error to prevent stale directives
@@ -1450,5 +1464,23 @@ mod test {
             }),
         );
         tester.test_and_snapshot_single_file("foo-bar.astro");
+    }
+
+    #[test]
+    fn test_rules_customization_severity() {
+        let tester = Tester::new(
+            "fixtures/lsp/rules_customization/severity",
+            json!({
+                "rulesCustomization": {
+                    "no-debugger": {
+                        "severity": "warn"
+                    },
+                    "no-console": {
+                        "severity": "off"
+                    }
+                }
+            }),
+        );
+        tester.test_and_snapshot_single_file("test.ts");
     }
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_rules_customization_severity@test.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_rules_customization_severity@test.ts.snap
@@ -1,0 +1,92 @@
+---
+source: apps/oxlint/src/lsp/tester.rs
+---
+########## 
+Linted file: fixtures/lsp/rules_customization/severity/test.ts
+----------
+########## Diagnostic Reports
+File URI: file://<variable>/fixtures/lsp/rules_customization/severity/test.ts
+
+code: "eslint(no-debugger)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
+range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/lsp/rules_customization/severity/test.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+
+########### Code Actions/Commands
+CodeAction: 
+Title: Remove the debugger statement
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    },
+    new_text: "",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this line
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable-next-line no-debugger\n",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this whole file
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable no-debugger\n",
+}
+
+
+########### Fix All Action
+CodeAction: 
+Title: fix all safe fixable oxlint issues
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    },
+    new_text: "",
+}


### PR DESCRIPTION
> ## Pull request overview

> This PR updates the oxlint LSP pipeline so that per-rule `rulesCustomization.severity` can override the severity of emitted LSP diagnostics (and suppress diagnostics entirely when set to `off`), 