### PR TITLE
refactor(allocator): replace `ChunkFooter::is_empty` with free function

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -13,6 +13,7 @@ use oxc_data_structures::assert_unchecked;
 use super::{
     Arena, CHUNK_FOOTER_SIZE, DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER,
     bumpalo_alloc::{Alloc as BumpaloAlloc, AllocErr},
+    is_empty_footer,
     utils::{
         is_pointer_aligned_to, layout_from_size_align, oom, round_down_to, round_mut_ptr_down_to,
         round_nonnull_ptr_up_to_unchecked, round_up_to_unchecked,
@@ -365,7 +366,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // to the empty chunk's footer, which is the existing value of empty chunk footer's `cursor_ptr` anyway.
             // But nonetheless, the empty chunk footer is a `static`, accessible from all threads simultaneously.
             // Updating it from 2 threads simultaneously would be a data race (UB), even though both writes are no-ops.
-            if !current_footer_ptr.as_ref().is_empty() {
+            if !is_empty_footer(current_footer_ptr) {
                 current_footer_ptr.as_ref().cursor_ptr.set(self.cursor_ptr.get());
             }
 

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -2,7 +2,7 @@
 
 use std::{iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull};
 
-use super::{Arena, CHUNK_FOOTER_SIZE, ChunkFooter};
+use super::{Arena, CHUNK_FOOTER_SIZE, ChunkFooter, is_empty_footer};
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Gets the remaining capacity in the current chunk (in bytes).
@@ -156,7 +156,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // SAFETY: Walk the chunk list until the empty sentinel chunk.
         // Every non-empty chunk is a live allocation whose `layout.size()` includes the footer.
         unsafe {
-            while !footer_ptr.as_ref().is_empty() {
+            while !is_empty_footer(footer_ptr) {
                 total += footer_ptr.as_ref().layout.size() - CHUNK_FOOTER_SIZE;
                 footer_ptr = footer_ptr.as_ref().previous_chunk_footer_ptr.get();
             }
@@ -176,11 +176,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// [`allocated_bytes`]: Self::allocated_bytes
     pub fn used_bytes(&self) -> usize {
         let mut footer_ptr = self.current_chunk_footer_ptr.get();
-        // SAFETY: `self.current_chunk_footer_ptr` always points to a valid `ChunkFooter`
-        let footer = unsafe { footer_ptr.as_ref() };
 
         // If `Arena` owns no memory, return 0
-        if footer.is_empty() {
+        if is_empty_footer(footer_ptr) {
             return 0;
         }
 
@@ -189,11 +187,11 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`
         let mut total = unsafe { end_ptr.offset_from_unsigned(self.cursor_ptr.get()) };
 
-        // Add used bytes from previous chunks, getting pointer from their `ChunkFooter`s
-        footer_ptr = footer.previous_chunk_footer_ptr.get();
+        // Add used bytes from previous chunks, getting pointer from their `ChunkFooter`s.
+        // SAFETY: `self.current_chunk_footer_ptr` always points to a valid `ChunkFooter`.
+        footer_ptr = unsafe { footer_ptr.as_ref() }.previous_chunk_footer_ptr.get();
 
-        // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
-        while !unsafe { footer_ptr.as_ref() }.is_empty() {
+        while !is_empty_footer(footer_ptr) {
             // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
             let footer = unsafe { footer_ptr.as_ref() };
 
@@ -263,11 +261,11 @@ impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
     fn next(&mut self) -> Option<(NonNull<u8>, usize)> {
         unsafe {
             let footer_ptr = self.footer_ptr;
-            let footer = footer_ptr.as_ref();
-            if footer.is_empty() {
+            if is_empty_footer(footer_ptr) {
                 return None;
             }
 
+            let footer = footer_ptr.as_ref();
             let cursor_ptr =
                 self.current_chunk_cursor_ptr.take().unwrap_or_else(|| footer.cursor_ptr.get());
             let end_ptr = footer_ptr.cast::<u8>();

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -2,7 +2,9 @@
 
 use std::{alloc, ptr::NonNull};
 
-use super::{Arena, ChunkFooter, EMPTY_CHUNK_FOOTER, utils::is_pointer_aligned_to};
+use super::{
+    Arena, ChunkFooter, EMPTY_CHUNK_FOOTER, is_empty_footer, utils::is_pointer_aligned_to,
+};
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Reset this arena.
@@ -46,11 +48,11 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // Takes `&mut self` so `self` must be unique, and there can't be any borrows active
         // that would get invalidated by resetting
         unsafe {
-            if self.current_chunk_footer_ptr.get().as_ref().is_empty() {
+            let current_footer_ptr = self.current_chunk_footer_ptr.get();
+
+            if is_empty_footer(current_footer_ptr) {
                 return;
             }
-
-            let current_footer_ptr = self.current_chunk_footer_ptr.get();
 
             // Deallocate all chunks except the current one
             let prev_footer_ptr = current_footer_ptr
@@ -70,7 +72,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
             let current_chunk_footer = self.current_chunk_footer_ptr.get().as_ref();
             debug_assert!(
-                current_chunk_footer.previous_chunk_footer_ptr.get().as_ref().is_empty(),
+                is_empty_footer(current_chunk_footer.previous_chunk_footer_ptr.get()),
                 "We should only have a single chunk"
             );
             debug_assert_eq!(
@@ -94,7 +96,7 @@ impl<const MIN_ALIGN: usize> Drop for Arena<MIN_ALIGN> {
 #[inline]
 unsafe fn dealloc_chunk_list(mut footer_ptr: NonNull<ChunkFooter>) {
     unsafe {
-        while !footer_ptr.as_ref().is_empty() {
+        while !is_empty_footer(footer_ptr) {
             let current_footer_ptr = footer_ptr;
             footer_ptr = current_footer_ptr.as_ref().previous_chunk_footer_ptr.get();
             alloc::dealloc(

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -310,9 +310,8 @@ impl EmptyChunkFooter {
     }
 }
 
-impl ChunkFooter {
-    /// Returns `true` if this chunk is the empty chunk (end of the linked list).
-    fn is_empty(&self) -> bool {
-        NonNull::from_ref(self) == EMPTY_CHUNK_FOOTER.get()
-    }
+/// Returns `true` if the given `footer_ptr` points to the canonical empty chunk footer.
+#[inline(always)] // Because it's only 1 instruction
+fn is_empty_footer(footer_ptr: NonNull<ChunkFooter>) -> bool {
+    footer_ptr == EMPTY_CHUNK_FOOTER.get()
 }


### PR DESCRIPTION
Remove `ChunkFooter::is_empty` method and add an `is_empty_footer` free function instead. This is beneficial as it removes the need for unsafe pointer to reference conversions.