### PR TITLE
feat(allocator): add `Allocator::cursor_ptr` method

### DIFF
--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -64,6 +64,11 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         arena
     }
 
+    /// Get the current cursor pointer for this [`Arena`]'s current chunk.
+    pub fn cursor_ptr(&self) -> NonNull<u8> {
+        self.cursor_ptr.get()
+    }
+
     /// Set cursor pointer for this [`Arena`]'s current chunk.
     ///
     /// This is dangerous, and this method should not ordinarily be used.

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -1,6 +1,7 @@
 //! Define additional methods, used only by raw transfer:
 //!
 //! * [`Allocator::from_raw_parts`]
+//! * [`Allocator::cursor_ptr`]
 //! * [`Allocator::set_cursor_ptr`]
 //! * [`Allocator::data_end_ptr`]
 //! * [`Allocator::end_ptr`]
@@ -44,6 +45,11 @@ impl Allocator {
         // SAFETY: Safety requirements of `Arena::from_raw_parts` are the same as for this method
         let arena = unsafe { Arena::from_raw_parts(ptr, size) };
         Self::from_arena(arena)
+    }
+
+    /// Get the current cursor pointer for this [`Allocator`]'s current chunk.
+    pub fn cursor_ptr(&self) -> NonNull<u8> {
+        self.arena().cursor_ptr()
     }
 
     /// Set cursor pointer for this [`Allocator`]'s current chunk.


### PR DESCRIPTION
Add a method `Allocator::cursor_ptr` to get the cursor pointer for current chunk. Only available when `from_raw_parts` Cargo feature is enabled.