### PR TITLE
fix(linter): add checks that `Program` is in current allocator chunk before JS plugins linting

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -446,14 +446,13 @@ impl Linter {
         // So instead we get a pointer to `Program`.
         // The pointer is obtained initially from `&Program` in `Semantic`, but that pointer
         // has no provenance for mutation, so can't be converted to `&mut Program`.
-        // So create a new pointer to `Program` which inherits `data_end_ptr`'s provenance,
-        // which does allow mutation.
+        // So create a new pointer to `Program` which inherits `cursor_ptr`'s provenance, which does allow mutation.
         //
         // We then drop `Semantic`, after which no references to any AST nodes remain.
-        // We can then safety convert the pointer to `&mut Program`.
+        // We can then safely convert the pointer to `&mut Program`.
         //
-        // `Program` was created in `allocator`, and that allocator is a `FixedSizeAllocator`,
-        // so only has 1 chunk. So `data_end_ptr` and `Program` are within the same allocation.
+        // `Program` was created in `allocator`, and `Program` is the last thing to be allocated, so is in current chunk.
+        // So `cursor_ptr` and `Program` are within the same allocation.
         // All callers of `Linter::run` obtain `allocator` and `Semantic` from `ModuleContent`,
         // which ensure they are in same allocation.
         // However, we have no static guarantee of this, so strictly speaking it's unsound.
@@ -462,11 +461,13 @@ impl Linter {
         let ctx_host = Rc::get_mut(ctx_host).unwrap();
         let semantic = mem::take(ctx_host.semantic_mut());
         let program_addr = NonNull::from(semantic.nodes().program()).addr();
-        let mut program_ptr =
-            allocator.data_end_ptr().cast::<Program<'a>>().with_addr(program_addr);
+        // Check `Program` is in `Allocator`'s current chunk
+        debug_assert!(program_addr >= allocator.cursor_ptr().addr());
+        debug_assert!(program_addr < allocator.data_end_ptr().addr());
+        let mut program_ptr = allocator.cursor_ptr().cast::<Program<'a>>().with_addr(program_addr);
         drop(semantic);
         // SAFETY: Now that we've dropped `Semantic`, no references to any AST nodes remain,
-        // so can get a mutable reference to `Program` without aliasing violations.
+        // so can get a mutable reference to `Program` without aliasing violations
         let program = unsafe { program_ptr.as_mut() };
 
         // If `js_allocator_pool` is provided, use clone-into-fixed-allocator approach


### PR DESCRIPTION
When sending an AST to JS for JS plugins, we have to obtain a `&mut Program` reference, so that AST can be mutated to update spans to UTF-16.

We do this via some unsafe pointer manipulation. 3 changes:

1. Use the arena's cursor pointer as source of provenance for the pointer which is converted to the `&mut Program` reference. This makes no difference at present - both pointers have provenence for writing - but it makes more sense.
2. Correct the comment which explains why obtaining a `&mut Program` reference is (mostly) sound.
3. Add debug assertions that check the safety preconditions.

This remains fragile, impossible to prove as sound, and inadvisable. We'll remove this hack as soon as it's practical to do so.