### PR TITLE
refactor(allocator): remove sentinel empty chunk

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -11,9 +11,8 @@ use allocator_api2::alloc::{AllocError, Allocator};
 use oxc_data_structures::assert_unchecked;
 
 use super::{
-    Arena, CHUNK_FOOTER_SIZE, DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER,
+    Arena, CHUNK_FOOTER_SIZE, DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER, EMPTY_ARENA_DATA_PTR,
     bumpalo_alloc::{Alloc as BumpaloAlloc, AllocErr},
-    is_empty_footer,
     utils::{
         is_pointer_aligned_to, layout_from_size_align, oom, round_down_to, round_mut_ptr_down_to,
         round_nonnull_ptr_up_to_unchecked, round_up_to_unchecked,
@@ -74,11 +73,16 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             start_ptr <= cursor_ptr,
             "start pointer {start_ptr:#p} should be less than or equal to bump pointer {cursor_ptr:#p}"
         );
-        debug_assert!(
-            cursor_ptr <= self.current_chunk_footer_ptr.get().cast::<u8>().as_ptr(),
-            "bump pointer {cursor_ptr:#p} should be less than or equal to footer pointer {:#p}",
-            self.current_chunk_footer_ptr.get()
-        );
+        if cfg!(debug_assertions) {
+            let end_ptr = self
+                .current_chunk_footer_ptr
+                .get()
+                .map_or(EMPTY_ARENA_DATA_PTR, NonNull::cast::<u8>);
+            assert!(
+                cursor_ptr <= end_ptr.as_ptr(),
+                "bump pointer {cursor_ptr:#p} should be less than or equal to footer pointer {end_ptr:#p}",
+            );
+        }
         #[expect(clippy::checked_conversions)]
         {
             debug_assert!(
@@ -332,8 +336,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // Get a new chunk from the global allocator
             let current_footer_ptr = self.current_chunk_footer_ptr.get();
 
-            let current_layout = current_footer_ptr.as_ref().layout;
-            let current_size_without_footer = current_layout.size() - CHUNK_FOOTER_SIZE;
+            // For an empty arena (no chunks), treat the current chunk's "size without footer" as 0,
+            // so the doubling below still produces a sensible `min_new_chunk_size` floor.
+            let current_size_without_footer = match current_footer_ptr {
+                Some(footer_ptr) => footer_ptr.as_ref().layout.size() - CHUNK_FOOTER_SIZE,
+                None => 0,
+            };
 
             // By default, we want our new chunk to be about twice as big as the previous chunk.
             // If the global allocator refuses it, we try to divide it by half until it works
@@ -359,14 +367,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             debug_assert!(is_pointer_aligned_to(new_footer_ptr.as_ref().start_ptr, layout.align()));
 
             // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
-            // can read its final cursor position later.
-            //
-            // Do not update `cursor_ptr` of the empty chunk.
-            // That update would be a no-op - when current chunk is the empty chunk, `self.cursor_ptr` always points
-            // to the empty chunk's footer, which is the existing value of empty chunk footer's `cursor_ptr` anyway.
-            // But nonetheless, the empty chunk footer is a `static`, accessible from all threads simultaneously.
-            // Updating it from 2 threads simultaneously would be a data race (UB), even though both writes are no-ops.
-            if !is_empty_footer(current_footer_ptr) {
+            // can read its final cursor position later. Skip this if there was no current chunk.
+            if let Some(current_footer_ptr) = current_footer_ptr {
                 current_footer_ptr.as_ref().cursor_ptr.set(self.cursor_ptr.get());
             }
 
@@ -375,7 +377,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // The footer is aligned on `CHUNK_ALIGN >= MIN_ALIGN`, so no rounding is needed.
             self.start_ptr.set(new_footer_ptr.as_ref().start_ptr);
             self.cursor_ptr.set(new_footer_ptr.cast::<u8>());
-            self.current_chunk_footer_ptr.set(new_footer_ptr);
+            self.current_chunk_footer_ptr.set(Some(new_footer_ptr));
 
             // And then we can rely on `try_alloc_layout_fast` to allocate space within this chunk
             let ptr = self.try_alloc_layout_fast(layout);

--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -2,7 +2,7 @@
 
 use std::{iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull};
 
-use super::{Arena, CHUNK_FOOTER_SIZE, ChunkFooter, is_empty_footer};
+use super::{Arena, CHUNK_FOOTER_SIZE, ChunkFooter};
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Gets the remaining capacity in the current chunk (in bytes).
@@ -18,8 +18,21 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// assert!(capacity >= 100);
     /// ```
     pub fn chunk_capacity(&self) -> usize {
-        // SAFETY: `cursor_ptr` is always equal to or after `start_ptr`.
-        // Both pointers point to within the same allocation.
+        // SAFETY:
+        // `cursor_ptr` is always equal to or after `start_ptr`.
+        // Both pointers point to within the same allocation, or are both the same `EMPTY_ARENA_DATA_PTR` sentinel.
+        //
+        // Docs for `NonNull::offset_from_unsigned` refer to safety conditions of `NonNull::offset_from`.
+        // `offset_from`'s docs state:
+        //
+        // > `self` and `origin` must either:
+        // > * point to the same address, or
+        // > * both be derived from a pointer to the same allocation, and the memory range between the two pointers
+        // >   must be in bounds of that object.
+        // https://doc.rust-lang.org/std/ptr/struct.NonNull.html#method.offset_from
+        //
+        // When both pointers are `EMPTY_ARENA_DATA_PTR` sentinel, the 1st condition is satisfied.
+        // When `Arena` owns a chunk, the 2nd condition is satisfied.
         unsafe { self.cursor_ptr.get().offset_from_unsigned(self.start_ptr.get()) }
     }
 
@@ -152,15 +165,17 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// ```
     pub fn allocated_bytes(&self) -> usize {
         let mut total = 0;
-        let mut footer_ptr = self.current_chunk_footer_ptr.get();
-        // SAFETY: Walk the chunk list until the empty sentinel chunk.
-        // Every non-empty chunk is a live allocation whose `layout.size()` includes the footer.
-        unsafe {
-            while !is_empty_footer(footer_ptr) {
-                total += footer_ptr.as_ref().layout.size() - CHUNK_FOOTER_SIZE;
-                footer_ptr = footer_ptr.as_ref().previous_chunk_footer_ptr.get();
-            }
+        let mut next_footer_ptr = self.current_chunk_footer_ptr.get();
+
+        // Walk the chunk list until the end (`None`).
+        // Every chunk in the list is a live allocation whose `layout.size()` includes the footer.
+        while let Some(footer_ptr) = next_footer_ptr {
+            // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
+            let footer = unsafe { footer_ptr.as_ref() };
+            total += footer.layout.size() - CHUNK_FOOTER_SIZE;
+            next_footer_ptr = footer.previous_chunk_footer_ptr.get();
         }
+
         total
     }
 
@@ -175,23 +190,22 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     ///
     /// [`allocated_bytes`]: Self::allocated_bytes
     pub fn used_bytes(&self) -> usize {
-        let mut footer_ptr = self.current_chunk_footer_ptr.get();
-
         // If `Arena` owns no memory, return 0
-        if is_empty_footer(footer_ptr) {
+        let Some(current_footer_ptr) = self.current_chunk_footer_ptr.get() else {
             return 0;
-        }
+        };
 
         // Get current chunk's used bytes from pointers in `self`, not from the `ChunkFooter`
-        let end_ptr = footer_ptr.cast::<u8>();
+        let end_ptr = current_footer_ptr.cast::<u8>();
         // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`
         let mut total = unsafe { end_ptr.offset_from_unsigned(self.cursor_ptr.get()) };
 
         // Add used bytes from previous chunks, getting pointer from their `ChunkFooter`s.
-        // SAFETY: `self.current_chunk_footer_ptr` always points to a valid `ChunkFooter`.
-        footer_ptr = unsafe { footer_ptr.as_ref() }.previous_chunk_footer_ptr.get();
+        // SAFETY: `current_footer_ptr` always points to a valid `ChunkFooter`.
+        let mut next_footer_ptr =
+            unsafe { current_footer_ptr.as_ref() }.previous_chunk_footer_ptr.get();
 
-        while !is_empty_footer(footer_ptr) {
+        while let Some(footer_ptr) = next_footer_ptr {
             // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
             let footer = unsafe { footer_ptr.as_ref() };
 
@@ -201,7 +215,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`, and both are within the same allocation
             total += unsafe { end_ptr.offset_from_unsigned(cursor_ptr) };
 
-            footer_ptr = footer.previous_chunk_footer_ptr.get();
+            next_footer_ptr = footer.previous_chunk_footer_ptr.get();
         }
 
         total
@@ -248,7 +262,7 @@ impl<const MIN_ALIGN: usize> FusedIterator for ChunkIter<'_, MIN_ALIGN> {}
 /// [`iter_allocated_chunks_raw`]: Arena::iter_allocated_chunks_raw
 #[derive(Debug)]
 pub struct ChunkRawIter<'a, const MIN_ALIGN: usize = 1> {
-    footer_ptr: NonNull<ChunkFooter>,
+    footer_ptr: Option<NonNull<ChunkFooter>>,
     /// Cursor for the current chunk, taken from `Arena::cursor_ptr` at iterator creation.
     /// Consumed on the first iteration. Subsequent iterations read the cursor from each retired chunk's footer.
     current_chunk_cursor_ptr: Option<NonNull<u8>>,
@@ -260,10 +274,7 @@ impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
 
     fn next(&mut self) -> Option<(NonNull<u8>, usize)> {
         unsafe {
-            let footer_ptr = self.footer_ptr;
-            if is_empty_footer(footer_ptr) {
-                return None;
-            }
+            let footer_ptr = self.footer_ptr?;
 
             let footer = footer_ptr.as_ref();
             let cursor_ptr =

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -12,7 +12,7 @@ use super::bumpalo_alloc::AllocErr;
 use crate::tracking::AllocationStats;
 
 use super::{
-    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK_FOOTER,
+    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_ARENA_DATA_PTR,
     utils::{
         is_pointer_aligned_to, layout_from_size_align, oom, round_up_to, round_up_to_unchecked,
     },
@@ -190,7 +190,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     // for specifying the minimum alignment.
     #[inline] // Because it's very cheap
     pub fn with_min_align() -> Self {
-        Self::new_impl(EMPTY_CHUNK_FOOTER.get())
+        Self::new_impl(EMPTY_ARENA_DATA_PTR, EMPTY_ARENA_DATA_PTR, None)
     }
 
     /// Create a new `Arena` that enforces a minimum alignment, and starts with room for at least `capacity` bytes.
@@ -280,33 +280,43 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 // to avoid `Arena::with_capacity` allocating 16 KiB even when requested `capacity` is much smaller.
                 Self::new_chunk_memory_details(capacity, layout).ok_or(AllocErr)?,
                 layout,
-                EMPTY_CHUNK_FOOTER.get(),
+                None,
             )
             .ok_or(AllocErr)?
         };
 
-        Ok(Self::new_impl(chunk_footer_ptr))
+        // SAFETY: `chunk_footer_ptr` points to a valid `ChunkFooter`
+        let start_ptr = unsafe { chunk_footer_ptr.as_ref().start_ptr };
+        // Initial cursor sits at the footer, which is the end of the allocatable region.
+        // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
+        let cursor_ptr = chunk_footer_ptr.cast::<u8>();
+
+        Ok(Self::new_impl(start_ptr, cursor_ptr, Some(chunk_footer_ptr)))
     }
 
-    /// Create a new `Arena` from a chunk footer pointer.
+    /// Create a new `Arena`.
+    ///
+    /// `chunk_footer_ptr` is `None` if no initial chunk has been allocated (the empty `Arena` case).
     ///
     /// This is a helper function for all code paths which create an `Arena`.
     /// All code paths which create an `Arena` must go through this method in order to validate `MIN_ALIGN`.
     #[inline(always)]
-    pub(super) fn new_impl(chunk_footer_ptr: NonNull<ChunkFooter>) -> Self {
+    pub(super) fn new_impl(
+        start_ptr: NonNull<u8>,
+        cursor_ptr: NonNull<u8>,
+        chunk_footer_ptr: Option<NonNull<ChunkFooter>>,
+    ) -> Self {
         // Const assert that `MIN_ALIGN` is valid.
         // This line must be present - the validation assertions don't run unless the const is referenced
         // in active code paths. This method is called by all other methods which create an `Arena`,
         // so we only need it here to ensure that it's impossible to create an `Arena` with an invalid `MIN_ALIGN`.
         const { Self::MIN_ALIGN };
 
-        // SAFETY: `chunk_footer_ptr` points to a valid `ChunkFooter` (either a freshly allocated chunk,
-        // a caller-provided chunk in `from_raw_parts`, or the canonical empty chunk)
-        let start_ptr = unsafe { chunk_footer_ptr.as_ref().start_ptr };
-
-        // Initial cursor sits at the footer, which is the end of the allocatable region.
-        // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
-        let cursor_ptr = chunk_footer_ptr.cast::<u8>();
+        debug_assert!(is_pointer_aligned_to(cursor_ptr, MIN_ALIGN));
+        debug_assert!(start_ptr <= cursor_ptr);
+        debug_assert!(
+            chunk_footer_ptr.is_none_or(|footer_ptr| cursor_ptr <= footer_ptr.cast::<u8>())
+        );
 
         Self {
             cursor_ptr: Cell::new(cursor_ptr),
@@ -396,10 +406,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     }
 
     /// Allocate a new chunk and return its initialized footer.
+    ///
+    /// `previous_chunk_footer_ptr` is `None` when the new chunk will be the first chunk in the arena.
     pub(super) unsafe fn new_chunk(
         new_chunk_memory_details: NewChunkMemoryDetails,
         requested_layout: Layout,
-        previous_chunk_footer_ptr: NonNull<ChunkFooter>,
+        previous_chunk_footer_ptr: Option<NonNull<ChunkFooter>>,
     ) -> Option<NonNull<ChunkFooter>> {
         unsafe {
             let NewChunkMemoryDetails { new_size_without_footer, align, size } =

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -2,9 +2,7 @@
 
 use std::{alloc, ptr::NonNull};
 
-use super::{
-    Arena, ChunkFooter, EMPTY_CHUNK_FOOTER, is_empty_footer, utils::is_pointer_aligned_to,
-};
+use super::{Arena, ChunkFooter, utils::is_pointer_aligned_to};
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Reset this arena.
@@ -48,17 +46,13 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // Takes `&mut self` so `self` must be unique, and there can't be any borrows active
         // that would get invalidated by resetting
         unsafe {
-            let current_footer_ptr = self.current_chunk_footer_ptr.get();
-
-            if is_empty_footer(current_footer_ptr) {
+            let Some(current_footer_ptr) = self.current_chunk_footer_ptr.get() else {
                 return;
-            }
+            };
 
             // Deallocate all chunks except the current one
-            let prev_footer_ptr = current_footer_ptr
-                .as_ref()
-                .previous_chunk_footer_ptr
-                .replace(EMPTY_CHUNK_FOOTER.get());
+            let prev_footer_ptr =
+                current_footer_ptr.as_ref().previous_chunk_footer_ptr.replace(None);
             dealloc_chunk_list(prev_footer_ptr);
 
             // Reset the bump cursor to the end of the chunk.
@@ -70,14 +64,13 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             );
             self.cursor_ptr.set(current_footer_ptr.cast::<u8>());
 
-            let current_chunk_footer = self.current_chunk_footer_ptr.get().as_ref();
             debug_assert!(
-                is_empty_footer(current_chunk_footer.previous_chunk_footer_ptr.get()),
+                current_footer_ptr.as_ref().previous_chunk_footer_ptr.get().is_none(),
                 "We should only have a single chunk"
             );
             debug_assert_eq!(
                 self.cursor_ptr.get(),
-                self.current_chunk_footer_ptr.get().cast::<u8>(),
+                current_footer_ptr.cast::<u8>(),
                 "Our chunk's bump cursor should be reset to the start of its allocation"
             );
         }
@@ -94,10 +87,9 @@ impl<const MIN_ALIGN: usize> Drop for Arena<MIN_ALIGN> {
 }
 
 #[inline]
-unsafe fn dealloc_chunk_list(mut footer_ptr: NonNull<ChunkFooter>) {
+unsafe fn dealloc_chunk_list(mut footer_ptr: Option<NonNull<ChunkFooter>>) {
     unsafe {
-        while !is_empty_footer(footer_ptr) {
-            let current_footer_ptr = footer_ptr;
+        while let Some(current_footer_ptr) = footer_ptr {
             footer_ptr = current_footer_ptr.as_ref().previous_chunk_footer_ptr.get();
             alloc::dealloc(
                 current_footer_ptr.as_ref().start_ptr.as_ptr(),

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -4,7 +4,7 @@
 use std::{alloc::Layout, cell::Cell, ptr::NonNull};
 
 use super::{
-    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_CHUNK_FOOTER,
+    Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE, ChunkFooter, EMPTY_ARENA_DATA_PTR,
     utils::is_pointer_aligned_to,
 };
 
@@ -44,11 +44,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // Caller guarantees region from `start_ptr` to `start_ptr + size` forms a single allocation,
         // so it must be a valid layout.
         let layout = unsafe { Layout::from_size_align_unchecked(size, CHUNK_ALIGN) };
+        // Initial cursor sits at the footer, which is the end of the allocatable region.
+        // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
+        let cursor_ptr = chunk_footer_ptr.cast::<u8>();
         let chunk_footer = ChunkFooter {
             start_ptr,
             layout,
-            previous_chunk_footer_ptr: Cell::new(EMPTY_CHUNK_FOOTER.get()),
-            cursor_ptr: Cell::new(chunk_footer_ptr.cast::<u8>()),
+            previous_chunk_footer_ptr: Cell::new(None),
+            cursor_ptr: Cell::new(cursor_ptr),
         };
 
         // SAFETY: If caller has upheld safety requirements, `chunk_footer_ptr` is `CHUNK_FOOTER_SIZE` bytes
@@ -59,12 +62,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // Create `Arena` and set `can_grow` to `false`. This means that the memory chunk we've just created
         // will remain its only chunk. Therefore it can never be deallocated, until the `Arena` is dropped.
         // `Arena::reset` would only reset the "cursor" pointer, not deallocate the memory.
-        let mut arena = Self::new_impl(chunk_footer_ptr);
+        let mut arena = Self::new_impl(start_ptr, cursor_ptr, Some(chunk_footer_ptr));
         arena.can_grow = false;
         arena
     }
 
     /// Get the current cursor pointer for this [`Arena`]'s current chunk.
+    ///
+    /// If the `Arena` is empty (has no chunks), this returns a dangling pointer aligned to `CHUNK_ALIGN`.
     pub fn cursor_ptr(&self) -> NonNull<u8> {
         self.cursor_ptr.get()
     }
@@ -85,7 +90,11 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// * No live references to data in the current chunk before `cursor_ptr` can exist.
     pub unsafe fn set_cursor_ptr(&self, cursor_ptr: NonNull<u8>) {
         debug_assert!(cursor_ptr >= self.start_ptr.get());
-        debug_assert!(cursor_ptr <= self.current_chunk_footer_ptr.get().cast::<u8>());
+        debug_assert!(
+            self.current_chunk_footer_ptr
+                .get()
+                .is_some_and(|footer_ptr| cursor_ptr <= footer_ptr.cast::<u8>())
+        );
         debug_assert!(is_pointer_aligned_to(cursor_ptr, MIN_ALIGN));
 
         // SAFETY: Caller guarantees `Arena` has at least 1 allocated chunk, and `cursor_ptr` is valid
@@ -95,17 +104,24 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
     /// Get pointer to end of the data region of this [`Arena`]'s current chunk
     /// i.e to the start of the `ChunkFooter`.
+    ///
+    /// If `Arena` has not allocated any chunks, returns a dangling pointer aligned to `CHUNK_ALIGN`.
     pub fn data_end_ptr(&self) -> NonNull<u8> {
-        self.current_chunk_footer_ptr.get().cast::<u8>()
+        match self.current_chunk_footer_ptr.get() {
+            Some(chunk_footer_ptr) => chunk_footer_ptr.cast::<u8>(),
+            None => EMPTY_ARENA_DATA_PTR,
+        }
     }
 
     /// Get pointer to end of this [`Arena`]'s current chunk (after the `ChunkFooter`).
+    ///
+    /// If `Arena` has not allocated any chunks, returns a dangling pointer aligned to `CHUNK_ALIGN`.
     pub fn end_ptr(&self) -> NonNull<u8> {
-        let chunk_footer_ptr = self.current_chunk_footer_ptr.get();
-
-        // SAFETY: `chunk_footer_ptr` always points to a valid `ChunkFooter`, so stepping past it cannot be
-        // out of bounds of the chunk's allocation. If `Arena` has not allocated, `chunk_footer_ptr`
-        // returns a pointer to the static empty chunk, it's still valid.
-        unsafe { chunk_footer_ptr.add(1).cast::<u8>() }
+        match self.current_chunk_footer_ptr.get() {
+            // SAFETY: `chunk_footer_ptr` always points to a valid `ChunkFooter`, so stepping past it
+            // cannot be out of bounds of the chunk's allocation.
+            Some(chunk_footer_ptr) => unsafe { chunk_footer_ptr.add(1).cast::<u8>() },
+            None => EMPTY_ARENA_DATA_PTR,
+        }
     }
 }

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -169,15 +169,33 @@ mod tests_alloc;
 #[repr(C)]
 #[derive(Debug)]
 pub struct Arena<const MIN_ALIGN: usize = 1> {
-    /// Bump allocation cursor. Always in the range `self.start_ptr..=self.current_chunk_footer_ptr`.
+    /// Bump allocation cursor.
+    ///
+    /// `Arena` bumps downwards, so this is pointer to the start of the last allocated object in the current chunk,
+    /// or to the current chunk's `ChunkFooter` if nothing has been allocated in the current chunk yet.
+    ///
+    /// When an object is allocated in the arena, the cursor is bumped downwards (towards `start_ptr`),
+    /// and the object is written at the new cursor position.
+    ///
+    /// * When arena is empty, and owns no chunks (`current_chunk_footer_ptr` is `None`):
+    ///   This is set to [`EMPTY_ARENA_DATA_PTR`] (same as `start_ptr`).
+    /// * When arena owns at least one chunk (`current_chunk_footer_ptr` is `Some`):
+    ///   `cursor_ptr` is always in the range `self.start_ptr..=self.current_chunk_footer_ptr`.
+    ///
+    /// This field is duplicated in `ChunkFooter`, but the pointer here is authoritative for current chunk.
     cursor_ptr: Cell<NonNull<u8>>,
 
     /// Pointer to footer of current chunk we are bump allocating within.
-    current_chunk_footer_ptr: Cell<NonNull<ChunkFooter>>,
+    ///
+    /// `None` if `Arena` is empty (owns no chunks).
+    current_chunk_footer_ptr: Cell<Option<NonNull<ChunkFooter>>>,
 
     /// Pointer to the start of the current chunk's allocatable region.
     ///
-    /// Stored here as well as in the `ChunkFooter` so it can be accessed without indirection through the footer.
+    /// When arena owns no chunks (`current_chunk_footer_ptr` is `None`), this is set to [`EMPTY_ARENA_DATA_PTR`]
+    /// (equal to `cursor_ptr`).
+    ///
+    /// This field is duplicated in `ChunkFooter`.
     start_ptr: Cell<NonNull<u8>>,
 
     /// Whether this `Arena` is allowed to allocate additional chunks when the current one is full.
@@ -244,11 +262,9 @@ unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 ///
 /// Chunks form a linked list with `Arena::current_chunk_footer_ptr` pointing to current chunk's footer,
 /// and each chunk's `ChunkFooter::previous_chunk_footer_ptr` pointing to the previous chunk's footer.
-/// The list ends with the canonical empty chunk footer `EMPTY_CHUNK_FOOTER`, whose `previous_chunk_footer_ptr`
-/// points to itself.
+/// The list ends with `previous_chunk_footer_ptr` of the oldest chunk being `None`.
 ///
-/// An empty `Arena`, which does not own any memory, has `Arena::current_chunk_footer_ptr` pointing to
-/// the canonical empty chunk footer `EMPTY_CHUNK_FOOTER`.
+/// An empty `Arena`, which does not own any memory, has `Arena::current_chunk_footer_ptr` set to `None`.
 #[repr(C, align(16))]
 #[derive(Debug)]
 struct ChunkFooter {
@@ -263,9 +279,8 @@ struct ChunkFooter {
 
     /// Link to the previous chunk.
     ///
-    /// The last node in the chunks linked list is the canonical empty chunk footer `EMPTY_CHUNK_FOOTER`,
-    /// whose `previous_chunk_footer_ptr` link points to itself.
-    previous_chunk_footer_ptr: Cell<NonNull<ChunkFooter>>,
+    /// `None` for the oldest chunk in the linked list.
+    previous_chunk_footer_ptr: Cell<Option<NonNull<ChunkFooter>>>,
 
     /// Bump allocation cursor, valid only for retired (non-current) chunks.
     /// This field is written when a chunk is retired (when a new chunk is created).
@@ -281,37 +296,12 @@ pub const CHUNK_FOOTER_SIZE: usize = size_of::<ChunkFooter>();
 
 const _: () = assert!(align_of::<ChunkFooter>() == CHUNK_ALIGN);
 
-/// A wrapper type for the canonical, statically allocated empty chunk.
+/// Sentinel value used for `Arena::start_ptr` and `Arena::cursor_ptr` when the arena owns no chunks.
 ///
-/// For the canonical empty chunk to be `static`, its type must be `Sync`, which is the purpose of this wrapper type.
-/// This is safe because the empty chunk is immutable and never actually modified.
-#[repr(transparent)]
-struct EmptyChunkFooter(ChunkFooter);
-
-unsafe impl Sync for EmptyChunkFooter {}
-
-static EMPTY_CHUNK_FOOTER: EmptyChunkFooter = EmptyChunkFooter(ChunkFooter {
-    // The start of the (empty) allocatable region for this chunk is itself
-    start_ptr: NonNull::from_ref(&EMPTY_CHUNK_FOOTER).cast::<u8>(),
-
-    // This chunk is empty (except the footer itself)
-    layout: Layout::new::<ChunkFooter>(),
-
-    // Points to itself as the previous chunk
-    previous_chunk_footer_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK_FOOTER.0)),
-
-    // The end of the (empty) allocatable region for this chunk is also itself
-    cursor_ptr: Cell::new(NonNull::from_ref(&EMPTY_CHUNK_FOOTER).cast::<u8>()),
-});
-
-impl EmptyChunkFooter {
-    fn get(&'static self) -> NonNull<ChunkFooter> {
-        NonNull::from(&self.0)
-    }
-}
-
-/// Returns `true` if the given `footer_ptr` points to the canonical empty chunk footer.
-#[inline(always)] // Because it's only 1 instruction
-fn is_empty_footer(footer_ptr: NonNull<ChunkFooter>) -> bool {
-    footer_ptr == EMPTY_CHUNK_FOOTER.get()
-}
+/// This is a dangling, non-null pointer aligned to `CHUNK_ALIGN`, which is `>= MIN_ALIGN` for any valid
+/// `MIN_ALIGN`. So the cursor satisfies the `Arena` invariant of being aligned to `MIN_ALIGN`.
+///
+/// Setting `cursor_ptr == start_ptr == EMPTY_ARENA_DATA_PTR` gives a chunk with zero capacity, so any
+/// non-zero-sized allocation fails the fast path bounds check and falls through to the slow path
+/// (which allocates a new chunk).
+const EMPTY_ARENA_DATA_PTR: NonNull<u8> = NonNull::<ChunkFooter>::dangling().cast::<u8>();

--- a/crates/oxc_allocator/src/arena/tests_alloc.rs
+++ b/crates/oxc_allocator/src/arena/tests_alloc.rs
@@ -44,7 +44,7 @@ impl<const MIN_ALIGN: usize> TestArena<MIN_ALIGN> {
         let start_ptr = NonNull::new(start as *mut u8).unwrap();
         let arena = Arena {
             cursor_ptr: Cell::new(cursor_ptr),
-            current_chunk_footer_ptr: Cell::new(cursor_ptr.cast::<ChunkFooter>()),
+            current_chunk_footer_ptr: Cell::new(Some(cursor_ptr.cast::<ChunkFooter>())),
             start_ptr: Cell::new(start_ptr),
             can_grow: false,
             #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -48,6 +48,8 @@ impl Allocator {
     }
 
     /// Get the current cursor pointer for this [`Allocator`]'s current chunk.
+    ///
+    /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
     pub fn cursor_ptr(&self) -> NonNull<u8> {
         self.arena().cursor_ptr()
     }
@@ -74,11 +76,15 @@ impl Allocator {
 
     /// Get pointer to end of the data region of this [`Allocator`]'s current chunk
     /// i.e to the start of the `ChunkFooter`.
+    ///
+    /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
     pub fn data_end_ptr(&self) -> NonNull<u8> {
         self.arena().data_end_ptr()
     }
 
     /// Get pointer to end of this [`Allocator`]'s current chunk (after the `ChunkFooter`).
+    ///
+    /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
     pub fn end_ptr(&self) -> NonNull<u8> {
         self.arena().end_ptr()
     }


### PR DESCRIPTION
The chunks in an `Arena` form a linked list. Previously the list was terminated with a canonical empty chunk, defined as a `static`.

Now that we store `start_ptr` and `cursor_ptr` in `Arena` itself (#21483), an empty `Arena` doesn't need to have a pointer to a chunk.

Remove the empty chunk, and use `None` to signify the end of the linked list instead.

This makes checking "is this chunk the last?" a little cheaper (comparison to 0, not a 64-bit static value), and feels less hacky, and more explicit. It also removes the potential hazard of accidentally mutating the immutable `static` empty chunk.