### PR TITLE
chore(oxlint/lsp): respect `RuleCustomization.autofix` for "fix all" code actions

### DIFF
--- a/apps/oxlint/fixtures/lsp/rules_customization/autofix/test.ts
+++ b/apps/oxlint/fixtures/lsp/rules_customization/autofix/test.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lsp/code_actions.rs
+++ b/apps/oxlint/src/lsp/code_actions.rs
@@ -1,10 +1,12 @@
+use oxc_diagnostics::OxcCode;
 use oxc_linter::FixKind;
 use tower_lsp_server::ls_types::{CodeAction, CodeActionKind, TextEdit, Uri, WorkspaceEdit};
 use tracing::debug;
 
 use crate::lsp::{
     error_with_position::{FixedContent, FixedContentKind, LinterCodeAction},
-    utils::range_overlaps,
+    options::RulesCustomization,
+    utils::{get_full_rule_name, range_overlaps},
 };
 
 pub const CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC: CodeActionKind =
@@ -49,7 +51,7 @@ pub fn apply_fix_code_actions(action: LinterCodeAction, uri: &Uri) -> Vec<CodeAc
         let preferred = preferred_possible
             && matches!(
                 fixed.lsp_kind,
-                FixedContentKind::LintRule | FixedContentKind::UnusedDirective
+                FixedContentKind::LintRule(_) | FixedContentKind::UnusedDirective
             );
         if preferred {
             // only the first fix can be preferred, if there are multiple fixes available.
@@ -62,11 +64,46 @@ pub fn apply_fix_code_actions(action: LinterCodeAction, uri: &Uri) -> Vec<CodeAc
     code_actions
 }
 
+impl RulesCustomization {
+    pub fn is_rule_autofix_disabled(&self, rule_code: &OxcCode) -> bool {
+        let Some(rule) = get_full_rule_name(rule_code) else {
+            return false;
+        };
+        self.rules
+            .get(rule.as_ref())
+            .is_some_and(|customization| customization.autofix.is_some_and(|autofix| !autofix))
+    }
+}
+
+fn filter_disabled_by_customization<'a>(
+    actions: impl Iterator<Item = LinterCodeAction> + 'a,
+    rules_customization: Option<&'a RulesCustomization>,
+) -> impl Iterator<Item = LinterCodeAction> + 'a {
+    actions.filter(move |action| {
+        let Some(customization) = rules_customization else {
+            return true;
+        };
+
+        for fixed in &action.fixed_content {
+            if let FixedContentKind::LintRule(rule_code) = &fixed.lsp_kind
+                && customization.is_rule_autofix_disabled(rule_code)
+            {
+                debug!("Skipping code action for rule disabled by customization: {:?}", rule_code);
+                return false;
+            }
+        }
+
+        true
+    })
+}
+
 pub fn apply_all_fix_code_action(
     actions: impl Iterator<Item = LinterCodeAction>,
     uri: Uri,
+    rules_customization: Option<&RulesCustomization>,
 ) -> Option<CodeAction> {
-    let quick_fixes: Vec<TextEdit> = fix_all_text_edit(actions);
+    let quick_fixes: Vec<TextEdit> =
+        fix_all_text_edit(filter_disabled_by_customization(actions, rules_customization));
 
     if quick_fixes.is_empty() {
         return None;
@@ -91,8 +128,10 @@ pub fn apply_all_fix_code_action(
 pub fn apply_dangerous_fix_code_action(
     actions: impl Iterator<Item = LinterCodeAction>,
     uri: Uri,
+    rules_customization: Option<&RulesCustomization>,
 ) -> Option<CodeAction> {
-    let quick_fixes: Vec<TextEdit> = dangerous_fix_all_text_edit(actions);
+    let quick_fixes: Vec<TextEdit> =
+        dangerous_fix_all_text_edit(filter_disabled_by_customization(actions, rules_customization));
 
     if quick_fixes.is_empty() {
         return None;
@@ -122,7 +161,10 @@ pub fn fix_all_text_edit(actions: impl Iterator<Item = LinterCodeAction>) -> Vec
         // Applying all possible fixes at once is not possible in this context.
         // Search for the first "real" fix for the rule, and ignore the rest of the fixes for the same rule.
         let Some(fixed_content) = action.fixed_content.into_iter().find(|fixed| {
-            matches!(fixed.lsp_kind, FixedContentKind::LintRule | FixedContentKind::UnusedDirective)
+            matches!(
+                fixed.lsp_kind,
+                FixedContentKind::LintRule(_) | FixedContentKind::UnusedDirective
+            )
         }) else {
             continue;
         };
@@ -144,7 +186,10 @@ fn dangerous_fix_all_text_edit(actions: impl Iterator<Item = LinterCodeAction>) 
 
     for action in actions {
         let Some(fixed_content) = action.fixed_content.into_iter().find(|fixed| {
-            matches!(fixed.lsp_kind, FixedContentKind::LintRule | FixedContentKind::UnusedDirective)
+            matches!(
+                fixed.lsp_kind,
+                FixedContentKind::LintRule(_) | FixedContentKind::UnusedDirective
+            )
         }) else {
             continue;
         };
@@ -184,6 +229,7 @@ fn remove_overlapping_edits(mut edits: Vec<TextEdit>) -> Vec<TextEdit> {
 mod tests {
     use std::str::FromStr;
 
+    use oxc_diagnostics::OxcCode;
     use tower_lsp_server::ls_types::{Position, Range};
 
     use oxc_linter::FixKind;
@@ -206,7 +252,7 @@ mod tests {
                 code: String::new(),
                 range,
                 kind: FixKind::SafeFix,
-                lsp_kind: FixedContentKind::LintRule,
+                lsp_kind: FixedContentKind::LintRule(OxcCode { scope: None, number: None }),
             }],
         }
     }
@@ -249,7 +295,7 @@ mod tests {
                 code: String::new(),
                 range: Range::new(Position::new(0, 0), Position::new(0, 10)),
                 kind,
-                lsp_kind: FixedContentKind::LintRule,
+                lsp_kind: FixedContentKind::LintRule(OxcCode { scope: None, number: None }),
             }],
         }
     }
@@ -272,6 +318,7 @@ mod tests {
         let action = apply_all_fix_code_action(
             std::iter::once(make_fix_kind_action(FixKind::SafeFix)),
             Uri::from_str("file:///test.js").unwrap(),
+            None,
         )
         .unwrap();
         assert_eq!(action.kind, Some(CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC));
@@ -282,6 +329,7 @@ mod tests {
         let action = apply_dangerous_fix_code_action(
             std::iter::once(make_fix_kind_action(FixKind::DangerousFix)),
             Uri::from_str("file:///test.js").unwrap(),
+            None,
         )
         .unwrap();
         assert_eq!(action.kind, Some(CODE_ACTION_KIND_SOURCE_FIX_ALL_DANGEROUS_OXC));

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -12,7 +12,10 @@ use oxc_linter::{
     AllowWarnDeny, DisableDirectives, Fix, FixKind, Message, PossibleFixes, RuleCommentType,
 };
 
-use crate::lsp::options::{RuleCustomizationSeverity, RulesCustomization};
+use crate::lsp::{
+    options::{RuleCustomizationSeverity, RulesCustomization},
+    utils::get_full_rule_name,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct DiagnosticReport {
@@ -37,7 +40,7 @@ pub struct FixedContent {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FixedContentKind {
-    LintRule,
+    LintRule(OxcCode),
     IgnoreLintRuleLine,
     IgnoreLintRuleSection,
     UnusedDirective,
@@ -45,17 +48,8 @@ pub enum FixedContentKind {
 
 impl RulesCustomization {
     fn get_severity_for_rule(&self, code: &OxcCode) -> Option<RuleCustomizationSeverity> {
-        let rule_name = code.number.as_ref()?;
-        let scope = code.scope.as_ref()?;
-
-        if scope == "eslint" {
-            self.rules
-                .get(rule_name.as_ref())
-                .and_then(|customization| customization.severity.clone())
-        } else {
-            let lookup = format!("{scope}/{rule_name}");
-            self.rules.get(lookup.as_str()).and_then(|customization| customization.severity.clone())
-        }
+        let lookup = get_full_rule_name(code)?;
+        self.rules.get(lookup.as_ref()).and_then(|customization| customization.severity.clone())
     }
 }
 
@@ -188,7 +182,7 @@ pub fn message_to_lsp_diagnostic(
                 &fix,
                 rope,
                 source_text,
-                FixedContentKind::LintRule,
+                FixedContentKind::LintRule(message.error.code.clone()),
             ));
         }
         PossibleFixes::Multiple(fixes) => {
@@ -196,7 +190,12 @@ pub fn message_to_lsp_diagnostic(
                 if fix.message.is_none() {
                     fix.message = Some(alternative_fix_title.clone());
                 }
-                fix_to_fixed_content(&fix, rope, source_text, FixedContentKind::LintRule)
+                fix_to_fixed_content(
+                    &fix,
+                    rope,
+                    source_text,
+                    FixedContentKind::LintRule(message.error.code.clone()),
+                )
             }));
         }
     }
@@ -425,33 +424,18 @@ fn add_ignore_fixes(
         "Unused disable directives should never pass pass this point, as they should be handled separately in `create_unused_directives_messages`."
     );
 
-    if let Some(rule_name) = code.number.as_ref() {
-        // this conversion is a bit messy, but basically we need to reconstruct the rule name with plugin prefix
-        let rule_name_with_plugin = if let Some(scope) = &code.scope
-            && !scope.is_empty()
-            // eslint does not has a plugin prefix
-            && scope != "eslint"
-        {
-            format!("{scope}/{rule_name}")
-        } else {
-            rule_name.to_string()
-        };
-
-        // TODO: doesn't support disabling multiple rules by name for a given line.
-        fixes.push(disable_for_this_line(
-            &rule_name_with_plugin,
-            error_offset,
-            section_offset,
-            rope,
-            source_text,
-        ));
-        fixes.push(disable_for_this_section(
-            &rule_name_with_plugin,
-            section_offset,
-            rope,
-            source_text,
-        ));
-    }
+    let Some(rule_name_with_plugin) = get_full_rule_name(code) else {
+        return;
+    };
+    // TODO: doesn't support disabling multiple rules by name for a given line.
+    fixes.push(disable_for_this_line(
+        &rule_name_with_plugin,
+        error_offset,
+        section_offset,
+        rope,
+        source_text,
+    ));
+    fixes.push(disable_for_this_section(&rule_name_with_plugin, section_offset, rope, source_text));
 }
 
 fn disable_for_this_line(

--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -152,7 +152,7 @@ pub struct RuleCustomization {
     // note: this will not enable "off" rules; it only customizes active rules
     // it only modifies the severity of returned diagnostics, not the linter configuration
     pub severity: Option<RuleCustomizationSeverity>,
-    // some editors support "fix all" code action, this flag indicates whether to include this rule in "fix all" code action
+    // this flag indicates whether to include this rule in "fix all" and "fix all dangerous" code action
     pub autofix: Option<bool>,
 }
 

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -601,7 +601,11 @@ impl Tool for ServerLinter {
         for kind in applying_kinds {
             // `CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC` was filtered out by `applying_kinds`, so we don't need to check it here.
             if kind == CodeActionKind::SOURCE_FIX_ALL {
-                let Some(fix_all) = apply_all_fix_code_action(actions.clone(), uri.clone()) else {
+                let Some(fix_all) = apply_all_fix_code_action(
+                    actions.clone(),
+                    uri.clone(),
+                    self.rules_customization.as_ref(),
+                ) else {
                     continue;
                 };
                 code_actions_vec.push(CodeActionOrCommand::CodeAction(fix_all));
@@ -612,8 +616,11 @@ impl Tool for ServerLinter {
                     );
                     continue;
                 }
-                let Some(fix_all) = apply_dangerous_fix_code_action(actions.clone(), uri.clone())
-                else {
+                let Some(fix_all) = apply_dangerous_fix_code_action(
+                    actions.clone(),
+                    uri.clone(),
+                    self.rules_customization.as_ref(),
+                ) else {
                     continue;
                 };
                 code_actions_vec.push(CodeActionOrCommand::CodeAction(fix_all));
@@ -1477,6 +1484,21 @@ mod test {
                     },
                     "no-console": {
                         "severity": "off"
+                    }
+                }
+            }),
+        );
+        tester.test_and_snapshot_single_file("test.ts");
+    }
+
+    #[test]
+    fn test_rules_customization_autofix() {
+        let tester = Tester::new(
+            "fixtures/lsp/rules_customization/autofix",
+            json!({
+                "rulesCustomization": {
+                    "no-debugger": {
+                        "autofix": false
                     }
                 }
             }),

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_rules_customization_autofix@test.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_rules_customization_autofix@test.ts.snap
@@ -1,0 +1,77 @@
+---
+source: apps/oxlint/src/lsp/tester.rs
+---
+########## 
+Linted file: fixtures/lsp/rules_customization/autofix/test.ts
+----------
+########## Diagnostic Reports
+File URI: file://<variable>/fixtures/lsp/rules_customization/autofix/test.ts
+
+code: "eslint(no-debugger)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
+range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/lsp/rules_customization/autofix/test.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 9 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+
+########### Code Actions/Commands
+CodeAction: 
+Title: Remove the debugger statement
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    },
+    new_text: "",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this line
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable-next-line no-debugger\n",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this whole file
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable no-debugger\n",
+}
+
+
+########### Fix All Action
+None

--- a/apps/oxlint/src/lsp/utils.rs
+++ b/apps/oxlint/src/lsp/utils.rs
@@ -1,5 +1,9 @@
-use std::path::{Component, Path, PathBuf};
+use std::{
+    borrow::Cow,
+    path::{Component, Path, PathBuf},
+};
 
+use oxc_diagnostics::OxcCode;
 use tower_lsp_server::ls_types::Range;
 
 /// Normalize a path by removing `.` and resolving `..` components,
@@ -36,6 +40,21 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
 /// applying edits that share a boundary (which is rare in practice and safe to defer).
 pub(super) fn range_overlaps(a: Range, b: Range) -> bool {
     a.start <= b.end && a.end >= b.start
+}
+
+/// Converts an `OxcCode` to a full rule name string, including plugin prefix if applicable.
+///
+/// this conversion is a bit messy, but basically we need to reconstruct the rule name with plugin prefix
+pub fn get_full_rule_name(rule_code: &OxcCode) -> Option<Cow<'_, str>> {
+    let rule_name = rule_code.number.as_ref()?;
+    let scope = rule_code.scope.as_ref()?;
+
+    // eslint does not have a plugin prefix
+    if scope == "eslint" || scope.is_empty() {
+        Some(Cow::Borrowed(rule_name))
+    } else {
+        Some(Cow::Owned(format!("{scope}/{rule_name}")))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
> ## Pull request overview

> Updates the oxlint LSP “fix all” / “fix all dangerous” code actions to respect `rulesCustomization.<rule>.autofix = false`, so rules opted out of autofix aren’t included in fix-all edits.