### PR TITLE
chore(linter): mark `typescript/no-unsafe-enum-comparison` as suggestion fix

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_enum_comparison.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_enum_comparison.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
     NoUnsafeEnumComparison(tsgolint),
     typescript,
     suspicious,
-    pending,
+    suggestion,
     version = "1.12.0",
 );
 


### PR DESCRIPTION
upstream PR: https://github.com/oxc-project/tsgolint/pull/910