### PR TITLE
chore(linter): mark `typescript/no-unnecessary-template-expression` as fix

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_template_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_template_expression.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
     NoUnnecessaryTemplateExpression(tsgolint),
     typescript,
     suspicious,
-    pending,
+    fix,
     version = "1.12.0",
 );
 


### PR DESCRIPTION
upstream PR: https://github.com/oxc-project/tsgolint/pull/911