### PR TITLE
refactor(allocator): clarify `max` calculations in `Arena`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -339,7 +339,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // By default, we want our new chunk to be about twice as big as the previous chunk.
             // If the global allocator refuses it, we try to divide it by half until it works for `layout`
             // or the requested size is smaller than the default chunk size.
-            let min_new_chunk_size = layout.size().max(DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
+            let min_new_chunk_size = max(layout.size(), DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
 
             let mut size = match current_footer_ptr {
                 // Double the size of the current chunk, but not less than `min_new_chunk_size`
@@ -450,7 +450,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         let new_size = new_layout.size();
 
         // This is how much space we would *actually* reclaim while satisfying the requested alignment
-        let delta = round_down_to(old_size - new_size, new_layout.align().max(MIN_ALIGN));
+        let delta = round_down_to(old_size - new_size, max(new_layout.align(), MIN_ALIGN));
 
         if self.is_last_allocation(ptr)
                 // Only reclaim the excess space (which requires a copy) if it is worth it:

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -3,6 +3,7 @@
 use std::{
     alloc::{self, Layout},
     cell::Cell,
+    cmp::max,
     ptr::NonNull,
 };
 
@@ -336,17 +337,14 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         requested_layout: Layout,
         previous_chunk_footer_ptr: Option<NonNull<ChunkFooter>>,
     ) -> Option<NonNull<ChunkFooter>> {
-        // We must have `CHUNK_ALIGN` or better alignment...
-        let align = CHUNK_ALIGN
-            // and we have to have at least our configured minimum alignment...
-            .max(MIN_ALIGN)
-            // and make sure we satisfy the requested allocation's alignment
-            .max(requested_layout.align());
+        // Chunks must be aligned to at least `CHUNK_ALIGN` and `MIN_ALIGN`.
+        // `MIN_ALIGN` is always `<= CHUNK_ALIGN`, so aligning to `CHUNK_ALIGN` satisfies both.
+        let align = max(requested_layout.align(), CHUNK_ALIGN);
 
         // SAFETY: `Layout::size()` is always `<= isize::MAX`. `align` is a `usize` power of 2.
         // So rounding up can result in at maximum `isize::MAX + 1` - cannot overflow `usize`.
         let requested_size = unsafe { round_up_to_unchecked(requested_layout.size(), align) };
-        let new_size_without_footer = new_size_without_footer.max(requested_size);
+        let new_size_without_footer = max(new_size_without_footer, requested_size);
 
         // We want our allocations to play nice with the memory allocator, and waste as little memory as possible.
         // For small allocations, this means that the entire allocation including the chunk footer and `malloc`'s

--- a/crates/oxc_allocator/tests/arena/alloc_fill.rs
+++ b/crates/oxc_allocator/tests/arena/alloc_fill.rs
@@ -1,4 +1,4 @@
-use std::{alloc::Layout, cmp, mem};
+use std::{alloc::Layout, cmp::max, mem};
 
 use oxc_allocator::arena::Arena;
 
@@ -18,7 +18,7 @@ fn alloc_slice_fill_zero() {
     b.alloc_slice_fill_clone(0, &"hello".to_string());
     b.alloc_slice_fill_default::<String>(0);
     let ptr2 = b.alloc(MyZeroSizedType);
-    let alignment = cmp::max(mem::align_of::<u64>(), mem::align_of::<String>());
+    let alignment = max(mem::align_of::<u64>(), mem::align_of::<String>());
     assert_eq!(ptr1.as_ptr() as usize & !(alignment - 1), ptr2 as *mut _ as usize);
 
     let ptr3 = b.alloc_layout(u8_layout);
@@ -26,7 +26,7 @@ fn alloc_slice_fill_zero() {
     dbg!(ptr3);
     assert_eq!(
         ptr2 as *mut _ as usize,
-        (ptr3.as_ptr() as usize) + b.min_align().max(u8_layout.align()),
+        (ptr3.as_ptr() as usize) + max(b.min_align(), u8_layout.align()),
     );
 }
 


### PR DESCRIPTION
Small refactor to `Arena`. Use `cmp::max(a, b)` instead of the chained version `a.max(b)`. I find the former clearer.

Also simplify one `max` operation (see comment in code).