### PR TITLE
refactor(linter/plugins, napi/plugins): use constant for arena alignment from `Allocator`

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -17,7 +17,7 @@ use oxc_semantic::SemanticBuilder;
 
 use crate::generated::raw_transfer_constants::{BLOCK_ALIGN as BUFFER_ALIGN, BUFFER_SIZE};
 
-const BUMP_ALIGN: usize = 16;
+const ARENA_ALIGN: usize = Allocator::RAW_MIN_ALIGN;
 
 /// Sentinel value for program offset to indicate parsing failed.
 ///
@@ -124,29 +124,32 @@ unsafe fn parse_raw_impl(
 
     // Get offsets and size of data region to be managed by arena allocator.
     // Leave space for source before it, and space for metadata after it.
-    // Metadata is rounded up to multiple of 16,
-    // as the arena allocator requires that alignment.
+    // Check `RawTransferMetadata`'s size is a multiple of `ARENA_ALIGN`,
+    // as the arena allocator requires start and end of the chunk to have that alignment.
     const RAW_METADATA_SIZE: usize = size_of::<RawTransferMetadata>();
     const {
-        assert!(RAW_METADATA_SIZE >= BUMP_ALIGN);
-        assert!(RAW_METADATA_SIZE.is_multiple_of(BUMP_ALIGN));
+        assert!(RAW_METADATA_SIZE >= ARENA_ALIGN);
+        assert!(RAW_METADATA_SIZE.is_multiple_of(ARENA_ALIGN));
     };
     const RAW_METADATA_OFFSET: usize = BUFFER_SIZE - RAW_METADATA_SIZE;
-    const _: () = assert!(RAW_METADATA_OFFSET.is_multiple_of(BUMP_ALIGN));
+    const _: () = {
+        assert!(RAW_METADATA_OFFSET.is_multiple_of(ARENA_ALIGN));
+        assert!(RAW_METADATA_OFFSET >= Allocator::RAW_MIN_SIZE);
+    };
 
     // Create `Allocator`.
     // Wrap in `ManuallyDrop` so the allocation doesn't get freed at end of function, or if panic.
     // SAFETY: `buffer_ptr` and `RAW_METADATA_OFFSET` outline a section of the memory in `buffer`.
-    // `buffer_ptr` and `RAW_METADATA_OFFSET` are multiples of 16.
-    // `RAW_METADATA_OFFSET` is greater than `Allocator::MIN_SIZE`.
+    // `buffer_ptr` and `RAW_METADATA_OFFSET` are multiples of `ARENA_ALIGN`.
+    // `RAW_METADATA_OFFSET` is `>= Allocator::RAW_MIN_SIZE`.
     let allocator = unsafe { Allocator::from_raw_parts(buffer_ptr, RAW_METADATA_OFFSET) };
     let allocator = ManuallyDrop::new(allocator);
 
     // Set cursor to before start of source text. AST will be written into the buffer before the source text.
-    // Round down the pointer, so it's aligned on `BUMP_ALIGN`.
+    // Round down the pointer, so it's aligned on `ARENA_ALIGN`.
     // SAFETY: Caller guarantees that source text starts at `source_start` bytes from start of buffer.
     unsafe {
-        let cursor_pos = source_start as usize & !(BUMP_ALIGN - 1);
+        let cursor_pos = source_start as usize & !(ARENA_ALIGN - 1);
         let cursor_ptr = buffer_ptr.add(cursor_pos);
         allocator.set_cursor_ptr(cursor_ptr);
     }
@@ -266,7 +269,7 @@ unsafe fn parse_raw_impl(
         tokens_len,
     );
     // SAFETY: `RAW_METADATA_OFFSET` is less than length of `buffer`.
-    // `RAW_METADATA_OFFSET` is aligned on 16.
+    // `RAW_METADATA_OFFSET` is aligned to `ARENA_ALIGN`.
     unsafe {
         buffer_ptr.add(RAW_METADATA_OFFSET).cast::<RawTransferMetadata>().write(metadata);
     }

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -38,7 +38,7 @@ use crate::{
 //    So avoiding the 32nd bit being set enables using `>>` bitshift operator,
 //    which is cheaper than `>>>`, and does not risk offsets being interpreted as negative.
 
-const BUMP_ALIGN: usize = 16;
+const ARENA_ALIGN: usize = Allocator::RAW_MIN_ALIGN;
 
 /// Get offset within a `Uint8Array` which is aligned on `BUFFER_ALIGN`.
 ///
@@ -183,15 +183,15 @@ unsafe fn parse_raw_impl(
 
     // Get offsets and size of data region to be managed by arena allocator.
     // Leave space for source before it, and space for metadata after it.
-    // Metadata actually only takes 5 bytes, but round everything up to multiple of 16,
-    // as the arena allocator requires that alignment.
+    // Check `RawTransferMetadata`'s size is a multiple of `ARENA_ALIGN`,
+    // as the arena allocator requires start and end of the chunk to have that alignment.
     const RAW_METADATA_SIZE: usize = size_of::<RawTransferMetadata>();
     const {
-        assert!(RAW_METADATA_SIZE >= BUMP_ALIGN);
-        assert!(RAW_METADATA_SIZE.is_multiple_of(BUMP_ALIGN));
+        assert!(RAW_METADATA_SIZE >= ARENA_ALIGN);
+        assert!(RAW_METADATA_SIZE.is_multiple_of(ARENA_ALIGN));
     };
     let source_len = source_len as usize;
-    let data_offset = source_len.next_multiple_of(BUMP_ALIGN);
+    let data_offset = source_len.next_multiple_of(ARENA_ALIGN);
     let data_size = (BUFFER_SIZE - RAW_METADATA_SIZE).saturating_sub(data_offset);
     assert!(data_size >= Allocator::RAW_MIN_SIZE, "Source text is too long");
 
@@ -200,11 +200,11 @@ unsafe fn parse_raw_impl(
     // SAFETY: `data_offset` is less than `buffer.len()`, so `.add(data_offset)` cannot wrap
     // or be out of bounds.
     let data_ptr = unsafe { buffer_ptr.add(data_offset) };
-    debug_assert!((data_ptr as usize).is_multiple_of(BUMP_ALIGN));
-    debug_assert!(data_size.is_multiple_of(BUMP_ALIGN));
+    debug_assert!((data_ptr as usize).is_multiple_of(ARENA_ALIGN));
+    debug_assert!(data_size.is_multiple_of(ARENA_ALIGN));
     // SAFETY: `data_ptr` and `data_size` outline a section of the memory in `buffer`.
-    // `data_ptr` and `data_size` are multiples of 16.
-    // `data_size` is greater than `Allocator::MIN_SIZE`.
+    // `data_ptr` and `data_size` are multiples of `ARENA_ALIGN`.
+    // `data_size` is greater than `Allocator::RAW_MIN_SIZE`.
     let allocator =
         unsafe { Allocator::from_raw_parts(NonNull::new_unchecked(data_ptr), data_size) };
     let allocator = ManuallyDrop::new(allocator);
@@ -293,9 +293,9 @@ unsafe fn parse_raw_impl(
     // Write metadata into end of buffer
     let metadata = RawTransferMetadata::new(data_offset, is_ts, tokens_offset, tokens_len);
     const RAW_METADATA_OFFSET: usize = BUFFER_SIZE - RAW_METADATA_SIZE;
-    const _: () = assert!(RAW_METADATA_OFFSET.is_multiple_of(BUMP_ALIGN));
+    const _: () = assert!(RAW_METADATA_OFFSET.is_multiple_of(ARENA_ALIGN));
     // SAFETY: `RAW_METADATA_OFFSET` is less than length of `buffer`.
-    // `RAW_METADATA_OFFSET` is aligned on 16.
+    // `RAW_METADATA_OFFSET` is aligned on `ARENA_ALIGN`.
     #[expect(clippy::cast_ptr_alignment)]
     unsafe {
         buffer_ptr.add(RAW_METADATA_OFFSET).cast::<RawTransferMetadata>().write(metadata);


### PR DESCRIPTION
Refactor.

Don't hard-code the minimum alignment of `Arena` chunks in `apps/oxlint` and `napi/parser`. Get the value from a property on `Allocator`. This will avoid this code getting out of sync if the value changes in future.

Also rename the vars `BUMP_ALIGN` to `ARENA_ALIGN`, as the arena type is now called `Arena` not `Bump`, and update some comments which were out of date.