### PR TITLE
chore(linter): Remove valid-title from Vitest compatible Jest rules.

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/overrides_with_plugin
    `----
   help: Write a meaningful title for your test
 
-  ! eslint-plugin-vitest(valid-title): Should not have an empty title
+  x eslint-plugin-vitest(valid-title): Should not have an empty title
    ,-[index.test.ts:1:10]
  1 | describe("", () => {
    :          ^^
@@ -49,7 +49,7 @@ working directory: fixtures/cli/overrides_with_plugin
    `----
   help: Write a meaningful title for your test
 
-  ! eslint-plugin-vitest(valid-title): Should not have an empty title
+  x eslint-plugin-vitest(valid-title): Should not have an empty title
    ,-[index.test.ts:4:6]
  3 | 
  4 |   it("", () => {});
@@ -67,7 +67,7 @@ working directory: fixtures/cli/overrides_with_plugin
    `----
   help: Consider removing this declaration.
 
-Found 5 warnings and 2 errors.
+Found 3 warnings and 4 errors.
 Finished in <variable>ms on 2 files with 95 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_check_only_svelte_syntax_error_--type-check-only@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_check_only_svelte_syntax_error_--type-check-only@oxlint.snap
@@ -1,6 +1,5 @@
 ---
 source: apps/oxlint/src/tester.rs
-assertion_line: 134
 ---
 ########## 
 arguments: --type-check-only

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_check_only_syntax_error_--type-check-only@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_check_only_syntax_error_--type-check-only@oxlint.snap
@@ -1,6 +1,5 @@
 ---
 source: apps/oxlint/src/tester.rs
-assertion_line: 134
 ---
 ########## 
 arguments: --type-check-only

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check-only --fix@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check-only --fix@oxlint.snap
@@ -1,6 +1,5 @@
 ---
 source: apps/oxlint/src/tester.rs
-assertion_line: 134
 ---
 ########## 
 arguments: --type-check-only --fix

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check-only@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check-only@oxlint.snap
@@ -1,6 +1,5 @@
 ---
 source: apps/oxlint/src/tester.rs
-assertion_line: 134
 ---
 ########## 
 arguments: --type-check-only

--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -36,6 +36,5 @@
   "require-top-level-describe",
   "valid-describe-callback",
   "valid-expect",
-  "valid-expect-in-promise",
-  "valid-title"
+  "valid-expect-in-promise"
 ]

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -904,7 +904,7 @@ mod test {
             {
                 "plugins": ["vitest", "typescript"],
                 "rules": {
-                    "vitest/valid-title": "error",
+                    "vitest/valid-expect": "error",
                     "typescript/no-explicit-any": "error"
                 },
                 "overrides": [
@@ -923,7 +923,7 @@ mod test {
             rules_for_test_file
                 .rules
                 .iter()
-                .any(|(rule, _)| rule.plugin_name() == "jest" && rule.name() == "valid-title"),
+                .any(|(rule, _)| rule.plugin_name() == "jest" && rule.name() == "valid-expect"),
             "vitest-compatible jest rules should remain enabled when an override matches"
         );
         assert!(

--- a/crates/oxc_linter/src/snapshots/react_only_export_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_only_export_components.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_string_replace_all.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_string_replace_all.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-unicorn(prefer-string-replace-all): Prefer `String#replaceAll()` over `String#replace()` when using a regex with the global flag.
    ╭─[prefer_string_replace_all.tsx:1:5]
  1 │ foo.replace(/a/g, bar)

--- a/crates/oxc_linter/src/snapshots/unicorn_require_number_to_fixed_digits_argument.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_require_number_to_fixed_digits_argument.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint-plugin-unicorn(require-number-to-fixed-digits-argument): Number method .toFixed() should have an argument

--- a/crates/oxc_linter/src/snapshots/unicorn_require_post_message_target_origin.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_require_post_message_target_origin.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.

--- a/crates/oxc_linter/src/snapshots/vitest_consistent_test_it.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_consistent_test_it.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-vitest(consistent-test-it): Enforce `test` and `it` usage conventions
    ╭─[consistent_test_it.tsx:1:1]
  1 │ test("shows error", () => {});

--- a/crates/oxc_linter/src/snapshots/vitest_expect_expect.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_expect_expect.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
  1 │ it("should fail", () => {});

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_data_object_declaration.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_data_object_declaration.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-vue(no-deprecated-data-object-declaration): Object declaration on `data` property is deprecated.
    ╭─[no_deprecated_data_object_declaration.tsx:4:23]
  3 │                         export default {

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_vue_config_keycodes.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_vue_config_keycodes.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-vue(no-deprecated-vue-config-keycodes): `Vue.config.keyCodes` are deprecated.
    ╭─[no_deprecated_vue_config_keycodes.tsx:1:1]
  1 │ Vue.config.keyCodes = {}

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 39] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 38] = [
     "no-disabled-tests",
     "no-duplicate-hooks",
     "no-focused-tests",
@@ -76,7 +76,6 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 39] = [
     "valid-describe-callback",
     "valid-expect",
     "valid-expect-in-promise",
-    "valid-title",
 ];
 
 /// List of Eslint rules that have TypeScript equivalents.


### PR DESCRIPTION
This rule was split already, but wasn't removed from the compatible rules list like it should've been.