### PR TITLE
docs(linter): Remove no-longer-relevant documentation about vitest compatibility from shared Jest/Vitest rules.

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -26,7 +26,7 @@ fn expect_expect_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 This rule triggers when there is no call made to `expect` in a test, ensure that there is at least one `expect` call made in a test.
 
@@ -43,18 +43,7 @@ it('should be a test', () => {
 });
 test('should assert something', () => {});
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/docs/rules/expect-expect.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/expect-expect": "error"
-  }
-}
-```
-"#;
+";
 #[derive(Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ExpectExpectConfig {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/max_expects.rs
@@ -17,7 +17,7 @@ fn exceeded_max_assertion(count: usize, max: usize, span: Span) -> OxcDiagnostic
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 This rule enforces a maximum number of `expect()` calls in a single test.
 
@@ -49,18 +49,7 @@ it('should not pass', () => {
     expect(true).toBeDefined();
 });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-expects.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/max-expects": "error"
-  }
-}
-```
-"#;
+";
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/max_nested_describe.rs
@@ -103,17 +103,6 @@ describe('foo', function () {
     });
 });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/max-nested-describe": "error"
-  }
-}
-```
 "#;
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_alias_methods.rs
@@ -13,6 +13,7 @@ fn no_alias_methods_diagnostic(name: &str, canonical_name: &str, span: Span) -> 
         .with_label(span)
 }
 
+// TODO: This rule's documentation should be genericized to apply to Vitest as well, probably?
 pub const DOCUMENTATION: &str = r#"### What it does
 
 This rule ensures that only the canonical name as used in the Jest documentation is used in the code.
@@ -52,17 +53,6 @@ expect(a).toHaveReturnedWith()
 expect(a).toHaveLastReturnedWith()
 expect(a).toHaveNthReturnedWith()
 expect(a).toThrow()
-```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-alias-methods.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-alias-methods": "error"
-  }
-}
 ```
 
 Examples of **incorrect** code for this rule with vitest:

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_commented_out_tests.rs
@@ -10,9 +10,9 @@ fn no_commented_out_tests_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
-This rule raises a warning about commented out tests. It's similar to the
+This rule raises a warning about commented-out tests. It's similar to the
 `no-disabled-tests` rule.
 
 ### Why is this bad?
@@ -33,18 +33,7 @@ Examples of **incorrect** code for this rule:
 // it.skip('foo', () => {});
 // test.skip('foo', () => {});
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-commented-out-tests.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-commented-out-tests": "error"
-  }
-}
-```
-"#;
+";
 
 //  /^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/mu
 static RE: Lazy<Regex> =

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_conditional_expect.rs
@@ -18,15 +18,15 @@ fn no_conditional_expect_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
-This rule prevents the use of expect in conditional blocks, such as ifs & catch(s).
-This includes using expect in callbacks to functions named catch, which are assumed to be promises.
+This rule prevents the use of `expect` in conditional blocks, such as `if` and `catch`.
+This includes using `expect` in callbacks to functions named `catch`, which are assumed to be promises.
 
 ### Why is this bad?
 
 Jest only considers a test to have failed if it throws an error, meaning if calls to
-assertion functions like expect occur in conditional code such as a catch statement,
+assertion functions like `expect` occur in conditional code such as a `catch` statement,
 tests can end up passing but not actually test anything. Additionally, conditionals
 tend to make tests more brittle and complex, as they increase the amount of mental
 thinking needed to understand what is actually being tested.
@@ -87,18 +87,7 @@ it('throws an error', async () => {
   await expect(foo).rejects.toThrow(Error);
 });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-expect.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-conditional-expect": "error"
-  }
-}
-```
-"#;
+";
 
 // To flag we encountered a conditional block/catch block when traversing the parents.
 #[derive(Debug, Clone, Copy)]

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_conditional_in_test.rs
@@ -14,13 +14,14 @@ fn no_conditional_in_test(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 Disallow conditional statements in tests.
 
 ### Why is this bad?
 
-Conditional statements in tests can make the test harder to read and understand. It is better to have a single test case per test function.
+Conditional statements in tests can make the test harder to read and understand.
+It is better to have a single test case per test function.
 
 ### Examples
 
@@ -89,18 +90,7 @@ it('baz', async () => {
   await expect(promiseValue()).resolves.toBe(1);
 });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-conditional-in-test.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-conditional-in-test": "error"
-  }
-}
-```
-"#;
+";
 
 pub fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
     match node.kind() {

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -753,17 +753,6 @@ it('should be a test', () => {
 test('should assert something', () => {});
 ```
 
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/docs/rules/expect-expect.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/expect-expect": "error"
-  }
-}
-```
-
 
 ## Configuration
 


### PR DESCRIPTION
There's no reason to mention this on the Jest page because the equivalent Vitest rule will have its own page, and the Vitest rule page doesn't need this info either.

Also a few minor tweaks to phrasing otherwise.