### PR TITLE
docs(linter): Fix the configuration docs for no-underscore-dangle rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -28,23 +28,23 @@ fn no_underscore_dangle_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnderscoreDangleConfig {
-    // Whether to allow dangling underscores in members of the `super` object.
+    /// Whether to allow dangling underscores in members of the `super` object.
     allow_after_super: bool,
-    // Whether to allow dangling underscores in members of the `this.constructor` object.
+    /// Whether to allow dangling underscores in members of the `this.constructor` object.
     allow_after_this_constructor: bool,
-    // An array of variable names that are allowed to have dangling underscores.
+    /// An array of variable names that are allowed to have dangling underscores.
     allow: Vec<String>,
-    // Whether to allow dangling underscores in members of the `this` object.
+    /// Whether to allow dangling underscores in members of the `this` object.
     allow_after_this: bool,
-    // Whether to allow dangling underscores in variable names assigned by array destructuring.
+    /// Whether to allow dangling underscores in variable names assigned by array destructuring.
     allow_in_array_destructuring: bool,
-    // Whether to allow dangling underscores in variable names assigned by object destructuring.
+    /// Whether to allow dangling underscores in variable names assigned by object destructuring.
     allow_in_object_destructuring: bool,
-    // Whether to allow dangling underscores in function parameter names.
+    /// Whether to allow dangling underscores in function parameter names.
     allow_function_params: bool,
-    // Whether to enforce dangling underscores in class field names.
+    /// Whether to enforce dangling underscores in class field names.
     enforce_in_class_fields: bool,
-    // Whether to enforce dangling underscores in method names.
+    /// Whether to enforce dangling underscores in method names.
     enforce_in_method_names: bool,
 }
 
@@ -84,7 +84,7 @@ declare_oxc_lint!(
     ///
     /// There is a long history of using `_` as a prefix or suffix for private members in JavaScript.
     /// It is however recommended to use the formal private class feature introduced in ES2022.
-    /// See  <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements> for more information.
+    /// See <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements> for more information.
     ///
     /// ### Examples
     ///


### PR DESCRIPTION
The comments were just normal comments, not rust doc comments.