### PR TITLE
ci(security): run security analysis on ubuntu-latest

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: oxc-project/security-action@f14eeb22b9ee0f7d3b242e5017ed0fdfada66f74 # v1.0.2


### PR DESCRIPTION
## Summary
- run the `Security Analysis` workflow on `ubuntu-latest` instead of `ubuntu-slim`
- keep `oxc-project/security-action` pinned at `v1.0.2`, which is already the latest release

## Why
The failing job in PR #21789 (`Security Analysis`, run [24968796582 / job 73108088098](https://github.com/oxc-project/oxc/actions/runs/24968796582/job/73108088098?pr=21789)) was using `ubuntu-slim` and failed with `cargo: command not found` when `security-action` ran `cargo deny` after detecting a `Cargo.lock` change.

Switching this workflow to `ubuntu-latest` provides the expected toolchain on the runner and addresses the immediate failure.

## Testing
- not run locally; workflow-only change

## AI Disclosure
- this PR was prepared with AI assistance and reviewed before submission
