### PR TITLE
docs(agents): mention scoped PR title requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Prerequisites: Rust (MSRV: 1.91), Node.js, pnpm, just
 
 - All tools already installed (`cargo-insta`, `typos-cli`, `cargo-shear`, `ast-grep`)
 - Rust components already installed (`clippy`, `rust-docs`, `rustfmt`)
+- Use Conventional Commits for commit messages; `.github/workflows/pr.yml` requires a scoped title like `fix(parser): handle trailing comma`
 - Run `just ready` after commits for final checks
 - You run in an environment where `ast-grep` is available; whenever a search requires syntax-aware or structural matching, default to `ast-grep --lang rust -p '<pattern>'` (or set `--lang` appropriately) and avoid falling back to text-only tools like `rg` or `grep` unless I explicitly request a plain-text search.
 


### PR DESCRIPTION
## Summary
- document that `.github/workflows/pr.yml` requires scoped Conventional Commit PR titles
- add an example title to the contributor setup notes in `AGENTS.md`

## Testing
- not run; documentation-only change

## AI Usage
- Codex assisted with drafting the documentation change and PR description