### PR TITLE
perf(napi/parser): do not generate tokens except in tests

### DIFF
--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -25,7 +25,7 @@ doctest = false
 oxc = { workspace = true, features = ["ast_visit", "regular_expression", "semantic", "serialize"] }
 oxc_ast_macros = { workspace = true }
 oxc_estree = { workspace = true }
-oxc_estree_tokens = { workspace = true }
+oxc_estree_tokens = { workspace = true, optional = true }
 oxc_napi = { workspace = true }
 oxc_str = { workspace = true }
 
@@ -56,6 +56,7 @@ napi-build = { workspace = true }
 [features]
 default = []
 allocator = ["dep:mimalloc-safe"]
+tokens = ["dep:oxc_estree_tokens"]
 
 [package.metadata.cargo-shear]
 ignored-paths = ["src/generated/derive_estree.rs"]

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "build-dev": "napi build --esm --platform --js bindings.js --dts index.d.ts --output-dir src-js",
-    "build-test": "pnpm run build-dev --profile coverage",
+    "build-test": "pnpm run build-dev --features tokens --profile coverage",
     "build": "pnpm run build-dev --features allocator --release",
     "postbuild": "publint",
     "postbuild-dev": "node scripts/patch.js",

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -3,9 +3,11 @@ use std::mem;
 use napi::{Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
 
+#[cfg(feature = "tokens")]
+use oxc::parser::config::RuntimeParserConfig;
 use oxc::{
     allocator::Allocator,
-    parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig},
+    parser::{ParseOptions, Parser, ParserReturn},
     semantic::SemanticBuilder,
     span::SourceType,
 };
@@ -80,13 +82,18 @@ fn parse_impl<'a>(
     source_text: &'a str,
     options: &ParserOptions,
 ) -> ParserReturn<'a> {
-    Parser::new(allocator, source_text, source_type)
-        .with_options(ParseOptions {
-            preserve_parens: options.preserve_parens.unwrap_or(true),
-            ..ParseOptions::default()
-        })
-        .with_config(RuntimeParserConfig::new(options.tokens.unwrap_or(false)))
-        .parse()
+    let parser = Parser::new(allocator, source_text, source_type).with_options(ParseOptions {
+        preserve_parens: options.preserve_parens.unwrap_or(true),
+        ..ParseOptions::default()
+    });
+
+    // When `tokens` feature is disabled, parser uses the default `NoTokensParserConfig`,
+    // which avoids the runtime branch on whether to collect tokens, and so is faster.
+    // The `experimentalTokens` option in `ParserOptions` is silently ignored in that case.
+    #[cfg(feature = "tokens")]
+    let parser = parser.with_config(RuntimeParserConfig::new(options.tokens.unwrap_or(false)));
+
+    parser.parse()
 }
 
 fn parse_with_return(filename: &str, source_text: &str, options: &ParserOptions) -> ParseResult {

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -15,6 +15,7 @@ use oxc::{
     ast_visit::utf8_to_utf16::Utf8ToUtf16,
     semantic::SemanticBuilder,
 };
+#[cfg(feature = "tokens")]
 use oxc_estree_tokens::{ESTreeTokenOptions, update_tokens};
 use oxc_napi::get_source_type;
 
@@ -252,9 +253,12 @@ unsafe fn parse_raw_impl(
             ArenaVec::new_in(&allocator)
         };
 
-        // Convert tokens
         let span_converter = Utf8ToUtf16::new(source_text);
 
+        // Convert tokens.
+        // `experimentalTokens` option is only honored when `tokens` Cargo feature is enabled.
+        // Otherwise, parser doesn't collect tokens, and `tokens_offset` / `tokens_len` are 0.
+        #[cfg(feature = "tokens")]
         let (tokens_offset, tokens_len) = if options.tokens == Some(true) {
             let mut tokens = ret.tokens;
             update_tokens(&mut tokens, &program, &span_converter, ESTreeTokenOptions::new(is_ts));
@@ -266,6 +270,8 @@ unsafe fn parse_raw_impl(
         } else {
             (0, 0)
         };
+        #[cfg(not(feature = "tokens"))]
+        let (tokens_offset, tokens_len) = (0, 0);
 
         // Convert spans to UTF-16
         span_converter.convert_program(&mut program);


### PR DESCRIPTION
#19885 added support for tokens in `oxc-parser`, but only via raw transfer and behind an undocumented `experimentalTokens` option. It's currently only used in tests for the purpose of conformance testing.

This slowed down `oxc-parser` a little (very little as the difference in execution time on Rust side is dwarfed by the cost of JSON transfer).

The worse effect is that it caused a large binary size increase in Rolldown (https://github.com/rolldown/rolldown/issues/9166) because Rolldown re-exports `napi/parser`'s Rust code, which meant that Rolldown now contains 2 versions of Oxc's parser with different `ParserConfig`s, leading to the entire parser being compiled and included in the binary twice.

Fix this by introducing a Cargo feature `tokens` on `napi/parser` crate. Only when `tokens` feature is enabled is a `ParserConfig` which generates tokens used. When disabled (the default), the default `ParserConfig` which does not produce tokens is used.

Enable the `tokens` feature only in tests.