### PR TITLE
ci(release): gate apps publish and notify core

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -278,9 +278,20 @@ jobs:
             rust-oxlint-**.zip
             rust-oxlint-**.tar.gz
 
+  notify-approval:
+    needs: [check, build-oxlint, build-oxlint-freebsd, build-oxfmt, build-oxfmt-freebsd]
+    if: needs.check.outputs.version_changed == 'true'
+    name: Notify Approval
+    runs-on: ubuntu-slim
+    steps:
+      - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_OXC_CORE_CHANNEL }}
+          content: "Requesting approval: https://github.com/oxc-project/oxc/actions/workflows/release_apps.yml"
+
   publish-oxlint:
     name: Publish Oxlint
-    needs: [check, build-oxlint, build-oxlint-freebsd]
+    needs: [check, build-oxlint, build-oxlint-freebsd, notify-approval]
     runs-on: ubuntu-slim
     environment: release
     permissions:
@@ -574,7 +585,7 @@ jobs:
 
   publish-oxfmt:
     name: Publish Oxfmt
-    needs: [check, build-oxfmt, build-oxfmt-freebsd]
+    needs: [check, build-oxfmt, build-oxfmt-freebsd, notify-approval]
     runs-on: ubuntu-slim
     environment: release
     permissions:
@@ -712,11 +723,6 @@ jobs:
           embed-description: A new release is available! Check the changelog for details.
           embed-url: https://github.com/${{ github.repository }}/releases/tag/apps_v${{ needs.check.outputs.oxlint_version }}
 
-      - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_OXC_CORE_CHANNEL }}
-          content: Requesting approval: https://github.com/oxc-project/oxc/actions/workflows/release_apps.yml
-
       - name: wait 3 minutes for smoke test
         run: sleep 180s
 
@@ -739,7 +745,7 @@ jobs:
         uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_OXC_CORE_CHANNEL }}
-          content: Released: https://github.com/oxc-project/oxc/actions/workflows/release_apps.yml
+          content: "Released: https://github.com/oxc-project/oxc/actions/workflows/release_apps.yml"
 
       - name: Test
         # These commands should be run on these defaults:

--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -282,6 +282,7 @@ jobs:
     name: Publish Oxlint
     needs: [check, build-oxlint, build-oxlint-freebsd]
     runs-on: ubuntu-slim
+    environment: release
     permissions:
       id-token: write # for `pnpm publish --provenance`
     env:
@@ -575,6 +576,7 @@ jobs:
     name: Publish Oxfmt
     needs: [check, build-oxfmt, build-oxfmt-freebsd]
     runs-on: ubuntu-slim
+    environment: release
     permissions:
       id-token: write # for `pnpm publish --provenance`
     env:
@@ -710,6 +712,11 @@ jobs:
           embed-description: A new release is available! Check the changelog for details.
           embed-url: https://github.com/${{ github.repository }}/releases/tag/apps_v${{ needs.check.outputs.oxlint_version }}
 
+      - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_OXC_CORE_CHANNEL }}
+          content: Requesting approval: https://github.com/oxc-project/oxc/actions/workflows/release_apps.yml
+
       - name: wait 3 minutes for smoke test
         run: sleep 180s
 
@@ -728,6 +735,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
+      - if: ${{ matrix.os == 'windows-latest' }}
+        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_OXC_CORE_CHANNEL }}
+          content: Released: https://github.com/oxc-project/oxc/actions/workflows/release_apps.yml
+
       - name: Test
         # These commands should be run on these defaults:
         # - windows: pwsh

--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -716,13 +716,6 @@ jobs:
           TITLE: "oxlint v${{ needs.check.outputs.oxlint_version }} & oxfmt v${{ needs.check.outputs.oxfmt_version }}"
         run: gh release create ${GIT_TAG} ./release-artifacts/* --title "${TITLE}" --notes-file ./target/RELEASE_BODY.md --target ${GIT_TARGET}
 
-      - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_OXC_RELEASES_CHANNEL }}
-          embed-title: oxlint v${{ needs.check.outputs.oxlint_version }} & oxfmt v${{ needs.check.outputs.oxfmt_version }}
-          embed-description: A new release is available! Check the changelog for details.
-          embed-url: https://github.com/${{ github.repository }}/releases/tag/apps_v${{ needs.check.outputs.oxlint_version }}
-
       - name: wait 3 minutes for smoke test
         run: sleep 180s
 
@@ -740,13 +733,11 @@ jobs:
     name: Smoke Test ${{ matrix.os }} ${{ matrix.container }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    env:
+      RELEASE_EMBED_TITLE: oxlint v${{ needs.check.outputs.oxlint_version }} & oxfmt v${{ needs.check.outputs.oxfmt_version }}
+      RELEASE_EMBED_DESCRIPTION: A new release is available! Check the changelog for details.
+      RELEASE_EMBED_URL: https://github.com/${{ github.repository }}/releases/tag/apps_v${{ needs.check.outputs.oxlint_version }}
     steps:
-      - if: ${{ matrix.os == 'windows-latest' }}
-        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
-        with:
-          webhook-url: ${{ secrets.DISCORD_OXC_CORE_CHANNEL }}
-          content: "Released: https://github.com/oxc-project/oxc/actions/workflows/release_apps.yml"
-
       - name: Test
         # These commands should be run on these defaults:
         # - windows: pwsh
@@ -758,6 +749,22 @@ jobs:
           ldd --version || true
           npx oxfmt@${{ needs.check.outputs.oxfmt_version }} ./test.js
           npx oxlint@${{ needs.check.outputs.oxlint_version }} ./test.js
+
+      - if: ${{ matrix.os == 'windows-latest' }}
+        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_OXC_CORE_CHANNEL }}
+          embed-title: ${{ env.RELEASE_EMBED_TITLE }}
+          embed-description: ${{ env.RELEASE_EMBED_DESCRIPTION }}
+          embed-url: ${{ env.RELEASE_EMBED_URL }}
+
+      - if: ${{ matrix.os == 'windows-latest' }}
+        uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_OXC_RELEASES_CHANNEL }}
+          embed-title: ${{ env.RELEASE_EMBED_TITLE }}
+          embed-description: ${{ env.RELEASE_EMBED_DESCRIPTION }}
+          embed-url: ${{ env.RELEASE_EMBED_URL }}
 
   bump:
     needs: [check, smoke]


### PR DESCRIPTION
## Summary
- add `environment: release` to the `publish-oxlint` and `publish-oxfmt` jobs
- send a core Discord message with the approval workflow link before the release jobs publish
- move the released Discord notifications into the `smoke` job so they fire after the smoke test step succeeds
- share the same release embed title, description, and URL across the core and releases Discord webhooks

## Validation
- `git diff --check -- .github/workflows/release_apps.yml`
- `actionlint` was not available in the local environment

## AI Disclosure
This PR was prepared with AI assistance. I reviewed the generated changes before opening the PR.
