### PR TITLE
feat(linter): Split jest/require-top-level-describe rule into a Jest and a Vitest rule.

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -24,7 +24,6 @@
   "prefer-to-have-length",
   "require-hook",
   "require-to-throw-message",
-  "require-top-level-describe",
   "valid-describe-callback",
   "valid-expect",
   "valid-expect-in-promise"

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4570,6 +4570,11 @@ impl RuleRunner for crate::rules::vitest::require_test_timeout::RequireTestTimeo
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vitest::require_top_level_describe::RequireTopLevelDescribe {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::vitest::valid_title::ValidTitle {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -732,6 +732,7 @@ pub use crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectP
 pub use crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots as VitestRequireLocalTestContextForConcurrentSnapshots;
 pub use crate::rules::vitest::require_mock_type_parameters::RequireMockTypeParameters as VitestRequireMockTypeParameters;
 pub use crate::rules::vitest::require_test_timeout::RequireTestTimeout as VitestRequireTestTimeout;
+pub use crate::rules::vitest::require_top_level_describe::RequireTopLevelDescribe as VitestRequireTopLevelDescribe;
 pub use crate::rules::vitest::valid_title::ValidTitle as VitestValidTitle;
 pub use crate::rules::vitest::warn_todo::WarnTodo as VitestWarnTodo;
 pub use crate::rules::vue::define_emits_declaration::DefineEmitsDeclaration as VueDefineEmitsDeclaration;
@@ -1484,6 +1485,7 @@ pub enum RuleEnum {
     ),
     VitestRequireMockTypeParameters(VitestRequireMockTypeParameters),
     VitestRequireTestTimeout(VitestRequireTestTimeout),
+    VitestRequireTopLevelDescribe(VitestRequireTopLevelDescribe),
     VitestValidTitle(VitestValidTitle),
     VitestWarnTodo(VitestWarnTodo),
     NodeGlobalRequire(NodeGlobalRequire),
@@ -2320,7 +2322,8 @@ const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
 const VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID: usize =
     VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID + 1usize;
 const VITEST_REQUIRE_TEST_TIMEOUT_ID: usize = VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID + 1usize;
-const VITEST_VALID_TITLE_ID: usize = VITEST_REQUIRE_TEST_TIMEOUT_ID + 1usize;
+const VITEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID: usize = VITEST_REQUIRE_TEST_TIMEOUT_ID + 1usize;
+const VITEST_VALID_TITLE_ID: usize = VITEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID + 1usize;
 const VITEST_WARN_TODO_ID: usize = VITEST_VALID_TITLE_ID + 1usize;
 const NODE_GLOBAL_REQUIRE_ID: usize = VITEST_WARN_TODO_ID + 1usize;
 const NODE_HANDLE_CALLBACK_ERR_ID: usize = NODE_GLOBAL_REQUIRE_ID + 1usize;
@@ -3185,6 +3188,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID,
             Self::VitestRequireTestTimeout(_) => VITEST_REQUIRE_TEST_TIMEOUT_ID,
+            Self::VitestRequireTopLevelDescribe(_) => VITEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID,
             Self::VitestValidTitle(_) => VITEST_VALID_TITLE_ID,
             Self::VitestWarnTodo(_) => VITEST_WARN_TODO_ID,
             Self::NodeGlobalRequire(_) => NODE_GLOBAL_REQUIRE_ID,
@@ -4036,6 +4040,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::NAME,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::NAME,
+            Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::NAME,
             Self::VitestValidTitle(_) => VitestValidTitle::NAME,
             Self::VitestWarnTodo(_) => VitestWarnTodo::NAME,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::NAME,
@@ -4939,6 +4944,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::CATEGORY,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::CATEGORY,
+            Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::CATEGORY,
             Self::VitestValidTitle(_) => VitestValidTitle::CATEGORY,
             Self::VitestWarnTodo(_) => VitestWarnTodo::CATEGORY,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::CATEGORY,
@@ -5793,6 +5799,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::FIX,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::FIX,
+            Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::FIX,
             Self::VitestValidTitle(_) => VitestValidTitle::FIX,
             Self::VitestWarnTodo(_) => VitestWarnTodo::FIX,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::FIX,
@@ -6863,6 +6870,9 @@ impl RuleEnum {
                 VitestRequireMockTypeParameters::documentation()
             }
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::documentation(),
+            Self::VitestRequireTopLevelDescribe(_) => {
+                VitestRequireTopLevelDescribe::documentation()
+            }
             Self::VitestValidTitle(_) => VitestValidTitle::documentation(),
             Self::VitestWarnTodo(_) => VitestWarnTodo::documentation(),
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::documentation(),
@@ -8949,6 +8959,10 @@ impl RuleEnum {
             }
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::config_schema(generator)
                 .or_else(|| VitestRequireTestTimeout::schema(generator)),
+            Self::VitestRequireTopLevelDescribe(_) => {
+                VitestRequireTopLevelDescribe::config_schema(generator)
+                    .or_else(|| VitestRequireTopLevelDescribe::schema(generator))
+            }
             Self::VitestValidTitle(_) => VitestValidTitle::config_schema(generator)
                 .or_else(|| VitestValidTitle::schema(generator)),
             Self::VitestWarnTodo(_) => VitestWarnTodo::config_schema(generator)
@@ -9746,6 +9760,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => "vitest",
             Self::VitestRequireMockTypeParameters(_) => "vitest",
             Self::VitestRequireTestTimeout(_) => "vitest",
+            Self::VitestRequireTopLevelDescribe(_) => "vitest",
             Self::VitestValidTitle(_) => "vitest",
             Self::VitestWarnTodo(_) => "vitest",
             Self::NodeGlobalRequire(_) => "node",
@@ -12092,6 +12107,9 @@ impl RuleEnum {
             Self::VitestRequireTestTimeout(_) => Ok(Self::VitestRequireTestTimeout(
                 VitestRequireTestTimeout::from_configuration(value)?,
             )),
+            Self::VitestRequireTopLevelDescribe(_) => Ok(Self::VitestRequireTopLevelDescribe(
+                VitestRequireTopLevelDescribe::from_configuration(value)?,
+            )),
             Self::VitestValidTitle(_) => {
                 Ok(Self::VitestValidTitle(VitestValidTitle::from_configuration(value)?))
             }
@@ -12903,6 +12921,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(rule) => rule.to_configuration(),
             Self::VitestRequireTestTimeout(rule) => rule.to_configuration(),
+            Self::VitestRequireTopLevelDescribe(rule) => rule.to_configuration(),
             Self::VitestValidTitle(rule) => rule.to_configuration(),
             Self::VitestWarnTodo(rule) => rule.to_configuration(),
             Self::NodeGlobalRequire(rule) => rule.to_configuration(),
@@ -13652,6 +13671,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run(node, ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.run(node, ctx),
             Self::VitestRequireTestTimeout(rule) => rule.run(node, ctx),
+            Self::VitestRequireTopLevelDescribe(rule) => rule.run(node, ctx),
             Self::VitestValidTitle(rule) => rule.run(node, ctx),
             Self::VitestWarnTodo(rule) => rule.run(node, ctx),
             Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
@@ -14401,6 +14421,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_once(ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.run_once(ctx),
             Self::VitestRequireTestTimeout(rule) => rule.run_once(ctx),
+            Self::VitestRequireTopLevelDescribe(rule) => rule.run_once(ctx),
             Self::VitestValidTitle(rule) => rule.run_once(ctx),
             Self::VitestWarnTodo(rule) => rule.run_once(ctx),
             Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
@@ -15254,6 +15275,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireTestTimeout(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestRequireTopLevelDescribe(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestWarnTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeGlobalRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16005,6 +16027,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.should_run(ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.should_run(ctx),
             Self::VitestRequireTestTimeout(rule) => rule.should_run(ctx),
+            Self::VitestRequireTopLevelDescribe(rule) => rule.should_run(ctx),
             Self::VitestValidTitle(rule) => rule.should_run(ctx),
             Self::VitestWarnTodo(rule) => rule.should_run(ctx),
             Self::NodeGlobalRequire(rule) => rule.should_run(ctx),
@@ -17072,6 +17095,9 @@ impl RuleEnum {
                 VitestRequireMockTypeParameters::IS_TSGOLINT_RULE
             }
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::IS_TSGOLINT_RULE,
+            Self::VitestRequireTopLevelDescribe(_) => {
+                VitestRequireTopLevelDescribe::IS_TSGOLINT_RULE
+            }
             Self::VitestValidTitle(_) => VitestValidTitle::IS_TSGOLINT_RULE,
             Self::VitestWarnTodo(_) => VitestWarnTodo::IS_TSGOLINT_RULE,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::IS_TSGOLINT_RULE,
@@ -17981,6 +18007,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::VERSION,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::VERSION,
+            Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::VERSION,
             Self::VitestValidTitle(_) => VitestValidTitle::VERSION,
             Self::VitestWarnTodo(_) => VitestWarnTodo::VERSION,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::VERSION,
@@ -18915,6 +18942,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::HAS_CONFIG,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::HAS_CONFIG,
+            Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::HAS_CONFIG,
             Self::VitestValidTitle(_) => VitestValidTitle::HAS_CONFIG,
             Self::VitestWarnTodo(_) => VitestWarnTodo::HAS_CONFIG,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::HAS_CONFIG,
@@ -19670,6 +19698,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.types_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.types_info(),
             Self::VitestRequireTestTimeout(rule) => rule.types_info(),
+            Self::VitestRequireTopLevelDescribe(rule) => rule.types_info(),
             Self::VitestValidTitle(rule) => rule.types_info(),
             Self::VitestWarnTodo(rule) => rule.types_info(),
             Self::NodeGlobalRequire(rule) => rule.types_info(),
@@ -20419,6 +20448,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.run_info(),
             Self::VitestRequireTestTimeout(rule) => rule.run_info(),
+            Self::VitestRequireTopLevelDescribe(rule) => rule.run_info(),
             Self::VitestValidTitle(rule) => rule.run_info(),
             Self::VitestWarnTodo(rule) => rule.run_info(),
             Self::NodeGlobalRequire(rule) => rule.run_info(),
@@ -21290,6 +21320,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         ),
         RuleEnum::VitestRequireMockTypeParameters(VitestRequireMockTypeParameters::default()),
         RuleEnum::VitestRequireTestTimeout(VitestRequireTestTimeout::default()),
+        RuleEnum::VitestRequireTopLevelDescribe(VitestRequireTopLevelDescribe::default()),
         RuleEnum::VitestValidTitle(VitestValidTitle::default()),
         RuleEnum::VitestWarnTodo(VitestWarnTodo::default()),
         RuleEnum::NodeGlobalRequire(NodeGlobalRequire::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -760,6 +760,7 @@ pub(crate) mod vitest {
     pub mod require_local_test_context_for_concurrent_snapshots;
     pub mod require_mock_type_parameters;
     pub mod require_test_timeout;
+    pub mod require_top_level_describe;
     pub mod valid_title;
     pub mod warn_todo;
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -15,4 +15,5 @@ pub mod no_interpolation_in_snapshots;
 pub mod no_large_snapshots;
 pub mod no_mocks_import;
 pub mod prefer_todo;
+pub mod require_top_level_describe;
 pub mod valid_title;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/require_top_level_describe.rs
@@ -1,0 +1,168 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::ScopeId;
+use oxc_span::Span;
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::DefaultRuleConfig,
+    utils::{
+        JestFnKind, JestGeneralFnKind, ParsedGeneralJestFnCall, ParsedJestFnCallNew,
+        PossibleJestNode, collect_possible_jest_call_node, parse_jest_fn_call,
+    },
+};
+
+fn too_many_describes(max: usize, repeat: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
+        .with_help(format!(
+            "There should not be more than {max:?} describe{repeat} at the top level."
+        ))
+        .with_label(span)
+}
+
+fn unexpected_test_case(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
+        .with_help("All test cases must be wrapped in a describe block.")
+        .with_label(span)
+}
+
+fn unexpected_hook(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Require test cases and hooks to be inside a `describe` block")
+        .with_help("All hooks must be wrapped in a describe block.")
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+Requires test cases and hooks to be inside a top-level `describe` block.
+
+### Why is this bad?
+
+Having tests and hooks organized within `describe` blocks provides better
+structure and grouping for test suites. It makes test output more readable
+and helps with test organization, especially in larger codebases.
+
+This rule triggers a warning if a test case (`test` and `it`) or a hook
+(`beforeAll`, `beforeEach`, `afterEach`, `afterAll`) is not located in a
+top-level `describe` block.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+// Above a describe block
+test('my test', () => {});
+describe('test suite', () => {
+    it('test', () => {});
+});
+
+// Below a describe block
+describe('test suite', () => {});
+test('my test', () => {});
+
+// Same for hooks
+beforeAll('my beforeAll', () => {});
+describe('test suite', () => {});
+afterEach('my afterEach', () => {});
+```
+
+Examples of **correct** code for this rule:
+```javascript
+// Above a describe block
+// In a describe block
+describe('test suite', () => {
+    test('my test', () => {});
+});
+
+// In a nested describe block
+describe('test suite', () => {
+    test('my test', () => {});
+    describe('another test suite', () => {
+        test('my other test', () => {});
+    });
+});
+```
+";
+
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct RequireTopLevelDescribeConfig {
+    /// The maximum number of top-level `describe` blocks allowed in a test file.
+    pub max_number_of_top_level_describes: usize,
+}
+
+impl Default for RequireTopLevelDescribeConfig {
+    fn default() -> Self {
+        Self { max_number_of_top_level_describes: usize::MAX }
+    }
+}
+
+impl RequireTopLevelDescribeConfig {
+    pub fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    pub fn run_once(&self, ctx: &LintContext) {
+        let mut describe_contexts: FxHashMap<ScopeId, usize> = FxHashMap::default();
+        let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);
+        possibles_jest_nodes.sort_unstable_by_key(|n| n.node.id());
+
+        for possible_jest_node in &possibles_jest_nodes {
+            self.run(possible_jest_node, &mut describe_contexts, ctx);
+        }
+    }
+
+    fn run<'a>(
+        &self,
+        possible_jest_node: &PossibleJestNode<'a, '_>,
+        describe_contexts: &mut FxHashMap<ScopeId, usize>,
+        ctx: &LintContext<'a>,
+    ) {
+        let node = possible_jest_node.node;
+        let scopes = ctx.scoping();
+        let is_top = scopes.scope_flags(node.scope_id()).is_top();
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Some(ParsedJestFnCallNew::GeneralJest(ParsedGeneralJestFnCall { kind, .. })) =
+            parse_jest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
+            return;
+        };
+
+        match kind {
+            JestFnKind::General(JestGeneralFnKind::Test) if is_top => {
+                ctx.diagnostic(unexpected_test_case(call_expr.span));
+            }
+            JestFnKind::General(JestGeneralFnKind::Hook) if is_top => {
+                ctx.diagnostic(unexpected_hook(call_expr.span));
+            }
+            JestFnKind::General(JestGeneralFnKind::Describe) => {
+                if !is_top {
+                    return;
+                }
+
+                let Some((_, count)) = describe_contexts.get_key_value(&node.scope_id()) else {
+                    describe_contexts.insert(node.scope_id(), 1);
+                    return;
+                };
+
+                if count >= &self.max_number_of_top_level_describes {
+                    ctx.diagnostic(too_many_describes(
+                        self.max_number_of_top_level_describes,
+                        if *count == 1 { "" } else { "s" },
+                        call_expr.span,
+                    ));
+                } else {
+                    describe_contexts.insert(node.scope_id(), count + 1);
+                }
+            }
+            _ => (),
+        }
+    }
+}

--- a/crates/oxc_linter/src/rules/vitest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_top_level_describe.rs
@@ -11,7 +11,7 @@ pub struct RequireTopLevelDescribe(Box<RequireTopLevelDescribeConfig>);
 
 declare_oxc_lint!(
     RequireTopLevelDescribe,
-    jest,
+    vitest,
     style,
     config = RequireTopLevelDescribeConfig,
     docs = DOCUMENTATION,
@@ -99,13 +99,13 @@ fn test() {
         ),
         (
             "
-                import { jest } from '@jest/globals';
+                import { vi } from 'vitest';
 
-                jest.doMock('my-module');
+                vi.doMock('my-module');
             ",
             None,
         ),
-        ("jest.doMock(\"my-module\")", None),
+        ("vi.doMock(\"my-module\")", None),
         ("describe(\"test suite\", () => { test(\"my test\") });", None),
         ("foo()", None),
         (
@@ -158,7 +158,7 @@ fn test() {
         ),
         (
             "
-                import { describe, afterAll as onceEverythingIsDone } from '@jest/globals';
+                import { describe, afterAll as onceEverythingIsDone } from 'vitest';
 
                 describe(\"test suite\", () => {});
                 onceEverythingIsDone(\"my test\", () => {})
@@ -203,7 +203,7 @@ fn test() {
                     describe as describe1,
                     describe as describe2,
                     describe as describe3,
-                } from '@jest/globals';
+                } from 'vitest';
 
                 describe1('one', () => {
                     describe('one (nested)', () => {});
@@ -233,6 +233,6 @@ fn test() {
     ];
 
     Tester::new(RequireTopLevelDescribe::NAME, RequireTopLevelDescribe::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_require_top_level_describe.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_require_top_level_describe.snap
@@ -1,0 +1,132 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:1:1]
+ 1 │ beforeEach("my test", () => {})
+   · ───────────────────────────────
+   ╰────
+  help: All hooks must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:2:17]
+ 1 │ 
+ 2 │                 test("my test", () => {})
+   ·                 ─────────────────────────
+ 3 │                 describe("test suite", () => {});
+   ╰────
+  help: All test cases must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:2:17]
+ 1 │ 
+ 2 │                 test("my test", () => {})
+   ·                 ─────────────────────────
+ 3 │                 describe("test suite", () => {
+   ╰────
+  help: All test cases must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:3:17]
+ 2 │                 describe("test suite", () => {});
+ 3 │                 afterAll("my test", () => {})
+   ·                 ─────────────────────────────
+ 4 │             
+   ╰────
+  help: All hooks must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:5:17]
+ 4 │                 describe("test suite", () => {});
+ 5 │                 onceEverythingIsDone("my test", () => {})
+   ·                 ─────────────────────────────────────────
+ 6 │             
+   ╰────
+  help: All hooks must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:1:1]
+ 1 │ it.skip('test', () => {});
+   · ─────────────────────────
+   ╰────
+  help: All test cases must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:1:1]
+ 1 │ it.each([1, 2, 3])('%n', () => {});
+   · ──────────────────────────────────
+   ╰────
+  help: All test cases must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:1:1]
+ 1 │ it.skip.each([1, 2, 3])('%n', () => {});
+   · ───────────────────────────────────────
+   ╰────
+  help: All test cases must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:1:1]
+ 1 │ it.skip.each``('%n', () => {});
+   · ──────────────────────────────
+   ╰────
+  help: All test cases must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:1:1]
+ 1 │ it.each``('%n', () => {});
+   · ─────────────────────────
+   ╰────
+  help: All test cases must be wrapped in a describe block.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:4:17]
+ 3 │                 describe("two", () => {});
+ 4 │                 describe("three", () => {});
+   ·                 ───────────────────────────
+ 5 │             
+   ╰────
+  help: There should not be more than 2 describes at the top level.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+    ╭─[require_top_level_describe.tsx:11:17]
+ 10 │                     });
+ 11 │ ╭─▶                 describe('three', () => {
+ 12 │ │                       describe('one (nested)', () => {});
+ 13 │ │                       describe('two (nested)', () => {});
+ 14 │ │                       describe('three (nested)', () => {});
+ 15 │ ╰─▶                 });
+ 16 │                 
+    ╰────
+  help: There should not be more than 2 describes at the top level.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+    ╭─[require_top_level_describe.tsx:17:17]
+ 16 │                     });
+ 17 │ ╭─▶                 describe3('three', () => {
+ 18 │ │                       describe('one (nested)', () => {});
+ 19 │ │                       describe('two (nested)', () => {});
+ 20 │ │                       describe('three (nested)', () => {});
+ 21 │ ╰─▶                 });
+ 22 │                 
+    ╰────
+  help: There should not be more than 2 describes at the top level.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:3:17]
+ 2 │                 describe('one', () => {});
+ 3 │                 describe('two', () => {});
+   ·                 ─────────────────────────
+ 4 │                 describe('three', () => {});
+   ╰────
+  help: There should not be more than 1 describe at the top level.
+
+  ⚠ eslint-plugin-vitest(require-top-level-describe): Require test cases and hooks to be inside a `describe` block
+   ╭─[require_top_level_describe.tsx:4:17]
+ 3 │                 describe('two', () => {});
+ 4 │                 describe('three', () => {});
+   ·                 ───────────────────────────
+ 5 │             
+   ╰────
+  help: There should not be more than 1 describe at the top level.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 29] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 28] = [
     "no-restricted-jest-methods",
     "no-restricted-matchers",
     "no-standalone-expect",
@@ -63,7 +63,6 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 29] = [
     "prefer-to-have-length",
     "require-hook",
     "require-to-throw-message",
-    "require-top-level-describe",
     "valid-describe-callback",
     "valid-expect",
     "valid-expect-in-promise",


### PR DESCRIPTION
Part of #21664.

Generated with Claude Code, Opus 4.7. Reviewed by me.

Only change from the original was to update the tests to use Vitest imports for the Vitest rule, rather than using Jest imports.