### PR TITLE
test(linter): Replace jest-specific tests in vitest/no-identical-title rule.

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_identical_title.rs
@@ -249,7 +249,7 @@ fn test() {
         ),
         (
             "
-              xtest('this', () => {});
+              test.skip('this', () => {});
               test('this', () => {});
             ",
             None,
@@ -285,13 +285,13 @@ fn test() {
         (
             "
               describe('foo', () => {});
-              xdescribe('foo', () => {});
+              describe.skip('foo', () => {});
             ",
             None,
         ),
         (
             "
-              fdescribe('foo', () => {});
+              describe.only('foo', () => {});
               describe('foo', () => {});
             ",
             None,
@@ -381,7 +381,6 @@ fn test() {
     fail.extend(fail_vitest.into_iter().map(|x| (x, None)));
 
     Tester::new(NoIdenticalTitle::NAME, NoIdenticalTitle::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
         .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_no_identical_title.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_identical_title.snap
@@ -30,11 +30,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of test.
 
   ⚠ eslint-plugin-vitest(no-identical-title): Test title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:2:21]
- 1 │ 
- 2 │               xtest('this', () => {});
-   ·                     ──────
+   ╭─[no_identical_title.tsx:3:20]
+ 2 │               test.skip('this', () => {});
  3 │               test('this', () => {});
+   ·                    ──────
+ 4 │             
    ╰────
   help: Change the title of test.
 
@@ -75,17 +75,17 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of describe block.
 
   ⚠ eslint-plugin-vitest(no-identical-title): Describe block title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:3:25]
+   ╭─[no_identical_title.tsx:3:29]
  2 │               describe('foo', () => {});
- 3 │               xdescribe('foo', () => {});
-   ·                         ─────
+ 3 │               describe.skip('foo', () => {});
+   ·                             ─────
  4 │             
    ╰────
   help: Change the title of describe block.
 
   ⚠ eslint-plugin-vitest(no-identical-title): Describe block title is used multiple times in the same describe block.
    ╭─[no_identical_title.tsx:3:24]
- 2 │               fdescribe('foo', () => {});
+ 2 │               describe.only('foo', () => {});
  3 │               describe('foo', () => {});
    ·                        ─────
  4 │             


### PR DESCRIPTION
These tests don't actually work if `jest` isn't available, as the globals don't exist in vitest. So update them to code that does make sense in Vitest.

This allows removing `with_jest_plugin()` here. We could probably clean up the test block here a bit more, but it didn't seem worth the trouble.