### PR TITLE
docs(linter): Remove now-unnecessary compatibility notes from shared Jest/Vitest rules.

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_disabled_tests.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 This rule raises a warning about disabled tests.
 
@@ -43,18 +43,7 @@ it('foo', () => {
   pending();
 });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-disabled-tests.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-disabled-tests": "error"
-  }
-}
-```
-"#;
+";
 
 fn no_disabled_tests_diagnostic(x1: &'static str, x2: &'static str, span3: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(x1).with_help(x2).with_label(span3)

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_duplicate_hooks.rs
@@ -18,7 +18,7 @@ fn no_duplicate_hooks_diagnostic(hook_name: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 Disallows duplicate hooks in describe blocks.
 
@@ -94,18 +94,7 @@ describe('foo', () => {
     });
 });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-duplicate-hooks": "error"
-  }
-}
-```
-"#;
+";
 
 pub fn run_once(ctx: &LintContext) {
     let mut hook_contexts: FxHashMap<NodeId, Vec<FxHashMap<String, i32>>> = FxHashMap::default();

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_focused_tests.rs
@@ -16,7 +16,7 @@ fn no_focused_tests_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 This rule reminds you to remove `.only` from your tests by raising a warning
 whenever you are using the exclusivity feature.
@@ -45,18 +45,7 @@ fit.each`
 table
 `();
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-focused-tests.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-focused-tests": "error"
-  }
-}
-```
-"#;
+";
 
 pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
     let node = possible_jest_node.node;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_hooks.rs
@@ -17,7 +17,7 @@ fn unexpected_hook_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 Disallows Jest setup and teardown hooks, such as `beforeAll`.
 
@@ -65,18 +65,7 @@ describe('foo', () => {
     });
 });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-hooks.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-hooks": "error"
-  }
-}
-```
-"#;
+";
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_identical_title.rs
@@ -28,7 +28,7 @@ fn test_repeat(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 This rule looks at the title of every test and test suite.
 It will report when two test suites or two test cases at the same level of a test suite have the same title.
@@ -51,18 +51,7 @@ Examples of **incorrect** code for this rule:
    // ...
  });
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.1.9/docs/rules/no-identical-title.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-identical-title": "error"
-  }
-}
-```
-"#;
+";
 
 pub fn run_once(ctx: &LintContext) {
     let possible_jest_nodes = collect_possible_jest_call_node(ctx);

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_interpolation_in_snapshots.rs
@@ -13,7 +13,7 @@ fn no_interpolation_in_snapshots_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 Prevents the use of string interpolations in snapshots.
 
@@ -45,18 +45,7 @@ expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
   `${interpolated}`,
 );
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-interpolation-in-snapshots.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-interpolation-in-snapshots": "error"
-  }
-}
-```
-"#;
+";
 
 pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
     let node = possible_jest_node.node;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
@@ -31,7 +31,7 @@ fn too_long_snapshot(line_limit: usize, line_count: usize, span: Span) -> OxcDia
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
 Disallow large snapshots.
 
@@ -111,18 +111,7 @@ line 3
 line 4
 `;
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-large-snapshots.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-large-snapshots": "error"
-  }
-}
-```
-"#;
+";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_mocks_import.rs
@@ -12,9 +12,9 @@ fn no_mocks_import_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub const DOCUMENTATION: &str = r#"### What it does
+pub const DOCUMENTATION: &str = r"### What it does
 
-This rule reports imports from a path containing a __mocks__ component.
+This rule reports imports from a path containing a `__mocks__` component.
 
 ### Why is this bad?
 
@@ -37,18 +37,7 @@ Examples of **correct** code for this rule:
 import thing from 'thing';
 require('thing');
 ```
-
-This rule is compatible with [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-mocks-import.md),
-to use it, add the following configuration to your `.oxlintrc.json`:
-
-```json
-{
-  "rules": {
-     "vitest/no-mocks-import": "error"
-  }
-}
-```
-"#;
+";
 
 pub fn run_once(ctx: &LintContext) {
     let module_records = ctx.module_record();


### PR DESCRIPTION
Just a bit of cleanup on the rules that have been split so far.