### PR TITLE
fix(linter/no-non-null-asserted-nullish-coalescing): add fixer

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -66,7 +66,7 @@ declare_oxc_lint!(
     NoNonNullAssertedNullishCoalescing,
     typescript,
     restriction,
-    fix,
+    suggestion,
     version = "0.5.0",
 );
 
@@ -85,7 +85,7 @@ impl Rule for NoNonNullAssertedNullishCoalescing {
             return;
         }
 
-        ctx.diagnostic_with_fix(
+        ctx.diagnostic_with_suggestion(
             no_non_null_asserted_nullish_coalescing_diagnostic(ts_non_null_expr.span),
             |fixer| {
                 let spans = non_null_assertion_spans(ts_non_null_expr);

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -3,6 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
+use oxc_syntax::operator::LogicalOperator;
 
 use crate::{
     AstNode,
@@ -65,26 +66,67 @@ declare_oxc_lint!(
     NoNonNullAssertedNullishCoalescing,
     typescript,
     restriction,
-    pending,
+    fix,
     version = "0.5.0",
 );
 
 impl Rule for NoNonNullAssertedNullishCoalescing {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(expr) = node.kind() else { return };
+        if expr.operator != LogicalOperator::Coalesce {
+            return;
+        }
+
         let Expression::TSNonNullExpression(ts_non_null_expr) = &expr.left else { return };
-        if let Expression::Identifier(ident) = &ts_non_null_expr.expression
+        if let Expression::Identifier(ident) = ts_non_null_expr.expression.without_parentheses()
             && let Some(symbol_id) = ctx.scoping().get_binding(node.scope_id(), ident.name)
             && !has_assignment_before_node(symbol_id, ctx, expr.span.end)
         {
             return;
         }
 
-        ctx.diagnostic(no_non_null_asserted_nullish_coalescing_diagnostic(ts_non_null_expr.span));
+        ctx.diagnostic_with_fix(
+            no_non_null_asserted_nullish_coalescing_diagnostic(ts_non_null_expr.span),
+            |fixer| {
+                let spans = non_null_assertion_spans(ts_non_null_expr);
+                let fixer = fixer.for_multifix();
+                let mut fix = fixer.new_fix_with_capacity(spans.len());
+
+                for span in spans {
+                    fix.push(fixer.delete_range(span));
+                }
+
+                fix.with_message("Remove the non-null assertion.")
+            },
+        );
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_typescript()
+    }
+}
+
+fn non_null_assertion_spans(expr: &oxc_ast::ast::TSNonNullExpression) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_non_null_assertion_spans(expr, &mut spans);
+    spans
+}
+
+fn collect_non_null_assertion_spans(
+    expr: &oxc_ast::ast::TSNonNullExpression,
+    spans: &mut Vec<Span>,
+) {
+    collect_non_null_assertion_spans_from_expression(&expr.expression, spans);
+    spans.push(Span::sized(expr.span.end - 1, 1));
+}
+
+fn collect_non_null_assertion_spans_from_expression(expr: &Expression, spans: &mut Vec<Span>) {
+    match expr {
+        Expression::TSNonNullExpression(expr) => collect_non_null_assertion_spans(expr, spans),
+        Expression::ParenthesizedExpression(expr) => {
+            collect_non_null_assertion_spans_from_expression(&expr.expression, spans);
+        }
+        _ => {}
     }
 }
 
@@ -122,9 +164,19 @@ fn test() {
         "foo() ?? bar;",
         "foo() ?? bar!;",
         "(foo ?? bar)!;",
+        "foo! || bar;",
+        "foo! && bar;",
         "
                   let x: string;
                   x! ?? '';
+                ",
+        "
+                  let x: string;
+                  (x)! ?? '';
+                ",
+        "
+                  let x: string;
+                  ((x))! ?? '';
                 ",
         "
                   let x: string;
@@ -177,6 +229,17 @@ fn test() {
         "foo!.bazz! ?? bar!;",
         "foo()! ?? bar;",
         "foo()! ?? bar!;",
+        "foo['bar']! ?? baz;",
+        "foo[bar]! ?? baz;",
+        "(foo)! ?? bar;",
+        "((foo))! ?? bar;",
+        "(foo ? bar : baz)! ?? qux;",
+        "(foo || bar)! ?? baz;",
+        "foo/* keep */! ?? bar;",
+        "foo!! ?? bar;",
+        "(foo!)! ?? bar;",
+        "((foo!)!)! ?? bar;",
+        "foo()! ?? bar; baz()! ?? qux;",
         "
             let x!: string;
             x! ?? '';
@@ -214,11 +277,118 @@ fn test() {
                   ",
     ];
 
+    let fix = vec![
+        ("foo! ?? bar;", "foo ?? bar;"),
+        ("foo! ?? bar!;", "foo ?? bar!;"),
+        ("foo.bazz! ?? bar;", "foo.bazz ?? bar;"),
+        ("foo.bazz! ?? bar!;", "foo.bazz ?? bar!;"),
+        ("foo!.bazz! ?? bar;", "foo!.bazz ?? bar;"),
+        ("foo!.bazz! ?? bar!;", "foo!.bazz ?? bar!;"),
+        ("foo()! ?? bar;", "foo() ?? bar;"),
+        ("foo()! ?? bar!;", "foo() ?? bar!;"),
+        ("foo['bar']! ?? baz;", "foo['bar'] ?? baz;"),
+        ("foo[bar]! ?? baz;", "foo[bar] ?? baz;"),
+        ("(foo)! ?? bar;", "(foo) ?? bar;"),
+        ("((foo))! ?? bar;", "((foo)) ?? bar;"),
+        ("(foo ? bar : baz)! ?? qux;", "(foo ? bar : baz) ?? qux;"),
+        ("(foo || bar)! ?? baz;", "(foo || bar) ?? baz;"),
+        ("foo/* keep */! ?? bar;", "foo/* keep */ ?? bar;"),
+        ("foo!! ?? bar;", "foo ?? bar;"),
+        ("(foo!)! ?? bar;", "(foo) ?? bar;"),
+        ("((foo!)!)! ?? bar;", "((foo)) ?? bar;"),
+        ("foo()! ?? bar; baz()! ?? qux;", "foo() ?? bar; baz() ?? qux;"),
+        (
+            "
+            let x!: string;
+            x! ?? '';
+                  ",
+            "
+            let x!: string;
+            x ?? '';
+                  ",
+        ),
+        (
+            "
+            let x: string;
+            x = foo();
+            x! ?? '';
+                  ",
+            "
+            let x: string;
+            x = foo();
+            x ?? '';
+                  ",
+        ),
+        (
+            "
+            let x: string;
+            x = foo();
+            x! ?? '';
+            x = foo();
+                  ",
+            "
+            let x: string;
+            x = foo();
+            x ?? '';
+            x = foo();
+                  ",
+        ),
+        (
+            "
+            let x = foo();
+            x! ?? '';
+                  ",
+            "
+            let x = foo();
+            x ?? '';
+                  ",
+        ),
+        (
+            "
+            function foo() {
+              let x!: string;
+              return x! ?? '';
+            }
+                  ",
+            "
+            function foo() {
+              let x!: string;
+              return x ?? '';
+            }
+                  ",
+        ),
+        (
+            "
+            let x!: string;
+            function foo() {
+              return x! ?? '';
+            }
+                  ",
+            "
+            let x!: string;
+            function foo() {
+              return x ?? '';
+            }
+                  ",
+        ),
+        (
+            "
+            let x = foo();
+            x  ! ?? '';
+                  ",
+            "
+            let x = foo();
+            x   ?? '';
+                  ",
+        ),
+    ];
+
     Tester::new(
         NoNonNullAssertedNullishCoalescing::NAME,
         NoNonNullAssertedNullishCoalescing::PLUGIN,
         pass,
         fail,
     )
+    .expect_fix(fix)
     .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/typescript_no_non_null_asserted_nullish_coalescing.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_non_null_asserted_nullish_coalescing.snap
@@ -59,6 +59,90 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ foo['bar']! ?? baz;
+   · ───────────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ foo[bar]! ?? baz;
+   · ─────────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ (foo)! ?? bar;
+   · ──────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ ((foo))! ?? bar;
+   · ────────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ (foo ? bar : baz)! ?? qux;
+   · ──────────────────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ (foo || bar)! ?? baz;
+   · ─────────────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ foo/* keep */! ?? bar;
+   · ──────────────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ foo!! ?? bar;
+   · ─────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ (foo!)! ?? bar;
+   · ───────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ ((foo!)!)! ?? bar;
+   · ──────────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:1]
+ 1 │ foo()! ?? bar; baz()! ?? qux;
+   · ──────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:1:16]
+ 1 │ foo()! ?? bar; baz()! ?? qux;
+   ·                ──────
+   ╰────
+  help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
+
+  ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
    ╭─[no_non_null_asserted_nullish_coalescing.tsx:3:13]
  2 │             let x!: string;
  3 │             x! ?? '';


### PR DESCRIPTION
## Summary
- Add a safe fixer for `typescript/no-non-null-asserted-nullish-coalescing`
- Only report and fix non-null assertions on the left operand of `??`
- Remove nested redundant assertions across parentheses without deleting the parentheses
- Preserve the existing unassigned-identifier guard, including parenthesized identifiers

## Tests
- `just fmt`
- `cargo lintgen`
- `cargo test -p oxc_linter no_non_null_asserted_nullish_coalescing`
- `cargo check -p oxc_linter`
- `cargo insta pending-snapshots`
- `git diff --check`
