### PR TITLE
fix(transformer/typescript): emit class fields for parameter properties

### DIFF
--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -1,5 +1,7 @@
+use rustc_hash::FxHashSet;
+
 use oxc_allocator::{TakeIn, Vec as ArenaVec};
-use oxc_ast::ast::*;
+use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::SPAN;
 use oxc_str::Ident;
@@ -25,9 +27,11 @@ impl<'a> TypeScript<'a> {
     ///    after the super call in the constructor body.
     ///
     /// Same as `Self::convert_constructor_params` does, the reason why we still need that method because
-    /// this method only calls when `set_public_class_fields` is `true` and `class_properties` plugin is
-    /// disabled, otherwise the `convert_constructor_params` method will be called. Merging them together
-    /// will increase unnecessary check when only transform constructor parameters.
+    /// this method only runs when `set_public_class_fields` is `true` and the `class_properties` plugin
+    /// is disabled. The other branches (`class_properties` enabled, or `set_public_class_fields: false`
+    /// — see [`Self::add_parameter_property_fields`]) reach the parameter-property assignments via
+    /// `convert_constructor_params` directly. Merging them together would add unnecessary checks for
+    /// the param-only paths.
     ///
     /// 2. Convert class fields to `this` assignments in the constructor body.
     ///
@@ -229,6 +233,128 @@ impl<'a> TypeScript<'a> {
         } else if let Some(element) = computed_key_assignment_static_block {
             class.body.body.insert(0, element);
         }
+    }
+
+    /// Insert an uninitialized class field declaration for each constructor parameter property.
+    ///
+    /// Aligns with TypeScript's output under `useDefineForClassFields: true`, which is the
+    /// default since TypeScript 4.0. Runs when [`crate::CompilerAssumptions::set_public_class_fields`]
+    /// is `false` (the inverse of the `useDefineForClassFields: false` mapping).
+    ///
+    /// Input:
+    /// ```ts
+    /// class C {
+    ///   constructor(public x = 1) {}
+    /// }
+    /// ```
+    ///
+    /// Output:
+    /// ```js
+    /// class C {
+    ///   x;
+    ///   constructor(x = 1) {
+    ///     this.x = x;
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Skips parameter properties whose name matches an existing instance field declaration on
+    /// the same class (matching TypeScript's dedup). Only static-identifier instance fields
+    /// count — static, private, computed, and `declare`-only fields don't suppress the new field.
+    pub(super) fn add_parameter_property_fields(class: &mut Class<'a>, ctx: &TraverseCtx<'a>) {
+        let Some(params) = Self::find_constructor_params(class) else { return };
+
+        // Bail before allocating when there are no parameter properties to emit.
+        // Parameter properties are TS-specific and uncommon, so most classes hit this path.
+        if !params.iter().any(FormalParameter::has_modifier) {
+            return;
+        }
+
+        let mut declared_names = Self::collect_instance_field_names(class);
+        let fields = ctx.ast.vec_from_iter(
+            params
+                .iter()
+                .filter(|param| param.has_modifier())
+                .filter_map(|param| param.pattern.get_binding_identifier())
+                .filter(|id| declared_names.insert(id.name))
+                .map(|id| Self::build_uninitialized_field(id, ctx)),
+        );
+
+        class.body.body.splice(0..0, fields);
+    }
+
+    /// Returns the body-bearing constructor's parameter list, or `None` if the class has none.
+    fn find_constructor_params<'b>(
+        class: &'b Class<'a>,
+    ) -> Option<&'b ArenaVec<'a, FormalParameter<'a>>> {
+        class.body.body.iter().find_map(|element| {
+            if let ClassElement::MethodDefinition(method) = element
+                && method.kind.is_constructor()
+                && method.value.body.is_some()
+            {
+                Some(&method.value.params.items)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Collect names of instance field declarations keyed by a static identifier.
+    ///
+    /// Static, private, computed, and `declare`-only fields don't suppress a parameter-property
+    /// field — they're different bindings or erased before emit. Plain instance-field collisions
+    /// are a TS `Duplicate identifier` error, so this dedup is mostly defensive.
+    fn collect_instance_field_names(class: &Class<'a>) -> FxHashSet<Ident<'a>> {
+        class
+            .body
+            .body
+            .iter()
+            .filter_map(|element| match element {
+                ClassElement::PropertyDefinition(prop)
+                    if !prop.r#static
+                        && !prop.declare
+                        && let PropertyKey::StaticIdentifier(ident) = &prop.key =>
+                {
+                    Some(ident.name)
+                }
+                ClassElement::AccessorProperty(prop)
+                    if !prop.r#static
+                        && let PropertyKey::StaticIdentifier(ident) = &prop.key =>
+                {
+                    Some(ident.name)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Build `<id.name>;` — an uninitialized public class field declaration.
+    ///
+    /// Safe to read `id.name` directly here — `add_parameter_property_fields` is gated on
+    /// `!is_class_properties_plugin_enabled`, so no rename has happened.
+    /// `convert_constructor_params` uses the span trick because it also runs alongside
+    /// class-properties.
+    fn build_uninitialized_field(
+        id: &BindingIdentifier<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> ClassElement<'a> {
+        let key = ctx.ast.property_key_static_identifier(id.span, id.name);
+        ctx.ast.class_element_property_definition(
+            id.span,
+            PropertyDefinitionType::PropertyDefinition,
+            ctx.ast.vec(),
+            key,
+            NONE,
+            None,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            None,
+        )
     }
 
     pub(super) fn transform_class_on_exit(&self, class: &mut Class<'a>, ctx: &TraverseCtx<'a>) {

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -120,8 +120,15 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScript<'a> {
 
         // Avoid converting class fields when class-properties plugin is enabled, that plugin has covered all
         // this transformation does.
-        if !self.is_class_properties_plugin_enabled && self.set_public_class_fields {
-            self.transform_class_fields(class, ctx);
+        if !self.is_class_properties_plugin_enabled {
+            if self.set_public_class_fields {
+                self.transform_class_fields(class, ctx);
+            } else {
+                // Default oxc behavior matches `useDefineForClassFields: true`. Emit an uninitialized
+                // field declaration for each constructor parameter property so downstream `[[Define]]`
+                // semantics see the property, matching TypeScript's output.
+                Self::add_parameter_property_fields(class, ctx);
+            }
         }
     }
 

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-super/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-with-super/output.js
@@ -1,0 +1,7 @@
+class C extends Object {
+  x;
+  constructor(x) {
+    super();
+    this.x = x;
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties/output.js
@@ -1,0 +1,10 @@
+class C {
+  x;
+  y;
+  z;
+  constructor(x, y = 0, z = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: c543b031
 
-Passed: 222/369
+Passed: 224/371
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -69,7 +69,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (17/50)
+# babel-plugin-transform-typescript (19/52)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-declared-fields/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-declared-fields/input.ts
@@ -1,0 +1,18 @@
+// Static and private fields with the same name as a constructor parameter
+// property are different bindings, so the parameter property still emits its
+// own field declaration. (Same-name plain instance fields would be a
+// `Duplicate identifier` error in TypeScript, so dedup against those is
+// purely defensive.)
+export class WithStaticSameName {
+  static x = 0;
+  constructor(public x = 1) {}
+}
+
+export class WithPrivateSameName {
+  #x = 0;
+  constructor(public x = 1) {}
+
+  read() {
+    return this.#x;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-declared-fields/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-declared-fields/output.js
@@ -1,0 +1,17 @@
+export class WithStaticSameName {
+  x;
+  static x = 0;
+  constructor(x = 1) {
+    this.x = x;
+  }
+}
+export class WithPrivateSameName {
+  x;
+  #x = 0;
+  constructor(x = 1) {
+    this.x = x;
+  }
+  read() {
+    return this.#x;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-default-value/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-default-value/input.ts
@@ -1,0 +1,7 @@
+// Repro of issue #21600: parameter property with default value should still
+// emit an uninitialized class field declaration to match TypeScript's
+// `useDefineForClassFields: true` output.
+class Foo {
+  constructor(public b1 = 2.1) {
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-default-value/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-default-value/output.js
@@ -1,0 +1,6 @@
+class Foo {
+  b1;
+  constructor(b1 = 2.1) {
+    this.b1 = b1;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/output.js
@@ -1,4 +1,8 @@
 class Foo {
+  foo;
+  bar;
+  zoo;
+  bang;
   boom;
   constructor(foo, bar, zoo, bang, too) {
     this.foo = foo;
@@ -8,8 +12,12 @@ class Foo {
     console.log(this.foo, this.bar, this.zoo, this.bang);
   }
 }
-
 class Bar extends Foo {
+  foo;
+  bar;
+  zoo;
+  bang;
+  boom;
   constructor(foo, bar, zoo, bang, boom, too) {
     super(foo, bar, zoo, bang, too);
     this.foo = foo;
@@ -19,8 +27,12 @@ class Bar extends Foo {
     this.boom = boom;
   }
 }
-
 class Baz extends Bar {
+  foo;
+  bar;
+  zoo;
+  bang;
+  boom;
   constructor(foo, bar, zoo, bang, boom, too) {
     this.foo = foo;
     this.bar = bar;

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/output.ts
@@ -2,6 +2,7 @@ import { dce, Dependency } from "mod";
 
 var _ref;
 let AbstractClass = class AbstractClass {
+  dependency;
   constructor(dependency) {
     this.dependency = dependency;
   }


### PR DESCRIPTION
## Summary

Fixes a long-standing inconsistency in the TypeScript transformer's handling of constructor parameter properties under the documented default (`useDefineForClassFields: true` per [`compiler_assumptions.rs:137-139`](https://github.com/oxc-project/oxc/blob/main/crates/oxc_transformer/src/compiler_assumptions.rs#L137-L139)).

The transformer already emitted TS-true-aligned output for **declared** fields (kept `boom: number;` as `boom;`) but silently dropped the field declaration for **parameter properties**, so downstream tools that re-analyze the transformed AST saw the property only as a `this.*` write, not as a declared class field.

```ts
// input
class Foo {
  boom: number;                  // declared field
  constructor(public foo) {}     // parameter property
}
```

```js
// before — inconsistent
class Foo {
  boom;                          // ✅ kept (TS-true)
  constructor(foo) {             // ❌ missing `foo;` (TS-false-style for params only)
    this.foo = foo;
  }
}

// after — consistent
class Foo {
  foo;                           // ✅ now matches `boom;`
  boom;
  constructor(foo) {
    this.foo = foo;
  }
}
```

This is **not a policy change** — the documented default has always been `useDefineForClassFields: true` (set both `set_public_class_fields` and `remove_class_fields_without_initializer` to `true` to opt into `false` semantics). The fix just closes the missing case for parameter properties.

## Implementation

- Add `add_parameter_property_fields` to the `enter_class` path that runs when `set_public_class_fields` is `false`, mirroring the existing branch that calls `transform_class_fields` when it is `true`.
- Skip parameter properties whose name matches an existing instance field on the same class (matches tsc's dedup). Static, private, and `declare`-only fields are different bindings, so they don't suppress the new field.
- Early-bail before allocating the dedup set when the class has no parameter properties — keeps the transformer-allocations snapshot at baseline.

No new option is added; the existing `set_public_class_fields` assumption already maps cleanly to `useDefineForClassFields` (the playground's `useDefineForClassFields: true` already toggles `set_public_class_fields = false`).

Closes #21600
Closes #21831