### PR TITLE
fix(formatter/sort_imports): Keep leading blank line when decreasing group transitions

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -247,7 +247,7 @@ impl SortImportsTransform {
                     // import B from "b";
                     // // chunk trailing
                     // ```
-                    let (sorted_imports, orphan_contents, trailing_lines) =
+                    let (sorted_imports, orphan_contents, trailing_lines, slot_had_leading_blank) =
                         chunk.into_sorted_import_units(&group_matcher, options);
 
                     // Output leading orphan content (after_slot: None)
@@ -268,6 +268,8 @@ impl SortImportsTransform {
                         // 2. At least one non-ignored import has already been output
                         //    (leading ignored imports don't trigger group boundaries)
                         // 3. The boundary override (or global `newlines_between`) says to insert
+                        //    For decreasing transitions, fall back to whether the original input
+                        //    had a blank line at this slot position (matches perfectionist).
                         let current_group_idx = sorted_import.group_idx;
                         if let Some(prev_idx) = prev_group_idx
                             && prev_idx != current_group_idx
@@ -277,6 +279,7 @@ impl SortImportsTransform {
                                 &options.newline_boundary_overrides,
                                 prev_idx,
                                 current_group_idx,
+                                slot_had_leading_blank[slot_idx],
                             )
                         {
                             next_elements.push(FormatElement::Line(LineMode::Empty));
@@ -353,26 +356,27 @@ impl SortImportsTransform {
 /// multiple boundaries are evaluated with OR semantics.
 /// If any single boundary in the range resolves to `true`, a blank line is inserted.
 ///
-/// Handles both increasing and decreasing group transitions.
-/// Decreasing transitions can occur when ignored (side-effect) imports
-/// preserve their original positions while other imports are sorted.
+/// Decreasing transitions (`prev_group_idx > current_group_idx`) can occur when
+/// ignored (side-effect) imports preserve their original positions while other
+/// imports are sorted. To match perfectionist's behavior, the configured boundary
+/// rules are not enforced in that direction; instead, the original blank-line state
+/// at this slot is preserved via `slot_had_leading_blank`.
 fn should_insert_newline_between(
     global_newlines_between: bool,
     newline_boundary_overrides: &[Option<bool>],
     prev_group_idx: usize,
     current_group_idx: usize,
+    slot_had_leading_blank: bool,
 ) -> bool {
+    if prev_group_idx > current_group_idx {
+        return slot_had_leading_blank;
+    }
+
     if newline_boundary_overrides.is_empty() {
         return global_newlines_between;
     }
 
-    let (start, end) = if prev_group_idx < current_group_idx {
-        (prev_group_idx, current_group_idx)
-    } else {
-        (current_group_idx, prev_group_idx)
-    };
-
-    for idx in start..end {
+    for idx in prev_group_idx..current_group_idx {
         if newline_boundary_overrides.get(idx).copied().flatten().unwrap_or(global_newlines_between)
         {
             return true;

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
@@ -57,27 +57,31 @@ impl<'a> PartitionedChunk<'a> {
     }
 
     /// Convert this import chunk into `SortableImport` units with `OrphanContent`.
-    /// Returns a tuple of `(sortable_imports, orphan_contents, trailing_lines)`.
+    /// Returns a tuple of `(sortable_imports, orphan_contents, trailing_lines, slot_had_leading_blank)`.
     ///
     /// - `sortable_imports`: Import statements with their attached leading lines.
     ///   - `leading_lines`: Comments directly before this import (no empty line between).
     /// - `orphan_contents`: Orphan comments (separated by empty line from next import) with their slot positions.
     ///   - `after_slot: None` = before first import, `Some(n)` = after slot n
     /// - `trailing_lines`: Lines at the end of the chunk after all imports.
+    /// - `slot_had_leading_blank`: For each slot index, whether the original input had
+    ///   at least one blank line before that slot. Indexed by slot position
+    ///   (which is preserved across sorting), not by the import currently at that slot.
     #[must_use]
     pub fn into_sorted_import_units(
         self,
         group_matcher: &GroupMatcher,
         options: &SortImportsOptions,
-    ) -> (Vec<SortableImport<'a>>, Vec<OrphanContent<'a>>, Vec<SourceLine<'a>>) {
+    ) -> (Vec<SortableImport<'a>>, Vec<OrphanContent<'a>>, Vec<SourceLine<'a>>, Vec<bool>) {
         let Self::Imports(lines) = self else {
             unreachable!(
                 "`into_import_units()` must be called on `PartitionedChunk::Imports` only."
             );
         };
 
-        let mut sortable_imports: Vec<SortableImport<'a>> = vec![];
+        let mut sortable_imports: Vec<SortableImport<'a>> = Vec::with_capacity(lines.len());
         let mut orphan_contents: Vec<OrphanContent<'a>> = vec![];
+        let mut slot_had_leading_blank: Vec<bool> = Vec::with_capacity(lines.len());
 
         // Comments separated from the next import by empty line.
         // These stay at their slot position, not attached to any import.
@@ -89,6 +93,11 @@ impl<'a> PartitionedChunk<'a> {
         for line in lines {
             match line {
                 SourceLine::Import(_, ref metadata) => {
+                    // A blank line in the original source ends up in `orphan_pending`,
+                    // so its presence there marks this slot as having a leading blank.
+                    slot_had_leading_blank
+                        .push(orphan_pending.iter().any(|l| matches!(l, SourceLine::Empty)));
+
                     // Handle orphan content (separated by empty line from this import)
                     // These stay at their original slot position, not attached to any import.
                     if !orphan_pending.is_empty() {
@@ -157,6 +166,6 @@ impl<'a> PartitionedChunk<'a> {
         // Let's sort this chunk!
         sortable_imports.sort(options);
 
-        (sortable_imports, orphan_contents, trailing_lines)
+        (sortable_imports, orphan_contents, trailing_lines, slot_had_leading_blank)
     }
 }

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
@@ -898,6 +898,25 @@ import "./side-effect2";
 "#,
     );
 
+    // No blank line should be inserted on a "decreasing" group transition
+    // (e.g. ignored `style` side-effect → `internal` import) to align with
+    // the perfectionist plugin behavior.
+    assert_format(
+        r#"
+import { z } from "@/z";
+
+import "./style.css";
+import { a } from "@/a";
+"#,
+        r#"{ "sortImports": {} }"#,
+        r#"
+import { a } from "@/a";
+
+import "./style.css";
+import { z } from "@/z";
+"#,
+    );
+
     assert_format(
         r#"
 import y from "y";


### PR DESCRIPTION
Fixes regression introduced by #21692, found by https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/24981948386