### PR TITLE
fix(linter/valid-expect): clarify fixer suggestion messages

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
@@ -230,23 +230,24 @@ impl ValidExpectConfig {
 
                 let multifixer = fixer.for_multifix();
 
-                let capacity =
-                    if fixed_function_expression.contains(&function_scope_id) { 1 } else { 2 };
-
-                let mut fixes = multifixer.new_fix_with_capacity(capacity);
-
                 let is_async_function = match function_scope_node.kind() {
                     AstKind::ArrowFunctionExpression(fn_kind) => fn_kind.r#async,
                     AstKind::Function(fn_kind) => fn_kind.r#async,
                     _ => return fixer.noop(),
                 };
 
-                if !fixed_function_expression.contains(&function_scope_id) && !is_async_function {
+                let needs_async =
+                    !fixed_function_expression.contains(&function_scope_id) && !is_async_function;
+                let capacity = if needs_async { 2 } else { 1 };
+
+                let mut fixes = multifixer.new_fix_with_capacity(capacity);
+
+                if needs_async {
                     fixed_function_expression.insert(function_scope_id);
 
                     let context_function = ctx.nodes().parent_node(function_scope_node.id());
 
-                    /* Diff between Estree and Oxc in the following scenearion
+                    /* Difference between ESTree and Oxc in the following scenario
                      *
                      * expect.extend({
                      *               toResolve(obj) {
@@ -256,9 +257,9 @@ impl ValidExpectConfig {
                      *               }
                      *             })
                      *
-                     * Eslint span returns the toResolve(obj) {...}, but Oxc only returns (obj){...}.
-                     * This difference produce an invalid fix adding `async` between the function name and arguments,
-                     * writing toResolveasync (obj), instead of async toResolve(obj).
+                     * ESLint's span returns toResolve(obj) {...}, but Oxc only returns (obj){...}.
+                     * This difference produces an invalid fix by adding `async` between the function name and arguments,
+                     * writing toResolveasync (obj) instead of async toResolve(obj).
                      *
                      */
                     let span_to_insert_before =
@@ -287,7 +288,11 @@ impl ValidExpectConfig {
                     fixes.push(fixer.insert_text_before_range(final_node.span(), "await "));
                 }
 
-                fixes.with_message("WIP")
+                fixes.with_message(if needs_async {
+                    "Add `await` and make the enclosing function `async`."
+                } else {
+                    "Add `await`."
+                })
             });
         }
     }
@@ -465,11 +470,11 @@ impl Message {
         match self {
             Self::MatcherNotFound => (
                 "Expect must have a corresponding matcher call.",
-                "Did you forget add a matcher, e.g. `toBe`, `toBeDefined`",
+                "Did you forget to add a matcher, e.g. `toBe`, `toBeDefined`",
             ),
             Self::MatcherNotCalled => (
                 "Matchers must be called to assert.",
-                "You need call your matcher, e.g. `expect(true).toBe(true)`.",
+                "You need to call your matcher, e.g. `expect(true).toBe(true)`.",
             ),
             Self::ModifierUnknown => {
                 ("Expect has an unknown modifier.", "Is it a spelling mistake?")

--- a/crates/oxc_linter/src/snapshots/jest_valid_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_expect.snap
@@ -70,35 +70,35 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect('something');
    · ───────────────────
    ╰────
-  help: Did you forget add a matcher, e.g. `toBe`, `toBeDefined`
+  help: Did you forget to add a matcher, e.g. `toBe`, `toBeDefined`
 
   ⚠ eslint-plugin-jest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect();
    · ────────
    ╰────
-  help: Did you forget add a matcher, e.g. `toBe`, `toBeDefined`
+  help: Did you forget to add a matcher, e.g. `toBe`, `toBeDefined`
 
   ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).toBeDefined;
    · ────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.toBeDefined;
    · ────────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined;
    · ─────────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-jest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
@@ -133,21 +133,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(true).resolves;
    · ─────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).rejects;
    · ────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-jest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not;
    · ────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
@@ -470,7 +470,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(Promise.resolve(2)).resolves.toBe;
    · ────────────────────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-jest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
@@ -497,4 +497,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ──────────────────────────
  4 │                 });
    ╰────
-  help: Did you forget add a matcher, e.g. `toBe`, `toBeDefined`
+  help: Did you forget to add a matcher, e.g. `toBe`, `toBeDefined`

--- a/crates/oxc_linter/src/snapshots/vitest_valid_expect.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_valid_expect.snap
@@ -70,35 +70,35 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect("something");
    · ───────────────────
    ╰────
-  help: Did you forget add a matcher, e.g. `toBe`, `toBeDefined`
+  help: Did you forget to add a matcher, e.g. `toBe`, `toBeDefined`
 
   ⚠ eslint-plugin-vitest(valid-expect): Expect must have a corresponding matcher call.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect();
    · ────────
    ╰────
-  help: Did you forget add a matcher, e.g. `toBe`, `toBeDefined`
+  help: Did you forget to add a matcher, e.g. `toBe`, `toBeDefined`
 
   ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).toBeDefined;
    · ────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not.toBeDefined;
    · ────────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).nope.toBeDefined;
    · ─────────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-vitest(valid-expect): Expect has an unknown modifier.
    ╭─[valid_expect.tsx:1:1]
@@ -133,21 +133,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(true).resolves;
    · ─────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).rejects;
    · ────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-vitest(valid-expect): Matchers must be called to assert.
    ╭─[valid_expect.tsx:1:1]
  1 │ expect(true).not;
    · ────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:1:1]
@@ -425,7 +425,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(Promise.resolve(2)).resolves.toBe;
    · ────────────────────────────────────────
    ╰────
-  help: You need call your matcher, e.g. `expect(true).toBe(true)`.
+  help: You need to call your matcher, e.g. `expect(true).toBe(true)`.
 
   ⚠ eslint-plugin-vitest(valid-expect): Async assertions must be awaited.
    ╭─[valid_expect.tsx:4:25]
@@ -452,4 +452,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ──────────────────────────
  4 │                 });
    ╰────
-  help: Did you forget add a matcher, e.g. `toBe`, `toBeDefined`
+  help: Did you forget to add a matcher, e.g. `toBe`, `toBeDefined`


### PR DESCRIPTION
The `valid-expect` fixer used a generic suggestion message even when only `await` was inserted, and a few nearby user-facing strings had spelling and grammar issues.

This updates the fixer message based on whether `async` is added and refreshes the affected snapshots.