### PR TITLE
fix(oxlint,oxfmt): disable nested vite+ config support

### DIFF
--- a/apps/oxfmt/src/cli/resolve.rs
+++ b/apps/oxfmt/src/cli/resolve.rs
@@ -4,7 +4,9 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
-use crate::core::{ConfigResolver, utils::normalize_relative_path};
+use crate::core::{
+    ConfigResolver, config_discovery, is_nested_vite_config_dir, utils::normalize_relative_path,
+};
 
 /// Resolve ignore file paths from CLI args or defaults.
 ///
@@ -119,8 +121,15 @@ pub(super) fn resolve_file_scope_config(
         return Ok(None);
     };
 
+    let Some(config_dir) = parent.ancestors().find(|dir| {
+        !config_discovery().find_configs_in_directory(dir).is_empty()
+            && !is_nested_vite_config_dir(dir, root_config_dir)
+    }) else {
+        return Ok(None);
+    };
+
     let mut resolver = ConfigResolver::from_config(
-        parent,
+        config_dir,
         None,
         editorconfig_path,
         #[cfg(feature = "napi")]

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 use super::resolve::{build_global_ignore_matchers, is_ignored, resolve_file_scope_config};
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
-use crate::core::{ConfigResolver, FormatStrategy, config_discovery};
+use crate::core::{ConfigResolver, FormatStrategy, config_discovery, is_nested_vite_config_dir};
 
 /// A file entry paired with its scope's config resolver.
 pub struct FormatEntry {
@@ -420,6 +420,10 @@ fn resolve_child_scope_configs(
     let mut map = FxHashMap::default();
     let mut has_children = false;
     for config_dir in config_dirs {
+        if is_nested_vite_config_dir(config_dir, root_config_dir) {
+            continue;
+        }
+
         let mut resolver = ConfigResolver::from_config(
             config_dir,
             // NOTE: Let it auto-discover (not a direct path) config,

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -40,6 +40,17 @@ pub fn config_discovery() -> ConfigDiscovery {
     )
 }
 
+pub fn is_nested_vite_config_dir(config_dir: &Path, root_config_dir: Option<&Path>) -> bool {
+    if root_config_dir.is_some_and(|root| config_dir == root) {
+        return false;
+    }
+
+    config_discovery()
+        .find_configs_in_directory(config_dir)
+        .into_iter()
+        .any(|config| matches!(config, DiscoveredConfigFile::Vite(_)))
+}
+
 pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
     // Search the nearest `.editorconfig` from cwd upwards
     cwd.ancestors().map(|dir| dir.join(".editorconfig")).find(|p| p.exists())

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -11,7 +11,10 @@ mod js_config;
 
 #[cfg(feature = "napi")]
 pub use config::resolve_options_from_value;
-pub use config::{ConfigResolver, ResolvedOptions, config_discovery, resolve_editorconfig_path};
+pub use config::{
+    ConfigResolver, ResolvedOptions, config_discovery, is_nested_vite_config_dir,
+    resolve_editorconfig_path,
+};
 pub use format::{FormatResult, SourceFormatter};
 pub use support::{FormatStrategy, FormatStrategyBuilder};
 

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -12,7 +12,7 @@ use oxc_language_server::{
 
 use crate::core::{
     ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, SourceFormatter,
-    config_discovery, resolve_editorconfig_path, utils,
+    config_discovery, is_nested_vite_config_dir, resolve_editorconfig_path, utils,
 };
 use crate::lsp::create_fake_file_path_from_language_id;
 use crate::lsp::options::FormatOptions as LSPFormatOptions;
@@ -300,7 +300,9 @@ impl ServerFormatter {
         };
 
         for dir in start_dir.ancestors() {
-            if !config_discovery().find_configs_in_directory(dir).is_empty() {
+            if !config_discovery().find_configs_in_directory(dir).is_empty()
+                && !is_nested_vite_config_dir(dir, Some(&self.root_path))
+            {
                 return ConfigScope::Dir(dir.to_path_buf());
             }
         }

--- a/apps/oxfmt/test/cli/vite_plus/8.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/8.snap.md
@@ -1,0 +1,55 @@
+# Input
+
+## Command
+```
+VP_VERSION=1 oxfmt --check child/test.ts
+```
+
+## File tree
+```
+- fixtures/
+  - basic/
+    - test.ts
+    - vite.config.ts
+  - error_load_failure/ <CWD>
+    - .oxfmtrc.json
+    - child/
+      - test.ts
+      - vite.config.ts
+  - no_fmt_field/
+    - test.ts
+    - vite.config.ts
+  - priority/
+    - oxfmt.config.ts
+    - test.ts
+    - vite.config.ts
+  - skip_finds_parent/
+    - .oxfmtrc.json
+    - child/
+      - test.ts
+      - vite.config.ts
+  - skip_fn_export/
+    - test.ts
+    - vite.config.ts
+```
+
+# Result
+
+## Exit code
+0
+
+## stdout
+```
+Checking formatting...
+
+All matched files use the correct format.
+Finished in <time> on 1 files using 1 threads.
+```
+
+## stderr
+```
+
+```
+
+## File changes
+No changes

--- a/apps/oxfmt/test/cli/vite_plus/options.json
+++ b/apps/oxfmt/test/cli/vite_plus/options.json
@@ -22,5 +22,10 @@
     "env": { "VP_VERSION": "1" }
   },
   { "cwd": "skip_fn_export", "args": ["--check", "test.ts"], "env": { "VP_VERSION": "1" } },
-  { "cwd": "priority", "args": ["--check", "test.ts"], "env": { "VP_VERSION": "1" } }
+  { "cwd": "priority", "args": ["--check", "test.ts"], "env": { "VP_VERSION": "1" } },
+  {
+    "cwd": "error_load_failure",
+    "args": ["--check", "child/test.ts"],
+    "env": { "VP_VERSION": "1" }
+  }
 ]

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -353,6 +353,14 @@ impl<'a> ConfigLoader<'a> {
                 continue;
             };
 
+            // TODO: revert or clean up depending on if we decide
+            // to support nested vite+ configs
+            if matches!(config, DiscoveredConfigFile::Vite(_))
+                && root_config_dir.is_some_and(|root| dir != root)
+            {
+                continue;
+            }
+
             by_dir.entry(dir).or_default().push(config);
         }
 
@@ -1206,9 +1214,8 @@ mod test {
         assert_eq!(configs.len(), 1);
     }
 
-    #[cfg(feature = "napi")]
     #[test]
-    fn test_nested_vite_config_loads() {
+    fn test_nested_vite_config_is_ignored() {
         let root_dir = tempfile::tempdir().unwrap();
         let nested_path = root_dir.path().join("nested/vite.config.ts");
         std::fs::create_dir_all(nested_path.parent().unwrap()).unwrap();
@@ -1217,22 +1224,12 @@ mod test {
         let mut external_plugin_store = ExternalPluginStore::new(false);
         let mut loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
 
-        let expected_path = nested_path.clone();
-        let js_loader = make_js_loader(move |paths| {
-            assert_eq!(paths, vec![expected_path.to_string_lossy().to_string()]);
-            Ok(paths
-                .into_iter()
-                .map(|path| make_js_config(PathBuf::from(path), None, None))
-                .collect())
-        });
-        loader = loader.with_js_config_loader(Some(&js_loader));
-
         let (configs, errors) = loader.load_discovered_with_root_dir(
             root_dir.path(),
             [DiscoveredConfigFile::Vite(nested_path)],
         );
         assert!(errors.is_empty());
-        assert_eq!(configs.len(), 1);
+        assert!(configs.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
note this implementation is a little messy, once we have made a concrete decision as to whether/not to support nested vite+ configs, we should revert/implement this properly