### PR TITLE
feat(oxlint/lsp): support `rulesCustomization` lsp option

### DIFF
--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -249,9 +249,6 @@ impl TryFrom<Value> for LintOptions {
                     Some(&"all") => LintFixKindFlag::All,
                     _ => LintFixKindFlag::default(),
                 }),
-            #[cfg(not(test))]
-            rules_customization: None,
-            #[cfg(test)]
             rules_customization: object
                 .get("rulesCustomization")
                 .and_then(|key| RulesCustomization::deserialize(key).ok()),

--- a/apps/oxlint/test/lsp/code_action/__snapshots__/code_action.test.ts.snap
+++ b/apps/oxlint/test/lsp/code_action/__snapshots__/code_action.test.ts.snap
@@ -168,6 +168,17 @@ let pi = 3.141592
 --------------------"
 `;
 
+exports[`LSP code actions > rulesCustomization > should hide rule fix in \`source.fixAll.oxc\` when rulesCustomization disables this rule 1`] = `
+"--- FILE -----------
+rules_customization/test.ts
+--- Original Content ---------
+debugger;
+
+--- Code Actions ---------
+
+--------------------"
+`;
+
 exports[`LSP code actions > with code action only context > should handle quickfix 1`] = `
 "--- FILE -----------
 context_only/test.ts

--- a/apps/oxlint/test/lsp/code_action/code_action.test.ts
+++ b/apps/oxlint/test/lsp/code_action/code_action.test.ts
@@ -53,4 +53,27 @@ describe("LSP code actions", () => {
       ).toMatchSnapshot();
     });
   });
+
+  describe("rulesCustomization", () => {
+    it("should hide rule fix in `source.fixAll.oxc` when rulesCustomization disables this rule", async () => {
+      expect(
+        await fixFixture(
+          FIXTURES_DIR,
+          "rules_customization/test.ts",
+          "typescript",
+          {
+            rulesCustomization: {
+              "no-debugger": {
+                autofix: false,
+              },
+            },
+          },
+          {
+            diagnostics: [],
+            only: ["source.fixAll.oxc"],
+          },
+        ),
+      ).toMatchSnapshot();
+    });
+  });
 });

--- a/apps/oxlint/test/lsp/code_action/fixtures/rules_customization/test.ts
+++ b/apps/oxlint/test/lsp/code_action/fixtures/rules_customization/test.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/lsp/utils.ts
+++ b/apps/oxlint/test/lsp/utils.ts
@@ -419,6 +419,12 @@ type OxlintLSPConfig = {
   fixKind?: string;
   configPath?: string;
   typeAware?: boolean;
+  rulesCustomization?: Record<
+    string,
+    {
+      autofix?: boolean;
+    }
+  >;
 };
 
 async function getDiagnosticSnapshot(

--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -36,6 +36,7 @@ These options can be passed with [initialize](#initialize), [workspace/didChange
 | `typeAware`               | `<boolean>` \| `null`             | `null`                   | Enables type-aware linting. When unset (`null`), uses the root config's `options.typeAware` value.                                                     |
 | `disableNestedConfig`     | `false` \| `true`                 | `false`                  | Disabled nested configuration and searches only for `configPath`.                                                                                      |
 | `fixKind`                 | [fixKind values](#fixkind-values) | `safe_fix_or_suggestion` | The level of a possible fix for a diagnostic, will be applied for the complete workspace (diagnostic, code action, commands and more).                 |
+| `rulesCustomization`      | `Map<string, RulesCustomization>` | `<empty>`                | Rules customization, overriding severity or autofix with `source.fixAll.oxc`. The map key is the rule name, example: `typescript/no-unused-vars`       |
 | `fmt.configPath`          | `<string>` \| `null`              | `null`                   | Path to a oxfmt configuration file, when `null` is passed, the server will use `.oxfmtrc.json` and the workspace root                                  |
 | Diagnostic Pull Mode      |                                   |                          |                                                                                                                                                        |
 | `run`                     | `"onSave" \| "onType"`            | `"onType"`               | Should the server lint the files when the user is typing or saving. In Pull Mode, the editor requests the diagnostic.                                  |
@@ -51,6 +52,19 @@ These options can be passed with [initialize](#initialize), [workspace/didChange
 - `"dangerous_fix_or_suggestion"`
 - `"none"`
 - `"all"`
+
+### `RulesCustomization` struct:
+
+```ts
+interface RulesCustomization {
+  // overriding the rule severity, when "off", the rule will not output diagnostics.
+  severity?: "off" | "warn" | "error" | "hint" | "info";
+
+  // allows to disable the autofix for a specific rule, even when the rule has a fix and the workspace `fixKind` allows it.
+  // the user code action `quickfix` will still be available, but the `source.fixAll.oxc` & `source.fixAllDangerous.oxc` will ignore the rule.
+  autofix?: boolean;
+}
+```
 
 ## Diagnostics Modes
 
@@ -77,7 +91,9 @@ The client can pass the workspace options like following:
         "typeAware": false,
         "disableNestedConfig": false,
         "fixKind": "safe_fix",
-        "fmt.configPath": null
+        "rulesCustomization": {},
+        "fmt.configPath": null,
+        }
       }
     }
   ]
@@ -117,6 +133,7 @@ The client can pass the workspace options like following:
         "typeAware": false,
         "disableNestedConfig": false,
         "fixKind": "safe_fix",
+        "rulesCustomization": {},
         "fmt.configPath": null
       }
     }
@@ -230,6 +247,7 @@ The client can return a response like:
     "typeAware": false,
     "disableNestedConfig": false,
     "fixKind": "safe_fix",
+    "rulesCustomization": {},
     "fmt.configPath": null
   }
 ]


### PR DESCRIPTION
> Adds support for an LSP workspace option (`rulesCustomization`) that lets clients customize rule severity and control whether specific rules participate in “fix all” code actions.

related https://github.com/oxc-project/oxc-vscode/issues/22
closes https://github.com/oxc-project/oxc/issues/21538