### PR TITLE
feat(linter): split `no-restricted-jest-methods` rule into jest and vitest

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__cli__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc-vitest.json --report-unused-disable-directives test.js
 working directory: fixtures/cli/disable_vitest_rules
 ----------
 
-  x jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
+  x vitest(no-restricted-vi-methods): Use of `advanceTimersByTime` is not allowed
    ,-[test.js:7:6]
  6 | it('calls the callback after 1 second via advanceTimersByTime', () => {
  7 |   vi.advanceTimersByTime(1000);

--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,5 +1,4 @@
 [
-  "no-restricted-jest-methods",
   "no-restricted-matchers",
   "no-standalone-expect",
   "no-test-prefixes",

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -234,11 +234,6 @@ fn transform_rule_and_plugin_name<'a>(
     rule_name: &'a str,
     plugin_name: &'a str,
 ) -> (&'a str, &'a str) {
-    // Special case: vitest/no-restricted-vi-methods is implemented by jest/no-restricted-jest-methods
-    if plugin_name == "vitest" && rule_name == "no-restricted-vi-methods" {
-        return ("no-restricted-jest-methods", "jest");
-    }
-
     let plugin_name = match plugin_name {
         "vitest" if is_jest_rule_adapted_to_vitest(rule_name) => "jest",
         "unicorn" if rule_name == "no-negated-condition" => "eslint",

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -291,15 +291,7 @@ impl DisableDirectives {
                 //
                 // This enables matching rules across different plugins that share the same
                 // rule name, such as jest<->vitest rules and eslint<->typescript rules.
-                DisabledRule::Single { rule_name: name, .. } => {
-                    if name.contains(rule_name) {
-                        true
-                    } else {
-                        // Special-case mapping: `vitest/no-restricted-vi-methods` is implemented by `jest/no-restricted-jest-methods`.
-                        name == "vitest/no-restricted-vi-methods"
-                            && rule_name == "no-restricted-jest-methods"
-                    }
-                }
+                DisabledRule::Single { rule_name: name, .. } => name.contains(rule_name),
             };
 
             if !rule_matches {

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4486,6 +4486,11 @@ impl RuleRunner for crate::rules::vitest::no_mocks_import::NoMocksImport {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vitest::no_restricted_vi_methods::NoRestrictedViMethods {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner
     for crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith
 {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -717,6 +717,7 @@ pub use crate::rules::vitest::no_importing_vitest_globals::NoImportingVitestGlob
 pub use crate::rules::vitest::no_interpolation_in_snapshots::NoInterpolationInSnapshots as VitestNoInterpolationInSnapshots;
 pub use crate::rules::vitest::no_large_snapshots::NoLargeSnapshots as VitestNoLargeSnapshots;
 pub use crate::rules::vitest::no_mocks_import::NoMocksImport as VitestNoMocksImport;
+pub use crate::rules::vitest::no_restricted_vi_methods::NoRestrictedViMethods as VitestNoRestrictedViMethods;
 pub use crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith as VitestPreferCalledExactlyOnceWith;
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
@@ -1475,6 +1476,7 @@ pub enum RuleEnum {
     VitestNoInterpolationInSnapshots(VitestNoInterpolationInSnapshots),
     VitestNoLargeSnapshots(VitestNoLargeSnapshots),
     VitestNoMocksImport(VitestNoMocksImport),
+    VitestNoRestrictedViMethods(VitestNoRestrictedViMethods),
     VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith),
     VitestPreferCalledOnce(VitestPreferCalledOnce),
     VitestPreferCalledTimes(VitestPreferCalledTimes),
@@ -2318,7 +2320,9 @@ const VITEST_NO_INTERPOLATION_IN_SNAPSHOTS_ID: usize =
     VITEST_NO_IMPORTING_VITEST_GLOBALS_ID + 1usize;
 const VITEST_NO_LARGE_SNAPSHOTS_ID: usize = VITEST_NO_INTERPOLATION_IN_SNAPSHOTS_ID + 1usize;
 const VITEST_NO_MOCKS_IMPORT_ID: usize = VITEST_NO_LARGE_SNAPSHOTS_ID + 1usize;
-const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize = VITEST_NO_MOCKS_IMPORT_ID + 1usize;
+const VITEST_NO_RESTRICTED_VI_METHODS_ID: usize = VITEST_NO_MOCKS_IMPORT_ID + 1usize;
+const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
+    VITEST_NO_RESTRICTED_VI_METHODS_ID + 1usize;
 const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID + 1usize;
 const VITEST_PREFER_CALLED_TIMES_ID: usize = VITEST_PREFER_CALLED_ONCE_ID + 1usize;
 const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
@@ -3189,6 +3193,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VITEST_NO_INTERPOLATION_IN_SNAPSHOTS_ID,
             Self::VitestNoLargeSnapshots(_) => VITEST_NO_LARGE_SNAPSHOTS_ID,
             Self::VitestNoMocksImport(_) => VITEST_NO_MOCKS_IMPORT_ID,
+            Self::VitestNoRestrictedViMethods(_) => VITEST_NO_RESTRICTED_VI_METHODS_ID,
             Self::VitestPreferCalledExactlyOnceWith(_) => VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID,
             Self::VitestPreferCalledOnce(_) => VITEST_PREFER_CALLED_ONCE_ID,
             Self::VitestPreferCalledTimes(_) => VITEST_PREFER_CALLED_TIMES_ID,
@@ -4050,6 +4055,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::NAME,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::NAME,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::NAME,
+            Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::NAME,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::NAME,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
@@ -4953,6 +4959,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::CATEGORY,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::CATEGORY,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::CATEGORY,
+            Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::CATEGORY,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::CATEGORY
             }
@@ -5823,6 +5830,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::FIX,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::FIX,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::FIX,
+            Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::FIX,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::FIX,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
@@ -6889,6 +6897,7 @@ impl RuleEnum {
             }
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::documentation(),
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::documentation(),
+            Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::documentation(),
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::documentation()
             }
@@ -8970,6 +8979,10 @@ impl RuleEnum {
                 .or_else(|| VitestNoLargeSnapshots::schema(generator)),
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::config_schema(generator)
                 .or_else(|| VitestNoMocksImport::schema(generator)),
+            Self::VitestNoRestrictedViMethods(_) => {
+                VitestNoRestrictedViMethods::config_schema(generator)
+                    .or_else(|| VitestNoRestrictedViMethods::schema(generator))
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::config_schema(generator)
                     .or_else(|| VitestPreferCalledExactlyOnceWith::schema(generator))
@@ -9820,6 +9833,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => "vitest",
             Self::VitestNoLargeSnapshots(_) => "vitest",
             Self::VitestNoMocksImport(_) => "vitest",
+            Self::VitestNoRestrictedViMethods(_) => "vitest",
             Self::VitestPreferCalledExactlyOnceWith(_) => "vitest",
             Self::VitestPreferCalledOnce(_) => "vitest",
             Self::VitestPreferCalledTimes(_) => "vitest",
@@ -12134,6 +12148,9 @@ impl RuleEnum {
             Self::VitestNoMocksImport(_) => {
                 Ok(Self::VitestNoMocksImport(VitestNoMocksImport::from_configuration(value)?))
             }
+            Self::VitestNoRestrictedViMethods(_) => Ok(Self::VitestNoRestrictedViMethods(
+                VitestNoRestrictedViMethods::from_configuration(value)?,
+            )),
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 Ok(Self::VitestPreferCalledExactlyOnceWith(
                     VitestPreferCalledExactlyOnceWith::from_configuration(value)?,
@@ -13007,6 +13024,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.to_configuration(),
             Self::VitestNoLargeSnapshots(rule) => rule.to_configuration(),
             Self::VitestNoMocksImport(rule) => rule.to_configuration(),
+            Self::VitestNoRestrictedViMethods(rule) => rule.to_configuration(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.to_configuration(),
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
@@ -13766,6 +13784,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run(node, ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.run(node, ctx),
             Self::VitestNoMocksImport(rule) => rule.run(node, ctx),
+            Self::VitestNoRestrictedViMethods(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
@@ -14523,6 +14542,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run_once(ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.run_once(ctx),
             Self::VitestNoMocksImport(rule) => rule.run_once(ctx),
+            Self::VitestNoRestrictedViMethods(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
@@ -15382,6 +15402,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoMocksImport(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestNoRestrictedViMethods(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16143,6 +16164,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.should_run(ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.should_run(ctx),
             Self::VitestNoMocksImport(rule) => rule.should_run(ctx),
+            Self::VitestNoRestrictedViMethods(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
@@ -17204,6 +17226,7 @@ impl RuleEnum {
             }
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::IS_TSGOLINT_RULE,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::IS_TSGOLINT_RULE,
+            Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::IS_TSGOLINT_RULE,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::IS_TSGOLINT_RULE
             }
@@ -18127,6 +18150,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::VERSION,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::VERSION,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::VERSION,
+            Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::VERSION,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::VERSION
             }
@@ -19069,6 +19093,7 @@ impl RuleEnum {
             }
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::HAS_CONFIG,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::HAS_CONFIG,
+            Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::HAS_CONFIG,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::HAS_CONFIG
             }
@@ -19842,6 +19867,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.types_info(),
             Self::VitestNoLargeSnapshots(rule) => rule.types_info(),
             Self::VitestNoMocksImport(rule) => rule.types_info(),
+            Self::VitestNoRestrictedViMethods(rule) => rule.types_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.types_info(),
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
@@ -20599,6 +20625,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run_info(),
             Self::VitestNoLargeSnapshots(rule) => rule.run_info(),
             Self::VitestNoMocksImport(rule) => rule.run_info(),
+            Self::VitestNoRestrictedViMethods(rule) => rule.run_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_info(),
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
@@ -21476,6 +21503,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestNoInterpolationInSnapshots(VitestNoInterpolationInSnapshots::default()),
         RuleEnum::VitestNoLargeSnapshots(VitestNoLargeSnapshots::default()),
         RuleEnum::VitestNoMocksImport(VitestNoMocksImport::default()),
+        RuleEnum::VitestNoRestrictedViMethods(VitestNoRestrictedViMethods::default()),
         RuleEnum::VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith::default()),
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -745,6 +745,7 @@ pub(crate) mod vitest {
     pub mod no_interpolation_in_snapshots;
     pub mod no_large_snapshots;
     pub mod no_mocks_import;
+    pub mod no_restricted_vi_methods;
     pub mod prefer_called_exactly_once_with;
     pub mod prefer_called_once;
     pub mod prefer_called_times;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -14,6 +14,7 @@ pub mod no_identical_title;
 pub mod no_interpolation_in_snapshots;
 pub mod no_large_snapshots;
 pub mod no_mocks_import;
+pub mod no_restricted_jest_methods;
 pub mod prefer_expect_assertions;
 pub mod prefer_to_contain;
 pub mod prefer_todo;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_jest_methods.rs
@@ -1,0 +1,136 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, is_type_of_jest_fn_call},
+};
+
+fn restricted_jest_method(method_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use of `{method_name}` is not allowed")).with_label(span)
+}
+
+fn restricted_jest_method_with_message(message: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(message.to_string()).with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+Restrict the use of specific `jest` and `vi` methods.
+
+### Why is this bad?
+
+Certain Jest or Vitest methods may be deprecated, discouraged in specific
+contexts, or incompatible with your testing environment. Restricting
+them helps maintain consistent and reliable test practices.
+
+By default, no methods are restricted by this rule.
+You must configure the rule for it to disable anything.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+jest.useFakeTimers();
+it('calls the callback after 1 second via advanceTimersByTime', () => {
+  // ...
+
+  jest.advanceTimersByTime(1000);
+
+  // ...
+});
+
+test('plays video', () => {
+  const spy = jest.spyOn(video, 'play');
+
+  // ...
+});
+```
+";
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoRestrictedJestMethodsConfig {
+    /// A mapping of restricted Jest method names to custom messages - or
+    /// `null`, for a generic message.
+    pub restricted_jest_methods: FxHashMap<String, String>,
+}
+
+impl NoRestrictedJestMethodsConfig {
+    #[expect(clippy::unnecessary_wraps)]
+    pub fn from_configuration(value: &serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let restricted_jest_methods = value
+            .get(0)
+            .and_then(serde_json::Value::as_object)
+            .map(Self::compile_restricted_jest_methods)
+            .unwrap_or_default();
+
+        Ok(NoRestrictedJestMethodsConfig { restricted_jest_methods })
+    }
+    pub fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+        let node = possible_jest_node.node;
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if !is_type_of_jest_fn_call(
+            call_expr,
+            possible_jest_node,
+            ctx,
+            &[
+                JestFnKind::General(JestGeneralFnKind::Jest),
+                JestFnKind::General(JestGeneralFnKind::Vitest),
+            ],
+        ) {
+            return;
+        }
+
+        let Some(mem_expr) = call_expr.callee.as_member_expression() else {
+            return;
+        };
+        let Some(property_name) = mem_expr.static_property_name() else {
+            return;
+        };
+        let Some((span, _)) = mem_expr.static_property_info() else {
+            return;
+        };
+
+        if self.contains(property_name) {
+            self.get_message(property_name).map_or_else(
+                || {
+                    ctx.diagnostic(restricted_jest_method(property_name, span));
+                },
+                |message| {
+                    if message.trim() == "" {
+                        ctx.diagnostic(restricted_jest_method(property_name, span));
+                    } else {
+                        ctx.diagnostic(restricted_jest_method_with_message(&message, span));
+                    }
+                },
+            );
+        }
+    }
+
+    fn contains(&self, key: &str) -> bool {
+        self.restricted_jest_methods.contains_key(key)
+    }
+
+    fn get_message(&self, name: &str) -> Option<String> {
+        self.restricted_jest_methods.get(name).cloned()
+    }
+
+    pub fn compile_restricted_jest_methods(
+        matchers: &serde_json::Map<String, serde_json::Value>,
+    ) -> FxHashMap<String, String> {
+        matchers
+            .iter()
+            .map(|(key, value)| {
+                (String::from(key), String::from(value.as_str().unwrap_or_default()))
+            })
+            .collect()
+    }
+}

--- a/crates/oxc_linter/src/rules/vitest/no_restricted_vi_methods.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_restricted_vi_methods.rs
@@ -9,20 +9,18 @@ use crate::{
 };
 
 #[derive(Debug, Default, Clone)]
-pub struct NoRestrictedJestMethods(
-    Box<SharedNoRestrictedJestMethods::NoRestrictedJestMethodsConfig>,
-);
+pub struct NoRestrictedViMethods(Box<SharedNoRestrictedJestMethods::NoRestrictedJestMethodsConfig>);
 
 declare_oxc_lint!(
-    NoRestrictedJestMethods,
-    jest,
+    NoRestrictedViMethods,
+    vitest,
     style,
     config = SharedNoRestrictedJestMethods::NoRestrictedJestMethodsConfig,
     docs = SharedNoRestrictedJestMethods::DOCUMENTATION,
     version = "0.2.3",
 );
 
-impl Rule for NoRestrictedJestMethods {
+impl Rule for NoRestrictedViMethods {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
         Ok(Self(Box::new(
             SharedNoRestrictedJestMethods::NoRestrictedJestMethodsConfig::from_configuration(
@@ -45,35 +43,33 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("jest", None),
-        ("jest()", None),
-        ("jest.mock()", None),
+        ("vi", None),
+        ("vi()", None),
+        ("vi.mock()", None),
         ("expect(a).rejects;", None),
         ("expect(a);", None),
         (
             "
-                import { jest } from '@jest/globals';
-
-                jest;
-            ",
+			     import { vi } from 'vitest';
+			     vi;
+			    ",
             None,
-        ),
+        ), // { "parserOptions": { "sourceType": "module" } }
     ];
 
     let fail = vec![
-        ("jest.fn()", Some(serde_json::json!([{ "fn": null }]))),
-        ("jest[\"fn\"]()", Some(serde_json::json!([{ "fn": null }]))),
-        ("jest.mock()", Some(serde_json::json!([{ "mock": "Do not use mocks" }]))),
-        ("jest[\"mock\"]()", Some(serde_json::json!([{ "mock": "Do not use mocks" }]))),
+        ("vi.fn()", Some(serde_json::json!([{ "fn": null }]))),
+        ("vi.mock()", Some(serde_json::json!([{ "mock": "Do not use mocks" }]))),
         (
             "
-                import { jest } from '@jest/globals';
-                jest.advanceTimersByTime();
-            ",
+			     import { vi } from 'vitest';
+			     vi.advanceTimersByTime();
+			    ",
             Some(serde_json::json!([{ "advanceTimersByTime": null }])),
-        ),
+        ), // { "parserOptions": { "sourceType": "module" } },
+        (r#"vi["fn"]()"#, Some(serde_json::json!([{ "fn": null }]))),
     ];
 
-    Tester::new(NoRestrictedJestMethods::NAME, NoRestrictedJestMethods::PLUGIN, pass, fail)
+    Tester::new(NoRestrictedViMethods::NAME, NoRestrictedViMethods::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest.fn()
@@ -32,30 +31,4 @@ source: crates/oxc_linter/src/tester.rs
  3 │                 jest.advanceTimersByTime();
    ·                      ───────────────────
  4 │             
-   ╰────
-
-  ⚠ jest(no-restricted-jest-methods): Use of `fn` is not allowed
-   ╭─[no_restricted_jest_methods.tsx:1:4]
- 1 │ vi.fn()
-   ·    ──
-   ╰────
-
-  ⚠ jest(no-restricted-jest-methods): Do not use mocks
-   ╭─[no_restricted_jest_methods.tsx:1:4]
- 1 │ vi.mock()
-   ·    ────
-   ╰────
-
-  ⚠ jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
-   ╭─[no_restricted_jest_methods.tsx:3:12]
- 2 │                  import { vi } from 'vitest';
- 3 │                  vi.advanceTimersByTime();
-   ·                     ───────────────────
- 4 │                 
-   ╰────
-
-  ⚠ jest(no-restricted-jest-methods): Use of `fn` is not allowed
-   ╭─[no_restricted_jest_methods.tsx:1:4]
- 1 │ vi["fn"]()
-   ·    ────
    ╰────

--- a/crates/oxc_linter/src/snapshots/vitest_no_restricted_vi_methods.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_restricted_vi_methods.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ vitest(no-restricted-vi-methods): Use of `fn` is not allowed
+   ╭─[no_restricted_vi_methods.tsx:1:4]
+ 1 │ vi.fn()
+   ·    ──
+   ╰────
+
+  ⚠ vitest(no-restricted-vi-methods): Do not use mocks
+   ╭─[no_restricted_vi_methods.tsx:1:4]
+ 1 │ vi.mock()
+   ·    ────
+   ╰────
+
+  ⚠ vitest(no-restricted-vi-methods): Use of `advanceTimersByTime` is not allowed
+   ╭─[no_restricted_vi_methods.tsx:3:12]
+ 2 │                  import { vi } from 'vitest';
+ 3 │                  vi.advanceTimersByTime();
+   ·                     ───────────────────
+ 4 │                 
+   ╰────
+
+  ⚠ vitest(no-restricted-vi-methods): Use of `fn` is not allowed
+   ╭─[no_restricted_vi_methods.tsx:1:4]
+ 1 │ vi["fn"]()
+   ·    ────
+   ╰────

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,8 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 25] = [
-    "no-restricted-jest-methods",
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 24] = [
     "no-restricted-matchers",
     "no-standalone-expect",
     "no-test-prefixes",


### PR DESCRIPTION
Mostly generated by AI. After some iterations I took over and reviewed it.
related https://github.com/oxc-project/oxc/issues/21664