### PR TITLE
feat(linter): split `no-restricted-matchers` rule into jest and vitest

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,5 +1,4 @@
 [
-  "no-restricted-matchers",
   "no-standalone-expect",
   "no-test-prefixes",
   "no-test-return-statement",

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4486,6 +4486,11 @@ impl RuleRunner for crate::rules::vitest::no_mocks_import::NoMocksImport {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vitest::no_restricted_matchers::NoRestrictedMatchers {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::no_restricted_vi_methods::NoRestrictedViMethods {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -717,6 +717,7 @@ pub use crate::rules::vitest::no_importing_vitest_globals::NoImportingVitestGlob
 pub use crate::rules::vitest::no_interpolation_in_snapshots::NoInterpolationInSnapshots as VitestNoInterpolationInSnapshots;
 pub use crate::rules::vitest::no_large_snapshots::NoLargeSnapshots as VitestNoLargeSnapshots;
 pub use crate::rules::vitest::no_mocks_import::NoMocksImport as VitestNoMocksImport;
+pub use crate::rules::vitest::no_restricted_matchers::NoRestrictedMatchers as VitestNoRestrictedMatchers;
 pub use crate::rules::vitest::no_restricted_vi_methods::NoRestrictedViMethods as VitestNoRestrictedViMethods;
 pub use crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith as VitestPreferCalledExactlyOnceWith;
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
@@ -1476,6 +1477,7 @@ pub enum RuleEnum {
     VitestNoInterpolationInSnapshots(VitestNoInterpolationInSnapshots),
     VitestNoLargeSnapshots(VitestNoLargeSnapshots),
     VitestNoMocksImport(VitestNoMocksImport),
+    VitestNoRestrictedMatchers(VitestNoRestrictedMatchers),
     VitestNoRestrictedViMethods(VitestNoRestrictedViMethods),
     VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith),
     VitestPreferCalledOnce(VitestPreferCalledOnce),
@@ -2320,7 +2322,8 @@ const VITEST_NO_INTERPOLATION_IN_SNAPSHOTS_ID: usize =
     VITEST_NO_IMPORTING_VITEST_GLOBALS_ID + 1usize;
 const VITEST_NO_LARGE_SNAPSHOTS_ID: usize = VITEST_NO_INTERPOLATION_IN_SNAPSHOTS_ID + 1usize;
 const VITEST_NO_MOCKS_IMPORT_ID: usize = VITEST_NO_LARGE_SNAPSHOTS_ID + 1usize;
-const VITEST_NO_RESTRICTED_VI_METHODS_ID: usize = VITEST_NO_MOCKS_IMPORT_ID + 1usize;
+const VITEST_NO_RESTRICTED_MATCHERS_ID: usize = VITEST_NO_MOCKS_IMPORT_ID + 1usize;
+const VITEST_NO_RESTRICTED_VI_METHODS_ID: usize = VITEST_NO_RESTRICTED_MATCHERS_ID + 1usize;
 const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
     VITEST_NO_RESTRICTED_VI_METHODS_ID + 1usize;
 const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID + 1usize;
@@ -3193,6 +3196,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VITEST_NO_INTERPOLATION_IN_SNAPSHOTS_ID,
             Self::VitestNoLargeSnapshots(_) => VITEST_NO_LARGE_SNAPSHOTS_ID,
             Self::VitestNoMocksImport(_) => VITEST_NO_MOCKS_IMPORT_ID,
+            Self::VitestNoRestrictedMatchers(_) => VITEST_NO_RESTRICTED_MATCHERS_ID,
             Self::VitestNoRestrictedViMethods(_) => VITEST_NO_RESTRICTED_VI_METHODS_ID,
             Self::VitestPreferCalledExactlyOnceWith(_) => VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID,
             Self::VitestPreferCalledOnce(_) => VITEST_PREFER_CALLED_ONCE_ID,
@@ -4055,6 +4059,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::NAME,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::NAME,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::NAME,
+            Self::VitestNoRestrictedMatchers(_) => VitestNoRestrictedMatchers::NAME,
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::NAME,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::NAME,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
@@ -4959,6 +4964,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::CATEGORY,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::CATEGORY,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::CATEGORY,
+            Self::VitestNoRestrictedMatchers(_) => VitestNoRestrictedMatchers::CATEGORY,
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::CATEGORY,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::CATEGORY
@@ -5830,6 +5836,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::FIX,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::FIX,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::FIX,
+            Self::VitestNoRestrictedMatchers(_) => VitestNoRestrictedMatchers::FIX,
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::FIX,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::FIX,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
@@ -6897,6 +6904,7 @@ impl RuleEnum {
             }
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::documentation(),
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::documentation(),
+            Self::VitestNoRestrictedMatchers(_) => VitestNoRestrictedMatchers::documentation(),
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::documentation(),
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::documentation()
@@ -8979,6 +8987,10 @@ impl RuleEnum {
                 .or_else(|| VitestNoLargeSnapshots::schema(generator)),
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::config_schema(generator)
                 .or_else(|| VitestNoMocksImport::schema(generator)),
+            Self::VitestNoRestrictedMatchers(_) => {
+                VitestNoRestrictedMatchers::config_schema(generator)
+                    .or_else(|| VitestNoRestrictedMatchers::schema(generator))
+            }
             Self::VitestNoRestrictedViMethods(_) => {
                 VitestNoRestrictedViMethods::config_schema(generator)
                     .or_else(|| VitestNoRestrictedViMethods::schema(generator))
@@ -9833,6 +9845,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => "vitest",
             Self::VitestNoLargeSnapshots(_) => "vitest",
             Self::VitestNoMocksImport(_) => "vitest",
+            Self::VitestNoRestrictedMatchers(_) => "vitest",
             Self::VitestNoRestrictedViMethods(_) => "vitest",
             Self::VitestPreferCalledExactlyOnceWith(_) => "vitest",
             Self::VitestPreferCalledOnce(_) => "vitest",
@@ -12148,6 +12161,9 @@ impl RuleEnum {
             Self::VitestNoMocksImport(_) => {
                 Ok(Self::VitestNoMocksImport(VitestNoMocksImport::from_configuration(value)?))
             }
+            Self::VitestNoRestrictedMatchers(_) => Ok(Self::VitestNoRestrictedMatchers(
+                VitestNoRestrictedMatchers::from_configuration(value)?,
+            )),
             Self::VitestNoRestrictedViMethods(_) => Ok(Self::VitestNoRestrictedViMethods(
                 VitestNoRestrictedViMethods::from_configuration(value)?,
             )),
@@ -13024,6 +13040,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.to_configuration(),
             Self::VitestNoLargeSnapshots(rule) => rule.to_configuration(),
             Self::VitestNoMocksImport(rule) => rule.to_configuration(),
+            Self::VitestNoRestrictedMatchers(rule) => rule.to_configuration(),
             Self::VitestNoRestrictedViMethods(rule) => rule.to_configuration(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.to_configuration(),
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
@@ -13784,6 +13801,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run(node, ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.run(node, ctx),
             Self::VitestNoMocksImport(rule) => rule.run(node, ctx),
+            Self::VitestNoRestrictedMatchers(rule) => rule.run(node, ctx),
             Self::VitestNoRestrictedViMethods(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
@@ -14542,6 +14560,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run_once(ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.run_once(ctx),
             Self::VitestNoMocksImport(rule) => rule.run_once(ctx),
+            Self::VitestNoRestrictedMatchers(rule) => rule.run_once(ctx),
             Self::VitestNoRestrictedViMethods(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
@@ -15402,6 +15421,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoMocksImport(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestNoRestrictedMatchers(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoRestrictedViMethods(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16164,6 +16184,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.should_run(ctx),
             Self::VitestNoLargeSnapshots(rule) => rule.should_run(ctx),
             Self::VitestNoMocksImport(rule) => rule.should_run(ctx),
+            Self::VitestNoRestrictedMatchers(rule) => rule.should_run(ctx),
             Self::VitestNoRestrictedViMethods(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
@@ -17226,6 +17247,7 @@ impl RuleEnum {
             }
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::IS_TSGOLINT_RULE,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::IS_TSGOLINT_RULE,
+            Self::VitestNoRestrictedMatchers(_) => VitestNoRestrictedMatchers::IS_TSGOLINT_RULE,
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::IS_TSGOLINT_RULE,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::IS_TSGOLINT_RULE
@@ -18150,6 +18172,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(_) => VitestNoInterpolationInSnapshots::VERSION,
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::VERSION,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::VERSION,
+            Self::VitestNoRestrictedMatchers(_) => VitestNoRestrictedMatchers::VERSION,
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::VERSION,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::VERSION
@@ -19093,6 +19116,7 @@ impl RuleEnum {
             }
             Self::VitestNoLargeSnapshots(_) => VitestNoLargeSnapshots::HAS_CONFIG,
             Self::VitestNoMocksImport(_) => VitestNoMocksImport::HAS_CONFIG,
+            Self::VitestNoRestrictedMatchers(_) => VitestNoRestrictedMatchers::HAS_CONFIG,
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::HAS_CONFIG,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::HAS_CONFIG
@@ -19867,6 +19891,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.types_info(),
             Self::VitestNoLargeSnapshots(rule) => rule.types_info(),
             Self::VitestNoMocksImport(rule) => rule.types_info(),
+            Self::VitestNoRestrictedMatchers(rule) => rule.types_info(),
             Self::VitestNoRestrictedViMethods(rule) => rule.types_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.types_info(),
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
@@ -20625,6 +20650,7 @@ impl RuleEnum {
             Self::VitestNoInterpolationInSnapshots(rule) => rule.run_info(),
             Self::VitestNoLargeSnapshots(rule) => rule.run_info(),
             Self::VitestNoMocksImport(rule) => rule.run_info(),
+            Self::VitestNoRestrictedMatchers(rule) => rule.run_info(),
             Self::VitestNoRestrictedViMethods(rule) => rule.run_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_info(),
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
@@ -21503,6 +21529,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestNoInterpolationInSnapshots(VitestNoInterpolationInSnapshots::default()),
         RuleEnum::VitestNoLargeSnapshots(VitestNoLargeSnapshots::default()),
         RuleEnum::VitestNoMocksImport(VitestNoMocksImport::default()),
+        RuleEnum::VitestNoRestrictedMatchers(VitestNoRestrictedMatchers::default()),
         RuleEnum::VitestNoRestrictedViMethods(VitestNoRestrictedViMethods::default()),
         RuleEnum::VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith::default()),
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -745,6 +745,7 @@ pub(crate) mod vitest {
     pub mod no_interpolation_in_snapshots;
     pub mod no_large_snapshots;
     pub mod no_mocks_import;
+    pub mod no_restricted_matchers;
     pub mod no_restricted_vi_methods;
     pub mod prefer_called_exactly_once_with;
     pub mod prefer_called_once;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -15,6 +15,7 @@ pub mod no_interpolation_in_snapshots;
 pub mod no_large_snapshots;
 pub mod no_mocks_import;
 pub mod no_restricted_jest_methods;
+pub mod no_restricted_matchers;
 pub mod prefer_expect_assertions;
 pub mod prefer_to_contain;
 pub mod prefer_todo;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_matchers.rs
@@ -1,0 +1,171 @@
+use std::path::Path;
+
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    utils::{
+        JestFnKind, KnownMemberExpressionProperty, PossibleJestNode, is_type_of_jest_fn_call,
+        parse_expect_jest_fn_call,
+    },
+};
+
+fn restricted_chain(chain_call: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use of `{chain_call}` is disallowed")).with_label(span)
+}
+
+fn restricted_chain_with_message(chain_call: &str, message: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Use of `{chain_call}` is disallowed"))
+        .with_help(message.to_string())
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r#"### What it does
+
+Ban specific matchers & modifiers from being used, and can suggest alternatives.
+
+### Why is this bad?
+
+Some matchers or modifiers might be discouraged in your codebase for various reasons:
+they might be deprecated, cause confusion, have performance implications, or there
+might be better alternatives available. This rule allows you to enforce consistent
+testing patterns by restricting certain Jest matchers and providing guidance on
+preferred alternatives.
+
+### Examples
+
+Bans are expressed in the form of a map, with the value being either a string message to be shown,
+or null if only the default rule message should be used. Bans are checked against the start of
+the expect chain - this means that to ban a specific matcher entirely you must specify all
+six permutations, but allows you to ban modifiers as well. By default, this map is empty, meaning
+no matchers or modifiers are banned.
+
+Example configuration:
+```json
+{
+  "jest/no-restricted-matchers": [
+    "error",
+    {
+      "toBeFalsy": null,
+      "resolves": "Use `expect(await promise)` instead.",
+      "toHaveBeenCalledWith": null,
+      "not.toHaveBeenCalledWith": null,
+      "resolves.toHaveBeenCalledWith": null,
+      "rejects.toHaveBeenCalledWith": null,
+      "resolves.not.toHaveBeenCalledWith": null,
+      "rejects.not.toHaveBeenCalledWith": null
+    }
+  ]
+}
+```
+
+Examples of **incorrect** code for this rule with the above configuration:
+```javascript
+it('is false', () => {
+  // if this has a modifier (i.e. `not.toBeFalsy`), it would be considered fine
+  expect(a).toBeFalsy();
+});
+
+it('resolves', async () => {
+  // all uses of this modifier are disallowed, regardless of matcher
+  await expect(myPromise()).resolves.toBe(true);
+});
+
+describe('when an error happens', () => {
+  it('does not upload the file', async () => {
+    // all uses of this matcher are disallowed
+    expect(uploadFileMock).not.toHaveBeenCalledWith('file.name');
+  });
+});
+```
+"#;
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NoRestrictedMatchersConfig {
+    /// A map of restricted matchers/modifiers to custom messages.
+    /// The key is the matcher/modifier name (e.g., "toBeFalsy", "resolves", "not.toHaveBeenCalledWith").
+    /// The value is an optional custom message to display when the matcher/modifier is used.
+    pub restricted_matchers: FxHashMap<String, String>,
+}
+
+const MODIFIER_NAME: [&str; 3] = ["not", "rejects", "resolves"];
+
+impl NoRestrictedMatchersConfig {
+    #[expect(clippy::unnecessary_wraps)]
+    pub fn from_configuration(value: &serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let restricted_matchers = value
+            .get(0)
+            .and_then(serde_json::Value::as_object)
+            .map(Self::compile_restricted_matchers)
+            .unwrap_or_default();
+
+        Ok(NoRestrictedMatchersConfig { restricted_matchers })
+    }
+
+    pub fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+        let node = possible_jest_node.node;
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if !is_type_of_jest_fn_call(call_expr, possible_jest_node, ctx, &[JestFnKind::Expect]) {
+            return;
+        }
+
+        let Some(jest_fn_call) = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
+            return;
+        };
+
+        let members = &jest_fn_call.members;
+
+        if members.is_empty() {
+            return;
+        }
+
+        let chain_call = members
+            .iter()
+            .filter_map(KnownMemberExpressionProperty::name)
+            .collect::<Vec<_>>()
+            .join(".");
+
+        let span = Span::new(members.first().unwrap().span.start, members.last().unwrap().span.end);
+
+        for (restriction, message) in &self.restricted_matchers {
+            if Self::check_restriction(chain_call.as_str(), restriction.as_str()) {
+                if message.is_empty() {
+                    ctx.diagnostic(restricted_chain(&chain_call, span));
+                } else {
+                    ctx.diagnostic(restricted_chain_with_message(&chain_call, message, span));
+                }
+            }
+        }
+    }
+
+    fn check_restriction(chain_call: &str, restriction: &str) -> bool {
+        if MODIFIER_NAME.contains(&restriction)
+            || Path::new(restriction).extension().is_some_and(|ext| ext.eq_ignore_ascii_case("not"))
+        {
+            chain_call.starts_with(restriction)
+        } else {
+            chain_call == restriction
+        }
+    }
+
+    pub fn compile_restricted_matchers(
+        matchers: &serde_json::Map<String, serde_json::Value>,
+    ) -> FxHashMap<String, String> {
+        matchers
+            .iter()
+            .map(|(key, value)| {
+                (String::from(key), String::from(value.as_str().unwrap_or_default()))
+            })
+            .collect()
+    }
+}

--- a/crates/oxc_linter/src/rules/vitest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_restricted_matchers.rs
@@ -11,7 +11,7 @@ pub struct NoRestrictedMatchers(Box<SharedNoRestrictedMatchers::NoRestrictedMatc
 
 declare_oxc_lint!(
     NoRestrictedMatchers,
-    jest,
+    vitest,
     style,
     config = SharedNoRestrictedMatchers::NoRestrictedMatchersConfig,
     docs = SharedNoRestrictedMatchers::DOCUMENTATION,
@@ -38,8 +38,6 @@ impl Rule for NoRestrictedMatchers {
 fn test() {
     use crate::tester::Tester;
 
-    // Note: Both Jest and Vitest share the same unit tests
-
     let pass = vec![
         ("expect(a).toHaveBeenCalled()", None),
         ("expect(a).not.toHaveBeenCalled()", None),
@@ -61,24 +59,10 @@ fn test() {
         ("expect(a)[\"toBe\"](b)", Some(serde_json::json!([{ "not.toBe": null }]))),
         ("expect(a).resolves.not.toBe(b)", Some(serde_json::json!([{ "not": null }]))),
         ("expect(a).resolves.not.toBe(b)", Some(serde_json::json!([{ "not.toBe": null }]))),
-        (
-            "expect(uploadFileMock).resolves.toHaveBeenCalledWith('file.name')",
-            Some(
-                serde_json::json!([{ "not.toHaveBeenCalledWith": "Use not.toHaveBeenCalled instead" }]),
-            ),
-        ),
-        (
-            "expect(uploadFileMock).resolves.not.toHaveBeenCalledWith('file.name')",
-            Some(
-                serde_json::json!([{ "not.toHaveBeenCalledWith": "Use not.toHaveBeenCalled instead" }]),
-            ),
-        ),
+        ("import { expect } from 'vitest'; expect(a).toHaveBeenCalled()", None),
     ];
 
     let fail = vec![
-        ("expect(a).toBe(b)", Some(serde_json::json!([{ "toBe": null }]))),
-        ("expect(a)[\"toBe\"](b)", Some(serde_json::json!([{ "toBe": null }]))),
-        ("expect(a).not[x]()", Some(serde_json::json!([{ "not": null }]))),
         ("expect(a).not.toBe(b)", Some(serde_json::json!([{ "not": null }]))),
         ("expect(a).resolves.toBe(b)", Some(serde_json::json!([{ "resolves": null }]))),
         ("expect(a).resolves.not.toBe(b)", Some(serde_json::json!([{ "resolves": null }]))),
@@ -110,9 +94,12 @@ fn test() {
                 { "not.toHaveBeenCalledWith": "Use not.toHaveBeenCalled instead" },
             ])),
         ),
+        (
+            "import { expect } from 'vitest'; expect(a).toBe(b)",
+            Some(serde_json::json!([{ "toBe": null }])),
+        ),
     ];
 
     Tester::new(NoRestrictedMatchers::NAME, NoRestrictedMatchers::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_no_restricted_matchers.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_restricted_matchers.snap
@@ -1,0 +1,73 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ vitest(no-restricted-matchers): Use of `not.toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:11]
+ 1 │ expect(a).not.toBe(b)
+   ·           ────────
+   ╰────
+
+  ⚠ vitest(no-restricted-matchers): Use of `resolves.toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:11]
+ 1 │ expect(a).resolves.toBe(b)
+   ·           ─────────────
+   ╰────
+
+  ⚠ vitest(no-restricted-matchers): Use of `resolves.not.toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:11]
+ 1 │ expect(a).resolves.not.toBe(b)
+   ·           ─────────────────
+   ╰────
+
+  ⚠ vitest(no-restricted-matchers): Use of `resolves.not.toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:11]
+ 1 │ expect(a).resolves.not.toBe(b)
+   ·           ─────────────────
+   ╰────
+
+  ⚠ vitest(no-restricted-matchers): Use of `not.toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:11]
+ 1 │ expect(a).not.toBe(b)
+   ·           ────────
+   ╰────
+
+  ⚠ vitest(no-restricted-matchers): Use of `resolves.not.toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:11]
+ 1 │ expect(a).resolves.not.toBe(b)
+   ·           ─────────────────
+   ╰────
+
+  ⚠ vitest(no-restricted-matchers): Use of `toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:11]
+ 1 │ expect(a).toBe(b)
+   ·           ────
+   ╰────
+  help: Prefer `toStrictEqual` instead
+
+  ⚠ vitest(no-restricted-matchers): Use of `resolves.toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:3:54]
+ 2 │                 test('some test', async () => {
+ 3 │                     await expect(Promise.resolve(1)).resolves.toBe(1);
+   ·                                                      ─────────────
+ 4 │                 });
+   ╰────
+  help: Use `expect(await promise)` instead.
+
+  ⚠ vitest(no-restricted-matchers): Use of `rejects.toBeFalsy` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:29]
+ 1 │ expect(Promise.resolve({})).rejects.toBeFalsy()
+   ·                             ─────────────────
+   ╰────
+
+  ⚠ vitest(no-restricted-matchers): Use of `not.toHaveBeenCalledWith` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:24]
+ 1 │ expect(uploadFileMock).not.toHaveBeenCalledWith('file.name')
+   ·                        ────────────────────────
+   ╰────
+  help: Use not.toHaveBeenCalled instead
+
+  ⚠ vitest(no-restricted-matchers): Use of `toBe` is disallowed
+   ╭─[no_restricted_matchers.tsx:1:44]
+ 1 │ import { expect } from 'vitest'; expect(a).toBe(b)
+   ·                                            ────
+   ╰────

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,8 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 24] = [
-    "no-restricted-matchers",
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 23] = [
     "no-standalone-expect",
     "no-test-prefixes",
     "no-test-return-statement",


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/21664

Mostly AI, reviewed by myself.

Regenerated the test codes for `vitest`. They are matching. `vitest` has only two more test 