### PR TITLE
refactor(allocator): `Arena::new_chunk` return start pointer

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -353,12 +353,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 None => min_new_chunk_size,
             };
 
-            let new_footer_ptr = loop {
+            let (new_start_ptr, new_footer_ptr) = loop {
                 // Try to allocate a chunk of `size` bytes (plus footer and rounding).
                 // SAFETY: `current_footer_ptr` points to a valid `ChunkFooter` for a chunk in this `Arena`,
                 // or it's `None`.
-                if let Some(new_footer_ptr) = Self::new_chunk(size, layout, current_footer_ptr) {
-                    break new_footer_ptr;
+                if let Some(new_chunk) = Self::new_chunk(size, layout, current_footer_ptr) {
+                    break new_chunk;
                 }
 
                 // Failed. Halve size and try again.
@@ -370,7 +370,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 }
             };
 
-            debug_assert!(is_pointer_aligned_to(new_footer_ptr.as_ref().start_ptr, layout.align()));
+            debug_assert!(is_pointer_aligned_to(new_start_ptr, layout.align()));
 
             // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
             // can read its final cursor position later. Skip this if there was no current chunk.
@@ -381,7 +381,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // Set the new chunk as our new current chunk, and sync `start_ptr` and `cursor_ptr` accordingly.
             // Initial cursor sits at the footer (end of the allocatable region).
             // The footer is aligned on `CHUNK_ALIGN >= MIN_ALIGN`, so no rounding is needed.
-            self.start_ptr.set(new_footer_ptr.as_ref().start_ptr);
+            self.start_ptr.set(new_start_ptr);
             self.cursor_ptr.set(new_footer_ptr.cast::<u8>());
             self.current_chunk_footer_ptr.set(Some(new_footer_ptr));
 

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -270,11 +270,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // `Arena::with_capacity` allocating 16 KiB even when requested `capacity` is much smaller.
         //
         // SAFETY: We pass `None` as `previous_chunk_footer_ptr` (because we're creating the first chunk).
-        let chunk_footer_ptr = unsafe { Self::new_chunk(capacity, layout, None) };
-        let chunk_footer_ptr = chunk_footer_ptr.ok_or(AllocErr)?;
+        let (start_ptr, chunk_footer_ptr) =
+            unsafe { Self::new_chunk(capacity, layout, None) }.ok_or(AllocErr)?;
 
-        // SAFETY: `chunk_footer_ptr` points to a valid `ChunkFooter`
-        let start_ptr = unsafe { chunk_footer_ptr.as_ref().start_ptr };
         // Initial cursor sits at the footer, which is the end of the allocatable region.
         // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
         let cursor_ptr = chunk_footer_ptr.cast::<u8>();
@@ -316,7 +314,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         }
     }
 
-    /// Allocate a new chunk and return its initialized footer.
+    /// Allocate a new chunk and return pointers to its start and its initialized footer.
     ///
     /// The actual chunk size is derived from `new_size_without_footer` and `requested_layout`,
     /// rounded up to play nicely with the global allocator
@@ -336,7 +334,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         new_size_without_footer: usize,
         requested_layout: Layout,
         previous_chunk_footer_ptr: Option<NonNull<ChunkFooter>>,
-    ) -> Option<NonNull<ChunkFooter>> {
+    ) -> Option<(
+        // Pointer to start of allocatable region of the new chunk
+        NonNull<u8>,
+        // Pointer to the new chunk's footer
+        NonNull<ChunkFooter>,
+    )> {
         // Chunks must be aligned to at least `CHUNK_ALIGN` and `MIN_ALIGN`.
         // `MIN_ALIGN` is always `<= CHUNK_ALIGN`, so aligning to `CHUNK_ALIGN` satisfies both.
         let align = max(requested_layout.align(), CHUNK_ALIGN);
@@ -435,7 +438,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             });
         }
 
-        Some(footer_ptr)
+        Some((start_ptr, footer_ptr))
     }
 }
 


### PR DESCRIPTION
Refactor to `Arena`.

`Arena::new_chunk` return the chunk's start pointer directly, rather than the caller having to obtain it from the `ChunkFooter`.

This is a step towards separating the 2 pointers which live in `Arena` and `ChunkFooter`, continued in #21865.