### PR TITLE
refactor(allocator): `ChunkFooter` store pointer to backing allocation

### DIFF
--- a/crates/oxc_allocator/src/arena/chunks.rs
+++ b/crates/oxc_allocator/src/arena/chunks.rs
@@ -283,7 +283,6 @@ impl<const MIN_ALIGN: usize> Iterator for ChunkRawIter<'_, MIN_ALIGN> {
             self.current_chunk_cursor_ptr.take().unwrap_or_else(|| footer.cursor_ptr.get());
         let end_ptr = footer_ptr.cast::<u8>();
 
-        debug_assert!(footer.start_ptr <= cursor_ptr);
         debug_assert!(cursor_ptr <= end_ptr);
 
         // SAFETY: `cursor_ptr` is always before or equal to `end_ptr`, and both are within the same allocation

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -431,7 +431,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // and `footer_ptr` is aligned for `ChunkFooter`
         unsafe {
             footer_ptr.write(ChunkFooter {
-                start_ptr,
+                backing_alloc_ptr: start_ptr,
                 layout,
                 previous_chunk_footer_ptr: Cell::new(previous_chunk_footer_ptr),
                 cursor_ptr: Cell::new(cursor_ptr),

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -98,15 +98,15 @@ unsafe fn dealloc_chunk_list(footer_ptr: Option<NonNull<ChunkFooter>>) {
     while let Some(footer_ptr) = next_footer_ptr {
         // Create `&ChunkFooter` reference to within a block, to ensure the reference is not live
         // when we deallocate the chunk's memory (which includes the `ChunkFooter`)
-        let (start_ptr, layout) = {
+        let (backing_alloc_ptr, layout) = {
             // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
             let footer = unsafe { footer_ptr.as_ref() };
             next_footer_ptr = footer.previous_chunk_footer_ptr.get();
-            (footer.start_ptr, footer.layout)
+            (footer.backing_alloc_ptr, footer.layout)
         };
 
         // SAFETY: Each `ChunkFooter`'s `start_ptr` and `layout` describe its backing allocation,
         // which was allocated from the global allocator
-        unsafe { alloc::dealloc(start_ptr.as_ptr(), layout) };
+        unsafe { alloc::dealloc(backing_alloc_ptr.as_ptr(), layout) };
     }
 }

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -48,7 +48,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
         let cursor_ptr = chunk_footer_ptr.cast::<u8>();
         let chunk_footer = ChunkFooter {
-            start_ptr,
+            backing_alloc_ptr: start_ptr,
             layout,
             previous_chunk_footer_ptr: Cell::new(None),
             cursor_ptr: Cell::new(cursor_ptr),

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -268,11 +268,10 @@ unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 #[repr(C, align(16))]
 #[derive(Debug)]
 struct ChunkFooter {
-    /// Pointer to the start of this chunk's memory.
+    /// Pointer to the start of the allocation backing this chunk.
     ///
-    /// This field is only used when deallocating chunks.
-    /// Allocation methods use `Arena::start_ptr` instead, which is the authoritative pointer for current chunk.
-    start_ptr: NonNull<u8>,
+    /// This pointer is passed to `alloc::dealloc` when deallocating the chunk.
+    backing_alloc_ptr: NonNull<u8>,
 
     /// The layout of this chunk's backing allocation.
     layout: Layout,


### PR DESCRIPTION
Refactor to `Arena`.

`ChunkFooter` contained `start_ptr`, pointing to the start of the chunk. This pointer is the same one as `start_ptr` in `Arena`, but they serve different purposes. The one `Arena` is the boundary beyond which allocations cannot be made in chunk, the one in `ChunkFooter` is used for deallocating the chunk's memory.

Rename the field in `ChunkFooter` to `backing_alloc_ptr`, to reflect its purpose.

This is a step towards allowing the allocatable region of chunks to be cut from within a larger allocation, in order to support uncommitted memory backing `Arena`'s chunks.