### PR TITLE
docs(ast_tools): correct doc comment in raw transfer generator

### DIFF
--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -1488,7 +1488,7 @@ struct Constants {
     deserialized_flag_offset: u32,
     /// Discriminant value for `CommentKind::Line`
     comment_line_kind: u8,
-    /// Size of `RawTransferData` in bytes
+    /// Size of `RawTransferMetadata` in bytes
     raw_metadata_size: u32,
 }
 


### PR DESCRIPTION
Just correct a typos in a doc comment in raw transfer codegen.