### PR TITLE
refactor(allocator): fixed size allocators store backing allocation pointer in `ChunkFooter`

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -1,4 +1,5 @@
 use std::{
+    alloc::Layout,
     mem::ManuallyDrop,
     ptr::{self, NonNull},
 };
@@ -18,6 +19,12 @@ use oxc_semantic::SemanticBuilder;
 use crate::generated::raw_transfer_constants::{BLOCK_ALIGN as BUFFER_ALIGN, BUFFER_SIZE};
 
 const ARENA_ALIGN: usize = Allocator::RAW_MIN_ALIGN;
+
+/// Layout describing the JS-owned buffer (`BUFFER_SIZE` bytes, aligned on `BUFFER_ALIGN`).
+const BUFFER_LAYOUT: Layout = match Layout::from_size_align(BUFFER_SIZE, BUFFER_ALIGN) {
+    Ok(layout) => layout,
+    Err(_) => unreachable!(),
+};
 
 /// Sentinel value for program offset to indicate parsing failed.
 ///
@@ -138,11 +145,19 @@ unsafe fn parse_raw_impl(
     };
 
     // Create `Allocator`.
+    //
     // Wrap in `ManuallyDrop` so the allocation doesn't get freed at end of function, or if panic.
+    // The buffer is owned by JS, so Rust must not free it - hence `ManuallyDrop`.
+    // The `backing_alloc_ptr` and `layout` we pass to `from_raw_parts` aren't used (the `Allocator` is never dropped),
+    // but the safety contract requires the chunk region to lie within them, so we describe the buffer itself.
+    //
     // SAFETY: `buffer_ptr` and `RAW_METADATA_OFFSET` outline a section of the memory in `buffer`.
     // `buffer_ptr` and `RAW_METADATA_OFFSET` are multiples of `ARENA_ALIGN`.
     // `RAW_METADATA_OFFSET` is `>= Allocator::RAW_MIN_SIZE`.
-    let allocator = unsafe { Allocator::from_raw_parts(buffer_ptr, RAW_METADATA_OFFSET) };
+    // The chunk region lies entirely within the buffer.
+    let allocator = unsafe {
+        Allocator::from_raw_parts(buffer_ptr, RAW_METADATA_OFFSET, buffer_ptr, BUFFER_LAYOUT)
+    };
     let allocator = ManuallyDrop::new(allocator);
 
     // Set cursor to before start of source text. AST will be written into the buffer before the source text.

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -9,10 +9,17 @@ use super::{
 };
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
-    /// Construct a static-sized [`Arena`] from an existing memory allocation.
+    /// Construct a static-sized [`Arena`] from a region within an existing memory allocation.
     ///
-    /// The [`Arena`] which is returned takes ownership of the memory allocation,
-    /// and the allocation will be freed if the `Arena` is dropped.
+    /// `start_ptr` and `size` describe the region the `Arena` will use as its single chunk.
+    ///
+    /// `backing_alloc_ptr` and `layout` describe the underlying allocation that owns this region.
+    /// They are stored in the `ChunkFooter` and used by the `Arena`'s [`Drop`] implementation to free the allocation.
+    /// The chunk region (`start_ptr..start_ptr + size`) must lie entirely within the allocation described by
+    /// `backing_alloc_ptr` and `layout`.
+    ///
+    /// The [`Arena`] which is returned takes ownership of the backing allocation, and it will be freed
+    /// via the global allocator (using `backing_alloc_ptr` and `layout`) when the `Arena` is dropped.
     /// If caller wishes to prevent that happening, they must wrap the `Arena` in `ManuallyDrop`.
     ///
     /// The [`Arena`] returned by this function cannot grow.
@@ -22,40 +29,50 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// * `start_ptr` must be aligned on [`CHUNK_ALIGN`].
     /// * `size` must be a multiple of [`CHUNK_ALIGN`].
     /// * `size` must be at least [`CHUNK_FOOTER_SIZE`].
-    /// * The memory region starting at `start_ptr` and encompassing `size` bytes must be within a single allocation.
-    /// * The memory region starting at `start_ptr` and encompassing `size` bytes must have been allocated
-    ///   from system allocator with alignment of [`CHUNK_ALIGN`] (or caller must wrap the `Arena` in `ManuallyDrop`
+    /// * The memory region starting at `start_ptr` and encompassing `size` bytes must be entirely within
+    ///   the allocation described by `backing_alloc_ptr` and `layout`
+    ///   (i.e. `start_ptr >= backing_alloc_ptr` and `start_ptr + size <= backing_alloc_ptr + layout.size()`).
+    /// * The allocation described by `backing_alloc_ptr` and `layout` must have been allocated from
+    ///   the global allocator with that same `layout` (or caller must wrap the `Arena` in `ManuallyDrop`
     ///   and ensure the backing memory is freed correctly themselves).
-    /// * `start_ptr` must have permission for writes.
-    pub unsafe fn from_raw_parts(start_ptr: NonNull<u8>, size: usize) -> Self {
+    /// * `start_ptr` and `backing_alloc_ptr` must have permission for writes.
+    pub unsafe fn from_raw_parts(
+        start_ptr: NonNull<u8>,
+        size: usize,
+        backing_alloc_ptr: NonNull<u8>,
+        layout: Layout,
+    ) -> Self {
         // Debug assert that `start_ptr` and `size` fulfill size and alignment requirements
         debug_assert!(is_pointer_aligned_to(start_ptr, CHUNK_ALIGN));
         debug_assert!(size.is_multiple_of(CHUNK_ALIGN));
         debug_assert!(size >= CHUNK_FOOTER_SIZE);
+        debug_assert!(start_ptr.addr().get().checked_add(size).is_some());
+
+        // Debug assert that the chunk region lies within the backing allocation
+        debug_assert!(start_ptr >= backing_alloc_ptr);
+        debug_assert!(backing_alloc_ptr.addr().get().checked_add(layout.size()).is_some());
+        debug_assert!(
+            start_ptr.addr().get() + size <= backing_alloc_ptr.addr().get() + layout.size()
+        );
 
         let size_without_footer = size - CHUNK_FOOTER_SIZE;
 
-        // Construct `ChunkFooter` and write into end of allocation.
+        // Construct `ChunkFooter` and write into end of chunk region.
         // SAFETY: Caller guarantees:
-        // * `start_ptr` is the start of an allocation of `size` bytes.
+        // * `start_ptr` is the start of a region of `size` bytes within the backing allocation.
         // * `size` is `>= CHUNK_FOOTER_SIZE` - so `size - CHUNK_FOOTER_SIZE` cannot wrap around.
         let chunk_footer_ptr = unsafe { start_ptr.add(size_without_footer) }.cast::<ChunkFooter>();
-        // SAFETY: Caller guarantees `size` is a multiple of `CHUNK_ALIGN`.
-        // Caller guarantees region from `start_ptr` to `start_ptr + size` forms a single allocation,
-        // so it must be a valid layout.
-        let layout = unsafe { Layout::from_size_align_unchecked(size, CHUNK_ALIGN) };
         // Initial cursor sits at the footer, which is the end of the allocatable region.
         // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
         let cursor_ptr = chunk_footer_ptr.cast::<u8>();
         let chunk_footer = ChunkFooter {
-            backing_alloc_ptr: start_ptr,
+            backing_alloc_ptr,
             layout,
             previous_chunk_footer_ptr: Cell::new(None),
             cursor_ptr: Cell::new(cursor_ptr),
         };
-
         // SAFETY: If caller has upheld safety requirements, `chunk_footer_ptr` is `CHUNK_FOOTER_SIZE` bytes
-        // from the end of the allocation, and aligned on `CHUNK_ALIGN`.
+        // from the end of the chunk region, and aligned on `CHUNK_ALIGN`.
         // Therefore `chunk_footer_ptr` is valid for writing a `ChunkFooter`.
         unsafe { chunk_footer_ptr.write(chunk_footer) };
 

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -267,7 +267,7 @@ unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 /// An empty `Arena`, which does not own any memory, has `Arena::current_chunk_footer_ptr` set to `None`.
 #[repr(C, align(16))]
 #[derive(Debug)]
-struct ChunkFooter {
+pub(crate) struct ChunkFooter {
     /// Pointer to the start of the allocation backing this chunk.
     ///
     /// This pointer is passed to `alloc::dealloc` when deallocating the chunk.
@@ -286,6 +286,18 @@ struct ChunkFooter {
     /// Allocation methods use `Arena::cursor_ptr` instead, which is the authoritative pointer for current chunk.
     /// This field is only used in `ChunkIter` and `ChunkRawIter` iterators, and `used_bytes` method.
     cursor_ptr: Cell<NonNull<u8>>,
+}
+
+#[cfg(feature = "fixed_size")]
+impl ChunkFooter {
+    /// Get the backing allocation pointer and layout for this chunk.
+    ///
+    /// Together these identify the underlying allocation owned by the chunk.
+    /// Used by callers which manage their own deallocation (e.g. `FixedSizeAllocator`).
+    #[inline]
+    pub(crate) fn backing_alloc_info(&self) -> (NonNull<u8>, Layout) {
+        (self.backing_alloc_ptr, self.layout)
+    }
 }
 
 /// We only support alignments of up to 16 bytes for `iter_allocated_chunks`.

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -6,7 +6,7 @@
 //! * [`Allocator::data_end_ptr`]
 //! * [`Allocator::end_ptr`]
 
-use std::ptr::NonNull;
+use std::{alloc::Layout, ptr::NonNull};
 
 use crate::{
     Allocator,
@@ -20,30 +20,44 @@ impl Allocator {
     /// Minimum alignment for memory chunk passed to [`Allocator::from_raw_parts`].
     pub const RAW_MIN_ALIGN: usize = CHUNK_ALIGN;
 
-    /// Construct a static-sized [`Allocator`] from an existing memory allocation.
+    /// Construct a static-sized [`Allocator`] from a region within an existing memory allocation.
     ///
-    /// The [`Allocator`] which is returned takes ownership of the memory allocation,
-    /// and the allocation will be freed if the `Allocator` is dropped.
+    /// `start_ptr` and `size` describe the region the `Allocator` will use as its single chunk.
+    ///
+    /// `backing_alloc_ptr` and `layout` describe the underlying allocation that owns this region.
+    /// They are stored in the `ChunkFooter` and used by the `Allocator`'s [`Drop`] implementation to free the allocation.
+    /// The chunk region (`start_ptr..start_ptr + size`) must lie entirely within the allocation described by
+    /// `backing_alloc_ptr` and `layout`.
+    ///
+    /// The [`Allocator`] which is returned takes ownership of the backing allocation, and it will be freed
+    /// via the global allocator (using `backing_alloc_ptr` and `layout`) when the `Allocator` is dropped.
     /// If caller wishes to prevent that happening, they must wrap the `Allocator` in `ManuallyDrop`.
     ///
     /// The [`Allocator`] returned by this function cannot grow.
     ///
     /// # SAFETY
     ///
-    /// * `ptr` must be aligned on [`RAW_MIN_ALIGN`].
+    /// * `start_ptr` must be aligned on [`RAW_MIN_ALIGN`].
     /// * `size` must be a multiple of [`RAW_MIN_ALIGN`].
     /// * `size` must be at least [`RAW_MIN_SIZE`].
-    /// * The memory region starting at `ptr` and encompassing `size` bytes must be within a single allocation.
-    /// * The memory region starting at `ptr` and encompassing `size` bytes must have been allocated from system
-    ///   allocator with alignment of [`RAW_MIN_ALIGN`] (or caller must wrap the `Allocator` in `ManuallyDrop`
+    /// * The memory region starting at `start_ptr` and encompassing `size` bytes must be entirely within
+    ///   the allocation described by `backing_alloc_ptr` and `layout`
+    ///   (i.e. `start_ptr >= backing_alloc_ptr` and `start_ptr + size <= backing_alloc_ptr + layout.size()`).
+    /// * The allocation described by `backing_alloc_ptr` and `layout` must have been allocated from
+    ///   the global allocator with that same `layout` (or caller must wrap the `Allocator` in `ManuallyDrop`
     ///   and ensure the backing memory is freed correctly themselves).
-    /// * `ptr` must have permission for writes.
+    /// * `start_ptr` and `backing_alloc_ptr` must have permission for writes.
     ///
     /// [`RAW_MIN_ALIGN`]: Self::RAW_MIN_ALIGN
     /// [`RAW_MIN_SIZE`]: Self::RAW_MIN_SIZE
-    pub unsafe fn from_raw_parts(ptr: NonNull<u8>, size: usize) -> Self {
+    pub unsafe fn from_raw_parts(
+        start_ptr: NonNull<u8>,
+        size: usize,
+        backing_alloc_ptr: NonNull<u8>,
+        layout: Layout,
+    ) -> Self {
         // SAFETY: Safety requirements of `Arena::from_raw_parts` are the same as for this method
-        let arena = unsafe { Arena::from_raw_parts(ptr, size) };
+        let arena = unsafe { Arena::from_raw_parts(start_ptr, size, backing_alloc_ptr, layout) };
         Self::from_arena(arena)
     }
 

--- a/crates/oxc_allocator/src/generated/assert_layouts.rs
+++ b/crates/oxc_allocator/src/generated/assert_layouts.rs
@@ -10,21 +10,19 @@ use crate::*;
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     // Padding: 3 bytes
-    assert!(size_of::<FixedSizeAllocatorMetadata>() == 16);
-    assert!(align_of::<FixedSizeAllocatorMetadata>() == 8);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 8);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 12);
+    assert!(size_of::<FixedSizeAllocatorMetadata>() == 8);
+    assert!(align_of::<FixedSizeAllocatorMetadata>() == 4);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 0);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 4);
 };
 
 #[cfg(target_pointer_width = "32")]
 const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     // Padding: 3 bytes
-    assert!(size_of::<FixedSizeAllocatorMetadata>() == 12);
+    assert!(size_of::<FixedSizeAllocatorMetadata>() == 8);
     assert!(align_of::<FixedSizeAllocatorMetadata>() == 4);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, alloc_ptr) == 0);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 4);
-    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 8);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, id) == 0);
+    assert!(offset_of!(FixedSizeAllocatorMetadata, is_double_owned) == 4);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -16,6 +16,7 @@ use oxc_data_structures::stack::Stack;
 
 use crate::{
     Allocator,
+    arena::{CHUNK_FOOTER_SIZE, ChunkFooter},
     generated::fixed_size_constants::{BLOCK_ALIGN, BLOCK_SIZE, RAW_METADATA_SIZE},
 };
 
@@ -263,8 +264,6 @@ impl FixedSizeAllocatorPool {
 pub struct FixedSizeAllocatorMetadata {
     /// ID of this allocator
     pub id: u32,
-    /// Pointer to start of original allocation backing the `FixedSizeAllocator`
-    pub(crate) alloc_ptr: NonNull<u8>,
     /// `true` if both Rust and JS currently hold references to this `FixedSizeAllocator`.
     ///
     /// * `false` initially.
@@ -406,16 +405,15 @@ impl FixedSizeAllocator {
         const CHUNK_SIZE: usize = FIXED_METADATA_OFFSET - RAW_METADATA_SIZE;
         const _: () = assert!(CHUNK_SIZE.is_multiple_of(Allocator::RAW_MIN_ALIGN));
 
-        // SAFETY: Memory region starting at `chunk_ptr` with `CHUNK_SIZE` bytes is within
-        // the allocation we just made.
+        // SAFETY: Memory region starting at `chunk_ptr` with `CHUNK_SIZE` bytes is within the allocation we just made.
         // `chunk_ptr` has high alignment (4 GiB). `CHUNK_SIZE` is large and a multiple of 16.
-        let allocator = unsafe { Allocator::from_raw_parts(chunk_ptr, CHUNK_SIZE) };
+        let allocator =
+            unsafe { Allocator::from_raw_parts(chunk_ptr, CHUNK_SIZE, alloc_ptr, ALLOC_LAYOUT) };
         let allocator = ManuallyDrop::new(allocator);
 
         // Write `FixedSizeAllocatorMetadata` to after space reserved for `RawTransferMetadata`,
         // which is after the end of the allocator chunk
-        let metadata =
-            FixedSizeAllocatorMetadata { alloc_ptr, id, is_double_owned: AtomicBool::new(false) };
+        let metadata = FixedSizeAllocatorMetadata { id, is_double_owned: AtomicBool::new(false) };
         // SAFETY: `FIXED_METADATA_OFFSET` is `FIXED_METADATA_SIZE_ROUNDED` bytes before end of
         // the allocation, so there's space for `FixedSizeAllocatorMetadata`.
         // It's sufficiently aligned for `FixedSizeAllocatorMetadata`.
@@ -449,7 +447,8 @@ impl FixedSizeAllocator {
 
 impl Drop for FixedSizeAllocator {
     fn drop(&mut self) {
-        // SAFETY: This `Allocator` was created by this `FixedSizeAllocator`
+        // SAFETY: This `Allocator` was created by this `FixedSizeAllocator`,
+        // so its current chunk has a valid `ChunkFooter` and a valid `FixedSizeAllocatorMetadata`
         unsafe {
             let metadata_ptr = self.allocator.fixed_size_metadata_ptr();
             free_fixed_size_allocator(metadata_ptr);
@@ -466,17 +465,29 @@ impl Drop for FixedSizeAllocator {
 /// # SAFETY
 ///
 /// This function must be called only when either:
-/// 1. The corresponding `FixedSizeAllocator` is dropped on Rust side. or
+/// 1. The corresponding `FixedSizeAllocator` is dropped on Rust side, or
 /// 2. The buffer on JS side corresponding to this `FixedSizeAllocatorMetadata` is garbage collected.
 ///
 /// Calling this function in any other circumstances would result in a double-free.
 ///
-/// `metadata_ptr` must point to a valid `FixedSizeAllocatorMetadata`.
+/// `metadata_ptr` must point to a valid `FixedSizeAllocatorMetadata` belonging to a `FixedSizeAllocator`.
+/// The `FixedSizeAllocator`'s `ChunkFooter`, which sits immediately before the `RawTransferMetadata`
+/// (which sits immediately before the `FixedSizeAllocatorMetadata`), must contain a `backing_alloc_ptr`
+/// and `layout` describing a backing allocation made via [`System::alloc`].
 pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocatorMetadata>) {
-    // Get pointer to start of original allocation from `FixedSizeAllocatorMetadata`
-    let alloc_ptr = {
-        // SAFETY: This `Allocator` was created by the `FixedSizeAllocator`.
-        // `&FixedSizeAllocatorMetadata` ref only lives until end of this block.
+    // The `ChunkFooter` sits at offset `-(RAW_METADATA_SIZE + CHUNK_FOOTER_SIZE)` from
+    // `FixedSizeAllocatorMetadata`, with `RawTransferMetadata` filling the gap between them
+    const FOOTER_OFFSET_FROM_METADATA: usize = RAW_METADATA_SIZE + CHUNK_FOOTER_SIZE;
+
+    // SAFETY: Caller guarantees `metadata_ptr` points to a `FixedSizeAllocatorMetadata` belonging to
+    // a `FixedSizeAllocator`, so the `ChunkFooter` is at a fixed offset before it within the same allocation
+    let chunk_footer_ptr =
+        unsafe { metadata_ptr.byte_sub(FOOTER_OFFSET_FROM_METADATA) }.cast::<ChunkFooter>();
+
+    // Read `is_double_owned` flag in a block, so the `&FixedSizeAllocatorMetadata` reference is not live
+    // during the deallocation below (the `FixedSizeAllocatorMetadata` lives in the memory we're about to free).
+    {
+        // SAFETY: Caller guarantees `metadata_ptr` points to a valid `FixedSizeAllocatorMetadata`.
         let metadata = unsafe { metadata_ptr.as_ref() };
 
         // * If `is_double_owned` is already `false`, then one of:
@@ -493,17 +504,24 @@ pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocator
         // so going with `Ordering::SeqCst` to be on safe side.
         // Deallocation only happens at the end of the whole process, so it shouldn't matter much.
         // TODO: Figure out if can use `Ordering::Relaxed`.
-        let is_double_owned = metadata.is_double_owned.swap(false, Ordering::SeqCst);
-        if is_double_owned {
+        if metadata.is_double_owned.swap(false, Ordering::SeqCst) {
             return;
         }
+    }
 
-        metadata.alloc_ptr
+    // Read backing allocation info from the `ChunkFooter`.
+    // Read in a block so the `&ChunkFooter` reference is not live during the deallocation below
+    // (the `ChunkFooter` lives in the memory we're about to free).
+    let (backing_alloc_ptr, layout) = {
+        // SAFETY: `chunk_footer_ptr` points to a valid `ChunkFooter` (caller guarantees the `FixedSizeAllocator`
+        // was created in the standard layout, with the `ChunkFooter` at this offset)
+        let footer = unsafe { chunk_footer_ptr.as_ref() };
+        footer.backing_alloc_info()
     };
 
     // Deallocate the memory backing the `FixedSizeAllocator`.
-    // SAFETY: Originally allocated from `System` allocator at `alloc_ptr`, with layout `ALLOC_LAYOUT`.
-    unsafe { System.dealloc(alloc_ptr.as_ptr(), ALLOC_LAYOUT) }
+    // SAFETY: Caller guarantees the backing allocation was made via `System` allocator with `layout`.
+    unsafe { System.dealloc(backing_alloc_ptr.as_ptr(), layout) }
 }
 
 impl Allocator {

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -155,7 +155,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         ("TSMappedType", StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 8, 2]) }),
         ("TSTypeReference", StructDetails { field_order: Some(&[1, 0, 2, 3]) }),
         ("SymbolId", StructDetails { field_order: None }),
-        ("FixedSizeAllocatorMetadata", StructDetails { field_order: Some(&[1, 0, 2]) }),
+        ("FixedSizeAllocatorMetadata", StructDetails { field_order: None }),
         ("RawTransferData", StructDetails { field_order: None }),
         ("CharacterClassRange", StructDetails { field_order: None }),
         ("Hashbang", StructDetails { field_order: Some(&[1, 0, 2]) }),

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -1,4 +1,5 @@
 use std::{
+    alloc::Layout,
     mem::{self, ManuallyDrop},
     ptr::{self, NonNull},
     str,
@@ -40,6 +41,12 @@ use crate::{
 //    which is cheaper than `>>>`, and does not risk offsets being interpreted as negative.
 
 const ARENA_ALIGN: usize = Allocator::RAW_MIN_ALIGN;
+
+/// Layout describing the JS-owned buffer (`BUFFER_SIZE` bytes, aligned on `BUFFER_ALIGN`).
+const BUFFER_LAYOUT: Layout = match Layout::from_size_align(BUFFER_SIZE, BUFFER_ALIGN) {
+    Ok(layout) => layout,
+    Err(_) => unreachable!(),
+};
 
 /// Get offset within a `Uint8Array` which is aligned on `BUFFER_ALIGN`.
 ///
@@ -198,6 +205,10 @@ unsafe fn parse_raw_impl(
 
     // Create `Allocator`.
     // Wrap in `ManuallyDrop` so the allocation doesn't get freed at end of function, or if panic.
+    // The buffer is owned by JS, so Rust must not free it - hence `ManuallyDrop`. The
+    // `backing_alloc_ptr` and `layout` we pass to `from_raw_parts` are never used (the `Allocator`
+    // is never dropped), but the safety contract requires the chunk region to lie within them,
+    // so we describe the buffer itself.
     // SAFETY: `data_offset` is less than `buffer.len()`, so `.add(data_offset)` cannot wrap
     // or be out of bounds.
     let data_ptr = unsafe { buffer_ptr.add(data_offset) };
@@ -206,8 +217,15 @@ unsafe fn parse_raw_impl(
     // SAFETY: `data_ptr` and `data_size` outline a section of the memory in `buffer`.
     // `data_ptr` and `data_size` are multiples of `ARENA_ALIGN`.
     // `data_size` is greater than `Allocator::RAW_MIN_SIZE`.
-    let allocator =
-        unsafe { Allocator::from_raw_parts(NonNull::new_unchecked(data_ptr), data_size) };
+    // The chunk region (`data_ptr..data_ptr + data_size`) lies entirely within the buffer.
+    let allocator = unsafe {
+        Allocator::from_raw_parts(
+            NonNull::new_unchecked(data_ptr),
+            data_size,
+            NonNull::new_unchecked(buffer_ptr),
+            BUFFER_LAYOUT,
+        )
+    };
     let allocator = ManuallyDrop::new(allocator);
 
     // Parse source.


### PR DESCRIPTION
Previously, fixed size allocators stored the pointer to the start of `Allocator`'s backing memory in `FixedSizeAllocatorMetadata`. Instead, store this pointer in `ChunkFooter`, in the field introduced in #21865.