### PR TITLE
refactor(allocator, linter/plugins, napi/parser): store raw transfer metadata within `Arena` chunk

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -44,10 +44,10 @@ export declare const enum Severity {
 export declare function applyFixes(sourceText: string, fixesJson: string, eslintCompat: boolean): string | null
 
 /**
- * Get offset within a `Uint8Array` which is aligned on `BUFFER_ALIGN`.
+ * Get offset within a `Uint8Array` which is aligned on `BLOCK_ALIGN`.
  *
  * Does not check that the offset is within bounds of `buffer`.
- * To ensure it always is, provide a `Uint8Array` of at least `BUFFER_SIZE + BUFFER_ALIGN` bytes.
+ * To ensure it always is, provide a `Uint8Array` of at least `BLOCK_SIZE + BLOCK_ALIGN` bytes.
  */
 export declare function getBufferOffset(buffer: Uint8Array): number
 

--- a/apps/oxlint/src-js/generated/constants.ts
+++ b/apps/oxlint/src-js/generated/constants.ts
@@ -1,50 +1,60 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-/**
- * Total size of the transfer buffer in bytes (block size minus allocator metadata).
- */
-export const BUFFER_SIZE = 2147483616;
+// See `crates/oxc_allocator/src/pool/fixed_size.rs` for a diagram showing
+// how the constituent parts of the arena fit together.
 
 /**
- * Required alignment of the transfer buffer (4 GiB).
+ * Total size of the allocator block (including metadata and allocator `ChunkFooter`).
  */
-export const BUFFER_ALIGN = 4294967296;
+export const BLOCK_SIZE = 2147483632;
 
 /**
- * Size of the active data area in bytes (buffer size minus raw metadata and chunk footer).
+ * Required alignment of the allocator block (4 GiB).
  */
-export const ACTIVE_SIZE = 2147483552;
+export const BLOCK_ALIGN = 4294967296;
+
+/**
+ * Total size of the transfer buffer used on JS side, in bytes
+ * (`BLOCK_SIZE` minus `FixedSizeAllocatorMetadata` and `ChunkFooter`).
+ */
+export const BUFFER_SIZE = 2147483576;
+
+/**
+ * Size of the active data region in bytes - the region where source text and AST live
+ * (`BUFFER_SIZE` minus `RawTransferMetadata`).
+ */
+export const ACTIVE_SIZE = 2147483560;
 
 /**
  * Byte offset of the data pointer within the buffer, divided by 4 (for `Int32Array` indexing).
  */
-export const DATA_POINTER_POS_32 = 536870900;
+export const DATA_POINTER_POS_32 = 536870890;
 
 /**
  * Byte offset of the `is_ts` flag within the buffer.
  */
-export const IS_TS_FLAG_POS = 2147483612;
+export const IS_TS_FLAG_POS = 2147483572;
 
 /**
  * Byte offset of the `is_jsx` flag within the buffer.
  */
-export const IS_JSX_FLAG_POS = 2147483613;
+export const IS_JSX_FLAG_POS = 2147483573;
 
 /**
  * Byte offset of the `has_bom` flag within the buffer.
  */
-export const HAS_BOM_FLAG_POS = 2147483614;
+export const HAS_BOM_FLAG_POS = 2147483574;
 
 /**
  * Byte offset of the tokens offset within the buffer, divided by 4 (for `Int32Array` indexing).
  */
-export const TOKENS_OFFSET_POS_32 = 536870901;
+export const TOKENS_OFFSET_POS_32 = 536870891;
 
 /**
  * Byte offset of the tokens length within the buffer, divided by 4 (for `Int32Array` indexing).
  */
-export const TOKENS_LEN_POS_32 = 536870902;
+export const TOKENS_LEN_POS_32 = 536870892;
 
 /**
  * Byte offset of the `program` field, relative to start of `RawTransferData`.

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -49,7 +49,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/apps/oxlint/src-js/package/parse.ts
+++ b/apps/oxlint/src-js/package/parse.ts
@@ -6,8 +6,9 @@ import {
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 import { buffers } from "../plugins/lint.ts";
 import {
+  BLOCK_SIZE,
+  BLOCK_ALIGN,
   BUFFER_SIZE,
-  BUFFER_ALIGN,
   DATA_POINTER_POS_32,
   ACTIVE_SIZE,
 } from "../generated/constants.ts";
@@ -18,7 +19,7 @@ import type { ParserOptions as ParseOptions } from "../bindings.js";
 export type { ParseOptions };
 
 // Size array buffer for raw transfer
-const ARRAY_BUFFER_SIZE = BUFFER_SIZE + BUFFER_ALIGN;
+const ARRAY_BUFFER_SIZE = BLOCK_SIZE + BLOCK_ALIGN;
 
 // 1 GiB
 const ONE_GIB = 1 << 30;
@@ -26,8 +27,10 @@ const ONE_GIB = 1 << 30;
 // Text encoder for encoding source text into buffer
 const textEncoder = new TextEncoder();
 
-// Buffer for raw transfer
+// Buffers for raw transfer.
+// Both are views of the same memory, but `blockBuffer` is slightly larger, and is what we pass to Rust.
 let buffer: BufferWithArrays | null = null;
+let blockBuffer: Uint8Array | null = null;
 
 // Whether raw transfer is supported
 let rawTransferIsSupported: boolean | null = null;
@@ -50,6 +53,7 @@ export function parse(path: string, sourceText: string, options?: ParseOptions) 
   // Initialize buffer, if not already
   if (buffer === null) initBuffer();
   debugAssertIsNonNull(buffer);
+  debugAssertIsNonNull(blockBuffer);
 
   // Write source into end of buffer.
   // Maximum size of a string encoded in UTF-8 is 3 x the length of the string in UTF-16 characters
@@ -68,9 +72,10 @@ export function parse(path: string, sourceText: string, options?: ParseOptions) 
   );
   const { read, written: sourceByteLen } = textEncoder.encodeInto(sourceText, sourceBuffer);
   if (read !== sourceText.length) throw new Error("Failed to write source text into buffer");
+  debugAssert(sourceByteLen <= maxSourceByteLen);
 
   // Parse into buffer
-  parseRawSync(path, buffer, sourceStartPos, sourceByteLen, options);
+  parseRawSync(path, blockBuffer, sourceStartPos, sourceByteLen, options);
 
   // Check parsing succeeded.
   // 0 is used as sentinel value to indicate parsing failed.
@@ -90,6 +95,12 @@ export function parse(path: string, sourceText: string, options?: ParseOptions) 
  * It's always possible to obtain a 2 GiB slice aligned on 4 GiB within a 6 GiB buffer,
  * no matter how the 6 GiB buffer is aligned.
  *
+ * `buffer` itself, and `int32` and `float64` views of `buffer`, are `BUFFER_SIZE` bytes,
+ * which excludes `FixedSizeAllocatorMetadata` and `ChunkFooter`.
+ * This ensures this critical data cannot be accidentally overwritten on JS side.
+ * `blockBuffer` is `BLOCK_SIZE` bytes, which includes `FixedSizeAllocatorMetadata` and `ChunkFooter`.
+ * `blockBuffer` is what we pass to Rust, which needs to write them.
+ *
  * Note: On systems with virtual memory, this only consumes 6 GiB of *virtual* memory.
  * It does not consume physical memory until data is actually written to the `Uint8Array`.
  * Physical memory consumed corresponds to the quantity of data actually written.
@@ -101,6 +112,8 @@ export function initBuffer() {
   buffer = new Uint8Array(arrayBuffer, offset, BUFFER_SIZE) as BufferWithArrays;
   buffer.int32 = new Int32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
+
+  blockBuffer = new Uint8Array(arrayBuffer, offset, BLOCK_SIZE);
 
   // Store in `buffers`, at index 0
   debugAssert(buffers.length === 0, "`buffers` array should be empty");

--- a/apps/oxlint/src/generated/raw_transfer_constants.rs
+++ b/apps/oxlint/src/generated/raw_transfer_constants.rs
@@ -1,11 +1,39 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
+//! Constants for raw transfer / fixed-sized allocators.
+//!
+//! See `crates/oxc_allocator/src/pool/fixed_size.rs` for a diagram showing
+//! how the constituent parts of the arena fit together.
+//!
+//! This file must be feature-gated so it is not loaded on 32-bit platforms.
+//! It will cause a compilation error on 32-bit platforms, as some values are too large for 32-bit `usize`.
+
 #![expect(clippy::unreadable_literal)]
 #![allow(dead_code)]
 
+/// Total size of the allocator block (including metadata and allocator `ChunkFooter`).
 pub const BLOCK_SIZE: usize = 2147483632;
+
+/// Required alignment of the allocator block (4 GiB).
 pub const BLOCK_ALIGN: usize = 4294967296;
-pub const BUFFER_SIZE: usize = 2147483616;
+
+/// Total size of the transfer buffer used on JS side, in bytes
+/// (`BLOCK_SIZE` minus `FixedSizeAllocatorMetadata` and `ChunkFooter`).
+pub const BUFFER_SIZE: usize = 2147483576;
+
+/// Size of the active data region in bytes - the region where source text and AST live
+/// (`BUFFER_SIZE` minus `RawTransferMetadata`).
+pub const ACTIVE_SIZE: usize = 2147483560;
+
+/// Size of `RawTransferMetadata` in bytes.
 pub const RAW_METADATA_SIZE: usize = 16;
+
+/// Alignment of `RawTransferMetadata`.
+pub const RAW_METADATA_ALIGN: usize = 4;
+
+/// Size of `ChunkFooter` struct in bytes.
 pub const CHUNK_FOOTER_SIZE: usize = 48;
+
+/// Minimum alignment requirement for `Arena`'s cursor pointer (`ARENA::MIN_ALIGN`).
+pub const CURSOR_MIN_ALIGN: usize = 1;

--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -297,6 +297,9 @@ unsafe fn get_buffer(
     // so that shouldn't break the guarantees of `&` references.
     //
     // This is all a bit wavy, but such is the way with sharing memory outside of Rust.
+    //
+    // The `Uint8Array` shared with JS covers the allocatable region plus `RawTransferMetadata`.
+    // It does not include `FixedSizeAllocatorMetadata` or `ChunkFooter`, which sit at the end of the block.
     let buffer = unsafe {
         Uint8Array::with_external_data(chunk_ptr.as_ptr(), BUFFER_SIZE, move |_ptr, _len| {
             free_fixed_size_allocator(metadata_ptr);

--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -16,12 +16,12 @@ use oxc_napi::get_source_type;
 use oxc_parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig};
 use oxc_semantic::SemanticBuilder;
 
-use crate::generated::raw_transfer_constants::{BLOCK_ALIGN as BUFFER_ALIGN, BUFFER_SIZE};
+use crate::generated::raw_transfer_constants::{
+    ACTIVE_SIZE, BLOCK_ALIGN, BLOCK_SIZE, CURSOR_MIN_ALIGN,
+};
 
-const ARENA_ALIGN: usize = Allocator::RAW_MIN_ALIGN;
-
-/// Layout describing the JS-owned buffer (`BUFFER_SIZE` bytes, aligned on `BUFFER_ALIGN`).
-const BUFFER_LAYOUT: Layout = match Layout::from_size_align(BUFFER_SIZE, BUFFER_ALIGN) {
+/// Layout describing the JS-owned buffer (`BLOCK_SIZE` bytes, aligned on `BLOCK_ALIGN`).
+const BLOCK_LAYOUT: Layout = match Layout::from_size_align(BLOCK_SIZE, BLOCK_ALIGN) {
     Ok(layout) => layout,
     Err(_) => unreachable!(),
 };
@@ -48,15 +48,15 @@ pub struct ParserOptions {
     pub ignore_non_fatal_errors: Option<bool>,
 }
 
-/// Get offset within a `Uint8Array` which is aligned on `BUFFER_ALIGN`.
+/// Get offset within a `Uint8Array` which is aligned on `BLOCK_ALIGN`.
 ///
 /// Does not check that the offset is within bounds of `buffer`.
-/// To ensure it always is, provide a `Uint8Array` of at least `BUFFER_SIZE + BUFFER_ALIGN` bytes.
+/// To ensure it always is, provide a `Uint8Array` of at least `BLOCK_SIZE + BLOCK_ALIGN` bytes.
 #[napi]
 #[allow(clippy::needless_pass_by_value, clippy::allow_attributes)]
 pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
     let buffer = &*buffer;
-    let offset = (BUFFER_ALIGN - (buffer.as_ptr() as usize % BUFFER_ALIGN)) % BUFFER_ALIGN;
+    let offset = (BLOCK_ALIGN - (buffer.as_ptr() as usize % BLOCK_ALIGN)) % BLOCK_ALIGN;
     #[expect(clippy::cast_possible_truncation)]
     return offset as u32;
 }
@@ -111,6 +111,7 @@ pub unsafe fn parse_raw_sync(
 /// Caller must ensure:
 /// * Source text is written into the buffer.
 /// * Start of source text is at `source_start` bytes from the start of the buffer.
+/// * End of source text is not after `ACTIVE_SIZE` bytes from the start of the buffer.
 /// * Source text's UTF-8 byte length is `source_len`.
 /// * This section of bytes in the buffer comprises a valid UTF-8 string.
 ///
@@ -125,23 +126,14 @@ unsafe fn parse_raw_impl(
     options: Option<ParserOptions>,
 ) {
     // Check buffer has expected size and alignment
-    assert_eq!(buffer.len(), BUFFER_SIZE);
+    assert_eq!(buffer.len(), BLOCK_SIZE);
     let buffer_ptr = NonNull::from_mut(buffer).cast::<u8>();
-    assert!(buffer_ptr.addr().get().is_multiple_of(BUFFER_ALIGN));
+    assert!(buffer_ptr.addr().get().is_multiple_of(BLOCK_ALIGN));
 
-    // Get offsets and size of data region to be managed by arena allocator.
-    // Leave space for source before it, and space for metadata after it.
-    // Check `RawTransferMetadata`'s size is a multiple of `ARENA_ALIGN`,
-    // as the arena allocator requires start and end of the chunk to have that alignment.
-    const RAW_METADATA_SIZE: usize = size_of::<RawTransferMetadata>();
-    const {
-        assert!(RAW_METADATA_SIZE >= ARENA_ALIGN);
-        assert!(RAW_METADATA_SIZE.is_multiple_of(ARENA_ALIGN));
-    };
-    const RAW_METADATA_OFFSET: usize = BUFFER_SIZE - RAW_METADATA_SIZE;
     const _: () = {
-        assert!(RAW_METADATA_OFFSET.is_multiple_of(ARENA_ALIGN));
-        assert!(RAW_METADATA_OFFSET >= Allocator::RAW_MIN_SIZE);
+        assert!(BLOCK_SIZE.is_multiple_of(Allocator::RAW_MIN_ALIGN));
+        assert!(BLOCK_SIZE >= Allocator::RAW_MIN_SIZE);
+        assert!(BLOCK_ALIGN.is_multiple_of(Allocator::RAW_MIN_ALIGN));
     };
 
     // Create `Allocator`.
@@ -151,20 +143,20 @@ unsafe fn parse_raw_impl(
     // The `backing_alloc_ptr` and `layout` we pass to `from_raw_parts` aren't used (the `Allocator` is never dropped),
     // but the safety contract requires the chunk region to lie within them, so we describe the buffer itself.
     //
-    // SAFETY: `buffer_ptr` and `RAW_METADATA_OFFSET` outline a section of the memory in `buffer`.
-    // `buffer_ptr` and `RAW_METADATA_OFFSET` are multiples of `ARENA_ALIGN`.
-    // `RAW_METADATA_OFFSET` is `>= Allocator::RAW_MIN_SIZE`.
-    // The chunk region lies entirely within the buffer.
-    let allocator = unsafe {
-        Allocator::from_raw_parts(buffer_ptr, RAW_METADATA_OFFSET, buffer_ptr, BUFFER_LAYOUT)
-    };
+    // SAFETY: `buffer_ptr` and `BLOCK_SIZE` outline the entirety of `buffer`.
+    // `buffer_ptr` and `BLOCK_SIZE` are multiples of `ARENA_ALIGN`.
+    // `BLOCK_SIZE` is `>= Allocator::RAW_MIN_SIZE`.
+    // `buffer_ptr` is derived from a `&mut [u8]` slice, so has permission for writes.
+    let allocator =
+        unsafe { Allocator::from_raw_parts(buffer_ptr, BLOCK_SIZE, buffer_ptr, BLOCK_LAYOUT) };
     let allocator = ManuallyDrop::new(allocator);
 
     // Set cursor to before start of source text. AST will be written into the buffer before the source text.
-    // Round down the pointer, so it's aligned on `ARENA_ALIGN`.
+    // Round down the pointer, so it's aligned on `CURSOR_MIN_ALIGN`.
     // SAFETY: Caller guarantees that source text starts at `source_start` bytes from start of buffer.
     unsafe {
-        let cursor_pos = source_start as usize & !(ARENA_ALIGN - 1);
+        let cursor_pos = source_start as usize & !(CURSOR_MIN_ALIGN - 1);
+        debug_assert!(cursor_pos <= ACTIVE_SIZE);
         let cursor_ptr = buffer_ptr.add(cursor_pos);
         allocator.set_cursor_ptr(cursor_ptr);
     }
@@ -181,6 +173,7 @@ unsafe fn parse_raw_impl(
         // SAFETY: Caller guarantees source occupies this region of the buffer and is valid UTF-8
         let source_text = unsafe {
             let source_end = source_start as usize + source_len as usize;
+            debug_assert!(source_end <= ACTIVE_SIZE);
             let source_bytes = buffer.get_unchecked(source_start as usize..source_end);
             str::from_utf8_unchecked(source_bytes)
         };
@@ -273,7 +266,17 @@ unsafe fn parse_raw_impl(
         }
     };
 
-    // Write metadata into end of buffer
+    // Write metadata into end of buffer.
+    //
+    // `RawTransferMetadata` is written at offset `ACTIVE_SIZE` (the end of the allocatable region).
+    // After it sits a slot reserved for `FixedSizeAllocatorMetadata` (left unused in `napi/parser`-style code),
+    // and finally `ChunkFooter` in the last `CHUNK_FOOTER_SIZE` bytes of the buffer.
+    const RAW_METADATA_OFFSET: usize = ACTIVE_SIZE;
+    const _: () = {
+        assert!(RAW_METADATA_OFFSET + size_of::<RawTransferMetadata>() < BLOCK_SIZE);
+        assert!(RAW_METADATA_OFFSET.is_multiple_of(align_of::<RawTransferMetadata>()));
+    };
+
     #[allow(clippy::cast_possible_truncation)]
     let metadata = RawTransferMetadata::new(
         program_offset,
@@ -283,8 +286,9 @@ unsafe fn parse_raw_impl(
         tokens_offset,
         tokens_len,
     );
-    // SAFETY: `RAW_METADATA_OFFSET` is less than length of `buffer`.
-    // `RAW_METADATA_OFFSET` is aligned to `ARENA_ALIGN`.
+
+    // SAFETY: `RAW_METADATA_OFFSET + size_of::<RawTransferMetadata>()` is less than length of `buffer`.
+    // `buffer_ptr + RAW_METADATA_OFFSET` is aligned for `RawTransferMetadata`.
     unsafe {
         buffer_ptr.add(RAW_METADATA_OFFSET).cast::<RawTransferMetadata>().write(metadata);
     }

--- a/crates/oxc_allocator/src/generated/fixed_size_constants.rs
+++ b/crates/oxc_allocator/src/generated/fixed_size_constants.rs
@@ -1,11 +1,39 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
+//! Constants for raw transfer / fixed-sized allocators.
+//!
+//! See `crates/oxc_allocator/src/pool/fixed_size.rs` for a diagram showing
+//! how the constituent parts of the arena fit together.
+//!
+//! This file must be feature-gated so it is not loaded on 32-bit platforms.
+//! It will cause a compilation error on 32-bit platforms, as some values are too large for 32-bit `usize`.
+
 #![expect(clippy::unreadable_literal)]
 #![allow(dead_code)]
 
+/// Total size of the allocator block (including metadata and allocator `ChunkFooter`).
 pub const BLOCK_SIZE: usize = 2147483632;
+
+/// Required alignment of the allocator block (4 GiB).
 pub const BLOCK_ALIGN: usize = 4294967296;
-pub const BUFFER_SIZE: usize = 2147483616;
+
+/// Total size of the transfer buffer used on JS side, in bytes
+/// (`BLOCK_SIZE` minus `FixedSizeAllocatorMetadata` and `ChunkFooter`).
+pub const BUFFER_SIZE: usize = 2147483576;
+
+/// Size of the active data region in bytes - the region where source text and AST live
+/// (`BUFFER_SIZE` minus `RawTransferMetadata`).
+pub const ACTIVE_SIZE: usize = 2147483560;
+
+/// Size of `RawTransferMetadata` in bytes.
 pub const RAW_METADATA_SIZE: usize = 16;
+
+/// Alignment of `RawTransferMetadata`.
+pub const RAW_METADATA_ALIGN: usize = 4;
+
+/// Size of `ChunkFooter` struct in bytes.
 pub const CHUNK_FOOTER_SIZE: usize = 48;
+
+/// Minimum alignment requirement for `Arena`'s cursor pointer (`ARENA::MIN_ALIGN`).
+pub const CURSOR_MIN_ALIGN: usize = 1;

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -17,7 +17,10 @@ use oxc_data_structures::stack::Stack;
 use crate::{
     Allocator,
     arena::{CHUNK_FOOTER_SIZE, ChunkFooter},
-    generated::fixed_size_constants::{BLOCK_ALIGN, BLOCK_SIZE, RAW_METADATA_SIZE},
+    generated::fixed_size_constants::{
+        ACTIVE_SIZE, BLOCK_ALIGN, BLOCK_SIZE, BUFFER_SIZE, CURSOR_MIN_ALIGN, RAW_METADATA_ALIGN,
+        RAW_METADATA_SIZE,
+    },
 };
 
 const TWO_GIB: usize = 1 << 31;
@@ -258,8 +261,7 @@ impl FixedSizeAllocatorPool {
 
 /// Metadata about a `FixedSizeAllocator`.
 ///
-/// Is stored in the memory backing the `FixedSizeAllocator`, after `RawTransferMetadata`,
-/// which is after the section of the allocation which `Allocator` uses for its chunk.
+/// Is stored in the memory backing the `FixedSizeAllocator`, between `RawTransferMetadata` and `ChunkFooter`.
 #[ast]
 pub struct FixedSizeAllocatorMetadata {
     /// ID of this allocator
@@ -299,6 +301,41 @@ const ALLOC_LAYOUT: Layout = match Layout::from_size_align(ALLOC_SIZE, ALLOC_ALI
     Err(_) => unreachable!(),
 };
 
+/// Size of `FixedSizeAllocatorMetadata`.
+const FIXED_METADATA_SIZE: usize = size_of::<FixedSizeAllocatorMetadata>();
+
+/// Offset within the block where `FixedSizeAllocatorMetadata` is stored.
+/// `ChunkFooter` sits immediately after it (filling the last `CHUNK_FOOTER_SIZE` bytes of the block).
+const FIXED_METADATA_OFFSET: usize = BUFFER_SIZE;
+
+/// Offset within the block where `RawTransferMetadata` is stored.
+/// `FixedSizeAllocatorMetadata` sits immediately after it.
+/// This is also the size of the allocatable region, and (with the trailing `RawTransferMetadata` slot
+/// added) the size of the `Uint8Array` shared with JS.
+const RAW_METADATA_OFFSET: usize = ACTIVE_SIZE;
+
+const _: () = {
+    // `ChunkFooter` lives in the last `CHUNK_FOOTER_SIZE` bytes of the block and must be aligned on `CHUNK_ALIGN` (16).
+    // `BLOCK_SIZE` and `CHUNK_FOOTER_SIZE` are both multiples of `Allocator::RAW_MIN_ALIGN` (16).
+    assert!(BLOCK_SIZE.is_multiple_of(Allocator::RAW_MIN_ALIGN));
+    assert!(CHUNK_FOOTER_SIZE.is_multiple_of(Allocator::RAW_MIN_ALIGN));
+
+    // `FIXED_METADATA_OFFSET` is aligned for and has space for a `FixedSizeAllocatorMetadata`
+    assert!(FIXED_METADATA_OFFSET.is_multiple_of(align_of::<FixedSizeAllocatorMetadata>()));
+    assert!(
+        FIXED_METADATA_OFFSET + size_of::<FixedSizeAllocatorMetadata>()
+            == BLOCK_SIZE - CHUNK_FOOTER_SIZE
+    );
+
+    // `RAW_METADATA_OFFSET` is aligned for and has space for a `RawTransferMetadata`
+    assert!(RAW_METADATA_OFFSET.is_multiple_of(RAW_METADATA_ALIGN));
+    assert!(RAW_METADATA_OFFSET + RAW_METADATA_SIZE == FIXED_METADATA_OFFSET);
+
+    // `RawTransferMetadata` is aligned on `CURSOR_MIN_ALIGN`,
+    // so the initial `cursor_ptr` is correctly aligned on `Arena::MIN_ALIGN` (`CURSOR_MIN_ALIGN`)
+    assert!(RAW_METADATA_OFFSET.is_multiple_of(CURSOR_MIN_ALIGN));
+};
+
 /// Structure which wraps an [`Allocator`] with fixed size of 2 GiB - 16, and aligned on 4 GiB.
 ///
 /// # Allocation strategy
@@ -325,31 +362,25 @@ const ALLOC_LAYOUT: Layout = match Layout::from_size_align(ALLOC_SIZE, ALLOC_ALI
 /// The remaining 2 GiB - 16 bytes, which *is* used, is split up as follows:
 ///
 /// ```txt
-///                                                         WHOLE BLOCK - aligned on 4 GiB
+///                                                         WHOLE BLOCK - size 2 GiB - 16, aligned on 4 GiB
 /// <-----------------------------------------------------> Allocated block (`BLOCK_SIZE` bytes)
 ///
-///                                                         ALLOCATOR
-/// <----------------------------------------->             `Allocator` chunk (`CHUNK_SIZE` bytes)
-///                                      <---->             `ChunkFooter` (aligned on 16)
-/// <----------------------------------->                   `Allocator` chunk data storage (for AST)
-///                                                         (`ACTIVE_SIZE` bytes)
-///
-///                                                         METADATA
-///                                            <---->       `RawTransferMetadata`
-///                                                  <----> `FixedSizeAllocatorMetadata`
+///                                                         ARENA
+/// <-----------------------------------------------------> Chunk (fills whole block)
+/// <-------------------------------------->                Allocatable region for AST (`ACTIVE_SIZE` bytes)
+///                                         <--->           `RawTransferMetadata`
+///                                              <--->      `FixedSizeAllocatorMetadata`
+///                                                   <---> `ChunkFooter` (aligned on 16, last in block)
 ///
 ///                                                         BUFFER SENT TO JS
-/// <----------------------------------------------->       Buffer sent to JS (`BUFFER_SIZE` bytes)
+/// <------------------------------------------->           Buffer sent to JS (`BUFFER_SIZE` bytes)
 /// ```
 ///
-/// Note that the buffer sent to JS includes both the `Allocator` chunk, and `RawTransferMetadata`,
-/// but does NOT include `FixedSizeAllocatorMetadata`.
+/// The buffer sent to JS covers the allocatable region plus `RawTransferMetadata`, and stops there.
+/// `FixedSizeAllocatorMetadata` and `ChunkFooter` are not visible to JS.
 ///
 /// The end of the region used for `Allocator` chunk must be aligned on `Allocator::RAW_MIN_ALIGN` (16).
-/// We manage that by:
-/// * `BLOCK_SIZE` is a multiple of 16.
-/// * `RawTransferMetadata` is 16 bytes.
-/// * Size of `FixedSizeAllocatorMetadata` is rounded up to a multiple of 16.
+/// `BLOCK_SIZE` is a multiple of 16.
 #[repr(transparent)]
 struct FixedSizeAllocator {
     /// `Allocator` which utilizes part of the original allocation
@@ -360,7 +391,6 @@ impl FixedSizeAllocator {
     /// Try to create a new [`FixedSizeAllocator`].
     ///
     /// Returns `Err` if memory allocation fails.
-    #[expect(clippy::items_after_statements)]
     fn try_new(id: u32) -> Result<Self, ()> {
         // Only support little-endian systems. `Allocator::from_raw_parts` includes this same assertion.
         // This module is only compiled on 64-bit little-endian systems, so it should be impossible for
@@ -394,28 +424,35 @@ impl FixedSizeAllocator {
         // SAFETY: We allocated 4 GiB of memory, so adding `offset` to `alloc_ptr` is in bounds
         let chunk_ptr = unsafe { alloc_ptr.add(offset) };
 
-        debug_assert!((chunk_ptr.as_ptr() as usize).is_multiple_of(BLOCK_ALIGN));
+        debug_assert!(chunk_ptr.addr().get().is_multiple_of(BLOCK_ALIGN));
 
-        const FIXED_METADATA_SIZE_ROUNDED: usize =
-            size_of::<FixedSizeAllocatorMetadata>().next_multiple_of(Allocator::RAW_MIN_ALIGN);
-        const FIXED_METADATA_OFFSET: usize = BLOCK_SIZE - FIXED_METADATA_SIZE_ROUNDED;
-        const _: () =
-            assert!(FIXED_METADATA_OFFSET.is_multiple_of(align_of::<FixedSizeAllocatorMetadata>()));
-
-        const CHUNK_SIZE: usize = FIXED_METADATA_OFFSET - RAW_METADATA_SIZE;
-        const _: () = assert!(CHUNK_SIZE.is_multiple_of(Allocator::RAW_MIN_ALIGN));
-
-        // SAFETY: Memory region starting at `chunk_ptr` with `CHUNK_SIZE` bytes is within the allocation we just made.
-        // `chunk_ptr` has high alignment (4 GiB). `CHUNK_SIZE` is large and a multiple of 16.
+        // The `Allocator` chunk fills the whole block. `ChunkFooter` sits in the last `CHUNK_FOOTER_SIZE`
+        // bytes of the block. `FixedSizeAllocatorMetadata` and `RawTransferMetadata` are written into the
+        // chunk just before `ChunkFooter`. We later set the cursor to before `RawTransferMetadata` so
+        // allocations don't overwrite the metadata regions.
+        //
+        // SAFETY: Memory region starting at `chunk_ptr` with `BLOCK_SIZE` bytes is within the allocation
+        // we just made. `chunk_ptr` has high alignment (4 GiB). `BLOCK_SIZE` is large and a multiple of 16.
+        // `chunk_ptr` has permission for writes.
         let allocator =
-            unsafe { Allocator::from_raw_parts(chunk_ptr, CHUNK_SIZE, alloc_ptr, ALLOC_LAYOUT) };
+            unsafe { Allocator::from_raw_parts(chunk_ptr, BLOCK_SIZE, alloc_ptr, ALLOC_LAYOUT) };
         let allocator = ManuallyDrop::new(allocator);
 
-        // Write `FixedSizeAllocatorMetadata` to after space reserved for `RawTransferMetadata`,
-        // which is after the end of the allocator chunk
+        // Check `CURSOR_MIN_ALIGN` is accurate. This check will be const-folded out.
+        assert!(
+            allocator.arena().min_align() == CURSOR_MIN_ALIGN,
+            "Update `CURSOR_MIN_ALIGN` to match `Arena`'s `MIN_ALIGN`",
+        );
+
+        // Set cursor to the end of the allocatable region (= start of `RawTransferMetadata`).
+        // SAFETY: `RAW_METADATA_OFFSET` is within the chunk, after `start_ptr` and before the `ChunkFooter`,
+        // and is a multiple of `CURSOR_MIN_ALIGN` (`Arena::MIN_ALIGN`).
+        unsafe { allocator.set_cursor_ptr(chunk_ptr.add(RAW_METADATA_OFFSET)) };
+
+        // Write `FixedSizeAllocatorMetadata` between `RawTransferMetadata` and `ChunkFooter`
         let metadata = FixedSizeAllocatorMetadata { id, is_double_owned: AtomicBool::new(false) };
-        // SAFETY: `FIXED_METADATA_OFFSET` is `FIXED_METADATA_SIZE_ROUNDED` bytes before end of
-        // the allocation, so there's space for `FixedSizeAllocatorMetadata`.
+        // SAFETY: `FIXED_METADATA_OFFSET` is `FIXED_METADATA_SIZE + CHUNK_FOOTER_SIZE` bytes before
+        // the end of the allocation, so there's space for `FixedSizeAllocatorMetadata`.
         // It's sufficiently aligned for `FixedSizeAllocatorMetadata`.
         unsafe {
             let metadata_ptr =
@@ -427,8 +464,20 @@ impl FixedSizeAllocator {
     }
 
     /// Reset this [`FixedSizeAllocator`].
+    ///
+    /// `Allocator::reset` would set cursor to the `ChunkFooter` (end of block). We override that and set cursor
+    /// to before `RawTransferMetadata` instead, so future allocations don't overwrite the metadata regions.
     fn reset(&mut self) {
-        self.allocator.reset();
+        // SAFETY: `Allocator` was created by `try_new` with at least one chunk.
+        // `data_end_ptr()` returns the `ChunkFooter` pointer (= chunk_ptr + BLOCK_SIZE - CHUNK_FOOTER_SIZE),
+        // so subtracting `FIXED_METADATA_SIZE + RAW_METADATA_SIZE` gives the start of `RawTransferMetadata`,
+        // which lies within the chunk, and is aligned to `Arena::MIN_ALIGN`.
+        unsafe {
+            let cursor_ptr =
+                self.allocator.data_end_ptr().sub(FIXED_METADATA_SIZE + RAW_METADATA_SIZE);
+            debug_assert!(cursor_ptr.addr().get().is_multiple_of(CURSOR_MIN_ALIGN));
+            self.allocator.set_cursor_ptr(cursor_ptr);
+        }
     }
 
     /// Unwrap a [`FixedSizeAllocator`] into the [`Allocator`] it contains.
@@ -471,18 +520,14 @@ impl Drop for FixedSizeAllocator {
 /// Calling this function in any other circumstances would result in a double-free.
 ///
 /// `metadata_ptr` must point to a valid `FixedSizeAllocatorMetadata` belonging to a `FixedSizeAllocator`.
-/// The `FixedSizeAllocator`'s `ChunkFooter`, which sits immediately before the `RawTransferMetadata`
-/// (which sits immediately before the `FixedSizeAllocatorMetadata`), must contain a `backing_alloc_ptr`
-/// and `layout` describing a backing allocation made via [`System::alloc`].
+/// The `FixedSizeAllocator`'s `ChunkFooter`, which sits immediately after the `FixedSizeAllocatorMetadata`,
+/// must contain a `backing_alloc_ptr` and `layout` describing a backing allocation made via [`System::alloc`].
 pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocatorMetadata>) {
-    // The `ChunkFooter` sits at offset `-(RAW_METADATA_SIZE + CHUNK_FOOTER_SIZE)` from
-    // `FixedSizeAllocatorMetadata`, with `RawTransferMetadata` filling the gap between them
-    const FOOTER_OFFSET_FROM_METADATA: usize = RAW_METADATA_SIZE + CHUNK_FOOTER_SIZE;
-
+    // The `ChunkFooter` sits immediately after `FixedSizeAllocatorMetadata` in memory.
     // SAFETY: Caller guarantees `metadata_ptr` points to a `FixedSizeAllocatorMetadata` belonging to
-    // a `FixedSizeAllocator`, so the `ChunkFooter` is at a fixed offset before it within the same allocation
+    // a `FixedSizeAllocator`, so the `ChunkFooter` is at a fixed offset after it within the same allocation.
     let chunk_footer_ptr =
-        unsafe { metadata_ptr.byte_sub(FOOTER_OFFSET_FROM_METADATA) }.cast::<ChunkFooter>();
+        unsafe { metadata_ptr.byte_add(FIXED_METADATA_SIZE).cast::<ChunkFooter>() };
 
     // Read `is_double_owned` flag in a block, so the `&FixedSizeAllocatorMetadata` reference is not live
     // during the deallocation below (the `FixedSizeAllocatorMetadata` lives in the memory we're about to free).
@@ -534,13 +579,12 @@ impl Allocator {
     pub unsafe fn fixed_size_metadata_ptr(&self) -> NonNull<FixedSizeAllocatorMetadata> {
         // SAFETY: Caller guarantees this `Allocator` was created by a `FixedSizeAllocator`.
         //
-        // `FixedSizeAllocator::new` writes `FixedSizeAllocatorMetadata` after the end of
-        // the chunk owned by the `Allocator`, and `RawTransferMetadata` (see above).
-        // `end_ptr` is end of the allocator chunk (after the chunk header).
-        // So `end_ptr + RAW_METADATA_SIZE` points to a valid, initialized `FixedSizeAllocatorMetadata`.
+        // `FixedSizeAllocator::try_new` writes `FixedSizeAllocatorMetadata` immediately before the
+        // `ChunkFooter`. `data_end_ptr` returns the start of the `ChunkFooter`, so subtracting
+        // `FIXED_METADATA_SIZE` gives the start of the `FixedSizeAllocatorMetadata`.
         //
         // We never create `&mut` references to `FixedSizeAllocatorMetadata`,
         // and it's not part of the buffer sent to JS, so no danger of aliasing violations.
-        unsafe { self.end_ptr().add(RAW_METADATA_SIZE).cast::<FixedSizeAllocatorMetadata>() }
+        unsafe { self.data_end_ptr().sub(FIXED_METADATA_SIZE).cast::<FixedSizeAllocatorMetadata>() }
     }
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -666,10 +666,21 @@ impl Linter {
             tokens_offset,
             tokens_len,
         );
-        let metadata_ptr = allocator.end_ptr().cast::<RawTransferMetadata>();
-        // SAFETY: `Allocator` was created by `FixedSizeAllocator` which reserved space after `end_ptr`
-        // for a `RawTransferMetadata`. `end_ptr` is aligned for `RawTransferMetadata`.
-        unsafe { metadata_ptr.write(metadata) };
+        // `RawTransferMetadata` sits immediately before `FixedSizeAllocatorMetadata` in the chunk.
+        // SAFETY: `Allocator` was created by `FixedSizeAllocator`, so the chunk has a valid
+        // `FixedSizeAllocatorMetadata` and a `RawTransferMetadata`-sized region right before it.
+        // The position is aligned for `RawTransferMetadata`.
+        unsafe {
+            let metadata_ptr = allocator
+                .fixed_size_metadata_ptr()
+                .cast::<u8>()
+                .sub(size_of::<RawTransferMetadata>())
+                .cast::<RawTransferMetadata>();
+            debug_assert!(
+                metadata_ptr.addr().get().is_multiple_of(align_of::<RawTransferMetadata>())
+            );
+            metadata_ptr.write(metadata);
+        }
 
         let path = path.to_string_lossy();
         let path = path.as_ref();

--- a/napi/parser/src-js/generated/constants.js
+++ b/napi/parser/src-js/generated/constants.js
@@ -1,50 +1,60 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-/**
- * Total size of the transfer buffer in bytes (block size minus allocator metadata).
- */
-export const BUFFER_SIZE = 2147483616;
+// See `crates/oxc_allocator/src/pool/fixed_size.rs` for a diagram showing
+// how the constituent parts of the arena fit together.
 
 /**
- * Required alignment of the transfer buffer (4 GiB).
+ * Total size of the allocator block (including metadata and allocator `ChunkFooter`).
  */
-export const BUFFER_ALIGN = 4294967296;
+export const BLOCK_SIZE = 2147483632;
 
 /**
- * Size of the active data area in bytes (buffer size minus raw metadata and chunk footer).
+ * Required alignment of the allocator block (4 GiB).
  */
-export const ACTIVE_SIZE = 2147483552;
+export const BLOCK_ALIGN = 4294967296;
+
+/**
+ * Total size of the transfer buffer used on JS side, in bytes
+ * (`BLOCK_SIZE` minus `FixedSizeAllocatorMetadata` and `ChunkFooter`).
+ */
+export const BUFFER_SIZE = 2147483576;
+
+/**
+ * Size of the active data region in bytes - the region where source text and AST live
+ * (`BUFFER_SIZE` minus `RawTransferMetadata`).
+ */
+export const ACTIVE_SIZE = 2147483560;
 
 /**
  * Byte offset of the data pointer within the buffer, divided by 4 (for `Int32Array` indexing).
  */
-export const DATA_POINTER_POS_32 = 536870900;
+export const DATA_POINTER_POS_32 = 536870890;
 
 /**
  * Byte offset of the `is_ts` flag within the buffer.
  */
-export const IS_TS_FLAG_POS = 2147483612;
+export const IS_TS_FLAG_POS = 2147483572;
 
 /**
  * Byte offset of the `is_jsx` flag within the buffer.
  */
-export const IS_JSX_FLAG_POS = 2147483613;
+export const IS_JSX_FLAG_POS = 2147483573;
 
 /**
  * Byte offset of the `has_bom` flag within the buffer.
  */
-export const HAS_BOM_FLAG_POS = 2147483614;
+export const HAS_BOM_FLAG_POS = 2147483574;
 
 /**
  * Byte offset of the tokens offset within the buffer, divided by 4 (for `Int32Array` indexing).
  */
-export const TOKENS_OFFSET_POS_32 = 536870901;
+export const TOKENS_OFFSET_POS_32 = 536870891;
 
 /**
  * Byte offset of the tokens length within the buffer, divided by 4 (for `Int32Array` indexing).
  */
-export const TOKENS_LEN_POS_32 = 536870902;
+export const TOKENS_LEN_POS_32 = 536870892;
 
 /**
  * Byte offset of the `program` field, relative to start of `RawTransferData`.

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -33,7 +33,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -34,7 +34,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -33,7 +33,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -34,7 +34,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -33,7 +33,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -34,7 +34,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -33,7 +33,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -34,7 +34,7 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  let data = deserialize(int32[536870900]);
+  let data = deserialize(int32[536870890]);
   resetBuffer();
   return data;
 }

--- a/napi/parser/src-js/raw-transfer/common.js
+++ b/napi/parser/src-js/raw-transfer/common.js
@@ -1,5 +1,5 @@
 import os from "node:os";
-import { BUFFER_ALIGN, BUFFER_SIZE, IS_TS_FLAG_POS } from "../generated/constants.js";
+import { BLOCK_SIZE, BLOCK_ALIGN, BUFFER_SIZE, IS_TS_FLAG_POS } from "../generated/constants.js";
 import {
   getBufferOffset,
   parseRaw as parseRawBinding,
@@ -34,7 +34,7 @@ if (!rawTransferSupported()) {
  */
 export function parseSyncRawImpl(filename, sourceText, options, convert) {
   const { buffer, sourceByteLen } = prepareRaw(sourceText);
-  parseRawSyncBinding(filename, buffer, sourceByteLen, options);
+  parseRawSyncBinding(filename, buffer.block, sourceByteLen, options);
   return convert(buffer, sourceText, sourceByteLen, options);
 }
 
@@ -114,7 +114,7 @@ export async function parseAsyncRawImpl(filename, sourceText, options, convert) 
 
   // Parse
   const { buffer, sourceByteLen } = prepareRaw(sourceText);
-  await parseRawBinding(filename, buffer, sourceByteLen, options);
+  await parseRawBinding(filename, buffer.block, sourceByteLen, options);
   const data = convert(buffer, sourceText, sourceByteLen, options);
 
   // Free the CPU core
@@ -131,7 +131,7 @@ export async function parseAsyncRawImpl(filename, sourceText, options, convert) 
   return data;
 }
 
-const ARRAY_BUFFER_SIZE = BUFFER_SIZE + BUFFER_ALIGN;
+const ARRAY_BUFFER_SIZE = BLOCK_SIZE + BLOCK_ALIGN;
 const ONE_GIB = 1 << 30;
 
 // We keep a cache of buffers for raw transfer, so we can reuse them as much as possible.
@@ -260,6 +260,12 @@ function clearBuffersCache() {
  * It's always possible to obtain a 2 GiB slice aligned on 4 GiB within a 6 GiB buffer,
  * no matter how the 6 GiB buffer is aligned.
  *
+ * `buffer` itself, and `int32` and `float64` views of `buffer`, are `BUFFER_SIZE` bytes,
+ * which excludes `FixedSizeAllocatorMetadata` and `ChunkFooter`.
+ * This ensures this critical data cannot be accidentally overwritten on JS side.
+ * `block` is `BLOCK_SIZE` bytes, which includes `FixedSizeAllocatorMetadata` and `ChunkFooter`.
+ * `block` is what we pass to Rust, which needs to write `ChunkFooter`.
+ *
  * Note: On systems with virtual memory, this only consumes 6 GiB of *virtual* memory.
  * It does not consume physical memory until data is actually written to the `Uint8Array`.
  * Physical memory consumed corresponds to the quantity of data actually written.
@@ -272,5 +278,6 @@ function createBuffer() {
   const buffer = new Uint8Array(arrayBuffer, offset, BUFFER_SIZE);
   buffer.int32 = new Int32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
+  buffer.block = new Uint8Array(arrayBuffer, offset, BLOCK_SIZE);
   return buffer;
 }

--- a/napi/parser/src/generated/raw_transfer_constants.rs
+++ b/napi/parser/src/generated/raw_transfer_constants.rs
@@ -1,11 +1,39 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
+//! Constants for raw transfer / fixed-sized allocators.
+//!
+//! See `crates/oxc_allocator/src/pool/fixed_size.rs` for a diagram showing
+//! how the constituent parts of the arena fit together.
+//!
+//! This file must be feature-gated so it is not loaded on 32-bit platforms.
+//! It will cause a compilation error on 32-bit platforms, as some values are too large for 32-bit `usize`.
+
 #![expect(clippy::unreadable_literal)]
 #![allow(dead_code)]
 
+/// Total size of the allocator block (including metadata and allocator `ChunkFooter`).
 pub const BLOCK_SIZE: usize = 2147483632;
+
+/// Required alignment of the allocator block (4 GiB).
 pub const BLOCK_ALIGN: usize = 4294967296;
-pub const BUFFER_SIZE: usize = 2147483616;
+
+/// Total size of the transfer buffer used on JS side, in bytes
+/// (`BLOCK_SIZE` minus `FixedSizeAllocatorMetadata` and `ChunkFooter`).
+pub const BUFFER_SIZE: usize = 2147483576;
+
+/// Size of the active data region in bytes - the region where source text and AST live
+/// (`BUFFER_SIZE` minus `RawTransferMetadata`).
+pub const ACTIVE_SIZE: usize = 2147483560;
+
+/// Size of `RawTransferMetadata` in bytes.
 pub const RAW_METADATA_SIZE: usize = 16;
+
+/// Alignment of `RawTransferMetadata`.
+pub const RAW_METADATA_ALIGN: usize = 4;
+
+/// Size of `ChunkFooter` struct in bytes.
 pub const CHUNK_FOOTER_SIZE: usize = 48;
+
+/// Minimum alignment requirement for `Arena`'s cursor pointer (`ARENA::MIN_ALIGN`).
+pub const CURSOR_MIN_ALIGN: usize = 1;

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -22,7 +22,7 @@ use oxc_napi::get_source_type;
 
 use crate::{
     AstType, ParserOptions, get_ast_type, parse_impl,
-    raw_transfer_constants::{BLOCK_ALIGN as BUFFER_ALIGN, BUFFER_SIZE},
+    raw_transfer_constants::{ACTIVE_SIZE, BLOCK_ALIGN, BLOCK_SIZE, CURSOR_MIN_ALIGN},
     raw_transfer_types::{EcmaScriptModule, Error, RawTransferData, RawTransferMetadata},
 };
 
@@ -42,21 +42,21 @@ use crate::{
 
 const ARENA_ALIGN: usize = Allocator::RAW_MIN_ALIGN;
 
-/// Layout describing the JS-owned buffer (`BUFFER_SIZE` bytes, aligned on `BUFFER_ALIGN`).
-const BUFFER_LAYOUT: Layout = match Layout::from_size_align(BUFFER_SIZE, BUFFER_ALIGN) {
+/// Layout describing the JS-owned buffer (`BLOCK_SIZE` bytes, aligned on `BLOCK_ALIGN`).
+const BLOCK_LAYOUT: Layout = match Layout::from_size_align(BLOCK_SIZE, BLOCK_ALIGN) {
     Ok(layout) => layout,
     Err(_) => unreachable!(),
 };
 
-/// Get offset within a `Uint8Array` which is aligned on `BUFFER_ALIGN`.
+/// Get offset within a `Uint8Array` which is aligned on `BLOCK_ALIGN`.
 ///
 /// Does not check that the offset is within bounds of `buffer`.
-/// To ensure it always is, provide a `Uint8Array` of at least `BUFFER_SIZE + BUFFER_ALIGN` bytes.
+/// To ensure it always is, provide a `Uint8Array` of at least `BLOCK_SIZE + BLOCK_ALIGN` bytes.
 #[napi(skip_typescript)]
 #[allow(clippy::needless_pass_by_value, clippy::allow_attributes)]
 pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
     let buffer = &*buffer;
-    let offset = (BUFFER_ALIGN - (buffer.as_ptr() as usize % BUFFER_ALIGN)) % BUFFER_ALIGN;
+    let offset = (BLOCK_ALIGN - (buffer.as_ptr() as usize % BLOCK_ALIGN)) % BLOCK_ALIGN;
     #[expect(clippy::cast_possible_truncation)]
     return offset as u32;
 }
@@ -185,23 +185,29 @@ unsafe fn parse_raw_impl(
     options: Option<ParserOptions>,
 ) {
     // Check buffer has expected size and alignment
-    assert_eq!(buffer.len(), BUFFER_SIZE);
+    assert_eq!(buffer.len(), BLOCK_SIZE);
     let buffer_ptr = ptr::from_mut(buffer).cast::<u8>();
-    assert!((buffer_ptr as usize).is_multiple_of(BUFFER_ALIGN));
+    assert!((buffer_ptr as usize).is_multiple_of(BLOCK_ALIGN));
 
     // Get offsets and size of data region to be managed by arena allocator.
-    // Leave space for source before it, and space for metadata after it.
-    // Check `RawTransferMetadata`'s size is a multiple of `ARENA_ALIGN`,
-    // as the arena allocator requires start and end of the chunk to have that alignment.
-    const RAW_METADATA_SIZE: usize = size_of::<RawTransferMetadata>();
-    const {
-        assert!(RAW_METADATA_SIZE >= ARENA_ALIGN);
-        assert!(RAW_METADATA_SIZE.is_multiple_of(ARENA_ALIGN));
-    };
+    //
+    // After the source text, the allocator's chunk fills the rest of the buffer from `data_ptr` to the end.
+    // After the allocatable region (size `ACTIVE_SIZE`) sits:
+    // * `RawTransferMetadata`
+    // * A reserved slot for `FixedSizeAllocatorMetadata` (unused in `napi/parser`)
+    // * `ChunkFooter`
+    // The end of `ChunkFooter` is the end of the buffer.
+    //
+    // We set the cursor to before `RawTransferMetadata` so allocations don't overwrite the metadata regions.
+    //
+    // Round up `data_offset` to next multiple of `ARENA_ALIGN`, as required by `Allocator`.
+    // Check that there's enough space for `RawTransferMetadata`, `FixedSizeAllocatorMetadata`, and `ChunkFooter`.
     let source_len = source_len as usize;
     let data_offset = source_len.next_multiple_of(ARENA_ALIGN);
-    let data_size = (BUFFER_SIZE - RAW_METADATA_SIZE).saturating_sub(data_offset);
-    assert!(data_size >= Allocator::RAW_MIN_SIZE, "Source text is too long");
+    assert!(data_offset <= ACTIVE_SIZE, "Source text is too long");
+
+    // Calculate size of allocator chunk (including metadata and `ChunkFooter`)
+    let data_size = BLOCK_SIZE - data_offset;
 
     // Create `Allocator`.
     // Wrap in `ManuallyDrop` so the allocation doesn't get freed at end of function, or if panic.
@@ -214,19 +220,33 @@ unsafe fn parse_raw_impl(
     let data_ptr = unsafe { buffer_ptr.add(data_offset) };
     debug_assert!((data_ptr as usize).is_multiple_of(ARENA_ALIGN));
     debug_assert!(data_size.is_multiple_of(ARENA_ALIGN));
+
     // SAFETY: `data_ptr` and `data_size` outline a section of the memory in `buffer`.
     // `data_ptr` and `data_size` are multiples of `ARENA_ALIGN`.
     // `data_size` is greater than `Allocator::RAW_MIN_SIZE`.
     // The chunk region (`data_ptr..data_ptr + data_size`) lies entirely within the buffer.
+    // `buffer_ptr` was derived from a `&mut [u8]` slice, so has permission for writes.
+    // `data_ptr` was derived from `buffer_ptr`, so inherits that permission.
     let allocator = unsafe {
         Allocator::from_raw_parts(
             NonNull::new_unchecked(data_ptr),
             data_size,
             NonNull::new_unchecked(buffer_ptr),
-            BUFFER_LAYOUT,
+            BLOCK_LAYOUT,
         )
     };
     let allocator = ManuallyDrop::new(allocator);
+
+    const _: () = assert!(ACTIVE_SIZE.is_multiple_of(CURSOR_MIN_ALIGN));
+
+    // Set cursor to before `RawTransferMetadata` so allocations don't overwrite the metadata regions.
+    // `RawTransferMetadata` starts at offset `ACTIVE_SIZE` within the buffer.
+    // SAFETY: `ACTIVE_SIZE` is within the chunk (after `data_ptr`, before the `ChunkFooter`).
+    // `ACTIVE_SIZE` is aligned on `Arena::MIN_ALIGN`.
+    unsafe {
+        let cursor_ptr = buffer_ptr.add(ACTIVE_SIZE);
+        allocator.set_cursor_ptr(NonNull::new_unchecked(cursor_ptr));
+    }
 
     // Parse source.
     // Enclose parsing logic in a scope to make 100% sure no references to within `Allocator`
@@ -316,12 +336,12 @@ unsafe fn parse_raw_impl(
 
     // Write metadata into end of buffer
     let metadata = RawTransferMetadata::new(data_offset, is_ts, tokens_offset, tokens_len);
-    const RAW_METADATA_OFFSET: usize = BUFFER_SIZE - RAW_METADATA_SIZE;
-    const _: () = assert!(RAW_METADATA_OFFSET.is_multiple_of(ARENA_ALIGN));
-    // SAFETY: `RAW_METADATA_OFFSET` is less than length of `buffer`.
-    // `RAW_METADATA_OFFSET` is aligned on `ARENA_ALIGN`.
-    #[expect(clippy::cast_ptr_alignment)]
+    const RAW_METADATA_OFFSET: usize = ACTIVE_SIZE;
+    // SAFETY: `RAW_METADATA_OFFSET` is less than length of `buffer`, and aligned for `RawTransferMetadata`
     unsafe {
-        buffer_ptr.add(RAW_METADATA_OFFSET).cast::<RawTransferMetadata>().write(metadata);
+        #[expect(clippy::cast_ptr_alignment)]
+        let metadata_ptr = buffer_ptr.add(RAW_METADATA_OFFSET).cast::<RawTransferMetadata>();
+        debug_assert!(metadata_ptr.addr().is_multiple_of(align_of::<RawTransferMetadata>()));
+        metadata_ptr.write(metadata);
     }
 }

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -42,6 +42,10 @@ const STR_LEN_OFFSET: u32 = 8;
 /// Bytes reserved for `malloc`'s metadata
 const MALLOC_RESERVED_SIZE: u32 = 16;
 
+/// Minimum alignment of arena (`Arena::MIN_ALIGN`).
+/// Code in `oxc_allocator` crate checks that this is correct.
+const ARENA_CURSOR_MIN_ALIGN: u32 = 1;
+
 /// Size of `ChunkFooter` struct.
 /// Code in `oxc_allocator` crate checks that this is correct.
 const CHUNK_FOOTER_SIZE: u32 = 48;
@@ -1490,6 +1494,8 @@ struct Constants {
     comment_line_kind: u8,
     /// Size of `RawTransferMetadata` in bytes
     raw_metadata_size: u32,
+    /// Alignment of `RawTransferMetadata`
+    raw_metadata_align: u32,
 }
 
 /// Generate constants file.
@@ -1513,6 +1519,7 @@ fn generate_constants(consts: Constants) -> (String, TokenStream) {
         deserialized_flag_offset,
         comment_line_kind,
         raw_metadata_size,
+        raw_metadata_align,
     } = consts;
 
     let data_pointer_pos_32 = data_pointer_pos / 4;
@@ -1521,18 +1528,28 @@ fn generate_constants(consts: Constants) -> (String, TokenStream) {
 
     #[rustfmt::skip]
     let js_output = format!("
+        // See `crates/oxc_allocator/src/pool/fixed_size.rs` for a diagram showing
+        // how the constituent parts of the arena fit together.
+
         /**
-         * Total size of the transfer buffer in bytes (block size minus allocator metadata).
+         * Total size of the allocator block (including metadata and allocator `ChunkFooter`).
+         */
+        export const BLOCK_SIZE = {BLOCK_SIZE};
+
+        /**
+         * Required alignment of the allocator block (4 GiB).
+         */
+        export const BLOCK_ALIGN = {BLOCK_ALIGN};
+
+        /**
+         * Total size of the transfer buffer used on JS side, in bytes
+         * (`BLOCK_SIZE` minus `FixedSizeAllocatorMetadata` and `ChunkFooter`).
          */
         export const BUFFER_SIZE = {buffer_size};
 
         /**
-         * Required alignment of the transfer buffer (4 GiB).
-         */
-        export const BUFFER_ALIGN = {BLOCK_ALIGN};
-
-        /**
-         * Size of the active data area in bytes (buffer size minus raw metadata and chunk footer).
+         * Size of the active data region in bytes - the region where source text and AST live
+         * (`BUFFER_SIZE` minus `RawTransferMetadata`).
          */
         export const ACTIVE_SIZE = {active_size};
 
@@ -1618,18 +1635,58 @@ fn generate_constants(consts: Constants) -> (String, TokenStream) {
     let block_size = number_lit(BLOCK_SIZE);
     let block_align = number_lit(BLOCK_ALIGN);
     let buffer_size = number_lit(buffer_size);
+    let active_size = number_lit(active_size);
     let raw_metadata_size = number_lit(raw_metadata_size);
+    let raw_metadata_align = number_lit(raw_metadata_align);
     let chunk_footer_size = number_lit(CHUNK_FOOTER_SIZE);
+    let arena_cursor_min_align = number_lit(ARENA_CURSOR_MIN_ALIGN);
+
     let rust_output = quote! {
+        //! Constants for raw transfer / fixed-sized allocators.
+        //!
+        //! See `crates/oxc_allocator/src/pool/fixed_size.rs` for a diagram showing
+        //! how the constituent parts of the arena fit together.
+        //!
+        //! This file must be feature-gated so it is not loaded on 32-bit platforms.
+        //! It will cause a compilation error on 32-bit platforms, as some values are too large for 32-bit `usize`.
+
+        //!@@line_break
         #![expect(clippy::unreadable_literal)]
         #![allow(dead_code)]
 
         ///@@line_break
+        /// Total size of the allocator block (including metadata and allocator `ChunkFooter`).
         pub const BLOCK_SIZE: usize = #block_size;
+
+        ///@@line_break
+        /// Required alignment of the allocator block (4 GiB).
         pub const BLOCK_ALIGN: usize = #block_align;
+
+        ///@@line_break
+        /// Total size of the transfer buffer used on JS side, in bytes
+        /// (`BLOCK_SIZE` minus `FixedSizeAllocatorMetadata` and `ChunkFooter`).
         pub const BUFFER_SIZE: usize = #buffer_size;
+
+        ///@@line_break
+        /// Size of the active data region in bytes - the region where source text and AST live
+        /// (`BUFFER_SIZE` minus `RawTransferMetadata`).
+        pub const ACTIVE_SIZE: usize = #active_size;
+
+        ///@@line_break
+        /// Size of `RawTransferMetadata` in bytes.
         pub const RAW_METADATA_SIZE: usize = #raw_metadata_size;
+
+        ///@@line_break
+        /// Alignment of `RawTransferMetadata`.
+        pub const RAW_METADATA_ALIGN: usize = #raw_metadata_align;
+
+        ///@@line_break
+        /// Size of `ChunkFooter` struct in bytes.
         pub const CHUNK_FOOTER_SIZE: usize = #chunk_footer_size;
+
+        ///@@line_break
+        /// Minimum alignment requirement for `Arena`'s cursor pointer (`ARENA::MIN_ALIGN`).
+        pub const CURSOR_MIN_ALIGN: usize = #arena_cursor_min_align;
     };
 
     (js_output, rust_output)
@@ -1672,18 +1729,23 @@ fn get_constants(schema: &Schema) -> Constants {
     let tokens_len_field = tokens_len_field.unwrap();
 
     let raw_metadata_size = raw_metadata_struct.layout_64().size;
+    let raw_metadata_align = raw_metadata_struct.layout_64().align;
 
-    // Round up to multiple of `ALLOCATOR_CHUNK_END_ALIGN`
     let fixed_metadata_struct =
         schema.type_by_name("FixedSizeAllocatorMetadata").as_struct().unwrap();
-    let fixed_metadata_size =
-        fixed_metadata_struct.layout_64().size.next_multiple_of(ALLOCATOR_CHUNK_END_ALIGN);
+    let fixed_metadata_size = fixed_metadata_struct.layout_64().size;
 
-    let buffer_size = BLOCK_SIZE - fixed_metadata_size;
-    let active_size = buffer_size - raw_metadata_size - CHUNK_FOOTER_SIZE;
+    // Buffer on JS side excludes `FixedSizeAllocatorMetadata` and `ChunkFooter`, but includes `RawTransferMetadata`.
+    // In the linter, `FixedSizeAllocatorMetadata` sits between `RawTransferMetadata` and `ChunkFooter`
+    // (`fixed_metadata_size` bytes). In `napi/parser`, there is no `FixedSizeAllocatorMetadata`, but the same slot
+    // is reserved (left unused) so layout is the same in both cases, with `RawTransferMetadata` in the same position.
+    let buffer_size = BLOCK_SIZE - fixed_metadata_size - CHUNK_FOOTER_SIZE;
+    let active_size = buffer_size - raw_metadata_size;
 
-    // Get offsets of data within buffer
-    let raw_metadata_pos = buffer_size - raw_metadata_size;
+    // Get offsets of data within buffer.
+    // `RawTransferMetadata` sits immediately before `FixedSizeAllocatorMetadata`, which sits immediately before
+    // `ChunkFooter` (which lives in the last `CHUNK_FOOTER_SIZE` bytes of the buffer).
+    let raw_metadata_pos = active_size;
     let data_pointer_pos = raw_metadata_pos + data_offset_field.offset_64();
     let is_ts_pos = raw_metadata_pos + is_ts_field.offset_64();
     let is_jsx_pos = raw_metadata_pos + is_jsx_field.offset_64();
@@ -1735,6 +1797,7 @@ fn get_constants(schema: &Schema) -> Constants {
         deserialized_flag_offset,
         comment_line_kind,
         raw_metadata_size,
+        raw_metadata_align,
     }
 }
 


### PR DESCRIPTION
Large change to how raw transfer stores metadata about the allocations it uses.

Previously the two metadata structures `RawTransferMetadata` and `FixedSizeAllocator` after the chunk's `ChunkFooter`.

This had a few problems:

1. It was confusing and unwieldy - a recipe for bugs.
2. `ChunkFooter`'s memory was exposed on JS side - a bit unsafe as altering bytes in this region could easily trigger UB.
3. It entwined `Arena` (which is just the thing that allocates) with the details of exactly _what_ raw transfer allocates.
4. Imposed annoying alignment requirements, because `ChunkFooter` must be aligned on 16, and so anything after it must ensure it doesn't break that invariant.

Old layout:

```
                                                        WHOLE BLOCK - aligned on 4 GiB
<-----------------------------------------------------> Allocated block (`BLOCK_SIZE` bytes)

                                                        ALLOCATOR
<----------------------------------------->             `Allocator` chunk (`CHUNK_SIZE` bytes)
                                     <---->             `ChunkFooter` (aligned on 16)
<----------------------------------->                   `Allocator` chunk data storage (for AST)
                                                        (`ACTIVE_SIZE` bytes)

                                                        METADATA
                                           <---->       `RawTransferMetadata`
                                                 <----> `FixedSizeAllocatorMetadata`

                                                        BUFFER SENT TO JS
<----------------------------------------------->       Buffer sent to JS (`BUFFER_SIZE` bytes)
```

This PR moves `RawTransferMetadata` and `FixedSizeAllocatorMetadata` into the chunk itself. New layout:

```
                                                        WHOLE BLOCK - size 2 GiB - 16, aligned on 4 GiB
<-----------------------------------------------------> Allocated block (`BLOCK_SIZE` bytes)

                                                        ARENA
<-----------------------------------------------------> Chunk (fills whole block)
<-------------------------------------->                Allocatable region for AST (`ACTIVE_SIZE` bytes)
                                        <--->           `RawTransferMetadata`
                                             <--->      `FixedSizeAllocatorMetadata`
                                                  <---> `ChunkFooter` (aligned on 16, last in block)

                                                        BUFFER SENT TO JS
<------------------------------------------->           Buffer sent to JS (`BUFFER_SIZE` bytes)
```

`FixedSizeAllocatorMetadata` and `ChunkFooter` are no longer in the region which is shared with JS side. As far as `Arena` is concerned, they're now just some data (like any other data) which is allocated in the arena.

Also:

- Introduce more consistency to the naming of constants which specify the size and position of these various data structures in the arena.
- Add more const assertions to ensure everything is laid out and aligned as it should be.