### PR TITLE
refactor(linter/plugins, napi/parser): document pointer arithmetic

### DIFF
--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -278,7 +278,7 @@ unsafe fn get_buffer(
     // the backing allocation.
     let chunk_ptr = unsafe {
         let ptr = metadata_ptr.cast::<u8>();
-        let offset = ptr.as_ptr() as usize % BLOCK_ALIGN;
+        let offset = ptr.addr().get() % BLOCK_ALIGN;
         ptr.sub(offset)
     };
 

--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -56,7 +56,10 @@ pub struct ParserOptions {
 #[allow(clippy::needless_pass_by_value, clippy::allow_attributes)]
 pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
     let buffer = &*buffer;
-    let offset = (BLOCK_ALIGN - (buffer.as_ptr() as usize % BLOCK_ALIGN)) % BLOCK_ALIGN;
+    // The final `% BLOCK_ALIGN` is to handle where `buffer` is already aligned on `BLOCK_ALIGN`.
+    // In that case, `buffer.as_ptr().addr() % BLOCK_ALIGN == 0`, so without the final `% BLOCK_ALIGN`,
+    // `offset` would be `BLOCK_ALIGN`. The final `% BLOCK_ALIGN` reduces it to `0`.
+    let offset = (BLOCK_ALIGN - (buffer.as_ptr().addr() % BLOCK_ALIGN)) % BLOCK_ALIGN;
     #[expect(clippy::cast_possible_truncation)]
     return offset as u32;
 }

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -56,7 +56,10 @@ const BLOCK_LAYOUT: Layout = match Layout::from_size_align(BLOCK_SIZE, BLOCK_ALI
 #[allow(clippy::needless_pass_by_value, clippy::allow_attributes)]
 pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
     let buffer = &*buffer;
-    let offset = (BLOCK_ALIGN - (buffer.as_ptr() as usize % BLOCK_ALIGN)) % BLOCK_ALIGN;
+    // The final `% BLOCK_ALIGN` is to handle where `buffer` is already aligned on `BLOCK_ALIGN`.
+    // In that case, `buffer.as_ptr().addr() % BLOCK_ALIGN == 0`, so without the final `% BLOCK_ALIGN`,
+    // `offset` would be `BLOCK_ALIGN`. The final `% BLOCK_ALIGN` reduces it to `0`.
+    let offset = (BLOCK_ALIGN - (buffer.as_ptr().addr() % BLOCK_ALIGN)) % BLOCK_ALIGN;
     #[expect(clippy::cast_possible_truncation)]
     return offset as u32;
 }


### PR DESCRIPTION
Refactor. Document some quite unintuitive pointer arithmetic, and avoid casting pointers to integers with `as usize`.