### PR TITLE
refactor(oxfmt): Resolve options on walk phase

### DIFF
--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -38,7 +38,7 @@ impl FormatService {
         rx_entry.into_iter().par_bridge().for_each(|entry| {
             let start_time = matches!(self.format_mode, OutputMode::Check).then(Instant::now);
 
-            let FormatEntry { strategy, config_resolver } = entry;
+            let FormatEntry { strategy, resolved_options } = entry;
             let path = strategy.path();
             let Ok(source_text) = utils::read_to_string(path) else {
                 // This happens if binary file is attempted to be formatted
@@ -57,27 +57,6 @@ impl FormatService {
                 );
                 let _ = tx_error.send(diagnostics);
                 return;
-            };
-
-            // Resolve options for this specific file using its scope's config
-            let resolved_options = match config_resolver.resolve(&strategy) {
-                Ok(options) => options,
-                Err(err) => {
-                    let diagnostics = DiagnosticService::wrap_diagnostics(
-                        self.cwd.clone(),
-                        path,
-                        "",
-                        vec![
-                            oxc_diagnostics::OxcDiagnostic::error(format!(
-                                "Invalid resolved configuration for {}",
-                                path.display()
-                            ))
-                            .with_help(err),
-                        ],
-                    );
-                    let _ = tx_error.send(diagnostics);
-                    return;
-                }
             };
 
             let (code, is_changed) =

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -9,15 +9,20 @@ use ignore::gitignore::Gitignore;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::instrument;
 
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
+
 use super::resolve::{build_global_ignore_matchers, is_ignored, resolve_file_scope_config};
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
-use crate::core::{ConfigResolver, FormatStrategy, config_discovery};
+use crate::core::{ConfigResolver, FormatStrategy, ResolvedOptions, config_discovery};
 
-/// A file entry paired with its scope's config resolver.
+/// A file entry paired with its resolved options.
+///
+/// `ResolvedOptions` is computed upfront in the walk thread (per-file, including overrides),
+/// so the format service can consume it directly without re-resolving.
 pub struct FormatEntry {
     pub strategy: FormatStrategy,
-    pub config_resolver: Arc<ConfigResolver>,
+    pub resolved_options: ResolvedOptions,
 }
 
 /// Orchestrates file discovery with nested config and ignore handling.
@@ -126,6 +131,7 @@ impl ScopedWalker {
         editorconfig_path: Option<&Path>,
         #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
         sender: &mpsc::Sender<FormatEntry>,
+        tx_error: &DiagnosticSender,
     ) -> Result<bool, String> {
         let root_config_resolver = Arc::new(root_config);
 
@@ -225,8 +231,21 @@ impl ScopedWalker {
                     continue;
                 }
 
+                let resolved_options = match file_config.resolve(&strategy) {
+                    Ok(options) => options,
+                    Err(err) => {
+                        report_resolve_error(
+                            tx_error,
+                            self.cwd.clone().into_boxed_path(),
+                            file,
+                            err,
+                        );
+                        continue;
+                    }
+                };
+
                 directly_processed.insert(file.clone());
-                if sender.send(FormatEntry { strategy, config_resolver: file_config }).is_err() {
+                if sender.send(FormatEntry { strategy, resolved_options }).is_err() {
                     break;
                 }
             }
@@ -279,6 +298,7 @@ impl ScopedWalker {
         };
 
         walk_and_stream(
+            &self.cwd,
             &walk_targets,
             Arc::clone(&ignore_file_matchers),
             with_node_modules,
@@ -288,6 +308,7 @@ impl ScopedWalker {
             config_ancestors.as_ref(),
             &child_scope_map,
             sender,
+            tx_error,
         );
 
         Ok(any_config)
@@ -469,6 +490,7 @@ fn build_config_ancestors(config_dirs: &[PathBuf]) -> Arc<FxHashSet<PathBuf>> {
 /// Build a Walk, stream entries to the shared channel.
 #[expect(clippy::needless_pass_by_value)] // Arcs are moved into closures/structs
 fn walk_and_stream(
+    cwd: &Path,
     target_paths: &[PathBuf],
     ignore_file_matchers: Arc<[Gitignore]>,
     with_node_modules: bool,
@@ -478,6 +500,7 @@ fn walk_and_stream(
     config_ancestors: Option<&Arc<FxHashSet<PathBuf>>>,
     child_scope_map: &Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
     sender: &mpsc::Sender<FormatEntry>,
+    tx_error: &DiagnosticSender,
 ) {
     let Some(first_path) = target_paths.first() else {
         return;
@@ -529,7 +552,9 @@ fn walk_and_stream(
     });
 
     let mut builder = WalkVisitorBuilder {
+        cwd: cwd.to_path_buf().into_boxed_path(),
         sender: sender.clone(),
+        tx_error: tx_error.clone(),
         root_config_resolver: Arc::clone(root_config_resolver),
         glob_matcher: glob_matcher.cloned(),
         child_scope_map: Arc::clone(child_scope_map),
@@ -572,7 +597,9 @@ fn configure_walk_builder(mut builder: ignore::WalkBuilder) -> ignore::WalkBuild
 }
 
 struct WalkVisitorBuilder {
+    cwd: Box<Path>,
     sender: mpsc::Sender<FormatEntry>,
+    tx_error: DiagnosticSender,
     root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
     child_scope_map: Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
@@ -583,7 +610,9 @@ struct WalkVisitorBuilder {
 impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkVisitorBuilder {
     fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
         Box::new(WalkVisitor {
+            cwd: self.cwd.clone(),
             sender: self.sender.clone(),
+            tx_error: self.tx_error.clone(),
             root_config_resolver: Arc::clone(&self.root_config_resolver),
             glob_matcher: self.glob_matcher.clone(),
             child_scope_map: Arc::clone(&self.child_scope_map),
@@ -594,7 +623,9 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkVisitorBuilder {
 }
 
 struct WalkVisitor {
+    cwd: Box<Path>,
     sender: mpsc::Sender<FormatEntry>,
+    tx_error: DiagnosticSender,
     root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
     child_scope_map: Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
@@ -687,11 +718,20 @@ impl ignore::ParallelVisitor for WalkVisitor {
                         return ignore::WalkState::Continue;
                     }
 
-                    if self
-                        .sender
-                        .send(FormatEntry { strategy, config_resolver: Arc::clone(resolver) })
-                        .is_err()
-                    {
+                    let resolved_options = match resolver.resolve(&strategy) {
+                        Ok(options) => options,
+                        Err(err) => {
+                            report_resolve_error(
+                                &self.tx_error,
+                                self.cwd.clone(),
+                                strategy.path(),
+                                err,
+                            );
+                            return ignore::WalkState::Continue;
+                        }
+                    };
+
+                    if self.sender.send(FormatEntry { strategy, resolved_options }).is_err() {
                         return ignore::WalkState::Quit;
                     }
                 }
@@ -704,6 +744,20 @@ impl ignore::ParallelVisitor for WalkVisitor {
 }
 
 // ---
+
+/// Report a per-file config resolve error via the diagnostic channel.
+fn report_resolve_error(tx_error: &DiagnosticSender, cwd: Box<Path>, path: &Path, err: String) {
+    let diagnostics = DiagnosticService::wrap_diagnostics(
+        cwd,
+        path,
+        "",
+        vec![
+            OxcDiagnostic::error(format!("Invalid resolved configuration for {}", path.display()))
+                .with_help(err),
+        ],
+    );
+    let _ = tx_error.send(diagnostics);
+}
 
 /// Check if a directory should be excluded from walking.
 ///

--- a/apps/oxfmt/src/cli/walk_runner.rs
+++ b/apps/oxfmt/src/cli/walk_runner.rs
@@ -153,14 +153,18 @@ impl WalkRunner {
         #[cfg(feature = "napi")]
         let source_formatter = source_formatter.with_external_formatter(self.external_formatter);
 
+        // Clone `tx_error` so both the walk threads and the format service can report errors
+        let tx_error_for_format = tx_error.clone();
+
         // Spawn formatting service on a dedicated thread so it doesn't occupy the rayon pool.
         // It just blocks on `rx_entry` waiting for entries; `par_bridge()` inside still uses rayon.
         std::thread::spawn(move || {
             let format_service = FormatService::new(cwd, format_mode, source_formatter);
-            format_service.run_streaming(rx_entry, &tx_error, &tx_success);
+            format_service.run_streaming(rx_entry, &tx_error_for_format, &tx_success);
         });
 
-        // Run scoped walks (root + nested) — sends entries to `tx_entry`
+        // Run scoped walks (root + nested) sends entries to `tx_entry` and errors to `tx_error`.
+        // Manually drop after the walk to signal the formatting service that no more entries will be sent.
         let any_config_found = match scoped_walker.run(
             root_config_resolver,
             &resolved_ignore_paths,
@@ -172,16 +176,20 @@ impl WalkRunner {
             #[cfg(feature = "napi")]
             self.js_config_loader.as_ref(),
             &tx_entry,
+            &tx_error,
         ) {
-            Ok(found) => found,
+            Ok(found) => {
+                drop(tx_entry);
+                drop(tx_error);
+                found
+            }
             Err(err) => {
                 drop(tx_entry);
+                drop(tx_error);
                 utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
                 return CliRunResult::InvalidOptionConfig;
             }
         };
-        // Drop sender so the formatting service knows no more entries are coming
-        drop(tx_entry);
 
         // Collect results and separate changed paths from unchanged count
         let mut changed_paths: Vec<String> = vec![];


### PR DESCRIPTION
Prepare for Svelte and Astro support.

In order to enable or disable the detection of `.svelte` files based on the presence of the `svelte` option with the `overrides` resolved, we need to resolve the final options during the walk phase.
