### PR TITLE
feat(linter): split jest/no-test-return-statement into separate vitest rule

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,5 +1,4 @@
 [
-  "no-test-return-statement",
   "no-unneeded-async-expect-function",
   "prefer-called-with",
   "prefer-comparison-matcher",

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -904,7 +904,7 @@ mod test {
             {
                 "plugins": ["vitest", "typescript"],
                 "rules": {
-                    "vitest/no-test-return-statement": "error",
+                    "vitest/no-unneeded-async-expect-function": "error",
                     "typescript/no-explicit-any": "error"
                 },
                 "overrides": [
@@ -921,7 +921,7 @@ mod test {
 
         assert!(
             rules_for_test_file.rules.iter().any(|(rule, _)| {
-                rule.plugin_name() == "jest" && rule.name() == "no-test-return-statement"
+                rule.plugin_name() == "jest" && rule.name() == "no-unneeded-async-expect-function"
             }),
             "vitest-compatible jest rules should remain enabled when an override matches"
         );

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4505,6 +4505,12 @@ impl RuleRunner for crate::rules::vitest::no_test_prefixes::NoTestPrefixes {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::no_test_return_statement::NoTestReturnStatement {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Function]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner
     for crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith
 {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -721,6 +721,7 @@ pub use crate::rules::vitest::no_restricted_matchers::NoRestrictedMatchers as Vi
 pub use crate::rules::vitest::no_restricted_vi_methods::NoRestrictedViMethods as VitestNoRestrictedViMethods;
 pub use crate::rules::vitest::no_standalone_expect::NoStandaloneExpect as VitestNoStandaloneExpect;
 pub use crate::rules::vitest::no_test_prefixes::NoTestPrefixes as VitestNoTestPrefixes;
+pub use crate::rules::vitest::no_test_return_statement::NoTestReturnStatement as VitestNoTestReturnStatement;
 pub use crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith as VitestPreferCalledExactlyOnceWith;
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
@@ -1489,6 +1490,7 @@ pub enum RuleEnum {
     VitestNoRestrictedViMethods(VitestNoRestrictedViMethods),
     VitestNoStandaloneExpect(VitestNoStandaloneExpect),
     VitestNoTestPrefixes(VitestNoTestPrefixes),
+    VitestNoTestReturnStatement(VitestNoTestReturnStatement),
     VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith),
     VitestPreferCalledOnce(VitestPreferCalledOnce),
     VitestPreferCalledTimes(VitestPreferCalledTimes),
@@ -2342,7 +2344,9 @@ const VITEST_NO_RESTRICTED_MATCHERS_ID: usize = VITEST_NO_MOCKS_IMPORT_ID + 1usi
 const VITEST_NO_RESTRICTED_VI_METHODS_ID: usize = VITEST_NO_RESTRICTED_MATCHERS_ID + 1usize;
 const VITEST_NO_STANDALONE_EXPECT_ID: usize = VITEST_NO_RESTRICTED_VI_METHODS_ID + 1usize;
 const VITEST_NO_TEST_PREFIXES_ID: usize = VITEST_NO_STANDALONE_EXPECT_ID + 1usize;
-const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize = VITEST_NO_TEST_PREFIXES_ID + 1usize;
+const VITEST_NO_TEST_RETURN_STATEMENT_ID: usize = VITEST_NO_TEST_PREFIXES_ID + 1usize;
+const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
+    VITEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
 const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID + 1usize;
 const VITEST_PREFER_CALLED_TIMES_ID: usize = VITEST_PREFER_CALLED_ONCE_ID + 1usize;
 const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
@@ -3223,6 +3227,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VITEST_NO_RESTRICTED_VI_METHODS_ID,
             Self::VitestNoStandaloneExpect(_) => VITEST_NO_STANDALONE_EXPECT_ID,
             Self::VitestNoTestPrefixes(_) => VITEST_NO_TEST_PREFIXES_ID,
+            Self::VitestNoTestReturnStatement(_) => VITEST_NO_TEST_RETURN_STATEMENT_ID,
             Self::VitestPreferCalledExactlyOnceWith(_) => VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID,
             Self::VitestPreferCalledOnce(_) => VITEST_PREFER_CALLED_ONCE_ID,
             Self::VitestPreferCalledTimes(_) => VITEST_PREFER_CALLED_TIMES_ID,
@@ -4094,6 +4099,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::NAME,
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::NAME,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::NAME,
+            Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::NAME,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::NAME,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
@@ -5007,6 +5013,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::CATEGORY,
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::CATEGORY,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::CATEGORY,
+            Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::CATEGORY,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::CATEGORY
             }
@@ -5887,6 +5894,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::FIX,
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::FIX,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::FIX,
+            Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::FIX,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::FIX,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
@@ -6963,6 +6971,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::documentation(),
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::documentation(),
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::documentation(),
+            Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::documentation(),
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::documentation()
             }
@@ -9064,6 +9073,10 @@ impl RuleEnum {
                 .or_else(|| VitestNoStandaloneExpect::schema(generator)),
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::config_schema(generator)
                 .or_else(|| VitestNoTestPrefixes::schema(generator)),
+            Self::VitestNoTestReturnStatement(_) => {
+                VitestNoTestReturnStatement::config_schema(generator)
+                    .or_else(|| VitestNoTestReturnStatement::schema(generator))
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::config_schema(generator)
                     .or_else(|| VitestPreferCalledExactlyOnceWith::schema(generator))
@@ -9936,6 +9949,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => "vitest",
             Self::VitestNoStandaloneExpect(_) => "vitest",
             Self::VitestNoTestPrefixes(_) => "vitest",
+            Self::VitestNoTestReturnStatement(_) => "vitest",
             Self::VitestPreferCalledExactlyOnceWith(_) => "vitest",
             Self::VitestPreferCalledOnce(_) => "vitest",
             Self::VitestPreferCalledTimes(_) => "vitest",
@@ -12268,6 +12282,9 @@ impl RuleEnum {
             Self::VitestNoTestPrefixes(_) => {
                 Ok(Self::VitestNoTestPrefixes(VitestNoTestPrefixes::from_configuration(value)?))
             }
+            Self::VitestNoTestReturnStatement(_) => Ok(Self::VitestNoTestReturnStatement(
+                VitestNoTestReturnStatement::from_configuration(value)?,
+            )),
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 Ok(Self::VitestPreferCalledExactlyOnceWith(
                     VitestPreferCalledExactlyOnceWith::from_configuration(value)?,
@@ -13163,6 +13180,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(rule) => rule.to_configuration(),
             Self::VitestNoStandaloneExpect(rule) => rule.to_configuration(),
             Self::VitestNoTestPrefixes(rule) => rule.to_configuration(),
+            Self::VitestNoTestReturnStatement(rule) => rule.to_configuration(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.to_configuration(),
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
@@ -13932,6 +13950,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(rule) => rule.run(node, ctx),
             Self::VitestNoStandaloneExpect(rule) => rule.run(node, ctx),
             Self::VitestNoTestPrefixes(rule) => rule.run(node, ctx),
+            Self::VitestNoTestReturnStatement(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
@@ -14699,6 +14718,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(rule) => rule.run_once(ctx),
             Self::VitestNoStandaloneExpect(rule) => rule.run_once(ctx),
             Self::VitestNoTestPrefixes(rule) => rule.run_once(ctx),
+            Self::VitestNoTestReturnStatement(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
@@ -15568,6 +15588,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoStandaloneExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoTestPrefixes(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestNoTestReturnStatement(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16339,6 +16360,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(rule) => rule.should_run(ctx),
             Self::VitestNoStandaloneExpect(rule) => rule.should_run(ctx),
             Self::VitestNoTestPrefixes(rule) => rule.should_run(ctx),
+            Self::VitestNoTestReturnStatement(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
@@ -17410,6 +17432,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::IS_TSGOLINT_RULE,
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::IS_TSGOLINT_RULE,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::IS_TSGOLINT_RULE,
+            Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::IS_TSGOLINT_RULE,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::IS_TSGOLINT_RULE
             }
@@ -18345,6 +18368,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::VERSION,
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::VERSION,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::VERSION,
+            Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::VERSION,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::VERSION
             }
@@ -19297,6 +19321,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(_) => VitestNoRestrictedViMethods::HAS_CONFIG,
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::HAS_CONFIG,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::HAS_CONFIG,
+            Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::HAS_CONFIG,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::HAS_CONFIG
             }
@@ -20080,6 +20105,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(rule) => rule.types_info(),
             Self::VitestNoStandaloneExpect(rule) => rule.types_info(),
             Self::VitestNoTestPrefixes(rule) => rule.types_info(),
+            Self::VitestNoTestReturnStatement(rule) => rule.types_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.types_info(),
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
@@ -20847,6 +20873,7 @@ impl RuleEnum {
             Self::VitestNoRestrictedViMethods(rule) => rule.run_info(),
             Self::VitestNoStandaloneExpect(rule) => rule.run_info(),
             Self::VitestNoTestPrefixes(rule) => rule.run_info(),
+            Self::VitestNoTestReturnStatement(rule) => rule.run_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_info(),
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
@@ -21734,6 +21761,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestNoRestrictedViMethods(VitestNoRestrictedViMethods::default()),
         RuleEnum::VitestNoStandaloneExpect(VitestNoStandaloneExpect::default()),
         RuleEnum::VitestNoTestPrefixes(VitestNoTestPrefixes::default()),
+        RuleEnum::VitestNoTestReturnStatement(VitestNoTestReturnStatement::default()),
         RuleEnum::VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith::default()),
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -749,6 +749,7 @@ pub(crate) mod vitest {
     pub mod no_restricted_vi_methods;
     pub mod no_standalone_expect;
     pub mod no_test_prefixes;
+    pub mod no_test_return_statement;
     pub mod prefer_called_exactly_once_with;
     pub mod prefer_called_once;
     pub mod prefer_called_times;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -18,6 +18,7 @@ pub mod no_restricted_jest_methods;
 pub mod no_restricted_matchers;
 pub mod no_standalone_expect;
 pub mod no_test_prefixes;
+pub mod no_test_return_statement;
 pub mod prefer_expect_assertions;
 pub mod prefer_snapshot_hint;
 pub mod prefer_to_contain;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
@@ -1,0 +1,128 @@
+use oxc_allocator::Box as OBox;
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression, FunctionBody, Statement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::AstNode;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    context::LintContext,
+    utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, is_type_of_jest_fn_call},
+};
+
+fn no_test_return_statement_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Jest tests should not return a value")
+        .with_help("Use `await` for async assertions or remove the return statement.")
+        .with_note("Jest ignores returned values from tests.")
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+Disallow explicitly returning from tests.
+
+### Why is this bad?
+
+Tests in Jest should be void and not return values.
+If you are returning Promises then you should update the test to use
+`async/await`.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+test('one', () => {
+   return expect(1).toBe(1);
+});
+```
+
+Examples of **correct** code for this rule:
+```javascript
+test('one', () => {
+   expect(1).toBe(1);
+});
+```
+";
+
+pub fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
+    match node.kind() {
+        AstKind::CallExpression(call_expr) => {
+            check_call_expression(call_expr, node, ctx);
+        }
+        AstKind::Function(fn_decl) => {
+            let Some(func_body) = &fn_decl.body else {
+                return;
+            };
+            check_test_return_statement(func_body, ctx);
+        }
+        _ => (),
+    }
+}
+
+fn check_call_expression<'a>(
+    call_expr: &'a CallExpression<'a>,
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) {
+    if !is_type_of_jest_fn_call(
+        call_expr,
+        &PossibleJestNode { node, original: None },
+        ctx,
+        &[JestFnKind::General(JestGeneralFnKind::Test)],
+    ) {
+        return;
+    }
+
+    for argument in &call_expr.arguments {
+        let Some(arg_expr) = argument.as_expression() else {
+            continue;
+        };
+        match arg_expr {
+            Expression::ArrowFunctionExpression(arrow_expr) => {
+                check_test_return_statement(&arrow_expr.body, ctx);
+            }
+            Expression::FunctionExpression(func_expr) => {
+                let Some(func_body) = &func_expr.body else {
+                    continue;
+                };
+                check_test_return_statement(func_body, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn check_test_return_statement<'a>(func_body: &OBox<'_, FunctionBody<'a>>, ctx: &LintContext<'a>) {
+    let Some(return_stmt) =
+        func_body.statements.iter().find(|stmt| matches!(stmt, Statement::ReturnStatement(_)))
+    else {
+        return;
+    };
+
+    let Statement::ReturnStatement(stmt) = return_stmt else {
+        return;
+    };
+    let Some(Expression::CallExpression(call_expr)) = &stmt.argument else {
+        return;
+    };
+    let Some(mem_expr) = call_expr.callee.as_member_expression() else {
+        return;
+    };
+    let Expression::CallExpression(mem_call_expr) = mem_expr.object() else {
+        return;
+    };
+    let Expression::Identifier(ident) = &mem_call_expr.callee else {
+        return;
+    };
+
+    if ident.name != "expect" {
+        return;
+    }
+
+    ctx.diagnostic(no_test_return_statement_diagnostic(Span::new(
+        return_stmt.span().start,
+        call_expr.span.start - 1,
+    )));
+}

--- a/crates/oxc_linter/src/rules/vitest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_test_return_statement.rs
@@ -11,7 +11,7 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct NoTestReturnStatement;
 
-declare_oxc_lint!(NoTestReturnStatement, jest, style, docs = DOCUMENTATION, version = "0.2.0",);
+declare_oxc_lint!(NoTestReturnStatement, vitest, style, docs = DOCUMENTATION, version = "0.2.0",);
 
 impl Rule for NoTestReturnStatement {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -137,6 +137,6 @@ fn test() {
     ];
 
     Tester::new(NoTestReturnStatement::NAME, NoTestReturnStatement::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_no_test_return_statement.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_test_return_statement.snap
@@ -1,0 +1,143 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:20]
+ 2 │                 test('one', () => {
+ 3 │                    return expect(1).toBe(1);
+   ·                    ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.skip('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.skip('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.each``('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.each``('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.each()('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.each()('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.only.each``('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.only.each``('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.only.each()('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:3:21]
+ 2 │                 it.only.each()('one', function () {
+ 3 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 4 │                 });
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.
+
+  ⚠ vitest(no-test-return-statement): Jest tests should not return a value
+   ╭─[no_test_return_statement.tsx:4:21]
+ 3 │                 function myTest () {
+ 4 │                     return expect(1).toBe(1);
+   ·                     ──────
+ 5 │                 }
+   ╰────
+  help: Use `await` for async assertions or remove the return statement.
+  note: Jest ignores returned values from tests.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,8 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 16] = [
-    "no-test-return-statement",
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 15] = [
     "no-unneeded-async-expect-function",
     "prefer-called-with",
     "prefer-comparison-matcher",


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/21664