### PR TITLE
feat(linter): split jest/no-unneeded-async-expect-function into separate vitest rule

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,5 +1,4 @@
 [
-  "no-unneeded-async-expect-function",
   "prefer-called-with",
   "prefer-comparison-matcher",
   "prefer-each",

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -898,42 +898,6 @@ mod test {
     }
 
     #[test]
-    fn test_vitest_root_override_keeps_jest_compatible_rules() {
-        let config = config_from_str(
-            r#"
-            {
-                "plugins": ["vitest", "typescript"],
-                "rules": {
-                    "vitest/no-unneeded-async-expect-function": "error",
-                    "typescript/no-explicit-any": "error"
-                },
-                "overrides": [
-                    {
-                        "files": ["*.test.ts"],
-                        "rules": { "typescript/no-explicit-any": "off" }
-                    }
-                ]
-            }
-            "#,
-        );
-
-        let rules_for_test_file = config.apply_overrides("foo.test.ts".as_ref());
-
-        assert!(
-            rules_for_test_file.rules.iter().any(|(rule, _)| {
-                rule.plugin_name() == "jest" && rule.name() == "no-unneeded-async-expect-function"
-            }),
-            "vitest-compatible jest rules should remain enabled when an override matches"
-        );
-        assert!(
-            rules_for_test_file.rules.iter().all(|(rule, _)| {
-                !(rule.plugin_name() == "typescript" && rule.name() == "no-explicit-any")
-            }),
-            "the override should still disable the targeted typescript rule"
-        );
-    }
-
-    #[test]
     fn test_categories_only_applied_to_new_plugins_not_in_root() {
         // Test that categories are only applied to plugins that weren't in the root config
 
@@ -1358,20 +1322,6 @@ mod test {
         );
         let store = ConfigStore::new(base, FxHashMap::default(), ExternalPluginStore::default());
         assert_eq!(store.max_warnings(), None);
-    }
-
-    fn config_from_str(s: &str) -> Config {
-        let mut external_plugin_store = ExternalPluginStore::default();
-        ConfigStoreBuilder::from_oxlintrc(
-            true,
-            serde_json::from_str::<Oxlintrc>(s).unwrap(),
-            None,
-            &mut external_plugin_store,
-            None,
-        )
-        .unwrap()
-        .build(&mut external_plugin_store)
-        .unwrap()
     }
 
     fn config_from_str_with_defaults(s: &str) -> Config {

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4512,6 +4512,13 @@ impl RuleRunner for crate::rules::vitest::no_test_return_statement::NoTestReturn
 }
 
 impl RuleRunner
+    for crate::rules::vitest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
+impl RuleRunner
     for crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith
 {
     const NODE_TYPES: Option<&AstTypesBitset> =

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -722,6 +722,7 @@ pub use crate::rules::vitest::no_restricted_vi_methods::NoRestrictedViMethods as
 pub use crate::rules::vitest::no_standalone_expect::NoStandaloneExpect as VitestNoStandaloneExpect;
 pub use crate::rules::vitest::no_test_prefixes::NoTestPrefixes as VitestNoTestPrefixes;
 pub use crate::rules::vitest::no_test_return_statement::NoTestReturnStatement as VitestNoTestReturnStatement;
+pub use crate::rules::vitest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction as VitestNoUnneededAsyncExpectFunction;
 pub use crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith as VitestPreferCalledExactlyOnceWith;
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
@@ -1491,6 +1492,7 @@ pub enum RuleEnum {
     VitestNoStandaloneExpect(VitestNoStandaloneExpect),
     VitestNoTestPrefixes(VitestNoTestPrefixes),
     VitestNoTestReturnStatement(VitestNoTestReturnStatement),
+    VitestNoUnneededAsyncExpectFunction(VitestNoUnneededAsyncExpectFunction),
     VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith),
     VitestPreferCalledOnce(VitestPreferCalledOnce),
     VitestPreferCalledTimes(VitestPreferCalledTimes),
@@ -2345,8 +2347,10 @@ const VITEST_NO_RESTRICTED_VI_METHODS_ID: usize = VITEST_NO_RESTRICTED_MATCHERS_
 const VITEST_NO_STANDALONE_EXPECT_ID: usize = VITEST_NO_RESTRICTED_VI_METHODS_ID + 1usize;
 const VITEST_NO_TEST_PREFIXES_ID: usize = VITEST_NO_STANDALONE_EXPECT_ID + 1usize;
 const VITEST_NO_TEST_RETURN_STATEMENT_ID: usize = VITEST_NO_TEST_PREFIXES_ID + 1usize;
-const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
+const VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID: usize =
     VITEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
+const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
+    VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
 const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID + 1usize;
 const VITEST_PREFER_CALLED_TIMES_ID: usize = VITEST_PREFER_CALLED_ONCE_ID + 1usize;
 const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
@@ -3228,6 +3232,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VITEST_NO_STANDALONE_EXPECT_ID,
             Self::VitestNoTestPrefixes(_) => VITEST_NO_TEST_PREFIXES_ID,
             Self::VitestNoTestReturnStatement(_) => VITEST_NO_TEST_RETURN_STATEMENT_ID,
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID,
             Self::VitestPreferCalledOnce(_) => VITEST_PREFER_CALLED_ONCE_ID,
             Self::VitestPreferCalledTimes(_) => VITEST_PREFER_CALLED_TIMES_ID,
@@ -4100,6 +4107,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::NAME,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::NAME,
             Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::NAME,
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::NAME
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::NAME,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
@@ -5014,6 +5024,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::CATEGORY,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::CATEGORY,
             Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::CATEGORY,
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::CATEGORY
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::CATEGORY
             }
@@ -5895,6 +5908,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::FIX,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::FIX,
             Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::FIX,
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::FIX
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::FIX,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
@@ -6972,6 +6988,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::documentation(),
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::documentation(),
             Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::documentation(),
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::documentation()
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::documentation()
             }
@@ -9077,6 +9096,10 @@ impl RuleEnum {
                 VitestNoTestReturnStatement::config_schema(generator)
                     .or_else(|| VitestNoTestReturnStatement::schema(generator))
             }
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::config_schema(generator)
+                    .or_else(|| VitestNoUnneededAsyncExpectFunction::schema(generator))
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::config_schema(generator)
                     .or_else(|| VitestPreferCalledExactlyOnceWith::schema(generator))
@@ -9950,6 +9973,7 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => "vitest",
             Self::VitestNoTestPrefixes(_) => "vitest",
             Self::VitestNoTestReturnStatement(_) => "vitest",
+            Self::VitestNoUnneededAsyncExpectFunction(_) => "vitest",
             Self::VitestPreferCalledExactlyOnceWith(_) => "vitest",
             Self::VitestPreferCalledOnce(_) => "vitest",
             Self::VitestPreferCalledTimes(_) => "vitest",
@@ -12285,6 +12309,11 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(_) => Ok(Self::VitestNoTestReturnStatement(
                 VitestNoTestReturnStatement::from_configuration(value)?,
             )),
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                Ok(Self::VitestNoUnneededAsyncExpectFunction(
+                    VitestNoUnneededAsyncExpectFunction::from_configuration(value)?,
+                ))
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 Ok(Self::VitestPreferCalledExactlyOnceWith(
                     VitestPreferCalledExactlyOnceWith::from_configuration(value)?,
@@ -13181,6 +13210,7 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(rule) => rule.to_configuration(),
             Self::VitestNoTestPrefixes(rule) => rule.to_configuration(),
             Self::VitestNoTestReturnStatement(rule) => rule.to_configuration(),
+            Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.to_configuration(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.to_configuration(),
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
@@ -13951,6 +13981,7 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(rule) => rule.run(node, ctx),
             Self::VitestNoTestPrefixes(rule) => rule.run(node, ctx),
             Self::VitestNoTestReturnStatement(rule) => rule.run(node, ctx),
+            Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
@@ -14719,6 +14750,7 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(rule) => rule.run_once(ctx),
             Self::VitestNoTestPrefixes(rule) => rule.run_once(ctx),
             Self::VitestNoTestReturnStatement(rule) => rule.run_once(ctx),
+            Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
@@ -15589,6 +15621,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoTestPrefixes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestNoTestReturnStatement(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestNoUnneededAsyncExpectFunction(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16361,6 +16396,7 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(rule) => rule.should_run(ctx),
             Self::VitestNoTestPrefixes(rule) => rule.should_run(ctx),
             Self::VitestNoTestReturnStatement(rule) => rule.should_run(ctx),
+            Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
@@ -17433,6 +17469,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::IS_TSGOLINT_RULE,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::IS_TSGOLINT_RULE,
             Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::IS_TSGOLINT_RULE,
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::IS_TSGOLINT_RULE
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::IS_TSGOLINT_RULE
             }
@@ -18369,6 +18408,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::VERSION,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::VERSION,
             Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::VERSION,
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::VERSION
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::VERSION
             }
@@ -19322,6 +19364,9 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(_) => VitestNoStandaloneExpect::HAS_CONFIG,
             Self::VitestNoTestPrefixes(_) => VitestNoTestPrefixes::HAS_CONFIG,
             Self::VitestNoTestReturnStatement(_) => VitestNoTestReturnStatement::HAS_CONFIG,
+            Self::VitestNoUnneededAsyncExpectFunction(_) => {
+                VitestNoUnneededAsyncExpectFunction::HAS_CONFIG
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::HAS_CONFIG
             }
@@ -20106,6 +20151,7 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(rule) => rule.types_info(),
             Self::VitestNoTestPrefixes(rule) => rule.types_info(),
             Self::VitestNoTestReturnStatement(rule) => rule.types_info(),
+            Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.types_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.types_info(),
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
@@ -20874,6 +20920,7 @@ impl RuleEnum {
             Self::VitestNoStandaloneExpect(rule) => rule.run_info(),
             Self::VitestNoTestPrefixes(rule) => rule.run_info(),
             Self::VitestNoTestReturnStatement(rule) => rule.run_info(),
+            Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_info(),
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
@@ -21762,6 +21809,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestNoStandaloneExpect(VitestNoStandaloneExpect::default()),
         RuleEnum::VitestNoTestPrefixes(VitestNoTestPrefixes::default()),
         RuleEnum::VitestNoTestReturnStatement(VitestNoTestReturnStatement::default()),
+        RuleEnum::VitestNoUnneededAsyncExpectFunction(
+            VitestNoUnneededAsyncExpectFunction::default(),
+        ),
         RuleEnum::VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith::default()),
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -750,6 +750,7 @@ pub(crate) mod vitest {
     pub mod no_standalone_expect;
     pub mod no_test_prefixes;
     pub mod no_test_return_statement;
+    pub mod no_unneeded_async_expect_function;
     pub mod prefer_called_exactly_once_with;
     pub mod prefer_called_once;
     pub mod prefer_called_times;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -19,6 +19,7 @@ pub mod no_restricted_matchers;
 pub mod no_standalone_expect;
 pub mod no_test_prefixes;
 pub mod no_test_return_statement;
+pub mod no_unneeded_async_expect_function;
 pub mod prefer_expect_assertions;
 pub mod prefer_snapshot_hint;
 pub mod prefer_to_contain;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_unneeded_async_expect_function.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_unneeded_async_expect_function.rs
@@ -1,0 +1,134 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression, Statement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    utils::{ParsedJestFnCallNew, PossibleJestNode, parse_jest_fn_call},
+};
+
+fn no_unneeded_async_expect_function_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unnecessary async function wrapper")
+        .with_help("Remove the async wrapper and pass the promise directly to expect")
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+Disallows unnecessary async function wrapper for expected promises.
+
+### Why is this bad?
+
+When the only statement inside an async wrapper is `await someCall()`,
+the call should be passed directly to `expect` instead. This makes the
+test code more concise and easier to read.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```js
+await expect(async () => {
+  await doSomethingAsync();
+}).rejects.toThrow();
+
+await expect(async () => await doSomethingAsync()).rejects.toThrow();
+```
+
+Examples of **correct** code for this rule:
+```js
+await expect(doSomethingAsync()).rejects.toThrow();
+```
+";
+
+pub fn run_on_jest_node<'a, 'c>(jest_node: &PossibleJestNode<'a, 'c>, ctx: &'c LintContext<'a>) {
+    let node = jest_node.node;
+    let AstKind::CallExpression(call_expr) = node.kind() else {
+        return;
+    };
+
+    let Some(ParsedJestFnCallNew::Expect(parsed_expect_call)) =
+        parse_jest_fn_call(call_expr, jest_node, ctx)
+    else {
+        return;
+    };
+
+    // Ensure we have a valid matcher (this ensures we're processing the full chain)
+    if parsed_expect_call.matcher().is_none() {
+        return;
+    }
+
+    // Get the expect() CallExpression from head.parent
+    let Some(Expression::CallExpression(expect_call_expr)) = parsed_expect_call.head.parent else {
+        return;
+    };
+
+    // Get the first argument of expect()
+    let Some(first_arg) = expect_call_expr.arguments.first() else {
+        return;
+    };
+
+    // Check if it's an async function expression and get the inner call span
+    let (func_span, inner_call_span) = match first_arg {
+        Argument::ArrowFunctionExpression(arrow) => {
+            if !arrow.r#async {
+                return;
+            }
+            let Some(inner_span) = get_awaited_call_span_from_arrow(arrow) else {
+                return;
+            };
+            (arrow.span, inner_span)
+        }
+        Argument::FunctionExpression(func) => {
+            if !func.r#async {
+                return;
+            }
+            let Some(body) = &func.body else {
+                return;
+            };
+            let Some(inner_span) = get_awaited_call_span_from_block(body) else {
+                return;
+            };
+            (func.span, inner_span)
+        }
+        _ => return,
+    };
+
+    ctx.diagnostic_with_fix(no_unneeded_async_expect_function_diagnostic(func_span), |fixer| {
+        fixer.replace(func_span, fixer.source_range(inner_call_span).to_string())
+    });
+}
+
+/// Gets the span of the awaited call expression from an async arrow function.
+/// Returns `None` if the function body doesn't contain exactly one await of a call expression.
+fn get_awaited_call_span_from_arrow(arrow: &oxc_ast::ast::ArrowFunctionExpression) -> Option<Span> {
+    // Case 1: Arrow function with expression body (async () => await doSomething())
+    if arrow.expression {
+        if let Some(first) = arrow.body.statements.first()
+            && let Statement::ExpressionStatement(expr_stmt) = first
+            && let Expression::AwaitExpression(await_expr) = &expr_stmt.expression
+            && let Expression::CallExpression(call) = &await_expr.argument
+        {
+            return Some(call.span);
+        }
+        return None;
+    }
+
+    // Case 2: Arrow function with block body
+    get_awaited_call_span_from_block(&arrow.body)
+}
+
+fn get_awaited_call_span_from_block(body: &oxc_ast::ast::FunctionBody) -> Option<Span> {
+    if body.statements.len() == 1
+        && let Some(stmt) = body.statements.first()
+        && let Statement::ExpressionStatement(expr_stmt) = stmt
+        && let Expression::AwaitExpression(await_expr) = &expr_stmt.expression
+        && let Expression::CallExpression(call) = &await_expr.argument
+    {
+        return Some(call.span);
+    }
+
+    None
+}

--- a/crates/oxc_linter/src/rules/vitest/no_unneeded_async_expect_function.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_unneeded_async_expect_function.rs
@@ -12,7 +12,7 @@ pub struct NoUnneededAsyncExpectFunction;
 
 declare_oxc_lint!(
     NoUnneededAsyncExpectFunction,
-    jest,
+    vitest,
     style,
     fix,
     docs = DOCUMENTATION,
@@ -33,7 +33,7 @@ impl Rule for NoUnneededAsyncExpectFunction {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![
+    let mut pass = vec![
         "expect.hasAssertions()",
         "
                 it('pass', async () => {
@@ -276,13 +276,24 @@ fn test() {
         ),
     ];
 
+    let pass_vitest = vec![
+        "
+                import { expect as pleaseExpect } from 'vitest';
+                it('pass', async () => {
+                  await pleaseExpect(doSomethingAsync()).rejects.toThrow();
+                })
+                ",
+    ];
+
+    pass.extend(pass_vitest);
+
     Tester::new(
         NoUnneededAsyncExpectFunction::NAME,
         NoUnneededAsyncExpectFunction::PLUGIN,
         pass,
         fail,
     )
-    .with_jest_plugin(true)
+    .with_vitest_plugin(true)
     .expect_fix(fix)
     .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_no_unneeded_async_expect_function.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_unneeded_async_expect_function.snap
@@ -1,0 +1,72 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(no-unneeded-async-expect-function): Unnecessary async function wrapper
+   ╭─[no_unneeded_async_expect_function.tsx:3:34]
+ 2 │                       it('should be fixed', async () => {
+ 3 │ ╭─▶                     await expect(async () => {
+ 4 │ │                         await doSomethingAsync();
+ 5 │ ╰─▶                     }).rejects.toThrow();
+ 6 │                       })
+   ╰────
+  help: Remove the async wrapper and pass the promise directly to expect
+
+  ⚠ vitest(no-unneeded-async-expect-function): Unnecessary async function wrapper
+   ╭─[no_unneeded_async_expect_function.tsx:3:34]
+ 2 │                   it('should be fixed', async () => {
+ 3 │                     await expect(async () => await doSomethingAsync()).rejects.toThrow();
+   ·                                  ────────────────────────────────────
+ 4 │                   })
+   ╰────
+  help: Remove the async wrapper and pass the promise directly to expect
+
+  ⚠ vitest(no-unneeded-async-expect-function): Unnecessary async function wrapper
+   ╭─[no_unneeded_async_expect_function.tsx:3:34]
+ 2 │                       it('should be fixed', async () => {
+ 3 │ ╭─▶                     await expect(async function () {
+ 4 │ │                         await doSomethingAsync();
+ 5 │ ╰─▶                     }).rejects.toThrow();
+ 6 │                       })
+   ╰────
+  help: Remove the async wrapper and pass the promise directly to expect
+
+  ⚠ vitest(no-unneeded-async-expect-function): Unnecessary async function wrapper
+   ╭─[no_unneeded_async_expect_function.tsx:3:36]
+ 2 │                         it('should be fixed for async arrow function', async () => {
+ 3 │ ╭─▶                       await expect(async () => {
+ 4 │ │                           await doSomethingAsync(1, 2);
+ 5 │ ╰─▶                       }).rejects.toThrow();
+ 6 │                         })
+   ╰────
+  help: Remove the async wrapper and pass the promise directly to expect
+
+  ⚠ vitest(no-unneeded-async-expect-function): Unnecessary async function wrapper
+   ╭─[no_unneeded_async_expect_function.tsx:3:36]
+ 2 │                         it('should be fixed for async normal function', async () => {
+ 3 │ ╭─▶                       await expect(async function () {
+ 4 │ │                           await doSomethingAsync(1, 2);
+ 5 │ ╰─▶                       }).rejects.toThrow();
+ 6 │                         })
+   ╰────
+  help: Remove the async wrapper and pass the promise directly to expect
+
+  ⚠ vitest(no-unneeded-async-expect-function): Unnecessary async function wrapper
+   ╭─[no_unneeded_async_expect_function.tsx:3:36]
+ 2 │                         it('should be fixed for Promise.all', async () => {
+ 3 │ ╭─▶                       await expect(async function () {
+ 4 │ │                           await Promise.all([doSomethingAsync(1, 2), doSomethingAsync()]);
+ 5 │ ╰─▶                       }).rejects.toThrow();
+ 6 │                         })
+   ╰────
+  help: Remove the async wrapper and pass the promise directly to expect
+
+  ⚠ vitest(no-unneeded-async-expect-function): Unnecessary async function wrapper
+   ╭─[no_unneeded_async_expect_function.tsx:4:36]
+ 3 │                           const a = async () => { await doSomethingAsync() };
+ 4 │ ╭─▶                       await expect(async () => {
+ 5 │ │                           await a();
+ 6 │ ╰─▶                       }).rejects.toThrow();
+ 7 │                         })
+   ╰────
+  help: Remove the async wrapper and pass the promise directly to expect

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,8 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 15] = [
-    "no-unneeded-async-expect-function",
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 14] = [
     "prefer-called-with",
     "prefer-comparison-matcher",
     "prefer-each",


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/21664