### PR TITLE
feat(linter): Split `jest/require-to-throw-message` into Jest and Vitest rules.

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -18,6 +18,5 @@
   "prefer-to-be",
   "prefer-to-have-been-called-times",
   "prefer-to-have-length",
-  "require-hook",
-  "require-to-throw-message"
+  "require-hook"
 ]

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4600,6 +4600,11 @@ impl RuleRunner for crate::rules::vitest::require_test_timeout::RequireTestTimeo
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vitest::require_to_throw_message::RequireToThrowMessage {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::require_top_level_describe::RequireTopLevelDescribe {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -738,6 +738,7 @@ pub use crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectP
 pub use crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots as VitestRequireLocalTestContextForConcurrentSnapshots;
 pub use crate::rules::vitest::require_mock_type_parameters::RequireMockTypeParameters as VitestRequireMockTypeParameters;
 pub use crate::rules::vitest::require_test_timeout::RequireTestTimeout as VitestRequireTestTimeout;
+pub use crate::rules::vitest::require_to_throw_message::RequireToThrowMessage as VitestRequireToThrowMessage;
 pub use crate::rules::vitest::require_top_level_describe::RequireTopLevelDescribe as VitestRequireTopLevelDescribe;
 pub use crate::rules::vitest::valid_describe_callback::ValidDescribeCallback as VitestValidDescribeCallback;
 pub use crate::rules::vitest::valid_expect::ValidExpect as VitestValidExpect;
@@ -1502,6 +1503,7 @@ pub enum RuleEnum {
     ),
     VitestRequireMockTypeParameters(VitestRequireMockTypeParameters),
     VitestRequireTestTimeout(VitestRequireTestTimeout),
+    VitestRequireToThrowMessage(VitestRequireToThrowMessage),
     VitestRequireTopLevelDescribe(VitestRequireTopLevelDescribe),
     VitestValidDescribeCallback(VitestValidDescribeCallback),
     VitestValidExpect(VitestValidExpect),
@@ -2350,7 +2352,8 @@ const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
 const VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID: usize =
     VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID + 1usize;
 const VITEST_REQUIRE_TEST_TIMEOUT_ID: usize = VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID + 1usize;
-const VITEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID: usize = VITEST_REQUIRE_TEST_TIMEOUT_ID + 1usize;
+const VITEST_REQUIRE_TO_THROW_MESSAGE_ID: usize = VITEST_REQUIRE_TEST_TIMEOUT_ID + 1usize;
+const VITEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID: usize = VITEST_REQUIRE_TO_THROW_MESSAGE_ID + 1usize;
 const VITEST_VALID_DESCRIBE_CALLBACK_ID: usize = VITEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID + 1usize;
 const VITEST_VALID_EXPECT_ID: usize = VITEST_VALID_DESCRIBE_CALLBACK_ID + 1usize;
 const VITEST_VALID_EXPECT_IN_PROMISE_ID: usize = VITEST_VALID_EXPECT_ID + 1usize;
@@ -3226,6 +3229,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID,
             Self::VitestRequireTestTimeout(_) => VITEST_REQUIRE_TEST_TIMEOUT_ID,
+            Self::VitestRequireToThrowMessage(_) => VITEST_REQUIRE_TO_THROW_MESSAGE_ID,
             Self::VitestRequireTopLevelDescribe(_) => VITEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID,
             Self::VitestValidDescribeCallback(_) => VITEST_VALID_DESCRIBE_CALLBACK_ID,
             Self::VitestValidExpect(_) => VITEST_VALID_EXPECT_ID,
@@ -4089,6 +4093,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::NAME,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::NAME,
+            Self::VitestRequireToThrowMessage(_) => VitestRequireToThrowMessage::NAME,
             Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::NAME,
             Self::VitestValidDescribeCallback(_) => VitestValidDescribeCallback::NAME,
             Self::VitestValidExpect(_) => VitestValidExpect::NAME,
@@ -5004,6 +5009,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::CATEGORY,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::CATEGORY,
+            Self::VitestRequireToThrowMessage(_) => VitestRequireToThrowMessage::CATEGORY,
             Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::CATEGORY,
             Self::VitestValidDescribeCallback(_) => VitestValidDescribeCallback::CATEGORY,
             Self::VitestValidExpect(_) => VitestValidExpect::CATEGORY,
@@ -5870,6 +5876,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::FIX,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::FIX,
+            Self::VitestRequireToThrowMessage(_) => VitestRequireToThrowMessage::FIX,
             Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::FIX,
             Self::VitestValidDescribeCallback(_) => VitestValidDescribeCallback::FIX,
             Self::VitestValidExpect(_) => VitestValidExpect::FIX,
@@ -6952,6 +6959,7 @@ impl RuleEnum {
                 VitestRequireMockTypeParameters::documentation()
             }
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::documentation(),
+            Self::VitestRequireToThrowMessage(_) => VitestRequireToThrowMessage::documentation(),
             Self::VitestRequireTopLevelDescribe(_) => {
                 VitestRequireTopLevelDescribe::documentation()
             }
@@ -9066,6 +9074,10 @@ impl RuleEnum {
             }
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::config_schema(generator)
                 .or_else(|| VitestRequireTestTimeout::schema(generator)),
+            Self::VitestRequireToThrowMessage(_) => {
+                VitestRequireToThrowMessage::config_schema(generator)
+                    .or_else(|| VitestRequireToThrowMessage::schema(generator))
+            }
             Self::VitestRequireTopLevelDescribe(_) => {
                 VitestRequireTopLevelDescribe::config_schema(generator)
                     .or_else(|| VitestRequireTopLevelDescribe::schema(generator))
@@ -9887,6 +9899,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => "vitest",
             Self::VitestRequireMockTypeParameters(_) => "vitest",
             Self::VitestRequireTestTimeout(_) => "vitest",
+            Self::VitestRequireToThrowMessage(_) => "vitest",
             Self::VitestRequireTopLevelDescribe(_) => "vitest",
             Self::VitestValidDescribeCallback(_) => "vitest",
             Self::VitestValidExpect(_) => "vitest",
@@ -12257,6 +12270,9 @@ impl RuleEnum {
             Self::VitestRequireTestTimeout(_) => Ok(Self::VitestRequireTestTimeout(
                 VitestRequireTestTimeout::from_configuration(value)?,
             )),
+            Self::VitestRequireToThrowMessage(_) => Ok(Self::VitestRequireToThrowMessage(
+                VitestRequireToThrowMessage::from_configuration(value)?,
+            )),
             Self::VitestRequireTopLevelDescribe(_) => Ok(Self::VitestRequireTopLevelDescribe(
                 VitestRequireTopLevelDescribe::from_configuration(value)?,
             )),
@@ -13092,6 +13108,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(rule) => rule.to_configuration(),
             Self::VitestRequireTestTimeout(rule) => rule.to_configuration(),
+            Self::VitestRequireToThrowMessage(rule) => rule.to_configuration(),
             Self::VitestRequireTopLevelDescribe(rule) => rule.to_configuration(),
             Self::VitestValidDescribeCallback(rule) => rule.to_configuration(),
             Self::VitestValidExpect(rule) => rule.to_configuration(),
@@ -13853,6 +13870,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run(node, ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.run(node, ctx),
             Self::VitestRequireTestTimeout(rule) => rule.run(node, ctx),
+            Self::VitestRequireToThrowMessage(rule) => rule.run(node, ctx),
             Self::VitestRequireTopLevelDescribe(rule) => rule.run(node, ctx),
             Self::VitestValidDescribeCallback(rule) => rule.run(node, ctx),
             Self::VitestValidExpect(rule) => rule.run(node, ctx),
@@ -14614,6 +14632,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_once(ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.run_once(ctx),
             Self::VitestRequireTestTimeout(rule) => rule.run_once(ctx),
+            Self::VitestRequireToThrowMessage(rule) => rule.run_once(ctx),
             Self::VitestRequireTopLevelDescribe(rule) => rule.run_once(ctx),
             Self::VitestValidDescribeCallback(rule) => rule.run_once(ctx),
             Self::VitestValidExpect(rule) => rule.run_once(ctx),
@@ -15479,6 +15498,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireTestTimeout(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestRequireToThrowMessage(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireTopLevelDescribe(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestValidDescribeCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestValidExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16242,6 +16262,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.should_run(ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.should_run(ctx),
             Self::VitestRequireTestTimeout(rule) => rule.should_run(ctx),
+            Self::VitestRequireToThrowMessage(rule) => rule.should_run(ctx),
             Self::VitestRequireTopLevelDescribe(rule) => rule.should_run(ctx),
             Self::VitestValidDescribeCallback(rule) => rule.should_run(ctx),
             Self::VitestValidExpect(rule) => rule.should_run(ctx),
@@ -17321,6 +17342,7 @@ impl RuleEnum {
                 VitestRequireMockTypeParameters::IS_TSGOLINT_RULE
             }
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::IS_TSGOLINT_RULE,
+            Self::VitestRequireToThrowMessage(_) => VitestRequireToThrowMessage::IS_TSGOLINT_RULE,
             Self::VitestRequireTopLevelDescribe(_) => {
                 VitestRequireTopLevelDescribe::IS_TSGOLINT_RULE
             }
@@ -18244,6 +18266,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::VERSION,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::VERSION,
+            Self::VitestRequireToThrowMessage(_) => VitestRequireToThrowMessage::VERSION,
             Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::VERSION,
             Self::VitestValidDescribeCallback(_) => VitestValidDescribeCallback::VERSION,
             Self::VitestValidExpect(_) => VitestValidExpect::VERSION,
@@ -19190,6 +19213,7 @@ impl RuleEnum {
             }
             Self::VitestRequireMockTypeParameters(_) => VitestRequireMockTypeParameters::HAS_CONFIG,
             Self::VitestRequireTestTimeout(_) => VitestRequireTestTimeout::HAS_CONFIG,
+            Self::VitestRequireToThrowMessage(_) => VitestRequireToThrowMessage::HAS_CONFIG,
             Self::VitestRequireTopLevelDescribe(_) => VitestRequireTopLevelDescribe::HAS_CONFIG,
             Self::VitestValidDescribeCallback(_) => VitestValidDescribeCallback::HAS_CONFIG,
             Self::VitestValidExpect(_) => VitestValidExpect::HAS_CONFIG,
@@ -19957,6 +19981,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.types_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.types_info(),
             Self::VitestRequireTestTimeout(rule) => rule.types_info(),
+            Self::VitestRequireToThrowMessage(rule) => rule.types_info(),
             Self::VitestRequireTopLevelDescribe(rule) => rule.types_info(),
             Self::VitestValidDescribeCallback(rule) => rule.types_info(),
             Self::VitestValidExpect(rule) => rule.types_info(),
@@ -20718,6 +20743,7 @@ impl RuleEnum {
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.run_info(),
             Self::VitestRequireTestTimeout(rule) => rule.run_info(),
+            Self::VitestRequireToThrowMessage(rule) => rule.run_info(),
             Self::VitestRequireTopLevelDescribe(rule) => rule.run_info(),
             Self::VitestValidDescribeCallback(rule) => rule.run_info(),
             Self::VitestValidExpect(rule) => rule.run_info(),
@@ -21601,6 +21627,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         ),
         RuleEnum::VitestRequireMockTypeParameters(VitestRequireMockTypeParameters::default()),
         RuleEnum::VitestRequireTestTimeout(VitestRequireTestTimeout::default()),
+        RuleEnum::VitestRequireToThrowMessage(VitestRequireToThrowMessage::default()),
         RuleEnum::VitestRequireTopLevelDescribe(VitestRequireTopLevelDescribe::default()),
         RuleEnum::VitestValidDescribeCallback(VitestValidDescribeCallback::default()),
         RuleEnum::VitestValidExpect(VitestValidExpect::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -766,6 +766,7 @@ pub(crate) mod vitest {
     pub mod require_local_test_context_for_concurrent_snapshots;
     pub mod require_mock_type_parameters;
     pub mod require_test_timeout;
+    pub mod require_to_throw_message;
     pub mod require_top_level_describe;
     pub mod valid_describe_callback;
     pub mod valid_expect;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -20,6 +20,7 @@ pub mod no_standalone_expect;
 pub mod prefer_expect_assertions;
 pub mod prefer_to_contain;
 pub mod prefer_todo;
+pub mod require_to_throw_message;
 pub mod require_top_level_describe;
 pub mod valid_describe_callback;
 pub mod valid_expect;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/require_to_throw_message.rs
@@ -1,0 +1,80 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    utils::{PossibleJestNode, parse_expect_jest_fn_call},
+};
+
+fn require_to_throw_message_diagnostic(matcher_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Require a message for {matcher_name:?}."))
+        .with_help(format!("Add an error message to {matcher_name:?}"))
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+This rule triggers a warning if `toThrow()` or `toThrowError()` is used without an error message.
+
+### Why is this bad?
+
+Using `toThrow()` or `toThrowError()` without specifying an expected error message
+makes tests less specific and harder to debug. When a test only checks that an
+error was thrown but not what kind of error, it can pass even when the wrong
+error is thrown, potentially hiding bugs. Providing an expected error message
+or error type makes tests more precise and helps catch regressions more effectively.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+test('all the things', async () => {
+    expect(() => a()).toThrow();
+    expect(() => a()).toThrowError();
+    await expect(a()).rejects.toThrow();
+    await expect(a()).rejects.toThrowError();
+});
+```
+
+Examples of **correct** code for this rule:
+```javascript
+test('all the things', async () => {
+  expect(() => a()).toThrow('a');
+  expect(() => a()).toThrowError('a');
+  await expect(a()).rejects.toThrow('a');
+  await expect(a()).rejects.toThrowError('a');
+});
+```
+";
+
+pub fn run_on_jest_node<'a, 'c>(
+    possible_jest_node: &PossibleJestNode<'a, 'c>,
+    ctx: &'c LintContext<'a>,
+) {
+    let node = possible_jest_node.node;
+    let AstKind::CallExpression(call_expr) = node.kind() else {
+        return;
+    };
+
+    let Some(jest_fn_call) = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx) else {
+        return;
+    };
+
+    let Some(matcher) = jest_fn_call.matcher() else {
+        return;
+    };
+
+    let Some(matcher_name) = matcher.name() else {
+        return;
+    };
+
+    let has_not = jest_fn_call.modifiers().iter().any(|modifier| modifier.is_name_equal("not"));
+
+    if jest_fn_call.args.is_empty()
+        && (matcher_name == "toThrow" || matcher_name == "toThrowError")
+        && !has_not
+    {
+        ctx.diagnostic(require_to_throw_message_diagnostic(&matcher_name, matcher.span));
+    }
+}

--- a/crates/oxc_linter/src/rules/vitest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_to_throw_message.rs
@@ -12,7 +12,7 @@ pub struct RequireToThrowMessage;
 
 declare_oxc_lint!(
     RequireToThrowMessage,
-    jest,
+    vitest,
     correctness,
     docs = DOCUMENTATION,
     version = "0.2.9",
@@ -122,6 +122,6 @@ fn test() {
     ];
 
     Tester::new(RequireToThrowMessage::NAME, RequireToThrowMessage::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_require_to_throw_message.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_require_to_throw_message.snap
@@ -1,0 +1,35 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(require-to-throw-message): Require a message for "toThrow".
+   ╭─[require_to_throw_message.tsx:1:41]
+ 1 │ expect(() => { throw new Error('a'); }).toThrow();
+   ·                                         ───────
+   ╰────
+  help: Add an error message to "toThrow"
+
+  ⚠ vitest(require-to-throw-message): Require a message for "toThrowError".
+   ╭─[require_to_throw_message.tsx:1:41]
+ 1 │ expect(() => { throw new Error('a'); }).toThrowError();
+   ·                                         ────────────
+   ╰────
+  help: Add an error message to "toThrowError"
+
+  ⚠ vitest(require-to-throw-message): Require a message for "toThrow".
+   ╭─[require_to_throw_message.tsx:4:61]
+ 3 │                     const throwErrorAsync = async () => { throw new Error('a') };
+ 4 │                     await expect(throwErrorAsync()).rejects.toThrow();
+   ·                                                             ───────
+ 5 │                     await expect(throwErrorAsync()).rejects.toThrowError();
+   ╰────
+  help: Add an error message to "toThrow"
+
+  ⚠ vitest(require-to-throw-message): Require a message for "toThrowError".
+   ╭─[require_to_throw_message.tsx:5:61]
+ 4 │                     await expect(throwErrorAsync()).rejects.toThrow();
+ 5 │                     await expect(throwErrorAsync()).rejects.toThrowError();
+   ·                                                             ────────────
+ 6 │                 })
+   ╰────
+  help: Add an error message to "toThrowError"

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 21] = [
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 20] = [
     "no-test-prefixes",
     "no-test-return-statement",
     "no-unneeded-async-expect-function",
@@ -58,7 +58,6 @@ const VITEST_COMPATIBLE_JEST_RULES: [&str; 21] = [
     "prefer-to-have-been-called-times",
     "prefer-to-have-length",
     "require-hook",
-    "require-to-throw-message",
 ];
 
 /// List of Eslint rules that have TypeScript equivalents.


### PR DESCRIPTION
Generated with Claude Code, reviewed by me.

Part of #21664.