### PR TITLE
refactor(oxfmt): Classify file kind and resolve option in 1 step

### DIFF
--- a/apps/oxfmt/src/api/format_api.rs
+++ b/apps/oxfmt/src/api/format_api.rs
@@ -5,9 +5,9 @@ use serde_json::Value;
 use oxc_napi::OxcError;
 
 use crate::core::{
-    ExternalFormatter, FormatResult, FormatStrategyBuilder, JsFormatEmbeddedCb,
-    JsFormatEmbeddedDocCb, JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb,
-    SourceFormatter, resolve_options_from_value, utils,
+    ExternalFormatter, FormatResult, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
+    JsInitExternalFormatterCb, JsSortTailwindClassesCb, SourceFormatter, classify_file_kind,
+    resolve, utils,
 };
 
 pub struct ApiFormatResult {
@@ -56,37 +56,31 @@ pub fn run(
         }
     }
 
-    // Determine format strategy from file path
     let filepath = utils::normalize_relative_path(&cwd, Path::new(filename));
-    let Ok(strategy) = FormatStrategyBuilder::default().build(filepath) else {
+    let Some(kind) = classify_file_kind(filepath) else {
         external_formatter.cleanup();
         return ApiFormatResult {
             code: source_text,
             errors: vec![OxcError::new(format!("Unsupported file type: {filename}"))],
         };
     };
-
-    // Resolve format options directly from the provided options
-    let resolved_options =
-        match resolve_options_from_value(options.unwrap_or_default(), &strategy, Some(&cwd)) {
-            Ok(options) => options,
-            Err(err) => {
-                external_formatter.cleanup();
-                return ApiFormatResult {
-                    code: source_text,
-                    errors: vec![OxcError::new(format!("Failed to parse configuration: {err}"))],
-                };
-            }
-        };
+    let strategy = match resolve(options.unwrap_or_default(), kind, Some(&cwd)) {
+        Ok(strategy) => strategy,
+        Err(err) => {
+            external_formatter.cleanup();
+            return ApiFormatResult {
+                code: source_text,
+                errors: vec![OxcError::new(format!("Failed to parse configuration: {err}"))],
+            };
+        }
+    };
 
     // Create formatter and format
     let formatter = SourceFormatter::new(num_of_threads)
         .with_external_formatter(Some(external_formatter.clone()));
 
     // Use `block_in_place()` to avoid nested async runtime access
-    let result = match tokio::task::block_in_place(|| {
-        formatter.format(&strategy, &source_text, resolved_options)
-    }) {
+    let result = match tokio::task::block_in_place(|| formatter.format(&source_text, strategy)) {
         FormatResult::Success { code, .. } => ApiFormatResult { code, errors: vec![] },
         FormatResult::Error(diagnostics) => {
             let errors = OxcError::from_diagnostics(filename, &source_text, diagnostics);

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -14,9 +14,8 @@ use oxc_span::SourceType;
 
 use crate::{
     core::{
-        ExternalFormatter, FormatStrategy, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb,
-        JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb, ResolvedOptions,
-        resolve_options_from_value,
+        ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
+        JsInitExternalFormatterCb, JsSortTailwindClassesCb, resolve_options_for_embedded_js,
     },
     prettier_compat::to_prettier_doc,
 };
@@ -137,19 +136,14 @@ fn run_full(
             .expect("source_ext should be a valid JS/TS extension"),
     );
 
-    let strategy =
-        FormatStrategy::OxcFormatter { path: format!("embedded.{source_ext}").into(), source_type };
-    let resolved_options = resolve_options_from_value(options, &strategy, None)
+    let (format_options, mut external_options, filepath_override) =
+        resolve_options_for_embedded_js(
+            options,
+            format!("embedded.{source_ext}").into(),
+            source_type,
+            None,
+        )
         .expect("`_oxfmtPluginOptionsJson` should contain valid config");
-    let ResolvedOptions::OxcFormatter {
-        format_options,
-        mut external_options,
-        filepath_override,
-        ..
-    } = resolved_options
-    else {
-        unreachable!("OxcFormatter strategy should always resolve to OxcFormatter options");
-    };
 
     // Set filepath on external options for Prettier plugins and Tailwind sorter.
     // Use the filepath override (parent filepath, e.g., `App.vue`) if available,
@@ -210,14 +204,13 @@ fn run_fragment(
     // And `run_fragment()` does not support external formatting, so no need to use `parent_filepath`.
     let (options, _parent_filepath) = parse_options_and_filepath(oxfmt_plugin_options_json);
 
-    let strategy =
-        FormatStrategy::OxcFormatter { path: format!("embedded.{source_ext}").into(), source_type };
-
-    let resolved_options = resolve_options_from_value(options, &strategy, None)
-        .expect("`_oxfmtPluginOptionsJson` should contain valid config");
-    let ResolvedOptions::OxcFormatter { format_options, .. } = resolved_options else {
-        unreachable!("OxcFormatter strategy should always resolve to OxcFormatter options");
-    };
+    let (format_options, _, _) = resolve_options_for_embedded_js(
+        options,
+        format!("embedded.{source_ext}").into(),
+        source_type,
+        None,
+    )
+    .expect("`_oxfmtPluginOptionsJson` should contain valid config");
 
     let allocator = Allocator::default();
     let ParserReturn { program, errors, .. } =

--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -6,8 +6,7 @@ use rayon::prelude::*;
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService};
 
 use super::command::OutputMode;
-use super::walk::FormatEntry;
-use crate::core::{FormatResult, SourceFormatter, utils};
+use crate::core::{FormatResult, FormatStrategy, SourceFormatter, utils};
 
 pub enum SuccessResult {
     Changed(String),
@@ -31,14 +30,13 @@ impl FormatService {
     /// Process entries as they are received from the channel
     pub fn run_streaming(
         &self,
-        rx_entry: mpsc::Receiver<FormatEntry>,
+        rx_entry: mpsc::Receiver<FormatStrategy>,
         tx_error: &DiagnosticSender,
         tx_success: &mpsc::Sender<SuccessResult>,
     ) {
-        rx_entry.into_iter().par_bridge().for_each(|entry| {
+        rx_entry.into_iter().par_bridge().for_each(|strategy| {
             let start_time = matches!(self.format_mode, OutputMode::Check).then(Instant::now);
 
-            let FormatEntry { strategy, resolved_options } = entry;
             let path = strategy.path();
             let Ok(source_text) = utils::read_to_string(path) else {
                 // This happens if binary file is attempted to be formatted
@@ -59,29 +57,30 @@ impl FormatService {
                 return;
             };
 
-            let (code, is_changed) =
-                match self.formatter.format(&strategy, &source_text, resolved_options) {
-                    FormatResult::Success { code, is_changed } => (code, is_changed),
-                    FormatResult::Error(diagnostics) => {
-                        let errors = DiagnosticService::wrap_diagnostics(
-                            self.cwd.clone(),
-                            path,
-                            &source_text,
-                            diagnostics,
-                        );
-                        let _ = tx_error.send(errors);
-                        return;
-                    }
-                };
+            let path = path.to_path_buf();
+
+            let (code, is_changed) = match self.formatter.format(&source_text, strategy) {
+                FormatResult::Success { code, is_changed } => (code, is_changed),
+                FormatResult::Error(diagnostics) => {
+                    let errors = DiagnosticService::wrap_diagnostics(
+                        self.cwd.clone(),
+                        &path,
+                        &source_text,
+                        diagnostics,
+                    );
+                    let _ = tx_error.send(errors);
+                    return;
+                }
+            };
 
             // Write back if needed
             if matches!(self.format_mode, OutputMode::Write) && is_changed {
-                match fs::write(path, &code) {
+                match fs::write(&path, &code) {
                     Ok(()) => (),
                     Err(err) => {
                         let diagnostics = DiagnosticService::wrap_diagnostics(
                             self.cwd.clone(),
-                            path,
+                            &path,
                             "",
                             vec![oxc_diagnostics::OxcDiagnostic::error(format!(
                                 "Failed to save '{}': {err}",
@@ -100,7 +99,7 @@ impl FormatService {
                     let display_path = path
                         // Show path relative to `cwd` for cleaner output
                         .strip_prefix(&self.cwd)
-                        .unwrap_or(path)
+                        .unwrap_or(&path)
                         .to_string_lossy()
                         // Normalize path separators for consistent output across platforms
                         .cow_replace('\\', "/")

--- a/apps/oxfmt/src/cli/stdin_runner.rs
+++ b/apps/oxfmt/src/cli/stdin_runner.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::core::{
     ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, SourceFormatter,
-    resolve_editorconfig_path, utils,
+    classify_file_kind, resolve_editorconfig_path, utils,
 };
 
 pub struct StdinRunner {
@@ -121,12 +121,6 @@ impl StdinRunner {
             }
         }
 
-        // Determine format strategy using config-aware builder
-        let Ok(strategy) = config_resolver.strategy_builder().build(filepath) else {
-            utils::print_and_flush(stderr, "Unsupported file type for stdin-filepath\n");
-            return CliRunResult::InvalidOptionConfig;
-        };
-
         // Check if the file is ignored by global ignores or config's `ignorePatterns`
         let global_matchers = match resolve_ignore_paths(&cwd, &ignore_options.ignore_path)
             .and_then(|paths| build_global_ignore_matchers(&cwd, &[], &paths))
@@ -137,16 +131,19 @@ impl StdinRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         };
-        if is_ignored(&global_matchers, strategy.path(), false, true)
-            || config_resolver.is_path_ignored(strategy.path(), false)
+        if is_ignored(&global_matchers, &filepath, false, true)
+            || config_resolver.is_path_ignored(&filepath, false)
         {
             utils::print_and_flush(stdout, &source_text);
             return CliRunResult::FormatSucceeded;
         }
 
-        // Resolve options for the stdin file entry
-        let resolved_options = match config_resolver.resolve(&strategy) {
-            Ok(options) => options,
+        let Some(kind) = classify_file_kind(filepath) else {
+            utils::print_and_flush(stderr, "Unsupported file type for stdin-filepath\n");
+            return CliRunResult::InvalidOptionConfig;
+        };
+        let strategy = match config_resolver.resolve(kind) {
+            Ok(strategy) => strategy,
             Err(err) => {
                 utils::print_and_flush(stderr, &format!("{err}\n"));
                 return CliRunResult::InvalidOptionConfig;
@@ -158,9 +155,7 @@ impl StdinRunner {
             .with_external_formatter(Some(self.external_formatter));
 
         // Use `block_in_place()` to avoid nested async runtime access
-        match tokio::task::block_in_place(|| {
-            source_formatter.format(&strategy, &source_text, resolved_options)
-        }) {
+        match tokio::task::block_in_place(|| source_formatter.format(&source_text, strategy)) {
             FormatResult::Success { code, .. } => {
                 utils::print_and_flush(stdout, &code);
                 CliRunResult::FormatSucceeded

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -14,16 +14,7 @@ use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
 use super::resolve::{build_global_ignore_matchers, is_ignored, resolve_file_scope_config};
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
-use crate::core::{ConfigResolver, FormatStrategy, ResolvedOptions, config_discovery};
-
-/// A file entry paired with its resolved options.
-///
-/// `ResolvedOptions` is computed upfront in the walk thread (per-file, including overrides),
-/// so the format service can consume it directly without re-resolving.
-pub struct FormatEntry {
-    pub strategy: FormatStrategy,
-    pub resolved_options: ResolvedOptions,
-}
+use crate::core::{ConfigResolver, FormatStrategy, classify_file_kind, config_discovery};
 
 /// Orchestrates file discovery with nested config and ignore handling.
 ///
@@ -130,7 +121,7 @@ impl ScopedWalker {
         detect_nested: bool,
         editorconfig_path: Option<&Path>,
         #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
-        sender: &mpsc::Sender<FormatEntry>,
+        sender: &mpsc::Sender<FormatStrategy>,
         tx_error: &DiagnosticSender,
     ) -> Result<bool, String> {
         let root_config_resolver = Arc::new(root_config);
@@ -223,16 +214,13 @@ impl ScopedWalker {
                 if file_config.is_path_ignored(file, false) {
                     continue;
                 }
-                let Ok(strategy) = file_config.strategy_builder().build(file.clone()) else {
+
+                // Not a formatting target (e.g. unsupported extension) — skip silently
+                let Some(kind) = classify_file_kind(file.clone()) else {
                     continue;
                 };
-                #[cfg(not(feature = "napi"))]
-                if !strategy.can_format_without_external() {
-                    continue;
-                }
-
-                let resolved_options = match file_config.resolve(&strategy) {
-                    Ok(options) => options,
+                let strategy = match file_config.resolve(kind) {
+                    Ok(strategy) => strategy,
                     Err(err) => {
                         report_resolve_error(
                             tx_error,
@@ -245,7 +233,7 @@ impl ScopedWalker {
                 };
 
                 directly_processed.insert(file.clone());
-                if sender.send(FormatEntry { strategy, resolved_options }).is_err() {
+                if sender.send(strategy).is_err() {
                     break;
                 }
             }
@@ -499,7 +487,7 @@ fn walk_and_stream(
     directly_processed: &Arc<FxHashSet<PathBuf>>,
     config_ancestors: Option<&Arc<FxHashSet<PathBuf>>>,
     child_scope_map: &Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
-    sender: &mpsc::Sender<FormatEntry>,
+    sender: &mpsc::Sender<FormatStrategy>,
     tx_error: &DiagnosticSender,
 ) {
     let Some(first_path) = target_paths.first() else {
@@ -598,7 +586,7 @@ fn configure_walk_builder(mut builder: ignore::WalkBuilder) -> ignore::WalkBuild
 
 struct WalkVisitorBuilder {
     cwd: Box<Path>,
-    sender: mpsc::Sender<FormatEntry>,
+    sender: mpsc::Sender<FormatStrategy>,
     tx_error: DiagnosticSender,
     root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
@@ -624,7 +612,7 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkVisitorBuilder {
 
 struct WalkVisitor {
     cwd: Box<Path>,
-    sender: mpsc::Sender<FormatEntry>,
+    sender: mpsc::Sender<FormatStrategy>,
     tx_error: DiagnosticSender,
     root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
@@ -710,28 +698,19 @@ impl ignore::ParallelVisitor for WalkVisitor {
                     // Tier 3 = `.html`, `.json`, etc: Other files supported by Prettier
                     // (Tier 4 = `.astro`, `.svelte`, etc: Other files supported by Prettier plugins)
                     // Everything else: Ignored
-                    let Ok(strategy) = resolver.strategy_builder().build(path) else {
+                    // Not a formatting target (e.g. unsupported extension) — skip silently
+                    let Some(kind) = classify_file_kind(path.clone()) else {
                         return ignore::WalkState::Continue;
                     };
-                    #[cfg(not(feature = "napi"))]
-                    if !strategy.can_format_without_external() {
-                        return ignore::WalkState::Continue;
-                    }
-
-                    let resolved_options = match resolver.resolve(&strategy) {
-                        Ok(options) => options,
+                    let strategy = match resolver.resolve(kind) {
+                        Ok(strategy) => strategy,
                         Err(err) => {
-                            report_resolve_error(
-                                &self.tx_error,
-                                self.cwd.clone(),
-                                strategy.path(),
-                                err,
-                            );
+                            report_resolve_error(&self.tx_error, self.cwd.clone(), &path, err);
                             return ignore::WalkState::Continue;
                         }
                     };
 
-                    if self.sender.send(FormatEntry { strategy, resolved_options }).is_err() {
+                    if self.sender.send(strategy).is_err() {
                         return ignore::WalkState::Quit;
                     }
                 }

--- a/apps/oxfmt/src/cli/walk_runner.rs
+++ b/apps/oxfmt/src/cli/walk_runner.rs
@@ -8,11 +8,13 @@ use super::{
     resolve::resolve_ignore_paths,
     result::CliRunResult,
     service::{FormatService, SuccessResult},
-    walk::{FormatEntry, ScopedWalker},
+    walk::ScopedWalker,
 };
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
-use crate::core::{ConfigResolver, SourceFormatter, resolve_editorconfig_path, utils};
+use crate::core::{
+    ConfigResolver, FormatStrategy, SourceFormatter, resolve_editorconfig_path, utils,
+};
 
 pub struct WalkRunner {
     options: FormatCommand,
@@ -134,7 +136,7 @@ impl WalkRunner {
         };
 
         // Shared channel for format entries from all scopes
-        let (tx_entry, rx_entry) = mpsc::channel::<FormatEntry>();
+        let (tx_entry, rx_entry) = mpsc::channel::<FormatStrategy>();
         // Collect format results (changed paths or unchanged count)
         let (tx_success, rx_success) = mpsc::channel();
         // Diagnostic from formatting service

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -12,19 +12,22 @@ use tracing::instrument;
 use oxc_config_discovery::{
     ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path,
 };
-use oxc_formatter::FormatOptions;
-use oxc_toml::Options as TomlFormatterOptions;
-
 #[cfg(feature = "napi")]
-use super::js_config::JsConfigLoaderCb;
+use oxc_formatter::FormatOptions;
+#[cfg(feature = "napi")]
+use oxc_span::SourceType;
+
 use super::{
-    FormatStrategy, FormatStrategyBuilder,
+    FormatStrategy,
     oxfmtrc::{
         EndOfLineConfig, FormatConfig, OxfmtOptions, OxfmtOverrideConfig, Oxfmtrc,
-        finalize_external_options, sync_external_options, to_oxfmt_options,
+        sync_external_options, to_oxfmt_options,
     },
+    support::FileKind,
     utils,
 };
+#[cfg(feature = "napi")]
+use super::{js_config::JsConfigLoaderCb, oxfmtrc::finalize_external_options};
 
 const OXFMT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: ".oxfmtrc.json",
@@ -45,18 +48,50 @@ pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
     cwd.ancestors().map(|dir| dir.join(".editorconfig")).find(|p| p.exists())
 }
 
-/// Resolve format options directly from a raw JSON config value.
+/// Resolve options for a pre-classified file and build a [`FormatStrategy`].
 ///
 /// This is the simplified path for the NAPI `format()` API,
 /// which doesn't need `.oxfmtrc` overrides, `.editorconfig`, or ignore patterns.
 ///
 /// If `cwd` is provided, relative Tailwind paths are resolved against it.
+///
+/// Returns `Err` only when the merged config fails validation.
 #[cfg(feature = "napi")]
-pub fn resolve_options_from_value(
+pub fn resolve(
     raw_config: Value,
-    strategy: &FormatStrategy,
+    kind: FileKind,
     cwd: Option<&Path>,
-) -> Result<ResolvedOptions, String> {
+) -> Result<FormatStrategy, String> {
+    let (oxfmt_options, external_options) = resolve_oxfmtrc_value(raw_config, cwd)?;
+    Ok(FormatStrategy::from_oxfmt_options(oxfmt_options, external_options, kind))
+}
+
+/// Resolve options for an embedded JS/TS fragment, returning the pieces needed by
+/// [`crate::api::text_to_doc_api`] without going through [`FormatStrategy`].
+///
+/// Returns `(format_options, external_options, filepath_override)`.
+/// The caller does not call `SourceFormatter::format()`, so wrapping in `FormatStrategy`
+/// would only force the caller to peel the `OxcFormatter` variant via `unreachable!`.
+#[cfg(feature = "napi")]
+pub fn resolve_options_for_embedded_js(
+    raw_config: Value,
+    path: PathBuf,
+    source_type: SourceType,
+    cwd: Option<&Path>,
+) -> Result<(Box<FormatOptions>, Value, Option<PathBuf>), String> {
+    let kind = FileKind::OxcFormatter { path, source_type };
+    let (oxfmt_options, mut external_options) = resolve_oxfmtrc_value(raw_config, cwd)?;
+    finalize_external_options(&mut external_options, &kind);
+    Ok((Box::new(oxfmt_options.format_options), external_options, None))
+}
+
+/// Shared core of NAPI option resolution: parse `raw_config`, resolve relative Tailwind paths,
+/// and produce the validated [`OxfmtOptions`] paired with the synced external options.
+#[cfg(feature = "napi")]
+fn resolve_oxfmtrc_value(
+    raw_config: Value,
+    cwd: Option<&Path>,
+) -> Result<(OxfmtOptions, Value), String> {
     let mut format_config: FormatConfig =
         serde_json::from_value(raw_config).map_err(|err| err.to_string())?;
     if let Some(cwd) = cwd {
@@ -69,88 +104,7 @@ pub fn resolve_options_from_value(
 
     sync_external_options(&oxfmt_options.format_options, &mut external_options);
 
-    Ok(ResolvedOptions::from_oxfmt_options(oxfmt_options, external_options, strategy))
-}
-
-// ---
-
-/// Resolved options for each file type.
-/// Each variant contains only the options needed for that formatter.
-#[derive(Debug)]
-pub enum ResolvedOptions {
-    /// For JS/TS files formatted by oxc_formatter.
-    OxcFormatter {
-        format_options: Box<FormatOptions>,
-        /// For embedded language (xxx-in-js) formatting
-        external_options: Value,
-        /// Optional filepath override for external callbacks (e.g., Tailwind sorter).
-        /// When set, this path is used instead of `FormatStrategy::path`
-        /// as the `options.filepath` passed to external callbacks.
-        /// Needed for js-in-xxx where the strategy path is a dummy,
-        /// but callbacks need the parent file path to resolve their config.
-        filepath_override: Option<PathBuf>,
-        insert_final_newline: bool,
-    },
-    /// For TOML files.
-    OxfmtToml { toml_options: TomlFormatterOptions, insert_final_newline: bool },
-    /// For non-JS files formatted by external formatter (Prettier).
-    #[cfg(feature = "napi")]
-    ExternalFormatter { external_options: Value, insert_final_newline: bool },
-    /// For `package.json` files: optionally sorted then formatted.
-    #[cfg(feature = "napi")]
-    ExternalFormatterPackageJson {
-        external_options: Value,
-        sort_package_json: Option<sort_package_json::SortOptions>,
-        insert_final_newline: bool,
-    },
-}
-
-impl ResolvedOptions {
-    /// Build `ResolvedOptions` from `OxfmtOptions`, `external_options`, and `FormatStrategy`.
-    ///
-    /// This also applies plugin-specific options (Tailwind, oxfmt plugin flags) based on strategy.
-    fn from_oxfmt_options(
-        oxfmt_options: OxfmtOptions,
-        mut external_options: Value,
-        strategy: &FormatStrategy,
-    ) -> Self {
-        // Apply plugin-specific options based on strategy
-        finalize_external_options(&mut external_options, strategy);
-
-        #[cfg(feature = "napi")]
-        let OxfmtOptions { format_options, toml_options, sort_package_json, insert_final_newline } =
-            oxfmt_options;
-        #[cfg(not(feature = "napi"))]
-        let OxfmtOptions { format_options, toml_options, insert_final_newline, .. } = oxfmt_options;
-
-        match strategy {
-            FormatStrategy::OxcFormatter { .. } => ResolvedOptions::OxcFormatter {
-                format_options: Box::new(format_options),
-                external_options,
-                filepath_override: None,
-                insert_final_newline,
-            },
-            FormatStrategy::OxfmtToml { .. } => {
-                ResolvedOptions::OxfmtToml { toml_options, insert_final_newline }
-            }
-            #[cfg(feature = "napi")]
-            FormatStrategy::ExternalFormatter { .. } => {
-                ResolvedOptions::ExternalFormatter { external_options, insert_final_newline }
-            }
-            #[cfg(feature = "napi")]
-            FormatStrategy::ExternalFormatterPackageJson { .. } => {
-                ResolvedOptions::ExternalFormatterPackageJson {
-                    external_options,
-                    sort_package_json,
-                    insert_final_newline,
-                }
-            }
-            #[cfg(not(feature = "napi"))]
-            _ => {
-                unreachable!("If `napi` feature is disabled, this should not be passed here")
-            }
-        }
-    }
+    Ok((oxfmt_options, external_options))
 }
 
 // ---
@@ -178,9 +132,6 @@ pub struct ConfigResolver {
     ignore_glob: Option<Gitignore>,
     /// Parsed `.editorconfig`, if any.
     editorconfig: Option<EditorConfig>,
-    /// Builder for creating [`FormatStrategy`] from file paths.
-    /// Carries per-scope experimental flags (e.g. `experimentalSvelte`).
-    strategy_builder: FormatStrategyBuilder,
 }
 
 impl ConfigResolver {
@@ -198,18 +149,12 @@ impl ConfigResolver {
             oxfmtrc_overrides: None,
             ignore_glob: None,
             editorconfig,
-            strategy_builder: FormatStrategyBuilder::default(),
         }
     }
 
     /// Returns the directory containing the config file, if any was loaded.
     pub fn config_dir(&self) -> Option<&Path> {
         self.config_dir.as_deref()
-    }
-
-    /// Returns the [`FormatStrategyBuilder`] for this config scope.
-    pub fn strategy_builder(&self) -> &FormatStrategyBuilder {
-        &self.strategy_builder
     }
 
     /// Returns `true` if this config has any `ignorePatterns`.
@@ -457,14 +402,13 @@ impl ConfigResolver {
         Ok(())
     }
 
-    /// Resolve format options for a specific file.
+    /// Resolve options for a pre-classified file and build a [`FormatStrategy`].
     ///
-    /// # Errors
-    /// Returns error if merged override options are invalid (e.g. conflicting settings).
-    #[instrument(level = "debug", name = "oxfmt::config::resolve", skip_all, fields(path = %strategy.path().display()))]
-    pub fn resolve(&self, strategy: &FormatStrategy) -> Result<ResolvedOptions, String> {
-        let (oxfmt_options, external_options) = self.resolve_options(strategy.path())?;
-        Ok(ResolvedOptions::from_oxfmt_options(oxfmt_options, external_options, strategy))
+    /// Returns `Err` only when the merged config (after override application) fails validation.
+    #[instrument(level = "debug", name = "oxfmt::config::resolve", skip_all, fields(path = %kind.path().display()))]
+    pub fn resolve(&self, kind: FileKind) -> Result<FormatStrategy, String> {
+        let (oxfmt_options, external_options) = self.resolve_options(kind.path())?;
+        Ok(FormatStrategy::from_oxfmt_options(oxfmt_options, external_options, kind))
     }
 
     /// Resolve options for a specific file path.

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 use tracing::instrument;
@@ -8,8 +8,116 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::{FormatOptions, Formatter, enable_jsx_source_type, get_parse_options};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use oxc_toml::Options as TomlFormatterOptions;
 
-use super::{FormatStrategy, ResolvedOptions};
+use super::{
+    oxfmtrc::{OxfmtOptions, finalize_external_options},
+    support::FileKind,
+};
+
+/// A resolved formatting target: classification + per-file resolved options.
+///
+/// Built by [`super::ConfigResolver::resolve`] (or the NAPI variant-specific helpers)
+/// from a [`FileKind`] and the resolved configuration for that file.
+/// Each variant carries everything needed to format the file.
+#[derive(Debug)]
+pub enum FormatStrategy {
+    /// For JS/TS files formatted by oxc_formatter.
+    OxcFormatter {
+        path: PathBuf,
+        source_type: SourceType,
+        format_options: Box<FormatOptions>,
+        /// For embedded language (xxx-in-js) formatting
+        external_options: Value,
+        /// Optional filepath override for external callbacks (e.g., Tailwind sorter).
+        /// When set, this path is used instead of `path` as the `options.filepath`
+        /// passed to external callbacks.
+        /// Needed for js-in-xxx where the path is a dummy, but callbacks need the
+        /// parent file path to resolve their config.
+        filepath_override: Option<PathBuf>,
+        insert_final_newline: bool,
+    },
+    /// For TOML files.
+    OxfmtToml { path: PathBuf, toml_options: TomlFormatterOptions, insert_final_newline: bool },
+    /// For non-JS files formatted by external formatter (Prettier).
+    #[cfg(feature = "napi")]
+    ExternalFormatter {
+        path: PathBuf,
+        parser_name: &'static str,
+        external_options: Value,
+        insert_final_newline: bool,
+    },
+    /// For `package.json` files: optionally sorted then formatted.
+    #[cfg(feature = "napi")]
+    ExternalFormatterPackageJson {
+        path: PathBuf,
+        parser_name: &'static str,
+        external_options: Value,
+        sort_package_json: Option<sort_package_json::SortOptions>,
+        insert_final_newline: bool,
+    },
+}
+
+impl FormatStrategy {
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::OxcFormatter { path, .. } | Self::OxfmtToml { path, .. } => path,
+            #[cfg(feature = "napi")]
+            Self::ExternalFormatter { path, .. }
+            | Self::ExternalFormatterPackageJson { path, .. } => path,
+        }
+    }
+
+    /// Build `FormatStrategy` from a [`FileKind`], `OxfmtOptions`, and external options.
+    ///
+    /// Also applies plugin-specific options (Tailwind, oxfmt plugin flags) based on file kind.
+    pub(crate) fn from_oxfmt_options(
+        oxfmt_options: OxfmtOptions,
+        mut external_options: Value,
+        kind: FileKind,
+    ) -> Self {
+        finalize_external_options(&mut external_options, &kind);
+
+        #[cfg(feature = "napi")]
+        let OxfmtOptions { format_options, toml_options, sort_package_json, insert_final_newline } =
+            oxfmt_options;
+        #[cfg(not(feature = "napi"))]
+        let OxfmtOptions { format_options, toml_options, insert_final_newline, .. } = oxfmt_options;
+
+        match kind {
+            FileKind::OxcFormatter { path, source_type } => Self::OxcFormatter {
+                path,
+                source_type,
+                format_options: Box::new(format_options),
+                external_options,
+                filepath_override: None,
+                insert_final_newline,
+            },
+            FileKind::OxfmtToml { path } => {
+                Self::OxfmtToml { path, toml_options, insert_final_newline }
+            }
+            #[cfg(feature = "napi")]
+            FileKind::ExternalFormatter { path, parser_name } => Self::ExternalFormatter {
+                path,
+                parser_name,
+                external_options,
+                insert_final_newline,
+            },
+            #[cfg(feature = "napi")]
+            FileKind::ExternalFormatterPackageJson { path, parser_name } => {
+                Self::ExternalFormatterPackageJson {
+                    path,
+                    parser_name,
+                    external_options,
+                    sort_package_json,
+                    insert_final_newline,
+                }
+            }
+        }
+    }
+}
+
+// ---
 
 pub enum FormatResult {
     Success { is_changed: bool, code: String },
@@ -31,65 +139,63 @@ impl SourceFormatter {
         }
     }
 
-    /// Format a file based on its entry type and resolved options.
-    #[instrument(level = "debug", name = "oxfmt::format", skip_all, fields(path = %entry.path().display()))]
-    pub fn format(
-        &self,
-        entry: &FormatStrategy,
-        source_text: &str,
-        resolved_options: ResolvedOptions,
-    ) -> FormatResult {
-        let (result, insert_final_newline) = match (entry, resolved_options) {
-            (
-                FormatStrategy::OxcFormatter { path, source_type },
-                ResolvedOptions::OxcFormatter {
-                    format_options,
-                    external_options,
-                    filepath_override,
-                    insert_final_newline,
-                },
-            ) => (
+    /// Format a file based on its resolved strategy.
+    #[instrument(level = "debug", name = "oxfmt::format", skip_all, fields(path = %resolved.path().display()))]
+    pub fn format(&self, source_text: &str, resolved: FormatStrategy) -> FormatResult {
+        let (result, insert_final_newline) = match resolved {
+            FormatStrategy::OxcFormatter {
+                path,
+                source_type,
+                format_options,
+                external_options,
+                filepath_override,
+                insert_final_newline,
+            } => (
                 self.format_by_oxc_formatter(
                     source_text,
-                    path,
-                    *source_type,
+                    &path,
+                    source_type,
                     *format_options,
                     external_options,
                     filepath_override.as_deref(),
                 ),
                 insert_final_newline,
             ),
-            (
-                FormatStrategy::OxfmtToml { .. },
-                ResolvedOptions::OxfmtToml { toml_options, insert_final_newline },
-            ) => (Ok(Self::format_by_toml(source_text, toml_options)), insert_final_newline),
+            FormatStrategy::OxfmtToml { toml_options, insert_final_newline, .. } => {
+                (Ok(Self::format_by_toml(source_text, toml_options)), insert_final_newline)
+            }
             #[cfg(feature = "napi")]
-            (
-                FormatStrategy::ExternalFormatter { path, parser_name },
-                ResolvedOptions::ExternalFormatter { external_options, insert_final_newline },
-            ) => (
-                self.format_by_external_formatter(source_text, path, parser_name, external_options),
+            FormatStrategy::ExternalFormatter {
+                path,
+                parser_name,
+                external_options,
+                insert_final_newline,
+            } => (
+                self.format_by_external_formatter(
+                    source_text,
+                    &path,
+                    parser_name,
+                    external_options,
+                ),
                 insert_final_newline,
             ),
             #[cfg(feature = "napi")]
-            (
-                FormatStrategy::ExternalFormatterPackageJson { path, parser_name },
-                ResolvedOptions::ExternalFormatterPackageJson {
-                    external_options,
-                    sort_package_json,
-                    insert_final_newline,
-                },
-            ) => (
+            FormatStrategy::ExternalFormatterPackageJson {
+                path,
+                parser_name,
+                external_options,
+                sort_package_json,
+                insert_final_newline,
+            } => (
                 self.format_by_external_formatter_package_json(
                     source_text,
-                    path,
+                    &path,
                     parser_name,
                     external_options,
                     sort_package_json.as_ref(),
                 ),
                 insert_final_newline,
             ),
-            _ => unreachable!("FormatStrategy and ResolvedOptions variant mismatch"),
         };
 
         match result {

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -9,11 +9,11 @@ mod external_formatter;
 #[cfg(feature = "napi")]
 mod js_config;
 
+pub use config::{ConfigResolver, config_discovery, resolve_editorconfig_path};
 #[cfg(feature = "napi")]
-pub use config::resolve_options_from_value;
-pub use config::{ConfigResolver, ResolvedOptions, config_discovery, resolve_editorconfig_path};
-pub use format::{FormatResult, SourceFormatter};
-pub use support::{FormatStrategy, FormatStrategyBuilder};
+pub use config::{resolve, resolve_options_for_embedded_js};
+pub use format::{FormatResult, FormatStrategy, SourceFormatter};
+pub use support::classify_file_kind;
 
 #[cfg(feature = "napi")]
 pub use external_formatter::{

--- a/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use oxc_formatter::{FormatOptions, IndentStyle, LineEnding};
 
-use crate::core::FormatStrategy;
+use crate::core::support::FileKind;
 
 /// Syncs resolved `FormatOptions` values into the raw config JSON.
 /// This ensures `external_formatter`(Prettier) receives the same options that `oxc_formatter` uses.
@@ -53,20 +53,20 @@ pub fn sync_external_options(options: &FormatOptions, config: &mut Value) {
     // Other options defined independently by plugins are also left as they are.
 }
 
-/// Finalizes external options by adding plugin-specific flags based on the formatting strategy.
+/// Finalizes external options by adding plugin-specific flags based on the file kind.
 /// This should be called during `resolve()` after getting cached config.
 ///
 /// - `_useTailwindPlugin`: Flag for JS side to load Tailwind plugin
 /// - `_oxfmtPluginOptionsJson`: Bundled options for `prettier-plugin-oxfmt`
 ///
 /// Also removes Prettier-unaware options to minimize payload size.
-pub fn finalize_external_options(config: &mut Value, strategy: &FormatStrategy) {
+pub fn finalize_external_options(config: &mut Value, kind: &FileKind) {
     let Some(obj) = config.as_object_mut() else {
         return;
     };
 
     // Add Tailwind plugin flag and map options if needed
-    if obj.contains_key("sortTailwindcss") && strategy.needs_tailwind_plugin() {
+    if obj.contains_key("sortTailwindcss") && kind.needs_tailwind_plugin() {
         if let Some(tailwind) = obj.get("sortTailwindcss").and_then(|v| v.as_object()).cloned() {
             // See: https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options
             for (src, dst) in [
@@ -87,8 +87,8 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatStrategy) 
 
     // Build oxfmt plugin options JSON for js-in-xxx parsers
     #[cfg(feature = "napi")]
-    if let FormatStrategy::ExternalFormatter { path, .. } = strategy
-        && strategy.needs_oxfmt_plugin()
+    if let FileKind::ExternalFormatter { path, .. } = kind
+        && kind.needs_oxfmt_plugin()
     {
         let mut oxfmt_plugin_options = serde_json::Map::new();
         for key in [
@@ -119,7 +119,7 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatStrategy) 
         // which Prettier overrides the full path with a `dummy.ts(x)`...
         // This filepath roundtrips:
         // Rust → JS (Prettier plugin options) → Rust (text_to_doc_api),
-        // where it becomes `filepath_override` in `ResolvedOptions::OxcFormatter`.
+        // where it becomes `filepath_override` in `FormatStrategy::OxcFormatter`.
         oxfmt_plugin_options
             .insert("filepath".to_string(), Value::String(path.to_string_lossy().to_string()));
 
@@ -254,11 +254,11 @@ mod tests {
         }"#;
         let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
 
-        let strategy = FormatStrategy::OxcFormatter {
+        let kind = FileKind::OxcFormatter {
             path: PathBuf::from("test.js"),
             source_type: SourceType::mjs(),
         };
-        finalize_external_options(&mut raw_config, &strategy);
+        finalize_external_options(&mut raw_config, &kind);
 
         let obj = raw_config.as_object().unwrap();
         // oxfmt extensions are removed by finalize_external_options
@@ -279,11 +279,11 @@ mod tests {
         }"#;
         let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
 
-        let strategy = FormatStrategy::ExternalFormatter {
+        let kind = FileKind::ExternalFormatter {
             path: PathBuf::from("/tmp/foo/bar/App.vue"),
             parser_name: "vue",
         };
-        finalize_external_options(&mut raw_config, &strategy);
+        finalize_external_options(&mut raw_config, &kind);
 
         let obj = raw_config.as_object().unwrap();
         let plugin_options_json = obj

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -4,7 +4,50 @@ use phf::phf_set;
 
 use oxc_span::SourceType;
 
-pub enum FormatStrategy {
+/// Classify a file path into a [`FileKind`].
+///
+/// Returns `None` when the file type is not a formatting target.
+pub fn classify_file_kind(path: PathBuf) -> Option<FileKind> {
+    if let Some(source_type) = get_oxc_formatter_source_type(&path) {
+        return Some(FileKind::OxcFormatter { path, source_type });
+    }
+
+    let file_name = path.file_name().and_then(|f| f.to_str())?;
+
+    // Excluded files like lock files
+    if EXCLUDE_FILENAMES.contains(file_name) {
+        return None;
+    }
+
+    if is_toml_file(file_name) {
+        return Some(FileKind::OxfmtToml { path });
+    }
+
+    // External formatter files are only supported with the `napi` feature
+    #[cfg(feature = "napi")]
+    {
+        // `package.json` is special: sorted then formatted
+        if file_name == "package.json" {
+            return Some(FileKind::ExternalFormatterPackageJson {
+                path,
+                parser_name: "json-stringify",
+            });
+        }
+
+        let extension = path.extension().and_then(|ext| ext.to_str());
+        if let Some(parser_name) = get_external_parser_name(file_name, extension) {
+            return Some(FileKind::ExternalFormatter { path, parser_name });
+        }
+    }
+
+    None
+}
+
+/// Internal classification of a file: which formatter handles it, plus minimal metadata.
+///
+/// This is a transient type produced by [`classify_file_kind`] and consumed by the
+/// resolver to construct a public [`super::FormatStrategy`] (with options).
+pub enum FileKind {
     OxcFormatter {
         path: PathBuf,
         source_type: SourceType,
@@ -13,100 +56,45 @@ pub enum FormatStrategy {
     OxfmtToml {
         path: PathBuf,
     },
+    /// Files formatted by external formatter (Prettier).
+    /// Only available with the `napi` feature; without it, the classifier rejects such files.
+    #[cfg(feature = "napi")]
     ExternalFormatter {
         path: PathBuf,
         parser_name: &'static str,
     },
     /// `package.json` is special: sorted by `sort-package-json` then formatted by external formatter.
+    /// Only available with the `napi` feature; without it, the classifier rejects such files.
+    #[cfg(feature = "napi")]
     ExternalFormatterPackageJson {
         path: PathBuf,
         parser_name: &'static str,
     },
 }
 
-/// Builder for creating [`FormatStrategy`] from file paths.
-///
-/// Carries per-scope configuration (e.g. experimental language flags)
-/// that influences which files are supported and how they are formatted.
-///
-/// Created from [`super::ConfigResolver::strategy_builder()`] for CLI/LSP paths,
-/// or via [`FormatStrategyBuilder::default()`] for the NAPI API path.
-#[derive(Debug, Default)]
-pub struct FormatStrategyBuilder {
-    // Future: experimental_svelte, experimental_astro, etc.
-    _private: (),
-}
-
-impl FormatStrategyBuilder {
-    /// Build a [`FormatStrategy`] from a file path.
-    ///
-    /// Returns `Ok` if the file type is supported, `Err(())` otherwise.
-    #[expect(clippy::unused_self)] // Will use `self` when experimental flags are added
-    pub fn build(&self, path: PathBuf) -> Result<FormatStrategy, ()> {
-        // Check JS/TS files first
-        if let Some(source_type) = get_oxc_formatter_source_type(&path) {
-            return Ok(FormatStrategy::OxcFormatter { path, source_type });
-        }
-
-        // Extract file_name and extension once for all subsequent checks
-        let Some(file_name) = path.file_name().and_then(|f| f.to_str()) else {
-            return Err(());
-        };
-
-        // Excluded files like lock files
-        if EXCLUDE_FILENAMES.contains(file_name) {
-            return Err(());
-        }
-
-        // Then TOML files
-        if is_toml_file(file_name) {
-            return Ok(FormatStrategy::OxfmtToml { path });
-        }
-
-        // Then external formatter files
-        // `package.json` is special: sorted then formatted
-        if file_name == "package.json" {
-            return Ok(FormatStrategy::ExternalFormatterPackageJson {
-                path,
-                parser_name: "json-stringify",
-            });
-        }
-
-        let extension = path.extension().and_then(|ext| ext.to_str());
-        if let Some(parser_name) = get_external_parser_name(file_name, extension) {
-            return Ok(FormatStrategy::ExternalFormatter { path, parser_name });
-        }
-
-        Err(())
-    }
-}
-
-impl FormatStrategy {
-    #[cfg(not(feature = "napi"))]
-    pub fn can_format_without_external(&self) -> bool {
-        matches!(self, Self::OxcFormatter { .. } | Self::OxfmtToml { .. })
-    }
-
+impl FileKind {
     pub fn path(&self) -> &Path {
         match self {
-            Self::OxcFormatter { path, .. }
-            | Self::OxfmtToml { path }
-            | Self::ExternalFormatter { path, .. }
+            Self::OxcFormatter { path, .. } | Self::OxfmtToml { path } => path,
+            #[cfg(feature = "napi")]
+            Self::ExternalFormatter { path, .. }
             | Self::ExternalFormatterPackageJson { path, .. } => path,
         }
     }
 
-    /// Returns `true` if this strategy supports the Tailwind CSS sorting plugin.
+    /// Returns `true` if this file kind supports the Tailwind CSS sorting plugin.
     pub fn needs_tailwind_plugin(&self) -> bool {
         match self {
             Self::OxcFormatter { .. } => true,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { parser_name, .. } => TAILWIND_PARSERS.contains(parser_name),
-            _ => false,
+            #[cfg(feature = "napi")]
+            Self::ExternalFormatterPackageJson { .. } => false,
+            Self::OxfmtToml { .. } => false,
         }
     }
 
-    /// Returns `true` if this strategy supports the `prettier-plugin-oxfmt` (js-in-xxx).
+    /// Returns `true` if this file kind supports the `prettier-plugin-oxfmt` (js-in-xxx).
     #[cfg(feature = "napi")]
     pub fn needs_oxfmt_plugin(&self) -> bool {
         matches!(
@@ -115,6 +103,8 @@ impl FormatStrategy {
         )
     }
 }
+
+// ---
 
 /// Parsers(files) that benefit from Tailwind plugin.
 #[cfg(feature = "napi")]
@@ -185,9 +175,10 @@ static TOML_FILENAMES: phf::Set<&'static str> = phf_set! {
 
 /// Returns parser name for external formatter, if supported.
 /// See also `prettier --support-info | jq '.languages[]'`
+#[cfg(feature = "napi")]
 fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
     // JSON and variants
-    // NOTE: `package.json` is handled separately in `FormatStrategyBuilder::build()`
+    // NOTE: `package.json` is handled separately in `classify_file_kind`
     if file_name == "composer.json" || extension == Some("importmap") {
         return Some("json-stringify");
     }
@@ -278,6 +269,7 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
     None
 }
 
+#[cfg(feature = "napi")]
 static JSON_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "json",
     "4DForm",
@@ -301,6 +293,7 @@ static JSON_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "yyp",
 };
 
+#[cfg(feature = "napi")]
 static JSON_FILENAMES: phf::Set<&'static str> = phf_set! {
     ".all-contributorsrc",
     ".arcconfig",
@@ -319,6 +312,7 @@ static JSON_FILENAMES: phf::Set<&'static str> = phf_set! {
     ".swcrc",
 };
 
+#[cfg(feature = "napi")]
 static JSONC_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "jsonc",
     "code-snippets",
@@ -339,6 +333,7 @@ static JSONC_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "sublime_session",
 };
 
+#[cfg(feature = "napi")]
 static HTML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "html",
     "hta",
@@ -348,6 +343,7 @@ static HTML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "xhtml",
 };
 
+#[cfg(feature = "napi")]
 static CSS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "css",
     "wxss",
@@ -355,22 +351,26 @@ static CSS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "postcss",
 };
 
+#[cfg(feature = "napi")]
 static GRAPHQL_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "graphql",
     "gql",
     "graphqls",
 };
 
+#[cfg(feature = "napi")]
 static HANDLEBARS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "handlebars",
     "hbs",
 };
 
+#[cfg(feature = "napi")]
 static MARKDOWN_FILENAMES: phf::Set<&'static str> = phf_set! {
     "contents.lr",
     "README",
 };
 
+#[cfg(feature = "napi")]
 static MARKDOWN_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "md",
     "livemd",
@@ -385,6 +385,7 @@ static MARKDOWN_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "workbook",
 };
 
+#[cfg(feature = "napi")]
 static YAML_FILENAMES: phf::Set<&'static str> = phf_set! {
     ".clang-format",
     ".clang-tidy",
@@ -398,6 +399,7 @@ static YAML_FILENAMES: phf::Set<&'static str> = phf_set! {
     ".lintstagedrc",
 };
 
+#[cfg(feature = "napi")]
 static YAML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "yml",
     "mir",
@@ -484,6 +486,7 @@ fn get_oxc_formatter_source_type(path: &Path) -> Option<SourceType> {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "napi")]
     fn get_parser_name(file_name: &str) -> Option<&'static str> {
         let path = Path::new(file_name);
         let extension = path.extension().and_then(|ext| ext.to_str());
@@ -491,9 +494,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "napi")]
     fn test_get_external_parser_name() {
         let test_cases = vec![
-            // JSON (NOTE: `package.json` is handled in FormatStrategyBuilder::build, not here)
+            // JSON (NOTE: `package.json` is handled in classify_file_kind, not here)
             ("config.importmap", Some("json-stringify")),
             ("data.json", Some("json")),
             ("schema.avsc", Some("json")),
@@ -549,13 +553,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "napi")]
     fn test_package_json_is_special() {
-        let source = FormatStrategyBuilder::default().build(PathBuf::from("package.json")).unwrap();
-        assert!(matches!(source, FormatStrategy::ExternalFormatterPackageJson { .. }));
+        let kind = classify_file_kind(PathBuf::from("package.json")).unwrap();
+        assert!(matches!(kind, FileKind::ExternalFormatterPackageJson { .. }));
 
-        let source =
-            FormatStrategyBuilder::default().build(PathBuf::from("composer.json")).unwrap();
-        assert!(matches!(source, FormatStrategy::ExternalFormatter { .. }));
+        let kind = classify_file_kind(PathBuf::from("composer.json")).unwrap();
+        assert!(matches!(kind, FileKind::ExternalFormatter { .. }));
     }
 
     #[test]
@@ -571,9 +575,9 @@ mod tests {
         ];
 
         for file_name in toml_files {
-            let result = FormatStrategyBuilder::default().build(PathBuf::from(file_name));
+            let result = classify_file_kind(PathBuf::from(file_name));
             assert!(
-                matches!(result, Ok(FormatStrategy::OxfmtToml { .. })),
+                matches!(result, Some(FileKind::OxfmtToml { .. })),
                 "`{file_name}` should be detected as TOML"
             );
         }
@@ -582,8 +586,8 @@ mod tests {
         let excluded_files = vec!["Cargo.lock", "poetry.lock", "pdm.lock", "uv.lock", "Gopkg.lock"];
 
         for file_name in excluded_files {
-            let result = FormatStrategyBuilder::default().build(PathBuf::from(file_name));
-            assert!(result.is_err(), "`{file_name}` should be excluded (lock file)");
+            let result = classify_file_kind(PathBuf::from(file_name));
+            assert!(result.is_none(), "`{file_name}` should be excluded (lock file)");
         }
     }
 }

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -12,7 +12,7 @@ use oxc_language_server::{
 
 use crate::core::{
     ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, SourceFormatter,
-    config_discovery, resolve_editorconfig_path, utils,
+    classify_file_kind, config_discovery, resolve_editorconfig_path, utils,
 };
 use crate::lsp::create_fake_file_path_from_language_id;
 use crate::lsp::options::FormatOptions as LSPFormatOptions;
@@ -351,23 +351,20 @@ impl ServerFormatter {
             return None;
         }
 
-        let Ok(strategy) = cached.strategy_builder().build(path.to_path_buf()) else {
+        let Some(kind) = classify_file_kind(path.to_path_buf()) else {
             debug!("Unsupported file type for formatting: {}", path.display());
             return None;
         };
-
-        let resolved_options = match cached.resolve(&strategy) {
-            Ok(options) => options,
+        let strategy = match cached.resolve(kind) {
+            Ok(strategy) => strategy,
             Err(err) => {
                 debug!("Config resolve error for {}: {err}", path.display());
                 return None;
             }
         };
-        debug!("resolved_options = {resolved_options:?}");
+        debug!("strategy = {strategy:?}");
 
-        Some(tokio::task::block_in_place(|| {
-            self.source_formatter.format(&strategy, source_text, resolved_options)
-        }))
+        Some(tokio::task::block_in_place(|| self.source_formatter.format(source_text, strategy)))
     }
 
     fn format_file(&self, path: &Path, source_text: &str) -> Option<FormatResult> {


### PR DESCRIPTION
We can't determine whether a file path should be formatted or ignored without resolving the options, including the `overrides`.

Since there's no longer any point in keeping these separate, merging them into one.