### PR TITLE
fix(linter/max-nested-describe): reset nested describe depth

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/max_nested_describe.rs
@@ -3,14 +3,12 @@ use serde::Deserialize;
 
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::ScopeId;
 use oxc_span::Span;
 
 use crate::{
     context::LintContext,
     utils::{
-        JestFnKind, JestGeneralFnKind, PossibleJestNode, collect_possible_jest_call_node,
-        is_type_of_jest_fn_call,
+        JestFnKind, JestGeneralFnKind, collect_possible_jest_call_node, is_type_of_jest_fn_call,
     },
 };
 
@@ -121,43 +119,37 @@ impl Default for MaxNestedDescribeConfig {
 
 impl MaxNestedDescribeConfig {
     pub fn run_once(&self, ctx: &LintContext) {
-        let mut describes_hooks_depth: Vec<ScopeId> = vec![];
-        let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);
-        possibles_jest_nodes.sort_unstable_by_key(|n| n.node.id());
+        let mut describe_call_spans = collect_possible_jest_call_node(ctx)
+            .into_iter()
+            .filter_map(|possible_jest_node| {
+                let AstKind::CallExpression(call_expr) = possible_jest_node.node.kind() else {
+                    return None;
+                };
 
-        for possible_jest_node in &possibles_jest_nodes {
-            self.run(possible_jest_node, &mut describes_hooks_depth, ctx);
-        }
-    }
+                is_type_of_jest_fn_call(
+                    call_expr,
+                    &possible_jest_node,
+                    ctx,
+                    &[JestFnKind::General(JestGeneralFnKind::Describe)],
+                )
+                .then_some(call_expr.span)
+            })
+            .collect::<Vec<_>>();
 
-    fn run<'a>(
-        &self,
-        possible_jest_node: &PossibleJestNode<'a, '_>,
-        describes_hooks_depth: &mut Vec<ScopeId>,
-        ctx: &LintContext<'a>,
-    ) {
-        let node = possible_jest_node.node;
-        let scope_id = node.scope_id();
-        let AstKind::CallExpression(call_expr) = node.kind() else {
-            return;
-        };
-        let is_describe_call = is_type_of_jest_fn_call(
-            call_expr,
-            possible_jest_node,
-            ctx,
-            &[JestFnKind::General(JestGeneralFnKind::Describe)],
-        );
+        describe_call_spans
+            .sort_unstable_by(|a, b| a.start.cmp(&b.start).then_with(|| b.end.cmp(&a.end)));
 
-        if is_describe_call && !describes_hooks_depth.contains(&scope_id) {
-            describes_hooks_depth.push(scope_id);
-        }
+        let mut active_describes: Vec<Span> = Vec::new();
+        for span in describe_call_spans {
+            while active_describes.last().is_some_and(|parent| !parent.contains_inclusive(span)) {
+                active_describes.pop();
+            }
+            active_describes.push(span);
 
-        if is_describe_call && describes_hooks_depth.len() > self.max {
-            ctx.diagnostic(exceeded_max_depth(
-                describes_hooks_depth.len(),
-                self.max,
-                call_expr.span,
-            ));
+            let current_depth = active_describes.len();
+            if current_depth > self.max {
+                ctx.diagnostic(exceeded_max_depth(current_depth, self.max, span));
+            }
         }
     }
 }

--- a/crates/oxc_linter/src/rules/vitest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/vitest/max_nested_describe.rs
@@ -99,6 +99,43 @@ fn test() {
         (
             "
                 describe('foo', () => {
+                    describe('bar', () => {
+                        it('should get something', () => {
+                            expect(getSomething()).toBe('Something');
+                        });
+                    });
+                    describe('qux', () => {
+                        it('should get something', () => {
+                            expect(getSomething()).toBe('Something');
+                        });
+                    });
+                });
+
+                describe('foo2', function () {
+                    it('should get something', () => {
+                        expect(getSomething()).toBe('Something');
+                    });
+                });
+
+                describe('foo', function () {
+                    describe('bar', function () {
+                        describe('baz', function () {
+                            describe('qux', function () {
+                                describe('this is the limit', function () {
+                                    it('should get something', () => {
+                                        expect(getSomething()).toBe('Something');
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            ",
+            None,
+        ),
+        (
+            "
+                describe('foo', () => {
                     describe.only('bar', () => {
                         describe.skip('baz', () => {
                             it('something', async () => {

--- a/crates/oxc_linter/src/snapshots/jest_max_nested_describe.snap
+++ b/crates/oxc_linter/src/snapshots/jest_max_nested_describe.snap
@@ -39,18 +39,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Too many nested describe calls (6) - maximum allowed is 5
 
   ⚠ jest(max-nested-describe): Enforces a maximum depth to nested describe calls.
-    ╭─[max_nested_describe.tsx:22:25]
- 21 │     
- 22 │ ╭─▶                         describe('qux', function () {
- 23 │ │                               it('should get something', () => {
- 24 │ │                                   expect(getSomething()).toBe('Something');
- 25 │ │                               });
- 26 │ ╰─▶                         });
- 27 │                         })
-    ╰────
-  help: Too many nested describe calls (6) - maximum allowed is 5
-
-  ⚠ jest(max-nested-describe): Enforces a maximum depth to nested describe calls.
    ╭─[max_nested_describe.tsx:4:25]
  3 │                         describe.only('bar', () => {
  4 │ ╭─▶                         describe.skip('baz', () => {
@@ -71,18 +59,6 @@ source: crates/oxc_linter/src/tester.rs
  13 │ │                               });
  14 │ ╰─▶                         });
  15 │                         });
-    ╰────
-  help: Too many nested describe calls (3) - maximum allowed is 2
-
-  ⚠ jest(max-nested-describe): Enforces a maximum depth to nested describe calls.
-    ╭─[max_nested_describe.tsx:18:17]
- 17 │     
- 18 │ ╭─▶                 xdescribe('qux', () => {
- 19 │ │                       it('should get something', () => {
- 20 │ │                           expect(getSomething()).toBe('Something');
- 21 │ │                       });
- 22 │ ╰─▶                 });
- 23 │                 
     ╰────
   help: Too many nested describe calls (3) - maximum allowed is 2
 

--- a/crates/oxc_linter/src/snapshots/vitest_max_nested_describe.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_max_nested_describe.snap
@@ -39,18 +39,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Too many nested describe calls (6) - maximum allowed is 5
 
   ⚠ vitest(max-nested-describe): Enforces a maximum depth to nested describe calls.
-    ╭─[max_nested_describe.tsx:22:25]
- 21 │     
- 22 │ ╭─▶                         describe('qux', function () {
- 23 │ │                               it('should get something', () => {
- 24 │ │                                   expect(getSomething()).toBe('Something');
- 25 │ │                               });
- 26 │ ╰─▶                         });
- 27 │                         })
-    ╰────
-  help: Too many nested describe calls (6) - maximum allowed is 5
-
-  ⚠ vitest(max-nested-describe): Enforces a maximum depth to nested describe calls.
    ╭─[max_nested_describe.tsx:4:25]
  3 │                         describe.only('bar', () => {
  4 │ ╭─▶                         describe.skip('baz', () => {
@@ -71,18 +59,6 @@ source: crates/oxc_linter/src/tester.rs
  13 │ │                               });
  14 │ ╰─▶                         });
  15 │                         });
-    ╰────
-  help: Too many nested describe calls (3) - maximum allowed is 2
-
-  ⚠ vitest(max-nested-describe): Enforces a maximum depth to nested describe calls.
-    ╭─[max_nested_describe.tsx:18:17]
- 17 │     
- 18 │ ╭─▶                 describe('qux', () => {
- 19 │ │                       it('should get something', () => {
- 20 │ │                           expect(getSomething()).toBe('Something');
- 21 │ │                       });
- 22 │ ╰─▶                 });
- 23 │                 
     ╰────
   help: Too many nested describe calls (3) - maximum allowed is 2
 


### PR DESCRIPTION
`max-nested-describe` was retaining depth across sibling and later top-level `describe` blocks, causing false positives after a nested block ended.

This computes depth with an active describe span stack so siblings reset correctly while preserving existing Jest/Vitest call recognition.

fixes #21888
