### PR TITLE
feat(linter/vue): implement no-deprecated-props-default-this rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1299,6 +1299,7 @@ export interface DummyRuleMap {
   "vue/no-deprecated-destroyed-lifecycle"?: DummyRule;
   "vue/no-deprecated-events-api"?: DummyRule;
   "vue/no-deprecated-model-definition"?: DummyRule;
+  "vue/no-deprecated-props-default-this"?: DummyRule;
   "vue/no-deprecated-vue-config-keycodes"?: DummyRule;
   "vue/no-export-in-script-setup"?: DummyRule;
   "vue/no-import-compiler-macros"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4832,6 +4832,11 @@ impl RuleRunner for crate::rules::vitest::require_awaited_expect_poll::RequireAw
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::require_hook::RequireHook {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
@@ -4982,6 +4987,12 @@ impl RuleRunner
 impl RuleRunner for crate::rules::vue::no_deprecated_events_api::NoDeprecatedEventsApi {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::vue::no_deprecated_model_definition::NoDeprecatedModelDefinition {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ObjectProperty]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4832,11 +4832,6 @@ impl RuleRunner for crate::rules::vitest::require_awaited_expect_poll::RequireAw
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
-impl RuleRunner for crate::rules::vitest::require_hook::RequireHook {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
 impl RuleRunner for crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
@@ -4990,9 +4985,11 @@ impl RuleRunner for crate::rules::vue::no_deprecated_events_api::NoDeprecatedEve
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
-impl RuleRunner for crate::rules::vue::no_deprecated_model_definition::NoDeprecatedModelDefinition {
+impl RuleRunner
+    for crate::rules::vue::no_deprecated_props_default_this::NoDeprecatedPropsDefaultThis
+{
     const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::ObjectProperty]));
+        Some(&AstTypesBitset::from_types(&[AstType::ThisExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -777,7 +777,6 @@ pub use crate::rules::vitest::prefer_to_have_been_called_times::PreferToHaveBeen
 pub use crate::rules::vitest::prefer_to_have_length::PreferToHaveLength as VitestPreferToHaveLength;
 pub use crate::rules::vitest::prefer_todo::PreferTodo as VitestPreferTodo;
 pub use crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll as VitestRequireAwaitedExpectPoll;
-pub use crate::rules::vitest::require_hook::RequireHook as VitestRequireHook;
 pub use crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots as VitestRequireLocalTestContextForConcurrentSnapshots;
 pub use crate::rules::vitest::require_mock_type_parameters::RequireMockTypeParameters as VitestRequireMockTypeParameters;
 pub use crate::rules::vitest::require_test_timeout::RequireTestTimeout as VitestRequireTestTimeout;
@@ -797,7 +796,7 @@ pub use crate::rules::vue::no_deprecated_data_object_declaration::NoDeprecatedDa
 pub use crate::rules::vue::no_deprecated_delete_set::NoDeprecatedDeleteSet as VueNoDeprecatedDeleteSet;
 pub use crate::rules::vue::no_deprecated_destroyed_lifecycle::NoDeprecatedDestroyedLifecycle as VueNoDeprecatedDestroyedLifecycle;
 pub use crate::rules::vue::no_deprecated_events_api::NoDeprecatedEventsApi as VueNoDeprecatedEventsApi;
-pub use crate::rules::vue::no_deprecated_model_definition::NoDeprecatedModelDefinition as VueNoDeprecatedModelDefinition;
+pub use crate::rules::vue::no_deprecated_props_default_this::NoDeprecatedPropsDefaultThis as VueNoDeprecatedPropsDefaultThis;
 pub use crate::rules::vue::no_deprecated_vue_config_keycodes::NoDeprecatedVueConfigKeycodes as VueNoDeprecatedVueConfigKeycodes;
 pub use crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup as VueNoExportInScriptSetup;
 pub use crate::rules::vue::no_import_compiler_macros::NoImportCompilerMacros as VueNoImportCompilerMacros;
@@ -1595,7 +1594,6 @@ pub enum RuleEnum {
     VitestPreferToHaveLength(VitestPreferToHaveLength),
     VitestPreferTodo(VitestPreferTodo),
     VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll),
-    VitestRequireHook(VitestRequireHook),
     VitestRequireLocalTestContextForConcurrentSnapshots(
         VitestRequireLocalTestContextForConcurrentSnapshots,
     ),
@@ -1624,7 +1622,7 @@ pub enum RuleEnum {
     VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet),
     VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle),
     VueNoDeprecatedEventsApi(VueNoDeprecatedEventsApi),
-    VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition),
+    VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis),
     VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes),
     VueNoExportInScriptSetup(VueNoExportInScriptSetup),
     VueNoImportCompilerMacros(VueNoImportCompilerMacros),
@@ -2503,9 +2501,8 @@ const VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID: usize = VITEST_PREFER_TO_CONTA
 const VITEST_PREFER_TO_HAVE_LENGTH_ID: usize = VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID + 1usize;
 const VITEST_PREFER_TODO_ID: usize = VITEST_PREFER_TO_HAVE_LENGTH_ID + 1usize;
 const VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID: usize = VITEST_PREFER_TODO_ID + 1usize;
-const VITEST_REQUIRE_HOOK_ID: usize = VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID + 1usize;
 const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
-    VITEST_REQUIRE_HOOK_ID + 1usize;
+    VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID + 1usize;
 const VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID: usize =
     VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID + 1usize;
 const VITEST_REQUIRE_TEST_TIMEOUT_ID: usize = VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID + 1usize;
@@ -2534,9 +2531,9 @@ const VUE_NO_DEPRECATED_DELETE_SET_ID: usize =
     VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID + 1usize;
 const VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID: usize = VUE_NO_DEPRECATED_DELETE_SET_ID + 1usize;
 const VUE_NO_DEPRECATED_EVENTS_API_ID: usize = VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID + 1usize;
-const VUE_NO_DEPRECATED_MODEL_DEFINITION_ID: usize = VUE_NO_DEPRECATED_EVENTS_API_ID + 1usize;
+const VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID: usize = VUE_NO_DEPRECATED_EVENTS_API_ID + 1usize;
 const VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID: usize =
-    VUE_NO_DEPRECATED_MODEL_DEFINITION_ID + 1usize;
+    VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID + 1usize;
 const VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID: usize = VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID + 1usize;
 const VUE_NO_IMPORT_COMPILER_MACROS_ID: usize = VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID + 1usize;
 const VUE_NO_LIFECYCLE_AFTER_AWAIT_ID: usize = VUE_NO_IMPORT_COMPILER_MACROS_ID + 1usize;
@@ -3442,7 +3439,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VITEST_PREFER_TO_HAVE_LENGTH_ID,
             Self::VitestPreferTodo(_) => VITEST_PREFER_TODO_ID,
             Self::VitestRequireAwaitedExpectPoll(_) => VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID,
-            Self::VitestRequireHook(_) => VITEST_REQUIRE_HOOK_ID,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID
             }
@@ -3473,7 +3469,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VUE_NO_DEPRECATED_DELETE_SET_ID,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID,
             Self::VueNoDeprecatedEventsApi(_) => VUE_NO_DEPRECATED_EVENTS_API_ID,
-            Self::VueNoDeprecatedModelDefinition(_) => VUE_NO_DEPRECATED_MODEL_DEFINITION_ID,
+            Self::VueNoDeprecatedPropsDefaultThis(_) => VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID,
             Self::VueNoExportInScriptSetup(_) => VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID,
             Self::VueNoImportCompilerMacros(_) => VUE_NO_IMPORT_COMPILER_MACROS_ID,
@@ -4365,7 +4361,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::NAME,
             Self::VitestPreferTodo(_) => VitestPreferTodo::NAME,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::NAME,
-            Self::VitestRequireHook(_) => VitestRequireHook::NAME,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::NAME
             }
@@ -4396,7 +4391,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::NAME,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::NAME,
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::NAME,
-            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::NAME,
+            Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::NAME,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::NAME,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::NAME,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::NAME,
@@ -5344,7 +5339,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::CATEGORY,
             Self::VitestPreferTodo(_) => VitestPreferTodo::CATEGORY,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::CATEGORY,
-            Self::VitestRequireHook(_) => VitestRequireHook::CATEGORY,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::CATEGORY
             }
@@ -5377,7 +5371,7 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::CATEGORY
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::CATEGORY,
-            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::CATEGORY,
+            Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::CATEGORY,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::CATEGORY,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::CATEGORY,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::CATEGORY,
@@ -6270,7 +6264,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::FIX,
             Self::VitestPreferTodo(_) => VitestPreferTodo::FIX,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::FIX,
-            Self::VitestRequireHook(_) => VitestRequireHook::FIX,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::FIX
             }
@@ -6301,7 +6294,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::FIX,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::FIX,
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::FIX,
-            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::FIX,
+            Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::FIX,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::FIX,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::FIX,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::FIX,
@@ -7432,7 +7425,6 @@ impl RuleEnum {
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::documentation()
             }
-            Self::VitestRequireHook(_) => VitestRequireHook::documentation(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::documentation()
             }
@@ -7469,8 +7461,8 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::documentation()
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::documentation(),
-            Self::VueNoDeprecatedModelDefinition(_) => {
-                VueNoDeprecatedModelDefinition::documentation()
+            Self::VueNoDeprecatedPropsDefaultThis(_) => {
+                VueNoDeprecatedPropsDefaultThis::documentation()
             }
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::documentation()
@@ -9685,8 +9677,6 @@ impl RuleEnum {
                 VitestRequireAwaitedExpectPoll::config_schema(generator)
                     .or_else(|| VitestRequireAwaitedExpectPoll::schema(generator))
             }
-            Self::VitestRequireHook(_) => VitestRequireHook::config_schema(generator)
-                .or_else(|| VitestRequireHook::schema(generator)),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::config_schema(generator)
                     .or_else(|| {
@@ -9766,9 +9756,9 @@ impl RuleEnum {
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::config_schema(generator)
                 .or_else(|| VueNoDeprecatedEventsApi::schema(generator)),
-            Self::VueNoDeprecatedModelDefinition(_) => {
-                VueNoDeprecatedModelDefinition::config_schema(generator)
-                    .or_else(|| VueNoDeprecatedModelDefinition::schema(generator))
+            Self::VueNoDeprecatedPropsDefaultThis(_) => {
+                VueNoDeprecatedPropsDefaultThis::config_schema(generator)
+                    .or_else(|| VueNoDeprecatedPropsDefaultThis::schema(generator))
             }
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::config_schema(generator)
@@ -10588,7 +10578,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => "vitest",
             Self::VitestPreferTodo(_) => "vitest",
             Self::VitestRequireAwaitedExpectPoll(_) => "vitest",
-            Self::VitestRequireHook(_) => "vitest",
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => "vitest",
             Self::VitestRequireMockTypeParameters(_) => "vitest",
             Self::VitestRequireTestTimeout(_) => "vitest",
@@ -10615,7 +10604,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => "vue",
             Self::VueNoDeprecatedDestroyedLifecycle(_) => "vue",
             Self::VueNoDeprecatedEventsApi(_) => "vue",
-            Self::VueNoDeprecatedModelDefinition(_) => "vue",
+            Self::VueNoDeprecatedPropsDefaultThis(_) => "vue",
             Self::VueNoDeprecatedVueConfigKeycodes(_) => "vue",
             Self::VueNoExportInScriptSetup(_) => "vue",
             Self::VueNoImportCompilerMacros(_) => "vue",
@@ -13102,9 +13091,6 @@ impl RuleEnum {
             Self::VitestRequireAwaitedExpectPoll(_) => Ok(Self::VitestRequireAwaitedExpectPoll(
                 VitestRequireAwaitedExpectPoll::from_configuration(value)?,
             )),
-            Self::VitestRequireHook(_) => {
-                Ok(Self::VitestRequireHook(VitestRequireHook::from_configuration(value)?))
-            }
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 Ok(Self::VitestRequireLocalTestContextForConcurrentSnapshots(
                     VitestRequireLocalTestContextForConcurrentSnapshots::from_configuration(value)?,
@@ -13187,8 +13173,8 @@ impl RuleEnum {
             Self::VueNoDeprecatedEventsApi(_) => Ok(Self::VueNoDeprecatedEventsApi(
                 VueNoDeprecatedEventsApi::from_configuration(value)?,
             )),
-            Self::VueNoDeprecatedModelDefinition(_) => Ok(Self::VueNoDeprecatedModelDefinition(
-                VueNoDeprecatedModelDefinition::from_configuration(value)?,
+            Self::VueNoDeprecatedPropsDefaultThis(_) => Ok(Self::VueNoDeprecatedPropsDefaultThis(
+                VueNoDeprecatedPropsDefaultThis::from_configuration(value)?,
             )),
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 Ok(Self::VueNoDeprecatedVueConfigKeycodes(
@@ -14017,7 +14003,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.to_configuration(),
             Self::VitestPreferTodo(rule) => rule.to_configuration(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.to_configuration(),
-            Self::VitestRequireHook(rule) => rule.to_configuration(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                 rule.to_configuration()
             }
@@ -14046,7 +14031,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.to_configuration(),
-            Self::VueNoDeprecatedModelDefinition(rule) => rule.to_configuration(),
+            Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.to_configuration(),
             Self::VueNoExportInScriptSetup(rule) => rule.to_configuration(),
             Self::VueNoImportCompilerMacros(rule) => rule.to_configuration(),
@@ -14840,7 +14825,6 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run(node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run(node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run(node, ctx),
-                Self::VitestRequireHook(rule) => rule.run(node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run(node, ctx)
                 }
@@ -14869,7 +14853,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run(node, ctx),
-                Self::VueNoDeprecatedModelDefinition(rule) => rule.run(node, ctx),
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
@@ -15656,7 +15640,6 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run(node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run(node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run(node, ctx),
-                Self::VitestRequireHook(rule) => rule.run(node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run(node, ctx)
                 }
@@ -15685,7 +15668,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run(node, ctx),
-                Self::VueNoDeprecatedModelDefinition(rule) => rule.run(node, ctx),
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
@@ -16479,7 +16462,6 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_once(ctx),
                 Self::VitestPreferTodo(rule) => rule.run_once(ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_once(ctx),
-                Self::VitestRequireHook(rule) => rule.run_once(ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_once(ctx)
                 }
@@ -16508,7 +16490,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_once(ctx),
-                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_once(ctx),
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
@@ -17295,7 +17277,6 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_once(ctx),
                 Self::VitestPreferTodo(rule) => rule.run_once(ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_once(ctx),
-                Self::VitestRequireHook(rule) => rule.run_once(ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_once(ctx)
                 }
@@ -17324,7 +17305,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_once(ctx),
-                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_once(ctx),
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
@@ -18363,7 +18344,6 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::VitestRequireHook(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -18398,7 +18378,9 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -19431,7 +19413,6 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::VitestRequireHook(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -19466,7 +19447,9 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -20255,7 +20238,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.should_run(ctx),
             Self::VitestPreferTodo(rule) => rule.should_run(ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.should_run(ctx),
-            Self::VitestRequireHook(rule) => rule.should_run(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.should_run(ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.should_run(ctx),
             Self::VitestRequireTestTimeout(rule) => rule.should_run(ctx),
@@ -20282,7 +20264,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedEventsApi(rule) => rule.should_run(ctx),
-            Self::VueNoDeprecatedModelDefinition(rule) => rule.should_run(ctx),
+            Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.should_run(ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.should_run(ctx),
             Self::VueNoImportCompilerMacros(rule) => rule.should_run(ctx),
@@ -21412,7 +21394,6 @@ impl RuleEnum {
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::IS_TSGOLINT_RULE
             }
-            Self::VitestRequireHook(_) => VitestRequireHook::IS_TSGOLINT_RULE,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::IS_TSGOLINT_RULE
             }
@@ -21449,8 +21430,8 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::IS_TSGOLINT_RULE
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::IS_TSGOLINT_RULE,
-            Self::VueNoDeprecatedModelDefinition(_) => {
-                VueNoDeprecatedModelDefinition::IS_TSGOLINT_RULE
+            Self::VueNoDeprecatedPropsDefaultThis(_) => {
+                VueNoDeprecatedPropsDefaultThis::IS_TSGOLINT_RULE
             }
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::IS_TSGOLINT_RULE
@@ -22403,7 +22384,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::VERSION,
             Self::VitestPreferTodo(_) => VitestPreferTodo::VERSION,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::VERSION,
-            Self::VitestRequireHook(_) => VitestRequireHook::VERSION,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::VERSION
             }
@@ -22436,7 +22416,7 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::VERSION
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::VERSION,
-            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::VERSION,
+            Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::VERSION,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::VERSION,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::VERSION,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::VERSION,
@@ -23419,7 +23399,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::HAS_CONFIG,
             Self::VitestPreferTodo(_) => VitestPreferTodo::HAS_CONFIG,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::HAS_CONFIG,
-            Self::VitestRequireHook(_) => VitestRequireHook::HAS_CONFIG,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::HAS_CONFIG
             }
@@ -23452,7 +23431,7 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::HAS_CONFIG
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::HAS_CONFIG,
-            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::HAS_CONFIG,
+            Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::HAS_CONFIG,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::HAS_CONFIG
             }
@@ -24240,7 +24219,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.types_info(),
             Self::VitestPreferTodo(rule) => rule.types_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.types_info(),
-            Self::VitestRequireHook(rule) => rule.types_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.types_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.types_info(),
             Self::VitestRequireTestTimeout(rule) => rule.types_info(),
@@ -24267,7 +24245,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.types_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.types_info(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.types_info(),
-            Self::VueNoDeprecatedModelDefinition(rule) => rule.types_info(),
+            Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.types_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.types_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.types_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.types_info(),
@@ -25053,7 +25031,6 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.run_info(),
             Self::VitestPreferTodo(rule) => rule.run_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_info(),
-            Self::VitestRequireHook(rule) => rule.run_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.run_info(),
             Self::VitestRequireTestTimeout(rule) => rule.run_info(),
@@ -25080,7 +25057,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_info(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.run_info(),
-            Self::VueNoDeprecatedModelDefinition(rule) => rule.run_info(),
+            Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.run_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.run_info(),
@@ -25994,7 +25971,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferToHaveLength(VitestPreferToHaveLength::default()),
         RuleEnum::VitestPreferTodo(VitestPreferTodo::default()),
         RuleEnum::VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll::default()),
-        RuleEnum::VitestRequireHook(VitestRequireHook::default()),
         RuleEnum::VitestRequireLocalTestContextForConcurrentSnapshots(
             VitestRequireLocalTestContextForConcurrentSnapshots::default(),
         ),
@@ -26025,7 +26001,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet::default()),
         RuleEnum::VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle::default()),
         RuleEnum::VueNoDeprecatedEventsApi(VueNoDeprecatedEventsApi::default()),
-        RuleEnum::VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition::default()),
+        RuleEnum::VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis::default()),
         RuleEnum::VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes::default()),
         RuleEnum::VueNoExportInScriptSetup(VueNoExportInScriptSetup::default()),
         RuleEnum::VueNoImportCompilerMacros(VueNoImportCompilerMacros::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -777,6 +777,7 @@ pub use crate::rules::vitest::prefer_to_have_been_called_times::PreferToHaveBeen
 pub use crate::rules::vitest::prefer_to_have_length::PreferToHaveLength as VitestPreferToHaveLength;
 pub use crate::rules::vitest::prefer_todo::PreferTodo as VitestPreferTodo;
 pub use crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll as VitestRequireAwaitedExpectPoll;
+pub use crate::rules::vitest::require_hook::RequireHook as VitestRequireHook;
 pub use crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots as VitestRequireLocalTestContextForConcurrentSnapshots;
 pub use crate::rules::vitest::require_mock_type_parameters::RequireMockTypeParameters as VitestRequireMockTypeParameters;
 pub use crate::rules::vitest::require_test_timeout::RequireTestTimeout as VitestRequireTestTimeout;
@@ -796,6 +797,7 @@ pub use crate::rules::vue::no_deprecated_data_object_declaration::NoDeprecatedDa
 pub use crate::rules::vue::no_deprecated_delete_set::NoDeprecatedDeleteSet as VueNoDeprecatedDeleteSet;
 pub use crate::rules::vue::no_deprecated_destroyed_lifecycle::NoDeprecatedDestroyedLifecycle as VueNoDeprecatedDestroyedLifecycle;
 pub use crate::rules::vue::no_deprecated_events_api::NoDeprecatedEventsApi as VueNoDeprecatedEventsApi;
+pub use crate::rules::vue::no_deprecated_model_definition::NoDeprecatedModelDefinition as VueNoDeprecatedModelDefinition;
 pub use crate::rules::vue::no_deprecated_props_default_this::NoDeprecatedPropsDefaultThis as VueNoDeprecatedPropsDefaultThis;
 pub use crate::rules::vue::no_deprecated_vue_config_keycodes::NoDeprecatedVueConfigKeycodes as VueNoDeprecatedVueConfigKeycodes;
 pub use crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup as VueNoExportInScriptSetup;
@@ -1594,6 +1596,7 @@ pub enum RuleEnum {
     VitestPreferToHaveLength(VitestPreferToHaveLength),
     VitestPreferTodo(VitestPreferTodo),
     VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll),
+    VitestRequireHook(VitestRequireHook),
     VitestRequireLocalTestContextForConcurrentSnapshots(
         VitestRequireLocalTestContextForConcurrentSnapshots,
     ),
@@ -1622,6 +1625,7 @@ pub enum RuleEnum {
     VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet),
     VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle),
     VueNoDeprecatedEventsApi(VueNoDeprecatedEventsApi),
+    VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition),
     VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis),
     VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes),
     VueNoExportInScriptSetup(VueNoExportInScriptSetup),
@@ -2501,8 +2505,9 @@ const VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID: usize = VITEST_PREFER_TO_CONTA
 const VITEST_PREFER_TO_HAVE_LENGTH_ID: usize = VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID + 1usize;
 const VITEST_PREFER_TODO_ID: usize = VITEST_PREFER_TO_HAVE_LENGTH_ID + 1usize;
 const VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID: usize = VITEST_PREFER_TODO_ID + 1usize;
+const VITEST_REQUIRE_HOOK_ID: usize = VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID + 1usize;
 const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
-    VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID + 1usize;
+    VITEST_REQUIRE_HOOK_ID + 1usize;
 const VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID: usize =
     VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID + 1usize;
 const VITEST_REQUIRE_TEST_TIMEOUT_ID: usize = VITEST_REQUIRE_MOCK_TYPE_PARAMETERS_ID + 1usize;
@@ -2531,7 +2536,9 @@ const VUE_NO_DEPRECATED_DELETE_SET_ID: usize =
     VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID + 1usize;
 const VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID: usize = VUE_NO_DEPRECATED_DELETE_SET_ID + 1usize;
 const VUE_NO_DEPRECATED_EVENTS_API_ID: usize = VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID + 1usize;
-const VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID: usize = VUE_NO_DEPRECATED_EVENTS_API_ID + 1usize;
+const VUE_NO_DEPRECATED_MODEL_DEFINITION_ID: usize = VUE_NO_DEPRECATED_EVENTS_API_ID + 1usize;
+const VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID: usize =
+    VUE_NO_DEPRECATED_MODEL_DEFINITION_ID + 1usize;
 const VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID: usize =
     VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID + 1usize;
 const VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID: usize = VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID + 1usize;
@@ -3439,6 +3446,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VITEST_PREFER_TO_HAVE_LENGTH_ID,
             Self::VitestPreferTodo(_) => VITEST_PREFER_TODO_ID,
             Self::VitestRequireAwaitedExpectPoll(_) => VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID,
+            Self::VitestRequireHook(_) => VITEST_REQUIRE_HOOK_ID,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID
             }
@@ -3469,6 +3477,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VUE_NO_DEPRECATED_DELETE_SET_ID,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID,
             Self::VueNoDeprecatedEventsApi(_) => VUE_NO_DEPRECATED_EVENTS_API_ID,
+            Self::VueNoDeprecatedModelDefinition(_) => VUE_NO_DEPRECATED_MODEL_DEFINITION_ID,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID,
             Self::VueNoExportInScriptSetup(_) => VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID,
@@ -4361,6 +4370,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::NAME,
             Self::VitestPreferTodo(_) => VitestPreferTodo::NAME,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::NAME,
+            Self::VitestRequireHook(_) => VitestRequireHook::NAME,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::NAME
             }
@@ -4391,6 +4401,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::NAME,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::NAME,
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::NAME,
+            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::NAME,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::NAME,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::NAME,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::NAME,
@@ -5339,6 +5350,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::CATEGORY,
             Self::VitestPreferTodo(_) => VitestPreferTodo::CATEGORY,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::CATEGORY,
+            Self::VitestRequireHook(_) => VitestRequireHook::CATEGORY,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::CATEGORY
             }
@@ -5371,6 +5383,7 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::CATEGORY
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::CATEGORY,
+            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::CATEGORY,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::CATEGORY,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::CATEGORY,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::CATEGORY,
@@ -6264,6 +6277,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::FIX,
             Self::VitestPreferTodo(_) => VitestPreferTodo::FIX,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::FIX,
+            Self::VitestRequireHook(_) => VitestRequireHook::FIX,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::FIX
             }
@@ -6294,6 +6308,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::FIX,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::FIX,
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::FIX,
+            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::FIX,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::FIX,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::FIX,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::FIX,
@@ -7425,6 +7440,7 @@ impl RuleEnum {
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::documentation()
             }
+            Self::VitestRequireHook(_) => VitestRequireHook::documentation(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::documentation()
             }
@@ -7461,6 +7477,9 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::documentation()
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::documentation(),
+            Self::VueNoDeprecatedModelDefinition(_) => {
+                VueNoDeprecatedModelDefinition::documentation()
+            }
             Self::VueNoDeprecatedPropsDefaultThis(_) => {
                 VueNoDeprecatedPropsDefaultThis::documentation()
             }
@@ -9677,6 +9696,8 @@ impl RuleEnum {
                 VitestRequireAwaitedExpectPoll::config_schema(generator)
                     .or_else(|| VitestRequireAwaitedExpectPoll::schema(generator))
             }
+            Self::VitestRequireHook(_) => VitestRequireHook::config_schema(generator)
+                .or_else(|| VitestRequireHook::schema(generator)),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::config_schema(generator)
                     .or_else(|| {
@@ -9756,6 +9777,10 @@ impl RuleEnum {
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::config_schema(generator)
                 .or_else(|| VueNoDeprecatedEventsApi::schema(generator)),
+            Self::VueNoDeprecatedModelDefinition(_) => {
+                VueNoDeprecatedModelDefinition::config_schema(generator)
+                    .or_else(|| VueNoDeprecatedModelDefinition::schema(generator))
+            }
             Self::VueNoDeprecatedPropsDefaultThis(_) => {
                 VueNoDeprecatedPropsDefaultThis::config_schema(generator)
                     .or_else(|| VueNoDeprecatedPropsDefaultThis::schema(generator))
@@ -10578,6 +10603,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => "vitest",
             Self::VitestPreferTodo(_) => "vitest",
             Self::VitestRequireAwaitedExpectPoll(_) => "vitest",
+            Self::VitestRequireHook(_) => "vitest",
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => "vitest",
             Self::VitestRequireMockTypeParameters(_) => "vitest",
             Self::VitestRequireTestTimeout(_) => "vitest",
@@ -10604,6 +10630,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => "vue",
             Self::VueNoDeprecatedDestroyedLifecycle(_) => "vue",
             Self::VueNoDeprecatedEventsApi(_) => "vue",
+            Self::VueNoDeprecatedModelDefinition(_) => "vue",
             Self::VueNoDeprecatedPropsDefaultThis(_) => "vue",
             Self::VueNoDeprecatedVueConfigKeycodes(_) => "vue",
             Self::VueNoExportInScriptSetup(_) => "vue",
@@ -13091,6 +13118,9 @@ impl RuleEnum {
             Self::VitestRequireAwaitedExpectPoll(_) => Ok(Self::VitestRequireAwaitedExpectPoll(
                 VitestRequireAwaitedExpectPoll::from_configuration(value)?,
             )),
+            Self::VitestRequireHook(_) => {
+                Ok(Self::VitestRequireHook(VitestRequireHook::from_configuration(value)?))
+            }
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 Ok(Self::VitestRequireLocalTestContextForConcurrentSnapshots(
                     VitestRequireLocalTestContextForConcurrentSnapshots::from_configuration(value)?,
@@ -13172,6 +13202,9 @@ impl RuleEnum {
             }
             Self::VueNoDeprecatedEventsApi(_) => Ok(Self::VueNoDeprecatedEventsApi(
                 VueNoDeprecatedEventsApi::from_configuration(value)?,
+            )),
+            Self::VueNoDeprecatedModelDefinition(_) => Ok(Self::VueNoDeprecatedModelDefinition(
+                VueNoDeprecatedModelDefinition::from_configuration(value)?,
             )),
             Self::VueNoDeprecatedPropsDefaultThis(_) => Ok(Self::VueNoDeprecatedPropsDefaultThis(
                 VueNoDeprecatedPropsDefaultThis::from_configuration(value)?,
@@ -14003,6 +14036,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.to_configuration(),
             Self::VitestPreferTodo(rule) => rule.to_configuration(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.to_configuration(),
+            Self::VitestRequireHook(rule) => rule.to_configuration(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                 rule.to_configuration()
             }
@@ -14031,6 +14065,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.to_configuration(),
+            Self::VueNoDeprecatedModelDefinition(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.to_configuration(),
             Self::VueNoExportInScriptSetup(rule) => rule.to_configuration(),
@@ -14825,6 +14860,7 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run(node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run(node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run(node, ctx),
+                Self::VitestRequireHook(rule) => rule.run(node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run(node, ctx)
                 }
@@ -14853,6 +14889,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run(node, ctx),
+                Self::VueNoDeprecatedModelDefinition(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
@@ -15640,6 +15677,7 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run(node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run(node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run(node, ctx),
+                Self::VitestRequireHook(rule) => rule.run(node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run(node, ctx)
                 }
@@ -15668,6 +15706,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run(node, ctx),
+                Self::VueNoDeprecatedModelDefinition(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
@@ -16462,6 +16501,7 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_once(ctx),
                 Self::VitestPreferTodo(rule) => rule.run_once(ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_once(ctx),
+                Self::VitestRequireHook(rule) => rule.run_once(ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_once(ctx)
                 }
@@ -16490,6 +16530,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_once(ctx),
+                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
@@ -17277,6 +17318,7 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_once(ctx),
                 Self::VitestPreferTodo(rule) => rule.run_once(ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_once(ctx),
+                Self::VitestRequireHook(rule) => rule.run_once(ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_once(ctx)
                 }
@@ -17305,6 +17347,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_once(ctx),
+                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
@@ -18344,6 +18387,7 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VitestRequireHook(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -18378,6 +18422,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -19413,6 +19458,7 @@ impl RuleEnum {
                 Self::VitestPreferToHaveLength(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VitestRequireHook(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -19447,6 +19493,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VueNoDeprecatedEventsApi(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoDeprecatedModelDefinition(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -20238,6 +20285,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.should_run(ctx),
             Self::VitestPreferTodo(rule) => rule.should_run(ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.should_run(ctx),
+            Self::VitestRequireHook(rule) => rule.should_run(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.should_run(ctx),
             Self::VitestRequireMockTypeParameters(rule) => rule.should_run(ctx),
             Self::VitestRequireTestTimeout(rule) => rule.should_run(ctx),
@@ -20264,6 +20312,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedEventsApi(rule) => rule.should_run(ctx),
+            Self::VueNoDeprecatedModelDefinition(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.should_run(ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.should_run(ctx),
@@ -21394,6 +21443,7 @@ impl RuleEnum {
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::IS_TSGOLINT_RULE
             }
+            Self::VitestRequireHook(_) => VitestRequireHook::IS_TSGOLINT_RULE,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::IS_TSGOLINT_RULE
             }
@@ -21430,6 +21480,9 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::IS_TSGOLINT_RULE
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::IS_TSGOLINT_RULE,
+            Self::VueNoDeprecatedModelDefinition(_) => {
+                VueNoDeprecatedModelDefinition::IS_TSGOLINT_RULE
+            }
             Self::VueNoDeprecatedPropsDefaultThis(_) => {
                 VueNoDeprecatedPropsDefaultThis::IS_TSGOLINT_RULE
             }
@@ -22384,6 +22437,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::VERSION,
             Self::VitestPreferTodo(_) => VitestPreferTodo::VERSION,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::VERSION,
+            Self::VitestRequireHook(_) => VitestRequireHook::VERSION,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::VERSION
             }
@@ -22416,6 +22470,7 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::VERSION
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::VERSION,
+            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::VERSION,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::VERSION,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::VERSION,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::VERSION,
@@ -23399,6 +23454,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::HAS_CONFIG,
             Self::VitestPreferTodo(_) => VitestPreferTodo::HAS_CONFIG,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::HAS_CONFIG,
+            Self::VitestRequireHook(_) => VitestRequireHook::HAS_CONFIG,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::HAS_CONFIG
             }
@@ -23431,6 +23487,7 @@ impl RuleEnum {
                 VueNoDeprecatedDestroyedLifecycle::HAS_CONFIG
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::HAS_CONFIG,
+            Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::HAS_CONFIG,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::HAS_CONFIG,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::HAS_CONFIG
@@ -24219,6 +24276,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.types_info(),
             Self::VitestPreferTodo(rule) => rule.types_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.types_info(),
+            Self::VitestRequireHook(rule) => rule.types_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.types_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.types_info(),
             Self::VitestRequireTestTimeout(rule) => rule.types_info(),
@@ -24245,6 +24303,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.types_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.types_info(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.types_info(),
+            Self::VueNoDeprecatedModelDefinition(rule) => rule.types_info(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.types_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.types_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.types_info(),
@@ -25031,6 +25090,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveLength(rule) => rule.run_info(),
             Self::VitestPreferTodo(rule) => rule.run_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_info(),
+            Self::VitestRequireHook(rule) => rule.run_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_info(),
             Self::VitestRequireMockTypeParameters(rule) => rule.run_info(),
             Self::VitestRequireTestTimeout(rule) => rule.run_info(),
@@ -25057,6 +25117,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_info(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.run_info(),
+            Self::VueNoDeprecatedModelDefinition(rule) => rule.run_info(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.run_info(),
@@ -25971,6 +26032,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferToHaveLength(VitestPreferToHaveLength::default()),
         RuleEnum::VitestPreferTodo(VitestPreferTodo::default()),
         RuleEnum::VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll::default()),
+        RuleEnum::VitestRequireHook(VitestRequireHook::default()),
         RuleEnum::VitestRequireLocalTestContextForConcurrentSnapshots(
             VitestRequireLocalTestContextForConcurrentSnapshots::default(),
         ),
@@ -26001,6 +26063,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet::default()),
         RuleEnum::VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle::default()),
         RuleEnum::VueNoDeprecatedEventsApi(VueNoDeprecatedEventsApi::default()),
+        RuleEnum::VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition::default()),
         RuleEnum::VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis::default()),
         RuleEnum::VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes::default()),
         RuleEnum::VueNoExportInScriptSetup(VueNoExportInScriptSetup::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -804,6 +804,7 @@ pub(crate) mod vitest {
     pub mod prefer_to_have_length;
     pub mod prefer_todo;
     pub mod require_awaited_expect_poll;
+    pub mod require_hook;
     pub mod require_local_test_context_for_concurrent_snapshots;
     pub mod require_mock_type_parameters;
     pub mod require_test_timeout;
@@ -836,6 +837,7 @@ pub(crate) mod vue {
     pub mod no_deprecated_delete_set;
     pub mod no_deprecated_destroyed_lifecycle;
     pub mod no_deprecated_events_api;
+    pub mod no_deprecated_model_definition;
     pub mod no_deprecated_props_default_this;
     pub mod no_deprecated_vue_config_keycodes;
     pub mod no_export_in_script_setup;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -804,7 +804,6 @@ pub(crate) mod vitest {
     pub mod prefer_to_have_length;
     pub mod prefer_todo;
     pub mod require_awaited_expect_poll;
-    pub mod require_hook;
     pub mod require_local_test_context_for_concurrent_snapshots;
     pub mod require_mock_type_parameters;
     pub mod require_test_timeout;
@@ -837,7 +836,7 @@ pub(crate) mod vue {
     pub mod no_deprecated_delete_set;
     pub mod no_deprecated_destroyed_lifecycle;
     pub mod no_deprecated_events_api;
-    pub mod no_deprecated_model_definition;
+    pub mod no_deprecated_props_default_this;
     pub mod no_deprecated_vue_config_keycodes;
     pub mod no_export_in_script_setup;
     pub mod no_import_compiler_macros;

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
@@ -1,0 +1,378 @@
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression, MemberExpression, ObjectExpression, ObjectPropertyKind},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_deprecated_props_default_this_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Props default value factory functions no longer have access to `this`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDeprecatedPropsDefaultThis;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow deprecated `this` access in props default function (in Vue.js 3.0.0+).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In Vue.js 3.0.0+, props default factory functions no longer have access to
+    /// `this`. They are invoked before the component instance is created, so
+    /// `this` is `undefined`. The factory should rely on its first argument (the
+    /// raw props passed by the parent) instead.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     a: String,
+    ///     b: {
+    ///       default() {
+    ///         return this.a
+    ///       }
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     a: String,
+    ///     b: {
+    ///       default(props) {
+    ///         return props.a
+    ///       }
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoDeprecatedPropsDefaultThis,
+    vue,
+    correctness,
+    pending,
+    version = "next",
+);
+
+impl Rule for NoDeprecatedPropsDefaultThis {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ThisExpression(this_expr) = node.kind() else { return };
+
+        let nodes = ctx.nodes();
+
+        // Walk up to the lexical `this` binding. Arrow functions are skipped
+        // because they bind `this` lexically.
+        let mut binding_fn_id = None;
+        for ancestor in nodes.ancestors(node.id()) {
+            if matches!(ancestor.kind(), AstKind::Function(_)) {
+                binding_fn_id = Some(ancestor.id());
+                break;
+            }
+        }
+        let Some(fn_id) = binding_fn_id else { return };
+
+        let prop_node = nodes.parent_node(fn_id);
+        let AstKind::ObjectProperty(default_prop) = prop_node.kind() else { return };
+        if !default_prop.key.is_specific_static_name("default") {
+            return;
+        }
+
+        // `type: Function` means `default` is the function value itself, not a
+        // factory that returns a value, so `this` inside is not the deprecated case.
+        let opts_node = nodes.parent_node(prop_node.id());
+        let AstKind::ObjectExpression(opts) = opts_node.kind() else { return };
+        if has_function_type(opts) {
+            return;
+        }
+
+        let in_props = nodes.ancestors(fn_id).any(|ancestor| {
+            matches!(
+                ancestor.kind(),
+                AstKind::ObjectProperty(op) if op.key.is_specific_static_name("props")
+            )
+        });
+        if !in_props {
+            return;
+        }
+
+        let in_vue_component =
+            nodes.ancestors(fn_id).any(|ancestor| is_vue_component_root(ancestor.kind()));
+        if !in_vue_component {
+            return;
+        }
+
+        ctx.diagnostic(no_deprecated_props_default_this_diagnostic(this_expr.span));
+    }
+}
+
+fn is_vue_component_root(kind: AstKind<'_>) -> bool {
+    match kind {
+        AstKind::ExportDefaultDeclaration(_) => true,
+        AstKind::CallExpression(call) => is_vue_component_definition_call(call),
+        AstKind::NewExpression(new_expr) => {
+            new_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == "Vue")
+        }
+        _ => false,
+    }
+}
+
+fn is_vue_component_definition_call(call: &CallExpression<'_>) -> bool {
+    let callee = call.callee.get_inner_expression();
+
+    if let Expression::Identifier(ident) = callee {
+        return matches!(
+            ident.name.as_str(),
+            "defineComponent" | "component" | "createApp" | "defineNuxtComponent"
+        );
+    }
+
+    let Some(MemberExpression::StaticMemberExpression(static_member)) =
+        callee.as_member_expression()
+    else {
+        return false;
+    };
+    let prop_name = static_member.property.name.as_str();
+    if let Expression::Identifier(obj_ident) = static_member.object.get_inner_expression()
+        && obj_ident.name == "Vue"
+    {
+        return matches!(prop_name, "component" | "mixin" | "extend");
+    }
+    matches!(prop_name, "component" | "mixin")
+}
+
+fn has_function_type(opts: &ObjectExpression<'_>) -> bool {
+    for property_kind in &opts.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = property_kind else { continue };
+        if !prop.key.is_specific_static_name("type") {
+            continue;
+        }
+        if is_function_identifier(&prop.value) {
+            return true;
+        }
+        if let Expression::ArrayExpression(arr) = prop.value.get_inner_expression() {
+            return arr
+                .elements
+                .iter()
+                .any(|el| el.as_expression().is_some_and(is_function_identifier));
+        }
+    }
+    false
+}
+
+fn is_function_identifier(expr: &Expression<'_>) -> bool {
+    if let Expression::Identifier(ident) = expr.get_inner_expression() {
+        return ident.name == "Function";
+    }
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: String,
+                        b: {
+                          default (props) {
+                            return props.a
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: String,
+                        b: {
+                          default: () => {
+                            return this.a
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: String,
+                        b: {
+                          default () {
+                            return function () {
+                              return this.a
+                            }
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    const Foo = {
+                      props: {
+                        a: String,
+                        b: {
+                          default () {
+                            return this.a
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                  <template>
+                    <button @click="printMessage">Print message</button>
+                  </template>
+
+                  <script>
+
+                  export default {
+                    name: 'App',
+                    props: {
+                      message: String,
+                      printMessage: {
+                        type: Function,
+                        default() {
+                          console.log(this.message);
+                        }
+                      }
+                    }
+                  }
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: String,
+                        b: {
+                          default () {
+                            return this.a
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: String,
+                        b: {
+                          default () {
+                            return () => this.a
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: String,
+                        b: {
+                          default () {
+                            return this.a
+                          }
+                        },
+                        c: {
+                          default () {
+                            return this.a
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(
+        NoDeprecatedPropsDefaultThis::NAME,
+        NoDeprecatedPropsDefaultThis::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
@@ -76,14 +76,13 @@ impl Rule for NoDeprecatedPropsDefaultThis {
 
         // Walk up to the lexical `this` binding. Arrow functions are skipped
         // because they bind `this` lexically.
-        let mut binding_fn_id = None;
-        for ancestor in nodes.ancestors(node.id()) {
-            if matches!(ancestor.kind(), AstKind::Function(_)) {
-                binding_fn_id = Some(ancestor.id());
-                break;
-            }
-        }
-        let Some(fn_id) = binding_fn_id else { return };
+        let Some(fn_id) = nodes
+            .ancestors(node.id())
+            .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
+            .map(AstNode::id)
+        else {
+            return;
+        };
 
         let prop_node = nodes.parent_node(fn_id);
         let AstKind::ObjectProperty(default_prop) = prop_node.kind() else { return };

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
@@ -1,12 +1,12 @@
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression, MemberExpression, ObjectExpression, ObjectPropertyKind},
+    ast::{Expression, ObjectExpression, ObjectPropertyKind},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_vue_component_options_object};
 
 fn no_deprecated_props_default_this_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Props default value factory functions no longer have access to `this`.")
@@ -103,59 +103,29 @@ impl Rule for NoDeprecatedPropsDefaultThis {
             return;
         }
 
-        let in_props = nodes.ancestors(fn_id).any(|ancestor| {
-            matches!(
-                ancestor.kind(),
-                AstKind::ObjectProperty(op) if op.key.is_specific_static_name("props")
-            )
-        });
-        if !in_props {
+        let prop_definition_node = nodes.parent_node(opts_node.id());
+        if !matches!(prop_definition_node.kind(), AstKind::ObjectProperty(_)) {
             return;
         }
 
-        let in_vue_component =
-            nodes.ancestors(fn_id).any(|ancestor| is_vue_component_root(ancestor.kind()));
-        if !in_vue_component {
+        let props_object_node = nodes.parent_node(prop_definition_node.id());
+        if !matches!(props_object_node.kind(), AstKind::ObjectExpression(_)) {
+            return;
+        }
+
+        let props_node = nodes.parent_node(props_object_node.id());
+        let AstKind::ObjectProperty(props_prop) = props_node.kind() else { return };
+        if !props_prop.key.is_specific_static_name("props") {
+            return;
+        }
+
+        let component_options_node = nodes.parent_node(props_node.id());
+        if !is_vue_component_options_object(component_options_node, ctx) {
             return;
         }
 
         ctx.diagnostic(no_deprecated_props_default_this_diagnostic(this_expr.span));
     }
-}
-
-fn is_vue_component_root(kind: AstKind<'_>) -> bool {
-    match kind {
-        AstKind::ExportDefaultDeclaration(_) => true,
-        AstKind::CallExpression(call) => is_vue_component_definition_call(call),
-        AstKind::NewExpression(new_expr) => {
-            new_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == "Vue")
-        }
-        _ => false,
-    }
-}
-
-fn is_vue_component_definition_call(call: &CallExpression<'_>) -> bool {
-    let callee = call.callee.get_inner_expression();
-
-    if let Expression::Identifier(ident) = callee {
-        return matches!(
-            ident.name.as_str(),
-            "defineComponent" | "component" | "createApp" | "defineNuxtComponent"
-        );
-    }
-
-    let Some(MemberExpression::StaticMemberExpression(static_member)) =
-        callee.as_member_expression()
-    else {
-        return false;
-    };
-    let prop_name = static_member.property.name.as_str();
-    if let Expression::Identifier(obj_ident) = static_member.object.get_inner_expression()
-        && obj_ident.name == "Vue"
-    {
-        return matches!(prop_name, "component" | "mixin" | "extend");
-    }
-    matches!(prop_name, "component" | "mixin")
 }
 
 fn has_function_type(opts: &ObjectExpression<'_>) -> bool {
@@ -294,6 +264,50 @@ fn test() {
                   }
                   </script>
                   "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: {
+                          validator () {
+                            return {
+                              default () {
+                                return this.a
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <template><div /></template>
+                    <script>
+                    export default {
+                      props: {
+                        a: {
+                          nested: {
+                            default () {
+                              return this.a
+                            }
+                          }
+                        }
+                      }
+                    }
+                    </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
@@ -148,10 +148,7 @@ fn has_function_type(opts: &ObjectExpression<'_>) -> bool {
 }
 
 fn is_function_identifier(expr: &Expression<'_>) -> bool {
-    if let Expression::Identifier(ident) = expr.get_inner_expression() {
-        return ident.name == "Function";
-    }
-    false
+    expr.get_inner_expression().is_specific_id("Function")
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_props_default_this.rs
@@ -69,10 +69,6 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDeprecatedPropsDefaultThis {
-    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_extension().is_some_and(|ext| ext == "vue")
-    }
-
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::ThisExpression(this_expr) = node.kind() else { return };
 
@@ -125,6 +121,10 @@ impl Rule for NoDeprecatedPropsDefaultThis {
         }
 
         ctx.diagnostic(no_deprecated_props_default_this_diagnostic(this_expr.span));
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_props_default_this.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_props_default_this.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ vue(no-deprecated-props-default-this): Props default value factory functions no longer have access to `this`.
+    ╭─[no_deprecated_props_default_this.tsx:9:36]
+  8 │                           default () {
+  9 │                             return this.a
+    ·                                    ────
+ 10 │                           }
+    ╰────
+
+  ⚠ vue(no-deprecated-props-default-this): Props default value factory functions no longer have access to `this`.
+    ╭─[no_deprecated_props_default_this.tsx:9:42]
+  8 │                           default () {
+  9 │                             return () => this.a
+    ·                                          ────
+ 10 │                           }
+    ╰────
+
+  ⚠ vue(no-deprecated-props-default-this): Props default value factory functions no longer have access to `this`.
+    ╭─[no_deprecated_props_default_this.tsx:9:36]
+  8 │                           default () {
+  9 │                             return this.a
+    ·                                    ────
+ 10 │                           }
+    ╰────
+
+  ⚠ vue(no-deprecated-props-default-this): Props default value factory functions no longer have access to `this`.
+    ╭─[no_deprecated_props_default_this.tsx:14:36]
+ 13 │                           default () {
+ 14 │                             return this.a
+    ·                                    ────
+ 15 │                           }
+    ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_props_default_this.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_props_default_this.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 490
 ---
 
   ⚠ vue(no-deprecated-props-default-this): Props default value factory functions no longer have access to `this`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2608,6 +2608,9 @@
         "vue/no-deprecated-model-definition": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-deprecated-props-default-this": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-deprecated-vue-config-keycodes": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2612,6 +2612,9 @@ expression: json
         "vue/no-deprecated-model-definition": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-deprecated-props-default-this": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-deprecated-vue-config-keycodes": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/no-deprecated-props-default-this.html

AI disclosure: implemented with Claude Code, reviewed manually.