### PR TITLE
fix(linter/no-standalone-expect): align vitest helper import behavior

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
@@ -202,9 +202,33 @@ fn test() {
                     ",
             None,
         ),
+        (
+            r"
+                import { it } from '#testUtils';
+
+                describe('Test', () => {
+                    it('passes', ({ fixture }) => {
+                        expect(true).toBe(true);
+                    });
+                });
+            ",
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["it"] }])),
+        ),
     ];
 
     let fail = vec![
+        (
+            r"
+                import { it } from '#testUtils';
+
+                describe('Test', () => {
+                    it('passes', ({ fixture }) => {
+                        expect(true).toBe(true);
+                    });
+                });
+            ",
+            None,
+        ),
         ("(() => {})('testing', () => expect(true).toBe(false))", None),
         ("expect.hasAssertions()", None),
         ("expect().hasAssertions()", None),

--- a/crates/oxc_linter/src/snapshots/vitest_no_standalone_expect.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_standalone_expect.snap
@@ -1,6 +1,16 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
+  ⚠ vitest(no-standalone-expect): `expect` must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:6:25]
+ 5 │                     it('passes', ({ fixture }) => {
+ 6 │                         expect(true).toBe(true);
+   ·                         ──────
+ 7 │                     });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
   ⚠ vitest(no-standalone-expect): `expect` must be inside of a test block.
    ╭─[no_standalone_expect.tsx:1:29]
  1 │ (() => {})('testing', () => expect(true).toBe(false))


### PR DESCRIPTION
This adds coverage matching `@vitest/eslint-plugin`: `import { it } from '#testUtils'` reports by default, while `additionalTestBlockFunctions: ["it"]` passes.

This regressed in #21668 (`52ecb45555`) because `test.extend` became a fixture call instead of a test block, exposing that re-exported `it` imports are unknown test functions; fixes #21844.