### PR TITLE
fix(linter): recover `require-hook` node types

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2385,7 +2385,8 @@ impl RuleRunner for crate::rules::jest::prefer_todo::PreferTodo {
 }
 
 impl RuleRunner for crate::rules::jest::require_hook::RequireHook {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Program]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -4595,7 +4596,8 @@ impl RuleRunner for crate::rules::vitest::require_awaited_expect_poll::RequireAw
 }
 
 impl RuleRunner for crate::rules::vitest::require_hook::RequireHook {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Program]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use serde::Deserialize;
@@ -26,7 +27,11 @@ impl Rule for RequireHook {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        self.0.run(node, ctx);
+        match node.kind() {
+            AstKind::Program(_) => self.0.run(node, ctx),
+            AstKind::CallExpression(_) => self.0.run(node, ctx),
+            _ => {}
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_hook.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use serde::Deserialize;
@@ -26,7 +27,11 @@ impl Rule for RequireHook {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        self.0.run(node, ctx);
+        match node.kind() {
+            AstKind::Program(_) => self.0.run(node, ctx),
+            AstKind::CallExpression(_) => self.0.run(node, ctx),
+            _ => {}
+        }
     }
 }
 


### PR DESCRIPTION
# Summary
I introduced this error, `cargo lintgen` can't inspect the shared impl to generate the correct `NodeTypes` in `rule_runner_impl`.  I'm not sure if it is better to update the task, or use this workaround and then update the task.