### PR TITLE
feat(linter/vue): implement return-in-computed-property rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4815,6 +4815,12 @@ impl RuleRunner for crate::rules::vue::require_typed_ref::RequireTypedRef {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::return_in_computed_property::ReturnInComputedProperty {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::valid_define_emits::ValidDefineEmits {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -768,6 +768,7 @@ pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnt
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
 pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRequireDefaultExport;
 pub use crate::rules::vue::require_typed_ref::RequireTypedRef as VueRequireTypedRef;
+pub use crate::rules::vue::return_in_computed_property::ReturnInComputedProperty as VueReturnInComputedProperty;
 pub use crate::rules::vue::valid_define_emits::ValidDefineEmits as VueValidDefineEmits;
 pub use crate::rules::vue::valid_define_props::ValidDefineProps as VueValidDefineProps;
 use crate::{
@@ -1543,6 +1544,7 @@ pub enum RuleEnum {
     VuePreferImportFromVue(VuePreferImportFromVue),
     VueRequireDefaultExport(VueRequireDefaultExport),
     VueRequireTypedRef(VueRequireTypedRef),
+    VueReturnInComputedProperty(VueReturnInComputedProperty),
     VueValidDefineEmits(VueValidDefineEmits),
     VueValidDefineProps(VueValidDefineProps),
 }
@@ -2398,7 +2400,8 @@ const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize = VUE_NO_REQUIRED_PROP_WITH_DE
 const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
 const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
 const VUE_REQUIRE_TYPED_REF_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
-const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_REQUIRE_TYPED_REF_ID + 1usize;
+const VUE_RETURN_IN_COMPUTED_PROPERTY_ID: usize = VUE_REQUIRE_TYPED_REF_ID + 1usize;
+const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_COMPUTED_PROPERTY_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 impl RuleEnum {
     pub fn id(&self) -> usize {
@@ -3279,6 +3282,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VUE_PREFER_IMPORT_FROM_VUE_ID,
             Self::VueRequireDefaultExport(_) => VUE_REQUIRE_DEFAULT_EXPORT_ID,
             Self::VueRequireTypedRef(_) => VUE_REQUIRE_TYPED_REF_ID,
+            Self::VueReturnInComputedProperty(_) => VUE_RETURN_IN_COMPUTED_PROPERTY_ID,
             Self::VueValidDefineEmits(_) => VUE_VALID_DEFINE_EMITS_ID,
             Self::VueValidDefineProps(_) => VUE_VALID_DEFINE_PROPS_ID,
         }
@@ -4147,6 +4151,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::NAME,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::NAME,
+            Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::NAME,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::NAME,
             Self::VueValidDefineProps(_) => VueValidDefineProps::NAME,
         }
@@ -5069,6 +5074,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::CATEGORY,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::CATEGORY,
+            Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::CATEGORY,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::CATEGORY,
             Self::VueValidDefineProps(_) => VueValidDefineProps::CATEGORY,
         }
@@ -5938,6 +5944,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::FIX,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::FIX,
+            Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::FIX,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::FIX,
             Self::VueValidDefineProps(_) => VueValidDefineProps::FIX,
         }
@@ -7033,6 +7040,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::documentation(),
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::documentation(),
+            Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::documentation(),
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::documentation(),
             Self::VueValidDefineProps(_) => VueValidDefineProps::documentation(),
         }
@@ -9211,6 +9219,10 @@ impl RuleEnum {
                 .or_else(|| VueRequireDefaultExport::schema(generator)),
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::config_schema(generator)
                 .or_else(|| VueRequireTypedRef::schema(generator)),
+            Self::VueReturnInComputedProperty(_) => {
+                VueReturnInComputedProperty::config_schema(generator)
+                    .or_else(|| VueReturnInComputedProperty::schema(generator))
+            }
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::config_schema(generator)
                 .or_else(|| VueValidDefineEmits::schema(generator)),
             Self::VueValidDefineProps(_) => VueValidDefineProps::config_schema(generator)
@@ -9979,6 +9991,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => "vue",
             Self::VueRequireDefaultExport(_) => "vue",
             Self::VueRequireTypedRef(_) => "vue",
+            Self::VueReturnInComputedProperty(_) => "vue",
             Self::VueValidDefineEmits(_) => "vue",
             Self::VueValidDefineProps(_) => "vue",
         }
@@ -12430,6 +12443,9 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => {
                 Ok(Self::VueRequireTypedRef(VueRequireTypedRef::from_configuration(value)?))
             }
+            Self::VueReturnInComputedProperty(_) => Ok(Self::VueReturnInComputedProperty(
+                VueReturnInComputedProperty::from_configuration(value)?,
+            )),
             Self::VueValidDefineEmits(_) => {
                 Ok(Self::VueValidDefineEmits(VueValidDefineEmits::from_configuration(value)?))
             }
@@ -13204,6 +13220,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
             Self::VueRequireDefaultExport(rule) => rule.to_configuration(),
             Self::VueRequireTypedRef(rule) => rule.to_configuration(),
+            Self::VueReturnInComputedProperty(rule) => rule.to_configuration(),
             Self::VueValidDefineEmits(rule) => rule.to_configuration(),
             Self::VueValidDefineProps(rule) => rule.to_configuration(),
         }
@@ -13970,6 +13987,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
             Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
             Self::VueRequireTypedRef(rule) => rule.run(node, ctx),
+            Self::VueReturnInComputedProperty(rule) => rule.run(node, ctx),
             Self::VueValidDefineEmits(rule) => rule.run(node, ctx),
             Self::VueValidDefineProps(rule) => rule.run(node, ctx),
         }
@@ -14736,6 +14754,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
             Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
             Self::VueRequireTypedRef(rule) => rule.run_once(ctx),
+            Self::VueReturnInComputedProperty(rule) => rule.run_once(ctx),
             Self::VueValidDefineEmits(rule) => rule.run_once(ctx),
             Self::VueValidDefineProps(rule) => rule.run_once(ctx),
         }
@@ -15608,6 +15627,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueRequireTypedRef(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueReturnInComputedProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidDefineEmits(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
         }
@@ -16374,6 +16394,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
             Self::VueRequireDefaultExport(rule) => rule.should_run(ctx),
             Self::VueRequireTypedRef(rule) => rule.should_run(ctx),
+            Self::VueReturnInComputedProperty(rule) => rule.should_run(ctx),
             Self::VueValidDefineEmits(rule) => rule.should_run(ctx),
             Self::VueValidDefineProps(rule) => rule.should_run(ctx),
         }
@@ -17468,6 +17489,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::IS_TSGOLINT_RULE,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::IS_TSGOLINT_RULE,
+            Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::IS_TSGOLINT_RULE,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::IS_TSGOLINT_RULE,
             Self::VueValidDefineProps(_) => VueValidDefineProps::IS_TSGOLINT_RULE,
         }
@@ -18392,6 +18414,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::VERSION,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::VERSION,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::VERSION,
+            Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::VERSION,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::VERSION,
             Self::VueValidDefineProps(_) => VueValidDefineProps::VERSION,
         }
@@ -19345,6 +19368,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::HAS_CONFIG,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::HAS_CONFIG,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::HAS_CONFIG,
+            Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::HAS_CONFIG,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::HAS_CONFIG,
             Self::VueValidDefineProps(_) => VueValidDefineProps::HAS_CONFIG,
         }
@@ -20111,6 +20135,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
             Self::VueRequireDefaultExport(rule) => rule.types_info(),
             Self::VueRequireTypedRef(rule) => rule.types_info(),
+            Self::VueReturnInComputedProperty(rule) => rule.types_info(),
             Self::VueValidDefineEmits(rule) => rule.types_info(),
             Self::VueValidDefineProps(rule) => rule.types_info(),
         }
@@ -20877,6 +20902,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
             Self::VueRequireDefaultExport(rule) => rule.run_info(),
             Self::VueRequireTypedRef(rule) => rule.run_info(),
+            Self::VueReturnInComputedProperty(rule) => rule.run_info(),
             Self::VueValidDefineEmits(rule) => rule.run_info(),
             Self::VueValidDefineProps(rule) => rule.run_info(),
         }
@@ -21767,6 +21793,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),
         RuleEnum::VueRequireDefaultExport(VueRequireDefaultExport::default()),
         RuleEnum::VueRequireTypedRef(VueRequireTypedRef::default()),
+        RuleEnum::VueReturnInComputedProperty(VueReturnInComputedProperty::default()),
         RuleEnum::VueValidDefineEmits(VueValidDefineEmits::default()),
         RuleEnum::VueValidDefineProps(VueValidDefineProps::default()),
     ]

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -808,6 +808,7 @@ pub(crate) mod vue {
     pub mod prefer_import_from_vue;
     pub mod require_default_export;
     pub mod require_typed_ref;
+    pub mod return_in_computed_property;
     pub mod valid_define_emits;
     pub mod valid_define_props;
 }

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -1,0 +1,670 @@
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression, MemberExpression},
+};
+use oxc_cfg::{
+    EdgeType, ErrorEdgeKind, InstructionKind, ReturnInstructionKind,
+    graph::{
+        Direction,
+        visit::{Control, DfsEvent, set_depth_first_search},
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn return_in_computed_property_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Expected to return a value in computed property.")
+        .with_help("All code paths inside a computed getter must return a value.")
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct ReturnInComputedPropertyConfig {
+    /// When `true` (default), `return;` (without a value) is treated as a missing return.
+    /// Set to `false` to allow bare `return;` as if it returned a value.
+    treat_undefined_as_unspecified: bool,
+}
+
+impl Default for ReturnInComputedPropertyConfig {
+    fn default() -> Self {
+        Self { treat_undefined_as_unspecified: true }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ReturnInComputedProperty(ReturnInComputedPropertyConfig);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce that a `return` statement is present in every computed property.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A Vue computed property is a getter that must produce a value. Forgetting
+    /// to return turns the value into `undefined`, which silently breaks
+    /// templates and reactive code that depend on the computed.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   computed: {
+    ///     foo() {
+    ///       // missing return
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   computed: {
+    ///     foo() {
+    ///       return this.bar
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ReturnInComputedProperty,
+    vue,
+    correctness,
+    config = ReturnInComputedProperty,
+    version = "next",
+);
+
+impl Rule for ReturnInComputedProperty {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let span = match node.kind() {
+            AstKind::Function(func) => func.span,
+            AstKind::ArrowFunctionExpression(arrow) => {
+                // Expression-body arrow (`() => x`) implicitly returns its expression,
+                // so it always has a return on every code path.
+                if arrow.expression {
+                    return;
+                }
+                arrow.span
+            }
+            _ => return,
+        };
+
+        if !is_vue_computed_getter(node, ctx) {
+            return;
+        }
+
+        if !definitely_returns_in_all_codepaths(node, ctx, self.0.treat_undefined_as_unspecified) {
+            ctx.diagnostic(return_in_computed_property_diagnostic(span));
+        }
+    }
+}
+
+fn is_vue_computed_getter(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let nodes = ctx.nodes();
+    let parent = nodes.parent_node(node.id());
+
+    let AstKind::ObjectProperty(prop) = parent.kind() else {
+        // `computed(() => {...})` / `computed(function() {...})` —
+        // the function is the direct argument of a `computed(...)` call.
+        return matches!(
+            parent.kind(),
+            AstKind::CallExpression(call) if is_computed_function_call(call)
+        );
+    };
+
+    // `set` accessors are setters — they don't need to return.
+    if prop.key.is_specific_static_name("set") {
+        return false;
+    }
+
+    let opts_node = nodes.parent_node(parent.id());
+    if !matches!(opts_node.kind(), AstKind::ObjectExpression(_)) {
+        return false;
+    }
+    let outer = nodes.parent_node(opts_node.id());
+
+    // Case A: `computed: { foo() {...} }` or `computed: { foo: function() {...} }`
+    //   function -> ObjectProperty(foo) -> ObjectExpression(computed body)
+    //            -> ObjectProperty(computed) [outer]
+    if let AstKind::ObjectProperty(outer_prop) = outer.kind()
+        && outer_prop.key.is_specific_static_name("computed")
+    {
+        return is_under_vue_root(outer, ctx);
+    }
+
+    // The remaining cases assume `prop` is the `get` accessor of a get/set object.
+    if !prop.key.is_specific_static_name("get") {
+        return false;
+    }
+
+    // Case B: `computed: { foo: { get() {...} } }`
+    //   get() -> ObjectProperty(get) -> ObjectExpression(get/set obj)
+    //         -> ObjectProperty(foo) [outer]
+    //         -> ObjectExpression(computed body)
+    //         -> ObjectProperty(computed)
+    if let AstKind::ObjectProperty(_) = outer.kind() {
+        let computed_body = nodes.parent_node(outer.id());
+        if !matches!(computed_body.kind(), AstKind::ObjectExpression(_)) {
+            return false;
+        }
+        let computed_prop = nodes.parent_node(computed_body.id());
+        if let AstKind::ObjectProperty(cp) = computed_prop.kind()
+            && cp.key.is_specific_static_name("computed")
+        {
+            return is_under_vue_root(computed_prop, ctx);
+        }
+        return false;
+    }
+
+    // Case C: `computed({ get() {...}, set() {} })`
+    //   get() -> ObjectProperty(get) -> ObjectExpression(get/set obj)
+    //         -> CallExpression(computed) [outer]
+    if let AstKind::CallExpression(call) = outer.kind() {
+        return is_computed_function_call(call);
+    }
+
+    false
+}
+
+fn is_under_vue_root(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    ctx.nodes().ancestors(node.id()).any(|a| is_vue_component_root(a.kind()))
+}
+
+fn is_computed_function_call(call: &CallExpression<'_>) -> bool {
+    matches!(
+        call.callee.get_inner_expression(),
+        Expression::Identifier(ident) if ident.name == "computed"
+    )
+}
+
+fn is_vue_component_root(kind: AstKind<'_>) -> bool {
+    match kind {
+        AstKind::ExportDefaultDeclaration(_) => true,
+        AstKind::CallExpression(call) => is_vue_component_definition_call(call),
+        AstKind::NewExpression(new_expr) => {
+            new_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == "Vue")
+        }
+        _ => false,
+    }
+}
+
+fn is_vue_component_definition_call(call: &CallExpression<'_>) -> bool {
+    let callee = call.callee.get_inner_expression();
+
+    if let Expression::Identifier(ident) = callee {
+        return matches!(
+            ident.name.as_str(),
+            "defineComponent" | "component" | "createApp" | "defineNuxtComponent"
+        );
+    }
+
+    let Some(MemberExpression::StaticMemberExpression(static_member)) =
+        callee.as_member_expression()
+    else {
+        return false;
+    };
+    let prop_name = static_member.property.name.as_str();
+    if let Expression::Identifier(obj_ident) = static_member.object.get_inner_expression()
+        && obj_ident.name == "Vue"
+    {
+        return matches!(prop_name, "component" | "mixin" | "extend");
+    }
+    matches!(prop_name, "component" | "mixin")
+}
+
+fn definitely_returns_in_all_codepaths(
+    node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+    treat_undefined_as_unspecified: bool,
+) -> bool {
+    let cfg = ctx.cfg();
+    let graph = cfg.graph();
+
+    let output =
+        set_depth_first_search(graph, Some(ctx.nodes().cfg_id(node.id())), |event| match event {
+            DfsEvent::TreeEdge(a, b) => {
+                let edges = graph.edges_connecting(a, b).collect::<Vec<_>>();
+                if edges.iter().any(|e| {
+                    matches!(
+                        e.weight(),
+                        EdgeType::Normal
+                            | EdgeType::Jump
+                            | EdgeType::Error(ErrorEdgeKind::Explicit)
+                    )
+                }) {
+                    Control::Continue
+                } else {
+                    Control::Prune
+                }
+            }
+            DfsEvent::Discover(basic_block_id, _) => {
+                let return_instruction =
+                    cfg.basic_block(basic_block_id).instructions().iter().find(|it| {
+                        match it.kind {
+                            InstructionKind::Return(_) | InstructionKind::Throw => true,
+                            InstructionKind::ImplicitReturn
+                            | InstructionKind::Break(_)
+                            | InstructionKind::Continue(_)
+                            | InstructionKind::Iteration(_)
+                            | InstructionKind::Unreachable
+                            | InstructionKind::Condition
+                            | InstructionKind::Statement => false,
+                        }
+                    });
+
+                let does_return = return_instruction.is_some_and(|ret| {
+                    !matches!(
+                        ret.kind,
+                        InstructionKind::Return(ReturnInstructionKind::ImplicitUndefined)
+                            if treat_undefined_as_unspecified
+                    )
+                });
+
+                if graph.edges_directed(basic_block_id, Direction::Outgoing).any(|e| {
+                    matches!(
+                        e.weight(),
+                        EdgeType::Jump
+                            | EdgeType::Normal
+                            | EdgeType::Backedge
+                            | EdgeType::Error(ErrorEdgeKind::Explicit)
+                    )
+                }) {
+                    Control::Continue
+                } else if does_return {
+                    Control::Prune
+                } else {
+                    Control::Break(())
+                }
+            }
+            _ => Control::Continue,
+        });
+
+    output.break_value().is_none()
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo () {
+                      return true
+                    },
+                    bar: function () {
+                      return false
+                    },
+                    bar3: {
+                      set () {
+                        return true
+                      },
+                      get () {
+                        return true
+                      }
+                    },
+                    bar4 () {
+                      if (foo) {
+                        return true
+                      } else {
+                        return false
+                      }
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo () {
+                      const options = []
+                      this.matches.forEach((match) => {
+                        options.push(match)
+                      })
+                      return options
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo () {
+                      const options = []
+                      this.matches.forEach(function (match) {
+                        options.push(match)
+                      })
+                      return options
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo: {
+                      get () {
+                        return
+                      }
+                    }
+                  }
+                }
+                </script>
+            ",
+            Some(serde_json::json!([{ "treatUndefinedAsUnspecified": false }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                import {computed} from 'vue'
+                export default {
+                  setup() {
+                    const foo = computed(() => true)
+                    const bar = computed(function() {
+                      return false
+                    })
+                    const bar3 = computed({
+                      set: () => true,
+                      get: () => true
+                    })
+                    const bar4 = computed(() => {
+                      if (foo) {
+                        return true
+                      } else {
+                        return false
+                      }
+                    })
+                    const foo2 = computed(() => {
+                      const options = []
+                      this.matches.forEach((match) => {
+                        options.push(match)
+                      })
+                      return options
+                    })
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                import {computed} from 'vue'
+                export default {
+                  setup() {
+                    const foo = computed({
+                      get: () => {
+                        return
+                      }
+                    })
+                  }
+                }
+                </script>
+            ",
+            Some(serde_json::json!([{ "treatUndefinedAsUnspecified": false }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo () {
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo: function () {
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo: function () {
+                      if (a) {
+                        return
+                      }
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo: {
+                      set () {
+                      },
+                      get () {
+                      }
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo: function () {
+                      function bar () {
+                        return this.baz * 2
+                      }
+                      bar()
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo () {
+                    },
+                    bar () {
+                      return
+                    }
+                  }
+                }
+                </script>
+            ",
+            Some(serde_json::json!([{ "treatUndefinedAsUnspecified": false }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  computed: {
+                    foo () {
+                      return
+                    }
+                  }
+                }
+                </script>
+            ",
+            Some(serde_json::json!([{ "treatUndefinedAsUnspecified": true }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                // @vue/component
+                export default {
+                  computed: {
+                      my_FALSE_test() {
+                          let aa = 2;
+                          this.my_id = aa;
+                      }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                import {computed} from 'vue'
+                export default {
+                  setup() {
+                    const foo = computed(() => {})
+                    const foo2 = computed(function() {})
+                    const foo3 = computed(() => {
+                      if (a) {
+                        return
+                      }
+                    })
+                    const foo4 = computed({
+                      set: () => {},
+                      get: () => {}
+                    })
+                    const foo5 = computed(() => {
+                      const bar = () => {
+                        return this.baz * 2
+                      }
+                      bar()
+                    })
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                import {computed} from 'vue'
+                export default {
+                  setup() {
+                    const foo = computed(() => {})
+                    const baz = computed(() => {
+                      return
+                    })
+                  }
+                }
+                </script>
+            ",
+            Some(serde_json::json!([{ "treatUndefinedAsUnspecified": false }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  'computed': {
+                    foo() {
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(ReturnInComputedProperty::NAME, ReturnInComputedProperty::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
+    module_record::ImportImportName,
     rule::{DefaultRuleConfig, Rule},
 };
 
@@ -131,7 +132,7 @@ fn is_vue_computed_getter(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
         // the function is the direct argument of a `computed(...)` call.
         return matches!(
             parent.kind(),
-            AstKind::CallExpression(call) if is_computed_function_call(call)
+            AstKind::CallExpression(call) if is_vue_computed_call(call, ctx)
         );
     };
 
@@ -183,7 +184,7 @@ fn is_vue_computed_getter(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
     //   get() -> ObjectProperty(get) -> ObjectExpression(get/set obj)
     //         -> CallExpression(computed) [outer]
     if let AstKind::CallExpression(call) = outer.kind() {
-        return is_computed_function_call(call);
+        return is_vue_computed_call(call, ctx);
     }
 
     false
@@ -193,11 +194,32 @@ fn is_under_vue_root(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
     ctx.nodes().ancestors(node.id()).any(|a| is_vue_component_root(a.kind()))
 }
 
-fn is_computed_function_call(call: &CallExpression<'_>) -> bool {
-    matches!(
-        call.callee.get_inner_expression(),
-        Expression::Identifier(ident) if ident.name == "computed"
-    )
+fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
+    let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
+        return false;
+    };
+    if ident.name != "computed" {
+        return false;
+    }
+
+    let scoping = ctx.scoping();
+    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
+        return false;
+    };
+
+    ctx.module_record().import_entries.iter().any(|entry| {
+        if entry.module_request.name() != "vue" {
+            return false;
+        }
+        let imported_name = match &entry.import_name {
+            ImportImportName::Name(name_span) => name_span.name(),
+            _ => return false,
+        };
+        if imported_name != "computed" {
+            return false;
+        }
+        scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
+    })
 }
 
 fn is_vue_component_root(kind: AstKind<'_>) -> bool {
@@ -455,6 +477,28 @@ fn test() {
                 </script>
             ",
             Some(serde_json::json!([{ "treatUndefinedAsUnspecified": false }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                import { computed } from 'other-lib'
+                computed(() => {})
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                const computed = (fn) => fn
+                computed(() => {})
+                </script>
+            ",
+            None,
             None,
             Some(PathBuf::from("test.vue")),
         ),

--- a/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
+++ b/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
@@ -1,0 +1,156 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:5:25]
+ 4 │                       computed: {
+ 5 │ ╭─▶                     foo () {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:5:26]
+ 4 │                       computed: {
+ 5 │ ╭─▶                     foo: function () {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+    ╭─[return_in_computed_property.tsx:5:26]
+  4 │                       computed: {
+  5 │ ╭─▶                     foo: function () {
+  6 │ │                         if (a) {
+  7 │ │                           return
+  8 │ │                         }
+  9 │ ╰─▶                     }
+ 10 │                       }
+    ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+    ╭─[return_in_computed_property.tsx:8:27]
+  7 │                           },
+  8 │ ╭─▶                       get () {
+  9 │ ╰─▶                       }
+ 10 │                         }
+    ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+    ╭─[return_in_computed_property.tsx:5:26]
+  4 │                       computed: {
+  5 │ ╭─▶                     foo: function () {
+  6 │ │                         function bar () {
+  7 │ │                           return this.baz * 2
+  8 │ │                         }
+  9 │ │                         bar()
+ 10 │ ╰─▶                     }
+ 11 │                       }
+    ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:5:25]
+ 4 │                       computed: {
+ 5 │ ╭─▶                     foo () {
+ 6 │ ╰─▶                     },
+ 7 │                         bar () {
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:5:25]
+ 4 │                       computed: {
+ 5 │ ╭─▶                     foo () {
+ 6 │ │                         return
+ 7 │ ╰─▶                     }
+ 8 │                       }
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+    ╭─[return_in_computed_property.tsx:6:36]
+  5 │                       computed: {
+  6 │ ╭─▶                       my_FALSE_test() {
+  7 │ │                             let aa = 2;
+  8 │ │                             this.my_id = aa;
+  9 │ ╰─▶                       }
+ 10 │                       }
+    ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:6:42]
+ 5 │                   setup() {
+ 6 │                     const foo = computed(() => {})
+   ·                                          ────────
+ 7 │                     const foo2 = computed(function() {})
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:7:43]
+ 6 │                     const foo = computed(() => {})
+ 7 │                     const foo2 = computed(function() {})
+   ·                                           ─────────────
+ 8 │                     const foo3 = computed(() => {
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+    ╭─[return_in_computed_property.tsx:8:43]
+  7 │                         const foo2 = computed(function() {})
+  8 │ ╭─▶                     const foo3 = computed(() => {
+  9 │ │                         if (a) {
+ 10 │ │                           return
+ 11 │ │                         }
+ 12 │ ╰─▶                     })
+ 13 │                         const foo4 = computed({
+    ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+    ╭─[return_in_computed_property.tsx:15:28]
+ 14 │                       set: () => {},
+ 15 │                       get: () => {}
+    ·                            ────────
+ 16 │                     })
+    ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+    ╭─[return_in_computed_property.tsx:17:43]
+ 16 │                         })
+ 17 │ ╭─▶                     const foo5 = computed(() => {
+ 18 │ │                         const bar = () => {
+ 19 │ │                           return this.baz * 2
+ 20 │ │                         }
+ 21 │ │                         bar()
+ 22 │ ╰─▶                     })
+ 23 │                       }
+    ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:6:42]
+ 5 │                   setup() {
+ 6 │                     const foo = computed(() => {})
+   ·                                          ────────
+ 7 │                     const baz = computed(() => {
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:5:24]
+ 4 │                       'computed': {
+ 5 │ ╭─▶                     foo() {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────
+  help: All code paths inside a computed getter must return a value.


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/return-in-computed-property.html

AI disclosure: implemented with Claude Code, reviewed manually.