### PR TITLE
fix(formatter): keep JSX expression child flat when fill expands its separator

### DIFF
--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -162,7 +162,9 @@ impl<'a> Printer<'a> {
             FormatElement::Tag(StartGroup(group)) => {
                 let group_mode = if group.mode().is_flat() {
                     match args.mode() {
-                        PrintMode::Flat if self.state.measured_group_fits => {
+                        PrintMode::Flat
+                            if self.state.measured_group_fits || self.state.in_flat_fill_item =>
+                        {
                             // A parent group has already verified that this group fits on a single line
                             // Thus, just continue in flat mode
                             PrintMode::Flat
@@ -532,6 +534,23 @@ impl<'a> Printer<'a> {
         indent_stack: &mut PrintIndentStack,
         args: PrintElementArgs,
     ) -> PrintResult<()> {
+        // When the fill has determined this entry fits in flat mode, inner
+        // groups should also print in flat mode without re-measuring. The
+        // re-measurement uses [`AllPredicate`], which walks past the entry
+        // boundary into subsequent fill entries and frequently overshoots
+        // the print width, causing inner groups to needlessly expand.
+        //
+        // This is scoped to regular groups; [`BestFitting`] still goes
+        // through its variant selection so that elements with both flat
+        // and expanded variants (e.g. JSX child lists) can pick the
+        // appropriate form when the surrounding context is too wide for
+        // the flat variant.
+        if args.mode().is_flat() {
+            let previous = std::mem::replace(&mut self.state.in_flat_fill_item, true);
+            let result = self.print_entry(queue, stack, indent_stack, args);
+            self.state.in_flat_fill_item = previous;
+            return result;
+        }
         self.print_entry(queue, stack, indent_stack, args)
     }
 
@@ -703,6 +722,10 @@ struct PrinterState<'a> {
     pending_indent: Indention,
     pending_space: bool,
     measured_group_fits: bool,
+    /// Set while printing a fill item that the surrounding fill has already
+    /// verified fits in flat mode. Tells inner groups they don't need to
+    /// re-measure their fit, which would walk past the entry boundary.
+    in_flat_fill_item: bool,
     line_width: usize,
     has_empty_line: bool,
     line_suffixes: LineSuffixes<'a>,

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/expression-child-fits-flat.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/expression-child-fits-flat.jsx
@@ -1,0 +1,11 @@
+const App = () => {
+  return (
+    <O>
+      <I>
+        <x />
+        {f(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx).y} (
+        {label})
+      </I>
+    </O>
+  );
+};

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/expression-child-fits-flat.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/expression-child-fits-flat.jsx.snap
@@ -1,0 +1,47 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const App = () => {
+  return (
+    <O>
+      <I>
+        <x />
+        {f(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx).y} (
+        {label})
+      </I>
+    </O>
+  );
+};
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const App = () => {
+  return (
+    <O>
+      <I>
+        <x />
+        {f(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx).y} (
+        {label})
+      </I>
+    </O>
+  );
+};
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const App = () => {
+  return (
+    <O>
+      <I>
+        <x />
+        {f(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx).y} ({label})
+      </I>
+    </O>
+  );
+};
+
+===================== End =====================


### PR DESCRIPTION
## Summary

Fixes #21916

When a JSX expression child whose flat width fits at its current indent is followed by literal text such as ` (`, the formatter was breaking the expression across three lines (`{`, content, `}`) even though the line as written is within `printWidth`. Prettier leaves it inline.

### Input
```jsx
const App = () => {
  return (
    <O>
      <I>
        <x />
        {f(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx).y} (
        {label})
      </I>
    </O>
  );
};
```

### Before (incorrect)
```jsx
const App = () => {
  return (
    <O>
      <I>
        <x />
        {
          f(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx).y
        } (
        {label})
      </I>
    </O>
  );
};
```

### After (matches Prettier)
```jsx
const App = () => {
  return (
    <O>
      <I>
        <x />
        {f(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx).y} (
        {label})
      </I>
    </O>
  );
};
```

## Root cause

In the printer's `Fill`, each entry's fit is measured with a flat-only `FitsMeasurer` bounded by `SingleEntryPredicate`, so the fill correctly determined the expression entry fit on a single line. While *printing* that flat entry, however, the inner expression group (`group(["{", indent([softline, expr]), softline, lineSuffixBoundary, "}"])`) re-ran its own `fits` check via `Printer::fits`, which uses `AllPredicate` and walks past the entry boundary into subsequent fill entries. The accumulated width frequently exceeded `printWidth`, so the inner group expanded — even though the fill had already proven the entry fits flat at the current column.

Soft line breaks don't terminate a flat-mode `fits` walk (they're a no-op), so the measurement happily kept reading through the next item, separator, and so on until either a hard break or the end of the document.

## Fix

Adds an `in_flat_fill_item` flag on the printer state that's set while `print_fill_item` is printing an entry in flat mode. The `StartGroup` arm honors it and treats nested groups the same way it would when a parent group has already verified the fit — i.e. it skips the re-measurement and prints the inner group flat.

The flag is intentionally scoped to **regular groups**: `BestFitting` still goes through `print_best_fitting`'s variant selection so JSX child lists with both flat and expanded variants (the `<Link>BREAK THIS</Link>` pattern in `issue-16199.jsx`) continue to choose the multi-line variant when the surrounding context is too wide for the flat one.

Prettier conformance: **no regressions** (746/753 JS, 591/601 TS — unchanged).

## AI Disclosure

This PR was co-authored with Claude Code (AI assistant), as noted in the commit. The fix was reviewed, tested against the full Prettier conformance suite, and verified to produce no regressions.