### PR TITLE
fix(oxfmt): `sortTailwindcss: false` still enables Tailwind sorting

### DIFF
--- a/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
@@ -66,7 +66,9 @@ pub fn finalize_external_options(config: &mut Value, kind: &FileKind) {
     };
 
     // Add Tailwind plugin flag and map options if needed
-    if obj.contains_key("sortTailwindcss") && kind.needs_tailwind_plugin() {
+    if !matches!(obj.get("sortTailwindcss"), None | Some(Value::Bool(false)))
+        && kind.needs_tailwind_plugin()
+    {
         if let Some(tailwind) = obj.get("sortTailwindcss").and_then(|v| v.as_object()).cloned() {
             // See: https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options
             for (src, dst) in [
@@ -265,6 +267,23 @@ mod tests {
         assert!(!obj.contains_key("overrides"));
         assert!(!obj.contains_key("ignorePatterns"));
         assert!(!obj.contains_key("sortImports"));
+    }
+
+    #[test]
+    fn test_finalize_external_options_sort_tailwindcss_false_does_not_enable_plugin() {
+        use std::{path::Path, sync::Arc};
+
+        let json_string = r#"{ "sortTailwindcss": false }"#;
+        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
+
+        let kind = FileKind::ExternalFormatter {
+            path: Arc::from(Path::new("test.html")),
+            parser_name: "html",
+        };
+        finalize_external_options(&mut raw_config, &kind);
+
+        let obj = raw_config.as_object().unwrap();
+        assert!(!obj.contains_key("_useTailwindPlugin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `finalize_external_options` checked only key **presence** (`contains_key`), so `sortTailwindcss: false` activated `_useTailwindPlugin` anyway — ignoring the explicit `false` value.
- Fixed by checking the actual value with `!matches!(…, None | Some(Value::Bool(false)))`.
- Added a regression test covering the `false` case.

## Root cause

```rust
// Before — checks presence only:
if obj.contains_key("sortTailwindcss") && kind.needs_tailwind_plugin() {

// After — checks value:
if !matches!(obj.get("sortTailwindcss"), None | Some(Value::Bool(false)))
    && kind.needs_tailwind_plugin()
```

The typed config (`SortTailwindcssUserConfig::Bool(false) → None`) was already correct; the bug was only in the raw-JSON path inside `finalize_external_options`.

## Test plan

- [x] New regression test: `test_finalize_external_options_sort_tailwindcss_false_does_not_enable_plugin`
- [x] All existing `to_external_options` tests pass

> AI-assisted: used Claude to identify and implement the fix.