### PR TITLE
feat(linter): split jest/prefer-called-with into separate vitest rule

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,5 +1,4 @@
 [
-  "prefer-called-with",
   "prefer-comparison-matcher",
   "prefer-each",
   "prefer-equality-matcher",

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4536,6 +4536,11 @@ impl RuleRunner for crate::rules::vitest::prefer_called_times::PreferCalledTimes
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_called_with::PreferCalledWith {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner
     for crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunctionTitle
 {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -726,6 +726,7 @@ pub use crate::rules::vitest::no_unneeded_async_expect_function::NoUnneededAsync
 pub use crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith as VitestPreferCalledExactlyOnceWith;
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
+pub use crate::rules::vitest::prefer_called_with::PreferCalledWith as VitestPreferCalledWith;
 pub use crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunctionTitle as VitestPreferDescribeFunctionTitle;
 pub use crate::rules::vitest::prefer_expect_assertions::PreferExpectAssertions as VitestPreferExpectAssertions;
 pub use crate::rules::vitest::prefer_expect_type_of::PreferExpectTypeOf as VitestPreferExpectTypeOf;
@@ -1497,6 +1498,7 @@ pub enum RuleEnum {
     VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith),
     VitestPreferCalledOnce(VitestPreferCalledOnce),
     VitestPreferCalledTimes(VitestPreferCalledTimes),
+    VitestPreferCalledWith(VitestPreferCalledWith),
     VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle),
     VitestPreferExpectAssertions(VitestPreferExpectAssertions),
     VitestPreferExpectTypeOf(VitestPreferExpectTypeOf),
@@ -2355,7 +2357,8 @@ const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
     VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
 const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID + 1usize;
 const VITEST_PREFER_CALLED_TIMES_ID: usize = VITEST_PREFER_CALLED_ONCE_ID + 1usize;
-const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
+const VITEST_PREFER_CALLED_WITH_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
+const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize = VITEST_PREFER_CALLED_WITH_ID + 1usize;
 const VITEST_PREFER_EXPECT_ASSERTIONS_ID: usize = VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID + 1usize;
 const VITEST_PREFER_EXPECT_TYPE_OF_ID: usize = VITEST_PREFER_EXPECT_ASSERTIONS_ID + 1usize;
 const VITEST_PREFER_IMPORT_IN_MOCK_ID: usize = VITEST_PREFER_EXPECT_TYPE_OF_ID + 1usize;
@@ -3241,6 +3244,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(_) => VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID,
             Self::VitestPreferCalledOnce(_) => VITEST_PREFER_CALLED_ONCE_ID,
             Self::VitestPreferCalledTimes(_) => VITEST_PREFER_CALLED_TIMES_ID,
+            Self::VitestPreferCalledWith(_) => VITEST_PREFER_CALLED_WITH_ID,
             Self::VitestPreferDescribeFunctionTitle(_) => VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID,
             Self::VitestPreferExpectAssertions(_) => VITEST_PREFER_EXPECT_ASSERTIONS_ID,
             Self::VitestPreferExpectTypeOf(_) => VITEST_PREFER_EXPECT_TYPE_OF_ID,
@@ -4117,6 +4121,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::NAME,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::NAME,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::NAME,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::NAME,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::NAME,
@@ -5037,6 +5042,7 @@ impl RuleEnum {
             }
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::CATEGORY,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::CATEGORY,
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::CATEGORY,
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::CATEGORY
             }
@@ -5920,6 +5926,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::FIX,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::FIX,
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::FIX,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::FIX,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::FIX,
@@ -7003,6 +7010,7 @@ impl RuleEnum {
             }
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::documentation(),
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::documentation(),
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::documentation(),
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::documentation()
             }
@@ -9116,6 +9124,8 @@ impl RuleEnum {
                 .or_else(|| VitestPreferCalledOnce::schema(generator)),
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::config_schema(generator)
                 .or_else(|| VitestPreferCalledTimes::schema(generator)),
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::config_schema(generator)
+                .or_else(|| VitestPreferCalledWith::schema(generator)),
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::config_schema(generator)
                     .or_else(|| VitestPreferDescribeFunctionTitle::schema(generator))
@@ -9989,6 +9999,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(_) => "vitest",
             Self::VitestPreferCalledOnce(_) => "vitest",
             Self::VitestPreferCalledTimes(_) => "vitest",
+            Self::VitestPreferCalledWith(_) => "vitest",
             Self::VitestPreferDescribeFunctionTitle(_) => "vitest",
             Self::VitestPreferExpectAssertions(_) => "vitest",
             Self::VitestPreferExpectTypeOf(_) => "vitest",
@@ -12338,6 +12349,9 @@ impl RuleEnum {
             Self::VitestPreferCalledTimes(_) => Ok(Self::VitestPreferCalledTimes(
                 VitestPreferCalledTimes::from_configuration(value)?,
             )),
+            Self::VitestPreferCalledWith(_) => {
+                Ok(Self::VitestPreferCalledWith(VitestPreferCalledWith::from_configuration(value)?))
+            }
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 Ok(Self::VitestPreferDescribeFunctionTitle(
                     VitestPreferDescribeFunctionTitle::from_configuration(value)?,
@@ -13230,6 +13244,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.to_configuration(),
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
+            Self::VitestPreferCalledWith(rule) => rule.to_configuration(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.to_configuration(),
             Self::VitestPreferExpectAssertions(rule) => rule.to_configuration(),
             Self::VitestPreferExpectTypeOf(rule) => rule.to_configuration(),
@@ -14002,6 +14017,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
+            Self::VitestPreferCalledWith(rule) => rule.run(node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run(node, ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.run(node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run(node, ctx),
@@ -14772,6 +14788,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
+            Self::VitestPreferCalledWith(rule) => rule.run_once(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_once(ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.run_once(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_once(ctx),
@@ -15646,6 +15663,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferCalledWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16420,6 +16438,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
+            Self::VitestPreferCalledWith(rule) => rule.should_run(ctx),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.should_run(ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.should_run(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.should_run(ctx),
@@ -17498,6 +17517,7 @@ impl RuleEnum {
             }
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::IS_TSGOLINT_RULE,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::IS_TSGOLINT_RULE,
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::IS_TSGOLINT_RULE,
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::IS_TSGOLINT_RULE
             }
@@ -18438,6 +18458,7 @@ impl RuleEnum {
             }
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::VERSION,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::VERSION,
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::VERSION,
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::VERSION
             }
@@ -19395,6 +19416,7 @@ impl RuleEnum {
             }
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::HAS_CONFIG,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::HAS_CONFIG,
+            Self::VitestPreferCalledWith(_) => VitestPreferCalledWith::HAS_CONFIG,
             Self::VitestPreferDescribeFunctionTitle(_) => {
                 VitestPreferDescribeFunctionTitle::HAS_CONFIG
             }
@@ -20179,6 +20201,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.types_info(),
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
+            Self::VitestPreferCalledWith(rule) => rule.types_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.types_info(),
             Self::VitestPreferExpectAssertions(rule) => rule.types_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.types_info(),
@@ -20949,6 +20972,7 @@ impl RuleEnum {
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_info(),
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
+            Self::VitestPreferCalledWith(rule) => rule.run_info(),
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_info(),
             Self::VitestPreferExpectAssertions(rule) => rule.run_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_info(),
@@ -21841,6 +21865,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith::default()),
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),
+        RuleEnum::VitestPreferCalledWith(VitestPreferCalledWith::default()),
         RuleEnum::VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle::default()),
         RuleEnum::VitestPreferExpectAssertions(VitestPreferExpectAssertions::default()),
         RuleEnum::VitestPreferExpectTypeOf(VitestPreferExpectTypeOf::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -754,6 +754,7 @@ pub(crate) mod vitest {
     pub mod prefer_called_exactly_once_with;
     pub mod prefer_called_once;
     pub mod prefer_called_times;
+    pub mod prefer_called_with;
     pub mod prefer_describe_function_title;
     pub mod prefer_expect_assertions;
     pub mod prefer_expect_type_of;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -20,6 +20,7 @@ pub mod no_standalone_expect;
 pub mod no_test_prefixes;
 pub mod no_test_return_statement;
 pub mod no_unneeded_async_expect_function;
+pub mod prefer_called_with;
 pub mod prefer_expect_assertions;
 pub mod prefer_snapshot_hint;
 pub mod prefer_to_contain;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_called_with.rs
@@ -1,0 +1,84 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    utils::{PossibleJestNode, parse_expect_jest_fn_call},
+};
+
+fn use_to_be_called_with(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
+        .with_help("Prefer toBeCalledWith(/* expected args */)")
+        .with_label(span)
+}
+
+fn use_have_been_called_with(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.")
+        .with_help("Prefer toHaveBeenCalledWith(/* expected args */)")
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`
+
+### Why is this bad?
+
+When testing function calls, it's often more valuable to assert both
+that a function was called AND what arguments it was called with.
+Using `toBeCalled()` or `toHaveBeenCalled()` only verifies the function
+was invoked, but doesn't validate the arguments, potentially missing
+bugs where functions are called with incorrect parameters.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+expect(someFunction).toBeCalled();
+expect(someFunction).toHaveBeenCalled();
+```
+
+Examples of **correct** code for this rule:
+```javascript
+expect(noArgsFunction).toBeCalledWith();
+expect(roughArgsFunction).toBeCalledWith(expect.anything(), expect.any(Date));
+expect(anyArgsFunction).toBeCalledTimes(1);
+expect(uncalledFunction).not.toBeCalled();
+```
+";
+
+pub fn run_on_jest_node<'a, 'c>(
+    possible_jest_node: &PossibleJestNode<'a, 'c>,
+    ctx: &'c LintContext<'a>,
+) {
+    let node = possible_jest_node.node;
+    let AstKind::CallExpression(call_expr) = node.kind() else {
+        return;
+    };
+
+    let Some(jest_fn_call) = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx) else {
+        return;
+    };
+
+    let has_not_modifier =
+        jest_fn_call.modifiers().iter().any(|modifier| modifier.is_name_equal("not"));
+
+    if has_not_modifier {
+        return;
+    }
+
+    if let Some(matcher_property) = jest_fn_call.matcher()
+        && let Some(matcher_name) = matcher_property.name()
+    {
+        if matcher_name == "toBeCalled" {
+            ctx.diagnostic_with_fix(use_to_be_called_with(matcher_property.span), |fixer| {
+                fixer.replace(matcher_property.span, "toBeCalledWith")
+            });
+        } else if matcher_name == "toHaveBeenCalled" {
+            ctx.diagnostic_with_fix(use_have_been_called_with(matcher_property.span), |fixer| {
+                fixer.replace(matcher_property.span, "toHaveBeenCalledWith")
+            });
+        }
+    }
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_with.rs
@@ -10,7 +10,7 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct PreferCalledWith;
 
-declare_oxc_lint!(PreferCalledWith, jest, style, fix, docs = DOCUMENTATION, version = "0.2.5",);
+declare_oxc_lint!(PreferCalledWith, vitest, style, fix, docs = DOCUMENTATION, version = "0.2.5",);
 
 impl Rule for PreferCalledWith {
     fn run_on_jest_node<'a, 'c>(
@@ -26,7 +26,7 @@ impl Rule for PreferCalledWith {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![
+    let mut pass = vec![
         ("expect(fn).toBeCalledWith();", None),
         ("expect(fn).toHaveBeenCalledWith();", None),
         ("expect(fn).toBeCalledWith(expect.anything());", None),
@@ -42,20 +42,52 @@ fn test() {
         ("expect(fn);", None),
     ];
 
-    let fail = vec![
+    let mut fail = vec![
         ("expect(fn).toBeCalled();", None),
         ("expect(fn).resolves.toBeCalled();", None),
         ("expect(fn).toHaveBeenCalled();", None),
     ];
 
-    let fix = vec![
+    let mut fix = vec![
         ("expect(fn).toBeCalled();", "expect(fn).toBeCalledWith();", None),
         ("expect(fn).resolves.toBeCalled();", "expect(fn).resolves.toBeCalledWith();", None),
         ("expect(fn).toHaveBeenCalled();", "expect(fn).toHaveBeenCalledWith();", None),
     ];
 
+    let vitest_pass = vec![
+        ("expect(fn).toBeCalledWith();", None),
+        ("expect(fn).toHaveBeenCalledWith();", None),
+        ("expect(fn).toBeCalledWith(expect.anything());", None),
+        ("expect(fn).toHaveBeenCalledWith(expect.anything());", None),
+        ("expect(fn).not.toBeCalled();", None),
+        ("expect(fn).rejects.not.toBeCalled();", None),
+        ("expect(fn).not.toHaveBeenCalled();", None),
+        ("expect(fn).not.toBeCalledWith();", None),
+        ("expect(fn).not.toHaveBeenCalledWith();", None),
+        ("expect(fn).resolves.not.toHaveBeenCalledWith();", None),
+        ("expect(fn).toBeCalledTimes(0);", None),
+        ("expect(fn).toHaveBeenCalledTimes(0);", None),
+        ("expect(fn);", None),
+    ];
+
+    let vitest_fail = vec![
+        ("expect(fn).toBeCalled();", None),
+        ("expect(fn).resolves.toBeCalled();", None),
+        ("expect(fn).toHaveBeenCalled();", None),
+    ];
+
+    let vitest_fix = vec![
+        ("expect(fn).toBeCalled();", "expect(fn).toBeCalledWith();", None),
+        ("expect(fn).resolves.toBeCalled();", "expect(fn).resolves.toBeCalledWith();", None),
+        ("expect(fn).toHaveBeenCalled();", "expect(fn).toHaveBeenCalledWith();", None),
+    ];
+
+    pass.extend(vitest_pass);
+    fail.extend(vitest_fail);
+    fix.extend(vitest_fix);
+
     Tester::new(PreferCalledWith::NAME, PreferCalledWith::PLUGIN, pass, fail)
         .expect_fix(fix)
-        .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/jest_prefer_called_with.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_called_with.snap
@@ -22,24 +22,3 @@ source: crates/oxc_linter/src/tester.rs
    ·            ────────────────
    ╰────
   help: Prefer toHaveBeenCalledWith(/* expected args */)
-
-  ⚠ jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
-   ╭─[prefer_called_with.tsx:1:12]
- 1 │ expect(fn).toBeCalled();
-   ·            ──────────
-   ╰────
-  help: Prefer toBeCalledWith(/* expected args */)
-
-  ⚠ jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
-   ╭─[prefer_called_with.tsx:1:21]
- 1 │ expect(fn).resolves.toBeCalled();
-   ·                     ──────────
-   ╰────
-  help: Prefer toBeCalledWith(/* expected args */)
-
-  ⚠ jest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
-   ╭─[prefer_called_with.tsx:1:12]
- 1 │ expect(fn).toHaveBeenCalled();
-   ·            ────────────────
-   ╰────
-  help: Prefer toHaveBeenCalledWith(/* expected args */)

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_called_with.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_called_with.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:12]
+ 1 │ expect(fn).toBeCalled();
+   ·            ──────────
+   ╰────
+  help: Prefer toBeCalledWith(/* expected args */)
+
+  ⚠ vitest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:21]
+ 1 │ expect(fn).resolves.toBeCalled();
+   ·                     ──────────
+   ╰────
+  help: Prefer toBeCalledWith(/* expected args */)
+
+  ⚠ vitest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:12]
+ 1 │ expect(fn).toHaveBeenCalled();
+   ·            ────────────────
+   ╰────
+  help: Prefer toHaveBeenCalledWith(/* expected args */)
+
+  ⚠ vitest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:12]
+ 1 │ expect(fn).toBeCalled();
+   ·            ──────────
+   ╰────
+  help: Prefer toBeCalledWith(/* expected args */)
+
+  ⚠ vitest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:21]
+ 1 │ expect(fn).resolves.toBeCalled();
+   ·                     ──────────
+   ╰────
+  help: Prefer toBeCalledWith(/* expected args */)
+
+  ⚠ vitest(prefer-called-with): Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`.
+   ╭─[prefer_called_with.tsx:1:12]
+ 1 │ expect(fn).toHaveBeenCalled();
+   ·            ────────────────
+   ╰────
+  help: Prefer toHaveBeenCalledWith(/* expected args */)

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,8 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 14] = [
-    "prefer-called-with",
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 13] = [
     "prefer-comparison-matcher",
     "prefer-each",
     "prefer-equality-matcher",


### PR DESCRIPTION
- part of #21664 