### PR TITLE
feat(transformer/jsx): add jsxDEV source metadata for fragments

### DIFF
--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -712,19 +712,16 @@ impl<'a> JsxImpl<'a> {
                 ));
             }
 
-            // Fragment doesn't have source and self
-            if is_element {
-                // { __source: { fileName, lineNumber, columnNumber } }
-                if self.options.jsx_source_plugin {
-                    let (line, column) = self.jsx_source.get_line_column(span.start, ctx);
-                    let expr = self.jsx_source.get_source_object(line, column, ctx);
-                    arguments.push(Argument::from(expr));
-                }
+            // { __source: { fileName, lineNumber, columnNumber } }
+            if self.options.jsx_source_plugin {
+                let (line, column) = self.jsx_source.get_line_column(span.start, ctx);
+                let expr = self.jsx_source.get_source_object(line, column, ctx);
+                arguments.push(Argument::from(expr));
+            }
 
-                // this
-                if self.options.jsx_self_plugin && JsxSelf::can_add_self_attribute(ctx) {
-                    arguments.push(Argument::from(ctx.ast.expression_this(SPAN)));
-                }
+            // this
+            if self.options.jsx_self_plugin && JsxSelf::can_add_self_attribute(ctx) {
+                arguments.push(Argument::from(ctx.ast.expression_this(SPAN)));
             }
         } else {
             // React.createElement's second argument

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/output.js
@@ -1,11 +1,45 @@
-var _jsxFileName = "<CWD>/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/input.jsx";
-import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
-/* @__PURE__ */ _jsxDEV(_Fragment, { children: [/* @__PURE__ */ _jsxDEV("div", {}, void 0, false, {
-  fileName: _jsxFileName,
-  lineNumber: 2,
-  columnNumber: 3
-}, this), /* @__PURE__ */ _jsxDEV("div", {}, void 0, false, {
-  fileName: _jsxFileName,
-  lineNumber: 3,
-  columnNumber: 3
-}, this)] }, void 0, true);
+var _jsxFileName =
+  "<CWD>/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/input.jsx";
+import {
+  jsxDEV as _jsxDEV,
+  Fragment as _Fragment,
+} from "react/jsx-dev-runtime";
+/* @__PURE__ */ _jsxDEV(
+  _Fragment,
+  {
+    children: [
+      /* @__PURE__ */ _jsxDEV(
+        "div",
+        {},
+        void 0,
+        false,
+        {
+          fileName: _jsxFileName,
+          lineNumber: 2,
+          columnNumber: 3,
+        },
+        this,
+      ),
+      /* @__PURE__ */ _jsxDEV(
+        "div",
+        {},
+        void 0,
+        false,
+        {
+          fileName: _jsxFileName,
+          lineNumber: 3,
+          columnNumber: 3,
+        },
+        this,
+      ),
+    ],
+  },
+  void 0,
+  true,
+  {
+    fileName: _jsxFileName,
+    lineNumber: 1,
+    columnNumber: 1,
+  },
+  this,
+);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/output.js
@@ -1,45 +1,15 @@
-var _jsxFileName =
-  "<CWD>/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/input.jsx";
-import {
-  jsxDEV as _jsxDEV,
-  Fragment as _Fragment,
-} from "react/jsx-dev-runtime";
-/* @__PURE__ */ _jsxDEV(
-  _Fragment,
-  {
-    children: [
-      /* @__PURE__ */ _jsxDEV(
-        "div",
-        {},
-        void 0,
-        false,
-        {
-          fileName: _jsxFileName,
-          lineNumber: 2,
-          columnNumber: 3,
-        },
-        this,
-      ),
-      /* @__PURE__ */ _jsxDEV(
-        "div",
-        {},
-        void 0,
-        false,
-        {
-          fileName: _jsxFileName,
-          lineNumber: 3,
-          columnNumber: 3,
-        },
-        this,
-      ),
-    ],
-  },
-  void 0,
-  true,
-  {
-    fileName: _jsxFileName,
-    lineNumber: 1,
-    columnNumber: 1,
-  },
-  this,
-);
+var _jsxFileName = "<CWD>/tests/babel-plugin-transform-react-jsx/test/fixtures/fragment-static-children/input.jsx";
+import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
+/* @__PURE__ */ _jsxDEV(_Fragment, { children: [/* @__PURE__ */ _jsxDEV("div", {}, void 0, false, {
+  fileName: _jsxFileName,
+  lineNumber: 2,
+  columnNumber: 3
+}, this), /* @__PURE__ */ _jsxDEV("div", {}, void 0, false, {
+  fileName: _jsxFileName,
+  lineNumber: 3,
+  columnNumber: 3
+}, this)] }, void 0, true, {
+  fileName: _jsxFileName,
+  lineNumber: 1,
+  columnNumber: 1
+}, this);


### PR DESCRIPTION
Before this change, fragment transforms omitted source location metadata:

```js
_jsxDEV(_Fragment, { children: "test" }, void 0, false);
```

After this change, fragments receive the same trailing development metadata as other JSX `jsxDEV` calls:

```js
_jsxDEV(_Fragment, { children: "test" }, void 0, false, {
  fileName: _jsxFileName,
  lineNumber: 2,
  columnNumber: 10
}, this);
```

## Motivation

This came from [#21042](https://github.com/oxc-project/oxc/issues/21042).

TypeScript's `react: reactJSXDev` transform also emits fragment source locations and `this` for same case:
https://www.typescriptlang.org/play/?jsx=5#code/DwPgUABBwCYJYDcTAPTyZa7lseV4QA

## Changes

- allow fragment `jsxDEV` calls to receive source metadata in the JSX transformer
- update the local transform conformance fixture for `fragment-static-children`