### PR TITLE
fix(linter): `jsx-a11y/prefer-tag-over-role` detect more roles

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
@@ -104,6 +104,8 @@ fn test() {
         "<other />",
         "<img role=\"img\" />",
         "<input role=\"checkbox\" />",
+        "<button role=\"button\" />",
+        "<header role=\"banner\" />",
         "<a role=\"link\" />",
         "<area role=\"link\" />",
         "<h1 role=\"heading\" />",

--- a/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/prefer_tag_over_role.rs
@@ -62,7 +62,7 @@ impl PreferTagOverRole {
 
     fn check_role(role: &str, jsx_name: &str, span: Span, ctx: &LintContext) {
         if let Some(tag) = get_tags_from_role(role)
-            && jsx_name != tag
+            && !tag.split(',').any(|t| t == jsx_name)
         {
             ctx.diagnostic(prefer_tag_over_role_diagnostic(span, tag, role));
         }
@@ -71,12 +71,15 @@ impl PreferTagOverRole {
 
 fn get_tags_from_role(role: &str) -> Option<&'static str> {
     match role {
-        "checkbox" => Some("input"),
+        "checkbox" | "slider" | "combobox" | "radio" => Some("input"),
         "button" => Some("button"),
         "heading" => Some("h1,h2,h3,h4,h5,h6"),
         "link" => Some("a,area"),
         "rowgroup" => Some("tbody,tfoot,thead"),
         "banner" => Some("header"),
+        "listbox" => Some("select"),
+        "region" => Some("section"),
+        "textbox" => Some("input,textarea"),
         _ => None,
     }
 }
@@ -101,6 +104,20 @@ fn test() {
         "<other />",
         "<img role=\"img\" />",
         "<input role=\"checkbox\" />",
+        "<a role=\"link\" />",
+        "<area role=\"link\" />",
+        "<h1 role=\"heading\" />",
+        "<h6 role=\"heading\" />",
+        "<tbody role=\"rowgroup\" />",
+        "<tfoot role=\"rowgroup\" />",
+        "<thead role=\"rowgroup\" />",
+        "<select role=\"listbox\" />",
+        "<section role=\"region\" />",
+        "<input role=\"slider\" />",
+        "<input role=\"combobox\" />",
+        "<input role=\"radio\" />",
+        "<input role=\"textbox\" />",
+        "<textarea role=\"textbox\" />",
     ];
     let fail: Vec<&str> = vec![
         r#"<div role="checkbox" />"#,
@@ -112,6 +129,12 @@ fn test() {
         r#"<other role="checkbox" />"#,
         r#"<other role="checkbox" />"#,
         r#"<div role="banner" />"#,
+        r#"<div role="listbox" />"#,
+        r#"<div role="region" />"#,
+        r#"<div role="slider" />"#,
+        r#"<div role="combobox" />"#,
+        r#"<div role="radio" />"#,
+        r#"<div role="textbox" />"#,
     ];
     Tester::new(PreferTagOverRole::NAME, PreferTagOverRole::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_prefer_tag_over_role.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_prefer_tag_over_role.snap
@@ -71,3 +71,45 @@ source: crates/oxc_linter/src/tester.rs
    ·      ─────────────
    ╰────
   help: Replace HTML elements with `role` attribute `banner` to corresponding semantic HTML tag `header`.
+
+  ⚠ jsx-a11y(prefer-tag-over-role): Prefer `select` over `role` attribute `listbox`.
+   ╭─[prefer_tag_over_role.tsx:1:6]
+ 1 │ <div role="listbox" />
+   ·      ──────────────
+   ╰────
+  help: Replace HTML elements with `role` attribute `listbox` to corresponding semantic HTML tag `select`.
+
+  ⚠ jsx-a11y(prefer-tag-over-role): Prefer `section` over `role` attribute `region`.
+   ╭─[prefer_tag_over_role.tsx:1:6]
+ 1 │ <div role="region" />
+   ·      ─────────────
+   ╰────
+  help: Replace HTML elements with `role` attribute `region` to corresponding semantic HTML tag `section`.
+
+  ⚠ jsx-a11y(prefer-tag-over-role): Prefer `input` over `role` attribute `slider`.
+   ╭─[prefer_tag_over_role.tsx:1:6]
+ 1 │ <div role="slider" />
+   ·      ─────────────
+   ╰────
+  help: Replace HTML elements with `role` attribute `slider` to corresponding semantic HTML tag `input`.
+
+  ⚠ jsx-a11y(prefer-tag-over-role): Prefer `input` over `role` attribute `combobox`.
+   ╭─[prefer_tag_over_role.tsx:1:6]
+ 1 │ <div role="combobox" />
+   ·      ───────────────
+   ╰────
+  help: Replace HTML elements with `role` attribute `combobox` to corresponding semantic HTML tag `input`.
+
+  ⚠ jsx-a11y(prefer-tag-over-role): Prefer `input` over `role` attribute `radio`.
+   ╭─[prefer_tag_over_role.tsx:1:6]
+ 1 │ <div role="radio" />
+   ·      ────────────
+   ╰────
+  help: Replace HTML elements with `role` attribute `radio` to corresponding semantic HTML tag `input`.
+
+  ⚠ jsx-a11y(prefer-tag-over-role): Prefer `input,textarea` over `role` attribute `textbox`.
+   ╭─[prefer_tag_over_role.tsx:1:6]
+ 1 │ <div role="textbox" />
+   ·      ──────────────
+   ╰────
+  help: Replace HTML elements with `role` attribute `textbox` to corresponding semantic HTML tag `input,textarea`.


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/21910

add missing role mappings (`listbox`, `region`, `slider`, `combobox`, `radio`, `textbox`).

also fixes false positives on existing multi-tag roles (`link`, `heading`, `rowgroup`) — the previous `jsx_name != tag` did a plain string equality against the comma-joined tag (`"a,area"` etc.), so `<a role="link" />` was incorrectly reported.