### PR TITLE
fix(linter): `jsx-a11y/media-has-caption` report only once for self-closing tags

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -152,35 +152,27 @@ impl Rule for MediaHasCaption {
             return;
         };
 
-        let has_caption = if parent.children.is_empty() {
-            ctx.diagnostic(media_has_caption_diagnostic(parent.opening_element.span));
-            false
-        } else {
-            parent.children.iter().any(|child| match child {
-                JSXChild::Element(child_el) => {
-                    let child_name = get_element_type(ctx, &child_el.opening_element);
+        let has_caption = parent.children.iter().any(|child| match child {
+            JSXChild::Element(child_el) => {
+                let child_name = get_element_type(ctx, &child_el.opening_element);
 
-                    self.0.track.contains(&child_name)
-                        && child_el.opening_element.attributes.iter().any(|attr| {
-                            let JSXAttributeItem::Attribute(attr) = attr else { return false };
-                            let JSXAttributeName::Identifier(iden) = &attr.name else {
-                                return false;
-                            };
-                            if let Some(JSXAttributeValue::StringLiteral(s)) = &attr.value {
-                                return iden.name == "kind"
-                                    && s.value.eq_ignore_ascii_case("captions");
-                            }
-                            false
-                        })
-                }
-                _ => false,
-            })
-        };
-
-        let span = parent.span;
+                self.0.track.contains(&child_name)
+                    && child_el.opening_element.attributes.iter().any(|attr| {
+                        let JSXAttributeItem::Attribute(attr) = attr else { return false };
+                        let JSXAttributeName::Identifier(iden) = &attr.name else {
+                            return false;
+                        };
+                        if let Some(JSXAttributeValue::StringLiteral(s)) = &attr.value {
+                            return iden.name == "kind" && s.value.eq_ignore_ascii_case("captions");
+                        }
+                        false
+                    })
+            }
+            _ => false,
+        });
 
         if !has_caption {
-            ctx.diagnostic(media_has_caption_diagnostic(span));
+            ctx.diagnostic(media_has_caption_diagnostic(parent.span));
         }
     }
 }
@@ -269,6 +261,8 @@ fn test() {
         (r"<Audio><Track kind='subtitles' /></Audio>", None, Some(settings())),
         (r"<Video><Track kind='subtitles' /></Video>", None, Some(settings())),
         (r"<Box as='audio'><Track kind='subtitles' /></Box>", None, Some(settings())),
+        (r#"<audio src="talk.mp3" controls />"#, None, None),
+        (r#"<video src="movie.mp4" controls />"#, None, None),
     ];
 
     Tester::new(MediaHasCaption::NAME, MediaHasCaption::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_media_has_caption.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_media_has_caption.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio><track /></audio>
@@ -13,13 +12,6 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[media_has_caption.tsx:1:1]
  1 │ <audio><track kind='subtitles' /></audio>
    · ─────────────────────────────────────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <audio />
-   · ─────────
    ╰────
   help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
@@ -47,21 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio muted={false}></Audio>
-   · ─────────────────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <Audio muted={false}></Audio>
    · ─────────────────────────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <Video muted={false}></Video>
-   · ─────────────────────
    ╰────
   help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
@@ -75,13 +53,6 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio muted={false}></Audio>
-   · ─────────────────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <Audio muted={false}></Audio>
    · ─────────────────────────────
    ╰────
   help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
@@ -89,21 +60,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Video muted={false}></Video>
-   · ─────────────────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <Video muted={false}></Video>
    · ─────────────────────────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <video />
-   · ─────────
    ╰────
   help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
 
@@ -137,20 +94,6 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
- 1 │ <Audio />
-   · ─────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <Video />
-   · ─────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
  1 │ <Video />
    · ─────────
    ╰────
@@ -159,20 +102,6 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Audio />
-   · ─────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <Audio />
-   · ─────────
-   ╰────
-  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
-
-  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
-   ╭─[media_has_caption.tsx:1:1]
- 1 │ <Video />
    · ─────────
    ╰────
   help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
@@ -230,5 +159,19 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[media_has_caption.tsx:1:1]
  1 │ <Box as='audio'><Track kind='subtitles' /></Box>
    · ────────────────────────────────────────────────
+   ╰────
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
+
+  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
+   ╭─[media_has_caption.tsx:1:1]
+ 1 │ <audio src="talk.mp3" controls />
+   · ─────────────────────────────────
+   ╰────
+  help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.
+
+  ⚠ jsx-a11y(media-has-caption): Missing `<track>` element with captions inside `<audio>` or `<video>` element
+   ╭─[media_has_caption.tsx:1:1]
+ 1 │ <video src="movie.mp4" controls />
+   · ──────────────────────────────────
    ╰────
   help: Media elements such as `<audio>` and `<video>` must have a `<track>` for captions.


### PR DESCRIPTION
closes #21911

`<audio />` / `<video />` reported the same violation twice — the early `ctx.diagnostic` branch was missing a `return`. Now emits once.

Mostly an indentation diff — easier to review with `?w=1`:
https://github.com/oxc-project/oxc/pull/21934/files?w=1

[playground](https://playground.oxc.rs/?lintRules=jsx-a11y%2Fmedia-has-caption&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Afalse%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22tsx%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%22config%22%3A%22%7B%5C%22categories%5C%22%3A%7B%5C%22correctness%5C%22%3A%5C%22off%5C%22%7D%2C%5C%22rules%5C%22%3A%7B%5C%22jsx-a11y%2Fmedia-has-caption%5C%22%3A%5C%22error%5C%22%7D%2C%5C%22plugins%5C%22%3A%5B%5C%22eslint%5C%22%2C%5C%22oxc%5C%22%2C%5C%22typescript%5C%22%2C%5C%22unicorn%5C%22%2C%5C%22jsx-a11y%5C%22%5D%7D%22%7D&code=function+Component%28%29%7B%0Areturn+%28%0A++%3C%3E%0A++++%3Cvideo+src%3D%22movie.mp4%22+controls+%2F%3E%0A++++%3Caudio+src%3D%22talk.mp3%22+controls+%2F%3E%0A%3C%2F%3E%0A%29%0A%7D)