### PR TITLE
feat(linter/vue): implement return-in-emits-validator rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1313,6 +1313,7 @@ export interface DummyRuleMap {
   "vue/require-slots-as-functions"?: DummyRule;
   "vue/require-typed-ref"?: DummyRule;
   "vue/return-in-computed-property"?: DummyRule;
+  "vue/return-in-emits-validator"?: DummyRule;
   "vue/valid-define-emits"?: DummyRule;
   "vue/valid-define-options"?: DummyRule;
   "vue/valid-define-props"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5085,6 +5085,12 @@ impl RuleRunner for crate::rules::vue::return_in_computed_property::ReturnInComp
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::return_in_emits_validator::ReturnInEmitsValidator {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::valid_define_emits::ValidDefineEmits {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -812,6 +812,7 @@ pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRe
 pub use crate::rules::vue::require_slots_as_functions::RequireSlotsAsFunctions as VueRequireSlotsAsFunctions;
 pub use crate::rules::vue::require_typed_ref::RequireTypedRef as VueRequireTypedRef;
 pub use crate::rules::vue::return_in_computed_property::ReturnInComputedProperty as VueReturnInComputedProperty;
+pub use crate::rules::vue::return_in_emits_validator::ReturnInEmitsValidator as VueReturnInEmitsValidator;
 pub use crate::rules::vue::valid_define_emits::ValidDefineEmits as VueValidDefineEmits;
 pub use crate::rules::vue::valid_define_options::ValidDefineOptions as VueValidDefineOptions;
 pub use crate::rules::vue::valid_define_props::ValidDefineProps as VueValidDefineProps;
@@ -1638,6 +1639,7 @@ pub enum RuleEnum {
     VueRequireSlotsAsFunctions(VueRequireSlotsAsFunctions),
     VueRequireTypedRef(VueRequireTypedRef),
     VueReturnInComputedProperty(VueReturnInComputedProperty),
+    VueReturnInEmitsValidator(VueReturnInEmitsValidator),
     VueValidDefineEmits(VueValidDefineEmits),
     VueValidDefineOptions(VueValidDefineOptions),
     VueValidDefineProps(VueValidDefineProps),
@@ -2548,7 +2550,8 @@ const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1us
 const VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
 const VUE_REQUIRE_TYPED_REF_ID: usize = VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID + 1usize;
 const VUE_RETURN_IN_COMPUTED_PROPERTY_ID: usize = VUE_REQUIRE_TYPED_REF_ID + 1usize;
-const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_COMPUTED_PROPERTY_ID + 1usize;
+const VUE_RETURN_IN_EMITS_VALIDATOR_ID: usize = VUE_RETURN_IN_COMPUTED_PROPERTY_ID + 1usize;
+const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usize;
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
@@ -3485,6 +3488,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID,
             Self::VueRequireTypedRef(_) => VUE_REQUIRE_TYPED_REF_ID,
             Self::VueReturnInComputedProperty(_) => VUE_RETURN_IN_COMPUTED_PROPERTY_ID,
+            Self::VueReturnInEmitsValidator(_) => VUE_RETURN_IN_EMITS_VALIDATOR_ID,
             Self::VueValidDefineEmits(_) => VUE_VALID_DEFINE_EMITS_ID,
             Self::VueValidDefineOptions(_) => VUE_VALID_DEFINE_OPTIONS_ID,
             Self::VueValidDefineProps(_) => VUE_VALID_DEFINE_PROPS_ID,
@@ -4407,6 +4411,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::NAME,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::NAME,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::NAME,
+            Self::VueReturnInEmitsValidator(_) => VueReturnInEmitsValidator::NAME,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::NAME,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::NAME,
             Self::VueValidDefineProps(_) => VueValidDefineProps::NAME,
@@ -5387,6 +5392,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::CATEGORY,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::CATEGORY,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::CATEGORY,
+            Self::VueReturnInEmitsValidator(_) => VueReturnInEmitsValidator::CATEGORY,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::CATEGORY,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::CATEGORY,
             Self::VueValidDefineProps(_) => VueValidDefineProps::CATEGORY,
@@ -6310,6 +6316,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::FIX,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::FIX,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::FIX,
+            Self::VueReturnInEmitsValidator(_) => VueReturnInEmitsValidator::FIX,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::FIX,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::FIX,
             Self::VueValidDefineProps(_) => VueValidDefineProps::FIX,
@@ -7481,6 +7488,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::documentation(),
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::documentation(),
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::documentation(),
+            Self::VueReturnInEmitsValidator(_) => VueReturnInEmitsValidator::documentation(),
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::documentation(),
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::documentation(),
             Self::VueValidDefineProps(_) => VueValidDefineProps::documentation(),
@@ -9802,6 +9810,10 @@ impl RuleEnum {
                 VueReturnInComputedProperty::config_schema(generator)
                     .or_else(|| VueReturnInComputedProperty::schema(generator))
             }
+            Self::VueReturnInEmitsValidator(_) => {
+                VueReturnInEmitsValidator::config_schema(generator)
+                    .or_else(|| VueReturnInEmitsValidator::schema(generator))
+            }
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::config_schema(generator)
                 .or_else(|| VueValidDefineEmits::schema(generator)),
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::config_schema(generator)
@@ -10618,6 +10630,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => "vue",
             Self::VueRequireTypedRef(_) => "vue",
             Self::VueReturnInComputedProperty(_) => "vue",
+            Self::VueReturnInEmitsValidator(_) => "vue",
             Self::VueValidDefineEmits(_) => "vue",
             Self::VueValidDefineOptions(_) => "vue",
             Self::VueValidDefineProps(_) => "vue",
@@ -13221,6 +13234,9 @@ impl RuleEnum {
             Self::VueReturnInComputedProperty(_) => Ok(Self::VueReturnInComputedProperty(
                 VueReturnInComputedProperty::from_configuration(value)?,
             )),
+            Self::VueReturnInEmitsValidator(_) => Ok(Self::VueReturnInEmitsValidator(
+                VueReturnInEmitsValidator::from_configuration(value)?,
+            )),
             Self::VueValidDefineEmits(_) => {
                 Ok(Self::VueValidDefineEmits(VueValidDefineEmits::from_configuration(value)?))
             }
@@ -14045,6 +14061,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(rule) => rule.to_configuration(),
             Self::VueRequireTypedRef(rule) => rule.to_configuration(),
             Self::VueReturnInComputedProperty(rule) => rule.to_configuration(),
+            Self::VueReturnInEmitsValidator(rule) => rule.to_configuration(),
             Self::VueValidDefineEmits(rule) => rule.to_configuration(),
             Self::VueValidDefineOptions(rule) => rule.to_configuration(),
             Self::VueValidDefineProps(rule) => rule.to_configuration(),
@@ -14867,6 +14884,7 @@ impl RuleEnum {
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run(node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run(node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run(node, ctx),
+                Self::VueReturnInEmitsValidator(rule) => rule.run(node, ctx),
                 Self::VueValidDefineEmits(rule) => rule.run(node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run(node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run(node, ctx),
@@ -15682,6 +15700,7 @@ impl RuleEnum {
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run(node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run(node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run(node, ctx),
+                Self::VueReturnInEmitsValidator(rule) => rule.run(node, ctx),
                 Self::VueValidDefineEmits(rule) => rule.run(node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run(node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run(node, ctx),
@@ -16504,6 +16523,7 @@ impl RuleEnum {
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_once(ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_once(ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_once(ctx),
+                Self::VueReturnInEmitsValidator(rule) => rule.run_once(ctx),
                 Self::VueValidDefineEmits(rule) => rule.run_once(ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_once(ctx),
                 Self::VueValidDefineProps(rule) => rule.run_once(ctx),
@@ -17319,6 +17339,7 @@ impl RuleEnum {
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_once(ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_once(ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_once(ctx),
+                Self::VueReturnInEmitsValidator(rule) => rule.run_once(ctx),
                 Self::VueValidDefineEmits(rule) => rule.run_once(ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_once(ctx),
                 Self::VueValidDefineProps(rule) => rule.run_once(ctx),
@@ -18394,6 +18415,7 @@ impl RuleEnum {
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueReturnInEmitsValidator(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineEmits(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19461,6 +19483,7 @@ impl RuleEnum {
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueReturnInEmitsValidator(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineEmits(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20274,6 +20297,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(rule) => rule.should_run(ctx),
             Self::VueRequireTypedRef(rule) => rule.should_run(ctx),
             Self::VueReturnInComputedProperty(rule) => rule.should_run(ctx),
+            Self::VueReturnInEmitsValidator(rule) => rule.should_run(ctx),
             Self::VueValidDefineEmits(rule) => rule.should_run(ctx),
             Self::VueValidDefineOptions(rule) => rule.should_run(ctx),
             Self::VueValidDefineProps(rule) => rule.should_run(ctx),
@@ -21444,6 +21468,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::IS_TSGOLINT_RULE,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::IS_TSGOLINT_RULE,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::IS_TSGOLINT_RULE,
+            Self::VueReturnInEmitsValidator(_) => VueReturnInEmitsValidator::IS_TSGOLINT_RULE,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::IS_TSGOLINT_RULE,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::IS_TSGOLINT_RULE,
             Self::VueValidDefineProps(_) => VueValidDefineProps::IS_TSGOLINT_RULE,
@@ -22426,6 +22451,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::VERSION,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::VERSION,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::VERSION,
+            Self::VueReturnInEmitsValidator(_) => VueReturnInEmitsValidator::VERSION,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::VERSION,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::VERSION,
             Self::VueValidDefineProps(_) => VueValidDefineProps::VERSION,
@@ -23443,6 +23469,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::HAS_CONFIG,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::HAS_CONFIG,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::HAS_CONFIG,
+            Self::VueReturnInEmitsValidator(_) => VueReturnInEmitsValidator::HAS_CONFIG,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::HAS_CONFIG,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::HAS_CONFIG,
             Self::VueValidDefineProps(_) => VueValidDefineProps::HAS_CONFIG,
@@ -24255,6 +24282,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(rule) => rule.types_info(),
             Self::VueRequireTypedRef(rule) => rule.types_info(),
             Self::VueReturnInComputedProperty(rule) => rule.types_info(),
+            Self::VueReturnInEmitsValidator(rule) => rule.types_info(),
             Self::VueValidDefineEmits(rule) => rule.types_info(),
             Self::VueValidDefineOptions(rule) => rule.types_info(),
             Self::VueValidDefineProps(rule) => rule.types_info(),
@@ -25067,6 +25095,7 @@ impl RuleEnum {
             Self::VueRequireSlotsAsFunctions(rule) => rule.run_info(),
             Self::VueRequireTypedRef(rule) => rule.run_info(),
             Self::VueReturnInComputedProperty(rule) => rule.run_info(),
+            Self::VueReturnInEmitsValidator(rule) => rule.run_info(),
             Self::VueValidDefineEmits(rule) => rule.run_info(),
             Self::VueValidDefineOptions(rule) => rule.run_info(),
             Self::VueValidDefineProps(rule) => rule.run_info(),
@@ -26011,6 +26040,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueRequireSlotsAsFunctions(VueRequireSlotsAsFunctions::default()),
         RuleEnum::VueRequireTypedRef(VueRequireTypedRef::default()),
         RuleEnum::VueReturnInComputedProperty(VueReturnInComputedProperty::default()),
+        RuleEnum::VueReturnInEmitsValidator(VueReturnInEmitsValidator::default()),
         RuleEnum::VueValidDefineEmits(VueValidDefineEmits::default()),
         RuleEnum::VueValidDefineOptions(VueValidDefineOptions::default()),
         RuleEnum::VueValidDefineProps(VueValidDefineProps::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -852,6 +852,7 @@ pub(crate) mod vue {
     pub mod require_slots_as_functions;
     pub mod require_typed_ref;
     pub mod return_in_computed_property;
+    pub mod return_in_emits_validator;
     pub mod valid_define_emits;
     pub mod valid_define_options;
     pub mod valid_define_props;

--- a/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
@@ -10,7 +10,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
 use oxc_span::{GetSpan, Span};
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
 
 fn expected_boolean_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -132,7 +132,8 @@ fn get_emit_validator_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<
 
     // Composition API: function -> ObjectProperty(emit name) -> ObjectExpression
     //                  -> CallExpression(`defineEmits(...)`)
-    if let AstKind::CallExpression(call) = outer.kind()
+    if ctx.frameworks_options() == FrameworkOptions::VueSetup
+        && let AstKind::CallExpression(call) = outer.kind()
         && call.callee.get_identifier_reference().is_some_and(|ident| ident.name == "defineEmits")
     {
         return Some(emit_name.into_owned());
@@ -247,7 +248,7 @@ fn is_falsy(expr: &Expression<'_>) -> bool {
         Expression::NumericLiteral(n) => n.value == 0.0,
         Expression::NullLiteral(_) => true,
         Expression::StringLiteral(s) => s.value.is_empty(),
-        Expression::BigIntLiteral(big) => big.raw.is_some_and(|s| s.as_str() == "0n"),
+        Expression::BigIntLiteral(big) => big.is_zero(),
         Expression::Identifier(ident) => matches!(ident.name.as_str(), "undefined" | "NaN"),
         _ => false,
     }
@@ -255,8 +256,9 @@ fn is_falsy(expr: &Expression<'_>) -> bool {
 
 #[test]
 fn test() {
-    use crate::tester::Tester;
     use std::path::PathBuf;
+
+    use crate::tester::Tester;
 
     let pass = vec![
         (
@@ -388,6 +390,19 @@ fn test() {
                 const emit = defineEmits<Emits>()
                 </script>
             "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                defineEmits({
+                  foo () {
+                  }
+                })
+                </script>
+            ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
@@ -527,6 +542,8 @@ fn test() {
                         return NaN
                       } else if (g) {
                         return 0n
+                      } else if (h) {
+                        return 0x0n
                       }
                     }
                   }

--- a/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
@@ -1,0 +1,557 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrowFunctionExpression, CallExpression, Expression, Function, ReturnStatement, Statement,
+    },
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::ScopeFlags;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn expected_boolean_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Expected to return a boolean value in \"{name}\" emits validator."
+    ))
+    .with_label(span)
+}
+
+fn expected_true_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Expected to return a true value in \"{name}\" emits validator."))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ReturnInEmitsValidator;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce that a `return` statement is present in `emits` validators
+    /// (in Vue.js 3.0.0+).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// An `emits` validator must return a boolean indicating whether the
+    /// emitted payload is valid. Forgetting to return a value (or returning
+    /// only falsy values) makes the validator effectively reject every emit,
+    /// breaking the component contract silently.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   emits: {
+    ///     foo() {
+    ///       // missing return
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   emits: {
+    ///     foo(payload) {
+    ///       return typeof payload === 'string'
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ReturnInEmitsValidator,
+    vue,
+    correctness,
+    version = "next",
+);
+
+impl Rule for ReturnInEmitsValidator {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let report_span = match node.kind() {
+            AstKind::Function(func) => func.span,
+            AstKind::ArrowFunctionExpression(arrow) => arrow.span,
+            _ => return,
+        };
+
+        let Some(emit_name) = get_emit_validator_name(node, ctx) else { return };
+
+        let (has_return_value, possible_of_return_true) = analyze_return_value(node.kind());
+        if possible_of_return_true {
+            return;
+        }
+
+        let diagnostic = if has_return_value {
+            expected_true_diagnostic(report_span, &emit_name)
+        } else {
+            expected_boolean_diagnostic(report_span, &emit_name)
+        };
+        ctx.diagnostic(diagnostic);
+    }
+}
+
+/// Returns the emit name (`foo` in `emits: { foo() {} }`) when `node` is a
+/// function/arrow function used as an emits validator. Otherwise returns
+/// `None`. Covers both Options API (`emits: {...}` inside a Vue component
+/// options object) and Composition API (`defineEmits({...})` in `<script setup>`).
+fn get_emit_validator_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    let nodes = ctx.nodes();
+    let parent = nodes.parent_node(node.id());
+    let AstKind::ObjectProperty(prop) = parent.kind() else { return None };
+    let emit_name = prop.key.static_name()?;
+
+    let obj_node = nodes.parent_node(parent.id());
+    if !matches!(obj_node.kind(), AstKind::ObjectExpression(_)) {
+        return None;
+    }
+    let outer = nodes.parent_node(obj_node.id());
+
+    // Options API: function -> ObjectProperty(emit name) -> ObjectExpression(emits body)
+    //              -> ObjectProperty("emits") -> ObjectExpression(component options)
+    if let AstKind::ObjectProperty(emits_prop) = outer.kind() {
+        if !emits_prop.key.is_specific_static_name("emits") {
+            return None;
+        }
+        let component_obj = nodes.parent_node(outer.id());
+        if is_vue_component_options_object(component_obj, ctx) {
+            return Some(emit_name.into_owned());
+        }
+        return None;
+    }
+
+    // Composition API: function -> ObjectProperty(emit name) -> ObjectExpression
+    //                  -> CallExpression(`defineEmits(...)`)
+    if let AstKind::CallExpression(call) = outer.kind()
+        && call.callee.get_identifier_reference().is_some_and(|ident| ident.name == "defineEmits")
+    {
+        return Some(emit_name.into_owned());
+    }
+
+    None
+}
+
+fn is_vue_component_options_object(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let AstKind::ObjectExpression(obj) = node.kind() else { return false };
+    ctx.nodes().ancestors(node.id()).any(|ancestor| match ancestor.kind() {
+        AstKind::ExportDefaultDeclaration(decl) => decl.declaration.span() == obj.span,
+        AstKind::CallExpression(call) => {
+            call.arguments
+                .iter()
+                .any(|arg| arg.as_expression().is_some_and(|e| e.span() == obj.span))
+                && is_vue_component_factory_call(call)
+        }
+        _ => false,
+    })
+}
+
+fn is_vue_component_factory_call(call: &CallExpression<'_>) -> bool {
+    if call
+        .callee
+        .get_identifier_reference()
+        .is_some_and(|ident| matches!(ident.name.as_str(), "createApp" | "defineComponent"))
+    {
+        return true;
+    }
+    call.callee.get_member_expr().is_some_and(|member_expr| {
+        member_expr.static_property_name().is_some_and(|name| name == "component")
+    })
+}
+
+/// Walks the body of an emits validator and reports whether at least one
+/// return statement carries a value, and whether at least one of those values
+/// can be truthy. Mirrors the upstream eslint-plugin-vue logic, with nested
+/// functions treated as opaque (their return statements don't count).
+fn analyze_return_value(kind: AstKind<'_>) -> (bool, bool) {
+    let mut visitor = ReturnVisitor::default();
+
+    match kind {
+        AstKind::Function(func) => {
+            if let Some(body) = &func.body {
+                visitor.visit_function_body(body);
+            }
+        }
+        AstKind::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                // Concise body `() => expr`: implicit return of `expr`.
+                visitor.has_return_value = true;
+                if let Some(expr) = arrow_expression_body(arrow)
+                    && !is_falsy(expr)
+                {
+                    visitor.possible_of_return_true = true;
+                }
+            } else {
+                visitor.visit_function_body(&arrow.body);
+            }
+        }
+        _ => {}
+    }
+
+    (visitor.has_return_value, visitor.possible_of_return_true)
+}
+
+fn arrow_expression_body<'a>(arrow: &'a ArrowFunctionExpression<'a>) -> Option<&'a Expression<'a>> {
+    let stmt = arrow.body.statements.first()?;
+    match stmt {
+        Statement::ExpressionStatement(expr_stmt) => Some(&expr_stmt.expression),
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+struct ReturnVisitor {
+    nested_depth: u32,
+    has_return_value: bool,
+    possible_of_return_true: bool,
+}
+
+impl<'a> Visit<'a> for ReturnVisitor {
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        self.nested_depth += 1;
+        walk::walk_function(self, func, flags);
+        self.nested_depth -= 1;
+    }
+
+    fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'a>) {
+        self.nested_depth += 1;
+        walk::walk_arrow_function_expression(self, arrow);
+        self.nested_depth -= 1;
+    }
+
+    fn visit_return_statement(&mut self, stmt: &ReturnStatement<'a>) {
+        if self.nested_depth == 0
+            && let Some(arg) = &stmt.argument
+        {
+            self.has_return_value = true;
+            if !is_falsy(arg) {
+                self.possible_of_return_true = true;
+            }
+        }
+        walk::walk_return_statement(self, stmt);
+    }
+}
+
+fn is_falsy(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::BooleanLiteral(b) => !b.value,
+        Expression::NumericLiteral(n) => n.value == 0.0,
+        Expression::NullLiteral(_) => true,
+        Expression::StringLiteral(s) => s.value.is_empty(),
+        Expression::BigIntLiteral(big) => big.raw.is_some_and(|s| s.as_str() == "0n"),
+        Expression::Identifier(ident) => matches!(ident.name.as_str(), "undefined" | "NaN"),
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo () {
+                      return true
+                    },
+                    bar: function (e) {
+                      return true
+                    },
+                    baz: (e) => {
+                      return e
+                    },
+                    baz2: (e) => e,
+                    qux () {
+                      if (foo) {
+                        return true
+                      } else {
+                        return false
+                      }
+                    },
+                    quux: null,
+                    corge (evt) {
+                      return evt
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo () {
+                      const options = []
+                      this.matches.forEach((match) => {
+                        options.push(match)
+                      })
+                      return options
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: ['foo']
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo () {
+                      const options = []
+                      this.matches.forEach(function (match) {
+                        options.push(match)
+                      })
+                      return options
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    a () {
+                      return 1n
+                    },
+                    b: function (e) {
+                      return 1
+                    },
+                    c: (e) => {
+                      return 'a'
+                    },
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script setup>
+                defineEmits({
+                  foo () {
+                    return true
+                  }
+                })
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                <script setup lang="ts">
+                import {Emits1 as Emits} from './test01'
+                const emit = defineEmits<Emits>()
+                </script>
+            "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo () {
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo: function () {
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo: () => {
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo: () => false
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo: function () {
+                      function bar () {
+                        return this.baz * 2
+                      }
+                      bar()
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo () {
+                    },
+                    bar () {
+                      return
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo () {
+                      return
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script>
+                export default {
+                  emits: {
+                    foo: function () {
+                      if (a) {
+                        return false
+                      } else if (b) {
+                        return 0
+                      } else if (c) {
+                        return null
+                      } else if (d) {
+                        return ''
+                      } else if (e) {
+                        return undefined
+                      } else if (f) {
+                        return NaN
+                      } else if (g) {
+                        return 0n
+                      }
+                    }
+                  }
+                }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                <script setup>
+                defineEmits({
+                  foo () {
+                  }
+                })
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(ReturnInEmitsValidator::NAME, ReturnInEmitsValidator::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vue_return_in_emits_validator.snap
+++ b/crates/oxc_linter/src/snapshots/vue_return_in_emits_validator.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
    ╭─[return_in_emits_validator.tsx:5:25]
  4 │                       emits: {
@@ -89,9 +90,11 @@ source: crates/oxc_linter/src/tester.rs
  17 │ │                           return NaN
  18 │ │                         } else if (g) {
  19 │ │                           return 0n
- 20 │ │                         }
- 21 │ ╰─▶                     }
- 22 │                       }
+ 20 │ │                         } else if (h) {
+ 21 │ │                           return 0x0n
+ 22 │ │                         }
+ 23 │ ╰─▶                     }
+ 24 │                       }
     ╰────
 
   ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.

--- a/crates/oxc_linter/src/snapshots/vue_return_in_emits_validator.snap
+++ b/crates/oxc_linter/src/snapshots/vue_return_in_emits_validator.snap
@@ -1,0 +1,103 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:5:25]
+ 4 │                       emits: {
+ 5 │ ╭─▶                     foo () {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:5:26]
+ 4 │                       emits: {
+ 5 │ ╭─▶                     foo: function () {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:5:26]
+ 4 │                       emits: {
+ 5 │ ╭─▶                     foo: () => {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a true value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:5:26]
+ 4 │                   emits: {
+ 5 │                     foo: () => false
+   ·                          ───────────
+ 6 │                   }
+   ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+    ╭─[return_in_emits_validator.tsx:5:26]
+  4 │                       emits: {
+  5 │ ╭─▶                     foo: function () {
+  6 │ │                         function bar () {
+  7 │ │                           return this.baz * 2
+  8 │ │                         }
+  9 │ │                         bar()
+ 10 │ ╰─▶                     }
+ 11 │                       }
+    ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:5:25]
+ 4 │                       emits: {
+ 5 │ ╭─▶                     foo () {
+ 6 │ ╰─▶                     },
+ 7 │                         bar () {
+   ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "bar" emits validator.
+    ╭─[return_in_emits_validator.tsx:7:25]
+  6 │                         },
+  7 │ ╭─▶                     bar () {
+  8 │ │                         return
+  9 │ ╰─▶                     }
+ 10 │                       }
+    ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:5:25]
+ 4 │                       emits: {
+ 5 │ ╭─▶                     foo () {
+ 6 │ │                         return
+ 7 │ ╰─▶                     }
+ 8 │                       }
+   ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a true value in "foo" emits validator.
+    ╭─[return_in_emits_validator.tsx:5:26]
+  4 │                       emits: {
+  5 │ ╭─▶                     foo: function () {
+  6 │ │                         if (a) {
+  7 │ │                           return false
+  8 │ │                         } else if (b) {
+  9 │ │                           return 0
+ 10 │ │                         } else if (c) {
+ 11 │ │                           return null
+ 12 │ │                         } else if (d) {
+ 13 │ │                           return ''
+ 14 │ │                         } else if (e) {
+ 15 │ │                           return undefined
+ 16 │ │                         } else if (f) {
+ 17 │ │                           return NaN
+ 18 │ │                         } else if (g) {
+ 19 │ │                           return 0n
+ 20 │ │                         }
+ 21 │ ╰─▶                     }
+ 22 │                       }
+    ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:4:23]
+ 3 │                     defineEmits({
+ 4 │ ╭─▶                   foo () {
+ 5 │ ╰─▶                   }
+ 6 │                     })
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2650,6 +2650,9 @@
         "vue/return-in-computed-property": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/return-in-emits-validator": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/valid-define-emits": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2654,6 +2654,9 @@ expression: json
         "vue/return-in-computed-property": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/return-in-emits-validator": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/valid-define-emits": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/return-in-emits-validator.html

AI disclosure: implemented with Claude Code, reviewed manually.