### PR TITLE
fix(linter/no-unused-vars): report unused re-exported imports

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -12,7 +12,7 @@ use oxc_semantic::{
 };
 use oxc_span::{GetSpan, Span};
 
-use crate::ModuleRecord;
+use crate::{ModuleRecord, module_record::ExportLocalName};
 
 #[derive(Clone)]
 pub(super) struct Symbol<'s, 'a> {
@@ -171,9 +171,16 @@ impl<'a> Symbol<'_, 'a> {
     /// NOTE: does not support CJS right now.
     pub fn is_exported(&self) -> bool {
         let is_in_exportable_scope = self.is_root() || self.is_in_ts_namespace();
-        is_in_exportable_scope
-            && (self.module_record.exported_bindings.contains_key(self.name())
-                || self.in_export_node())
+        is_in_exportable_scope && (self.is_local_exported_binding() || self.in_export_node())
+    }
+
+    fn is_local_exported_binding(&self) -> bool {
+        self.module_record.local_export_entries.iter().any(|entry| match &entry.local_name {
+            ExportLocalName::Name(name) | ExportLocalName::Default(name) => {
+                name.name() == self.name()
+            }
+            ExportLocalName::Null => false,
+        })
     }
 
     #[inline]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1025,12 +1025,16 @@ fn test_exports() {
         "export * as a from 'a'",
         "export { a, b } from 'a'",
     ];
-    let fail = vec!["import { a as b } from 'a'; export { a }"];
+    let fail = vec![
+        "import { a as b } from 'a'; export { a }",
+        r#"import { resolve } from "path";
+export { resolve } from "path";"#,
+    ];
 
-    // these are mostly pass[] cases, so do not snapshot
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()
-        .test();
+        .with_snapshot_suffix("oxc-exports")
+        .test_and_snapshot();
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-exports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-exports.snap
@@ -1,0 +1,20 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-unused-vars): Identifier 'b' is imported but never used.
+   ╭─[no_unused_vars.tsx:1:15]
+ 1 │ import { a as b } from 'a'; export { a }
+   ·               ┬
+   ·               ╰── 'b' is imported here
+   ╰────
+  help: Consider removing this import.
+
+  ⚠ eslint(no-unused-vars): Identifier 'resolve' is imported but never used.
+   ╭─[no_unused_vars.tsx:1:10]
+ 1 │ import { resolve } from "path";
+   ·          ───┬───
+   ·             ╰── 'resolve' is imported here
+ 2 │ export { resolve } from "path";
+   ╰────
+  help: Consider removing this import.


### PR DESCRIPTION
fixes #21930

Updates `no-unused-vars` to treat only local export entries as exported local bindings, so an import is still reported when a same-named re-export comes from another module.