### PR TITLE
test(minifier): pin remaining banner placement quirk for #19748

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -35,6 +35,11 @@ impl Codegen<'_> {
                 }
             }
             if add {
+                if comment.is_legal()
+                    && let Err(idx) = self.legal_comment_keys.binary_search(&comment.attached_to)
+                {
+                    self.legal_comment_keys.insert(idx, comment.attached_to);
+                }
                 self.comments.entry(comment.attached_to).or_default().push(*comment);
             }
         }
@@ -61,6 +66,46 @@ impl Codegen<'_> {
     pub(crate) fn print_comments_at(&mut self, start: u32) {
         if let Some(comments) = self.get_comments(start) {
             self.print_comments(&comments);
+        }
+    }
+
+    /// Whether a legal-comment orphan with `attached_to < end` is still
+    /// pending. Used by block emitters to keep an empty body multi-line.
+    #[inline]
+    pub(crate) fn has_legal_orphans_before(&self, end: u32) -> bool {
+        self.legal_comment_keys
+            .iter()
+            .take_while(|&&k| k < end)
+            .any(|k| self.comments.contains_key(k))
+    }
+
+    /// Drain pending legal-comment orphans with `attached_to < end` and emit
+    /// them in source order. Called at every statement boundary so legal
+    /// comments survive when their original anchor was removed by DCE.
+    #[inline]
+    pub(crate) fn print_legal_orphans_before(&mut self, end: u32) {
+        if self.legal_comment_keys.is_empty() {
+            return;
+        }
+        let idx = self.legal_comment_keys.partition_point(|&k| k < end);
+        if idx == 0 {
+            return;
+        }
+        // Concatenate across keys so `print_comments` sees one sequence;
+        // per-key calls would leak `print_next_indent_as_space` and produce
+        // stray leading spaces.
+        let mut legals: Vec<Comment> = Vec::new();
+        let comments = &mut self.comments;
+        for k in self.legal_comment_keys.drain(..idx) {
+            let Some(entry) = comments.get_mut(&k) else { continue };
+            debug_assert!(entry.iter().any(|c| c.is_legal()));
+            legals.extend(entry.extract_if(.., |c| c.is_legal()));
+            if entry.is_empty() {
+                comments.remove(&k);
+            }
+        }
+        if !legals.is_empty() {
+            self.print_comments(&legals);
         }
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -51,7 +51,7 @@ impl Gen for Program<'_> {
         if let Some(hashbang) = &self.hashbang {
             hashbang.print(p, ctx);
         }
-        p.print_directives_and_statements(&self.directives, &self.body, ctx);
+        p.print_directives_and_statements(&self.directives, &self.body, self.span.end, ctx);
         p.print_semicolon_if_needed();
         // Print trailing statement comments.
         p.print_comments_at(self.span.end);
@@ -530,17 +530,17 @@ impl Gen for SwitchCase<'_> {
         }
         p.print_colon();
 
-        if self.consequent.len() == 1 {
+        // Force multi-line if a legal orphan is pending; the inline path skips the flush.
+        let single_line = self.consequent.len() == 1
+            && !p.has_legal_orphans_before(self.consequent[0].span().start);
+        if single_line {
             p.print_body(&self.consequent[0], false, ctx);
             return;
         }
 
         p.print_soft_newline();
         p.indent();
-        for item in &self.consequent {
-            p.print_semicolon_if_needed();
-            item.print(p, ctx);
-        }
+        p.print_stmts_with_orphan_flush(&self.consequent, self.span.end, ctx);
         p.dedent();
     }
 }
@@ -759,14 +759,20 @@ impl Gen for FunctionBody<'_> {
         let span_end = self.span.end;
         let comments_at_end = if span_end > 0 { p.get_comments(span_end - 1) } else { None };
         let single_line = if self.is_empty() {
-            comments_at_end
-                .as_ref()
-                .is_none_or(|comments| comments.iter().all(|c| !c.has_newlines_around()))
+            !p.has_legal_orphans_before(self.span.end)
+                && comments_at_end
+                    .as_ref()
+                    .is_none_or(|comments| comments.iter().all(|c| !c.has_newlines_around()))
         } else {
             false
         };
         p.print_curly_braces(self.span, single_line, |p| {
-            p.print_directives_and_statements(&self.directives, &self.statements, ctx);
+            p.print_directives_and_statements(
+                &self.directives,
+                &self.statements,
+                self.span.end,
+                ctx,
+            );
             // Print trailing statement comments.
             if let Some(comments) = comments_at_end {
                 p.print_comments(&comments);
@@ -2671,11 +2677,9 @@ impl Gen for StaticBlock<'_> {
         p.add_source_mapping(self.span);
         p.print_str("static");
         p.print_soft_space();
-        p.print_curly_braces(self.span, self.body.is_empty(), |p| {
-            for stmt in &self.body {
-                p.print_semicolon_if_needed();
-                stmt.print(p, ctx);
-            }
+        let single_line = self.body.is_empty() && !p.has_legal_orphans_before(self.span.end);
+        p.print_curly_braces(self.span, single_line, |p| {
+            p.print_stmts_with_orphan_flush(&self.body, self.span.end, ctx);
         });
         p.needs_semicolon = false;
     }
@@ -3808,7 +3812,7 @@ impl Gen for TSModuleBlock<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         let is_empty = self.directives.is_empty() && self.body.is_empty();
         p.print_curly_braces(self.span, is_empty, |p| {
-            p.print_directives_and_statements(&self.directives, &self.body, ctx);
+            p.print_directives_and_statements(&self.directives, &self.body, self.span.end, ctx);
         });
         p.needs_semicolon = false;
     }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -123,6 +123,10 @@ pub struct Codegen<'a> {
     // Builders
     comments: CommentsMap,
 
+    /// Sorted, deduped `attached_to` keys for pending legal comments. Lets
+    /// `print_legal_orphans_before` flush via `partition_point` + `drain`.
+    legal_comment_keys: Vec<u32>,
+
     #[cfg(feature = "sourcemap")]
     sourcemap_builder: Option<SourcemapBuilder<'a>>,
 }
@@ -175,6 +179,7 @@ impl<'a> Codegen<'a> {
             indent: 0,
             quote: Quote::Double,
             comments: CommentsMap::default(),
+            legal_comment_keys: Vec::new(),
             #[cfg(feature = "sourcemap")]
             sourcemap_builder: None,
         }
@@ -603,27 +608,44 @@ impl<'a> Codegen<'a> {
     }
 
     fn print_block_statement(&mut self, stmt: &BlockStatement<'_>, ctx: Context) {
-        self.print_curly_braces(stmt.span, stmt.body.is_empty(), |p| {
-            for stmt in &stmt.body {
-                p.print_semicolon_if_needed();
-                stmt.print(p, ctx);
-            }
+        let single_line = stmt.body.is_empty() && !self.has_legal_orphans_before(stmt.span.end);
+        self.print_curly_braces(stmt.span, single_line, |p| {
+            p.print_stmts_with_orphan_flush(&stmt.body, stmt.span.end, ctx);
         });
         self.needs_semicolon = false;
+    }
+
+    /// Print `stmts`, flushing legal-comment orphans before each and at `scope_end`.
+    fn print_stmts_with_orphan_flush(
+        &mut self,
+        stmts: &[Statement<'_>],
+        scope_end: u32,
+        ctx: Context,
+    ) {
+        for stmt in stmts {
+            self.print_legal_orphans_before(stmt.span().start);
+            self.print_semicolon_if_needed();
+            stmt.print(self, ctx);
+        }
+        self.print_legal_orphans_before(scope_end);
     }
 
     fn print_directives_and_statements(
         &mut self,
         directives: &[Directive<'_>],
         stmts: &[Statement<'_>],
+        scope_end: u32,
         ctx: Context,
     ) {
         for directive in directives {
             directive.print(self, ctx);
         }
         let Some((first, rest)) = stmts.split_first() else {
+            self.print_legal_orphans_before(scope_end);
             return;
         };
+
+        self.print_legal_orphans_before(first.span().start);
 
         // Ensure first string literal is not a directive.
         let mut first_needs_parens = false;
@@ -645,10 +667,7 @@ impl<'a> Codegen<'a> {
             first.print(self, ctx);
         }
 
-        for stmt in rest {
-            self.print_semicolon_if_needed();
-            stmt.print(self, ctx);
-        }
+        self.print_stmts_with_orphan_flush(rest, scope_end, ctx);
     }
 
     #[inline]

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -40,13 +40,8 @@ fn test_same(source_text: &str) {
 
 #[track_caller]
 fn test_with_options(source_text: &str, expected: &str, options: CompressOptions) {
-    let allocator = Allocator::default();
     let source_type = SourceType::default();
-    let mut ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
-    let program = &mut ret.program;
-    Compressor::new(&allocator).dead_code_elimination(program, options);
-    let result = Codegen::new().build(program).code;
+    let result = run(source_text, source_type, Some(options));
     let expected = run(expected, source_type, None);
     assert_eq!(result, expected, "\nfor source\n{source_text}\nexpect\n{expected}\ngot\n{result}");
 }
@@ -411,6 +406,105 @@ fn drop_labels_with_vars() {
 #[test]
 fn keep_use_strict_directives() {
     test_same("'use strict'; export function foo() { 'use strict'; return 1; }");
+}
+
+#[test]
+fn preserve_legal_comment_when_dce_removes_anchor() {
+    // https://github.com/oxc-project/oxc/issues/19750
+    // Each test below covers a scope where DCE removes a legal comment's
+    // anchor; codegen must re-emit it at the next surviving anchor in scope.
+    test_with_options(
+        "//! some license\nconst foo = 'value';\nconsole.log(foo);",
+        "//! some license\nconsole.log('value');",
+        CompressOptions::dce(),
+    );
+    test_with_options(
+        "/*! @license */\nconst foo = 'value';\nconsole.log(foo);",
+        "/*! @license */\nconsole.log('value');",
+        CompressOptions::dce(),
+    );
+    test_with_options(
+        "/* @preserve */\nconst foo = 'value';\nconsole.log(foo);",
+        "/* @preserve */\nconsole.log('value');",
+        CompressOptions::dce(),
+    );
+    // Non-legal comment is dropped with its anchor.
+    test_with_options(
+        "// regular comment\nconst foo = 'value';\nconsole.log(foo);",
+        "console.log('value');",
+        CompressOptions::dce(),
+    );
+    // No DCE → comment stays at its original anchor.
+    test_with_options(
+        "//! some license\nconst foo = 'value';\nconsole.log(foo);\nconsole.log(foo);",
+        "//! some license\nconst foo = 'value';\nconsole.log(foo);\nconsole.log(foo);",
+        CompressOptions::dce(),
+    );
+    test_with_options(
+        "//! license\nconst foo = 'unused';\nbar();",
+        "//! license\nbar();",
+        CompressOptions::dce(),
+    );
+    // Multiple orphans flush in source order.
+    test_with_options(
+        "//! A\nconst a = 'x';\n//! B\nconst b = 'y';\nf(a, b);",
+        "//! A\n//! B\nf('x', 'y');",
+        CompressOptions::dce(),
+    );
+    // Orphan stays above a surviving sibling's own legal comment.
+    test_with_options(
+        "//! orphan-A\nconst a = 'unused';\n//! kept-B\nconsole.log('hi');",
+        "//! orphan-A\n//! kept-B\nconsole.log('hi');",
+        CompressOptions::dce(),
+    );
+    // All top-level removed → flushed at program scope-end.
+    test_with_options(
+        "//! license\nconst foo = 'unused';\n",
+        "//! license",
+        CompressOptions::dce(),
+    );
+    // Inner anchor survives → emitted at original spot.
+    test_with_options(
+        "//! top\nfunction f() {\n  //! body\n  return 1;\n}\nconst unused = 'x';\nconsole.log(f());",
+        "//! top\nfunction f() {\n\t//! body\n\treturn 1;\n}\nconsole.log(f());",
+        CompressOptions::dce(),
+    );
+    // Inner anchor removed, sibling survives → flushed inside function scope.
+    test_with_options(
+        "function f() {\n  //! body\n  const innerUnused = 'x';\n  return 1;\n}\nconsole.log(f());",
+        "function f() {\n\t//! body\n\treturn 1;\n}\nconsole.log(f());",
+        CompressOptions::dce(),
+    );
+    // No surviving sibling → DCE inlines empty `f()` to `void 0`; orphan
+    // re-anchors at the next surviving top-level stmt.
+    test_with_options(
+        "function f() {\n  //! body\n  const innerUnused = 'x';\n}\nconsole.log(f());",
+        "//! body\nconsole.log(void 0);",
+        CompressOptions::dce(),
+    );
+    // BlockStatement scope.
+    test_with_options(
+        "try {\n  //! caught\n  const ignored = 'x';\n  a();\n  b();\n} catch (e) {}",
+        "try {\n\t//! caught\n\ta();\n\tb();\n} catch (e) {}",
+        CompressOptions::dce(),
+    );
+    // SwitchCase scope, multi-stmt consequent.
+    test_with_options(
+        "switch (x) {\n  case 1:\n    //! case\n    const ignored = 'x';\n    a();\n    b();\n}",
+        "switch (x) {\n\tcase 1:\n\t\t//! case\n\t\ta();\n\t\tb();\n}",
+        CompressOptions::dce(),
+    );
+    // SwitchCase with one surviving consequent stmt: the inline `case 1: stmt`
+    // path must fall through to multi-line so the flush fires inside the case.
+    // Asserted directly because canonical roundtrip uses an inline format that
+    // doesn't match our multi-line orphan layout.
+    {
+        let source = "switch (x) {\n  case 1:\n    //! case\n    const ignored = 'x';\n    survivor();\n}\nafter();";
+        let result = run(source, SourceType::default(), Some(CompressOptions::dce()));
+        let case_pos = result.find("//! case").expect("comment preserved");
+        let close_pos = result.find("\n}").expect("switch close");
+        assert!(case_pos < close_pos, "legal comment escaped the case scope: {result}");
+    }
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -285,3 +285,23 @@ fn remove_unused_use_strict_directive() {
     test("'use strict'; function _() { 'use strict' }", "function _() {}");
     test("'use strict';", "");
 }
+
+// A legal banner anchored to a removed `"use strict"` is preserved, but if
+// another directive in the prologue survives, the banner currently lands below
+// that directive. It should stay above.
+//
+// Root cause: `print_directives_and_statements` emits all surviving directives
+// in a single loop and only drains legal orphans at the next statement boundary.
+//
+// See https://github.com/oxc-project/oxc/issues/19748.
+#[test]
+#[ignore = "TODO: currently failing, legal banner lands below surviving directive"]
+fn banner_above_removed_use_strict_should_stay_above_surviving_directive() {
+    test(
+        r"//! banner
+'use strict';
+'other';",
+        r"//! banner
+'other';",
+    );
+}


### PR DESCRIPTION
What
---

Add an `#[ignore]`'d failing test for a placement quirk that the parent PR (#21575) leaves on the table: when a legal banner is anchored to a removed `"use strict"` and another directive in the prologue survives, the banner lands below that directive, but should stay above.

Why
---

#21575 closes #19750 by adding `print_legal_orphans_before` to codegen. As a side effect, not stated in #21575, that same flush closes the legal-comment subset of #19748 (banner over a removed `"use strict"`) at both program and inner-function scope, with one exception: the placement quirk illustrated in this test.

Pinning it as `#[ignore]`'d (matching the convention in `peephole/minimize_exit_points.rs` for tracked-but-unfixed behaviour) to illustrate it and line up a future fix.

Root cause is in `print_directives_and_statements`: it emits all surviving directives in a single loop and only drains legal orphans at the next statement boundary. So any banner whose original anchor was inside the prologue ends up below all of it.

Out of scope
---

The non-legal subset of #19748 (normal comments above a removed directive). `print_legal_orphans_before` is gated on `Comment::is_legal()` by design.