### PR TITLE
docs(ast_tools): add doc comment to `Schema::enums` method

### DIFF
--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -107,6 +107,7 @@ impl Schema {
         StructsMut::new(self)
     }
 
+    /// Get iterator over all enums.
     pub fn enums(&self) -> Enums<'_> {
         Enums::new(self)
     }


### PR DESCRIPTION
Just add a doc comment that was missing.