### PR TITLE
fix(linter/jest/no-standalone-expect): false positive with expect in an `ObjectProperty`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -149,6 +149,14 @@ fn test() {
             r"describe('App', () => { it('should work with wrapper function', wrapperFn(() => { expect(true).toBeTruthy(); })); });",
             None,
         ),
+        (
+            r"const assertions = {
+                  assertFn: (a, b) => {
+                    expect(a).toBe(b); // Oxc Error: `expect` must be inside of a test block.
+                  }
+                };",
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_standalone_expect.rs
@@ -216,7 +216,7 @@ fn is_var_declarator_or_test_block<'a>(
                 );
             }
         }
-        AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_) => {
+        AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_) | AstKind::ObjectProperty(_) => {
             let mut current = node;
             loop {
                 let parent = ctx.nodes().parent_node(current.id());
@@ -229,7 +229,9 @@ fn is_var_declarator_or_test_block<'a>(
                             ctx,
                         );
                     }
-                    AstKind::ArrayExpression(_) | AstKind::ObjectExpression(_) => {
+                    AstKind::ArrayExpression(_)
+                    | AstKind::ObjectExpression(_)
+                    | AstKind::ObjectProperty(_) => {
                         current = parent;
                     }
                     _ => break,

--- a/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
@@ -202,6 +202,14 @@ fn test() {
                     ",
             None,
         ),
+        (
+            r"const assertions = {
+                  assertFn: (a, b) => {
+                    expect(a).toBe(b); // Oxc Error: `expect` must be inside of a test block.
+                  }
+                };",
+            None,
+        ),
     ];
 
     let fail = vec![


### PR DESCRIPTION
Fix https://github.com/oxc-project/oxc/issues/21897

# AI disclosure
Fix done without AI help.

# Summary

[Using the AST from this playground, simplified from the bug report](https://playground.oxc.rs/?lintRules=jest%2Fno-standalone-expect&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Afalse%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22tsx%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22es2015%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%2C%22optimizeEnums%22%3Atrue%2C%22optimizeConstEnums%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=const+assertions+%3D+%7B%0A++assertFn%3A+%28a%2C+b%29+%3D%3E+%7B%0A++++expect%28a%29.toBe%28b%29%3B+%2F%2F+Oxc+Error%3A+%60expect%60+must+be+inside+of+a+test+block.%0A++%7D%0A%7D%3B%0A), the fail point was in the method `is_var_declarator_or_test_block`. While we were going up in the AST, the impl stopped at `ObjectProperty` node instead keep going up until we reach the ObjectExpression.