### PR TITLE
fix(transformer/class-properties): preserve RHS in logical-assignment to static private field

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -669,9 +669,6 @@ impl<'a> ClassProperties<'a> {
                 assign_expr.right =
                     self.create_assert_class_brand(class_ident, object, value, SPAN, ctx);
             } else {
-                let class_ident = class_binding.create_read_expression(ctx);
-                let value = assign_expr.right.take_in(ctx.ast);
-
                 // Make 2 copies of `object`
                 let (object1, object2) = self.duplicate_object(object, ctx);
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: c7a0ae10
 
 semantic_typescript Summary:
 AST Parsed     : 4773/4773 (100.00%)
-Positive Passed: 2665/4773 (55.83%)
+Positive Passed: 2666/4773 (55.86%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -19578,11 +19578,6 @@ rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldAssignment.ts
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(26), ReferenceId(25), ReferenceId(24), ReferenceId(23), ReferenceId(22), ReferenceId(21), ReferenceId(20), ReferenceId(19), ReferenceId(18), ReferenceId(17), ReferenceId(16), ReferenceId(15), ReferenceId(14), ReferenceId(13), ReferenceId(54), ReferenceId(57), ReferenceId(58), ReferenceId(62), ReferenceId(66), ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(76), ReferenceId(80), ReferenceId(84), ReferenceId(85), ReferenceId(89), ReferenceId(93), ReferenceId(94), ReferenceId(98), ReferenceId(105), ReferenceId(106), ReferenceId(110), ReferenceId(114), ReferenceId(115), ReferenceId(119), ReferenceId(123), ReferenceId(124), ReferenceId(128), ReferenceId(132), ReferenceId(133), ReferenceId(137), ReferenceId(141), ReferenceId(142), ReferenceId(146), ReferenceId(150), ReferenceId(151), ReferenceId(155), ReferenceId(159), ReferenceId(160), ReferenceId(164)]
-rebuilt        : SymbolId(1): [ReferenceId(29), ReferenceId(30), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(71), ReferenceId(73), ReferenceId(76), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(90), ReferenceId(92), ReferenceId(94), ReferenceId(99), ReferenceId(101), ReferenceId(103), ReferenceId(108), ReferenceId(110), ReferenceId(112), ReferenceId(117), ReferenceId(119), ReferenceId(121), ReferenceId(126), ReferenceId(128), ReferenceId(130), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(142)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
 Symbol reference IDs mismatch for "A":

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: c543b031
 
-Passed: 224/371
+Passed: 225/372
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -40,7 +40,7 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# babel-plugin-transform-class-properties (25/32)
+# babel-plugin-transform-class-properties (26/33)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: c543b031
 
 node: v24.14.0
 
-Passed: 12 of 14 (85.71%)
+Passed: 13 of 15 (86.67%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-static-logical-assignment/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-static-logical-assignment/exec.js
@@ -1,0 +1,22 @@
+class Singleton {
+  static #shared;
+
+  static shared() {
+    this.#shared ??= 1;
+    return this.#shared;
+  }
+}
+
+class WithAndOr {
+  static #and = 1;
+  static #or = 0;
+
+  static run() {
+    this.#and &&= 2;
+    this.#or ||= 3;
+    return [this.#and, this.#or];
+  }
+}
+
+expect(Singleton.shared()).toBe(1);
+expect(WithAndOr.run()).toEqual([2, 3]);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-static-logical-assignment/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-static-logical-assignment/input.js
@@ -1,0 +1,11 @@
+class Foo {
+  static #nullish;
+  static #and = 1;
+  static #or;
+
+  static test() {
+    this.#nullish ??= 1;
+    this.#and &&= 2;
+    this.#or ||= 3;
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-static-logical-assignment/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/private-static-logical-assignment/output.js
@@ -1,0 +1,10 @@
+class Foo {
+	static test() {
+		babelHelpers.assertClassBrand(Foo, this, _nullish)._ ?? (_nullish._ = babelHelpers.assertClassBrand(Foo, this, 1));
+		babelHelpers.assertClassBrand(Foo, this, _and)._ && (_and._ = babelHelpers.assertClassBrand(Foo, this, 2));
+		babelHelpers.assertClassBrand(Foo, this, _or)._ || (_or._ = babelHelpers.assertClassBrand(Foo, this, 3));
+	}
+}
+var _nullish = { _: void 0 };
+var _and = { _: 1 };
+var _or = { _: void 0 };


### PR DESCRIPTION
fixes #21874

`transform_static_assignment_expression` took `assign_expr.right` once at the top of the function (correct for the `=` branch), then took it a second time inside the `else` branch that handles compound operators. The second `take_in` returned a `NullLiteral` dummy, so `??=` / `&&=` / `||=` (and the binary ops) on a static private field where the receiver isn't a direct class reference — e.g. `this.#shared ??= 1` inside a static method — emitted `null` in place of the RHS:

```js
// before
class Singleton {
  static #shared;
  static shared() {
    this.#shared ??= 1;
    return this.#shared;
  }
}

// transformer output (broken):
_assertClassBrand(Singleton, this, _shared)._ ?? (_shared._ = _assertClassBrand(Singleton, this, null));
//                                                                                              ^^^^ should be 1
```

Removes the redundant inner `let class_ident = …; let value = assign_expr.right.take_in(…);` shadowing so the compound-operator branches use the already-captured outer `value` (the real RHS) when building the `_assertClassBrand(Class, object, value)` call. Output now matches Babel.

Adds a `private-static-logical-assignment` conformance fixture covering `??=`, `&&=`, and `||=`, plus an `exec.js` to verify runtime behavior.