### PR TITLE
test(minifier): extend legal-comment coverage for #19750 and #19748

### DIFF
--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -519,29 +519,6 @@ fn preserve_at_license_legal_comment_when_dce_removes_anchor() {
 }
 
 #[test]
-fn preserve_legal_comment_when_dce_removes_one_of_multiple_declarators() {
-    // Multi-declarator pruning: `b` removed, then `a` inlined, leaving no
-    // declarator. Comment orphans the same as the single-declarator case.
-    test_with_options(
-        "//! lic\nconst a = 1, b = 2;\nfoo(a);",
-        "//! lic\nfoo(1);",
-        CompressOptions::dce(),
-    );
-}
-
-#[test]
-fn preserve_legal_comments_when_dce_removes_anchors_at_multiple_levels() {
-    // Both anchors lose their nodes in the same run. The inner orphan must
-    // flush at its own block's next surviving statement, not escape into the
-    // outer scope. Pins the per-scope semantics of `print_legal_orphans_before`.
-    test_with_options(
-        "//! outer\nconst unusedA = 'a';\nfunction f() {\n  //! inner\n  const unusedB = 'b';\n  return 1;\n}\nconsole.log(f());",
-        "//! outer\nfunction f() {\n\t//! inner\n\treturn 1;\n}\nconsole.log(f());",
-        CompressOptions::dce(),
-    );
-}
-
-#[test]
 fn preserve_annotation_comments_when_inlining_single_use_variable() {
     // https://github.com/rolldown/rolldown/issues/8248
     test(

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -508,6 +508,40 @@ fn preserve_legal_comment_when_dce_removes_anchor() {
 }
 
 #[test]
+fn preserve_at_license_legal_comment_when_dce_removes_anchor() {
+    // The omnibus test above pins `//!`, `/*! @license */`, and `/* @preserve */`.
+    // Cover the only remaining marker — `/* @license */` standalone (no `!`).
+    test_with_options(
+        "/* @license */\nconst foo = 'val';\nconsole.log(foo);",
+        "/* @license */\nconsole.log('val');",
+        CompressOptions::dce(),
+    );
+}
+
+#[test]
+fn preserve_legal_comment_when_dce_removes_one_of_multiple_declarators() {
+    // Multi-declarator pruning: `b` removed, then `a` inlined, leaving no
+    // declarator. Comment orphans the same as the single-declarator case.
+    test_with_options(
+        "//! lic\nconst a = 1, b = 2;\nfoo(a);",
+        "//! lic\nfoo(1);",
+        CompressOptions::dce(),
+    );
+}
+
+#[test]
+fn preserve_legal_comments_when_dce_removes_anchors_at_multiple_levels() {
+    // Both anchors lose their nodes in the same run. The inner orphan must
+    // flush at its own block's next surviving statement, not escape into the
+    // outer scope. Pins the per-scope semantics of `print_legal_orphans_before`.
+    test_with_options(
+        "//! outer\nconst unusedA = 'a';\nfunction f() {\n  //! inner\n  const unusedB = 'b';\n  return 1;\n}\nconsole.log(f());",
+        "//! outer\nfunction f() {\n\t//! inner\n\treturn 1;\n}\nconsole.log(f());",
+        CompressOptions::dce(),
+    );
+}
+
+#[test]
 fn preserve_annotation_comments_when_inlining_single_use_variable() {
     // https://github.com/rolldown/rolldown/issues/8248
     test(

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -285,3 +285,33 @@ fn remove_unused_use_strict_directive() {
     test("'use strict'; function _() { 'use strict' }", "function _() {}");
     test("'use strict';", "");
 }
+
+// Legal comments anchored to a removed `"use strict"` directive are rescued
+// by the same `print_legal_orphans_before` flush used for #19750: the
+// directive's `span.start` is gone, but the orphan re-anchors at the next
+// surviving statement. Pin that for the legal-comment subset of #19748.
+// Non-legal comments above a removed directive are not covered:
+// `print_legal_orphans_before` is gated on `Comment::is_legal()` by design.
+
+#[test]
+fn preserve_legal_comment_above_removed_use_strict() {
+    // Both `//!` and `/*! ... */` forms.
+    test(
+        "//! license\n'use strict';\nexport function foo(){}",
+        "//! license\nexport function foo() {}",
+    );
+    test(
+        "/*! banner */\n'use strict';\nexport function foo(){}",
+        "/*! banner */\nexport function foo() {}",
+    );
+}
+
+#[test]
+fn preserve_legal_comment_above_removed_inner_function_use_strict() {
+    // Redundant inner `"use strict"` is dropped under a strict outer scope;
+    // the comment must stay inside the function body, not escape outward.
+    test(
+        "//! outer\n'use strict';\nexport function f() {\n  //! inner\n  'use strict';\n  bar();\n}",
+        "//! outer\nexport function f() {\n\t//! inner\n\tbar();\n}",
+    );
+}


### PR DESCRIPTION
What
---

Three tests on top of #21575:

In `dead_code_elimination.rs`:

- `/* @license */` standalone — the only legal-comment marker the omnibus `preserve_legal_comment_when_dce_removes_anchor` doesn't pin.

In `normalize.rs`, covering the legal-comment subset of #19748 that #21575 also closes:

- Banner above a removed program-level `"use strict"`.
- Inner-function `"use strict"` removal preserving its inner legal comment.

The placement quirk for the legal-comment subset of #19748 is pinned separately in #21943.