### PR TITLE
fix(linter/jest/vitest): Padding around after all blocks not working as expected

### DIFF
--- a/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
@@ -82,14 +82,21 @@ fn test() {
         "afterAll(() => {});",
         "const thing = 123;\n\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\n});",
+        "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",
     ];
 
-    let fail = vec!["const thing = 123;\nafterAll(() => {});"];
-
-    let fix = vec![(
+    let fail = vec![
         "const thing = 123;\nafterAll(() => {});",
-        "const thing = 123;\n\nafterAll(() => {});",
-    )];
+        "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
+    ];
+
+    let fix = vec![
+        ("const thing = 123;\nafterAll(() => {});", "const thing = 123;\n\nafterAll(() => {});"),
+        (
+            "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
+            "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",
+        ),
+    ];
 
     Tester::new(PaddingAroundAfterAllBlocks::NAME, PaddingAroundAfterAllBlocks::PLUGIN, pass, fail)
         .with_jest_plugin(true)

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -98,12 +98,14 @@ fn test() {
         "const thing = 123;\n\ntest('foo', () => {});",
         "{ test('foo', () => {}); }",
         "describe('foo', () => {\ntest('bar', () => {});\n});",
+        "const thing = 123;\n\n/* one */\n/* two */\ntest('foo', () => {});",
     ];
 
     let fail = vec![
         "test('foo', () => {});test('bar', () => {});",
         "test('foo', () => {});\ntest('bar', () => {});",
         "it('foo', () => {});\nfit('bar', () => {});\ntest('baz', () => {});",
+        "const thing = 123;\n/* one */\n/* two */\ntest('foo', () => {});",
         r"
 const foo = 'bar';
 const bar = 'baz';
@@ -153,6 +155,10 @@ describe('other bar', function() {
         (
             "it('foo', () => {});\nfit('bar', () => {});\ntest('baz', () => {});",
             "it('foo', () => {});\n\nfit('bar', () => {});\n\ntest('baz', () => {});",
+        ),
+        (
+            "const thing = 123;\n/* one */\n/* two */\ntest('foo', () => {});",
+            "const thing = 123;\n\n/* one */\n/* two */\ntest('foo', () => {});",
         ),
         (
             r"

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
@@ -11,10 +11,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Make sure there is an empty new line before the afterAll block
 
   ⚠ jest(padding-around-after-all-blocks): Missing padding before afterAll block
-   ╭─[padding_around_after_all_blocks.tsx:2:1]
- 1 │ const thing = 123;
- 2 │ /* one */
-   · ▲
+   ╭─[padding_around_after_all_blocks.tsx:4:1]
  3 │ /* two */
+ 4 │ afterAll(() => {});
+   · ▲
    ╰────
   help: Make sure there is an empty new line before the afterAll block

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
@@ -9,3 +9,12 @@ source: crates/oxc_linter/src/tester.rs
    · ▲
    ╰────
   help: Make sure there is an empty new line before the afterAll block
+
+  ⚠ jest(padding-around-after-all-blocks): Missing padding before afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ /* one */
+   · ▲
+ 3 │ /* two */
+   ╰────
+  help: Make sure there is an empty new line before the afterAll block

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -35,11 +35,10 @@ source: crates/oxc_linter/src/tester.rs
   help: Make sure there is an empty new line before the fit block
 
   ⚠ jest(padding-around-test-blocks): Missing padding before test block
-   ╭─[padding_around_test_blocks.tsx:2:1]
- 1 │ const thing = 123;
- 2 │ /* one */
-   · ▲
+   ╭─[padding_around_test_blocks.tsx:4:1]
  3 │ /* two */
+ 4 │ test('foo', () => {});
+   · ▲
    ╰────
   help: Make sure there is an empty new line before the test block
 
@@ -53,11 +52,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Make sure there is an empty new line before the it block
 
   ⚠ jest(padding-around-test-blocks): Missing padding before it block
-    ╭─[padding_around_test_blocks.tsx:18:6]
- 17 │      });
+    ╭─[padding_around_test_blocks.tsx:19:6]
  18 │      // With a comment
-    ·      ▲
  19 │      it('is another bar w/ it', () => {
+    ·      ▲
+ 20 │      });
     ╰────
   help: Make sure there is an empty new line before the it block
 

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -34,6 +34,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the fit block
 
+  ⚠ jest(padding-around-test-blocks): Missing padding before test block
+   ╭─[padding_around_test_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ /* one */
+   · ▲
+ 3 │ /* two */
+   ╰────
+  help: Make sure there is an empty new line before the test block
+
   ⚠ jest(padding-around-test-blocks): Missing padding before it block
    ╭─[padding_around_test_blocks.tsx:4:1]
  3 │ const bar = 'baz';

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -34,21 +34,23 @@ pub fn report_missing_padding_before_jest_block<'a>(
         return;
     };
 
-    let mut comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
+    let comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
     let mut span_between_start = prev_statement_span.end;
     let mut span_between_end = node.span().start;
-    if let Some(last_comment_span) = comments_range.next_back().map(|comment| comment.span) {
-        let space_after_last_comment =
-            ctx.source_range(Span::new(last_comment_span.end, node.span().start));
-        let space_before_last_comment =
-            ctx.source_range(Span::new(prev_statement_span.end, last_comment_span.start));
-        if space_after_last_comment.matches('\n').count() > 1
-            || space_before_last_comment.matches('\n').count() == 0
-        {
-            span_between_start = last_comment_span.end;
-        } else {
-            span_between_end = last_comment_span.start;
+    let mut next_attached_start = node.span().start;
+    for comment in comments_range.rev() {
+        let comment_span = comment.span;
+        let space_after = ctx.source_range(Span::new(comment_span.end, next_attached_start));
+        if space_after.matches('\n').count() > 1 {
+            break;
         }
+        let space_before = ctx.source_range(Span::new(prev_statement_span.end, comment_span.start));
+        if space_before.matches('\n').count() == 0 {
+            span_between_start = comment_span.end;
+            break;
+        }
+        span_between_end = comment_span.start;
+        next_attached_start = comment_span.start;
     }
 
     let span_between = Span::new(span_between_start, span_between_end);

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -58,7 +58,7 @@ pub fn report_missing_padding_before_jest_block<'a>(
     if content.matches('\n').count() < 2 {
         ctx.diagnostic_with_fix(
             padding_around_jest_block_diagnostic(
-                Span::new(span_between_end, span_between_end),
+                Span::new(node.span().start, node.span().start),
                 name,
             ),
             |fixer| {


### PR DESCRIPTION
## AI usage disclosure

I used Claude code to generate the fix for this issue. I also reviewed the changes and iterated on them.
I also used it to explain some parts of the [`report_missing_padding_before_jest_block`](https://github.com/oxc-project/oxc/blob/c42d3a3550d40a3039d6984816fc52838a2fa25a/crates/oxc_linter/src/utils/jest/padding_around_block.rs#L14-L71) function that were not clear to me.
Additionally, I used it to generate this PR description.

## Summary

Fixes #21945: `jest/padding-around-after-all-blocks` (and the shared logic used by `jest/padding-around-test-blocks`) failed to report missing padding when two or more comments were stacked directly above a jest block with no blank line separating them from the previous statement.

Example that should fail but did not:

```js
const thing = 123;
/* one */
/* two */
afterAll(() => {});
```

## Root cause

The shared helper in `crates/oxc_linter/src/utils/jest/padding_around_block.rs` only inspected the **last** comment between the previous statement and the jest block. Because the inter-comment newlines counted toward the total, multi-comment groups always pushed the newline count past the threshold and the diagnostic never fired.

## Fix

Walk comments from last to first and greedily absorb the contiguous group attached to the jest block:

- If a blank line follows the comment, the comment belongs to a paragraph above — stop.
- If the comment sits on the same line as the previous statement (trailing comment), exclude it from the gap and stop.
- Otherwise the comment is part of the block's attached group; pull `span_between_end` back to its start and continue.

Then count newlines in the resulting gap as before. The original single-comment and trailing-comment behaviors are preserved.

The implementation iterates `CommentsRange` directly via its existing `DoubleEndedIterator` impl (`.rev()`), so there are no heap allocations on this hot path.