### PR TITLE
ci(pr): ignore graphite-base branches in PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,8 @@ on:
       - edited
       - synchronize
       - reopened
+    branches-ignore:
+      - "**/graphite-base/**"
 
 jobs:
   pr:


### PR DESCRIPTION
`branches-ignore: "/graphite-base/"` was added to this workflow in #18775, but was removed in #21566.

I _think_ this removal was an unintended byproduct of the valid security-related change, and we should bring it back to avoid pointless CI runs.