### PR TITLE
ci(pr): restore PR labeling for internal PRs

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,30 @@
+name: Label PR
+
+permissions: {}
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+    branches-ignore:
+      - "**/graphite-base/**"
+
+jobs:
+  label:
+    name: Label PR
+    # Skip on PRs from forks.
+    # In `pull_request` events, `GITHUB_TOKEN` is read-only for PRs from forks, so adding labels would fail.
+    # This means labeling only runs on internal PRs (i.e. from core contributors who have write access to the repo).
+    # The simplest way to extend it to external contributors making PRs from forks would be to switch to
+    # `pull_request_target` event, but we don't want to do that due to the security risks of `pull_request_target`
+    # (see PR #21566).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read # `actions/labeler` reads `.github/labeler.yml` via the GitHub API
+      pull-requests: write # `actions/labeler` adds labels to the PR, requires write permission
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1


### PR DESCRIPTION
 #21566 removed PR labelling for security reasons - it used `pull_request_target` event, which is a security hazard.

I noticed its absense, and missed it! Have been labelling all my PRs by hand.

Restore PR labelling only for "internal" PRs. This can work with `pull_request` target.

I've added it as a separate workflow `pr-label.yml`, instead of adding it back to the `pr.yml` workflow, so that the `pull-requests: write` permission is scoped just to the job that needs it. "Check PR Title" doesn't need this permission.

Claude tells me we could also support labelling external PRs by using `workflow_run` event instead:

> `workflow_run` runs in base-repo context with a write token, and avoids `pull_request_target`'s privileged-context hazard.

But I'm not confident enough in what he's saying, or in my own GitHub Actions chops, to propose that. So this is a "middle way" which I think is less risky.