### PR TITLE
refactor(linter): do not compile `Linter::convert_and_call_external_linter` on 32-bit or big endian

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -595,6 +595,7 @@ impl Linter {
     ///
     /// This is the common code path shared by both `run_external_rules` and
     /// `clone_into_fixed_size_allocator_and_run_external_rules`.
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
     fn convert_and_call_external_linter(
         &self,
         external_rules: &[(ExternalRuleId, ExternalOptionsId, AllowWarnDeny)],


### PR DESCRIPTION
This method is dead code on 32-bit or big endian platforms. Both callers are themselvs feature-gated to 64-bit little endian platforms already. So feature-gate this method too.