### PR TITLE
feat(linter): split jest/prefer-expect-resolves into separate vitest rule

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,5 +1,4 @@
 [
-  "prefer-expect-resolves",
   "prefer-hooks-in-order",
   "prefer-hooks-on-top",
   "prefer-lowercase-title",

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4583,6 +4583,11 @@ impl RuleRunner for crate::rules::vitest::prefer_expect_assertions::PreferExpect
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_expect_resolves::PreferExpectResolves {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_expect_type_of::PreferExpectTypeOf {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -734,6 +734,7 @@ pub use crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunc
 pub use crate::rules::vitest::prefer_each::PreferEach as VitestPreferEach;
 pub use crate::rules::vitest::prefer_equality_matcher::PreferEqualityMatcher as VitestPreferEqualityMatcher;
 pub use crate::rules::vitest::prefer_expect_assertions::PreferExpectAssertions as VitestPreferExpectAssertions;
+pub use crate::rules::vitest::prefer_expect_resolves::PreferExpectResolves as VitestPreferExpectResolves;
 pub use crate::rules::vitest::prefer_expect_type_of::PreferExpectTypeOf as VitestPreferExpectTypeOf;
 pub use crate::rules::vitest::prefer_import_in_mock::PreferImportInMock as VitestPreferImportInMock;
 pub use crate::rules::vitest::prefer_importing_vitest_globals::PreferImportingVitestGlobals as VitestPreferImportingVitestGlobals;
@@ -1512,6 +1513,7 @@ pub enum RuleEnum {
     VitestPreferEach(VitestPreferEach),
     VitestPreferEqualityMatcher(VitestPreferEqualityMatcher),
     VitestPreferExpectAssertions(VitestPreferExpectAssertions),
+    VitestPreferExpectResolves(VitestPreferExpectResolves),
     VitestPreferExpectTypeOf(VitestPreferExpectTypeOf),
     VitestPreferImportInMock(VitestPreferImportInMock),
     VitestPreferImportingVitestGlobals(VitestPreferImportingVitestGlobals),
@@ -2379,7 +2381,8 @@ const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize =
 const VITEST_PREFER_EACH_ID: usize = VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID + 1usize;
 const VITEST_PREFER_EQUALITY_MATCHER_ID: usize = VITEST_PREFER_EACH_ID + 1usize;
 const VITEST_PREFER_EXPECT_ASSERTIONS_ID: usize = VITEST_PREFER_EQUALITY_MATCHER_ID + 1usize;
-const VITEST_PREFER_EXPECT_TYPE_OF_ID: usize = VITEST_PREFER_EXPECT_ASSERTIONS_ID + 1usize;
+const VITEST_PREFER_EXPECT_RESOLVES_ID: usize = VITEST_PREFER_EXPECT_ASSERTIONS_ID + 1usize;
+const VITEST_PREFER_EXPECT_TYPE_OF_ID: usize = VITEST_PREFER_EXPECT_RESOLVES_ID + 1usize;
 const VITEST_PREFER_IMPORT_IN_MOCK_ID: usize = VITEST_PREFER_EXPECT_TYPE_OF_ID + 1usize;
 const VITEST_PREFER_IMPORTING_VITEST_GLOBALS_ID: usize = VITEST_PREFER_IMPORT_IN_MOCK_ID + 1usize;
 const VITEST_PREFER_SNAPSHOT_HINT_ID: usize = VITEST_PREFER_IMPORTING_VITEST_GLOBALS_ID + 1usize;
@@ -3272,6 +3275,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VITEST_PREFER_EACH_ID,
             Self::VitestPreferEqualityMatcher(_) => VITEST_PREFER_EQUALITY_MATCHER_ID,
             Self::VitestPreferExpectAssertions(_) => VITEST_PREFER_EXPECT_ASSERTIONS_ID,
+            Self::VitestPreferExpectResolves(_) => VITEST_PREFER_EXPECT_RESOLVES_ID,
             Self::VitestPreferExpectTypeOf(_) => VITEST_PREFER_EXPECT_TYPE_OF_ID,
             Self::VitestPreferImportInMock(_) => VITEST_PREFER_IMPORT_IN_MOCK_ID,
             Self::VitestPreferImportingVitestGlobals(_) => {
@@ -4157,6 +4161,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VitestPreferEach::NAME,
             Self::VitestPreferEqualityMatcher(_) => VitestPreferEqualityMatcher::NAME,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::NAME,
+            Self::VitestPreferExpectResolves(_) => VitestPreferExpectResolves::NAME,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::NAME,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::NAME,
             Self::VitestPreferImportingVitestGlobals(_) => VitestPreferImportingVitestGlobals::NAME,
@@ -5086,6 +5091,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VitestPreferEach::CATEGORY,
             Self::VitestPreferEqualityMatcher(_) => VitestPreferEqualityMatcher::CATEGORY,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::CATEGORY,
+            Self::VitestPreferExpectResolves(_) => VitestPreferExpectResolves::CATEGORY,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::CATEGORY,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::CATEGORY,
             Self::VitestPreferImportingVitestGlobals(_) => {
@@ -5976,6 +5982,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VitestPreferEach::FIX,
             Self::VitestPreferEqualityMatcher(_) => VitestPreferEqualityMatcher::FIX,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::FIX,
+            Self::VitestPreferExpectResolves(_) => VitestPreferExpectResolves::FIX,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::FIX,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::FIX,
             Self::VitestPreferImportingVitestGlobals(_) => VitestPreferImportingVitestGlobals::FIX,
@@ -7074,6 +7081,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VitestPreferEach::documentation(),
             Self::VitestPreferEqualityMatcher(_) => VitestPreferEqualityMatcher::documentation(),
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::documentation(),
+            Self::VitestPreferExpectResolves(_) => VitestPreferExpectResolves::documentation(),
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::documentation(),
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::documentation(),
             Self::VitestPreferImportingVitestGlobals(_) => {
@@ -9214,6 +9222,10 @@ impl RuleEnum {
                 VitestPreferExpectAssertions::config_schema(generator)
                     .or_else(|| VitestPreferExpectAssertions::schema(generator))
             }
+            Self::VitestPreferExpectResolves(_) => {
+                VitestPreferExpectResolves::config_schema(generator)
+                    .or_else(|| VitestPreferExpectResolves::schema(generator))
+            }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::config_schema(generator)
                 .or_else(|| VitestPreferExpectTypeOf::schema(generator)),
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::config_schema(generator)
@@ -10091,6 +10103,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => "vitest",
             Self::VitestPreferEqualityMatcher(_) => "vitest",
             Self::VitestPreferExpectAssertions(_) => "vitest",
+            Self::VitestPreferExpectResolves(_) => "vitest",
             Self::VitestPreferExpectTypeOf(_) => "vitest",
             Self::VitestPreferImportInMock(_) => "vitest",
             Self::VitestPreferImportingVitestGlobals(_) => "vitest",
@@ -12467,6 +12480,9 @@ impl RuleEnum {
             Self::VitestPreferExpectAssertions(_) => Ok(Self::VitestPreferExpectAssertions(
                 VitestPreferExpectAssertions::from_configuration(value)?,
             )),
+            Self::VitestPreferExpectResolves(_) => Ok(Self::VitestPreferExpectResolves(
+                VitestPreferExpectResolves::from_configuration(value)?,
+            )),
             Self::VitestPreferExpectTypeOf(_) => Ok(Self::VitestPreferExpectTypeOf(
                 VitestPreferExpectTypeOf::from_configuration(value)?,
             )),
@@ -13364,6 +13380,7 @@ impl RuleEnum {
             Self::VitestPreferEach(rule) => rule.to_configuration(),
             Self::VitestPreferEqualityMatcher(rule) => rule.to_configuration(),
             Self::VitestPreferExpectAssertions(rule) => rule.to_configuration(),
+            Self::VitestPreferExpectResolves(rule) => rule.to_configuration(),
             Self::VitestPreferExpectTypeOf(rule) => rule.to_configuration(),
             Self::VitestPreferImportInMock(rule) => rule.to_configuration(),
             Self::VitestPreferImportingVitestGlobals(rule) => rule.to_configuration(),
@@ -14143,6 +14160,7 @@ impl RuleEnum {
             Self::VitestPreferEach(rule) => rule.run(node, ctx),
             Self::VitestPreferEqualityMatcher(rule) => rule.run(node, ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.run(node, ctx),
+            Self::VitestPreferExpectResolves(rule) => rule.run(node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run(node, ctx),
             Self::VitestPreferImportInMock(rule) => rule.run(node, ctx),
             Self::VitestPreferImportingVitestGlobals(rule) => rule.run(node, ctx),
@@ -14920,6 +14938,7 @@ impl RuleEnum {
             Self::VitestPreferEach(rule) => rule.run_once(ctx),
             Self::VitestPreferEqualityMatcher(rule) => rule.run_once(ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.run_once(ctx),
+            Self::VitestPreferExpectResolves(rule) => rule.run_once(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_once(ctx),
             Self::VitestPreferImportInMock(rule) => rule.run_once(ctx),
             Self::VitestPreferImportingVitestGlobals(rule) => rule.run_once(ctx),
@@ -15801,6 +15820,7 @@ impl RuleEnum {
             Self::VitestPreferEach(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferEqualityMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferExpectResolves(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferImportInMock(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferImportingVitestGlobals(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16582,6 +16602,7 @@ impl RuleEnum {
             Self::VitestPreferEach(rule) => rule.should_run(ctx),
             Self::VitestPreferEqualityMatcher(rule) => rule.should_run(ctx),
             Self::VitestPreferExpectAssertions(rule) => rule.should_run(ctx),
+            Self::VitestPreferExpectResolves(rule) => rule.should_run(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.should_run(ctx),
             Self::VitestPreferImportInMock(rule) => rule.should_run(ctx),
             Self::VitestPreferImportingVitestGlobals(rule) => rule.should_run(ctx),
@@ -17675,6 +17696,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VitestPreferEach::IS_TSGOLINT_RULE,
             Self::VitestPreferEqualityMatcher(_) => VitestPreferEqualityMatcher::IS_TSGOLINT_RULE,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::IS_TSGOLINT_RULE,
+            Self::VitestPreferExpectResolves(_) => VitestPreferExpectResolves::IS_TSGOLINT_RULE,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::IS_TSGOLINT_RULE,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::IS_TSGOLINT_RULE,
             Self::VitestPreferImportingVitestGlobals(_) => {
@@ -18624,6 +18646,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VitestPreferEach::VERSION,
             Self::VitestPreferEqualityMatcher(_) => VitestPreferEqualityMatcher::VERSION,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::VERSION,
+            Self::VitestPreferExpectResolves(_) => VitestPreferExpectResolves::VERSION,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::VERSION,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::VERSION,
             Self::VitestPreferImportingVitestGlobals(_) => {
@@ -19592,6 +19615,7 @@ impl RuleEnum {
             Self::VitestPreferEach(_) => VitestPreferEach::HAS_CONFIG,
             Self::VitestPreferEqualityMatcher(_) => VitestPreferEqualityMatcher::HAS_CONFIG,
             Self::VitestPreferExpectAssertions(_) => VitestPreferExpectAssertions::HAS_CONFIG,
+            Self::VitestPreferExpectResolves(_) => VitestPreferExpectResolves::HAS_CONFIG,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::HAS_CONFIG,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::HAS_CONFIG,
             Self::VitestPreferImportingVitestGlobals(_) => {
@@ -20383,6 +20407,7 @@ impl RuleEnum {
             Self::VitestPreferEach(rule) => rule.types_info(),
             Self::VitestPreferEqualityMatcher(rule) => rule.types_info(),
             Self::VitestPreferExpectAssertions(rule) => rule.types_info(),
+            Self::VitestPreferExpectResolves(rule) => rule.types_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.types_info(),
             Self::VitestPreferImportInMock(rule) => rule.types_info(),
             Self::VitestPreferImportingVitestGlobals(rule) => rule.types_info(),
@@ -21160,6 +21185,7 @@ impl RuleEnum {
             Self::VitestPreferEach(rule) => rule.run_info(),
             Self::VitestPreferEqualityMatcher(rule) => rule.run_info(),
             Self::VitestPreferExpectAssertions(rule) => rule.run_info(),
+            Self::VitestPreferExpectResolves(rule) => rule.run_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_info(),
             Self::VitestPreferImportInMock(rule) => rule.run_info(),
             Self::VitestPreferImportingVitestGlobals(rule) => rule.run_info(),
@@ -22059,6 +22085,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferEach(VitestPreferEach::default()),
         RuleEnum::VitestPreferEqualityMatcher(VitestPreferEqualityMatcher::default()),
         RuleEnum::VitestPreferExpectAssertions(VitestPreferExpectAssertions::default()),
+        RuleEnum::VitestPreferExpectResolves(VitestPreferExpectResolves::default()),
         RuleEnum::VitestPreferExpectTypeOf(VitestPreferExpectTypeOf::default()),
         RuleEnum::VitestPreferImportInMock(VitestPreferImportInMock::default()),
         RuleEnum::VitestPreferImportingVitestGlobals(VitestPreferImportingVitestGlobals::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -762,6 +762,7 @@ pub(crate) mod vitest {
     pub mod prefer_each;
     pub mod prefer_equality_matcher;
     pub mod prefer_expect_assertions;
+    pub mod prefer_expect_resolves;
     pub mod prefer_expect_type_of;
     pub mod prefer_import_in_mock;
     pub mod prefer_importing_vitest_globals;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -25,6 +25,7 @@ pub mod prefer_comparison_matcher;
 pub mod prefer_each;
 pub mod prefer_equality_matcher;
 pub mod prefer_expect_assertions;
+pub mod prefer_expect_resolves;
 pub mod prefer_snapshot_hint;
 pub mod prefer_to_contain;
 pub mod prefer_to_have_been_called_times;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_resolves.rs
@@ -1,0 +1,105 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    context::LintContext,
+    utils::{PossibleJestNode, parse_expect_jest_fn_call},
+};
+
+fn expect_resolves(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer `await expect(...).resolves` over `expect(await ...)` syntax.")
+        .with_help("Use `await expect(...).resolves` instead")
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r#"### What it does
+
+Prefer `await expect(...).resolves` over `expect(await ...)` when testing
+promises.
+
+### Why is this bad?
+
+When working with promises, there are two primary ways you can test the
+resolved value:
+
+1. use the `resolve` modifier on `expect`
+(`await expect(...).resolves.<matcher>` style)
+2. `await` the promise and assert against its result
+(`expect(await ...).<matcher>` style)
+
+While the second style is arguably less dependent on `jest`, if the
+promise rejects it will be treated as a general error, resulting in less
+predictable behaviour and output from `jest`.
+
+Additionally, favoring the first style ensures consistency with its
+`rejects` counterpart, as there is no way of "awaiting" a rejection.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+it('passes', async () => {
+    expect(await someValue()).toBe(true);
+});
+it('is true', async () => {
+    const myPromise = Promise.resolve(true);
+    expect(await myPromise).toBe(true);
+});
+```
+
+Examples of **correct** code for this rule:
+```javascript
+it('passes', async () => {
+    await expect(someValue()).resolves.toBe(true);
+});
+it('is true', async () => {
+    const myPromise = Promise.resolve(true);
+
+    await expect(myPromise).resolves.toBe(true);
+});
+it('errors', async () => {
+    await expect(Promise.reject(new Error('oh noes!'))).rejects.toThrowError(
+        'oh noes!',
+    );
+});
+```
+"#;
+
+pub fn run_on_jest_node<'a, 'c>(
+    possible_jest_node: &PossibleJestNode<'a, 'c>,
+    ctx: &'c LintContext<'a>,
+) {
+    let node = possible_jest_node.node;
+    let AstKind::CallExpression(call_expr) = node.kind() else {
+        return;
+    };
+    let Some(jest_expect_fn_call) = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx)
+    else {
+        return;
+    };
+    let Some(Expression::CallExpression(call_expr)) = jest_expect_fn_call.head.parent else {
+        return;
+    };
+    let Some(argument) = call_expr.arguments.first() else {
+        return;
+    };
+    let Argument::AwaitExpression(await_expr) = argument else {
+        return;
+    };
+    ctx.diagnostic_with_fix(expect_resolves(await_expr.span), |fixer| {
+        let local = jest_expect_fn_call.local.as_ref();
+        // Get the source text of the awaited expression (without the `await` keyword)
+        let argument = fixer.source_range(await_expr.argument.span());
+        let mut code = String::with_capacity(local.len() + argument.len() + 17);
+        code.push_str("await ");
+        code.push_str(local);
+        code.push('(');
+        code.push_str(argument);
+        code.push_str(").resolves");
+        fixer.replace(call_expr.span, code)
+    });
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_expect_resolves.rs
@@ -10,7 +10,14 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct PreferExpectResolves;
 
-declare_oxc_lint!(PreferExpectResolves, jest, style, fix, docs = DOCUMENTATION, version = "0.2.14",);
+declare_oxc_lint!(
+    PreferExpectResolves,
+    vitest,
+    style,
+    fix,
+    docs = DOCUMENTATION,
+    version = "0.2.14",
+);
 
 impl Rule for PreferExpectResolves {
     fn run_on_jest_node<'a, 'c>(
@@ -145,7 +152,7 @@ fn tests() {
     ];
 
     Tester::new(PreferExpectResolves::NAME, PreferExpectResolves::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_expect_resolves.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_expect_resolves.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(prefer-expect-resolves): Prefer `await expect(...).resolves` over `expect(await ...)` syntax.
+   ╭─[prefer_expect_resolves.tsx:3:28]
+ 2 │                 it('passes', async () => {
+ 3 │                     expect(await someValue(),).toBe(true);
+   ·                            ─────────────────
+ 4 │                 });
+   ╰────
+  help: Use `await expect(...).resolves` instead
+
+  ⚠ vitest(prefer-expect-resolves): Prefer `await expect(...).resolves` over `expect(await ...)` syntax.
+   ╭─[prefer_expect_resolves.tsx:4:28]
+ 3 │                     const myPromise = Promise.resolve(true);
+ 4 │                     expect(await myPromise).toBe(true);
+   ·                            ───────────────
+ 5 │                 });
+   ╰────
+  help: Use `await expect(...).resolves` instead
+
+  ⚠ vitest(prefer-expect-resolves): Prefer `await expect(...).resolves` over `expect(await ...)` syntax.
+   ╭─[prefer_expect_resolves.tsx:6:34]
+ 5 │                     const myPromise = Promise.resolve(true);
+ 6 │                     pleaseExpect(await myPromise).toBe(true);
+   ·                                  ───────────────
+ 7 │                 });
+   ╰────
+  help: Use `await expect(...).resolves` instead

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,8 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 9] = [
-    "prefer-expect-resolves",
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 8] = [
     "prefer-hooks-in-order",
     "prefer-hooks-on-top",
     "prefer-lowercase-title",


### PR DESCRIPTION
- part of #21664 