### PR TITLE
feat(linter): split jest/prefer-strict-equal into separate vitest rule

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,1 +1,1 @@
-["prefer-strict-equal", "prefer-to-be"]
+["prefer-to-be"]

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4648,6 +4648,11 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_strict_equal::PreferStrictEqual {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -746,6 +746,7 @@ pub use crate::rules::vitest::prefer_mock_return_shorthand::PreferMockReturnShor
 pub use crate::rules::vitest::prefer_snapshot_hint::PreferSnapshotHint as VitestPreferSnapshotHint;
 pub use crate::rules::vitest::prefer_spy_on::PreferSpyOn as VitestPreferSpyOn;
 pub use crate::rules::vitest::prefer_strict_boolean_matchers::PreferStrictBooleanMatchers as VitestPreferStrictBooleanMatchers;
+pub use crate::rules::vitest::prefer_strict_equal::PreferStrictEqual as VitestPreferStrictEqual;
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
@@ -1531,6 +1532,7 @@ pub enum RuleEnum {
     VitestPreferSnapshotHint(VitestPreferSnapshotHint),
     VitestPreferSpyOn(VitestPreferSpyOn),
     VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers),
+    VitestPreferStrictEqual(VitestPreferStrictEqual),
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
@@ -2406,7 +2408,8 @@ const VITEST_PREFER_MOCK_RETURN_SHORTHAND_ID: usize =
 const VITEST_PREFER_SNAPSHOT_HINT_ID: usize = VITEST_PREFER_MOCK_RETURN_SHORTHAND_ID + 1usize;
 const VITEST_PREFER_SPY_ON_ID: usize = VITEST_PREFER_SNAPSHOT_HINT_ID + 1usize;
 const VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID: usize = VITEST_PREFER_SPY_ON_ID + 1usize;
-const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID + 1usize;
+const VITEST_PREFER_STRICT_EQUAL_ID: usize = VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID + 1usize;
+const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_STRICT_EQUAL_ID + 1usize;
 const VITEST_PREFER_TO_BE_OBJECT_ID: usize = VITEST_PREFER_TO_BE_FALSY_ID + 1usize;
 const VITEST_PREFER_TO_BE_TRUTHY_ID: usize = VITEST_PREFER_TO_BE_OBJECT_ID + 1usize;
 const VITEST_PREFER_TO_CONTAIN_ID: usize = VITEST_PREFER_TO_BE_TRUTHY_ID + 1usize;
@@ -3308,6 +3311,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(_) => VITEST_PREFER_SNAPSHOT_HINT_ID,
             Self::VitestPreferSpyOn(_) => VITEST_PREFER_SPY_ON_ID,
             Self::VitestPreferStrictBooleanMatchers(_) => VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID,
+            Self::VitestPreferStrictEqual(_) => VITEST_PREFER_STRICT_EQUAL_ID,
             Self::VitestPreferToBeFalsy(_) => VITEST_PREFER_TO_BE_FALSY_ID,
             Self::VitestPreferToBeObject(_) => VITEST_PREFER_TO_BE_OBJECT_ID,
             Self::VitestPreferToBeTruthy(_) => VITEST_PREFER_TO_BE_TRUTHY_ID,
@@ -4198,6 +4202,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(_) => VitestPreferSnapshotHint::NAME,
             Self::VitestPreferSpyOn(_) => VitestPreferSpyOn::NAME,
             Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::NAME,
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::NAME,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
@@ -5138,6 +5143,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => {
                 VitestPreferStrictBooleanMatchers::CATEGORY
             }
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::CATEGORY,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
@@ -6031,6 +6037,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(_) => VitestPreferSnapshotHint::FIX,
             Self::VitestPreferSpyOn(_) => VitestPreferSpyOn::FIX,
             Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::FIX,
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::FIX,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
@@ -7144,6 +7151,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => {
                 VitestPreferStrictBooleanMatchers::documentation()
             }
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::documentation(),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::documentation(),
@@ -9311,6 +9319,8 @@ impl RuleEnum {
                 VitestPreferStrictBooleanMatchers::config_schema(generator)
                     .or_else(|| VitestPreferStrictBooleanMatchers::schema(generator))
             }
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::config_schema(generator)
+                .or_else(|| VitestPreferStrictEqual::schema(generator)),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::config_schema(generator)
                 .or_else(|| VitestPreferToBeFalsy::schema(generator)),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::config_schema(generator)
@@ -10186,6 +10196,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(_) => "vitest",
             Self::VitestPreferSpyOn(_) => "vitest",
             Self::VitestPreferStrictBooleanMatchers(_) => "vitest",
+            Self::VitestPreferStrictEqual(_) => "vitest",
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
@@ -12599,6 +12610,9 @@ impl RuleEnum {
                     VitestPreferStrictBooleanMatchers::from_configuration(value)?,
                 ))
             }
+            Self::VitestPreferStrictEqual(_) => Ok(Self::VitestPreferStrictEqual(
+                VitestPreferStrictEqual::from_configuration(value)?,
+            )),
             Self::VitestPreferToBeFalsy(_) => {
                 Ok(Self::VitestPreferToBeFalsy(VitestPreferToBeFalsy::from_configuration(value)?))
             }
@@ -13489,6 +13503,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(rule) => rule.to_configuration(),
             Self::VitestPreferSpyOn(rule) => rule.to_configuration(),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.to_configuration(),
+            Self::VitestPreferStrictEqual(rule) => rule.to_configuration(),
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
@@ -14275,6 +14290,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(rule) => rule.run(node, ctx),
             Self::VitestPreferSpyOn(rule) => rule.run(node, ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run(node, ctx),
+            Self::VitestPreferStrictEqual(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -15059,6 +15075,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(rule) => rule.run_once(ctx),
             Self::VitestPreferSpyOn(rule) => rule.run_once(ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_once(ctx),
+            Self::VitestPreferStrictEqual(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -15947,6 +15964,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferSpyOn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferStrictEqual(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16735,6 +16753,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(rule) => rule.should_run(ctx),
             Self::VitestPreferSpyOn(rule) => rule.should_run(ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.should_run(ctx),
+            Self::VitestPreferStrictEqual(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
@@ -17843,6 +17862,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => {
                 VitestPreferStrictBooleanMatchers::IS_TSGOLINT_RULE
             }
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
@@ -18799,6 +18819,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => {
                 VitestPreferStrictBooleanMatchers::VERSION
             }
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::VERSION,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::VERSION,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::VERSION,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::VERSION,
@@ -19776,6 +19797,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => {
                 VitestPreferStrictBooleanMatchers::HAS_CONFIG
             }
+            Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::HAS_CONFIG,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::HAS_CONFIG,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::HAS_CONFIG,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::HAS_CONFIG,
@@ -20570,6 +20592,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(rule) => rule.types_info(),
             Self::VitestPreferSpyOn(rule) => rule.types_info(),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.types_info(),
+            Self::VitestPreferStrictEqual(rule) => rule.types_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
@@ -21354,6 +21377,7 @@ impl RuleEnum {
             Self::VitestPreferSnapshotHint(rule) => rule.run_info(),
             Self::VitestPreferSpyOn(rule) => rule.run_info(),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_info(),
+            Self::VitestPreferStrictEqual(rule) => rule.run_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
@@ -22260,6 +22284,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferSnapshotHint(VitestPreferSnapshotHint::default()),
         RuleEnum::VitestPreferSpyOn(VitestPreferSpyOn::default()),
         RuleEnum::VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers::default()),
+        RuleEnum::VitestPreferStrictEqual(VitestPreferStrictEqual::default()),
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -774,6 +774,7 @@ pub(crate) mod vitest {
     pub mod prefer_snapshot_hint;
     pub mod prefer_spy_on;
     pub mod prefer_strict_boolean_matchers;
+    pub mod prefer_strict_equal;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -33,6 +33,7 @@ pub mod prefer_mock_promise_shorthand;
 pub mod prefer_mock_return_shorthand;
 pub mod prefer_snapshot_hint;
 pub mod prefer_spy_on;
+pub mod prefer_strict_equal;
 pub mod prefer_to_contain;
 pub mod prefer_to_have_been_called_times;
 pub mod prefer_to_have_length;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_strict_equal.rs
@@ -1,0 +1,61 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    utils::{PossibleJestNode, parse_expect_jest_fn_call},
+};
+
+fn use_to_strict_equal(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Suggest using `toStrictEqual()`.")
+        .with_help("Use `toStrictEqual()` instead")
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+This rule triggers a warning if `toEqual()` is used to assert equality.
+
+### Why is this bad?
+
+The `toEqual()` matcher performs a deep equality check but ignores
+`undefined` values in objects and arrays. This can lead to false
+positives where tests pass when they should fail. `toStrictEqual()`
+provides more accurate comparison by checking for `undefined` values.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+expect({ a: 'a', b: undefined }).toEqual({ a: 'a' });
+```
+
+Examples of **correct** code for this rule:
+```javascript
+expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' });
+```
+";
+
+pub fn run_on_jest_node<'a, 'c>(jest_node: &PossibleJestNode<'a, 'c>, ctx: &'c LintContext<'a>) {
+    run(jest_node, ctx);
+}
+
+fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) -> Option<()> {
+    let call_expr = possible_jest_node.node.kind().as_call_expression()?;
+    let parse_jest_expect_fn_call = parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx)?;
+    let matcher = parse_jest_expect_fn_call.matcher()?;
+    let matcher_name = matcher.name()?;
+
+    if matcher_name.eq("toEqual") {
+        ctx.diagnostic_with_fix(use_to_strict_equal(matcher.span), |fixer| {
+            let replacement = match fixer.source_range(matcher.span).chars().next().unwrap() {
+                '\'' => "'toStrictEqual'",
+                '"' => "\"toStrictEqual\"",
+                '`' => "`toStrictEqual`",
+                _ => "toStrictEqual",
+            };
+            fixer.replace(matcher.span, replacement)
+        });
+    }
+    None
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_strict_equal.rs
@@ -10,7 +10,7 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct PreferStrictEqual;
 
-declare_oxc_lint!(PreferStrictEqual, jest, style, fix, docs = DOCUMENTATION, version = "0.2.13",);
+declare_oxc_lint!(PreferStrictEqual, vitest, style, fix, docs = DOCUMENTATION, version = "0.2.13",);
 
 impl Rule for PreferStrictEqual {
     fn run_on_jest_node<'a, 'c>(
@@ -25,8 +25,6 @@ impl Rule for PreferStrictEqual {
 #[test]
 fn test() {
     use crate::tester::Tester;
-
-    // Note: Both Jest and Vitest share the same unit tests
 
     let pass = vec![
         ("expect(something).toStrictEqual(somethingElse);", None),
@@ -59,7 +57,7 @@ fn test() {
     ];
 
     Tester::new(PreferStrictEqual::NAME, PreferStrictEqual::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_strict_equal.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_strict_equal.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(prefer-strict-equal): Suggest using `toStrictEqual()`.
+   ╭─[prefer_strict_equal.tsx:1:19]
+ 1 │ expect(something).toEqual(somethingElse);
+   ·                   ───────
+   ╰────
+  help: Use `toStrictEqual()` instead
+
+  ⚠ vitest(prefer-strict-equal): Suggest using `toStrictEqual()`.
+   ╭─[prefer_strict_equal.tsx:1:19]
+ 1 │ expect(something).toEqual(somethingElse,);
+   ·                   ───────
+   ╰────
+  help: Use `toStrictEqual()` instead
+
+  ⚠ vitest(prefer-strict-equal): Suggest using `toStrictEqual()`.
+   ╭─[prefer_strict_equal.tsx:1:19]
+ 1 │ expect(something)["toEqual"](somethingElse);
+   ·                   ─────────
+   ╰────
+  help: Use `toStrictEqual()` instead

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 2] = ["prefer-strict-equal", "prefer-to-be"];
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 1] = ["prefer-to-be"];
 
 /// List of Eslint rules that have TypeScript equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.


### PR DESCRIPTION
- part of #21664 