### PR TITLE
feat(linter): split jest/prefer-to-be into separate vitest rule

### DIFF
--- a/crates/oxc_linter/data/vitest_compatible_jest_rules.json
+++ b/crates/oxc_linter/data/vitest_compatible_jest_rules.json
@@ -1,1 +1,1 @@
-["prefer-to-be"]
+[]

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4653,6 +4653,11 @@ impl RuleRunner for crate::rules::vitest::prefer_strict_equal::PreferStrictEqual
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_to_be::PreferToBe {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -747,6 +747,7 @@ pub use crate::rules::vitest::prefer_snapshot_hint::PreferSnapshotHint as Vitest
 pub use crate::rules::vitest::prefer_spy_on::PreferSpyOn as VitestPreferSpyOn;
 pub use crate::rules::vitest::prefer_strict_boolean_matchers::PreferStrictBooleanMatchers as VitestPreferStrictBooleanMatchers;
 pub use crate::rules::vitest::prefer_strict_equal::PreferStrictEqual as VitestPreferStrictEqual;
+pub use crate::rules::vitest::prefer_to_be::PreferToBe as VitestPreferToBe;
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
@@ -1533,6 +1534,7 @@ pub enum RuleEnum {
     VitestPreferSpyOn(VitestPreferSpyOn),
     VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers),
     VitestPreferStrictEqual(VitestPreferStrictEqual),
+    VitestPreferToBe(VitestPreferToBe),
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
@@ -2409,7 +2411,8 @@ const VITEST_PREFER_SNAPSHOT_HINT_ID: usize = VITEST_PREFER_MOCK_RETURN_SHORTHAN
 const VITEST_PREFER_SPY_ON_ID: usize = VITEST_PREFER_SNAPSHOT_HINT_ID + 1usize;
 const VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID: usize = VITEST_PREFER_SPY_ON_ID + 1usize;
 const VITEST_PREFER_STRICT_EQUAL_ID: usize = VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID + 1usize;
-const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_STRICT_EQUAL_ID + 1usize;
+const VITEST_PREFER_TO_BE_ID: usize = VITEST_PREFER_STRICT_EQUAL_ID + 1usize;
+const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_TO_BE_ID + 1usize;
 const VITEST_PREFER_TO_BE_OBJECT_ID: usize = VITEST_PREFER_TO_BE_FALSY_ID + 1usize;
 const VITEST_PREFER_TO_BE_TRUTHY_ID: usize = VITEST_PREFER_TO_BE_OBJECT_ID + 1usize;
 const VITEST_PREFER_TO_CONTAIN_ID: usize = VITEST_PREFER_TO_BE_TRUTHY_ID + 1usize;
@@ -3312,6 +3315,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(_) => VITEST_PREFER_SPY_ON_ID,
             Self::VitestPreferStrictBooleanMatchers(_) => VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID,
             Self::VitestPreferStrictEqual(_) => VITEST_PREFER_STRICT_EQUAL_ID,
+            Self::VitestPreferToBe(_) => VITEST_PREFER_TO_BE_ID,
             Self::VitestPreferToBeFalsy(_) => VITEST_PREFER_TO_BE_FALSY_ID,
             Self::VitestPreferToBeObject(_) => VITEST_PREFER_TO_BE_OBJECT_ID,
             Self::VitestPreferToBeTruthy(_) => VITEST_PREFER_TO_BE_TRUTHY_ID,
@@ -4203,6 +4207,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(_) => VitestPreferSpyOn::NAME,
             Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::NAME,
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::NAME,
+            Self::VitestPreferToBe(_) => VitestPreferToBe::NAME,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
@@ -5144,6 +5149,7 @@ impl RuleEnum {
                 VitestPreferStrictBooleanMatchers::CATEGORY
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::CATEGORY,
+            Self::VitestPreferToBe(_) => VitestPreferToBe::CATEGORY,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
@@ -6038,6 +6044,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(_) => VitestPreferSpyOn::FIX,
             Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::FIX,
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::FIX,
+            Self::VitestPreferToBe(_) => VitestPreferToBe::FIX,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
@@ -7152,6 +7159,7 @@ impl RuleEnum {
                 VitestPreferStrictBooleanMatchers::documentation()
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::documentation(),
+            Self::VitestPreferToBe(_) => VitestPreferToBe::documentation(),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::documentation(),
@@ -9321,6 +9329,8 @@ impl RuleEnum {
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::config_schema(generator)
                 .or_else(|| VitestPreferStrictEqual::schema(generator)),
+            Self::VitestPreferToBe(_) => VitestPreferToBe::config_schema(generator)
+                .or_else(|| VitestPreferToBe::schema(generator)),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::config_schema(generator)
                 .or_else(|| VitestPreferToBeFalsy::schema(generator)),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::config_schema(generator)
@@ -10197,6 +10207,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(_) => "vitest",
             Self::VitestPreferStrictBooleanMatchers(_) => "vitest",
             Self::VitestPreferStrictEqual(_) => "vitest",
+            Self::VitestPreferToBe(_) => "vitest",
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
@@ -12613,6 +12624,9 @@ impl RuleEnum {
             Self::VitestPreferStrictEqual(_) => Ok(Self::VitestPreferStrictEqual(
                 VitestPreferStrictEqual::from_configuration(value)?,
             )),
+            Self::VitestPreferToBe(_) => {
+                Ok(Self::VitestPreferToBe(VitestPreferToBe::from_configuration(value)?))
+            }
             Self::VitestPreferToBeFalsy(_) => {
                 Ok(Self::VitestPreferToBeFalsy(VitestPreferToBeFalsy::from_configuration(value)?))
             }
@@ -13504,6 +13518,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(rule) => rule.to_configuration(),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.to_configuration(),
             Self::VitestPreferStrictEqual(rule) => rule.to_configuration(),
+            Self::VitestPreferToBe(rule) => rule.to_configuration(),
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
@@ -14291,6 +14306,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(rule) => rule.run(node, ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run(node, ctx),
             Self::VitestPreferStrictEqual(rule) => rule.run(node, ctx),
+            Self::VitestPreferToBe(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -15076,6 +15092,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(rule) => rule.run_once(ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_once(ctx),
             Self::VitestPreferStrictEqual(rule) => rule.run_once(ctx),
+            Self::VitestPreferToBe(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -15965,6 +15982,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferStrictEqual(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferToBe(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16754,6 +16772,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(rule) => rule.should_run(ctx),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.should_run(ctx),
             Self::VitestPreferStrictEqual(rule) => rule.should_run(ctx),
+            Self::VitestPreferToBe(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
@@ -17863,6 +17882,7 @@ impl RuleEnum {
                 VitestPreferStrictBooleanMatchers::IS_TSGOLINT_RULE
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::IS_TSGOLINT_RULE,
+            Self::VitestPreferToBe(_) => VitestPreferToBe::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
@@ -18820,6 +18840,7 @@ impl RuleEnum {
                 VitestPreferStrictBooleanMatchers::VERSION
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::VERSION,
+            Self::VitestPreferToBe(_) => VitestPreferToBe::VERSION,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::VERSION,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::VERSION,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::VERSION,
@@ -19798,6 +19819,7 @@ impl RuleEnum {
                 VitestPreferStrictBooleanMatchers::HAS_CONFIG
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::HAS_CONFIG,
+            Self::VitestPreferToBe(_) => VitestPreferToBe::HAS_CONFIG,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::HAS_CONFIG,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::HAS_CONFIG,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::HAS_CONFIG,
@@ -20593,6 +20615,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(rule) => rule.types_info(),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.types_info(),
             Self::VitestPreferStrictEqual(rule) => rule.types_info(),
+            Self::VitestPreferToBe(rule) => rule.types_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
@@ -21378,6 +21401,7 @@ impl RuleEnum {
             Self::VitestPreferSpyOn(rule) => rule.run_info(),
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_info(),
             Self::VitestPreferStrictEqual(rule) => rule.run_info(),
+            Self::VitestPreferToBe(rule) => rule.run_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
@@ -22285,6 +22309,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferSpyOn(VitestPreferSpyOn::default()),
         RuleEnum::VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers::default()),
         RuleEnum::VitestPreferStrictEqual(VitestPreferStrictEqual::default()),
+        RuleEnum::VitestPreferToBe(VitestPreferToBe::default()),
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -775,6 +775,7 @@ pub(crate) mod vitest {
     pub mod prefer_spy_on;
     pub mod prefer_strict_boolean_matchers;
     pub mod prefer_strict_equal;
+    pub mod prefer_to_be;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -34,6 +34,7 @@ pub mod prefer_mock_return_shorthand;
 pub mod prefer_snapshot_hint;
 pub mod prefer_spy_on;
 pub mod prefer_strict_equal;
+pub mod prefer_to_be;
 pub mod prefer_to_contain;
 pub mod prefer_to_have_been_called_times;
 pub mod prefer_to_have_length;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_to_be.rs
@@ -1,0 +1,350 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, CallExpression, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    utils::{
+        KnownMemberExpressionProperty, ParsedExpectFnCall, PossibleJestNode, is_equality_matcher,
+        parse_expect_jest_fn_call,
+    },
+};
+
+fn use_to_be(source_text: &str, suggestion: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBe` when expecting primitive literals.")
+        .with_help(format!("Replace `{source_text}` with `{suggestion}`."))
+        .with_label(span)
+}
+
+fn use_to_be_undefined(source_text: &str, suggestion: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeUndefined` instead.")
+        .with_help(format!("Replace `{source_text}` with `{suggestion}`."))
+        .with_label(span)
+}
+
+fn use_to_be_defined(source_text: &str, suggestion: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeDefined` instead.")
+        .with_help(format!("Replace `{source_text}` with `{suggestion}`."))
+        .with_label(span)
+}
+
+fn use_to_be_null(source_text: &str, suggestion: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeNull` instead.")
+        .with_help(format!("Replace `{source_text}` with `{suggestion}`."))
+        .with_label(span)
+}
+
+fn use_to_be_na_n(source_text: &str, suggestion: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `toBeNaN` instead.")
+        .with_help(format!("Replace `{source_text}` with `{suggestion}`."))
+        .with_label(span)
+}
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+Recommends using `toBe` matcher for primitive literals and specific
+matchers for `null`, `undefined`, and `NaN`.
+
+### Why is this bad?
+
+When asserting against primitive literals such as numbers and strings,
+the equality matchers all operate the same, but read slightly
+differently in code.
+
+This rule recommends using the `toBe` matcher in these situations, as
+it forms the most grammatically natural sentence. For `null`,
+`undefined`, and `NaN` this rule recommends using their specific `toBe`
+matchers, as they give better error messages as well.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```javascript
+expect(value).not.toEqual(5);
+expect(getMessage()).toStrictEqual('hello world');
+expect(loadMessage()).resolves.toEqual('hello world');
+```
+
+Examples of **correct** code for this rule:
+```javascript
+expect(value).not.toBe(5);
+expect(getMessage()).toBe('hello world');
+expect(loadMessage()).resolves.toBe('hello world');
+expect(didError).not.toBe(true);
+expect(catchError()).toStrictEqual({ message: 'oh noes!' });
+```
+";
+
+#[derive(Clone, Debug, PartialEq)]
+enum PreferToBeKind {
+    Defined,
+    NaN,
+    Null,
+    ToBe,
+    Undefined,
+}
+
+pub fn run_on_jest_node<'a, 'c>(jest_node: &PossibleJestNode<'a, 'c>, ctx: &'c LintContext<'a>) {
+    PreferToBe::run(jest_node, ctx);
+}
+
+struct PreferToBe;
+
+impl PreferToBe {
+    fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+        let node = possible_jest_node.node;
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+        let Some(jest_expect_fn_call) =
+            parse_expect_jest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
+            return;
+        };
+        let Some(matcher) = jest_expect_fn_call.matcher() else {
+            return;
+        };
+
+        let has_not_modifier =
+            jest_expect_fn_call.modifiers().iter().any(|modifier| modifier.is_name_equal("not"));
+
+        if has_not_modifier {
+            if matcher.is_name_equal("toBeUndefined") {
+                Self::check_and_fix(
+                    &PreferToBeKind::Defined,
+                    call_expr,
+                    matcher,
+                    &jest_expect_fn_call,
+                    ctx,
+                );
+                return;
+            } else if matcher.is_name_equal("toBeDefined") {
+                Self::check_and_fix(
+                    &PreferToBeKind::Undefined,
+                    call_expr,
+                    matcher,
+                    &jest_expect_fn_call,
+                    ctx,
+                );
+                return;
+            }
+        }
+
+        if !is_equality_matcher(matcher) || jest_expect_fn_call.args.is_empty() {
+            return;
+        }
+
+        let Some(arg_expr) = jest_expect_fn_call.args.first().and_then(Argument::as_expression)
+        else {
+            return;
+        };
+        let first_matcher_arg = arg_expr.get_inner_expression();
+
+        if first_matcher_arg.is_undefined() {
+            let kind =
+                if has_not_modifier { PreferToBeKind::Defined } else { PreferToBeKind::Undefined };
+            Self::check_and_fix(&kind, call_expr, matcher, &jest_expect_fn_call, ctx);
+            return;
+        }
+
+        if first_matcher_arg.is_nan() {
+            Self::check_and_fix(
+                &PreferToBeKind::NaN,
+                call_expr,
+                matcher,
+                &jest_expect_fn_call,
+                ctx,
+            );
+            return;
+        }
+
+        if first_matcher_arg.is_null() {
+            Self::check_and_fix(
+                &PreferToBeKind::Null,
+                call_expr,
+                matcher,
+                &jest_expect_fn_call,
+                ctx,
+            );
+            return;
+        }
+
+        if Self::should_use_tobe(first_matcher_arg)
+            && !matcher.is_name_equal("toBe")
+            && !Self::should_skip_float(first_matcher_arg, ctx)
+        {
+            Self::check_and_fix(
+                &PreferToBeKind::ToBe,
+                call_expr,
+                matcher,
+                &jest_expect_fn_call,
+                ctx,
+            );
+        }
+    }
+
+    fn should_use_tobe(first_matcher_arg: &Expression) -> bool {
+        let mut expr = first_matcher_arg;
+
+        if let Expression::UnaryExpression(unary_expr) = expr
+            && unary_expr.operator.as_str() == "-"
+        {
+            expr = &unary_expr.argument;
+        }
+
+        if matches!(expr, Expression::RegExpLiteral(_)) {
+            return false;
+        }
+
+        matches!(
+            expr,
+            Expression::BigIntLiteral(_)
+                | Expression::BooleanLiteral(_)
+                | Expression::NumericLiteral(_)
+                | Expression::NullLiteral(_)
+                | Expression::TemplateLiteral(_)
+                | Expression::StringLiteral(_)
+        )
+    }
+
+    fn should_skip_float(expr: &Expression, ctx: &LintContext) -> bool {
+        // Check if this is a float literal by examining the source text
+        if let Expression::NumericLiteral(num) = expr {
+            let source = ctx.source_range(num.span);
+            return source.contains('.');
+        }
+        false
+    }
+
+    /// Helper function to build suggestion for matchers that keep the "not" modifier (null, NaN).
+    /// Returns (source_start, suggestion_string).
+    fn build_suggestion_with_not_modifier(
+        matcher_name: &str,
+        not_modifier: Option<&&KnownMemberExpressionProperty>,
+        is_cmp_mem_expr: bool,
+        span_start: u32,
+    ) -> (u32, String) {
+        if let Some(&not_modifier) = not_modifier {
+            let not_is_computed =
+                matches!(not_modifier.parent, Some(Expression::ComputedMemberExpression(_)));
+
+            if not_is_computed {
+                // ["not"]["toBe"](value) -> ["not"]["toBeMatcher"]()
+                let start = not_modifier.span.start - 1; // Include opening bracket of ["not"]
+                let suggestion = if is_cmp_mem_expr {
+                    format!("[\"not\"][\"{matcher_name}\"]()")
+                } else {
+                    format!("[\"not\"].{matcher_name}()")
+                };
+                (start, suggestion)
+            } else if is_cmp_mem_expr {
+                // .not["toBe"](value) -> .not["toBeMatcher"]()
+                (not_modifier.span.start, format!("not[\"{matcher_name}\"]()"))
+            } else {
+                // .not.toBe(value) -> .not.toBeMatcher()
+                (not_modifier.span.start, format!("not.{matcher_name}()"))
+            }
+        } else {
+            // No "not" modifier
+            let start = if is_cmp_mem_expr { span_start - 1 } else { span_start };
+            let suggestion = if is_cmp_mem_expr {
+                format!("[\"{matcher_name}\"]()")
+            } else {
+                format!("{matcher_name}()")
+            };
+            (start, suggestion)
+        }
+    }
+
+    fn check_and_fix(
+        kind: &PreferToBeKind,
+        call_expr: &CallExpression,
+        matcher: &KnownMemberExpressionProperty,
+        jest_expect_fn_call: &ParsedExpectFnCall,
+        ctx: &LintContext,
+    ) {
+        let span = matcher.span;
+        let end = call_expr.span.end;
+
+        let is_cmp_mem_expr = match matcher.parent {
+            Some(Expression::ComputedMemberExpression(_)) => true,
+            Some(Expression::StaticMemberExpression(_) | Expression::PrivateFieldExpression(_)) => {
+                false
+            }
+            _ => return,
+        };
+
+        let modifiers = jest_expect_fn_call.modifiers();
+        let maybe_not_modifier = modifiers.iter().find(|modifier| modifier.is_name_equal("not"));
+
+        if kind == &PreferToBeKind::Undefined {
+            let replacement_span = if let Some(not_modifier) = maybe_not_modifier {
+                Span::new(not_modifier.span.start, end)
+            } else {
+                Span::new(span.start, end)
+            };
+            let source_text = ctx.source_range(replacement_span);
+            let new_matcher =
+                if is_cmp_mem_expr { "[\"toBeUndefined\"]()" } else { "toBeUndefined()" };
+
+            ctx.diagnostic_with_fix(
+                use_to_be_undefined(source_text, new_matcher, replacement_span),
+                |fixer| fixer.replace(replacement_span, new_matcher),
+            );
+        } else if kind == &PreferToBeKind::Defined {
+            let start = if is_cmp_mem_expr {
+                modifiers.first().unwrap().span.end
+            } else {
+                maybe_not_modifier.unwrap().span.start
+            };
+            let replacement_span = Span::new(start, end);
+            let source_text = ctx.source_range(replacement_span);
+            let new_matcher = if is_cmp_mem_expr { "[\"toBeDefined\"]()" } else { "toBeDefined()" };
+
+            ctx.diagnostic_with_fix(
+                use_to_be_defined(source_text, new_matcher, replacement_span),
+                |fixer| fixer.replace(replacement_span, new_matcher),
+            );
+        } else if kind == &PreferToBeKind::Null {
+            let (source_start, suggestion) = Self::build_suggestion_with_not_modifier(
+                "toBeNull",
+                maybe_not_modifier,
+                is_cmp_mem_expr,
+                span.start,
+            );
+
+            let replacement_span = Span::new(source_start, end);
+            let source_text = ctx.source_range(replacement_span);
+
+            ctx.diagnostic_with_fix(
+                use_to_be_null(source_text, &suggestion, replacement_span),
+                |fixer| fixer.replace(replacement_span, suggestion),
+            );
+        } else if kind == &PreferToBeKind::NaN {
+            let (source_start, suggestion) = Self::build_suggestion_with_not_modifier(
+                "toBeNaN",
+                maybe_not_modifier,
+                is_cmp_mem_expr,
+                span.start,
+            );
+
+            let replacement_span = Span::new(source_start, end);
+            let source_text = ctx.source_range(replacement_span);
+
+            ctx.diagnostic_with_fix(
+                use_to_be_na_n(source_text, &suggestion, replacement_span),
+                |fixer| fixer.replace(replacement_span, suggestion),
+            );
+        } else {
+            let source_text = ctx.source_range(span);
+            let new_matcher = if is_cmp_mem_expr { "\"toBe\"" } else { "toBe" };
+
+            ctx.diagnostic_with_fix(use_to_be(source_text, new_matcher, span), |fixer| {
+                fixer.replace(span, new_matcher)
+            });
+        }
+    }
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be.rs
@@ -10,7 +10,7 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct PreferToBe;
 
-declare_oxc_lint!(PreferToBe, jest, style, fix, docs = DOCUMENTATION, version = "0.2.14",);
+declare_oxc_lint!(PreferToBe, vitest, style, fix, docs = DOCUMENTATION, version = "0.2.14",);
 
 impl Rule for PreferToBe {
     fn run_on_jest_node<'a, 'c>(
@@ -313,7 +313,7 @@ fn tests() {
     ];
 
     Tester::new(PreferToBe::NAME, PreferToBe::PLUGIN, pass, fail)
-        .with_jest_plugin(true)
+        .with_vitest_plugin(true)
         .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_to_be.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_to_be.snap
@@ -1,0 +1,346 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value).toEqual("my string");
+   ·               ───────
+   ╰────
+  help: Replace `toEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value).toStrictEqual("my string");
+   ·               ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value).toStrictEqual(1);
+   ·               ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value).toStrictEqual(1,);
+   ·               ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value).toStrictEqual(-1);
+   ·               ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value).toEqual(`my string`);
+   ·               ───────
+   ╰────
+  help: Replace `toEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value)["toEqual"](`my string`);
+   ·               ─────────
+   ╰────
+  help: Replace `"toEqual"` with `"toBe"`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:15]
+ 1 │ expect(value).toStrictEqual(`my ${string}`);
+   ·               ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:32]
+ 1 │ expect(loadMessage()).resolves.toStrictEqual("hello world");
+   ·                                ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:32]
+ 1 │ expect(loadMessage()).resolves["toStrictEqual"]("hello world");
+   ·                                ───────────────
+   ╰────
+  help: Replace `"toStrictEqual"` with `"toBe"`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:35]
+ 1 │ expect(loadMessage())["resolves"].toStrictEqual("hello world");
+   ·                                   ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:32]
+ 1 │ expect(loadMessage()).resolves.toStrictEqual(false);
+   ·                                ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:14]
+ 1 │ expect(null).toBe(null);
+   ·              ──────────
+   ╰────
+  help: Replace `toBe(null)` with `toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:14]
+ 1 │ expect(null).toEqual(null);
+   ·              ─────────────
+   ╰────
+  help: Replace `toEqual(null)` with `toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:14]
+ 1 │ expect(null).toEqual(null,);
+   ·              ──────────────
+   ╰────
+  help: Replace `toEqual(null,)` with `toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:14]
+ 1 │ expect(null).toStrictEqual(null);
+   ·              ───────────────────
+   ╰────
+  help: Replace `toStrictEqual(null)` with `toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toBe(null);
+   ·                    ──────────────
+   ╰────
+  help: Replace `not.toBe(null)` with `not.toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not["toBe"](null);
+   ·                    ─────────────────
+   ╰────
+  help: Replace `not["toBe"](null)` with `not["toBeNull"]()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:19]
+ 1 │ expect("a string")["not"]["toBe"](null);
+   ·                   ─────────────────────
+   ╰────
+  help: Replace `["not"]["toBe"](null)` with `["not"]["toBeNull"]()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toEqual(null);
+   ·                    ─────────────────
+   ╰────
+  help: Replace `not.toEqual(null)` with `not.toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toStrictEqual(null);
+   ·                    ───────────────────────
+   ╰────
+  help: Replace `not.toStrictEqual(null)` with `not.toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:19]
+ 1 │ expect(undefined).toBe(undefined);
+   ·                   ───────────────
+   ╰────
+  help: Replace `toBe(undefined)` with `toBeUndefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:19]
+ 1 │ expect(undefined).toEqual(undefined);
+   ·                   ──────────────────
+   ╰────
+  help: Replace `toEqual(undefined)` with `toBeUndefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:19]
+ 1 │ expect(undefined).toStrictEqual(undefined);
+   ·                   ────────────────────────
+   ╰────
+  help: Replace `toStrictEqual(undefined)` with `toBeUndefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeDefined` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toBe(undefined);
+   ·                    ───────────────────
+   ╰────
+  help: Replace `not.toBe(undefined)` with `toBeDefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeDefined` instead.
+   ╭─[prefer_to_be.tsx:1:28]
+ 1 │ expect("a string").rejects.not.toBe(undefined);
+   ·                            ───────────────────
+   ╰────
+  help: Replace `not.toBe(undefined)` with `toBeDefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeDefined` instead.
+   ╭─[prefer_to_be.tsx:1:27]
+ 1 │ expect("a string").rejects.not["toBe"](undefined);
+   ·                           ───────────────────────
+   ╰────
+  help: Replace `.not["toBe"](undefined)` with `["toBeDefined"]()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeDefined` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toEqual(undefined);
+   ·                    ──────────────────────
+   ╰────
+  help: Replace `not.toEqual(undefined)` with `toBeDefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeDefined` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toStrictEqual(undefined);
+   ·                    ────────────────────────────
+   ╰────
+  help: Replace `not.toStrictEqual(undefined)` with `toBeDefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:13]
+ 1 │ expect(NaN).toBe(NaN);
+   ·             ─────────
+   ╰────
+  help: Replace `toBe(NaN)` with `toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:13]
+ 1 │ expect(NaN).toEqual(NaN);
+   ·             ────────────
+   ╰────
+  help: Replace `toEqual(NaN)` with `toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:13]
+ 1 │ expect(NaN).toStrictEqual(NaN);
+   ·             ──────────────────
+   ╰────
+  help: Replace `toStrictEqual(NaN)` with `toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toBe(NaN);
+   ·                    ─────────────
+   ╰────
+  help: Replace `not.toBe(NaN)` with `not.toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:28]
+ 1 │ expect("a string").rejects.not.toBe(NaN);
+   ·                            ─────────────
+   ╰────
+  help: Replace `not.toBe(NaN)` with `not.toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:31]
+ 1 │ expect("a string")["rejects"].not.toBe(NaN);
+   ·                               ─────────────
+   ╰────
+  help: Replace `not.toBe(NaN)` with `not.toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toEqual(NaN);
+   ·                    ────────────────
+   ╰────
+  help: Replace `not.toEqual(NaN)` with `not.toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNaN` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toStrictEqual(NaN);
+   ·                    ──────────────────────
+   ╰────
+  help: Replace `not.toStrictEqual(NaN)` with `not.toBeNaN()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:19]
+ 1 │ expect(undefined).not.toBeDefined();
+   ·                   ─────────────────
+   ╰────
+  help: Replace `not.toBeDefined()` with `toBeUndefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:28]
+ 1 │ expect(undefined).resolves.not.toBeDefined();
+   ·                            ─────────────────
+   ╰────
+  help: Replace `not.toBeDefined()` with `toBeUndefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:28]
+ 1 │ expect(undefined).resolves.toBe(undefined);
+   ·                            ───────────────
+   ╰────
+  help: Replace `toBe(undefined)` with `toBeUndefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeDefined` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toBeUndefined();
+   ·                    ───────────────────
+   ╰────
+  help: Replace `not.toBeUndefined()` with `toBeDefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeDefined` instead.
+   ╭─[prefer_to_be.tsx:1:28]
+ 1 │ expect("a string").rejects.not.toBeUndefined();
+   ·                            ───────────────────
+   ╰────
+  help: Replace `not.toBeUndefined()` with `toBeDefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:14]
+ 1 │ expect(null).toEqual(1 as unknown as string as unknown as any);
+   ·              ───────
+   ╰────
+  help: Replace `toEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:14]
+ 1 │ expect(null).toEqual(-1 as unknown as string as unknown as any);
+   ·              ───────
+   ╰────
+  help: Replace `toEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBe` when expecting primitive literals.
+   ╭─[prefer_to_be.tsx:1:24]
+ 1 │ expect("a string").not.toStrictEqual("string" as number);
+   ·                        ─────────────
+   ╰────
+  help: Replace `toStrictEqual` with `toBe`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:14]
+ 1 │ expect(null).toBe(null as unknown as string as unknown as any);
+   ·              ─────────────────────────────────────────────────
+   ╰────
+  help: Replace `toBe(null as unknown as string as unknown as any)` with `toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeNull` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").not.toEqual(null as number);
+   ·                    ───────────────────────────
+   ╰────
+  help: Replace `not.toEqual(null as number)` with `not.toBeNull()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:19]
+ 1 │ expect(undefined).toBe(undefined as unknown as string as any);
+   ·                   ───────────────────────────────────────────
+   ╰────
+  help: Replace `toBe(undefined as unknown as string as any)` with `toBeUndefined()`.
+
+  ⚠ vitest(prefer-to-be): Use `toBeUndefined` instead.
+   ╭─[prefer_to_be.tsx:1:20]
+ 1 │ expect("a string").toEqual(undefined as number);
+   ·                    ────────────────────────────
+   ╰────
+  help: Replace `toEqual(undefined as number)` with `toBeUndefined()`.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
 // the crates/oxc_linter/data/vitest_compatible_jest_rules.json
 // file is also updated. The JSON file is used by the oxlint-migrate
 // and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 1] = ["prefer-to-be"];
+const VITEST_COMPATIBLE_JEST_RULES: [&str; 0] = [];
 
 /// List of Eslint rules that have TypeScript equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.


### PR DESCRIPTION
- part of #21664 