### PR TITLE
refactor(oxfmt): Use FormatConfig as SoT

### DIFF
--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
@@ -2,8 +2,8 @@ import { jsTextToDoc } from "../../index";
 import type { Parser, Doc } from "prettier";
 
 export const textToDoc: Parser<Doc>["parse"] = async (embeddedSourceText, textToDocOptions) => {
-  // `_oxfmtPluginOptionsJson` is a JSON string bundled by Rust (`oxfmtrc::finalize_external_options`),
-  // containing format options + parent filepath for the Rust-side `oxc_formatter`.
+  // `_oxfmtPluginOptionsJson` is a JSON string bundled by Rust (`oxfmtrc::inject_oxfmt_plugin_payload`),
+  // carrying the typed `FormatConfig` + parent filepath for the Rust-side `oxc_formatter`.
   const { parser, parentParser, filepath, _oxfmtPluginOptionsJson } = textToDocOptions;
 
   // For (j|t)s-in-xxx, default `parser` is either `babel`, `babel-ts` or `typescript`

--- a/apps/oxfmt/src/api/format_api.rs
+++ b/apps/oxfmt/src/api/format_api.rs
@@ -7,7 +7,7 @@ use oxc_napi::OxcError;
 use crate::core::{
     ExternalFormatter, FormatResult, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
     JsInitExternalFormatterCb, JsSortTailwindClassesCb, SourceFormatter, classify_file_kind,
-    resolve, utils,
+    resolve_for_api, utils,
 };
 
 pub struct ApiFormatResult {
@@ -64,7 +64,7 @@ pub fn run(
             errors: vec![OxcError::new(format!("Unsupported file type: {filename}"))],
         };
     };
-    let strategy = match resolve(options.unwrap_or_default(), kind, Some(&cwd)) {
+    let strategy = match resolve_for_api(options.unwrap_or_default(), kind, &cwd) {
         Ok(strategy) => strategy,
         Err(err) => {
             external_formatter.cleanup();

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use serde::Deserialize;
 use serde_json::Value;
 use tracing::{debug, instrument};
 
@@ -15,7 +16,11 @@ use oxc_span::SourceType;
 use crate::{
     core::{
         ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
-        JsInitExternalFormatterCb, JsSortTailwindClassesCb, resolve_options_for_embedded_js,
+        JsInitExternalFormatterCb, JsSortTailwindClassesCb,
+        oxfmtrc::{
+            FormatConfig, inject_filepath, inject_tailwind_plugin_payload, to_prettier_options,
+        },
+        resolve_for_embedded_js,
     },
     prettier_compat::to_prettier_doc,
 };
@@ -107,10 +112,9 @@ fn run_full(
 ) -> Option<Value> {
     let num_of_threads = 1;
 
-    // Options and paths in `_oxfmtPluginOptionsJson` are already resolved to absolute paths
-    // by `finalize_external_options()` when processing the parent file (e.g., App.vue).
-    // No further relative path resolution is needed here.
-    let (options, parent_filepath) = parse_options_and_filepath(oxfmt_plugin_options_json);
+    // Tailwind paths in the payload are already absolute (resolved by the host before serialization),
+    // so no `cwd` is threaded through here.
+    let (config, parent_filepath) = parse_payload(oxfmt_plugin_options_json);
 
     let external_formatter = ExternalFormatter::new(
         init_external_formatter_cb,
@@ -136,25 +140,19 @@ fn run_full(
             .expect("source_ext should be a valid JS/TS extension"),
     );
 
-    let (format_options, mut external_options, filepath_override) =
-        resolve_options_for_embedded_js(
-            options,
-            format!("embedded.{source_ext}").into(),
-            source_type,
-            None,
-        )
+    let resolved = resolve_for_embedded_js(config, parent_filepath)
         .expect("`_oxfmtPluginOptionsJson` should contain valid config");
 
-    // Set filepath on external options for Prettier plugins and Tailwind sorter.
-    // Use the filepath override (parent filepath, e.g., `App.vue`) if available,
-    // otherwise fall back to the parent filepath from plugin options.
-    let filepath = filepath_override.as_deref().unwrap_or(&parent_filepath);
-    if let Value::Object(ref mut map) = external_options {
-        map.insert("filepath".to_string(), Value::String(filepath.to_string_lossy().to_string()));
-    }
+    // Prettier options for callbacks that `oxc_formatter` may dispatch (e.g., CSS-in-JS).
+    // The embedded JS context is treated as always Tailwind-capable, so the inject is unconditional.
+    // The helper no-ops when user config has Tailwind disabled.
+    let mut external_options = to_prettier_options(&resolved.config);
+    inject_filepath(&mut external_options, &resolved.parent_filepath);
+    inject_tailwind_plugin_payload(&mut external_options, &resolved.config);
 
     let external_callbacks =
-        external_formatter.to_external_callbacks(&format_options, external_options);
+        external_formatter.to_external_callbacks(&resolved.format_options, external_options);
+    let format_options = resolved.format_options;
 
     let allocator = Allocator::default();
     let ret =
@@ -200,17 +198,12 @@ fn run_fragment(
     let source_type = SourceType::from_extension(source_ext)
         .expect("source_ext should be a valid JS/TS extension");
 
-    // NOTE: Options and paths are already resolved (see `run_full()` comment).
-    // And `run_fragment()` does not support external formatting, so no need to use `parent_filepath`.
-    let (options, _parent_filepath) = parse_options_and_filepath(oxfmt_plugin_options_json);
-
-    let (format_options, _, _) = resolve_options_for_embedded_js(
-        options,
-        format!("embedded.{source_ext}").into(),
-        source_type,
-        None,
-    )
-    .expect("`_oxfmtPluginOptionsJson` should contain valid config");
+    let (config, parent_filepath) = parse_payload(oxfmt_plugin_options_json);
+    // Reuses the same config resolver as `run_full()`, but only `format_options` is needed here,
+    // since `run_fragment()` does not dispatch external formatter callbacks.
+    let resolved = resolve_for_embedded_js(config, parent_filepath)
+        .expect("`_oxfmtPluginOptionsJson` should contain valid config");
+    let format_options = resolved.format_options;
 
     let allocator = Allocator::default();
     let ParserReturn { program, errors, .. } =
@@ -292,16 +285,14 @@ fn run_fragment(
 
 // ---
 
-/// Parses the plugin options JSON and extracts parent file path for external callbacks.
-///
-/// The `filepath` field (set by `core::oxfmtrc::finalize_external_options`) stores
-/// the parent file path (e.g. `App.vue`) for js-in-xxx formatting.
-fn parse_options_and_filepath(oxfmt_plugin_options_json: &str) -> (Value, PathBuf) {
-    let Ok(Value::Object(mut obj)) = serde_json::from_str(oxfmt_plugin_options_json) else {
-        unreachable!("`_oxfmtPluginOptionsJson` should be a valid JSON object");
-    };
-    let Some(Value::String(s)) = obj.remove("filepath") else {
-        unreachable!("Expected `filepath` in `_oxfmtPluginOptionsJson`");
-    };
-    (Value::Object(obj), PathBuf::from(s))
+/// Deserialize `_oxfmtPluginOptionsJson` into the typed config + parent filepath.
+fn parse_payload(oxfmt_plugin_options_json: &str) -> (FormatConfig, PathBuf) {
+    #[derive(Deserialize)]
+    struct Payload {
+        config: FormatConfig,
+        filepath: String,
+    }
+    let payload: Payload = serde_json::from_str(oxfmt_plugin_options_json)
+        .expect("`_oxfmtPluginOptionsJson` should deserialize");
+    (payload.config, PathBuf::from(payload.filepath))
 }

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -1,6 +1,4 @@
 use std::path::{Path, PathBuf};
-#[cfg(feature = "napi")]
-use std::sync::Arc;
 
 use editorconfig_parser::{
     EditorConfig, EditorConfigProperties, EditorConfigProperty, EndOfLine, IndentStyle,
@@ -16,20 +14,15 @@ use oxc_config_discovery::{
 };
 #[cfg(feature = "napi")]
 use oxc_formatter::FormatOptions;
-#[cfg(feature = "napi")]
-use oxc_span::SourceType;
 
+#[cfg(feature = "napi")]
+use super::js_config::JsConfigLoaderCb;
 use super::{
     FormatStrategy,
-    oxfmtrc::{
-        EndOfLineConfig, FormatConfig, OxfmtOptions, OxfmtOverrideConfig, Oxfmtrc,
-        sync_external_options, to_oxfmt_options,
-    },
+    oxfmtrc::{EndOfLineConfig, FormatConfig, OxfmtOverrideConfig, Oxfmtrc, to_format_options},
     support::FileKind,
     utils,
 };
-#[cfg(feature = "napi")]
-use super::{js_config::JsConfigLoaderCb, oxfmtrc::finalize_external_options};
 
 const OXFMT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: ".oxfmtrc.json",
@@ -55,79 +48,77 @@ pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
 /// This is the simplified path for the NAPI `format()` API,
 /// which doesn't need `.oxfmtrc` overrides, `.editorconfig`, or ignore patterns.
 ///
-/// If `cwd` is provided, relative Tailwind paths are resolved against it.
+/// Relative Tailwind paths are resolved against provided `cwd`.
 ///
 /// Returns `Err` only when the merged config fails validation.
 #[cfg(feature = "napi")]
-pub fn resolve(
+pub fn resolve_for_api(
     raw_config: Value,
     kind: FileKind,
-    cwd: Option<&Path>,
+    cwd: &Path,
 ) -> Result<FormatStrategy, String> {
-    let (oxfmt_options, external_options) = resolve_oxfmtrc_value(raw_config, cwd)?;
-    Ok(FormatStrategy::from_oxfmt_options(oxfmt_options, external_options, kind))
-}
-
-/// Resolve options for an embedded JS/TS fragment, returning the pieces needed by
-/// [`crate::api::text_to_doc_api`] without going through [`FormatStrategy`].
-///
-/// Returns `(format_options, external_options, filepath_override)`.
-/// The caller does not call `SourceFormatter::format()`, so wrapping in `FormatStrategy`
-/// would only force the caller to peel the `OxcFormatter` variant via `unreachable!`.
-#[cfg(feature = "napi")]
-pub fn resolve_options_for_embedded_js(
-    raw_config: Value,
-    path: PathBuf,
-    source_type: SourceType,
-    cwd: Option<&Path>,
-) -> Result<(Box<FormatOptions>, Value, Option<PathBuf>), String> {
-    let kind = FileKind::OxcFormatter { path: Arc::from(path), source_type };
-    let (oxfmt_options, mut external_options) = resolve_oxfmtrc_value(raw_config, cwd)?;
-    finalize_external_options(&mut external_options, &kind);
-    Ok((Box::new(oxfmt_options.format_options), external_options, None))
-}
-
-/// Shared core of NAPI option resolution: parse `raw_config`, resolve relative Tailwind paths,
-/// and produce the validated [`OxfmtOptions`] paired with the synced external options.
-#[cfg(feature = "napi")]
-fn resolve_oxfmtrc_value(
-    raw_config: Value,
-    cwd: Option<&Path>,
-) -> Result<(OxfmtOptions, Value), String> {
     let mut format_config: FormatConfig =
         serde_json::from_value(raw_config).map_err(|err| err.to_string())?;
-    if let Some(cwd) = cwd {
-        format_config.resolve_tailwind_paths(cwd);
-    }
+    format_config.resolve_tailwind_paths(cwd);
+    // Validate eagerly: `from_format_config` skips validation for `ExternalFormatter*` kinds,
+    // so range-out values (e.g., `printWidth: 1000`) would otherwise silently reach Prettier.
+    let _ = to_format_options(&format_config)?;
+    FormatStrategy::from_format_config(format_config, kind)
+}
 
-    let mut external_options =
-        serde_json::to_value(&format_config).expect("FormatConfig serialization should not fail");
-    let oxfmt_options = to_oxfmt_options(format_config)?;
+/// Resolved options ready for the embedded callback to drive `oxc_formatter`.
+#[cfg(feature = "napi")]
+#[derive(Debug)]
+pub struct EmbeddedCallbackResolved {
+    pub format_options: Box<FormatOptions>,
+    /// Retained so nested embedded callbacks can derive Prettier options on demand.
+    /// (e.g., CSS-in-JS inside the embedded JS)
+    pub config: Box<FormatConfig>,
+    pub parent_filepath: PathBuf,
+}
 
-    sync_external_options(&oxfmt_options.format_options, &mut external_options);
-
-    Ok((oxfmt_options, external_options))
+/// Resolve options for an embedded JS/TS fragment.
+///
+/// Called from [`crate::api::text_to_doc_api`] when Prettier invokes the
+/// `prettier-plugin-oxfmt` callback with the typed config + parent filepath
+/// recovered from `_oxfmtPluginOptionsJson`.
+///
+/// Returns the materialized pieces directly rather than a [`FormatStrategy`]
+/// because the callback drives `oxc_formatter` itself, not via `SourceFormatter::format()`.
+///
+/// Tailwind paths in `config` are already absolute (resolved by the host before serialization),
+/// so no `cwd` is threaded through here.
+#[cfg(feature = "napi")]
+pub fn resolve_for_embedded_js(
+    config: FormatConfig,
+    parent_filepath: PathBuf,
+) -> Result<EmbeddedCallbackResolved, String> {
+    let format_options = Box::new(to_format_options(&config)?);
+    Ok(EmbeddedCallbackResolved { format_options, config: Box::new(config), parent_filepath })
 }
 
 // ---
 
 /// Configuration resolver to handle `.oxfmtrc` and `.editorconfig` files.
 ///
-/// Priority order: `Oxfmtrc::default()` → user's `.oxfmtrc` base → `.oxfmtrc` overrides
-/// `.editorconfig` is applied as fallback for unset fields only.
+/// Priority (later wins):
+/// - `.editorconfig` (fallback for unset fields)
+/// - `.oxfmtrc` base
+/// - `.oxfmtrc` overrides matching the file path.
 #[derive(Debug)]
 pub struct ConfigResolver {
     /// User's raw config as JSON value.
-    /// It contains every possible field, even those not recognized by `Oxfmtrc`.
-    /// e.g. `printWidth`: recognized by both `Oxfmtrc` and Prettier
-    /// e.g. `vueIndentScriptAndStyle`: not recognized by `Oxfmtrc`, but used by Prettier
-    /// e.g. `svelteSortAttributes`: not recognized by Prettier and require plugins
+    ///
+    /// Retained because the slow path must re-deserialize [`FormatConfig`] from it.
+    /// (see [`Self::resolve_options`]).
+    /// Cloning a typed `base_config` is not enough, since `apply_editorconfig` only fills `is_none()` fields,
+    /// so per-file `[src/*.ts]` sections couldn't override values that the `[*]` section already baked in.
     raw_config: Value,
     /// Directory containing the config file (for relative path resolution in overrides).
     config_dir: Option<PathBuf>,
-    /// Cached parsed options after validation.
-    /// Used to avoid re-parsing during per-file resolution, if no per-file overrides exist.
-    cached_options: Option<(OxfmtOptions, Value)>,
+    /// Cached typed `FormatConfig` after `.oxfmtrc` base + `.editorconfig` `[*]` section is folded in.
+    /// Used as the fast-path snapshot when no per-file overrides apply.
+    base_config: Option<FormatConfig>,
     /// Resolved overrides from `.oxfmtrc` for file-specific matching.
     oxfmtrc_overrides: Option<OxfmtrcOverrides>,
     /// Ignore glob built from this config's `ignorePatterns`.
@@ -137,8 +128,9 @@ pub struct ConfigResolver {
 }
 
 impl ConfigResolver {
-    /// Shared internal constructor used by both `from_json_config()` (JSON/JSONC)
-    /// and `from_config()` (JS/TS config evaluated externally).
+    /// Shared internal constructor used by both:
+    /// - `from_json_config()` (JSON/JSONC)
+    /// - and `from_config()` (JS/TS config evaluated externally)
     fn new(
         raw_config: Value,
         config_dir: Option<PathBuf>,
@@ -147,7 +139,7 @@ impl ConfigResolver {
         Self {
             raw_config,
             config_dir,
-            cached_options: None,
+            base_config: None,
             oxfmtrc_overrides: None,
             ignore_glob: None,
             editorconfig,
@@ -345,12 +337,20 @@ impl ConfigResolver {
         Ok(Self::new(raw_config, config_dir, editorconfig))
     }
 
-    /// Validate config and return ignore patterns (= non-formatting option) for file walking.
+    /// Validate config and build the ignore glob from `ignorePatterns` for file walking.
     ///
-    /// Validated options are cached for fast path resolution.
+    /// Side effects:
+    /// - `self.base_config` is set to the validated `FormatConfig` snapshot
+    ///   (with `.editorconfig` `[*]` already folded in)
+    /// - `self.oxfmtrc_overrides` is set if `overrides` exists
+    /// - `self.ignore_glob` is built from `ignorePatterns`
+    ///
+    /// Validation runs eagerly via `to_format_options(&base_config)` so invalid
+    /// values (e.g., `printWidth: 99999`) are surfaced at config load time
+    /// regardless of which file kind is later processed.
     ///
     /// # Errors
-    /// Returns error if config deserialization fails.
+    /// Returns error if config deserialization or validation fails.
     #[instrument(level = "debug", name = "oxfmt::config::build_and_validate", skip_all)]
     pub fn build_and_validate(&mut self) -> Result<(), String> {
         let oxfmtrc: Oxfmtrc =
@@ -363,8 +363,8 @@ impl ConfigResolver {
 
         let mut format_config = oxfmtrc.format_config;
 
-        // If `.editorconfig` is used, apply its root section first
-        // If there are per-file overrides, they will be applied during `resolve()`
+        // Apply `.editorconfig` root section now. Per-file `[src/*.ts]` sections
+        // are deferred to the slow path during `resolve_options()`.
         if let Some(editorconfig) = &self.editorconfig
             && let Some(props) =
                 editorconfig.sections().iter().find(|s| s.name == "*").map(|s| &s.properties)
@@ -372,30 +372,15 @@ impl ConfigResolver {
             apply_editorconfig(&mut format_config, props);
         }
 
-        // Resolve relative tailwind paths before serialization
         if let Some(config_dir) = &self.config_dir {
             format_config.resolve_tailwind_paths(config_dir);
         }
 
-        // NOTE: Revisit this when adding Prettier plugin support.
-        // We use `format_config` directly instead of merging with `raw_config`.
-        // To preserve plugin-specific options,
-        // we would need to merge `raw_config` first, then apply `format_config` values on top.
-        // Or we could keep track of plugin options separately in `FormatConfig` itself,
-        // like how Tailwindcss options are handled currently.
-        let mut external_options = serde_json::to_value(&format_config)
-            .expect("FormatConfig serialization should not fail");
+        // Eagerly validate; see method doc for the rationale.
+        let _ = to_format_options(&format_config)?;
 
-        // Convert `FormatConfig` to `OxfmtOptions`, applying defaults where needed
-        let oxfmt_options = to_oxfmt_options(format_config)?;
-
-        // Apply common Prettier mappings for caching.
-        // Plugin options will be added later in `resolve()` via `finalize_external_options()`.
-        // If we finalize here, every per-file options contain plugin options even if not needed.
-        sync_external_options(&oxfmt_options.format_options, &mut external_options);
-
-        // Save cache for fast path: no per-file overrides
-        self.cached_options = Some((oxfmt_options, external_options));
+        // Save cached snapshot for fast path: no per-file overrides
+        self.base_config = Some(format_config);
 
         // Build ignore glob from `ignorePatterns` config field
         let ignore_patterns = oxfmtrc.ignore_patterns.unwrap_or_default();
@@ -409,31 +394,43 @@ impl ConfigResolver {
     /// Returns `Err` only when the merged config (after override application) fails validation.
     #[instrument(level = "debug", name = "oxfmt::config::resolve", skip_all, fields(path = %kind.path().display()))]
     pub fn resolve(&self, kind: FileKind) -> Result<FormatStrategy, String> {
-        let (oxfmt_options, external_options) = self.resolve_options(kind.path())?;
-        Ok(FormatStrategy::from_oxfmt_options(oxfmt_options, external_options, kind))
+        let format_config = self.resolve_options(kind.path())?;
+        FormatStrategy::from_format_config(format_config, kind)
     }
 
-    /// Resolve options for a specific file path.
-    /// Priority: oxfmtrc base → oxfmtrc overrides → editorconfig (fallback for unset fields) -> defaults
+    /// Resolve `FormatConfig` for a specific file path.
     ///
-    /// Returns cached options (with `strategy: None` applied) for later plugin option addition.
-    fn resolve_options(&self, path: &Path) -> Result<(OxfmtOptions, Value), String> {
+    /// Priority (later wins):
+    /// - `.editorconfig` (fallback for unset fields)
+    /// - `.oxfmtrc` base
+    /// - `.oxfmtrc` overrides matching the file path
+    ///
+    /// Fast path: Skips validation within this method because `base_config` is pre-validated in [`Self::build_and_validate`].
+    /// Slow path: Always validates the merged config here.
+    /// - For `OxcFormatter` / `OxfmtToml` kinds, [`FormatStrategy::from_format_config`] also re-validates via typed conversion (redundant but harmless).
+    /// - For `ExternalFormatter*` kinds, this is the only safety net before values reach Prettier.
+    ///
+    /// # Errors
+    /// Returns `Err` when overrides introduce invalid values, including:
+    /// - range-out values (e.g., `printWidth: 1000`)
+    /// - broken compound-option combinations (e.g., `sortImports.groups` + `partitionByNewline`)
+    fn resolve_options(&self, path: &Path) -> Result<FormatConfig, String> {
         let has_editorconfig_overrides =
             self.editorconfig.as_ref().is_some_and(|ec| has_editorconfig_overrides(ec, path));
         let has_oxfmtrc_overrides =
             self.oxfmtrc_overrides.as_ref().is_some_and(|o| o.has_match(path));
 
-        // Fast path: no per-file overrides
-        // `.editorconfig` root section is already applied during `build_and_validate()`
+        // Fast path: no per-file overrides → reuse the cached (already-validated) snapshot.
+        // `.editorconfig` `[*]` is already folded in during `build_and_validate()`.
         if !has_editorconfig_overrides && !has_oxfmtrc_overrides {
             return Ok(self
-                .cached_options
+                .base_config
                 .clone()
                 .expect("`build_and_validate()` must be called first"));
         }
 
-        // Slow path: reconstruct `FormatConfig` to apply overrides
-        // Overrides are merged at `FormatConfig` level, not `OxfmtOptions` level
+        // Slow path: must rebuild from `raw_config`, NOT from `base_config`.
+        // See `raw_config` field doc for why cloning the typed snapshot is insufficient.
         let mut format_config: FormatConfig = serde_json::from_value(self.raw_config.clone())
             .expect("`build_and_validate()` should catch this before");
 
@@ -443,25 +440,23 @@ impl ConfigResolver {
                 format_config.merge(options);
             }
         }
-        // Apply `.editorconfig` as fallback (fills in unset fields only)
+        // Apply `.editorconfig` as fallback (fills in unset fields only).
+        // `EditorConfig::resolve` returns `[*]` + `[src/*.ts]` merged, with per-file
+        // values winning, so per-file editorconfig fallback works even after overrides.
         if let Some(ec) = &self.editorconfig {
             let props = ec.resolve(path);
             apply_editorconfig(&mut format_config, &props);
         }
 
-        // Resolve relative tailwind paths before serialization
         if let Some(config_dir) = &self.config_dir {
             format_config.resolve_tailwind_paths(config_dir);
         }
 
-        // NOTE: See `build_and_validate()` for details about `external_options` handling
-        let mut external_options = serde_json::to_value(&format_config)
-            .expect("FormatConfig serialization should not fail");
-        let oxfmt_options = to_oxfmt_options(format_config)?;
+        // Validate the merged config; see method doc for what kinds of errors are caught
+        // and why this is the only safety net for `ExternalFormatter*` kinds.
+        let _ = to_format_options(&format_config)?;
 
-        sync_external_options(&oxfmt_options.format_options, &mut external_options);
-
-        Ok((oxfmt_options, external_options))
+        Ok(format_config)
     }
 }
 
@@ -712,5 +707,95 @@ fn apply_editorconfig(config: &mut FormatConfig, props: &EditorConfigProperties)
             }
             _ => {}
         }
+    }
+}
+
+// ---
+
+#[cfg(test)]
+mod tests_slow_path_validation {
+    use std::{path::PathBuf, sync::Arc};
+
+    use super::*;
+
+    fn resolver_from_json(raw: serde_json::Value) -> ConfigResolver {
+        let mut resolver = ConfigResolver::new(raw, None, None);
+        resolver.build_and_validate().expect("base config must be valid for these tests");
+        resolver
+    }
+
+    /// PR #21919 follow-up: invalid override values must be caught at resolve time
+    /// even for `ExternalFormatter*` kinds (which don't re-validate inside
+    /// `from_format_config`). Without slow-path validation in `resolve_options`,
+    /// `printWidth: 1000` (above LineWidth::MAX = 320) would silently leak into
+    /// the Prettier options.
+    #[test]
+    #[cfg(feature = "napi")]
+    fn override_only_invalid_value_is_rejected_for_external_formatter() {
+        let resolver = resolver_from_json(serde_json::json!({
+            "printWidth": 80,
+            "overrides": [
+                { "files": ["*.json"], "options": { "printWidth": 1000 } }
+            ]
+        }));
+
+        // Slow path triggers because the override matches.
+        let kind = FileKind::ExternalFormatter {
+            path: Arc::from(PathBuf::from("data.json").as_path()),
+            parser_name: "json",
+            supports_tailwind: false,
+            supports_oxfmt: false,
+        };
+        let err = resolver.resolve(kind).unwrap_err();
+        assert!(err.contains("printWidth"), "expected printWidth validation error, got: {err}");
+    }
+
+    #[test]
+    fn override_only_invalid_value_is_rejected_for_oxc_formatter() {
+        let resolver = resolver_from_json(serde_json::json!({
+            "tabWidth": 2,
+            "overrides": [
+                { "files": ["*.ts"], "options": { "tabWidth": 250 } }
+            ]
+        }));
+
+        let kind = FileKind::OxcFormatter {
+            path: Arc::from(PathBuf::from("src/test.ts").as_path()),
+            source_type: oxc_span::SourceType::ts(),
+        };
+        let err = resolver.resolve(kind).unwrap_err();
+        assert!(err.contains("tabWidth"), "expected tabWidth validation error, got: {err}");
+    }
+
+    /// Smoke test: when no overrides match, `resolve()` returns successfully.
+    ///
+    /// `resolve_options` itself skips re-validation on the fast path
+    /// (just clones the pre-validated `base_config`), but
+    /// `FormatStrategy::from_format_config` still calls `to_format_options` for
+    /// `OxcFormatter`/`OxfmtToml`, so this test cannot directly assert "no re-validation"
+    /// — only that the overall call succeeds.
+    #[test]
+    fn fast_path_resolve_succeeds() {
+        let resolver = resolver_from_json(serde_json::json!({ "printWidth": 80 }));
+
+        let kind = FileKind::OxfmtToml { path: Arc::from(PathBuf::from("Cargo.toml").as_path()) };
+        assert!(resolver.resolve(kind).is_ok());
+    }
+
+    /// `resolve_for_api` must validate even for `ExternalFormatter*` kinds.
+    /// Without the eager `to_format_options` call, `printWidth: 1000` would
+    /// silently flow through to Prettier via the NAPI `format()` API.
+    #[test]
+    #[cfg(feature = "napi")]
+    fn resolve_for_api_rejects_invalid_value_for_external_formatter() {
+        let kind = FileKind::ExternalFormatter {
+            path: Arc::from(PathBuf::from("style.css").as_path()),
+            parser_name: "css",
+            supports_tailwind: true,
+            supports_oxfmt: false,
+        };
+        let err = resolve_for_api(serde_json::json!({ "printWidth": 1000 }), kind, Path::new("."))
+            .unwrap_err();
+        assert!(err.contains("printWidth"), "expected printWidth validation error, got: {err}");
     }
 }

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -14,7 +14,7 @@ use oxc_formatter::{
     TailwindCallback,
 };
 
-use crate::prettier_compat::from_prettier_doc;
+use crate::{core::oxfmtrc::inject_parser, prettier_compat::from_prettier_doc};
 
 /// Type alias for the init external formatter callback function signature.
 /// Takes num_threads as argument and returns plugin languages.
@@ -254,12 +254,7 @@ impl ExternalFormatter {
                         // `clone()` is unavoidable here,
                         // because there may be multiple embedded sections in one JS/TS file.
                         let mut options = options_for_embedded.clone();
-                        if let Value::Object(ref mut map) = options {
-                            map.insert(
-                                "parser".to_string(),
-                                Value::String(parser_name.to_string()),
-                            );
-                        }
+                        inject_parser(&mut options, parser_name);
                         (format_embedded)(options, code)
                             .map(|mut code| {
                                 // Remove trailing newline added by Prettier without allocation
@@ -288,12 +283,7 @@ impl ExternalFormatter {
                 debug_span!("oxfmt::external::format_embedded_doc", parser = parser_name)
                     .in_scope(|| {
                         let mut options = options_for_doc.clone();
-                        if let Value::Object(ref mut map) = options {
-                            map.insert(
-                                "parser".to_string(),
-                                Value::String(parser_name.to_string()),
-                            );
-                        }
+                        inject_parser(&mut options, parser_name);
                         let doc_json_strs =
                             (format_embedded_doc)(options, texts).map_err(|err| {
                                 format!(

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -1,8 +1,6 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::Path, sync::Arc};
 
+#[cfg(feature = "napi")]
 use serde_json::Value;
 use tracing::instrument;
 
@@ -13,41 +11,54 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxc_toml::Options as TomlFormatterOptions;
 
+#[cfg(feature = "napi")]
+use super::oxfmtrc::{
+    SortPackageJsonConfig, SortPackageJsonUserConfig, inject_filepath, inject_oxfmt_plugin_payload,
+    inject_parser, inject_tailwind_plugin_payload, to_prettier_options,
+};
 use super::{
-    oxfmtrc::{OxfmtOptions, finalize_external_options},
+    oxfmtrc::{FormatConfig, to_format_options, to_toml_options},
     support::FileKind,
 };
 
 /// A resolved formatting target: classification + per-file resolved options.
 ///
 /// Built by [`super::ConfigResolver::resolve`] (or the NAPI variant-specific helpers)
-/// from a [`FileKind`] and the resolved configuration for that file.
+/// from a [`FileKind`] and the resolved [`FormatConfig`] for that file.
 /// Each variant carries everything needed to format the file.
+///
+/// Prettier `Value` options are derived from `config` at the format step, not stored.
 #[derive(Debug)]
 pub enum FormatStrategy {
     /// For JS/TS files formatted by oxc_formatter.
+    /// `config` is retained so embedded callbacks (e.g., CSS-in-JS) can lazily
+    /// derive Prettier options at callback time.
     OxcFormatter {
         path: Arc<Path>,
         source_type: SourceType,
         format_options: Box<FormatOptions>,
-        /// For embedded language (xxx-in-js) formatting
-        external_options: Value,
-        /// Optional filepath override for external callbacks (e.g., Tailwind sorter).
-        /// When set, this path is used instead of `path` as the `options.filepath`
-        /// passed to external callbacks.
-        /// Needed for js-in-xxx where the path is a dummy, but callbacks need the
-        /// parent file path to resolve their config.
-        filepath_override: Option<PathBuf>,
+        #[cfg(feature = "napi")]
+        config: Box<FormatConfig>,
         insert_final_newline: bool,
     },
     /// For TOML files.
     OxfmtToml { path: Arc<Path>, toml_options: TomlFormatterOptions, insert_final_newline: bool },
     /// For non-JS files formatted by external formatter (Prettier).
+    ///
+    /// `supports_tailwind` / `supports_oxfmt` are capability flags carried over from
+    /// [`FileKind::ExternalFormatter`]. The format step injects the corresponding
+    /// payload (`_useTailwindPlugin` / `_oxfmtPluginOptionsJson`) only when the
+    /// capability AND the user config both enable the plugin.
+    ///
+    /// When `supports_oxfmt` is true, `config` doubles as the host Prettier options
+    /// source AND the `_oxfmtPluginOptionsJson` payload — single SoT for both.
     #[cfg(feature = "napi")]
     ExternalFormatter {
         path: Arc<Path>,
         parser_name: &'static str,
-        external_options: Value,
+        config: Box<FormatConfig>,
+        supports_tailwind: bool,
+        supports_oxfmt: bool,
         insert_final_newline: bool,
     },
     /// For `package.json` files: optionally sorted then formatted.
@@ -55,7 +66,7 @@ pub enum FormatStrategy {
     ExternalFormatterPackageJson {
         path: Arc<Path>,
         parser_name: &'static str,
-        external_options: Value,
+        config: Box<FormatConfig>,
         sort_package_json: Option<sort_package_json::SortOptions>,
         insert_final_newline: bool,
     },
@@ -71,52 +82,67 @@ impl FormatStrategy {
         }
     }
 
-    /// Build `FormatStrategy` from a [`FileKind`], `OxfmtOptions`, and external options.
+    /// Build a `FormatStrategy` from a typed [`FormatConfig`] and a [`FileKind`].
     ///
-    /// Also applies plugin-specific options (Tailwind, oxfmt plugin flags) based on file kind.
-    pub(crate) fn from_oxfmt_options(
-        oxfmt_options: OxfmtOptions,
-        mut external_options: Value,
-        kind: FileKind,
-    ) -> Self {
-        finalize_external_options(&mut external_options, &kind);
+    /// `to_format_options` / `to_toml_options` run eagerly: their validating
+    /// typed conversion belongs at carving so the format step stays infallible.
+    /// The Prettier `Value` for `ExternalFormatter*` is deferred:
+    /// `FormatConfig` is the single SoT, no validation needed,
+    /// and `Box<FormatConfig>` is materially smaller per file than a fully-built `Value`.
+    ///
+    /// # Errors
+    /// Returns `Err` if the kind needs `FormatOptions`/`TomlFormatterOptions`
+    /// and the config fails validation.
+    // `config` is moved into the napi-only `ExternalFormatter*` variants;
+    // when the `napi` feature is off, those branches are cfg-gated out and the
+    // value is only borrowed, but we keep the by-value signature for symmetry.
+    #[cfg_attr(not(feature = "napi"), expect(clippy::needless_pass_by_value))]
+    pub(crate) fn from_format_config(config: FormatConfig, kind: FileKind) -> Result<Self, String> {
+        let insert_final_newline = config.insert_final_newline.unwrap_or(true);
 
-        #[cfg(feature = "napi")]
-        let OxfmtOptions { format_options, toml_options, sort_package_json, insert_final_newline } =
-            oxfmt_options;
-        #[cfg(not(feature = "napi"))]
-        let OxfmtOptions { format_options, toml_options, insert_final_newline, .. } = oxfmt_options;
-
-        match kind {
+        Ok(match kind {
             FileKind::OxcFormatter { path, source_type } => Self::OxcFormatter {
                 path,
                 source_type,
-                format_options: Box::new(format_options),
-                external_options,
-                filepath_override: None,
+                format_options: Box::new(to_format_options(&config)?),
+                #[cfg(feature = "napi")]
+                config: Box::new(config),
                 insert_final_newline,
             },
-            FileKind::OxfmtToml { path } => {
-                Self::OxfmtToml { path, toml_options, insert_final_newline }
-            }
+            FileKind::OxfmtToml { path } => Self::OxfmtToml {
+                path,
+                toml_options: to_toml_options(&config)?,
+                insert_final_newline,
+            },
             #[cfg(feature = "napi")]
-            FileKind::ExternalFormatter { path, parser_name } => Self::ExternalFormatter {
+            FileKind::ExternalFormatter {
                 path,
                 parser_name,
-                external_options,
+                supports_tailwind,
+                supports_oxfmt,
+            } => Self::ExternalFormatter {
+                path,
+                parser_name,
+                config: Box::new(config),
+                supports_tailwind,
+                supports_oxfmt,
                 insert_final_newline,
             },
             #[cfg(feature = "napi")]
             FileKind::ExternalFormatterPackageJson { path, parser_name } => {
+                let sort_package_json = config.sort_package_json.as_ref().map_or_else(
+                    || Some(SortPackageJsonConfig::default().to_sort_options()),
+                    SortPackageJsonUserConfig::to_sort_options,
+                );
                 Self::ExternalFormatterPackageJson {
                     path,
                     parser_name,
-                    external_options,
+                    config: Box::new(config),
                     sort_package_json,
                     insert_final_newline,
                 }
             }
-        }
+        })
     }
 }
 
@@ -150,8 +176,8 @@ impl SourceFormatter {
                 path,
                 source_type,
                 format_options,
-                external_options,
-                filepath_override,
+                #[cfg(feature = "napi")]
+                config,
                 insert_final_newline,
             } => (
                 self.format_by_oxc_formatter(
@@ -159,8 +185,8 @@ impl SourceFormatter {
                     &path,
                     source_type,
                     *format_options,
-                    external_options,
-                    filepath_override.as_deref(),
+                    #[cfg(feature = "napi")]
+                    &config,
                 ),
                 insert_final_newline,
             ),
@@ -171,14 +197,18 @@ impl SourceFormatter {
             FormatStrategy::ExternalFormatter {
                 path,
                 parser_name,
-                external_options,
+                config,
+                supports_tailwind,
+                supports_oxfmt,
                 insert_final_newline,
             } => (
                 self.format_by_external_formatter(
                     source_text,
                     &path,
                     parser_name,
-                    external_options,
+                    &config,
+                    supports_tailwind,
+                    supports_oxfmt,
                 ),
                 insert_final_newline,
             ),
@@ -186,7 +216,7 @@ impl SourceFormatter {
             FormatStrategy::ExternalFormatterPackageJson {
                 path,
                 parser_name,
-                external_options,
+                config,
                 sort_package_json,
                 insert_final_newline,
             } => (
@@ -194,7 +224,7 @@ impl SourceFormatter {
                     source_text,
                     &path,
                     parser_name,
-                    external_options,
+                    &config,
                     sort_package_json.as_ref(),
                 ),
                 insert_final_newline,
@@ -219,7 +249,7 @@ impl SourceFormatter {
     }
 
     /// Format JS/TS source code using `oxc_formatter`.
-    /// For embedded part and Tailwindcss sorting, `external_options` and `filepath_override` are used.
+    /// `config` is needed to derive Prettier options for embedded callbacks (CSS-in-JS, Tailwind).
     #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter", skip_all)]
     fn format_by_oxc_formatter(
         &self,
@@ -227,8 +257,7 @@ impl SourceFormatter {
         path: &Path,
         source_type: SourceType,
         format_options: FormatOptions,
-        external_options: Value,
-        filepath_override: Option<&Path>,
+        #[cfg(feature = "napi")] config: &FormatConfig,
     ) -> Result<String, OxcDiagnostic> {
         let source_type = enable_jsx_source_type(source_type);
         let allocator = self.allocator_pool.get();
@@ -242,15 +271,10 @@ impl SourceFormatter {
         }
 
         #[cfg(feature = "napi")]
-        let external_callbacks = Some(self.build_external_callbacks(
-            &format_options,
-            external_options,
-            path,
-            filepath_override,
-        ));
+        let external_callbacks = Some(self.build_external_callbacks(&format_options, config, path));
         #[cfg(not(feature = "napi"))]
         let external_callbacks = {
-            let _ = (path, external_options, filepath_override);
+            let _ = path;
             None
         };
 
@@ -303,55 +327,99 @@ impl SourceFormatter {
 
     /// Build external callbacks for `oxc_formatter` from the NAPI external formatter.
     ///
-    /// Sets `filepath` on options for Prettier plugins that depend on it,
-    /// and for the Tailwind sorter to resolve config.
-    /// `filepath_override` is `Some` in js-in-xxx flow (via `textToDoc()`),
-    /// where `path` is a dummy like `embedded.ts` but callbacks need the parent file path.
-    /// See `oxfmtrc::finalize_external_options()` for where this filepath originates.
+    /// Tailwind is always considered "capable" here because `oxc_formatter`
+    /// embeds the sorter internally; the inject helper itself decides whether
+    /// to fire based on user config.
     fn build_external_callbacks(
         &self,
         format_options: &FormatOptions,
-        mut external_options: Value,
+        config: &FormatConfig,
         path: &Path,
-        filepath_override: Option<&Path>,
     ) -> oxc_formatter::ExternalCallbacks {
         let external_formatter = self
             .external_formatter
             .as_ref()
             .expect("`external_formatter` must exist when `napi` feature is enabled");
 
-        if let Value::Object(ref mut map) = external_options {
-            let filepath = filepath_override.unwrap_or(path);
-            map.insert(
-                "filepath".to_string(),
-                Value::String(filepath.to_string_lossy().to_string()),
-            );
-        }
+        let mut external_options = to_prettier_options(config);
+        inject_filepath(&mut external_options, path);
+        inject_tailwind_plugin_payload(&mut external_options, config);
 
         external_formatter.to_external_callbacks(format_options, external_options)
     }
 
     /// Format non-JS/TS file using external formatter (Prettier).
+    ///
+    /// Plugin payloads are injected based on capability flags & user config.
     #[instrument(level = "debug", name = "oxfmt::format::external_formatter", skip_all, fields(parser = %parser_name))]
     fn format_by_external_formatter(
         &self,
         source_text: &str,
         path: &Path,
         parser_name: &str,
-        mut external_options: Value,
+        config: &FormatConfig,
+        supports_tailwind: bool,
+        supports_oxfmt: bool,
+    ) -> Result<String, OxcDiagnostic> {
+        let mut external_options = to_prettier_options(config);
+        inject_parser(&mut external_options, parser_name);
+        inject_filepath(&mut external_options, path);
+
+        if supports_tailwind {
+            inject_tailwind_plugin_payload(&mut external_options, config);
+        }
+        if supports_oxfmt {
+            inject_oxfmt_plugin_payload(&mut external_options, config, path);
+        }
+
+        self.invoke_external_formatter(external_options, source_text, path)
+    }
+
+    /// Format `package.json`: optionally sort then format by external formatter.
+    #[instrument(
+        level = "debug",
+        name = "oxfmt::format::external_formatter_package_json",
+        skip_all
+    )]
+    fn format_by_external_formatter_package_json(
+        &self,
+        source_text: &str,
+        path: &Path,
+        parser_name: &str,
+        config: &FormatConfig,
+        sort_options: Option<&sort_package_json::SortOptions>,
+    ) -> Result<String, OxcDiagnostic> {
+        use std::borrow::Cow;
+        let source_text: Cow<'_, str> = if let Some(options) = sort_options {
+            match sort_package_json::sort_package_json_with_options(source_text, options) {
+                Ok(sorted) => Cow::Owned(sorted),
+                // `sort_package_json` can only handle strictly valid JSON.
+                // On the other hand, Prettier's `json-stringify` parser is very permissive.
+                // It can format JSON like input even with unquoted keys or trailing commas.
+                // Therefore, rather than bailing out due to a sorting failure, we opt to format without sorting.
+                Err(_) => Cow::Borrowed(source_text),
+            }
+        } else {
+            Cow::Borrowed(source_text)
+        };
+
+        let mut external_options = to_prettier_options(config);
+        inject_parser(&mut external_options, parser_name);
+        inject_filepath(&mut external_options, path);
+        self.invoke_external_formatter(external_options, &source_text, path)
+    }
+
+    /// Invoke Prettier via NAPI and adapt error messages to look like `OxcDiagnostic`.
+    fn invoke_external_formatter(
+        &self,
+        external_options: Value,
+        source_text: &str,
+        path: &Path,
     ) -> Result<String, OxcDiagnostic> {
         let external_formatter = self
             .external_formatter
             .as_ref()
             .expect("`external_formatter` must exist when `napi` feature is enabled");
-
-        // Set `parser` and `filepath` on options for Prettier.
-        // We specify `parser` to skip parser inference for perf,
-        // and `filepath` because some plugins depend on it.
-        if let Value::Object(ref mut map) = external_options {
-            map.insert("parser".to_string(), Value::String(parser_name.to_string()));
-            map.insert("filepath".to_string(), Value::String(path.to_string_lossy().to_string()));
-        }
 
         external_formatter.format_file(external_options, source_text).map_err(|err| {
             // NOTE: We are trying to make the error from oxc_formatter and external_formatter (Prettier) look similar.
@@ -372,36 +440,5 @@ impl SourceFormatter {
             };
             OxcDiagnostic::error(message)
         })
-    }
-
-    /// Format `package.json`: optionally sort then format by external formatter.
-    #[instrument(
-        level = "debug",
-        name = "oxfmt::format::external_formatter_package_json",
-        skip_all
-    )]
-    fn format_by_external_formatter_package_json(
-        &self,
-        source_text: &str,
-        path: &Path,
-        parser_name: &str,
-        external_options: Value,
-        sort_options: Option<&sort_package_json::SortOptions>,
-    ) -> Result<String, OxcDiagnostic> {
-        use std::borrow::Cow;
-        let source_text: Cow<'_, str> = if let Some(options) = sort_options {
-            match sort_package_json::sort_package_json_with_options(source_text, options) {
-                Ok(sorted) => Cow::Owned(sorted),
-                // `sort_package_json` can only handle strictly valid JSON.
-                // On the other hand, Prettier's `json-stringify` parser is very permissive.
-                // It can format JSON like input even with unquoted keys or trailing commas.
-                // Therefore, rather than bailing out due to a sorting failure, we opt to format without sorting.
-                Err(_) => Cow::Borrowed(source_text),
-            }
-        } else {
-            Cow::Borrowed(source_text)
-        };
-
-        self.format_by_external_formatter(&source_text, path, parser_name, external_options)
     }
 }

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -11,7 +11,7 @@ mod js_config;
 
 pub use config::{ConfigResolver, config_discovery, resolve_editorconfig_path};
 #[cfg(feature = "napi")]
-pub use config::{resolve, resolve_options_for_embedded_js};
+pub use config::{resolve_for_api, resolve_for_embedded_js};
 pub use format::{FormatResult, FormatStrategy, SourceFormatter};
 pub use support::classify_file_kind;
 

--- a/apps/oxfmt/src/core/oxfmtrc/format_config.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/format_config.rs
@@ -622,7 +622,7 @@ pub struct SortPackageJsonConfig {
 }
 
 impl SortPackageJsonConfig {
-    pub(super) fn to_sort_options(&self) -> sort_package_json::SortOptions {
+    pub fn to_sort_options(&self) -> sort_package_json::SortOptions {
         sort_package_json::SortOptions {
             sort_scripts: self.sort_scripts.unwrap_or(false),
             // Small optimization: Prettier will reformat anyway

--- a/apps/oxfmt/src/core/oxfmtrc/mod.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/mod.rs
@@ -3,7 +3,12 @@ mod to_external_options;
 mod to_oxfmt_options;
 
 pub use format_config::{
-    EndOfLineConfig, FormatConfig, OxfmtOverrideConfig, Oxfmtrc, SortPackageJsonUserConfig,
+    EndOfLineConfig, FormatConfig, OxfmtOverrideConfig, Oxfmtrc, SortPackageJsonConfig,
+    SortPackageJsonUserConfig,
 };
-pub use to_external_options::{finalize_external_options, sync_external_options};
-pub use to_oxfmt_options::{OxfmtOptions, to_oxfmt_options};
+#[cfg(feature = "napi")]
+pub use to_external_options::inject_oxfmt_plugin_payload;
+pub use to_external_options::{
+    inject_filepath, inject_parser, inject_tailwind_plugin_payload, to_prettier_options,
+};
+pub use to_oxfmt_options::{to_format_options, to_toml_options};

--- a/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
@@ -1,188 +1,241 @@
+use std::path::Path;
+
+#[cfg(feature = "napi")]
+use serde::Serialize;
 use serde_json::Value;
 
-use oxc_formatter::{FormatOptions, IndentStyle, LineEnding};
+use oxc_formatter::FormatOptions;
 
-use crate::core::support::FileKind;
+use super::format_config::{
+    ArrowParensConfig, EmbeddedLanguageFormattingConfig, EndOfLineConfig, FormatConfig,
+    HtmlWhitespaceSensitivityConfig, ObjectWrapConfig, ProseWrapConfig, QuotePropsConfig,
+    SortTailwindcssUserConfig, TrailingCommaConfig,
+};
 
-/// Syncs resolved `FormatOptions` values into the raw config JSON.
-/// This ensures `external_formatter`(Prettier) receives the same options that `oxc_formatter` uses.
+/// Build base Prettier-compatible options from a typed `FormatConfig`.
 ///
-/// Only options that meet one of these criteria need to be mapped:
-/// - 1. Different defaults between Prettier and oxc_formatter
-///   - e.g. `printWidth`: Prettier: 80, Oxfmt: 100
-/// - 2. Can be set via `.editorconfig` (values won't be in raw config JSON)
-///   - `max_line_length` -> `printWidth`
-///   - `end_of_line` -> `endOfLine`
-///   - `indent_style` -> `useTabs`
-///   - `indent_size` -> `tabWidth`
+/// Emits only Prettier-known keys.
+/// - `printWidth` is always present because Prettier's default (80) differs from oxfmt's (100)
+///   - We must send oxfmt's default explicitly
+/// - Every other key is emitted only when the user (or `.editorconfig` via `apply_editorconfig`) set it
+/// - oxfmt-specific keys are never emitted
+///   - To reduce confusion and JSON size
 ///
-/// This function should be called once during config caching.
-/// For strategy-specific options (plugin flags), use [`finalize_external_options()`] separately.
-pub fn sync_external_options(options: &FormatOptions, config: &mut Value) {
-    let Some(obj) = config.as_object_mut() else {
-        return;
-    };
+/// `parser`, `filepath`, and plugin payloads are layered in via the dedicated `inject_*` helpers below.
+pub fn to_prettier_options(config: &FormatConfig) -> Value {
+    let mut obj = serde_json::Map::new();
 
-    // vs Prettier defaults and `.editorconfig` values
-    obj.insert("printWidth".to_string(), Value::from(options.line_width.value()));
-
-    // vs `.editorconfig` values
+    // `printWidth` is the one core option whose default genuinely differs
+    // (Prettier 80 vs oxfmt 100), so we send oxfmt's default when unset.
+    // TODO: Read the default from a neutral source (e.g. a shared `oxc_formatter_core`
+    // / `ResolvedFormatConfig`) instead of the JS formatter's typed enum once available.
     obj.insert(
-        "useTabs".to_string(),
-        Value::from(match options.indent_style {
-            IndentStyle::Tab => true,
-            IndentStyle::Space => false,
-        }),
-    );
-    obj.insert("tabWidth".to_string(), Value::from(options.indent_width.value()));
-    obj.insert(
-        "endOfLine".to_string(),
-        Value::from(match options.line_ending {
-            LineEnding::Lf => "lf",
-            LineEnding::Crlf => "crlf",
-            LineEnding::Cr => "cr",
-        }),
+        "printWidth".to_string(),
+        Value::from(config.print_width.unwrap_or(FormatOptions::default().line_width.value())),
     );
 
-    // Any other fields are preserved as-is.
-    // - e.g. `htmlWhitespaceSensitivity`, `vueIndentScriptAndStyle`, etc.
-    //   - Defined in `Oxfmtrc`, but only used by Prettier
-    // - e.g. `plugins`
-    //   - It does not mean plugin works correctly with Oxfmt
-    //   - Oxfmt still not aware of any plugin-defined languages
-    // Other options defined independently by plugins are also left as they are.
+    // Other Prettier core options share defaults with oxfmt,
+    // so we only emit when the user (or `.editorconfig` via `apply_editorconfig`) set them.
+    if let Some(v) = config.use_tabs {
+        obj.insert("useTabs".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.tab_width {
+        obj.insert("tabWidth".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.end_of_line {
+        obj.insert(
+            "endOfLine".to_string(),
+            Value::from(match v {
+                EndOfLineConfig::Lf => "lf",
+                EndOfLineConfig::Crlf => "crlf",
+                EndOfLineConfig::Cr => "cr",
+            }),
+        );
+    }
+    if let Some(v) = config.single_quote {
+        obj.insert("singleQuote".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.jsx_single_quote {
+        obj.insert("jsxSingleQuote".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.quote_props {
+        obj.insert(
+            "quoteProps".to_string(),
+            Value::from(match v {
+                QuotePropsConfig::AsNeeded => "as-needed",
+                QuotePropsConfig::Consistent => "consistent",
+                QuotePropsConfig::Preserve => "preserve",
+            }),
+        );
+    }
+    if let Some(v) = config.trailing_comma {
+        obj.insert(
+            "trailingComma".to_string(),
+            Value::from(match v {
+                TrailingCommaConfig::All => "all",
+                TrailingCommaConfig::Es5 => "es5",
+                TrailingCommaConfig::None => "none",
+            }),
+        );
+    }
+    if let Some(v) = config.semi {
+        obj.insert("semi".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.arrow_parens {
+        obj.insert(
+            "arrowParens".to_string(),
+            Value::from(match v {
+                ArrowParensConfig::Always => "always",
+                ArrowParensConfig::Avoid => "avoid",
+            }),
+        );
+    }
+    if let Some(v) = config.bracket_spacing {
+        obj.insert("bracketSpacing".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.bracket_same_line {
+        obj.insert("bracketSameLine".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.object_wrap {
+        obj.insert(
+            "objectWrap".to_string(),
+            Value::from(match v {
+                ObjectWrapConfig::Preserve => "preserve",
+                ObjectWrapConfig::Collapse => "collapse",
+            }),
+        );
+    }
+    if let Some(v) = config.single_attribute_per_line {
+        obj.insert("singleAttributePerLine".to_string(), Value::from(v));
+    }
+    if let Some(v) = config.embedded_language_formatting {
+        obj.insert(
+            "embeddedLanguageFormatting".to_string(),
+            Value::from(match v {
+                EmbeddedLanguageFormattingConfig::Auto => "auto",
+                EmbeddedLanguageFormattingConfig::Off => "off",
+            }),
+        );
+    }
+
+    // Prettier-only options
+    if let Some(v) = config.prose_wrap {
+        obj.insert(
+            "proseWrap".to_string(),
+            Value::from(match v {
+                ProseWrapConfig::Always => "always",
+                ProseWrapConfig::Never => "never",
+                ProseWrapConfig::Preserve => "preserve",
+            }),
+        );
+    }
+    if let Some(v) = config.html_whitespace_sensitivity {
+        obj.insert(
+            "htmlWhitespaceSensitivity".to_string(),
+            Value::from(match v {
+                HtmlWhitespaceSensitivityConfig::Css => "css",
+                HtmlWhitespaceSensitivityConfig::Strict => "strict",
+                HtmlWhitespaceSensitivityConfig::Ignore => "ignore",
+            }),
+        );
+    }
+    if let Some(v) = config.vue_indent_script_and_style {
+        obj.insert("vueIndentScriptAndStyle".to_string(), Value::from(v));
+    }
+
+    Value::Object(obj)
 }
 
-/// Finalizes external options by adding plugin-specific flags based on the file kind.
-/// This should be called during `resolve()` after getting cached config.
+// ---
+
+/// Unwrap a [`Value`] produced by [`to_prettier_options`] back to its underlying object map.
 ///
-/// - `_useTailwindPlugin`: Flag for JS side to load Tailwind plugin
-/// - `_oxfmtPluginOptionsJson`: Bundled options for `prettier-plugin-oxfmt`
+/// Used by every `inject_*` helper below
+/// so the invariant ("`to_prettier_options` returns [`Value::Object`]") lives in exactly one place.
+fn as_object_mut(opts: &mut Value) -> &mut serde_json::Map<String, Value> {
+    opts.as_object_mut().expect("`to_prettier_options` returns `Value::Object`")
+}
+
+/// Inject `parser` key.
+/// Set explicitly to skip Prettier's parser inference.
+pub fn inject_parser(opts: &mut Value, parser_name: &str) {
+    as_object_mut(opts).insert("parser".to_string(), Value::String(parser_name.to_string()));
+}
+
+/// Inject `filepath` key.
 ///
-/// Also removes Prettier-unaware options to minimize payload size.
-pub fn finalize_external_options(config: &mut Value, kind: &FileKind) {
-    let Some(obj) = config.as_object_mut() else {
+/// Some plugins (Tailwind sorter, etc.) depend on it.
+/// Shipped explicitly because Prettier replaces it with `dummy.{ts,tsx}`
+/// for some embedded contexts (e.g., js-in-mdx).
+pub fn inject_filepath(opts: &mut Value, path: &Path) {
+    as_object_mut(opts)
+        .insert("filepath".to_string(), Value::String(path.to_string_lossy().to_string()));
+}
+
+/// Inject Tailwind plugin keys derived from `config.sort_tailwindcss`.
+///
+/// No-ops when `sortTailwindcss` is disabled in config (activation check).
+/// The caller gates this on capability (`supports_tailwind`).
+///
+/// See: <https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options>
+pub fn inject_tailwind_plugin_payload(opts: &mut Value, config: &FormatConfig) {
+    let Some(tw) = config.sort_tailwindcss.clone().and_then(SortTailwindcssUserConfig::into_config)
+    else {
         return;
     };
+    let map = as_object_mut(opts);
 
-    // Add Tailwind plugin flag and map options if needed
-    if obj.contains_key("sortTailwindcss") && kind.needs_tailwind_plugin() {
-        if let Some(tailwind) = obj.get("sortTailwindcss").and_then(|v| v.as_object()).cloned() {
-            // See: https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options
-            for (src, dst) in [
-                ("config", "tailwindConfig"),
-                ("stylesheet", "tailwindStylesheet"),
-                ("functions", "tailwindFunctions"),
-                ("attributes", "tailwindAttributes"),
-                ("preserveWhitespace", "tailwindPreserveWhitespace"),
-                ("preserveDuplicates", "tailwindPreserveDuplicates"),
-            ] {
-                if let Some(value) = tailwind.get(src).cloned() {
-                    obj.insert(dst.to_string(), value);
-                }
-            }
-        }
-        obj.insert("_useTailwindPlugin".to_string(), Value::Number(1.into()));
+    if let Some(v) = tw.config {
+        map.insert("tailwindConfig".to_string(), Value::from(v));
     }
-
-    // Build oxfmt plugin options JSON for js-in-xxx parsers
-    #[cfg(feature = "napi")]
-    if let FileKind::ExternalFormatter { path, .. } = kind
-        && kind.needs_oxfmt_plugin()
-    {
-        let mut oxfmt_plugin_options = serde_json::Map::new();
-        for key in [
-            "printWidth",
-            "useTabs",
-            "tabWidth",
-            "endOfLine",
-            "singleQuote",
-            "bracketSpacing",
-            "bracketSameLine",
-            "semi",
-            "trailingComma",
-            "arrowParens",
-            "quoteProps",
-            "jsxSingleQuote",
-            "sortImports",
-            "sortTailwindcss",
-            "jsdoc",
-        ] {
-            if let Some(value) = obj.get(key) {
-                oxfmt_plugin_options.insert(key.to_string(), value.clone());
-            }
-        }
-
-        // NOTE: Pass the parent file path so embedded JS/TS formatting
-        // uses the same path for Tailwind config resolution as the parent file.
-        // This is needed for ts-in-(markdown|mdx),
-        // which Prettier overrides the full path with a `dummy.ts(x)`...
-        // This filepath roundtrips:
-        // Rust → JS (Prettier plugin options) → Rust (text_to_doc_api),
-        // where it becomes `filepath_override` in `FormatStrategy::OxcFormatter`.
-        oxfmt_plugin_options
-            .insert("filepath".to_string(), Value::String(path.to_string_lossy().to_string()));
-
-        if let Ok(json_str) = serde_json::to_string(&Value::Object(oxfmt_plugin_options)) {
-            obj.insert("_oxfmtPluginOptionsJson".to_string(), Value::String(json_str));
-        }
+    if let Some(v) = tw.stylesheet {
+        map.insert("tailwindStylesheet".to_string(), Value::from(v));
     }
-
-    // To minimize payload size, remove Prettier unaware options
-    for key in [
-        "sortImports",
-        "sortTailwindcss",
-        "sortPackageJson",
-        "insertFinalNewline",
-        "overrides",
-        "ignorePatterns",
-        "jsdoc",
-    ] {
-        obj.remove(key);
+    if let Some(v) = tw.functions {
+        map.insert("tailwindFunctions".to_string(), Value::from(v));
     }
+    if let Some(v) = tw.attributes {
+        map.insert("tailwindAttributes".to_string(), Value::from(v));
+    }
+    if let Some(v) = tw.preserve_whitespace {
+        map.insert("tailwindPreserveWhitespace".to_string(), Value::from(v));
+    }
+    if let Some(v) = tw.preserve_duplicates {
+        map.insert("tailwindPreserveDuplicates".to_string(), Value::from(v));
+    }
+    map.insert("_useTailwindPlugin".to_string(), Value::Number(1.into()));
+}
+
+/// Inject `_oxfmtPluginOptionsJson` carrying the typed [`FormatConfig`] plus
+/// the parent filepath for the embedded callback to recover.
+///
+/// `filepath` is shipped explicitly because Prettier replaces it with
+/// `dummy.{ts,tsx}` for some embedded contexts (e.g., js-in-mdx).
+///
+/// The caller gates this on capability (`supports_oxfmt`).
+///
+/// # Panics
+///
+/// Panics if payload serialization fails;
+/// Unreachable in practice because the payload is plainly-serializable data.
+#[cfg(feature = "napi")]
+pub fn inject_oxfmt_plugin_payload(opts: &mut Value, config: &FormatConfig, path: &Path) {
+    #[derive(Serialize)]
+    struct Payload<'a> {
+        config: &'a FormatConfig,
+        filepath: &'a str,
+    }
+    let filepath = path.to_string_lossy();
+    let payload_json = serde_json::to_string(&Payload { config, filepath: &filepath })
+        .expect("oxfmt plugin payload serialization should not fail");
+    as_object_mut(opts).insert("_oxfmtPluginOptionsJson".to_string(), Value::String(payload_json));
 }
 
 // ---
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::oxfmtrc::{FormatConfig, Oxfmtrc, to_oxfmt_options};
-
-    #[test]
-    fn test_sync_external_options_defaults() {
-        let json_string = r"{}";
-        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
-        let config: FormatConfig = serde_json::from_str(json_string).unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-
-        sync_external_options(&oxfmt_options.format_options, &mut raw_config);
-
-        let obj = raw_config.as_object().unwrap();
-        assert_eq!(obj.get("printWidth").unwrap(), 100);
-    }
-
-    #[test]
-    fn test_sync_external_options_with_user_values() {
-        let json_string = r#"{
-            "printWidth": 80,
-            "ignorePatterns": ["*.min.js"],
-            "experimentalSortImports": { "order": "asc" }
-        }"#;
-        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
-        let config: FormatConfig = serde_json::from_str(json_string).unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-
-        sync_external_options(&oxfmt_options.format_options, &mut raw_config);
-
-        let obj = raw_config.as_object().unwrap();
-        // User-specified value is preserved via FormatOptions
-        assert_eq!(obj.get("printWidth").unwrap(), 80);
-        // oxfmt extensions are preserved (for caching)
-        // They will be removed later by `finalize_external_options()`
-        assert!(obj.contains_key("ignorePatterns"));
-        assert!(obj.contains_key("experimentalSortImports"));
-    }
+mod tests_overrides_parsing {
+    use crate::core::oxfmtrc::Oxfmtrc;
 
     #[test]
     fn test_overrides_parsing() {
@@ -217,85 +270,146 @@ mod tests {
         assert_eq!(overrides[1].exclude_files, Some(vec!["*.min.js".to_string()]));
         assert_eq!(overrides[1].options.print_width, Some(80));
     }
+}
 
-    #[test]
-    fn test_sync_external_options_preserves_overrides() {
-        let json_string = r#"{
-            "tabWidth": 2,
-            "overrides": [
-                { "files": ["*.test.js"], "options": { "tabWidth": 4 } }
-            ]
-        }"#;
-        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
-        let oxfmtrc: Oxfmtrc = serde_json::from_str(json_string).unwrap();
-        let oxfmt_options = to_oxfmt_options(oxfmtrc.format_config).unwrap();
+// ---
 
-        sync_external_options(&oxfmt_options.format_options, &mut raw_config);
+#[cfg(test)]
+mod tests_to_prettier_options {
+    use super::*;
+    use crate::core::oxfmtrc::FormatConfig;
 
-        let obj = raw_config.as_object().unwrap();
-        // Overrides are preserved (for caching)
-        // They will be removed later by `finalize_external_options()`
-        assert!(obj.contains_key("overrides"));
+    fn config_from(json: &str) -> FormatConfig {
+        serde_json::from_str(json).unwrap()
     }
 
     #[test]
-    fn test_finalize_external_options_removes_oxfmt_extensions() {
-        use std::{path::Path, sync::Arc};
+    fn emits_only_print_width_for_empty_config() {
+        let config = config_from("{}");
+        let value = to_prettier_options(&config);
+        let obj = value.as_object().unwrap();
 
-        use oxc_span::SourceType;
-
-        let json_string = r#"{
-            "tabWidth": 2,
-            "overrides": [
-                { "files": ["*.test.js"], "options": { "tabWidth": 4 } }
-            ],
-            "ignorePatterns": ["*.min.js"],
-            "sortImports": { "order": "asc" }
-        }"#;
-        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
-
-        let kind = FileKind::OxcFormatter {
-            path: Arc::from(Path::new("test.js")),
-            source_type: SourceType::mjs(),
-        };
-        finalize_external_options(&mut raw_config, &kind);
-
-        let obj = raw_config.as_object().unwrap();
-        // oxfmt extensions are removed by finalize_external_options
-        assert!(!obj.contains_key("overrides"));
-        assert!(!obj.contains_key("ignorePatterns"));
-        assert!(!obj.contains_key("sortImports"));
+        // `printWidth` is always emitted because oxfmt's default (100) differs
+        // from Prettier's (80). The other core options share defaults and are
+        // omitted when unset.
+        assert_eq!(obj.get("printWidth"), Some(&Value::from(100)));
+        assert!(!obj.contains_key("useTabs"));
+        assert!(!obj.contains_key("tabWidth"));
+        assert!(!obj.contains_key("endOfLine"));
     }
 
     #[test]
-    #[cfg(feature = "napi")]
-    fn test_finalize_external_options_sets_oxfmt_plugin_filepath() {
-        use std::{path::Path, sync::Arc};
-
-        let json_string = r#"{
-            "printWidth": 100,
-            "singleQuote": true,
-            "experimentalSortImports": { "order": "asc" }
-        }"#;
-        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
-
-        let kind = FileKind::ExternalFormatter {
-            path: Arc::from(Path::new("/tmp/foo/bar/App.vue")),
-            parser_name: "vue",
-        };
-        finalize_external_options(&mut raw_config, &kind);
-
-        let obj = raw_config.as_object().unwrap();
-        let plugin_options_json = obj
-            .get("_oxfmtPluginOptionsJson")
-            .and_then(Value::as_str)
-            .expect("Expected `_oxfmtPluginOptionsJson` to be set");
-
-        let plugin_options: Value = serde_json::from_str(plugin_options_json).unwrap();
-        let plugin_obj = plugin_options.as_object().unwrap();
-        assert_eq!(
-            plugin_obj.get("filepath"),
-            Some(&Value::String("/tmp/foo/bar/App.vue".to_string()))
+    fn emits_user_set_core_options() {
+        let config = config_from(
+            r#"{ "printWidth": 80, "useTabs": true, "tabWidth": 4, "endOfLine": "crlf" }"#,
         );
+        let value = to_prettier_options(&config);
+        let obj = value.as_object().unwrap();
+
+        assert_eq!(obj.get("printWidth"), Some(&Value::from(80)));
+        assert_eq!(obj.get("useTabs"), Some(&Value::from(true)));
+        assert_eq!(obj.get("tabWidth"), Some(&Value::from(4)));
+        assert_eq!(obj.get("endOfLine"), Some(&Value::from("crlf")));
+    }
+
+    #[test]
+    fn omits_unset_optional_prettier_options() {
+        let config = config_from("{}");
+        let value = to_prettier_options(&config);
+        let obj = value.as_object().unwrap();
+
+        // Optional Prettier options are omitted when not set
+        assert!(!obj.contains_key("singleQuote"));
+        assert!(!obj.contains_key("trailingComma"));
+        assert!(!obj.contains_key("semi"));
+        assert!(!obj.contains_key("vueIndentScriptAndStyle"));
+        assert!(!obj.contains_key("htmlWhitespaceSensitivity"));
+    }
+
+    #[test]
+    fn emits_user_set_optional_prettier_options() {
+        let config = config_from(
+            r#"{
+                "singleQuote": true,
+                "trailingComma": "es5",
+                "semi": false,
+                "arrowParens": "avoid",
+                "quoteProps": "consistent",
+                "objectWrap": "collapse",
+                "embeddedLanguageFormatting": "off",
+                "proseWrap": "always",
+                "htmlWhitespaceSensitivity": "ignore",
+                "vueIndentScriptAndStyle": true
+            }"#,
+        );
+        let value = to_prettier_options(&config);
+        let obj = value.as_object().unwrap();
+
+        assert_eq!(obj.get("singleQuote"), Some(&Value::from(true)));
+        assert_eq!(obj.get("trailingComma"), Some(&Value::from("es5")));
+        assert_eq!(obj.get("semi"), Some(&Value::from(false)));
+        assert_eq!(obj.get("arrowParens"), Some(&Value::from("avoid")));
+        assert_eq!(obj.get("quoteProps"), Some(&Value::from("consistent")));
+        assert_eq!(obj.get("objectWrap"), Some(&Value::from("collapse")));
+        assert_eq!(obj.get("embeddedLanguageFormatting"), Some(&Value::from("off")));
+        assert_eq!(obj.get("proseWrap"), Some(&Value::from("always")));
+        assert_eq!(obj.get("htmlWhitespaceSensitivity"), Some(&Value::from("ignore")));
+        assert_eq!(obj.get("vueIndentScriptAndStyle"), Some(&Value::from(true)));
+    }
+
+    #[test]
+    fn never_emits_oxfmt_specific_keys() {
+        // Even with all oxfmt-specific options set, none should appear in the Prettier options
+        let config = config_from(
+            r#"{
+                "insertFinalNewline": false,
+                "sortImports": true,
+                "sortPackageJson": true,
+                "sortTailwindcss": true,
+                "jsdoc": true
+            }"#,
+        );
+        let value = to_prettier_options(&config);
+        let obj = value.as_object().unwrap();
+
+        for key in [
+            "insertFinalNewline",
+            "sortImports",
+            "experimentalSortImports",
+            "sortPackageJson",
+            "experimentalSortPackageJson",
+            "sortTailwindcss",
+            "experimentalTailwindcss",
+            "jsdoc",
+            "overrides",
+            "ignorePatterns",
+            "experimentalOperatorPosition",
+            "experimentalTernaries",
+        ] {
+            assert!(!obj.contains_key(key), "Key `{key}` must NOT be in Prettier options");
+        }
+    }
+
+    #[test]
+    fn to_prettier_options_never_injects_tailwind_keys() {
+        // Tailwind keys are always opt-in via `inject_tailwind_plugin_payload`.
+        let config = config_from(r#"{ "sortTailwindcss": true }"#);
+        let value = to_prettier_options(&config);
+        let obj = value.as_object().unwrap();
+
+        assert!(!obj.contains_key("_useTailwindPlugin"));
+        assert!(!obj.contains_key("tailwindConfig"));
+    }
+
+    #[test]
+    fn does_not_inject_filepath_or_plugin_options_json() {
+        // These belong to the format step, not to_prettier_options
+        let config = config_from(r#"{ "printWidth": 80 }"#);
+        let value = to_prettier_options(&config);
+        let obj = value.as_object().unwrap();
+
+        assert!(!obj.contains_key("filepath"));
+        assert!(!obj.contains_key("parser"));
+        assert!(!obj.contains_key("_oxfmtPluginOptionsJson"));
     }
 }

--- a/apps/oxfmt/src/core/oxfmtrc/to_oxfmt_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_oxfmt_options.rs
@@ -12,26 +12,14 @@ use super::format_config::{
     ArrowParensConfig, CustomGroupItemConfig, EmbeddedLanguageFormattingConfig, EndOfLineConfig,
     FormatConfig, HtmlWhitespaceSensitivityConfig, JsdocUserConfig, ObjectWrapConfig,
     QuotePropsConfig, SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig,
-    SortPackageJsonConfig, SortTailwindcssUserConfig, TrailingCommaConfig,
+    SortTailwindcssUserConfig, TrailingCommaConfig,
 };
 
-/// Resolved format options from `FormatConfig`.
-///
-/// Contains `FormatOptions` for `oxc_formatter` plus additional Oxfmt-specific options.
-/// All fields here are subject to per-file overrides.
-#[derive(Debug, Clone)]
-pub struct OxfmtOptions {
-    pub format_options: FormatOptions,
-    pub toml_options: TomlFormatterOptions,
-    pub sort_package_json: Option<sort_package_json::SortOptions>,
-    pub insert_final_newline: bool,
-}
-
-/// Convert `FormatConfig` into `OxfmtOptions`.
+/// Convert `FormatConfig` into validated `FormatOptions` for `oxc_formatter`.
 ///
 /// # Errors
 /// Returns error if any option value is invalid
-pub fn to_oxfmt_options(config: FormatConfig) -> Result<OxfmtOptions, String> {
+pub fn to_format_options(config: &FormatConfig) -> Result<FormatOptions, String> {
     // NOTE: Not yet supported options:
     // [Prettier] experimentalOperatorPosition: "start" | "end"
     // [Prettier] experimentalTernaries: boolean
@@ -154,7 +142,7 @@ pub fn to_oxfmt_options(config: FormatConfig) -> Result<OxfmtOptions, String> {
     // Below are our own extensions
 
     if let Some(sort_imports_config) =
-        config.sort_imports.and_then(SortImportsUserConfig::into_config)
+        config.sort_imports.clone().and_then(SortImportsUserConfig::into_config)
     {
         let mut sort_imports = SortImportsOptions::default();
 
@@ -272,7 +260,7 @@ pub fn to_oxfmt_options(config: FormatConfig) -> Result<OxfmtOptions, String> {
     }
 
     if let Some(tw_config) =
-        config.sort_tailwindcss.and_then(SortTailwindcssUserConfig::into_config)
+        config.sort_tailwindcss.clone().and_then(SortTailwindcssUserConfig::into_config)
     {
         format_options.sort_tailwindcss = Some(SortTailwindcssOptions {
             config: tw_config.config,
@@ -284,7 +272,7 @@ pub fn to_oxfmt_options(config: FormatConfig) -> Result<OxfmtOptions, String> {
         });
     }
 
-    if let Some(jsdoc_config) = config.jsdoc.and_then(JsdocUserConfig::into_config) {
+    if let Some(jsdoc_config) = config.jsdoc.clone().and_then(JsdocUserConfig::into_config) {
         let mut opts = oxc_formatter::JsdocOptions::default();
         if let Some(v) = jsdoc_config.capitalize_descriptions {
             opts.capitalize_descriptions = v;
@@ -339,26 +327,27 @@ pub fn to_oxfmt_options(config: FormatConfig) -> Result<OxfmtOptions, String> {
         format_options.jsdoc = Some(opts);
     }
 
-    // Currently, there is a no options for TOML formatter
-    let toml_options = build_toml_options(&format_options);
-
-    let sort_package_json = config.sort_package_json.map_or_else(
-        || Some(SortPackageJsonConfig::default().to_sort_options()),
-        |c| c.to_sort_options(),
-    );
-
-    let insert_final_newline = config.insert_final_newline.unwrap_or(true);
-
-    Ok(OxfmtOptions { format_options, toml_options, sort_package_json, insert_final_newline })
+    Ok(format_options)
 }
 
-// ---
-
-/// Build `toml` formatter options from `FormatOptions`.
-/// Use the same options as `prettier-plugin-toml`.
+/// Convert `FormatConfig` into validated `TomlFormatterOptions` for `oxc_toml`.
+///
+/// Routes through [`to_format_options`] so validation (e.g., `printWidth` bounds)
+/// and oxfmt's default fallbacks are applied consistently with the JS path.
+/// Mirrors `prettier-plugin-toml` semantics:
 /// <https://github.com/un-ts/prettier/blob/7a4346d5dbf6b63987c0f81228fc46bb12f8692f/packages/toml/src/index.ts#L27-L31>
-fn build_toml_options(format_options: &FormatOptions) -> TomlFormatterOptions {
-    TomlFormatterOptions {
+///
+/// TODO: After `oxc_formatter_core` separation lands, derive the core fields (`column_width` / `indent_string` / `crlf`)
+/// from a neutral resolved form instead of `oxc_formatter::FormatOptions`.
+/// `trailing_comma` is JS-specific (not a core option):
+/// - either keep mirroring Prettier's convention by reading it from `FormatConfig` directly,
+/// - or introduce a dedicated `toml: {}` namespace options in oxfmtrc for explicit TOML-side config
+///
+/// # Errors
+/// Returns error if any option value is invalid (delegates validation to `to_format_options`).
+pub fn to_toml_options(config: &FormatConfig) -> Result<TomlFormatterOptions, String> {
+    let format_options = to_format_options(config)?;
+    Ok(TomlFormatterOptions {
         column_width: format_options.line_width.value() as usize,
         indent_string: if format_options.indent_style.is_tab() {
             "\t".to_string()
@@ -367,11 +356,10 @@ fn build_toml_options(format_options: &FormatOptions) -> TomlFormatterOptions {
         },
         array_trailing_comma: !format_options.trailing_commas.is_none(),
         crlf: format_options.line_ending.is_carriage_return_line_feed(),
-        // NOTE: Need to align with `oxc_formatter` and Prettier defaults,
-        // to make `insertFinalNewline` option work correctly.
+        // Align with `oxc_formatter` and Prettier so `insertFinalNewline` works.
         trailing_newline: true,
         ..Default::default()
-    }
+    })
 }
 
 // ---
@@ -399,15 +387,15 @@ mod tests {
         }"#;
 
         let config: FormatConfig = serde_json::from_str(json).unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
+        let format_options = to_format_options(&config).unwrap();
 
-        assert!(oxfmt_options.format_options.indent_style.is_tab());
-        assert_eq!(oxfmt_options.format_options.indent_width.value(), 4);
-        assert_eq!(oxfmt_options.format_options.line_width.value(), 100);
-        assert!(!oxfmt_options.format_options.quote_style.is_double());
-        assert!(oxfmt_options.format_options.semicolons.is_as_needed());
+        assert!(format_options.indent_style.is_tab());
+        assert_eq!(format_options.indent_width.value(), 4);
+        assert_eq!(format_options.line_width.value(), 100);
+        assert!(!format_options.quote_style.is_double());
+        assert!(format_options.semicolons.is_as_needed());
 
-        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
+        let sort_imports = format_options.sort_imports.unwrap();
         assert!(sort_imports.partition_by_newline);
         assert!(sort_imports.order.is_desc());
         assert!(!sort_imports.ignore_case);
@@ -423,51 +411,51 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
+        let format_options = to_format_options(&config).unwrap();
 
         // Should use defaults
-        assert!(oxfmt_options.format_options.indent_style.is_space());
-        assert_eq!(oxfmt_options.format_options.indent_width.value(), 2);
-        assert_eq!(oxfmt_options.format_options.line_width.value(), 100);
-        assert_eq!(oxfmt_options.format_options.sort_imports, None);
+        assert!(format_options.indent_style.is_space());
+        assert_eq!(format_options.indent_width.value(), 2);
+        assert_eq!(format_options.line_width.value(), 100);
+        assert_eq!(format_options.sort_imports, None);
     }
 
     #[test]
     fn test_empty_config() {
         let config: FormatConfig = serde_json::from_str("{}").unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
+        let format_options = to_format_options(&config).unwrap();
 
         // Should use defaults
-        assert!(oxfmt_options.format_options.indent_style.is_space());
-        assert_eq!(oxfmt_options.format_options.indent_width.value(), 2);
-        assert_eq!(oxfmt_options.format_options.line_width.value(), 100);
-        assert_eq!(oxfmt_options.format_options.sort_imports, None);
+        assert!(format_options.indent_style.is_space());
+        assert_eq!(format_options.indent_width.value(), 2);
+        assert_eq!(format_options.line_width.value(), 100);
+        assert_eq!(format_options.sort_imports, None);
     }
 
     #[test]
     fn test_arrow_parens_normalization() {
         // Test "avoid" -> "as-needed" normalization
         let config: FormatConfig = serde_json::from_str(r#"{"arrowParens": "avoid"}"#).unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        assert!(oxfmt_options.format_options.arrow_parentheses.is_as_needed());
+        let format_options = to_format_options(&config).unwrap();
+        assert!(format_options.arrow_parentheses.is_as_needed());
 
         // Test "always" remains unchanged
         let config: FormatConfig = serde_json::from_str(r#"{"arrowParens": "always"}"#).unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        assert!(oxfmt_options.format_options.arrow_parentheses.is_always());
+        let format_options = to_format_options(&config).unwrap();
+        assert!(format_options.arrow_parentheses.is_always());
     }
 
     #[test]
     fn test_object_wrap_normalization() {
         // Test "preserve" -> "auto" normalization
         let config: FormatConfig = serde_json::from_str(r#"{"objectWrap": "preserve"}"#).unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        assert_eq!(oxfmt_options.format_options.expand, Expand::Auto);
+        let format_options = to_format_options(&config).unwrap();
+        assert_eq!(format_options.expand, Expand::Auto);
 
         // Test "collapse" -> "never" normalization
         let config: FormatConfig = serde_json::from_str(r#"{"objectWrap": "collapse"}"#).unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        assert_eq!(oxfmt_options.format_options.expand, Expand::Never);
+        let format_options = to_format_options(&config).unwrap();
+        assert_eq!(format_options.expand, Expand::Never);
     }
 
     #[test]
@@ -478,8 +466,8 @@ mod tests {
         }"#,
         )
         .unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
+        let format_options = to_format_options(&config).unwrap();
+        let sort_imports = format_options.sort_imports.unwrap();
         assert!(sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
 
@@ -492,8 +480,8 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
+        let format_options = to_format_options(&config).unwrap();
+        let sort_imports = format_options.sort_imports.unwrap();
         assert!(!sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
 
@@ -506,8 +494,8 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
+        let format_options = to_format_options(&config).unwrap();
+        let sort_imports = format_options.sort_imports.unwrap();
         assert!(sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
 
@@ -520,7 +508,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxfmt_options(config).is_ok());
+        assert!(to_format_options(&config).is_ok());
         let config: FormatConfig = serde_json::from_str(
             r#"{
                 "experimentalSortImports": {
@@ -530,7 +518,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxfmt_options(config).is_err_and(|e| e.contains("newlinesBetween")));
+        assert!(to_format_options(&config).is_err_and(|e| e.contains("newlinesBetween")));
 
         let config: FormatConfig = serde_json::from_str(
             r#"{
@@ -546,8 +534,8 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
+        let format_options = to_format_options(&config).unwrap();
+        let sort_imports = format_options.sort_imports.unwrap();
         assert_eq!(sort_imports.groups.len(), 5);
         assert_eq!(
             sort_imports.groups[0],
@@ -579,8 +567,8 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let oxfmt_options = to_oxfmt_options(config).unwrap();
-        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
+        let format_options = to_format_options(&config).unwrap();
+        let sort_imports = format_options.sort_imports.unwrap();
         assert_eq!(sort_imports.groups.len(), 3);
         assert_eq!(
             sort_imports.groups[0],
@@ -611,7 +599,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxfmt_options(config).is_err_and(|e| e.contains("start")));
+        assert!(to_format_options(&config).is_err_and(|e| e.contains("start")));
 
         // Test error: newlinesBetween at end of groups
         let config: FormatConfig = serde_json::from_str(
@@ -626,7 +614,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxfmt_options(config).is_err_and(|e| e.contains("end")));
+        assert!(to_format_options(&config).is_err_and(|e| e.contains("end")));
 
         // Test error: consecutive newlinesBetween markers
         let config: FormatConfig = serde_json::from_str(
@@ -642,7 +630,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxfmt_options(config).is_err_and(|e| e.contains("consecutive")));
+        assert!(to_format_options(&config).is_err_and(|e| e.contains("consecutive")));
 
         // Test error: partitionByNewline with per-group newlinesBetween markers
         let config: FormatConfig = serde_json::from_str(
@@ -658,27 +646,27 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxfmt_options(config).is_err_and(|e| e.contains("partitionByNewline")));
+        assert!(to_format_options(&config).is_err_and(|e| e.contains("partitionByNewline")));
     }
 
     #[test]
     fn test_bool_for_object_options() {
         let config: FormatConfig = serde_json::from_str(r#"{"sortImports": true}"#).unwrap();
-        assert!(to_oxfmt_options(config).unwrap().format_options.sort_imports.is_some());
+        assert!(to_format_options(&config).unwrap().sort_imports.is_some());
 
         let config: FormatConfig = serde_json::from_str(r#"{"sortImports": false}"#).unwrap();
-        assert!(to_oxfmt_options(config).unwrap().format_options.sort_imports.is_none());
+        assert!(to_format_options(&config).unwrap().sort_imports.is_none());
 
         let config: FormatConfig = serde_json::from_str(r#"{"sortTailwindcss": true}"#).unwrap();
-        assert!(to_oxfmt_options(config).unwrap().format_options.sort_tailwindcss.is_some());
+        assert!(to_format_options(&config).unwrap().sort_tailwindcss.is_some());
 
         let config: FormatConfig = serde_json::from_str(r#"{"sortTailwindcss": false}"#).unwrap();
-        assert!(to_oxfmt_options(config).unwrap().format_options.sort_tailwindcss.is_none());
+        assert!(to_format_options(&config).unwrap().sort_tailwindcss.is_none());
 
         let config: FormatConfig = serde_json::from_str(r#"{"jsdoc": true}"#).unwrap();
-        assert!(to_oxfmt_options(config).unwrap().format_options.jsdoc.is_some());
+        assert!(to_format_options(&config).unwrap().jsdoc.is_some());
 
         let config: FormatConfig = serde_json::from_str(r#"{"jsdoc": false}"#).unwrap();
-        assert!(to_oxfmt_options(config).unwrap().format_options.jsdoc.is_none());
+        assert!(to_format_options(&config).unwrap().jsdoc.is_none());
     }
 }

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -36,7 +36,14 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
 
         let extension = path.extension().and_then(|ext| ext.to_str());
         if let Some(parser_name) = get_external_parser_name(file_name, extension) {
-            return Some(FileKind::ExternalFormatter { path, parser_name });
+            let supports_tailwind = TAILWIND_PARSERS.contains(parser_name);
+            let supports_oxfmt = OXFMT_PARSERS.contains(parser_name);
+            return Some(FileKind::ExternalFormatter {
+                path,
+                parser_name,
+                supports_tailwind,
+                supports_oxfmt,
+            });
         }
     }
 
@@ -48,28 +55,28 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
 /// This is a transient type produced by [`classify_file_kind`] and consumed by the
 /// resolver to construct a public [`super::FormatStrategy`] (with options).
 pub enum FileKind {
-    OxcFormatter {
-        path: Arc<Path>,
-        source_type: SourceType,
-    },
+    /// JS/TS files formatted by `oxc_formatter`.
+    /// `supports_tailwind` is not needed, always enabled for JS/TS files.
+    OxcFormatter { path: Arc<Path>, source_type: SourceType },
     /// TOML files formatted by taplo (Pure Rust).
-    OxfmtToml {
-        path: Arc<Path>,
-    },
+    OxfmtToml { path: Arc<Path> },
     /// Files formatted by external formatter (Prettier).
+    ///
+    /// `supports_tailwind` and `supports_oxfmt` are capability flags that say
+    /// "this file kind CAN use the corresponding plugin".
+    /// Whether the plugin is actually activated is decided at the format step by resolved config.
     /// Only available with the `napi` feature; without it, the classifier rejects such files.
     #[cfg(feature = "napi")]
     ExternalFormatter {
         path: Arc<Path>,
         parser_name: &'static str,
+        supports_tailwind: bool,
+        supports_oxfmt: bool,
     },
     /// `package.json` is special: sorted by `sort-package-json` then formatted by external formatter.
     /// Only available with the `napi` feature; without it, the classifier rejects such files.
     #[cfg(feature = "napi")]
-    ExternalFormatterPackageJson {
-        path: Arc<Path>,
-        parser_name: &'static str,
-    },
+    ExternalFormatterPackageJson { path: Arc<Path>, parser_name: &'static str },
 }
 
 impl FileKind {
@@ -80,27 +87,6 @@ impl FileKind {
             Self::ExternalFormatter { path, .. }
             | Self::ExternalFormatterPackageJson { path, .. } => path,
         }
-    }
-
-    /// Returns `true` if this file kind supports the Tailwind CSS sorting plugin.
-    pub fn needs_tailwind_plugin(&self) -> bool {
-        match self {
-            Self::OxcFormatter { .. } => true,
-            #[cfg(feature = "napi")]
-            Self::ExternalFormatter { parser_name, .. } => TAILWIND_PARSERS.contains(parser_name),
-            #[cfg(feature = "napi")]
-            Self::ExternalFormatterPackageJson { .. } => false,
-            Self::OxfmtToml { .. } => false,
-        }
-    }
-
-    /// Returns `true` if this file kind supports the `prettier-plugin-oxfmt` (js-in-xxx).
-    #[cfg(feature = "napi")]
-    pub fn needs_oxfmt_plugin(&self) -> bool {
-        matches!(
-            self,
-            Self::ExternalFormatter { parser_name, .. } if OXFMT_PARSERS.contains(parser_name)
-        )
     }
 }
 

--- a/apps/oxfmt/test/api/sort_tailwindcss.test.ts
+++ b/apps/oxfmt/test/api/sort_tailwindcss.test.ts
@@ -54,6 +54,16 @@ describe("Tailwind CSS Sorting", () => {
     expect(result.errors).toStrictEqual([]);
   });
 
+  // Regression test for https://github.com/oxc-project/oxc/pull/21919
+  it("should NOT sort Tailwind classes when sortTailwindcss is explicitly false", async () => {
+    const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;
+
+    const result = await format("test.tsx", input, { sortTailwindcss: false });
+
+    expect(result.code).toContain('className="p-4 flex bg-red-500 text-white"');
+    expect(result.errors).toStrictEqual([]);
+  });
+
   it("should sort multiple className attributes", async () => {
     // Use classes that will definitely be reordered
     const input = `


### PR DESCRIPTION
In Oxfmt, there is only one config file, but there were multiple conversion paths to the specific options used by subsequent formatters.

For example, it would generate `FormatOptions` for `oxc_formatter`, while assembling the necessary `JSON` for `prettier`.

There was a lack of consistency here, as some paths referenced the parsed `FormatConfig` while others referenced the raw JSON of `Oxfmtrc`. This inconsistency led to issues like the one mentioned in #21919.

In this PR, I have established `FormatConfig` as the single SoT, ensuring that all options are derived from it.