### PR TITLE
fix(linter): Comptibles rules need to be disabled in jest and vitest at same time

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -418,7 +418,7 @@ impl ConfigStoreBuilder {
     }
 
     fn get_all_rules_for_plugins(&self, override_plugins: Option<LintPlugins>) -> Vec<RuleEnum> {
-        let mut builtin_plugins = if let Some(override_plugins) = override_plugins {
+        let builtin_plugins = if let Some(override_plugins) = override_plugins {
             self.config.plugins | override_plugins
         } else {
             self.config.plugins
@@ -427,11 +427,6 @@ impl ConfigStoreBuilder {
         if builtin_plugins.is_all() {
             RULES.clone()
         } else {
-            // we need to include some jest rules when vitest is enabled, see [`VITEST_COMPATIBLE_JEST_RULES`]
-            if builtin_plugins.contains(LintPlugins::VITEST) {
-                builtin_plugins |= LintPlugins::JEST;
-            }
-
             RULES
                 .iter()
                 .filter(|rule| {
@@ -475,12 +470,7 @@ impl ConfigStoreBuilder {
         // When a plugin gets disabled before build(), rules for that plugin aren't removed until
         // with_filters() gets called. If the user never calls it, those now-undesired rules need
         // to be taken out.
-        let mut plugins = self.plugins();
-
-        // Apply the same Vitest->Jest logic as in get_all_rules()
-        if plugins.contains(LintPlugins::VITEST) {
-            plugins |= LintPlugins::JEST;
-        }
+        let plugins = self.plugins();
 
         let overrides = std::mem::take(&mut self.overrides);
         let resolved_overrides = self.resolve_overrides(overrides, external_plugin_store)?;
@@ -552,10 +542,7 @@ impl ConfigStoreBuilder {
     }
 
     /// Warn for all correctness rules in the given set of plugins.
-    fn warn_correctness(mut plugins: LintPlugins) -> FxHashMap<RuleEnum, AllowWarnDeny> {
-        if plugins.contains(LintPlugins::VITEST) {
-            plugins |= LintPlugins::JEST;
-        }
+    fn warn_correctness(plugins: LintPlugins) -> FxHashMap<RuleEnum, AllowWarnDeny> {
         RULES
             .iter()
             .filter(|rule| {

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -78,10 +78,7 @@ pub struct Config {
 }
 
 impl Config {
-    fn builtin_rule_plugins(mut plugins: LintPlugins) -> LintPlugins {
-        if plugins.contains(LintPlugins::VITEST) {
-            plugins |= LintPlugins::JEST;
-        }
+    fn builtin_rule_plugins(plugins: LintPlugins) -> LintPlugins {
         plugins
     }
 

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -20,7 +20,7 @@ use crate::{
     AllowWarnDeny, ExternalPluginStore, LintPlugins,
     external_plugin_store::{ExternalOptionsId, ExternalRuleId, ExternalRuleLookupError},
     rules::{RULES, RuleEnum},
-    utils::{is_eslint_rule_adapted_to_typescript, is_jest_rule_adapted_to_vitest},
+    utils::is_eslint_rule_adapted_to_typescript,
 };
 
 /// Errors that can occur when overriding rules
@@ -235,7 +235,6 @@ fn transform_rule_and_plugin_name<'a>(
     plugin_name: &'a str,
 ) -> (&'a str, &'a str) {
     let plugin_name = match plugin_name {
-        "vitest" if is_jest_rule_adapted_to_vitest(rule_name) => "jest",
         "unicorn" if rule_name == "no-negated-condition" => "eslint",
         "typescript" if is_eslint_rule_adapted_to_typescript(rule_name) => "eslint",
         _ => plugin_name,

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -32,13 +32,6 @@ pub use self::{
     react_perf::*, regex::*, typescript::*, unicorn::*, url::*, vitest::*, vue::*,
 };
 
-/// List of Jest rules that have Vitest equivalents.
-// When adding a new rule to this list, please ensure that
-// the crates/oxc_linter/data/vitest_compatible_jest_rules.json
-// file is also updated. The JSON file is used by the oxlint-migrate
-// and eslint-plugin-oxlint repos to keep everything synced.
-const VITEST_COMPATIBLE_JEST_RULES: [&str; 0] = [];
-
 /// List of Eslint rules that have TypeScript equivalents.
 // When adding a new rule to this list, please ensure oxlint-migrate is also updated.
 // See https://github.com/oxc-project/oxlint-migrate/blob/659b461eaf5b2f8a7283822ae84a5e619c86fca3/src/constants.ts#L24
@@ -83,13 +76,6 @@ const TYPESCRIPT_COMPATIBLE_ESLINT_RULES: [&str; 18] = [
     // "space-before-function-paren",
     // "space-infix-ops"
 ];
-
-/// Check if the Jest rule is adapted to Vitest.
-/// Many Vitest rule are essentially ports of Jest plugin rules with minor modifications.
-/// For these rules, we use the corresponding jest rules with some adjustments for compatibility.
-pub fn is_jest_rule_adapted_to_vitest(rule_name: &str) -> bool {
-    VITEST_COMPATIBLE_JEST_RULES.binary_search(&rule_name).is_ok()
-}
 
 /// Check if the Eslint rule is adapted to Typescript.
 /// Many Typescript rule are essentially ports of Eslint plugin rules with minor modifications.
@@ -259,38 +245,10 @@ fn read_to_arena_bytes_unknown_size(mut file: File, allocator: &Allocator) -> io
 
 #[cfg(test)]
 mod test {
-    use crate::utils::{
-        TYPESCRIPT_COMPATIBLE_ESLINT_RULES, VITEST_COMPATIBLE_JEST_RULES, read_to_string,
-    };
-    use serde_json::from_str;
-    use std::path::Path;
+    use crate::utils::TYPESCRIPT_COMPATIBLE_ESLINT_RULES;
 
     #[test]
     fn test_typescript_rules_list_is_alphabetized() {
         assert!(TYPESCRIPT_COMPATIBLE_ESLINT_RULES.is_sorted());
-    }
-
-    #[test]
-    fn test_vitest_rules_list_is_alphabetized() {
-        assert!(VITEST_COMPATIBLE_JEST_RULES.is_sorted());
-    }
-
-    #[test]
-    fn test_vitest_rules_list_matches_json() {
-        let json_path =
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("data/vitest_compatible_jest_rules.json");
-        let json = read_to_string(&json_path).expect("Failed to read vitest rules JSON file");
-        let json_rules: Vec<String> =
-            from_str(&json).expect("Failed to parse vitest rules JSON file");
-        assert!(json_rules.is_sorted(), "vitest JSON list must be alphabetized");
-        let rust_rules: Vec<&str> = VITEST_COMPATIBLE_JEST_RULES.to_vec();
-        assert_eq!(
-            json_rules.len(),
-            rust_rules.len(),
-            "Rule counts differ between Rust constant and JSON, please ensure both are updated"
-        );
-        for (json_rule, rust_rule) in json_rules.iter().zip(rust_rules.iter()) {
-            assert_eq!(json_rule, rust_rule, "Mismatch for rule: {json_rule}");
-        }
     }
 }


### PR DESCRIPTION
Fix https://github.com/oxc-project/oxc/issues/21853