### PR TITLE
feat(formatter):  add `spaceBeforeFunctionParen` option for function formatting

### DIFF
--- a/apps/oxfmt/src/core/oxfmtrc/format_config.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/format_config.rs
@@ -129,6 +129,11 @@ pub struct FormatConfig {
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_same_line: Option<bool>,
+    /// Insert a space before function parentheses.
+    ///
+    /// - Default: `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub space_before_function_paren: Option<bool>,
     /// How to wrap object literals when they could fit on one line or span multiple lines.
     ///
     /// By default, formats objects as multi-line if there is a newline prior to the first property.

--- a/apps/oxfmt/src/core/oxfmtrc/to_oxfmt_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_oxfmt_options.rs
@@ -4,7 +4,7 @@ use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CustomGroupDefinition,
     EmbeddedLanguageFormatting, Expand, FormatOptions, GroupEntry, ImportModifier, ImportSelector,
     IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteProperties, QuoteStyle, Semicolons,
-    SortImportsOptions, SortOrder, SortTailwindcssOptions, TrailingCommas,
+    SortImportsOptions, SortOrder, SortTailwindcssOptions, SpaceBeforeFunctionParen, TrailingCommas,
 };
 use oxc_toml::Options as TomlFormatterOptions;
 
@@ -118,6 +118,11 @@ pub fn to_oxfmt_options(config: FormatConfig) -> Result<OxfmtOptions, String> {
     // [Prettier] bracketSameLine: boolean
     if let Some(same_line) = config.bracket_same_line {
         format_options.bracket_same_line = BracketSameLine::from(same_line);
+    }
+
+    // [Eslint] spaceBeforeFunctionParen: boolean
+    if let Some(space) = config.space_before_function_paren {
+        format_options.space_before_function_paren = SpaceBeforeFunctionParen::from(space);
     }
 
     // [Prettier] singleAttributePerLine: boolean

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -49,6 +49,9 @@ pub struct FormatOptions {
     /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
     pub bracket_same_line: BracketSameLine,
 
+    /// Whether to insert a space before function parentheses. Defaults to false.
+    pub space_before_function_paren: SpaceBeforeFunctionParen,
+
     /// Attribute position style. By default auto.
     pub attribute_position: AttributePosition,
 
@@ -232,6 +235,7 @@ impl FormatOptions {
             arrow_parentheses: ArrowParentheses::default(),
             bracket_spacing: BracketSpacing::default(),
             bracket_same_line: BracketSameLine::default(),
+            space_before_function_paren: SpaceBeforeFunctionParen::default(),
             attribute_position: AttributePosition::default(),
             expand: Expand::default(),
             experimental_operator_position: OperatorPosition::default(),
@@ -263,6 +267,7 @@ impl fmt::Display for FormatOptions {
         writeln!(f, "Arrow parentheses: {}", self.arrow_parentheses)?;
         writeln!(f, "Bracket spacing: {}", self.bracket_spacing.value())?;
         writeln!(f, "Bracket same line: {}", self.bracket_same_line.value())?;
+        writeln!(f, "Space before function paren: {}", self.space_before_function_paren.value())?;
         writeln!(f, "Attribute Position: {}", self.attribute_position)?;
         writeln!(f, "Expand lists: {}", self.expand)?;
         writeln!(f, "Experimental operator position: {}", self.experimental_operator_position)?;
@@ -1008,6 +1013,42 @@ impl FromStr for BracketSameLine {
             Ok(value) => Ok(Self(value)),
             Err(_) => Err(
                 "Value not supported for BracketSameLine. Supported values are 'true' and 'false'.",
+            ),
+        }
+    }
+}
+
+/// Whether to insert a space before function parentheses. Defaults to false.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct SpaceBeforeFunctionParen(bool);
+
+impl SpaceBeforeFunctionParen {
+    /// Return the boolean value for this [SpaceBeforeFunctionParen]
+    pub fn value(self) -> bool {
+        self.0
+    }
+}
+
+impl From<bool> for SpaceBeforeFunctionParen {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for SpaceBeforeFunctionParen {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt::Display::fmt(&self.value(), f)
+    }
+}
+
+impl FromStr for SpaceBeforeFunctionParen {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match bool::from_str(s) {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for SpaceBeforeFunctionParen. Supported values are 'true' and 'false'.",
             ),
         }
     }

--- a/crates/oxc_formatter/src/print/parameters.rs
+++ b/crates/oxc_formatter/src/print/parameters.rs
@@ -71,6 +71,16 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameters<'a>> {
         };
 
         if !parentheses_not_needed {
+            if f.options().space_before_function_paren.value() {
+                // Don't add space for type-level function signatures (e.g. `type Fn = (x: T) => R`)
+                let is_type_level = matches!(
+                    self.parent(),
+                    AstNodes::TSFunctionType(_) | AstNodes::TSCallSignatureDeclaration(_)
+                );
+                if !is_type_level {
+                    write!(f, " ");
+                }
+            }
             write!(f, "(");
         }
 

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -4,7 +4,7 @@ use oxc_allocator::Allocator;
 use oxc_formatter::{
     ArrowParentheses, BracketSameLine, BracketSpacing, FormatOptions, Formatter, IndentStyle,
     IndentWidth, JsdocOptions, LineEnding, LineWidth, QuoteProperties, QuoteStyle, Semicolons,
-    TrailingCommas, get_parse_options,
+    SpaceBeforeFunctionParen, TrailingCommas, get_parse_options,
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -107,6 +107,11 @@ fn parse_format_options(json: &OptionSet) -> FormatOptions {
             "bracketSameLine" | "jsxBracketSameLine" => {
                 if let Some(b) = value.as_bool() {
                     options.bracket_same_line = BracketSameLine::from(b);
+                }
+            }
+            "spaceBeforeFunctionParen" => {
+                if let Some(b) = value.as_bool() {
+                    options.space_before_function_paren = SpaceBeforeFunctionParen::from(b);
                 }
             }
             "endOfLine" => {

--- a/crates/oxc_formatter/tests/fixtures/ts/space-before-function-paren/basic.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/space-before-function-paren/basic.ts
@@ -1,0 +1,19 @@
+function named(a: string, b: number): void {}
+
+function anonymous() {}
+
+class MyClass {
+  fetchChanged(since: Date): void {}
+
+  async asyncMethod(x: number): Promise<void> {}
+
+  get value(): string { return ""; }
+
+  set value(v: string) {}
+}
+
+interface Fetcher {
+  fetchChanged(since: Date): void;
+}
+
+type FetchFn = (since: Date) => void;

--- a/crates/oxc_formatter/tests/fixtures/ts/space-before-function-paren/basic.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/space-before-function-paren/basic.ts.snap
@@ -1,0 +1,126 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+function named(a: string, b: number): void {}
+
+function anonymous() {}
+
+class MyClass {
+  fetchChanged(since: Date): void {}
+
+  async asyncMethod(x: number): Promise<void> {}
+
+  get value(): string { return ""; }
+
+  set value(v: string) {}
+}
+
+interface Fetcher {
+  fetchChanged(since: Date): void;
+}
+
+type FetchFn = (since: Date) => void;
+
+==================== Output ====================
+--------------------------------------------------
+{ printWidth: 80, spaceBeforeFunctionParen: true }
+--------------------------------------------------
+function named (a: string, b: number): void {}
+
+function anonymous () {}
+
+class MyClass {
+  fetchChanged (since: Date): void {}
+
+  async asyncMethod (x: number): Promise<void> {}
+
+  get value (): string {
+    return "";
+  }
+
+  set value (v: string) {}
+}
+
+interface Fetcher {
+  fetchChanged (since: Date): void;
+}
+
+type FetchFn = (since: Date) => void;
+
+---------------------------------------------------
+{ printWidth: 100, spaceBeforeFunctionParen: true }
+---------------------------------------------------
+function named (a: string, b: number): void {}
+
+function anonymous () {}
+
+class MyClass {
+  fetchChanged (since: Date): void {}
+
+  async asyncMethod (x: number): Promise<void> {}
+
+  get value (): string {
+    return "";
+  }
+
+  set value (v: string) {}
+}
+
+interface Fetcher {
+  fetchChanged (since: Date): void;
+}
+
+type FetchFn = (since: Date) => void;
+
+---------------------------------------------------
+{ printWidth: 80, spaceBeforeFunctionParen: false }
+---------------------------------------------------
+function named(a: string, b: number): void {}
+
+function anonymous() {}
+
+class MyClass {
+  fetchChanged(since: Date): void {}
+
+  async asyncMethod(x: number): Promise<void> {}
+
+  get value(): string {
+    return "";
+  }
+
+  set value(v: string) {}
+}
+
+interface Fetcher {
+  fetchChanged(since: Date): void;
+}
+
+type FetchFn = (since: Date) => void;
+
+----------------------------------------------------
+{ printWidth: 100, spaceBeforeFunctionParen: false }
+----------------------------------------------------
+function named(a: string, b: number): void {}
+
+function anonymous() {}
+
+class MyClass {
+  fetchChanged(since: Date): void {}
+
+  async asyncMethod(x: number): Promise<void> {}
+
+  get value(): string {
+    return "";
+  }
+
+  set value(v: string) {}
+}
+
+interface Fetcher {
+  fetchChanged(since: Date): void;
+}
+
+type FetchFn = (since: Date) => void;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/space-before-function-paren/options.json
+++ b/crates/oxc_formatter/tests/fixtures/ts/space-before-function-paren/options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "spaceBeforeFunctionParen": true
+  },
+  {
+    "spaceBeforeFunctionParen": false
+  }
+]


### PR DESCRIPTION
Resolves #21983