### PR TITLE
refactor(oxfmt): Extract sort_package_json option conversion

### DIFF
--- a/apps/oxfmt/src/core/options/to_package_json.rs
+++ b/apps/oxfmt/src/core/options/to_package_json.rs
@@ -6,8 +6,13 @@ use super::super::oxfmtrc::{FormatConfig, SortPackageJsonConfig, SortPackageJson
 /// it defaults to enabled with default options. Returns `None` only when
 /// the user explicitly sets `sort_package_json: false`.
 pub fn to_package_json(config: &FormatConfig) -> Option<sort_package_json::SortOptions> {
-    config.sort_package_json.as_ref().map_or_else(
-        || Some(SortPackageJsonConfig::default().to_sort_options()),
-        SortPackageJsonUserConfig::to_sort_options,
-    )
+    let sort_config = config.sort_package_json.clone().map_or_else(
+        || Some(SortPackageJsonConfig::default()),
+        SortPackageJsonUserConfig::into_config,
+    )?;
+    Some(sort_package_json::SortOptions {
+        sort_scripts: sort_config.sort_scripts.unwrap_or(false),
+        // Small optimization: Prettier will reformat anyway
+        pretty: false,
+    })
 }

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -600,13 +600,11 @@ impl Default for SortPackageJsonUserConfig {
 }
 
 impl SortPackageJsonUserConfig {
-    /// Convert to `sort_package_json::SortOptions`.
-    /// Returns `None` if sorting is disabled.
-    pub fn to_sort_options(&self) -> Option<sort_package_json::SortOptions> {
+    pub fn into_config(self) -> Option<SortPackageJsonConfig> {
         match self {
             Self::Bool(false) => None,
-            Self::Bool(true) => Some(SortPackageJsonConfig::default().to_sort_options()),
-            Self::Object(config) => Some(config.to_sort_options()),
+            Self::Bool(true) => Some(SortPackageJsonConfig::default()),
+            Self::Object(config) => Some(config),
         }
     }
 }
@@ -619,16 +617,6 @@ pub struct SortPackageJsonConfig {
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort_scripts: Option<bool>,
-}
-
-impl SortPackageJsonConfig {
-    pub fn to_sort_options(&self) -> sort_package_json::SortOptions {
-        sort_package_json::SortOptions {
-            sort_scripts: self.sort_scripts.unwrap_or(false),
-            // Small optimization: Prettier will reformat anyway
-            pretty: false,
-        }
-    }
 }
 
 // ---


### PR DESCRIPTION
All of this was left in `oxfmtrc.rs`, lacked consistency.