### PR TITLE
feat(linter/vue): implement no-watch-after-await rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1306,6 +1306,7 @@ export interface DummyRuleMap {
   "vue/no-required-prop-with-default"?: DummyRule;
   "vue/no-shared-component-data"?: DummyRule;
   "vue/no-this-in-before-route-enter"?: DummyRule;
+  "vue/no-watch-after-await"?: DummyRule;
   "vue/prefer-import-from-vue"?: DummyRule;
   "vue/require-default-export"?: DummyRule;
   "vue/require-slots-as-functions"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5037,6 +5037,14 @@ impl RuleRunner for crate::rules::vue::no_this_in_before_route_enter::NoThisInBe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::no_watch_after_await::NoWatchAfterAwait {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::ExportDefaultDeclaration,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::prefer_import_from_vue::PreferImportFromVue {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -805,6 +805,7 @@ pub use crate::rules::vue::no_multiple_slot_args::NoMultipleSlotArgs as VueNoMul
 pub use crate::rules::vue::no_required_prop_with_default::NoRequiredPropWithDefault as VueNoRequiredPropWithDefault;
 pub use crate::rules::vue::no_shared_component_data::NoSharedComponentData as VueNoSharedComponentData;
 pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnter as VueNoThisInBeforeRouteEnter;
+pub use crate::rules::vue::no_watch_after_await::NoWatchAfterAwait as VueNoWatchAfterAwait;
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
 pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRequireDefaultExport;
 pub use crate::rules::vue::require_slots_as_functions::RequireSlotsAsFunctions as VueRequireSlotsAsFunctions;
@@ -1629,6 +1630,7 @@ pub enum RuleEnum {
     VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault),
     VueNoSharedComponentData(VueNoSharedComponentData),
     VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter),
+    VueNoWatchAfterAwait(VueNoWatchAfterAwait),
     VuePreferImportFromVue(VuePreferImportFromVue),
     VueRequireDefaultExport(VueRequireDefaultExport),
     VueRequireSlotsAsFunctions(VueRequireSlotsAsFunctions),
@@ -2537,7 +2539,8 @@ const VUE_NO_MULTIPLE_SLOT_ARGS_ID: usize = VUE_NO_LIFECYCLE_AFTER_AWAIT_ID + 1u
 const VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID: usize = VUE_NO_MULTIPLE_SLOT_ARGS_ID + 1usize;
 const VUE_NO_SHARED_COMPONENT_DATA_ID: usize = VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID + 1usize;
 const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize = VUE_NO_SHARED_COMPONENT_DATA_ID + 1usize;
-const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
+const VUE_NO_WATCH_AFTER_AWAIT_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
+const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
 const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
 const VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
 const VUE_REQUIRE_TYPED_REF_ID: usize = VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID + 1usize;
@@ -3472,6 +3475,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID,
             Self::VueNoSharedComponentData(_) => VUE_NO_SHARED_COMPONENT_DATA_ID,
             Self::VueNoThisInBeforeRouteEnter(_) => VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID,
+            Self::VueNoWatchAfterAwait(_) => VUE_NO_WATCH_AFTER_AWAIT_ID,
             Self::VuePreferImportFromVue(_) => VUE_PREFER_IMPORT_FROM_VUE_ID,
             Self::VueRequireDefaultExport(_) => VUE_REQUIRE_DEFAULT_EXPORT_ID,
             Self::VueRequireSlotsAsFunctions(_) => VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID,
@@ -4392,6 +4396,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::NAME,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::NAME,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::NAME,
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::NAME,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::NAME,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::NAME,
@@ -5370,6 +5375,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::CATEGORY,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::CATEGORY,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::CATEGORY,
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::CATEGORY,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::CATEGORY,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::CATEGORY,
@@ -6291,6 +6297,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::FIX,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::FIX,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::FIX,
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::FIX,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::FIX,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::FIX,
@@ -7460,6 +7467,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::documentation(),
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::documentation(),
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::documentation(),
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::documentation(),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::documentation(),
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::documentation(),
@@ -9768,6 +9776,8 @@ impl RuleEnum {
                 VueNoThisInBeforeRouteEnter::config_schema(generator)
                     .or_else(|| VueNoThisInBeforeRouteEnter::schema(generator))
             }
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::config_schema(generator)
+                .or_else(|| VueNoWatchAfterAwait::schema(generator)),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::config_schema(generator)
                 .or_else(|| VuePreferImportFromVue::schema(generator)),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::config_schema(generator)
@@ -10591,6 +10601,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => "vue",
             Self::VueNoSharedComponentData(_) => "vue",
             Self::VueNoThisInBeforeRouteEnter(_) => "vue",
+            Self::VueNoWatchAfterAwait(_) => "vue",
             Self::VuePreferImportFromVue(_) => "vue",
             Self::VueRequireDefaultExport(_) => "vue",
             Self::VueRequireSlotsAsFunctions(_) => "vue",
@@ -13178,6 +13189,9 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => Ok(Self::VueNoThisInBeforeRouteEnter(
                 VueNoThisInBeforeRouteEnter::from_configuration(value)?,
             )),
+            Self::VueNoWatchAfterAwait(_) => {
+                Ok(Self::VueNoWatchAfterAwait(VueNoWatchAfterAwait::from_configuration(value)?))
+            }
             Self::VuePreferImportFromVue(_) => {
                 Ok(Self::VuePreferImportFromVue(VuePreferImportFromVue::from_configuration(value)?))
             }
@@ -14010,6 +14024,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.to_configuration(),
             Self::VueNoSharedComponentData(rule) => rule.to_configuration(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.to_configuration(),
+            Self::VueNoWatchAfterAwait(rule) => rule.to_configuration(),
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
             Self::VueRequireDefaultExport(rule) => rule.to_configuration(),
             Self::VueRequireSlotsAsFunctions(rule) => rule.to_configuration(),
@@ -14830,6 +14845,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run(node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run(node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
+                Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run(node, ctx),
@@ -15643,6 +15659,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run(node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run(node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
+                Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run(node, ctx),
@@ -16463,6 +16480,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_once(ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_once(ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
+                Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_once(ctx),
@@ -17276,6 +17294,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_once(ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_once(ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
+                Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_once(ctx),
@@ -18349,6 +18368,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19414,6 +19434,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20225,6 +20246,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.should_run(ctx),
             Self::VueNoSharedComponentData(rule) => rule.should_run(ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.should_run(ctx),
+            Self::VueNoWatchAfterAwait(rule) => rule.should_run(ctx),
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
             Self::VueRequireDefaultExport(rule) => rule.should_run(ctx),
             Self::VueRequireSlotsAsFunctions(rule) => rule.should_run(ctx),
@@ -21393,6 +21415,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::IS_TSGOLINT_RULE,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::IS_TSGOLINT_RULE,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::IS_TSGOLINT_RULE,
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::IS_TSGOLINT_RULE,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::IS_TSGOLINT_RULE,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::IS_TSGOLINT_RULE,
@@ -22373,6 +22396,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::VERSION,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::VERSION,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::VERSION,
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::VERSION,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::VERSION,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::VERSION,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::VERSION,
@@ -23388,6 +23412,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::HAS_CONFIG,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::HAS_CONFIG,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::HAS_CONFIG,
+            Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::HAS_CONFIG,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::HAS_CONFIG,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::HAS_CONFIG,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::HAS_CONFIG,
@@ -24198,6 +24223,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.types_info(),
             Self::VueNoSharedComponentData(rule) => rule.types_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.types_info(),
+            Self::VueNoWatchAfterAwait(rule) => rule.types_info(),
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
             Self::VueRequireDefaultExport(rule) => rule.types_info(),
             Self::VueRequireSlotsAsFunctions(rule) => rule.types_info(),
@@ -25008,6 +25034,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_info(),
             Self::VueNoSharedComponentData(rule) => rule.run_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_info(),
+            Self::VueNoWatchAfterAwait(rule) => rule.run_info(),
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
             Self::VueRequireDefaultExport(rule) => rule.run_info(),
             Self::VueRequireSlotsAsFunctions(rule) => rule.run_info(),
@@ -25950,6 +25977,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault::default()),
         RuleEnum::VueNoSharedComponentData(VueNoSharedComponentData::default()),
         RuleEnum::VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter::default()),
+        RuleEnum::VueNoWatchAfterAwait(VueNoWatchAfterAwait::default()),
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),
         RuleEnum::VueRequireDefaultExport(VueRequireDefaultExport::default()),
         RuleEnum::VueRequireSlotsAsFunctions(VueRequireSlotsAsFunctions::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -845,6 +845,7 @@ pub(crate) mod vue {
     pub mod no_required_prop_with_default;
     pub mod no_shared_component_data;
     pub mod no_this_in_before_route_enter;
+    pub mod no_watch_after_await;
     pub mod prefer_import_from_vue;
     pub mod require_default_export;
     pub mod require_slots_as_functions;

--- a/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
@@ -1,0 +1,592 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        AwaitExpression, ChainElement, ExportDefaultDeclarationKind, Expression,
+        ExpressionStatement, Function, ObjectExpression, ObjectPropertyKind,
+    },
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::{ScopeFlags, Scoping, SymbolId};
+use oxc_span::Span;
+use rustc_hash::FxHashMap;
+
+use crate::module_record::{ImportEntry, ImportImportName};
+use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
+
+fn no_watch_after_await_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{name}` is forbidden after an `await` expression."))
+        .with_help("`watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoWatchAfterAwait;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow asynchronously registered `watch`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `watch` and `watchEffect` registered after an `await` expression in
+    /// `setup()` may not work as expected because they are registered after
+    /// the component instance has finished setting up.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// import { watch } from 'vue'
+    /// export default {
+    ///   async setup() {
+    ///     await doSomething()
+    ///     watch(foo, () => { /* ... */ }) // error
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// import { watch } from 'vue'
+    /// export default {
+    ///   async setup() {
+    ///     watch(foo, () => { /* ... */ }) // ok
+    ///     await doSomething()
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoWatchAfterAwait,
+    vue,
+    correctness,
+    version = "next",
+);
+
+const WATCH_FUNCTIONS: &[&str] = &["watch", "watchEffect"];
+
+impl Rule for NoWatchAfterAwait {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            // e.g. `export default { setup() {} }`
+            AstKind::ExportDefaultDeclaration(export_decl) => {
+                if let ExportDefaultDeclarationKind::ObjectExpression(obj_expr) =
+                    &export_decl.declaration
+                {
+                    check_setup_in_object(obj_expr, ctx);
+                }
+            }
+            // e.g. `defineComponent({ setup() {} })`
+            AstKind::CallExpression(call_expr) => {
+                if let Some(ident) = call_expr.callee.get_identifier_reference()
+                    && ident.name == "defineComponent"
+                    && let Some(first_arg) = call_expr.arguments.first()
+                    && let Some(Expression::ObjectExpression(obj_expr)) = first_arg.as_expression()
+                {
+                    check_setup_in_object(obj_expr, ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+            && ctx.frameworks_options() != FrameworkOptions::VueSetup
+    }
+}
+
+fn check_setup_in_object<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+    let Some(setup_prop) = obj_expr.properties.iter().find_map(|prop| {
+        let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else {
+            return None;
+        };
+        obj_prop.key.static_name().is_some_and(|name| name == "setup").then_some(obj_prop)
+    }) else {
+        return;
+    };
+
+    let function_body_opt = match &setup_prop.value {
+        Expression::FunctionExpression(func_expr) => func_expr.body.as_ref(),
+        Expression::ArrowFunctionExpression(arrow_func_expr) => Some(&arrow_func_expr.body),
+        _ => None,
+    };
+    let Some(function_body) = function_body_opt else {
+        return;
+    };
+
+    let module_record = ctx.module_record();
+    let scoping = ctx.scoping();
+    let mut symbol_to_import_entry: FxHashMap<SymbolId, &ImportEntry> = FxHashMap::default();
+
+    for import_entry in &module_record.import_entries {
+        if import_entry.module_request.name() != "vue" {
+            continue;
+        }
+        let import_name = match &import_entry.import_name {
+            ImportImportName::Name(name_span) => name_span.name(),
+            _ => continue,
+        };
+
+        if !WATCH_FUNCTIONS.contains(&import_name) {
+            continue;
+        }
+        if let Some(symbol_id) = scoping.get_root_binding(import_entry.local_name.name().into()) {
+            symbol_to_import_entry.insert(symbol_id, import_entry);
+        }
+    }
+
+    let mut visitor = WatchAfterAwaitVisitor::new(scoping, symbol_to_import_entry);
+    visitor.visit_function_body(function_body);
+
+    visitor.errors.iter().for_each(|(span, name)| {
+        ctx.diagnostic(no_watch_after_await_diagnostic(*span, name));
+    });
+}
+
+struct WatchAfterAwaitVisitor<'a> {
+    found: bool,
+    errors: Vec<(Span, String)>,
+    scoping: &'a Scoping,
+    symbol_to_import_entry: FxHashMap<SymbolId, &'a ImportEntry>,
+}
+
+impl<'a> WatchAfterAwaitVisitor<'a> {
+    fn new(
+        scoping: &'a Scoping,
+        symbol_to_import_entry: FxHashMap<SymbolId, &'a ImportEntry>,
+    ) -> Self {
+        Self { found: false, errors: Vec::new(), scoping, symbol_to_import_entry }
+    }
+}
+
+impl<'a> Visit<'a> for WatchAfterAwaitVisitor<'a> {
+    fn visit_await_expression(&mut self, _expr: &AwaitExpression) {
+        self.found = true;
+    }
+
+    // Only `ExpressionStatement` direct children are reported. Stop handles such
+    // as `var a = watch()`, `c = watch()`, `d(watch())`, `{ foo: watch() }`,
+    // `[watch()]` are wrapped in another expression and are intentionally ignored.
+    fn visit_expression_statement(&mut self, stmt: &ExpressionStatement<'a>) {
+        if !self.found {
+            walk::walk_expression_statement(self, stmt);
+            return;
+        }
+
+        let inner = stmt.expression.get_inner_expression();
+        let call_expr = match inner {
+            Expression::CallExpression(c) => c,
+            Expression::ChainExpression(chain) => {
+                let ChainElement::CallExpression(c) = &chain.expression else {
+                    walk::walk_expression_statement(self, stmt);
+                    return;
+                };
+                c
+            }
+            _ => {
+                walk::walk_expression_statement(self, stmt);
+                return;
+            }
+        };
+
+        let Some(ident) = call_expr.callee.get_inner_expression().get_identifier_reference() else {
+            walk::walk_expression_statement(self, stmt);
+            return;
+        };
+
+        let reference = self.scoping.get_reference(ident.reference_id());
+        let Some(symbol_id) = reference.symbol_id() else {
+            walk::walk_expression_statement(self, stmt);
+            return;
+        };
+
+        if let Some(import_entry) = self.symbol_to_import_entry.get(&symbol_id)
+            && let ImportImportName::Name(name_span) = &import_entry.import_name
+        {
+            self.errors.push((call_expr.span, name_span.name().to_string()));
+        }
+        walk::walk_expression_statement(self, stmt);
+    }
+
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+
+    fn visit_arrow_function_expression(
+        &mut self,
+        _func: &oxc_ast::ast::ArrowFunctionExpression<'a>,
+    ) {
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    async setup() {
+                      watch(foo, () => { /* ... */ }) // ok
+            
+                      await doSomething()
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    async setup() {
+                      watch(foo, () => { /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {watch, watchEffect} from 'vue'
+                  export default {
+                    async setup() {
+                      watchEffect(() => { /* ... */ })
+                      watch(foo, () => { /* ... */ })
+                      await doSomething()
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {onMounted} from 'vue'
+                  export default {
+                    async _setup() {
+                      await doSomething()
+            
+                      onMounted(() => { /* ... */ }) // error
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {watch, watchEffect} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+                      const a = watchEffect(() => { /* ... */ })
+                      const b = watch(foo, () => { /* ... */ })
+                      c = watch()
+                      d(watch())
+                      e = {
+                        foo: watch()
+                      }
+                      f = [watch()]
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  Vue.component('test', {
+                    el: foo()
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  <script>
+                  import {watch, watchEffect} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+                      const a = watchEffect?.(() => { /* ... */ })
+                      const b = watch?.(foo, () => { /* ... */ })
+                      c = watch?.()
+                      d(watch?.())
+                      e = {
+                        foo: watch?.()
+                      }
+                      f = [watch?.()]
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  import {watchEffect} from 'vue'
+                  watchEffect(() => { /* ... */ })
+                  await doSomething()
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "
+                  <script setup>
+                  await doSomething()
+                  </script>
+                  <script>
+                  import {watchEffect} from 'vue'
+                  watchEffect(() => { /* ... */ }) // not error
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "
+                  <script setup>
+                  </script>
+                  <script>
+                  import {watchEffect} from 'vue'
+                  await doSomething()
+                  watchEffect(() => { /* ... */ }) // not error
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "
+                  <script setup>
+                  import {watch} from 'vue'
+                  watch(foo, () => { /* ... */ })
+
+                  await doSomething()
+
+                  watch(foo, () => { /* ... */ })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "ecmaVersion": 2022 }
+        // a function defined after `await` is fine
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+                      function logMessage() {
+                        watch(foo, () => { /* ... */ })
+                      }
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+            
+                      watch(foo, () => { /* ... */ }) // error
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {watch, watchEffect} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+            
+                      watchEffect(() => { /* ... */ })
+                      watch(foo, () => { /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+
+                      watch(foo, () => { /* ... */ })
+
+                      await doSomething()
+
+                      watch(foo, () => { /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // parenthesized callee
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething();
+                      (watch)(foo, () => { /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // `export default defineComponent({...})`
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default defineComponent({
+                    async setup() {
+                      await doSomething()
+                      watch(foo, () => { /* ... */ })
+                    }
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // `defineComponent({...})` without `export default`
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  defineComponent({
+                    async setup() {
+                      await doSomething()
+                      watch(foo, () => { /* ... */ })
+                    }
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // `setup: async () => {...}`
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    setup: async () => {
+                      await doSomething()
+                      watch(foo, () => { /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // optional chain at expression statement (not stop handle)
+        (
+            "
+                  <script>
+                  import {watch} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+                      watch?.(foo, () => { /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // import alias
+        (
+            "
+                  <script>
+                  import {watch as A} from 'vue'
+                  export default {
+                    async setup() {
+                      await doSomething()
+                      A(foo, () => { /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(NoWatchAfterAwait::NAME, NoWatchAfterAwait::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
@@ -1,8 +1,10 @@
+use rustc_hash::FxHashMap;
+
 use oxc_ast::{
     AstKind,
     ast::{
-        AwaitExpression, ChainElement, ExportDefaultDeclarationKind, Expression,
-        ExpressionStatement, Function, ObjectExpression, ObjectPropertyKind,
+        ArrowFunctionExpression, AwaitExpression, ChainElement, ExportDefaultDeclarationKind,
+        Expression, ExpressionStatement, Function, ObjectExpression, ObjectPropertyKind,
     },
 };
 use oxc_ast_visit::{Visit, walk};
@@ -10,7 +12,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ScopeFlags, Scoping, SymbolId};
 use oxc_span::Span;
-use rustc_hash::FxHashMap;
 
 use crate::module_record::{ImportEntry, ImportImportName};
 use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
@@ -216,17 +217,14 @@ impl<'a> Visit<'a> for WatchAfterAwaitVisitor<'a> {
 
     fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
 
-    fn visit_arrow_function_expression(
-        &mut self,
-        _func: &oxc_ast::ast::ArrowFunctionExpression<'a>,
-    ) {
-    }
+    fn visit_arrow_function_expression(&mut self, _func: &ArrowFunctionExpression<'a>) {}
 }
 
 #[test]
 fn test() {
-    use crate::tester::Tester;
     use std::path::PathBuf;
+
+    use crate::tester::Tester;
 
     let pass = vec![
         (

--- a/crates/oxc_linter/src/snapshots/vue_no_watch_after_await.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_watch_after_await.snap
@@ -1,0 +1,102 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:8:23]
+ 7 │             
+ 8 │                       watch(foo, () => { /* ... */ }) // error
+   ·                       ───────────────────────────────
+ 9 │                     }
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watchEffect` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:8:23]
+ 7 │             
+ 8 │                       watchEffect(() => { /* ... */ })
+   ·                       ────────────────────────────────
+ 9 │                       watch(foo, () => { /* ... */ })
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+    ╭─[no_watch_after_await.tsx:9:23]
+  8 │                       watchEffect(() => { /* ... */ })
+  9 │                       watch(foo, () => { /* ... */ })
+    ·                       ───────────────────────────────
+ 10 │                     }
+    ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:8:23]
+ 7 │ 
+ 8 │                       watch(foo, () => { /* ... */ })
+   ·                       ───────────────────────────────
+ 9 │ 
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+    ╭─[no_watch_after_await.tsx:12:23]
+ 11 │ 
+ 12 │                       watch(foo, () => { /* ... */ })
+    ·                       ───────────────────────────────
+ 13 │                     }
+    ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:7:23]
+ 6 │                       await doSomething();
+ 7 │                       (watch)(foo, () => { /* ... */ })
+   ·                       ─────────────────────────────────
+ 8 │                     }
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:7:23]
+ 6 │                       await doSomething()
+ 7 │                       watch(foo, () => { /* ... */ })
+   ·                       ───────────────────────────────
+ 8 │                     }
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:7:23]
+ 6 │                       await doSomething()
+ 7 │                       watch(foo, () => { /* ... */ })
+   ·                       ───────────────────────────────
+ 8 │                     }
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:7:23]
+ 6 │                       await doSomething()
+ 7 │                       watch(foo, () => { /* ... */ })
+   ·                       ───────────────────────────────
+ 8 │                     }
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:7:23]
+ 6 │                       await doSomething()
+ 7 │                       watch?.(foo, () => { /* ... */ })
+   ·                       ─────────────────────────────────
+ 8 │                     }
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.
+
+  ⚠ vue(no-watch-after-await): `watch` is forbidden after an `await` expression.
+   ╭─[no_watch_after_await.tsx:7:23]
+ 6 │                       await doSomething()
+ 7 │                       A(foo, () => { /* ... */ })
+   ·                       ───────────────────────────
+ 8 │                     }
+   ╰────
+  help: `watch` and `watchEffect` should be called synchronously in `setup()`. Move the call before the first `await`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2629,6 +2629,9 @@
         "vue/no-this-in-before-route-enter": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-watch-after-await": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/prefer-import-from-vue": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2633,6 +2633,9 @@ expression: json
         "vue/no-this-in-before-route-enter": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-watch-after-await": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/prefer-import-from-vue": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/no-watch-after-await.html

AI disclosure: implemented with Claude Code, reviewed manually.