### PR TITLE
feat(linter/no-else-return): improve nested if diagnostic spans

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -16,7 +16,7 @@ fn no_else_return_diagnostic(else_keyword: Span, last_return: Span) -> OxcDiagno
     OxcDiagnostic::warn("Unnecessary `else` after `return`.")
         .with_labels([
             last_return.label("This consequent block always returns,"),
-            else_keyword.label("Making this `else` block unnecessary."),
+            else_keyword.primary_label("Making this `else` block unnecessary."),
         ])
         .with_help("Remove the `else` block, moving its contents outside of the `if` statement.")
 }
@@ -276,10 +276,10 @@ fn check_for_return_or_if(node: &Statement) -> Option<Span> {
         Statement::ReturnStatement(r) => Some(r.span),
         Statement::IfStatement(if_stmt) => {
             let alternate = if_stmt.alternate.as_ref()?;
-            if let (Some(_), Some(ret_span)) =
-                (naive_has_return(alternate), naive_has_return(&if_stmt.consequent))
+            if naive_has_return(alternate).is_some()
+                && naive_has_return(&if_stmt.consequent).is_some()
             {
-                Some(ret_span)
+                Some(if_stmt.span)
             } else {
                 None
             }
@@ -630,6 +630,24 @@ fn test() {
         ("function foo() { if (bar) { return true; } else function baz() {} };", None),
         ("if (foo) { return true; } else { let a; }", None), // { "ecmaVersion": 6, "sourceType": "commonjs" },
         ("let a; if (foo) { return true; } else { let a; }", None), // { "ecmaVersion": 6, "sourceType": "commonjs" }
+        (
+            "
+                function createReexports(meta, builder, value) {
+                    return meta.items.map(item => {
+                        if (value) {
+                            if (meta.has(item)) {
+                                return builder.computed(item);
+                            } else {
+                                return builder.constant(item);
+                            }
+                        } else {
+                            return builder.spec(item);
+                        }
+                    });
+                }
+            ",
+            None,
+        ),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/eslint_no_else_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_else_return.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:6]
+   ╭─[no_else_return.tsx:1:13]
  1 │ if(0)return;else r
    ·      ───┬─────┬──
    ·         │     ╰── Making this `else` block unnecessary.
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:31]
+   ╭─[no_else_return.tsx:1:42]
  1 │ function foo1() { if (true) { return x; } else { return y; } }
    ·                               ────┬────  ───┬──
    ·                                   │         ╰── Making this `else` block unnecessary.
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:44]
+   ╭─[no_else_return.tsx:1:55]
  1 │ function foo2() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }
    ·                                            ────┬────  ───┬──
    ·                                                │         ╰── Making this `else` block unnecessary.
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:38]
  1 │ function foo3() { if (true) return x; else return y; }
    ·                             ────┬───────┬──
    ·                                 │       ╰── Making this `else` block unnecessary.
@@ -39,16 +39,16 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:42]
+   ╭─[no_else_return.tsx:1:68]
  1 │ function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }
-   ·                                          ────┬────                 ───┬──
-   ·                                              │                        ╰── Making this `else` block unnecessary.
-   ·                                              ╰── This consequent block always returns,
+   ·                               ─────────────────┬─────────────────  ───┬──
+   ·                                                │                      ╰── Making this `else` block unnecessary.
+   ·                                                ╰── This consequent block always returns,
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:42]
+   ╭─[no_else_return.tsx:1:51]
  1 │ function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }
    ·                                          ────┬───────┬──
    ·                                              │       ╰── Making this `else` block unnecessary.
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:54]
+   ╭─[no_else_return.tsx:1:63]
  1 │ function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }
    ·                                                      ────┬───────┬──
    ·                                                          │       ╰── Making this `else` block unnecessary.
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:54]
+   ╭─[no_else_return.tsx:1:63]
  1 │ function foo6() { if (true) { if (false) { if (true) return x; else return y; } } else { return z; } }
    ·                                                      ────┬───────┬──
    ·                                                          │       ╰── Making this `else` block unnecessary.
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:81]
+   ╭─[no_else_return.tsx:1:92]
  1 │ function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }
    ·                                                                                 ────┬────  ───┬──
    ·                                                                                     │         ╰── Making this `else` block unnecessary.
@@ -84,7 +84,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:54]
+   ╭─[no_else_return.tsx:1:63]
  1 │ function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }
    ·                                                      ────┬───────┬──
    ·                                                          │       ╰── Making this `else` block unnecessary.
@@ -93,16 +93,16 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:54]
+   ╭─[no_else_return.tsx:1:80]
  1 │ function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }
-   ·                                                      ────┬────                 ───┬──
-   ·                                                          │                        ╰── Making this `else` block unnecessary.
-   ·                                                          ╰── This consequent block always returns,
+   ·                                            ─────────────────┬────────────────  ───┬──
+   ·                                                             │                     ╰── Making this `else` block unnecessary.
+   ·                                                             ╰── This consequent block always returns,
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:54]
+   ╭─[no_else_return.tsx:1:63]
  1 │ function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }
    ·                                                      ────┬───────┬──
    ·                                                          │       ╰── Making this `else` block unnecessary.
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:56]
+   ╭─[no_else_return.tsx:1:70]
  1 │ function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }
    ·                                                        ──────┬─────  ───┬──
    ·                                                              │          ╰── Making this `else` block unnecessary.
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:28]
+   ╭─[no_else_return.tsx:1:42]
  1 │ function foo9a() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }
    ·                            ──────┬─────  ───┬──
    ·                                  │          ╰── Making this `else` block unnecessary.
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:52]
+   ╭─[no_else_return.tsx:1:66]
  1 │ function foo9b() {if (x) { return true; } if (y) { return true; } else { notAReturn(); } }
    ·                                                    ──────┬─────  ───┬──
    ·                                                          │          ╰── Making this `else` block unnecessary.
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:40]
  1 │ function foo10() { if (foo) return bar; else (foo).bar(); }
    ·                             ─────┬────────┬──
    ·                                  │        ╰── Making this `else` block unnecessary.
@@ -147,7 +147,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:39]
  1 │ ╭─▶ function foo11() { if (foo) return bar
    · │                               ─────┬────
    · │                                    ╰── This consequent block always returns,
@@ -157,7 +157,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:39]
  1 │ ╭─▶ function foo12() { if (foo) return bar
    · │                               ─────┬────
    · │                                    ╰── This consequent block always returns,
@@ -168,7 +168,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:40]
  1 │ ╭─▶ function foo13() { if (foo) return bar;
    · │                               ─────┬─────
    · │                                    ╰── This consequent block always returns,
@@ -178,7 +178,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:39]
  1 │ ╭─▶ function foo14() { if (foo) return bar
    · │                               ─────┬────
    · │                                    ╰── This consequent block always returns,
@@ -189,7 +189,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:40]
  1 │ function foo15() { if (foo) return bar; else { baz() } qaz() }
    ·                             ─────┬────────┬──
    ·                                  │        ╰── Making this `else` block unnecessary.
@@ -198,7 +198,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:39]
  1 │ ╭─▶ function foo16() { if (foo) return bar
    · │                               ─────┬────
    · │                                    ╰── This consequent block always returns,
@@ -208,7 +208,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:39]
  1 │ ╭─▶ function foo17() { if (foo) return bar
    · │                               ─────┬────
    · │                                    ╰── This consequent block always returns,
@@ -219,7 +219,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:49]
  1 │ ╭─▶ function foo18() { if (foo) return function() {}
    · │                               ──────────┬─────────
    · │                                         ╰── This consequent block always returns,
@@ -229,7 +229,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:32]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo19() { if (true) { return x; } else if (false) { return y; } }
    ·                                ────┬────  ───┬──
    ·                                    │         ╰── Making this `else` block unnecessary.
@@ -238,7 +238,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:28]
+   ╭─[no_else_return.tsx:1:42]
  1 │ function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }
    ·                            ──────┬─────  ───┬──
    ·                                  │          ╰── Making this `else` block unnecessary.
@@ -247,7 +247,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:43]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }
    ·                                           ────┬────  ───┬──
    ·                                               │         ╰── Making this `else` block unnecessary.
@@ -256,7 +256,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { var a; if (bar) { return true; } else { var a; } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -265,7 +265,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:47]
+   ╭─[no_else_return.tsx:1:61]
  1 │ function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }
    ·                                               ──────┬─────  ───┬──
    ·                                                     │          ╰── Making this `else` block unnecessary.
@@ -274,7 +274,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { var a; if (bar) { return true; } else { var a; } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -283,7 +283,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:47]
+   ╭─[no_else_return.tsx:1:61]
  1 │ function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }
    ·                                               ──────┬─────  ───┬──
    ·                                                     │          ╰── Making this `else` block unnecessary.
@@ -292,7 +292,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { let a; if (bar) { return true; } else { let a; } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -301,7 +301,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:39]
+   ╭─[no_else_return.tsx:1:53]
  1 │ class foo { bar() { let a; if (baz) { return true; } else { let a; } } }
    ·                                       ──────┬─────  ───┬──
    ·                                             │          ╰── Making this `else` block unnecessary.
@@ -310,7 +310,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:47]
+   ╭─[no_else_return.tsx:1:61]
  1 │ function foo() { if (bar) { let a; if (baz) { return true; } else { let a; } } }
    ·                                               ──────┬─────  ───┬──
    ·                                                     │          ╰── Making this `else` block unnecessary.
@@ -319,7 +319,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:46]
+   ╭─[no_else_return.tsx:1:60]
  1 │ function foo() {let a; if (bar) { if (baz) { return true; } else { let a; } } }
    ·                                              ──────┬─────  ───┬──
    ·                                                    │          ╰── Making this `else` block unnecessary.
@@ -328,7 +328,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:42]
+   ╭─[no_else_return.tsx:1:56]
  1 │ function foo() { const a = 1; if (bar) { return true; } else { let a; } }
    ·                                          ──────┬─────  ───┬──
    ·                                                │          ╰── Making this `else` block unnecessary.
@@ -337,7 +337,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:53]
+   ╭─[no_else_return.tsx:1:67]
  1 │ function foo() { if (bar) { const a = 1; if (baz) { return true; } else { let a; } } }
    ·                                                     ──────┬─────  ───┬──
    ·                                                           │          ╰── Making this `else` block unnecessary.
@@ -346,7 +346,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { let a; if (bar) { return true; } else { const a = 1 } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -355,7 +355,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:47]
+   ╭─[no_else_return.tsx:1:61]
  1 │ function foo() { if (bar) { let a; if (baz) { return true; } else { const a = 1; } } }
    ·                                               ──────┬─────  ───┬──
    ·                                                     │          ╰── Making this `else` block unnecessary.
@@ -364,7 +364,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:41]
+   ╭─[no_else_return.tsx:1:55]
  1 │ function foo() { class a {}; if (bar) { return true; } else { const a = 1; } }
    ·                                         ──────┬─────  ───┬──
    ·                                               │          ╰── Making this `else` block unnecessary.
@@ -373,7 +373,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:52]
+   ╭─[no_else_return.tsx:1:66]
  1 │ function foo() { if (bar) { class a {}; if (baz) { return true; } else { const a = 1; } } }
    ·                                                    ──────┬─────  ───┬──
    ·                                                          │          ╰── Making this `else` block unnecessary.
@@ -382,7 +382,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:42]
+   ╭─[no_else_return.tsx:1:56]
  1 │ function foo() { const a = 1; if (bar) { return true; } else { class a {} } }
    ·                                          ──────┬─────  ───┬──
    ·                                                │          ╰── Making this `else` block unnecessary.
@@ -391,7 +391,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:53]
+   ╭─[no_else_return.tsx:1:67]
  1 │ function foo() { if (bar) { const a = 1; if (baz) { return true; } else { class a {} } } }
    ·                                                     ──────┬─────  ───┬──
    ·                                                           │          ╰── Making this `else` block unnecessary.
@@ -400,7 +400,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { var a; if (bar) { return true; } else { let a; } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -409,7 +409,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { if (bar) { var a; return true; } else { let a; } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -418,7 +418,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let a; }  while (baz) { var a; } }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -427,7 +427,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:30]
+   ╭─[no_else_return.tsx:1:44]
  1 │ function foo(a) { if (bar) { return true; } else { let a; } }
    ·                              ──────┬─────  ───┬──
    ·                                    │          ╰── Making this `else` block unnecessary.
@@ -436,7 +436,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:34]
+   ╭─[no_else_return.tsx:1:48]
  1 │ function foo(a = 1) { if (bar) { return true; } else { let a; } }
    ·                                  ──────┬─────  ───┬──
    ·                                        │          ╰── Making this `else` block unnecessary.
@@ -445,7 +445,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:37]
+   ╭─[no_else_return.tsx:1:51]
  1 │ function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}
    ·                                     ──────┬─────  ───┬──
    ·                                           │          ╰── Making this `else` block unnecessary.
@@ -454,7 +454,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:80]
+   ╭─[no_else_return.tsx:1:94]
  1 │ function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}
    ·                                                                                ──────┬─────  ───┬──
    ·                                                                                      │          ╰── Making this `else` block unnecessary.
@@ -463,7 +463,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo(...args) { if (bar) { return true; } else { let args; } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -472,7 +472,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:48]
+   ╭─[no_else_return.tsx:1:62]
  1 │ function foo() { try {} catch (a) { if (bar) { return true; } else { let a; } } }
    ·                                                ──────┬─────  ───┬──
    ·                                                      │          ╰── Making this `else` block unnecessary.
@@ -481,7 +481,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:59]
+   ╭─[no_else_return.tsx:1:73]
  1 │ function foo() { try {} catch (a) { if (bar) { if (baz) { return true; } else { let a; } } } }
    ·                                                           ──────┬─────  ───┬──
    ·                                                                 │          ╰── Making this `else` block unnecessary.
@@ -490,7 +490,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:59]
+   ╭─[no_else_return.tsx:1:73]
  1 │ function foo() { try {} catch ({bar, a = 1}) { if (baz) { return true; } else { let a; } } }
    ·                                                           ──────┬─────  ───┬──
    ·                                                                 │          ╰── Making this `else` block unnecessary.
@@ -499,7 +499,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let arguments; } }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -508,7 +508,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let arguments; } return arguments[0]; }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -517,7 +517,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let arguments; } if (baz) { return arguments[0]; } }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -526,7 +526,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let arguments; } } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -535,7 +535,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let a; } a; }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -544,7 +544,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let a; } if (baz) { a; } }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -553,7 +553,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } a; }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -562,7 +562,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } a; } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -571,7 +571,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { a; } } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -580,7 +580,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:27]
+   ╭─[no_else_return.tsx:1:41]
  1 │ function a() { if (foo) { return true; } else { let a; } a(); }
    ·                           ──────┬─────  ───┬──
    ·                                 │          ╰── Making this `else` block unnecessary.
@@ -589,7 +589,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:25]
+   ╭─[no_else_return.tsx:1:39]
  1 │ function a() { if (a) { return true; } else { let a; } }
    ·                         ──────┬─────  ───┬──
    ·                               │          ╰── Making this `else` block unnecessary.
@@ -598,7 +598,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:27]
+   ╭─[no_else_return.tsx:1:38]
  1 │ function a() { if (foo) { return a; } else { let a; } }
    ·                           ────┬────  ───┬──
    ·                               │         ╰── Making this `else` block unnecessary.
@@ -607,7 +607,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let a; } function baz() { a; } }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -616,7 +616,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } (() => a) } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -625,7 +625,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let a; } var a; }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -634,7 +634,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } var a; } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -643,7 +643,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } var { a } = {}; } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -652,7 +652,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { var a; } } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -661,7 +661,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { var a; } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -670,7 +670,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:61]
+   ╭─[no_else_return.tsx:1:75]
  1 │ function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; } else { let a; } } }
    ·                                                             ──────┬─────  ───┬──
    ·                                                                   │          ╰── Making this `else` block unnecessary.
@@ -679,7 +679,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else { let a; } function a(){} }
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -688,7 +688,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (baz) { if (bar) { return true; } else { let a; } function a(){} } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -697,7 +697,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { function a(){}  } }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -706,7 +706,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:40]
+   ╭─[no_else_return.tsx:1:54]
  1 │ function foo() { if (bar) { if (baz) { return true; } else { let a; } } function a(){} }
    ·                                        ──────┬─────  ───┬──
    ·                                              │          ╰── Making this `else` block unnecessary.
@@ -715,7 +715,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { let a; if (bar) { return true; } else { function a(){} } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -724,7 +724,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:36]
+   ╭─[no_else_return.tsx:1:50]
  1 │ function foo() { var a; if (bar) { return true; } else { function a(){} } }
    ·                                    ──────┬─────  ───┬──
    ·                                          │          ╰── Making this `else` block unnecessary.
@@ -733,7 +733,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:29]
+   ╭─[no_else_return.tsx:1:43]
  1 │ function foo() { if (bar) { return true; } else function baz() {} };
    ·                             ──────┬─────  ───┬──
    ·                                   │          ╰── Making this `else` block unnecessary.
@@ -742,7 +742,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:12]
+   ╭─[no_else_return.tsx:1:26]
  1 │ if (foo) { return true; } else { let a; }
    ·            ──────┬─────  ───┬──
    ·                  │          ╰── Making this `else` block unnecessary.
@@ -751,10 +751,39 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the `else` block, moving its contents outside of the `if` statement.
 
   ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
-   ╭─[no_else_return.tsx:1:19]
+   ╭─[no_else_return.tsx:1:33]
  1 │ let a; if (foo) { return true; } else { let a; }
    ·                   ──────┬─────  ───┬──
    ·                         │          ╰── Making this `else` block unnecessary.
    ·                         ╰── This consequent block always returns,
+   ╰────
+  help: Remove the `else` block, moving its contents outside of the `if` statement.
+
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
+    ╭─[no_else_return.tsx:10:26]
+  4 │                             if (value) {
+  5 │ ╭─▶                             if (meta.has(item)) {
+  6 │ │                                   return builder.computed(item);
+  7 │ │                               } else {
+  8 │ │                                   return builder.constant(item);
+  9 │ ├─▶                             }
+    · ╰──── This consequent block always returns,
+ 10 │                             } else {
+    ·                              ───┬──
+    ·                                 ╰── Making this `else` block unnecessary.
+ 11 │                                 return builder.spec(item);
+    ╰────
+  help: Remove the `else` block, moving its contents outside of the `if` statement.
+
+  ⚠ eslint(no-else-return): Unnecessary `else` after `return`.
+   ╭─[no_else_return.tsx:7:30]
+ 5 │                             if (meta.has(item)) {
+ 6 │                                 return builder.computed(item);
+   ·                                 ───────────────┬──────────────
+   ·                                                ╰── This consequent block always returns,
+ 7 │                             } else {
+   ·                              ───┬──
+   ·                                 ╰── Making this `else` block unnecessary.
+ 8 │                                 return builder.constant(item);
    ╰────
   help: Remove the `else` block, moving its contents outside of the `if` statement.


### PR DESCRIPTION
Update no-else-return diagnostics to mark the unnecessary else as the primary span and label nested if/else consequents as a whole when both branches return. Add a regression case based on the ecosystem monitor failure so the inner and outer else reports stay distinct.