### PR TITLE
fix(linter/oxc): remove duplicate rule tests

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
@@ -107,7 +107,6 @@ fn test() {
         r"a.charAt(4) === 'a'",
         "a.charAt(4) === '\\n'",
         "a.charAt(4) === '\t'",
-        r"a.charAt(4) === 'a'",
         r"a.charAt(4) === '\ufeff'",
         r"a.charAt(4) !== '\ufeff'",
         "chatAt(4) === 'a2'",

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -132,7 +132,6 @@ fn test() {
         "x > y && x >= y",
         "x >= y && x > y",
         "x >= y && x >= y",
-        "x >= y && x >= y",
         "x == y || fs < y",
         "x < y || ab == y",
         "x == y || qr > y",

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -357,12 +357,10 @@ fn test() {
     let pass = vec![
         ("app.get('/', fooController)", None),
         ("app.get('/', (req, res) => {})", None),
-        ("app.get('/', (req, res) => {})", None),
         ("app.get('/', function (req, res) {})", None),
         ("app.get('/', middleware, function (req, res) {})", None),
         ("app.get('/', (req, res, next) => {})", None),
         ("app.get('/', (err, req, res, next) => {})", None),
-        ("app.get('/', (err, req, res) => {})", None),
         ("app.get('/', (err, req, res) => {})", None),
         ("app.get('/', (req, res) => Promise.resolve())", None),
         ("app.get('/', (req, res) => new Promise((resolve, reject) => resolve()))", None),
@@ -403,7 +401,6 @@ fn test() {
         ("app.get('/', async function (req, res) {})", None),
         ("app.get('/', async (req, res) =>  {})", None),
         ("app.get('/', async (req, res, next) =>  {})", None),
-        ("weirdName.get('/', async (req, res) =>  {})", None),
         ("weirdName.get('/', async (req, res) =>  {})", None),
         (
             "

--- a/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_optional_chaining.rs
@@ -98,7 +98,6 @@ fn test() {
         ("var x = ((a?.b)?.c)?.()", None),
         ("var x = a/*?.*/?.b", None),
         ("var x = '?.'?.['?.']", None),
-        ("var x = '?.'?.['?.']", None),
         ("a?.c?.b<c>", None),
         ("foo?.bar!", None),
         ("foo?.[bar]!", None),

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -673,12 +673,6 @@ fn test() {
                 test(arg0);
             }
         ",
-        // Unused Argument in Recursion
-        r"
-            function test(arg0, arg1) {
-                test(arg0);
-            }
-        ",
         r"
             module.exports = function test(a) {
                 test(a)

--- a/crates/oxc_linter/src/snapshots/oxc_no_async_endpoint_handlers.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_async_endpoint_handlers.snap
@@ -43,16 +43,6 @@ source: crates/oxc_linter/src/tester.rs
   note: If you're on Express 5, disable this rule. To allow specific functions, add their names to `allowedNames`.
 
   ⚠ oxc(no-async-endpoint-handlers): Express endpoint handler for `/` should not be `async`.
-   ╭─[no_async_endpoint_handlers.tsx:1:20]
- 1 │ weirdName.get('/', async (req, res) =>  {})
-   ·                    ──┬──
-   ·                      ╰── Async handler is used here
-   ╰────
-  help: Wrap the async handler and forward errors to `next()` (e.g. `(req, res, next) => Promise.resolve(handler(req, res, next)).catch(next)`).
-        Express does not automatically handle rejected promises from async handlers, which results in unhandled promise rejections and server crashes.
-  note: If you're on Express 5, disable this rule. To allow specific functions, add their names to `allowedNames`.
-
-  ⚠ oxc(no-async-endpoint-handlers): Express endpoint handler for `/` should not be `async`.
    ╭─[no_async_endpoint_handlers.tsx:3:27]
  1 │ 
  2 │             async function foo(req, res) {}

--- a/crates/oxc_linter/src/snapshots/oxc_no_optional_chaining.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_optional_chaining.snap
@@ -51,12 +51,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ oxc(no-optional-chaining): Optional chaining is not allowed.
-   ╭─[no_optional_chaining.tsx:1:9]
- 1 │ var x = '?.'?.['?.']
-   ·         ────────────
-   ╰────
-
-  ⚠ oxc(no-optional-chaining): Optional chaining is not allowed.
    ╭─[no_optional_chaining.tsx:1:1]
  1 │ a?.c?.b<c>
    · ───────

--- a/crates/oxc_linter/src/snapshots/oxc_only_used_in_recursion.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_only_used_in_recursion.snap
@@ -38,15 +38,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the argument and its usage. Alternatively, use the argument in the function body.
 
-  ⚠ oxc(only-used-in-recursion): Parameter `arg0` is only used in recursive calls
-   ╭─[only_used_in_recursion.tsx:2:27]
- 1 │ 
- 2 │             function test(arg0, arg1) {
-   ·                           ────
- 3 │                 test(arg0);
-   ╰────
-  help: Remove the argument and its usage. Alternatively, use the argument in the function body.
-
   ⚠ oxc(only-used-in-recursion): Parameter `a` is only used in recursive calls
    ╭─[only_used_in_recursion.tsx:2:44]
  1 │ 


### PR DESCRIPTION
Removes duplicated test cases from the `oxc` linter rules and updates the affected snapshots to match the reduced diagnostics.