### PR TITLE
test(linter/branches-sharing-code): add nested if regression

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
+++ b/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
@@ -263,6 +263,13 @@ fn test() {
             ;(originObject as IAnyObject)[property] = assignObject[property] as unknown
         }
         ",
+        r#"
+        if (maybe) {
+            if (maybe2) { console.log("maybe and maybe2"); }
+        } else {
+            if (maybe2) { console.log("not maybe and maybe2"); }
+        }
+        "#,
     ];
 
     let fail = vec![


### PR DESCRIPTION
Adds a regression test covering nested `if` statements in both branches with different inner bodies; AI assistance was used to prepare this PR.