### PR TITLE
test(linter/no-unused-vars): remove duplicate rule tests

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -419,7 +419,7 @@ fn test_vars_destructure() {
         ),
         (
             "const { a, ...rest } = obj; console.log(rest)",
-            Some(json!( [{ "ignoreRestSiblings": true, "vars": "all" }] )),
+            Some(json!( [{ "ignoreRestSiblings": true, "vars": "local" }] )),
         ),
         // https://github.com/oxc-project/oxc/issues/4888
         (
@@ -1010,7 +1010,6 @@ fn test_exports() {
         // default exports
         "export default class Foo {}",
         "export default [ class Foo {} ];",
-        "export default function foo() {}",
         "export default { foo() {} };",
         "export default { foo: function foo() {} };",
         "export default { get foo() {} };",

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -1624,14 +1624,6 @@ fn test() {
             "
           import test from 'test';
           import baz from 'baz';
-          export interface Bar extends baz.test {}
-                ",
-            None,
-        ),
-        (
-            "
-          import test from 'test';
-          import baz from 'baz';
           export class Bar implements baz.test {}
           ",
             None,

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@typescript-eslint.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@typescript-eslint.snap
@@ -169,16 +169,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this import.
 
-  ⚠ eslint(no-unused-vars): Identifier 'test' is imported but never used.
-   ╭─[no_unused_vars.ts:2:18]
- 1 │ 
- 2 │           import test from 'test';
-   ·                  ──┬─
-   ·                    ╰── 'test' is imported here
- 3 │           import baz from 'baz';
-   ╰────
-  help: Consider removing this import.
-
   ⚠ eslint(no-unused-vars): Variable 'Foo' is declared but never used.
    ╭─[no_unused_vars.ts:1:11]
  1 │ namespace Foo {}


### PR DESCRIPTION
Removes duplicated `no-unused-vars` rule test cases and updates the affected TypeScript-ESLint snapshot to match the reduced diagnostics.