### PR TITLE
chore(linter): remove stale rule doc comments

### DIFF
--- a/crates/oxc_linter/src/rules/import/exports_last.rs
+++ b/crates/oxc_linter/src/rules/import/exports_last.rs
@@ -7,7 +7,6 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn exports_last_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn("Export statements should appear at the end of the file")
         .with_help("Move this export to the end of the file, after all other statements.")
         .with_label(span)

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_been_called.rs
@@ -20,7 +20,6 @@ fn prefer_to_have_been_called_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct PreferToHaveBeenCalled;
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -10,7 +10,6 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_unsafe_function_type_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
     OxcDiagnostic::warn("The `Function` type accepts any function-like value.")
         .with_help("Prefer explicitly defining any function parameters and return type.")
         .with_label(span)


### PR DESCRIPTION
Removes stale linter rule documentation comments from three rule files.