### PR TITLE
feat(linter): suggest moving shared branch code

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
+++ b/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
@@ -1,13 +1,16 @@
 // Inspired by https://github.com/rust-lang/rust-clippy/blob/95f5a00d8628fba223c802251af3c42547927c5a/clippy_lints/src/ifs/branches_sharing_code.rs
 use oxc_ast::{
     AstKind,
-    ast::{Expression, IfStatement, Statement},
+    ast::{Expression, IdentifierReference, IfStatement, Statement},
 };
+use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::{ReferenceId, SymbolId};
 use oxc_span::{ContentEq, GetSpan, Span};
+use rustc_hash::FxHashSet;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, ast_util::get_preceding_indent_str, context::LintContext, rule::Rule};
 
 fn branches_sharing_code_at_start_diagnostic(
     span: Span,
@@ -86,6 +89,7 @@ declare_oxc_lint!(
     BranchesSharingCode,
     oxc,
     pedantic,
+    suggestion,
     version = "1.22.0",
 );
 
@@ -108,13 +112,62 @@ impl Rule for BranchesSharingCode {
         if let Some(start) =
             start_eq.filter(|&start| !duplicated_stmts_are_empty(start, &bodies, false))
         {
-            let spans = bodies.iter().map(|body| get_duplicated_span(start, body, false));
-            ctx.diagnostic(branches_sharing_code_at_start_diagnostic(if_span, spans));
+            let spans = bodies
+                .iter()
+                .map(|body| get_duplicated_span(start, body, false))
+                .collect::<Vec<_>>();
+            let diagnostic =
+                branches_sharing_code_at_start_diagnostic(if_span, spans.iter().copied());
+
+            if start == 1
+                && let Some(indent) = get_preceding_indent_str(ctx.source_text(), if_stmt.span)
+            {
+                let delete_spans = bodies
+                    .iter()
+                    .map(|body| get_duplicated_delete_span(start, body, false))
+                    .collect::<Vec<_>>();
+                let moved_code = ctx.source_range(spans[0]).to_string();
+                ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
+                    let fixer = fixer.for_multifix();
+                    let mut fix = fixer.new_fix_with_capacity(spans.len() + 1);
+                    fix.push(fixer.insert_text_before(if_stmt, format!("{moved_code}\n{indent}")));
+                    for span in delete_spans {
+                        fix.push(fixer.delete_range(span));
+                    }
+                    fix.with_message("Move the shared statements before the `if` statement.")
+                });
+            } else {
+                ctx.diagnostic(diagnostic);
+            }
         }
 
         if let Some(end) = end_eq.filter(|&end| !duplicated_stmts_are_empty(end, &bodies, true)) {
-            let spans = bodies.iter().map(|body| get_duplicated_span(end, body, true));
-            ctx.diagnostic(branches_sharing_code_at_end_diagnostic(if_span, spans));
+            let spans =
+                bodies.iter().map(|body| get_duplicated_span(end, body, true)).collect::<Vec<_>>();
+            let diagnostic =
+                branches_sharing_code_at_end_diagnostic(if_span, spans.iter().copied());
+
+            if end == 1
+                && let Some(indent) = get_preceding_indent_str(ctx.source_text(), if_stmt.span)
+                && !duplicated_end_references_branch_locals(end, &bodies, ctx)
+            {
+                let delete_spans = bodies
+                    .iter()
+                    .map(|body| get_duplicated_delete_span(end, body, true))
+                    .collect::<Vec<_>>();
+                let moved_code = ctx.source_range(spans[0]).to_string();
+                ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
+                    let fixer = fixer.for_multifix();
+                    let mut fix = fixer.new_fix_with_capacity(spans.len() + 1);
+                    for span in delete_spans {
+                        fix.push(fixer.delete_range(span));
+                    }
+                    fix.push(fixer.insert_text_after(if_stmt, format!("\n{indent}{moved_code}")));
+                    fix.with_message("Move the shared statements after the `if` statement.")
+                });
+            } else {
+                ctx.diagnostic(diagnostic);
+            }
         }
     }
 }
@@ -132,6 +185,86 @@ fn get_duplicated_span(count: usize, body: &Statement, reverse: bool) -> Span {
     let start = range.first().map(|s| s.span().start).unwrap();
     let end = range.last().map(|s| s.span().end).unwrap();
     Span::new(start, end)
+}
+
+fn get_duplicated_delete_span(count: usize, body: &Statement, reverse: bool) -> Span {
+    let stmts = get_block_statements(body);
+    let duplicated_span = get_duplicated_span(count, body, reverse);
+
+    if reverse {
+        let start_idx = stmts.len() - count;
+        return Span::new(
+            start_idx
+                .checked_sub(1)
+                .and_then(|idx| stmts.get(idx))
+                .map_or(duplicated_span.start, |s| s.span().end),
+            duplicated_span.end,
+        );
+    }
+
+    Span::new(
+        duplicated_span.start,
+        stmts.get(count).map_or(duplicated_span.end, |s| s.span().start),
+    )
+}
+
+fn duplicated_end_references_branch_locals(
+    count: usize,
+    bodies: &[&Statement],
+    ctx: &LintContext,
+) -> bool {
+    bodies.iter().any(|body| {
+        let stmts = get_block_statements(body);
+        let start_idx = stmts.len() - count;
+        let mut symbols = FxHashSet::default();
+
+        for stmt in &stmts[..start_idx] {
+            collect_lexical_declaration_symbols(stmt, &mut symbols);
+        }
+
+        if symbols.is_empty() {
+            return false;
+        }
+
+        duplicated_statements(body, count, true).iter().any(|stmt| {
+            let mut references = ReferenceCollector::default();
+            references.visit_statement(stmt);
+            references.references.iter().any(|reference_id| {
+                ctx.scoping()
+                    .get_reference(*reference_id)
+                    .symbol_id()
+                    .is_some_and(|symbol_id| symbols.contains(&symbol_id))
+            })
+        })
+    })
+}
+
+fn duplicated_statements<'a>(
+    body: &'a Statement<'a>,
+    count: usize,
+    reverse: bool,
+) -> &'a [Statement<'a>] {
+    let stmts = get_block_statements(body);
+    if reverse { &stmts[stmts.len() - count..] } else { &stmts[..count] }
+}
+
+fn collect_lexical_declaration_symbols(stmt: &Statement, symbols: &mut FxHashSet<SymbolId>) {
+    if let Statement::VariableDeclaration(decl) = stmt
+        && decl.kind.is_lexical()
+    {
+        symbols.extend(decl.declarations.iter().flat_map(|decl| decl.id.get_symbol_ids()));
+    }
+}
+
+#[derive(Default)]
+struct ReferenceCollector {
+    references: FxHashSet<ReferenceId>,
+}
+
+impl<'a> Visit<'a> for ReferenceCollector {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        self.references.insert(ident.reference_id());
+    }
 }
 
 fn duplicated_stmts_are_empty(count: usize, bodies: &[&Statement], reverse: bool) -> bool {
@@ -226,7 +359,7 @@ fn extract_if_sequence<'a>(
 
 #[test]
 fn test() {
-    use crate::tester::Tester;
+    use crate::{fixer::FixKind, tester::Tester};
 
     let pass = vec![
         "if (condition) { foo(); } else { bar(); }",
@@ -367,6 +500,220 @@ fn test() {
         ",
     ];
 
+    let fix = vec![
+        (
+            r"
+        if (condition) {
+            console.log('hello');
+            doA();
+        } else {
+            console.log('hello');
+            doB();
+        }
+        ",
+            r"
+        console.log('hello');
+        if (condition) {
+            doA();
+        } else {
+            doB();
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        if (condition) {
+            doA();
+            cleanup();
+        } else {
+            doB();
+            cleanup();
+        }
+        ",
+            r"
+        if (condition) {
+            doA();
+        } else {
+            doB();
+        }
+        cleanup();
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        let foo;
+        if (condition) {
+            console.log('start');
+            foo = 13;
+        } else {
+            console.log('start');
+            foo = 42;
+        }
+        ",
+            r"
+        let foo;
+        console.log('start');
+        if (condition) {
+            foo = 13;
+        } else {
+            foo = 42;
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        if (x) {
+            console.log('before');
+            doX();
+            console.log('after');
+        } else {
+            console.log('before');
+            doY();
+            console.log('after');
+        }
+        ",
+            r"
+        console.log('before');
+        if (x) {
+            doX();
+            console.log('after');
+        } else {
+            doY();
+            console.log('after');
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        if (flag) {
+            initialize();
+            processData();
+            finalize();
+        } else {
+            initialize();
+            processOtherData();
+            finalize();
+        }
+        ",
+            r"
+        initialize();
+        if (flag) {
+            processData();
+            finalize();
+        } else {
+            processOtherData();
+            finalize();
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        if (test) {
+            a++;
+            b++;
+        } else {
+            a++;
+            c++;
+        }
+        ",
+            r"
+        a++;
+        if (test) {
+            b++;
+        } else {
+            c++;
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        if (x > 0) {
+            const a = 1;
+            console.log(a);
+        } else {
+            const a = 2;
+            console.log(a);
+        }
+        ",
+            r"
+        if (x > 0) {
+            const a = 1;
+            console.log(a);
+        } else {
+            const a = 2;
+            console.log(a);
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        if (flag) {
+            console.log('start');
+            doA();
+        } else if (otherFlag) {
+            console.log('start');
+            doB();
+        } else {
+            console.log('start');
+            doC();
+        }
+        ",
+            r"
+        console.log('start');
+        if (flag) {
+            doA();
+        } else if (otherFlag) {
+            doB();
+        } else {
+            doC();
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r"
+        if (x === 1) {
+            setup();
+            return 1;
+        } else if (x === 2) {
+            setup();
+            return 2;
+        } else {
+            setup();
+            return 3;
+        }
+        ",
+            r"
+        setup();
+        if (x === 1) {
+            return 1;
+        } else if (x === 2) {
+            return 2;
+        } else {
+            return 3;
+        }
+        ",
+            None,
+            FixKind::Suggestion,
+        ),
+    ];
+
     Tester::new(BranchesSharingCode::NAME, BranchesSharingCode::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }


### PR DESCRIPTION
Adds suggestions for oxc/branches-sharing-code to move duplicated statements outside the if branches. Expands fixer coverage across the existing failing cases.