### PR TITLE
fix(linter/rules-of-hooks): improve diagnostic for hook inside class component

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -10,7 +10,7 @@ use oxc_cfg::{
 };
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNodes, NodeId};
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{
@@ -81,13 +81,27 @@ mod diagnostics {
         .with_error_code_scope(SCOPE)
     }
 
-    pub(super) fn class_component(span: Span, hook_name: &str) -> OxcDiagnostic {
+    pub(super) fn class_component(
+        hook_span: Span,
+        class_component_span: Option<Span>,
+        hook_name: &str,
+    ) -> OxcDiagnostic {
+        debug_assert!(
+            class_component_span.is_some(),
+            "Hooks in class components should have a containing class span"
+        );
+
+        let mut labels = vec![hook_span.primary_label("Hook is called here")];
+        if let Some(class_component_span) = class_component_span {
+            labels.push(class_component_span.label("Class component is defined here."));
+        }
+
         OxcDiagnostic::warn(format!(
             "React Hook {hook_name:?} cannot be called in a class component. React Hooks \
             must be called in a React function component or a custom React \
             Hook function."
         ))
-        .with_label(span)
+        .with_labels(labels)
         .with_error_code_scope(SCOPE)
     }
 
@@ -203,7 +217,11 @@ impl Rule for RulesOfHooks {
             nodes.parent_kind(parent_func.id()),
             AstKind::MethodDefinition(_) | AstKind::StaticBlock(_) | AstKind::PropertyDefinition(_)
         ) {
-            return ctx.diagnostic(diagnostics::class_component(span, hook_name));
+            return ctx.diagnostic(diagnostics::class_component(
+                span,
+                class_component_span(ctx, parent_func.id()),
+                hook_name,
+            ));
         }
 
         match parent_func.kind() {
@@ -314,6 +332,29 @@ impl Rule for RulesOfHooks {
             return ctx.diagnostic(diagnostics::conditional_hook(span, hook_name));
         }
     }
+}
+
+fn class_component_span(ctx: &LintContext<'_>, node_id: NodeId) -> Option<Span> {
+    ctx.nodes().ancestors(node_id).find_map(|node| match node.kind() {
+        AstKind::Class(class) => {
+            if let Some(id) = &class.id {
+                Some(id.span)
+            } else {
+                let search_start = class
+                    .decorators
+                    .last()
+                    .map_or(class.span.start, |decorator| decorator.span.end);
+                let offset =
+                    ctx.find_next_token_within(search_start, class.body.span.start, "class")?;
+                let start = search_start + offset;
+                Some(Span::new(
+                    start,
+                    start + u32::try_from("class".len()).expect("keyword length should fit in u32"),
+                ))
+            }
+        }
+        _ => None,
+    })
 }
 
 fn has_conditional_path_accept_throw(

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -76,25 +76,42 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:22]
+ 1 │ 
+ 2 │             class C {
+   ·                   ┬
+   ·                   ╰── Class component is defined here.
  3 │                  m() {
  4 │                      This.useHook();
-   ·                      ──────────────
+   ·                      ───────┬──────
+   ·                             ╰── Hook is called here
  5 │                      Super.useHook();
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:22]
+ 1 │ 
+ 2 │             class C {
+   ·                   ┬
+   ·                   ╰── Class component is defined here.
+ 3 │                  m() {
  4 │                      This.useHook();
  5 │                      Super.useHook();
-   ·                      ───────────────
+   ·                      ───────┬───────
+   ·                             ╰── Hook is called here
  6 │                  }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:25]
+ 1 │ 
+ 2 │             class Foo extends Component {
+   ·                   ─┬─
+   ·                    ╰── Class component is defined here.
+ 3 │                 render() {
  4 │                     if (cond) {
  5 │                         FooStore.useFeatureFlag();
-   ·                         ─────────────────────────
+   ·                         ────────────┬────────────
+   ·                                     ╰── Hook is called here
  6 │                     }
    ╰────
 
@@ -605,42 +622,61 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:29]
+ 1 │ 
+ 2 │                 class ClassComponentWithFeatureFlag extends React.Component {
+   ·                       ──────────────┬──────────────
+   ·                                     ╰── Class component is defined here.
+ 3 │                     render() {
  4 │                         if (foo) {
  5 │                             useFeatureFlag();
-   ·                             ────────────────
+   ·                             ────────┬───────
+   ·                                     ╰── Hook is called here
  6 │                         }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
+ 1 │ 
+ 2 │                 class ClassComponentWithHook extends React.Component {
+   ·                       ───────────┬──────────
+   ·                                  ╰── Class component is defined here.
  3 │                     render() {
  4 │                         React.useState();
-   ·                         ────────────────
+   ·                         ────────┬───────
+   ·                                 ╰── Hook is called here
  5 │                     }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:27]
  1 │ (class {useHook = () => { useState(); }});
-   ·                           ──────────
+   ·  ──┬──                    ─────┬────
+   ·    │                           ╰── Hook is called here
+   ·    ╰── Class component is defined here.
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:21]
  1 │ (class {useHook() { useState(); }});
-   ·                     ──────────
+   ·  ──┬──              ─────┬────
+   ·    │                     ╰── Hook is called here
+   ·    ╰── Class component is defined here.
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:21]
  1 │ (class {h = () => { useState(); }});
-   ·                     ──────────
+   ·  ──┬──              ─────┬────
+   ·    │                     ╰── Hook is called here
+   ·    ╰── Class component is defined here.
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:15]
  1 │ (class {i() { useState(); }});
-   ·               ──────────
+   ·  ──┬──        ─────┬────
+   ·    │               ╰── Hook is called here
+   ·    ╰── Class component is defined here.
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in an async function.
@@ -750,9 +786,14 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "use" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:21]
+ 1 │ 
+ 2 │             class C {
+   ·                   ┬
+   ·                   ╰── Class component is defined here.
  3 │                 m() {
  4 │                     use(promise);
-   ·                     ────────────
+   ·                     ──────┬─────
+   ·                           ╰── Hook is called here
  5 │                 }
    ╰────
 


### PR DESCRIPTION
This clarifies react-hooks class component diagnostics by marking the Hook call as primary and labeling the containing class declaration.