### PR TITLE
fix(linter/rules-of-hooks): clarify async component diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -73,11 +73,20 @@ mod diagnostics {
         .with_error_code_scope(SCOPE)
     }
 
-    pub(super) fn async_component(span: Span, func_name: &str) -> OxcDiagnostic {
+    pub(super) fn async_component(
+        hook_span: Span,
+        async_keyword_span: Option<Span>,
+        hook_name: &str,
+    ) -> OxcDiagnostic {
+        let mut labels = vec![hook_span.primary_label("Hook is called here")];
+        if let Some(async_keyword_span) = async_keyword_span {
+            labels.push(async_keyword_span.label("This function is async."));
+        }
+
         OxcDiagnostic::warn(format!(
-            "React Hook {func_name:?} cannot be called in an async function. "
+            "React Hook {hook_name:?} cannot be called in an async function. "
         ))
-        .with_label(span)
+        .with_labels(labels)
         .with_error_code_scope(SCOPE)
     }
 
@@ -285,16 +294,19 @@ impl Rule for RulesOfHooks {
                 }
             }
             // Hooks can't be called from async function.
-            AstKind::Function(Function { id: Some(_), r#async: true, .. }) => {
-                return ctx.diagnostic(diagnostics::async_component(span, hook_name));
-            }
-            // Hooks can't be called from async arrow function.
-            AstKind::ArrowFunctionExpression(ArrowFunctionExpression {
-                span,
+            AstKind::Function(Function {
+                id: Some(_), span: async_span, r#async: true, ..
+            })
+            | AstKind::ArrowFunctionExpression(ArrowFunctionExpression {
+                span: async_span,
                 r#async: true,
                 ..
             }) => {
-                return ctx.diagnostic(diagnostics::async_component(*span, "Anonymous"));
+                return ctx.diagnostic(diagnostics::async_component(
+                    span,
+                    async_keyword_span(ctx, *async_span),
+                    hook_name,
+                ));
             }
             _ => {}
         }
@@ -355,6 +367,12 @@ fn class_component_span(ctx: &LintContext<'_>, node_id: NodeId) -> Option<Span> 
         }
         _ => None,
     })
+}
+
+#[expect(clippy::cast_possible_truncation)]
+fn async_keyword_span(ctx: &LintContext<'_>, span: Span) -> Option<Span> {
+    let start = span.start + ctx.find_next_token_within(span.start, span.end, "async")?;
+    Some(Span::sized(start, "async".len() as u32))
 }
 
 fn has_conditional_path_accept_throw(

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -681,42 +681,62 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:21]
+ 1 │ 
  2 │                 async function AsyncComponent() {
+   ·                 ──┬──
+   ·                   ╰── This function is async.
  3 │                     useState();
-   ·                     ──────────
+   ·                     ─────┬────
+   ·                          ╰── Hook is called here
  4 │                 }
    ╰────
 
-  ⚠ react-hooks(rules-of-hooks): React Hook "Anonymous" cannot be called in an async function.
-   ╭─[rules_of_hooks.tsx:2:40]
- 1 │     
- 2 │ ╭─▶                 const AsyncComponent = async () => {
- 3 │ │                       useState();
- 4 │ ╰─▶                 }
- 5 │             
+  ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in an async function.
+   ╭─[rules_of_hooks.tsx:3:21]
+ 1 │ 
+ 2 │                 const AsyncComponent = async () => {
+   ·                                        ──┬──
+   ·                                          ╰── This function is async.
+ 3 │                     useState();
+   ·                     ─────┬────
+   ·                          ╰── Hook is called here
+ 4 │                 }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useId" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:19]
+ 1 │ 
  2 │                 async function Page() {
+   ·                 ──┬──
+   ·                   ╰── This function is async.
  3 │                   useId();
-   ·                   ───────
+   ·                   ───┬───
+   ·                      ╰── Hook is called here
  4 │                   React.useId();
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useId" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:4:19]
+ 1 │ 
+ 2 │                 async function Page() {
+   ·                 ──┬──
+   ·                   ╰── This function is async.
  3 │                   useId();
  4 │                   React.useId();
-   ·                   ─────────────
+   ·                   ──────┬──────
+   ·                         ╰── Hook is called here
  5 │                 }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:21]
+ 1 │ 
  2 │                 async function useAsyncHook() {
+   ·                 ──┬──
+   ·                   ╰── This function is async.
  3 │                     useState();
-   ·                     ──────────
+   ·                     ─────┬────
+   ·                          ╰── Hook is called here
  4 │                 }
    ╰────
 
@@ -799,9 +819,13 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "use" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:21]
+ 1 │ 
  2 │             async function AsyncComponent() {
+   ·             ──┬──
+   ·               ╰── This function is async.
  3 │                     use();
-   ·                     ─────
+   ·                     ──┬──
+   ·                       ╰── Hook is called here
  4 │             }
    ╰────
 


### PR DESCRIPTION
AI-assisted change reviewed locally. This clarifies async-function Rules of Hooks diagnostics by marking the Hook call as primary and labeling the async keyword.