### PR TITLE
refactor(linter): use Span::sized for relative spans

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -115,7 +115,7 @@ fn report_irregular_whitespace_in_span(ctx: &LintContext, source_text: &str, spa
             let offset = span.start + i as u32;
             #[expect(clippy::cast_possible_truncation)]
             let len = c.len_utf8() as u32;
-            ctx.diagnostic(no_irregular_whitespace_diagnostic(Span::new(offset, offset + len)));
+            ctx.diagnostic(no_irregular_whitespace_diagnostic(Span::sized(offset, len)));
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -296,7 +296,7 @@ fn can_be_fixed(target: &AssignmentTarget) -> bool {
 fn get_operator_span(init_span: Span, operator: &str, ctx: &LintContext) -> Span {
     let offset = init_span.source_text(ctx.source_text()).find(operator).unwrap_or(0) as u32;
     let start = init_span.start + offset;
-    Span::new(start, start + operator.len() as u32)
+    Span::sized(start, operator.len() as u32)
 }
 
 fn check_is_same_reference(left: &AssignmentTarget, right: &Expression, ctx: &LintContext) -> bool {

--- a/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_bitwise_operator.rs
@@ -119,7 +119,7 @@ impl BadBitwiseOperator {
             return fixer.noop();
         };
         let op_start = start + offset;
-        let op_span = Span::new(op_start, op_start + bad.len() as u32);
+        let op_span = Span::sized(op_start, bad.len() as u32);
         fixer.replace(op_span, good)
     }
 
@@ -132,7 +132,7 @@ impl BadBitwiseOperator {
             return fixer.noop();
         };
         let op_start = start + offset;
-        let op_span = Span::new(op_start, op_start + 2);
+        let op_span = Span::sized(op_start, 2);
         fixer.replace(op_span, "||=")
     }
 }

--- a/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
+++ b/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
@@ -107,7 +107,7 @@ impl Rule for BranchesSharingCode {
 
         let (start_eq, end_eq) = scan_blocks_for_eq(&bodies);
 
-        let if_span = Span::new(if_stmt.span.start, if_stmt.span.start + 2);
+        let if_span = Span::sized(if_stmt.span.start, 2);
 
         if let Some(start) =
             start_eq.filter(|&start| !duplicated_stmts_are_empty(start, &bodies, false))

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -757,8 +757,7 @@ fn build_missing_curly_fix_context_for_part(
     part.char_indices().find(|(_, ch)| !ch.is_whitespace()).map(|(first_char_index, _)| {
         let text = part.split_at(first_char_index).1;
         let new_start = span.start + part_start + u32::try_from(first_char_index).unwrap();
-        let span_from_first_char =
-            Span::new(new_start, new_start + u32::try_from(text.len()).unwrap());
+        let span_from_first_char = Span::sized(new_start, u32::try_from(text.len()).unwrap());
         (span_from_first_char, text)
     })
 }

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -347,9 +347,9 @@ fn class_component_span(ctx: &LintContext<'_>, node_id: NodeId) -> Option<Span> 
                 let offset =
                     ctx.find_next_token_within(search_start, class.body.span.start, "class")?;
                 let start = search_start + offset;
-                Some(Span::new(
+                Some(Span::sized(
                     start,
-                    start + u32::try_from("class".len()).expect("keyword length should fit in u32"),
+                    u32::try_from("class".len()).expect("keyword length should fit in u32"),
                 ))
             }
         }

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -131,7 +131,7 @@ impl Rule for ConsistentTypeDefinitions {
                             ctx.diagnostic_with_fix(
                                 consistent_type_definitions_diagnostic(
                                     ConsistentTypeDefinitionsConfig::Interface,
-                                    Span::new(start, start + 4),
+                                    Span::sized(start, 4),
                                 ),
                                 |fixer| {
                                     fixer.replace(

--- a/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_member_accessibility.rs
@@ -403,7 +403,7 @@ fn find_public_spans(ctx: &LintContext<'_>, search_start: u32, search_end: u32) 
         + ctx
             .find_next_token_within(search_start, search_end, "public")
             .expect("Expected 'public' keyword in source");
-    let keyword_span = Span::new(start, start + 6);
+    let keyword_span = Span::sized(start, 6);
     let end = skip_ascii_whitespace(ctx.source_text(), start + 6);
     (keyword_span, Span::new(start, end))
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -320,7 +320,7 @@ fn check_useless_iterable_to_array<'a>(
         return false;
     };
 
-    let span = Span::new(spread_elem.span.start, spread_elem.span.start + 3);
+    let span = Span::sized(spread_elem.span.start, 3);
 
     match parent.kind() {
         AstKind::ForOfStatement(for_of_stmt) => {
@@ -396,7 +396,7 @@ fn check_useless_clone<'a>(
     spread_elem: &SpreadElement<'a>,
     ctx: &LintContext<'a>,
 ) {
-    let span = Span::new(spread_elem.span.start, spread_elem.span.start + 3);
+    let span = Span::sized(spread_elem.span.start, 3);
     let target = spread_elem.argument.get_inner_expression();
 
     // already diagnosed by first check

--- a/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
@@ -115,8 +115,7 @@ impl Rule for RelativeUrlStyle {
                         if can_remove_dot_slash(raw, new_expr) {
                             ctx.diagnostic_with_fix(never_diagnostic(str_lit.span), |fixer| {
                                 let dot_slash_start = str_lit.span.start + 1;
-                                let dot_slash_span =
-                                    Span::new(dot_slash_start, dot_slash_start + 2);
+                                let dot_slash_span = Span::sized(dot_slash_start, 2);
                                 fixer
                                     .delete_range(dot_slash_span)
                                     .with_message("Remove leading `./`")
@@ -148,7 +147,7 @@ impl Rule for RelativeUrlStyle {
                 if first_quasi.value.raw.starts_with(DOT_SLASH) {
                     ctx.diagnostic_with_suggestion(never_diagnostic(template_lit.span), |fixer| {
                         let dot_slash_start = template_lit.span.start + 1;
-                        let dot_slash_span = Span::new(dot_slash_start, dot_slash_start + 2);
+                        let dot_slash_span = Span::sized(dot_slash_start, 2);
                         fixer.delete_range(dot_slash_span).with_message("Remove leading `./`")
                     });
                 }


### PR DESCRIPTION
Replace linter Span::new calls whose end is start plus a size with Span::sized.