### PR TITLE
refactor(parser): use Span::sized for relative spans

### DIFF
--- a/crates/oxc_parser/src/error_handler.rs
+++ b/crates/oxc_parser/src/error_handler.rs
@@ -147,7 +147,7 @@ impl<C: Config> ParserImpl<'_, C> {
             || remaining.starts_with("|||||||")
         {
             // Marker length is 7 bytes (all ASCII characters)
-            return Some(Span::new(span.start, span.start + 7));
+            return Some(Span::sized(span.start, 7));
         }
 
         None

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -37,7 +37,7 @@ impl<C: Config> Lexer<'_, C> {
             Some(b'!') if self.remaining().starts_with("!--") => {
                 if self.source_type.is_module() {
                     if self.token.is_on_new_line() {
-                        let span = Span::new(self.token.start(), self.token.start() + 4);
+                        let span = Span::sized(self.token.start(), 4);
                         self.errors.push(diagnostics::html_comment_in_module(span));
                         None
                     } else {
@@ -80,7 +80,7 @@ impl<C: Config> Lexer<'_, C> {
     /// Defer HTML comment error for unambiguous mode (emitted if file resolves to module)
     fn defer_html_comment_error(&mut self, len: u32) {
         if self.source_type.is_unambiguous() {
-            let span = Span::new(self.token.start(), self.token.start() + len);
+            let span = Span::sized(self.token.start(), len);
             self.deferred_module_errors.push(diagnostics::html_comment_in_module(span));
         }
     }

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -26,7 +26,7 @@ impl Modifier {
 
     #[inline]
     pub const fn span(&self) -> Span {
-        Span::new(self.span_start, self.span_start + self.kind.len())
+        Span::sized(self.span_start, self.kind.len())
     }
 }
 


### PR DESCRIPTION
Replace parser Span::new calls whose end is start plus a size with Span::sized.