### PR TITLE
fix(linter/rules-of-hooks): clarify loop diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -53,13 +53,22 @@ mod diagnostics {
         .with_error_code_scope(SCOPE)
     }
 
-    pub(super) fn loop_hook(span: Span, hook_name: &str) -> OxcDiagnostic {
+    pub(super) fn loop_hook(
+        hook_span: Span,
+        loop_keyword_span: Option<Span>,
+        hook_name: &str,
+    ) -> OxcDiagnostic {
+        let mut labels = vec![hook_span.primary_label("Hook is called here")];
+        if let Some(loop_keyword_span) = loop_keyword_span {
+            labels.push(loop_keyword_span.label("This loop may execute the Hook more than once."));
+        }
+
         OxcDiagnostic::warn(format!(
             "React Hook {hook_name:?} may be executed more than once. Possibly \
             because it is called in a loop. React Hooks must be called in the \
             exact same order in every component render."
         ))
-        .with_label(span)
+        .with_labels(labels)
         .with_error_code_scope(SCOPE)
     }
 
@@ -336,7 +345,11 @@ impl Rule for RulesOfHooks {
 
         // Is this node cyclic?
         if cfg.is_cyclic(node_cfg_id) {
-            return ctx.diagnostic(diagnostics::loop_hook(span, hook_name));
+            return ctx.diagnostic(diagnostics::loop_hook(
+                span,
+                loop_keyword_span(ctx, ctx.nodes(), node.id(), parent_func.id()),
+                hook_name,
+            ));
         }
 
         if has_conditional_path_accept_throw(ctx.nodes(), cfg, parent_func, node) {
@@ -373,6 +386,34 @@ fn class_component_span(ctx: &LintContext<'_>, node_id: NodeId) -> Option<Span> 
 fn async_keyword_span(ctx: &LintContext<'_>, span: Span) -> Option<Span> {
     let start = span.start + ctx.find_next_token_within(span.start, span.end, "async")?;
     Some(Span::sized(start, "async".len() as u32))
+}
+
+#[expect(clippy::cast_possible_truncation)]
+fn loop_keyword_span(
+    ctx: &LintContext<'_>,
+    nodes: &AstNodes<'_>,
+    hook_node_id: NodeId,
+    function_node_id: NodeId,
+) -> Option<Span> {
+    for ancestor in nodes.ancestors(hook_node_id) {
+        if ancestor.id() == function_node_id {
+            break;
+        }
+
+        let (span, keyword) = match ancestor.kind() {
+            AstKind::DoWhileStatement(stmt) => (stmt.span, "do"),
+            AstKind::WhileStatement(stmt) => (stmt.span, "while"),
+            AstKind::ForStatement(stmt) => (stmt.span, "for"),
+            AstKind::ForInStatement(stmt) => (stmt.span, "for"),
+            AstKind::ForOfStatement(stmt) => (stmt.span, "for"),
+            _ => continue,
+        };
+
+        let start = span.start + ctx.find_next_token_within(span.start, span.end, keyword)?;
+        return Some(Span::sized(start, keyword.len() as u32));
+    }
+
+    None
 }
 
 fn has_conditional_path_accept_throw(

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -213,25 +213,38 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
+ 2 │                 function ComponentWithHookInsideLoop() {
  3 │                     while (cond) {
+   ·                     ──┬──
+   ·                       ╰── This loop may execute the Hook more than once.
  4 │                         useHookInsideLoop();
-   ·                         ───────────────────
+   ·                         ─────────┬─────────
+   ·                                  ╰── Hook is called here
  5 │                     }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:17]
+ 2 │             function ComponentWithHookInsideLoop() {
  3 │               do {
+   ·               ─┬
+   ·                ╰── This loop may execute the Hook more than once.
  4 │                 useHookInsideLoop();
-   ·                 ───────────────────
+   ·                 ─────────┬─────────
+   ·                          ╰── Hook is called here
  5 │               } while (cond);
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:24]
+ 2 │             function ComponentWithHookInsideLoop() {
+ 3 │               do {
+   ·               ─┬
+   ·                ╰── This loop may execute the Hook more than once.
  4 │                 foo();
  5 │               } while (useHookInsideLoop());
-   ·                        ───────────────────
+   ·                        ─────────┬─────────
+   ·                                 ╰── Hook is called here
  6 │             }
    ╰────
 
@@ -298,97 +311,157 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
+ 2 │                 function useHookInLoops() {
  3 │                     while (a) {
+   ·                     ──┬──
+   ·                       ╰── This loop may execute the Hook more than once.
  4 │                         useHook1();
-   ·                         ──────────
+   ·                         ─────┬────
+   ·                              ╰── Hook is called here
  5 │                         if (b) return;
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:25]
+ 2 │                 function useHookInLoops() {
+ 3 │                     while (a) {
+   ·                     ──┬──
+   ·                       ╰── This loop may execute the Hook more than once.
+ 4 │                         useHook1();
  5 │                         if (b) return;
  6 │                         useHook2();
-   ·                         ──────────
+   ·                         ─────┬────
+   ·                              ╰── Hook is called here
  7 │                     }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:25]
+  7 │                     }
   8 │                     while (c) {
+    ·                     ──┬──
+    ·                       ╰── This loop may execute the Hook more than once.
   9 │                         useHook3();
-    ·                         ──────────
+    ·                         ─────┬────
+    ·                              ╰── Hook is called here
  10 │                         if (d) return;
     ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:11:25]
+  7 │                     }
+  8 │                     while (c) {
+    ·                     ──┬──
+    ·                       ╰── This loop may execute the Hook more than once.
+  9 │                         useHook3();
  10 │                         if (d) return;
  11 │                         useHook4();
-    ·                         ──────────
+    ·                         ─────┬────
+    ·                              ╰── Hook is called here
  12 │                     }
     ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
+ 2 │             function useHookInLoops() {
  3 │                 while (a) {
+   ·                 ──┬──
+   ·                   ╰── This loop may execute the Hook more than once.
  4 │                     useHook1();
-   ·                     ──────────
+   ·                     ─────┬────
+   ·                          ╰── Hook is called here
  5 │                     if (b) continue;
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:21]
+ 2 │             function useHookInLoops() {
+ 3 │                 while (a) {
+   ·                 ──┬──
+   ·                   ╰── This loop may execute the Hook more than once.
+ 4 │                     useHook1();
  5 │                     if (b) continue;
  6 │                     useHook2();
-   ·                     ──────────
+   ·                     ─────┬────
+   ·                          ╰── Hook is called here
  7 │                 }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:12]
+ 2 │        function useHookInLoops() {
  3 │          do {
+   ·          ─┬
+   ·           ╰── This loop may execute the Hook more than once.
  4 │            useHook1();
-   ·            ──────────
+   ·            ─────┬────
+   ·                 ╰── Hook is called here
  5 │            if (a) return;
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:12]
+ 2 │        function useHookInLoops() {
+ 3 │          do {
+   ·          ─┬
+   ·           ╰── This loop may execute the Hook more than once.
+ 4 │            useHook1();
  5 │            if (a) return;
  6 │            useHook2();
-   ·            ──────────
+   ·            ─────┬────
+   ·                 ╰── Hook is called here
  7 │          } while (b);
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:10:12]
+  8 │ 
   9 │          do {
+    ·          ─┬
+    ·           ╰── This loop may execute the Hook more than once.
  10 │            useHook3();
-    ·            ──────────
+    ·            ─────┬────
+    ·                 ╰── Hook is called here
  11 │            if (c) return;
     ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:12:12]
+  8 │ 
+  9 │          do {
+    ·          ─┬
+    ·           ╰── This loop may execute the Hook more than once.
+ 10 │            useHook3();
  11 │            if (c) return;
  12 │            useHook4();
-    ·            ──────────
+    ·            ─────┬────
+    ·                 ╰── Hook is called here
  13 │          } while (d)
     ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:13]
+ 2 │         function useHookInLoops() {
  3 │           do {
+   ·           ─┬
+   ·            ╰── This loop may execute the Hook more than once.
  4 │             useHook1();
-   ·             ──────────
+   ·             ─────┬────
+   ·                  ╰── Hook is called here
  5 │             if (a) continue;
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:13]
+ 2 │         function useHookInLoops() {
+ 3 │           do {
+   ·           ─┬
+   ·            ╰── This loop may execute the Hook more than once.
+ 4 │             useHook1();
  5 │             if (a) continue;
  6 │             useHook2();
-   ·             ──────────
+   ·             ─────┬────
+   ·                  ╰── Hook is called here
  7 │           } while (b);
    ╰────
 


### PR DESCRIPTION
Clarifies cyclic Rules of Hooks diagnostics by marking the Hook call as primary and labeling the loop keyword that can execute it repeatedly.