### PR TITLE
fix(linter/rules-of-hooks): clarify conditional diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -11,7 +11,7 @@ use oxc_cfg::{
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNodes, NodeId};
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::operator::AssignmentOperator;
+use oxc_syntax::operator::{AssignmentOperator, LogicalOperator};
 
 use crate::{
     AstNode,
@@ -24,6 +24,11 @@ mod diagnostics {
     use oxc_diagnostics::OxcDiagnostic;
     use oxc_span::Span;
     const SCOPE: &str = "react-hooks";
+
+    pub(super) struct ConditionalContext {
+        pub span: Span,
+        pub label: &'static str,
+    }
 
     pub(super) fn function_error(
         react_hook_span: Span,
@@ -44,13 +49,29 @@ mod diagnostics {
         .with_error_code_scope(SCOPE)
     }
 
-    pub(super) fn conditional_hook(span: Span, hook_name: &str) -> OxcDiagnostic {
-        OxcDiagnostic::warn(format!(
+    pub(super) fn conditional_hook(
+        span: Span,
+        hook_name: &str,
+        conditional_context: Option<ConditionalContext>,
+    ) -> OxcDiagnostic {
+        let diagnostic = OxcDiagnostic::warn(format!(
             "React Hook {hook_name:?} is called conditionally. React Hooks must be \
             called in the exact same order in every component render."
         ))
-        .with_label(span)
-        .with_error_code_scope(SCOPE)
+        .with_help(
+            "Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.",
+        )
+        .with_error_code_scope(SCOPE);
+
+        if let Some(context) = conditional_context {
+            diagnostic.with_labels([
+                span.primary_label("This Hook call is not reachable on every render path."),
+                context.span.label(context.label),
+            ])
+        } else {
+            diagnostic
+                .with_label(span.label("This Hook call is not reachable on every render path."))
+        }
     }
 
     pub(super) fn loop_hook(
@@ -78,7 +99,7 @@ mod diagnostics {
             must be called in a React function component or a custom React \
             Hook function."
         ))
-        .with_label(span)
+        .with_label(span.label("This Hook call is outside a component or custom Hook."))
         .with_error_code_scope(SCOPE)
     }
 
@@ -129,7 +150,7 @@ mod diagnostics {
             must be called in a React function component or a custom React \
             Hook function."
         ))
-        .with_label(span)
+        .with_label(span.label("This Hook call is inside a nested callback."))
         .with_error_code_scope(SCOPE)
     }
 }
@@ -354,7 +375,11 @@ impl Rule for RulesOfHooks {
 
         if has_conditional_path_accept_throw(ctx.nodes(), cfg, parent_func, node) {
             #[expect(clippy::needless_return)]
-            return ctx.diagnostic(diagnostics::conditional_hook(span, hook_name));
+            return ctx.diagnostic(diagnostics::conditional_hook(
+                span,
+                hook_name,
+                conditional_context(ctx, node.id(), span, parent_func.id()),
+            ));
         }
     }
 }
@@ -411,6 +436,103 @@ fn loop_keyword_span(
 
         let start = span.start + ctx.find_next_token_within(span.start, span.end, keyword)?;
         return Some(Span::sized(start, keyword.len() as u32));
+    }
+
+    None
+}
+
+/// Find the nearest conditional construct that can skip this Hook call.
+///
+/// Hooks inside condition/test expressions are evaluated before that branch is
+/// chosen, so keep walking until we find an ancestor that makes the Hook itself
+/// unreachable on some render path.
+#[expect(clippy::cast_possible_truncation)]
+fn conditional_context(
+    ctx: &LintContext<'_>,
+    hook_node_id: NodeId,
+    hook_span: Span,
+    function_node_id: NodeId,
+) -> Option<diagnostics::ConditionalContext> {
+    let nodes = ctx.nodes();
+    for ancestor in nodes.ancestors(hook_node_id) {
+        if ancestor.id() == function_node_id {
+            break;
+        }
+
+        let context = match ancestor.kind() {
+            AstKind::IfStatement(stmt) => {
+                let test_span = stmt.test.span();
+                if test_span.contains_inclusive(hook_span) {
+                    continue;
+                }
+
+                let label = if stmt
+                    .alternate
+                    .as_ref()
+                    .is_some_and(|alternate| alternate.span().contains_inclusive(hook_span))
+                {
+                    "When this condition is true, this Hook is skipped."
+                } else {
+                    "When this condition is false, this Hook is skipped."
+                };
+
+                diagnostics::ConditionalContext { span: test_span, label }
+            }
+            AstKind::ConditionalExpression(expr) => {
+                let test_span = expr.test.span();
+                if test_span.contains_inclusive(hook_span) {
+                    continue;
+                }
+
+                diagnostics::ConditionalContext {
+                    span: test_span,
+                    label: "Only one side of this conditional expression calls the Hook.",
+                }
+            }
+            AstKind::LogicalExpression(expr) => {
+                if expr.left.span().contains_inclusive(hook_span) {
+                    continue;
+                }
+
+                diagnostics::ConditionalContext {
+                    span: expr.left.span(),
+                    label: match expr.operator {
+                        LogicalOperator::And => {
+                            "This short-circuits when falsy, skipping the Hook call."
+                        }
+                        LogicalOperator::Or => {
+                            "This short-circuits when truthy, skipping the Hook call."
+                        }
+                        LogicalOperator::Coalesce => {
+                            "This short-circuits when not nullish, skipping the Hook call."
+                        }
+                    },
+                }
+            }
+            AstKind::SwitchCase(case) => {
+                let case_span = if let Some(test) = &case.test {
+                    test.span()
+                } else {
+                    let header_end =
+                        case.consequent.first().map_or(case.span.end, |stmt| stmt.span().start);
+                    let default_start = case.span.start
+                        + ctx.find_next_token_within(case.span.start, header_end, "default")?;
+                    Span::sized(default_start, "default".len() as u32)
+                };
+
+                if case_span.contains_inclusive(hook_span) {
+                    continue;
+                }
+
+                diagnostics::ConditionalContext {
+                    span: case_span,
+                    label: "Only this switch case calls the Hook.",
+                }
+            }
+            _ => continue,
+        };
+
+        return Some(context);
     }
 
     None
@@ -1226,6 +1348,27 @@ fn test() {
             return <Foo />
           }
           return <Content />;
+        }
+        ",
+        "
+        function Component() {
+          switch (foo) {
+            case 1:
+              useCaseHook();
+              break;
+            default:
+              break;
+          }
+        }
+        ",
+        "
+        function Component() {
+          switch (foo) {
+            case 1:
+              break;
+            default:
+              useDefaultHook();
+          }
         }
         ",
         // Invalid because hooks can only be called inside of a component.

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -4,57 +4,110 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:18]
+ 2 │         function ComponentWithConditionalHook() {
  3 │                if (cond) {
+   ·                    ──┬─
+   ·                      ╰── When this condition is false, this Hook is skipped.
  4 │                  useConditionalHook();
-   ·                  ────────────────────
+   ·                  ──────────┬─────────
+   ·                            ╰── This Hook call is not reachable on every render path.
  5 │                }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook1" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:22]
  2 │             function useHook() {
  3 │                 a && useHook1();
-   ·                      ──────────
+   ·                 ┬    ─────┬────
+   ·                 │         ╰── This Hook call is not reachable on every render path.
+   ·                 ╰── This short-circuits when falsy, skipping the Hook call.
  4 │                 b && useHook2();
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:22]
  3 │                 a && useHook1();
  4 │                 b && useHook2();
-   ·                      ──────────
+   ·                 ┬    ─────┬────
+   ·                 │         ╰── This Hook call is not reachable on every render path.
+   ·                 ╰── This short-circuits when falsy, skipping the Hook call.
  5 │             }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:21]
+ 2 │             function Component() {
+ 3 │                 if (condition) {
+   ·                     ────┬────
+   ·                         ╰── When this condition is false, this Hook is skipped.
  4 │                     // This is invalid because the hook is called conditionally
  5 │                     useHook();
-   ·                     ─────────
+   ·                     ────┬────
+   ·                         ╰── This Hook call is not reachable on every render path.
  6 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:29]
  2 │             function Component() {
  3 │                 condition ? useHook() : null;
-   ·                             ─────────
+   ·                 ────┬────   ────┬────
+   ·                     │           ╰── This Hook call is not reachable on every render path.
+   ·                     ╰── Only one side of this conditional expression calls the Hook.
  4 │             }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHasPermission" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:23]
+ 2 │         function Component() {
+ 3 │           if (Math.random()) {
+   ·               ──────┬──────
+   ·                     ╰── When this condition is true, this Hook is skipped.
  4 │             return null;
  5 │           } else if (!useHasPermission()) {
-   ·                       ──────────────────
+   ·                       ─────────┬────────
+   ·                                ╰── This Hook call is not reachable on every render path.
  6 │             return <Foo />
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
+
+  ⚠ react-hooks(rules-of-hooks): React Hook "useCaseHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+   ╭─[rules_of_hooks.tsx:5:15]
+ 3 │           switch (foo) {
+ 4 │             case 1:
+   ·                  ┬
+   ·                  ╰── Only this switch case calls the Hook.
+ 5 │               useCaseHook();
+   ·               ──────┬──────
+   ·                     ╰── This Hook call is not reachable on every render path.
+ 6 │               break;
+   ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
+
+  ⚠ react-hooks(rules-of-hooks): React Hook "useDefaultHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
+   ╭─[rules_of_hooks.tsx:7:15]
+ 5 │               break;
+ 6 │             default:
+   ·             ───┬───
+   ·                ╰── Only this switch case calls the Hook.
+ 7 │               useDefaultHook();
+   ·               ────────┬───────
+   ·                       ╰── This Hook call is not reachable on every render path.
+ 8 │           }
+   ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:13]
  1 │ 
  2 │             Hook.useState();
-   ·             ───────────────
+   ·             ───────┬───────
+   ·                    ╰── This Hook call is outside a component or custom Hook.
  3 │             Hook._useState();
    ╰────
 
@@ -62,7 +115,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:4:13]
  3 │             Hook._useState();
  4 │             Hook.use42();
-   ·             ────────────
+   ·             ──────┬─────
+   ·                   ╰── This Hook call is outside a component or custom Hook.
  5 │             Hook.useHook();
    ╰────
 
@@ -70,7 +124,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:5:13]
  4 │             Hook.use42();
  5 │             Hook.useHook();
-   ·             ──────────────
+   ·             ───────┬──────
+   ·                    ╰── This Hook call is outside a component or custom Hook.
  6 │             Hook.use_hook();
    ╰────
 
@@ -117,49 +172,73 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
+ 2 │             function ComponentWithConditionalHook() {
  3 │                 if (cond) {
+   ·                     ──┬─
+   ·                       ╰── When this condition is false, this Hook is skipped.
  4 │                     Namespace.useConditionalHook();
-   ·                     ──────────────────────────────
+   ·                     ───────────────┬──────────────
+   ·                                    ╰── This Hook call is not reachable on every render path.
  5 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:29]
+ 3 │                     return function ComponentWithConditionalHook() {
  4 │                         if (cond) {
+   ·                             ──┬─
+   ·                               ╰── When this condition is false, this Hook is skipped.
  5 │                             useConditionalHook();
-   ·                             ────────────────────
+   ·                             ──────────┬─────────
+   ·                                       ╰── This Hook call is not reachable on every render path.
  6 │                         }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
+ 2 │                 function useHookWithConditionalHook() {
  3 │                     if (cond) {
+   ·                         ──┬─
+   ·                           ╰── When this condition is false, this Hook is skipped.
  4 │                         useConditionalHook();
-   ·                         ────────────────────
+   ·                         ──────────┬─────────
+   ·                                   ╰── This Hook call is not reachable on every render path.
  5 │                     }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:29]
+ 3 │                     return function useHookWithConditionalHook() {
  4 │                         if (cond) {
+   ·                             ──┬─
+   ·                               ╰── When this condition is false, this Hook is skipped.
  5 │                             useConditionalHook();
-   ·                             ────────────────────
+   ·                             ──────────┬─────────
+   ·                                       ╰── This Hook call is not reachable on every render path.
  6 │                         }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useTernaryHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:28]
  2 │                 function ComponentWithTernaryHook() {
  3 │                     cond ? useTernaryHook() : null;
-   ·                            ────────────────
+   ·                     ──┬─   ────────┬───────
+   ·                       │            ╰── This Hook call is not reachable on every render path.
+   ·                       ╰── Only one side of this conditional expression calls the Hook.
  4 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     useEffect(() => {
  4 │                         useHookInsideCallback();
-   ·                         ───────────────────────
+   ·                         ───────────┬───────────
+   ·                                    ╰── This Hook call is inside a nested callback.
  5 │                     });
    ╰────
 
@@ -167,7 +246,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:5:29]
  4 │                         useEffect(() => {
  5 │                             useHookInsideCallback();
-   ·                             ───────────────────────
+   ·                             ───────────┬───────────
+   ·                                        ╰── This Hook call is inside a nested callback.
  6 │                         });
    ╰────
 
@@ -175,7 +255,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     useEffect(() => {
  4 │                         useHookInsideCallback();
-   ·                         ───────────────────────
+   ·                         ───────────┬───────────
+   ·                                    ╰── This Hook call is inside a nested callback.
  5 │                     });
    ╰────
 
@@ -183,7 +264,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:4:25]
  3 │                     useEffect(() => {
  4 │                         useHookInsideCallback();
-   ·                         ───────────────────────
+   ·                         ───────────┬───────────
+   ·                                    ╰── This Hook call is inside a nested callback.
  5 │                     });
    ╰────
 
@@ -469,9 +551,11 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:5:25]
  4 │                         if (a) break label;
  5 │                         useHook();
-   ·                         ─────────
+   ·                         ────┬────
+   ·                             ╰── This Hook call is not reachable on every render path.
  6 │                     }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called in function "a" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:28]
@@ -557,97 +641,135 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:4:21]
  3 │                     if (a) return;
  4 │                     useState();
-   ·                     ──────────
+   ·                     ─────┬────
+   ·                          ╰── This Hook call is not reachable on every render path.
  5 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:21]
   8 │                     }
   9 │                     useState();
-    ·                     ──────────
+    ·                     ─────┬────
+    ·                          ╰── This Hook call is not reachable on every render path.
  10 │                 }
     ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:21]
   8 │                     if (a) return;
   9 │                     useState();
-    ·                     ──────────
+    ·                     ─────┬────
+    ·                          ╰── This Hook call is not reachable on every render path.
  10 │                 }
     ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook1" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:26]
  2 │                 function useHook() {
  3 │                     a && useHook1();
-   ·                          ──────────
+   ·                     ┬    ─────┬────
+   ·                     │         ╰── This Hook call is not reachable on every render path.
+   ·                     ╰── This short-circuits when falsy, skipping the Hook call.
  4 │                     b && useHook2();
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:26]
  3 │                     a && useHook1();
  4 │                     b && useHook2();
-   ·                          ──────────
+   ·                     ┬    ─────┬────
+   ·                     │         ╰── This Hook call is not reachable on every render path.
+   ·                     ╰── This short-circuits when falsy, skipping the Hook call.
  5 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:25]
  4 │                         f();
  5 │                         useState();
-   ·                         ──────────
+   ·                         ─────┬────
+   ·                              ╰── This Hook call is not reachable on every render path.
  6 │                     } catch {}
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:39]
  2 │                 function useHook({ bar }) {
  3 │                     let foo1 = bar && useState();
-   ·                                       ──────────
+   ·                                ─┬─    ─────┬────
+   ·                                 │          ╰── This Hook call is not reachable on every render path.
+   ·                                 ╰── This short-circuits when falsy, skipping the Hook call.
  4 │                     let foo2 = bar || useState();
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:39]
  3 │                     let foo1 = bar && useState();
  4 │                     let foo2 = bar || useState();
-   ·                                       ──────────
+   ·                                ─┬─    ─────┬────
+   ·                                 │          ╰── This Hook call is not reachable on every render path.
+   ·                                 ╰── This short-circuits when truthy, skipping the Hook call.
  5 │                     let foo3 = bar ?? useState();
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:39]
  4 │                     let foo2 = bar || useState();
  5 │                     let foo3 = bar ?? useState();
-   ·                                       ──────────
+   ·                                ─┬─    ─────┬────
+   ·                                 │          ╰── This Hook call is not reachable on every render path.
+   ·                                 ╰── This short-circuits when not nullish, skipping the Hook call.
  6 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
+ 2 │                 const FancyButton = React.forwardRef((props, ref) => {
  3 │                     if (props.fancy) {
+   ·                         ─────┬─────
+   ·                              ╰── When this condition is false, this Hook is skipped.
  4 │                         useCustomHook();
-   ·                         ───────────────
+   ·                         ───────┬───────
+   ·                                ╰── This Hook call is not reachable on every render path.
  5 │                     }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
+ 2 │                 const FancyButton = forwardRef(function(props, ref) {
  3 │                     if (props.fancy) {
+   ·                         ─────┬─────
+   ·                              ╰── When this condition is false, this Hook is skipped.
  4 │                         useCustomHook();
-   ·                         ───────────────
+   ·                         ───────┬───────
+   ·                                ╰── This Hook call is not reachable on every render path.
  5 │                     }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
+ 2 │                 const MemoizedButton = memo(function(props) {
  3 │                     if (props.fancy) {
+   ·                         ─────┬─────
+   ·                              ╰── When this condition is false, this Hook is skipped.
  4 │                         useCustomHook();
-   ·                         ───────────────
+   ·                         ───────┬───────
+   ·                                ╰── This Hook call is not reachable on every render path.
  5 │                     }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useProbablyAHook" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:21]
@@ -665,7 +787,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:2:13]
  1 │ 
  2 │             useState();
-   ·             ──────────
+   ·             ─────┬────
+   ·                  ╰── This Hook call is outside a component or custom Hook.
  3 │             if (foo) {
    ╰────
 
@@ -673,7 +796,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:4:29]
  3 │             if (foo) {
  4 │                 const foo = React.useCallback(() => {});
-   ·                             ───────────────────────────
+   ·                             ─────────────┬─────────────
+   ·                                          ╰── This Hook call is outside a component or custom Hook.
  5 │             }
    ╰────
 
@@ -681,7 +805,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:6:13]
  5 │             }
  6 │             useCustomHook();
-   ·             ───────────────
+   ·             ───────┬───────
+   ·                    ╰── This Hook call is outside a component or custom Hook.
  7 │         
    ╰────
 
@@ -689,7 +814,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:3:36]
  2 │             const {createHistory, useBasename} = require('history-2.1.2');
  3 │             const browserHistory = useBasename(createHistory)({
-   ·                                    ──────────────────────────
+   ·                                    ─────────────┬────────────
+   ·                                                 ╰── This Hook call is outside a component or custom Hook.
  4 │                 basename: '/',
    ╰────
 
@@ -829,7 +955,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:2:13]
  1 │ 
  2 │             Hook.use();
-   ·             ──────────
+   ·             ─────┬────
+   ·                  ╰── This Hook call is outside a component or custom Hook.
  3 │             Hook._use();
    ╰────
 
@@ -837,7 +964,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:4:13]
  3 │             Hook._use();
  4 │             Hook.useState();
-   ·             ───────────────
+   ·             ───────┬───────
+   ·                    ╰── This Hook call is outside a component or custom Hook.
  5 │             Hook._useState();
    ╰────
 
@@ -845,7 +973,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:6:13]
  5 │             Hook._useState();
  6 │             Hook.use42();
-   ·             ────────────
+   ·             ──────┬─────
+   ·                   ╰── This Hook call is outside a component or custom Hook.
  7 │             Hook.useHook();
    ╰────
 
@@ -853,7 +982,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:7:13]
  6 │             Hook.use42();
  7 │             Hook.useHook();
-   ·             ──────────────
+   ·             ───────┬──────
+   ·                    ╰── This Hook call is outside a component or custom Hook.
  8 │             Hook.use_hook();
    ╰────
 
@@ -873,7 +1003,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:2:26]
  1 │ 
  2 │             const text = use(promise);
-   ·                          ────────────
+   ·                          ──────┬─────
+   ·                                ╰── This Hook call is outside a component or custom Hook.
  3 │             function App() {
    ╰────
 
@@ -916,19 +1047,29 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
+ 2 │             export default () => {
  3 │                 if (isVal) {
+   ·                     ──┬──
+   ·                       ╰── When this condition is false, this Hook is skipped.
  4 │                     useState(0);
-   ·                     ───────────
+   ·                     ─────┬─────
+   ·                          ╰── This Hook call is not reachable on every render path.
  5 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
+ 2 │             export default function() {
  3 │                 if (isVal) {
+   ·                     ──┬──
+   ·                       ╰── When this condition is false, this Hook is skipped.
  4 │                     useState(0);
-   ·                     ───────────
+   ·                     ─────┬─────
+   ·                          ╰── This Hook call is not reachable on every render path.
  5 │                 }
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useHook" is called in function "foo" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:1:54]
@@ -942,7 +1083,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:3:38]
  2 │             function Component() {
  3 │                 return <Foo>{() => { useState(); }}</Foo>;
-   ·                                      ──────────
+   ·                                      ─────┬────
+   ·                                           ╰── This Hook call is inside a nested callback.
  4 │             }
    ╰────
 
@@ -950,7 +1092,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:3:41]
  2 │             function Component() {
  3 │                 return <Foo>{props => { useMemo(() => {}, []); }}</Foo>;
-   ·                                         ─────────────────────
+   ·                                         ──────────┬──────────
+   ·                                                   ╰── This Hook call is inside a nested callback.
  4 │             }
    ╰────
 
@@ -958,7 +1101,8 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:3:45]
  2 │             function Component() {
  3 │                 return <Foo render={() => { useState(); }} />;
-   ·                                             ──────────
+   ·                                             ─────┬────
+   ·                                                  ╰── This Hook call is inside a nested callback.
  4 │             }
    ╰────
 
@@ -966,12 +1110,16 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[rules_of_hooks.tsx:3:48]
  2 │             function Component() {
  3 │                 return <Foo render={props => { useCallback(() => {}, []); }} />;
-   ·                                                ─────────────────────────
+   ·                                                ────────────┬────────────
+   ·                                                            ╰── This Hook call is inside a nested callback.
  4 │             }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:1:81]
  1 │ const Foo3 = hoc(function NamedComp(props) { if (props.cond) { const [_a, _b] = useState(false); } });
-   ·                                                                                 ───────────────
+   ·                                                  ─────┬────                     ───────┬───────
+   ·                                                       │                                ╰── This Hook call is not reachable on every render path.
+   ·                                                       ╰── When this condition is false, this Hook is skipped.
    ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.


### PR DESCRIPTION
Clarifies conditional Rules of Hooks diagnostics by labeling the Hook call and the conditional path that skips it.