### PR TITLE
fix(linter): stop gitignore lookup at repo boundary

### DIFF
--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -1,7 +1,13 @@
-use std::{ffi::OsStr, path::PathBuf, sync::Arc, sync::mpsc};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    sync::Arc,
+    sync::mpsc,
+};
 
 use ignore::{DirEntry, overrides::Override};
 use oxc_linter::LINTABLE_EXTENSIONS;
+use rustc_hash::FxHashMap;
 
 use crate::cli::IgnoreOptions;
 
@@ -52,9 +58,11 @@ impl ignore::ParallelVisitor for WalkCollector {
     fn visit(&mut self, entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
         match entry {
             Ok(entry) => {
-                // Skip traversing `.git` directories because `.git` is not a special case for `.hidden(false)`.
+                // Skip VCS metadata directories because they are not special cases for `.hidden(false)`.
                 // <https://github.com/BurntSushi/ripgrep/issues/3099#issuecomment-3052460027>
-                if entry.file_type().is_some_and(|ty| ty.is_dir()) && entry.file_name() == ".git" {
+                if entry.file_type().is_some_and(|ty| ty.is_dir())
+                    && (entry.file_name() == ".git" || entry.file_name() == ".jj")
+                {
                     return ignore::WalkState::Skip;
                 }
                 if Walk::is_wanted_entry(&entry, &self.extensions) {
@@ -97,13 +105,15 @@ impl Walk {
             }
         }
 
+        let require_git = all_paths_have_vcs_boundary(paths);
+
         let inner = inner
             .ignore(false)
             .git_global(false)
             .git_ignore(true)
             .follow_links(true)
             .hidden(false)
-            .require_git(false)
+            .require_git(require_git)
             .build_parallel();
         Self { inner, extensions: Extensions::default() }
     }
@@ -139,14 +149,68 @@ impl Walk {
     }
 }
 
+fn all_paths_have_vcs_boundary(paths: &[PathBuf]) -> bool {
+    let cwd = std::env::current_dir().ok();
+    let mut cache = FxHashMap::default();
+    paths.iter().all(|path| has_vcs_boundary(path, cwd.as_deref(), &mut cache))
+}
+
+fn has_vcs_boundary(path: &Path, cwd: Option<&Path>, cache: &mut FxHashMap<PathBuf, bool>) -> bool {
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.map_or_else(|| path.to_path_buf(), |cwd| cwd.join(path))
+    };
+
+    let start = if path.is_file() { path.parent().unwrap_or(&path) } else { path.as_path() };
+
+    if let Some(has_boundary) = cache.get(start) {
+        return *has_boundary;
+    }
+
+    let has_boundary = start.ancestors().any(|dir| {
+        cache
+            .get(dir)
+            .copied()
+            .unwrap_or_else(|| dir.join(".git").exists() || dir.join(".jj").exists())
+    });
+    cache.insert(start.to_path_buf(), has_boundary);
+    has_boundary
+}
+
 #[cfg(test)]
 mod test {
-    use std::{env, ffi::OsString, fs, path::Path};
+    use std::{env, ffi::OsString, fs, path::Path, slice};
 
     use ignore::overrides::OverrideBuilder;
 
     use super::{Extensions, Walk};
     use crate::cli::IgnoreOptions;
+
+    fn collect_js_paths(root: &Path, ignore_options: &IgnoreOptions) -> Vec<String> {
+        let override_builder = OverrideBuilder::new(root).build().unwrap();
+
+        let mut paths =
+            Walk::new(slice::from_ref(&root.to_path_buf()), ignore_options, Some(override_builder))
+                .with_extensions(Extensions(["js"].to_vec()))
+                .paths()
+                .into_iter()
+                .map(|path| {
+                    Path::new(&path).strip_prefix(root).unwrap().to_string_lossy().to_string()
+                })
+                .collect::<Vec<_>>();
+
+        paths.sort();
+        paths
+    }
+
+    fn empty_ignore_options() -> IgnoreOptions {
+        IgnoreOptions {
+            no_ignore: false,
+            ignore_path: OsString::from(".eslintignore"),
+            ignore_pattern: vec![],
+        }
+    }
 
     #[test]
     fn test_walk_with_extensions() {
@@ -190,35 +254,87 @@ mod test {
         // Verify no .git directory exists
         assert!(!temp_path.join(".git").exists());
 
-        // Use empty ignore_path to rely on auto-discovery, not explicit loading
-        let ignore_options = IgnoreOptions {
-            no_ignore: false,
-            ignore_path: OsString::from(""), // Empty = rely on auto-discovery
-            ignore_pattern: vec![],
-        };
-
-        let override_builder = OverrideBuilder::new(temp_path).build().unwrap();
-
-        let mut paths =
-            Walk::new(&[temp_path.to_path_buf()], &ignore_options, Some(override_builder))
-                .with_extensions(Extensions(["js"].to_vec()))
-                .paths()
-                .into_iter()
-                .map(|path| {
-                    Path::new(&path)
-                        .strip_prefix(temp_path)
-                        .unwrap()
-                        .file_name()
-                        .unwrap()
-                        .to_string_lossy()
-                        .to_string()
-                })
-                .collect::<Vec<_>>();
-
-        paths.sort();
+        // Use the default ignore filename without creating that file, so this relies on
+        // `.gitignore` auto-discovery rather than explicit ignore loading.
+        let ignore_options = empty_ignore_options();
 
         // Only included.js should be found; ignored.js should be filtered by auto-discovered .gitignore
         // Without .git_ignore(true) and .require_git(false), both files would be found
-        assert_eq!(paths, vec!["included.js"]);
+        assert_eq!(collect_js_paths(temp_path, &ignore_options), vec!["included.js"]);
+    }
+
+    #[test]
+    fn test_parent_gitignore_does_not_cross_git_repo_boundary() {
+        // A parent `.gitignore` must not apply once the walk enters a nested
+        // repository. The nested repo's own `.gitignore` should still apply.
+        //
+        // File structure:
+        // root/
+        //   .gitignore          # ignores everything
+        //   repo/
+        //     .git/
+        //     .gitignore        # ignores ignored.js
+        //     included.js
+        //     ignored.js
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path();
+        let repo_path = temp_path.join("repo");
+
+        fs::create_dir(&repo_path).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(temp_path.join(".gitignore"), "*\n").unwrap();
+        fs::write(repo_path.join(".gitignore"), "ignored.js\n").unwrap();
+        fs::write(repo_path.join("included.js"), "debugger;").unwrap();
+        fs::write(repo_path.join("ignored.js"), "debugger;").unwrap();
+
+        assert_eq!(collect_js_paths(&repo_path, &empty_ignore_options()), vec!["included.js"]);
+    }
+
+    #[test]
+    fn test_parent_gitignore_does_not_cross_git_worktree_file_boundary() {
+        // Git worktrees use a `.git` file instead of a `.git` directory. That
+        // file is still a repository boundary for parent `.gitignore` lookup.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path();
+        let repo_path = temp_path.join("repo");
+
+        fs::create_dir(&repo_path).unwrap();
+        fs::write(temp_path.join(".gitignore"), "*\n").unwrap();
+        fs::write(repo_path.join(".git"), "gitdir: /tmp/worktrees/repo/.git\n").unwrap();
+        fs::write(repo_path.join("included.js"), "debugger;").unwrap();
+
+        assert_eq!(collect_js_paths(&repo_path, &empty_ignore_options()), vec!["included.js"]);
+    }
+
+    #[test]
+    fn test_repo_gitignore_applies_when_walking_from_subdirectory() {
+        // Stopping parent lookup at the repository boundary must still keep
+        // repo-local parent `.gitignore` files active for subdirectory walks.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path();
+        let repo_path = temp_path.join("repo");
+        let src_path = repo_path.join("src");
+
+        fs::create_dir(&repo_path).unwrap();
+        fs::create_dir(&src_path).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(temp_path.join(".gitignore"), "*\n").unwrap();
+        fs::write(repo_path.join(".gitignore"), "ignored.js\n").unwrap();
+        fs::write(src_path.join("included.js"), "debugger;").unwrap();
+        fs::write(src_path.join("ignored.js"), "debugger;").unwrap();
+
+        assert_eq!(collect_js_paths(&src_path, &empty_ignore_options()), vec!["included.js"]);
+    }
+
+    #[test]
+    fn test_walk_skips_jj_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::create_dir(temp_path.join(".jj")).unwrap();
+        fs::write(temp_path.join("included.js"), "debugger;").unwrap();
+        fs::write(temp_path.join(".jj").join("ignored.js"), "debugger;").unwrap();
+
+        assert_eq!(collect_js_paths(temp_path, &empty_ignore_options()), vec!["included.js"]);
     }
 }


### PR DESCRIPTION
This regressed in oxlint v1.36.0 (fec2863267)

This is caused by the walker configuring `ignore` with `.require_git(false)`, which makes `.gitignore` files from parent directories above the current repository apply to the walk. That differs from Git behavior, where `.gitignore` lookup stops at the working tree root.

Here is how we handle it:

- detect whether all walk roots are inside a Git/JJ repository boundary
- enable `require_git(true)` for repository walks so parent `.gitignore` files above the repo boundary are ignored
- keep `require_git(false)` for non-repository walks so local `.gitignore` files still work outside Git repos
- add regression coverage for nested repositories, worktree-style `.git` files, and subdirectory walks inside a repo

Here is how the `ignore` crate checks for git directories:

- when `require_git(true)` is enabled, it records whether each directory has a `.git` or `.jj` entry
- while matching `.gitignore` rules, it applies parent gitignore matchers only until it has seen that repository boundary
- `.git` files are handled as boundaries too, which covers Git worktrees

Fixes #17510.
Fixes #17805.
Fixes #19902.
Closes #21727.
Closes #17513.
Closes #17813.
Closes #20951.
Closes #20952.
