### PR TITLE
fix(linter/react/only-export-components): align rule with upstream cases

### DIFF
--- a/crates/oxc_linter/src/rules/react/only_export_components.rs
+++ b/crates/oxc_linter/src/rules/react/only_export_components.rs
@@ -371,8 +371,14 @@ impl OnlyExportComponents {
             }
             ExportDefaultDeclarationKind::ClassDeclaration(class) => {
                 if let Some(id) = class.id.as_ref() {
-                    let export_type = self.classify_export(id.name.as_str(), id.span, false, None);
-                    analysis.add_export(export_type);
+                    analysis.add_export(
+                        if is_react_component_name(&id.name) && Self::extends_react_component(class)
+                        {
+                            ExportType::ReactComponent
+                        } else {
+                            ExportType::NonComponent(id.span)
+                        },
+                    );
                 } else {
                     analysis.anonymous_span = Some(class.span);
                 }
@@ -462,7 +468,13 @@ impl OnlyExportComponents {
                     |id| vec![self.classify_export(id.name.as_str(), id.span, true, None)],
                 ),
                 Declaration::ClassDeclaration(class) => class.id.as_ref().map_or(vec![], |id| {
-                    vec![self.classify_export(id.name.as_str(), id.span, false, None)]
+                    vec![if is_react_component_name(&id.name)
+                        && Self::extends_react_component(class)
+                    {
+                        ExportType::ReactComponent
+                    } else {
+                        ExportType::NonComponent(id.span)
+                    }]
                 }),
                 Declaration::TSEnumDeclaration(ts_enum) => {
                     vec![ExportType::NonComponent(ts_enum.id.span)]
@@ -517,6 +529,16 @@ impl OnlyExportComponents {
             && self.is_callee_hoc(&call_expr.callee)
             && !call_expr.arguments.is_empty()
             && is_react_component_name(name)
+        {
+            return ExportType::ReactComponent;
+        }
+
+        if let Some(init_expr) = init
+            && let Expression::ConditionalExpression(cond_expr) =
+                Self::skip_ts_expression(init_expr)
+            && is_react_component_name(name)
+            && self.is_react_component_initializer(&cond_expr.consequent)
+            && self.is_react_component_initializer(&cond_expr.alternate)
         {
             return ExportType::ReactComponent;
         }
@@ -590,6 +612,35 @@ impl OnlyExportComponents {
             Expression::ThisExpression(_) => "ThisExpression",
             Expression::UpdateExpression(_) => "UpdateExpression",
             _ => "",
+        }
+    }
+
+    fn extends_react_component(class: &Class) -> bool {
+        class.super_class.as_ref().is_some_and(|super_class| {
+            if let Some(member_expr) = super_class.as_member_expression()
+                && let Expression::Identifier(ident) = member_expr.object()
+                && ident.name == "React"
+            {
+                return member_expr
+                    .static_property_name()
+                    .is_some_and(|name| matches!(name, "Component" | "PureComponent"));
+            }
+
+            super_class
+                .get_identifier_reference()
+                .is_some_and(|id| matches!(id.name.as_str(), "Component" | "PureComponent"))
+        })
+    }
+
+    fn is_react_component_initializer(&self, expr: &Expression) -> bool {
+        match Self::skip_ts_expression(expr) {
+            Expression::ArrowFunctionExpression(_) => true,
+            Expression::FunctionExpression(func) => func.id.is_some(),
+            Expression::Identifier(ident) => is_react_component_name(&ident.name),
+            Expression::CallExpression(call_expr) => {
+                self.is_callee_hoc(&call_expr.callee) && !call_expr.arguments.is_empty()
+            }
+            _ => false,
         }
     }
 
@@ -697,6 +748,7 @@ fn test() {
         ("export default function Foo() {}", None),
         ("export const Foo = () => {};", None),
         ("export const Foo2 = () => {};", None),
+        ("export const Foo_ = () => {};", None),
         ("export function CMS() {};", None),
         ("export const SVG = forwardRef(() => <svg/>);", None),
         ("export const CMS = () => {};", None),
@@ -705,6 +757,22 @@ fn test() {
         ("const foo = 4; export const Bar = () => {}; export const Baz = () => {};", None),
         ("const foo = () => {}; export const Bar = () => {}; export const Baz = () => {};", None),
         ("export const Foo = () => {}; export const Bar = styled.div`padding-bottom: 6px;`;", None),
+        (
+            "export const Foo = () => {}; export const Flex = styled.div({ display: 'flex' });",
+            Some(serde_json::json!([{ "customHOCs": ["styled"] }])),
+        ),
+        (
+            "export const Foo = () => {}; export const Flex = styled('div')({display: 'flex'});",
+            Some(serde_json::json!([{ "customHOCs": ["styled"] }])),
+        ),
+        (
+            "export const Foo = () => {}; export const Flex = styled('div')`display: flex;`;",
+            Some(serde_json::json!([{ "customHOCs": ["styled"] }])),
+        ),
+        (
+            "export const Foo = () => {}; export const Flex = styled('div');",
+            Some(serde_json::json!([{ "customHOCs": ["styled"] }])),
+        ),
         ("export const foo = 3;", None),
         ("const foo = 3; const bar = 'Hello'; export { foo, bar };", None),
         ("export const foo = () => {};", None),
@@ -747,6 +815,10 @@ fn test() {
             "export const loader = () => {}; export const meta = { title: 'Home' };",
             Some(serde_json::json!([{ "allowExportNames": ["loader", "meta"] }])),
         ),
+        (
+            "export const viewport = { width: 'device-width', initialScale: 1 }; export const Page = () => {};",
+            Some(serde_json::json!([{ "allowExportNames": ["viewport"] }])),
+        ),
         ("export { App as default }; const App = () => <>Test</>;", None),
         ("const MyComponent = () => {}; export default connect(() => ({}))(MyComponent);", None),
         ("export const MyComponent = () => {}; export const ChatContext = () => {};", None),
@@ -777,6 +849,35 @@ fn test() {
             "export const MyComponent = () => {}; export default memo(forwardRef(MyComponent));",
             None,
         ),
+        (
+            "export const Devtools = import.meta.env.PROD ? () => null : React.lazy(() => import('devtools')); export const OtherComponent = () => {};",
+            None,
+        ),
+        (
+            "const RootComponent = () => {}; export const Route = createRootRoute()({ component: RootComponent });",
+            Some(serde_json::json!([{ "customHOCs": ["createRootRoute"] }])),
+        ),
+        ("export const Link = () => {}; export const RenamedLink = Link;", None),
+        ("export const Link = () => {}; export const TypedLink = Link<RouteParams>;", None),
+        (
+            "export class MyComponent extends React.Component<Props, State> { render() { return <div>Hello</div>; } }",
+            None,
+        ),
+        (
+            "export default class MyComponent extends Component { render() { return <div>Hello</div>; } }",
+            None,
+        ),
+        (
+            "export function Button(props: PropsWithChildren<{ onClick: () => void }>): ReactNode;
+export function Button(props: PropsWithChildren): ReactNode {
+  return <button {...props}>{props.children}</button>;
+}",
+            None,
+        ),
+        (
+            "export const Link = () => {}; export const Styles = styled('div').attrs((props) => ({ className: 'form-control' }))``;",
+            Some(serde_json::json!([{ "customHOCs": ["styled"] }])),
+        ),
         // Named export with React.memo member expression HOC call
         ("export const MyComponent = React.memo(function MyComponent() { return null; });", None),
         // React.lazy with arrow function
@@ -791,6 +892,7 @@ fn test() {
 
     let fail = vec![
         ("export const foo = () => {}; export const Bar = () => {};", None),
+        ("export const _Foo = () => {}; export const Foo = () => {};", None),
         (
             "export const foo = () => {}; export const Bar = () => {};",
             Some(serde_json::json!([{ "allowConstantExport": true }])),
@@ -816,7 +918,7 @@ fn test() {
         ",
             Some(serde_json::json!([{ "checkJS": true }])),
         ),
-        ("export default compose()(MainView);", None),
+        ("const MainView = () => {}; export default compose()(MainView);", None),
         (
             "export const loader = () => {}; export const Bar = () => {}; export const foo = () => {};",
             Some(serde_json::json!([{ "allowExportNames": ["loader", "meta"] }])),
@@ -831,6 +933,19 @@ fn test() {
             None,
         ),
         ("const MyComponent = () => {}; export default observer(MyComponent);", None),
+        (
+            "const MyComponent = () => {}; export const ENUM = Object.keys(TABLE) as EnumType[];",
+            None,
+        ),
+        (
+            "export const DevtoolsNotComponentInProd = import.meta.env.PROD ? null : React.lazy(() => import('devtools')); export const OtherComponent = () => {};",
+            None,
+        ),
+        (
+            "export const Foo = () => {}; export class MyComponent { bar() { return <div>Hello</div>; } }",
+            None,
+        ),
+        ("export default class { bar() { return <div>Hello</div>; } }", None),
         // Call expression initializer is not a constant or component (#20455)
         (
             "export const Route = createFileRoute('/example')({ component: RouteComponent }); function RouteComponent() { return <div>Hello</div>; }",
@@ -868,11 +983,21 @@ fn test_js_file_extension() {
         // Also passes both cases when checkJS is false.
         ("export default () => {};", Some(serde_json::json!([{ "checkJS": false }]))),
         (
+            "export const foo = () => {}; export const Bar = () => {};",
+            Some(serde_json::json!([{ "checkJS": false }])),
+        ),
+        (
             "import React from 'react'; export function Foo() {};",
             Some(serde_json::json!([{ "checkJS": false }])),
         ),
+        // Passes with checkJS enabled because React is not imported.
+        (
+            "export const foo = () => {}; export const Bar = () => {};",
+            Some(serde_json::json!([{ "checkJS": true }])),
+        ),
         // And with no config, as checkJS defaults to false.
         ("export default () => {};", None),
+        ("export const foo = () => {}; export const Bar = () => {};", None),
         ("import React from 'react'; export function Foo() {};", None),
     ];
 
@@ -893,6 +1018,10 @@ fn test_js_file_extension() {
         ),
         (
             "import React from 'react'; export default function () {};",
+            Some(serde_json::json!([{ "checkJS": true }])),
+        ),
+        (
+            "import React from 'react'; export const CONSTANT = 3; export const Foo = () => {};",
             Some(serde_json::json!([{ "checkJS": true }])),
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/react_only_export_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_only_export_components.snap
@@ -10,6 +10,12 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:14]
+ 1 │ export const _Foo = () => {}; export const Foo = () => {};
+   ·              ────
+   ╰────
+
+  ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
+   ╭─[only_export_components.tsx:1:14]
  1 │ export const foo = () => {}; export const Bar = () => {};
    ·              ───
    ╰────
@@ -89,9 +95,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
-   ╭─[only_export_components.tsx:1:1]
- 1 │ export default compose()(MainView);
-   · ───────────────────────────────────
+   ╭─[only_export_components.tsx:1:28]
+ 1 │ const MainView = () => {}; export default compose()(MainView);
+   ·                            ───────────────────────────────────
+   ╰────
+
+  ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
+   ╭─[only_export_components.tsx:1:7]
+ 1 │ const MainView = () => {}; export default compose()(MainView);
+   ·       ────────
    ╰────
 
   ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
@@ -128,6 +140,30 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[only_export_components.tsx:1:7]
  1 │ const MyComponent = () => {}; export default observer(MyComponent);
    ·       ───────────
+   ╰────
+
+  ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
+   ╭─[only_export_components.tsx:1:7]
+ 1 │ const MyComponent = () => {}; export const ENUM = Object.keys(TABLE) as EnumType[];
+   ·       ───────────
+   ╰────
+
+  ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
+   ╭─[only_export_components.tsx:1:14]
+ 1 │ export const DevtoolsNotComponentInProd = import.meta.env.PROD ? null : React.lazy(() => import('devtools')); export const OtherComponent = () => {};
+   ·              ──────────────────────────
+   ╰────
+
+  ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
+   ╭─[only_export_components.tsx:1:43]
+ 1 │ export const Foo = () => {}; export class MyComponent { bar() { return <div>Hello</div>; } }
+   ·                                           ───────────
+   ╰────
+
+  ⚠ react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
+   ╭─[only_export_components.tsx:1:16]
+ 1 │ export default class { bar() { return <div>Hello</div>; } }
+   ·                ────────────────────────────────────────────
    ╰────
 
   ⚠ react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.


### PR DESCRIPTION
follow on from https://github.com/oxc-project/oxc/pull/21937