### PR TITLE
fix(linter): print resolved extended config

### DIFF
--- a/apps/oxlint/test/fixtures/print_config_js_config_extends/base.ts
+++ b/apps/oxlint/test/fixtures/print_config_js_config_extends/base.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
+  plugins: ["import"],
+  rules: {
+    "import/no-unassigned-import": "error",
+  },
+  overrides: [
+    {
+      files: ["**/*.test.ts"],
+      rules: {
+        "no-debugger": "error",
+      },
+    },
+  ],
+});

--- a/apps/oxlint/test/fixtures/print_config_js_config_extends/files/test.js
+++ b/apps/oxlint/test/fixtures/print_config_js_config_extends/files/test.js
@@ -1,0 +1,1 @@
+import "./side-effect.js";

--- a/apps/oxlint/test/fixtures/print_config_js_config_extends/options.json
+++ b/apps/oxlint/test/fixtures/print_config_js_config_extends/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--print-config"]
+}

--- a/apps/oxlint/test/fixtures/print_config_js_config_extends/output.snap.md
+++ b/apps/oxlint/test/fixtures/print_config_js_config_extends/output.snap.md
@@ -1,0 +1,74 @@
+# Exit code
+0
+
+# stdout
+```
+{
+  "plugins": [
+    "unicorn",
+    "typescript",
+    "oxc",
+    "import"
+  ],
+  "categories": {
+    "correctness": "allow"
+  },
+  "rules": {
+    "import/no-unassigned-import": "deny"
+  },
+  "settings": {
+    "jsx-a11y": {
+      "polymorphicPropName": null,
+      "components": {},
+      "attributes": {}
+    },
+    "next": {
+      "rootDir": []
+    },
+    "react": {
+      "formComponents": [],
+      "linkComponents": [],
+      "version": null,
+      "componentWrapperFunctions": []
+    },
+    "jsdoc": {
+      "ignorePrivate": false,
+      "ignoreInternal": false,
+      "ignoreReplacesDocs": true,
+      "overrideReplacesDocs": true,
+      "augmentsExtendsReplacesDocs": false,
+      "implementsReplacesDocs": false,
+      "exemptDestructuredRootsFromChecks": false,
+      "tagNamePreference": {}
+    },
+    "vitest": {
+      "typecheck": false
+    },
+    "jest": {
+      "version": null
+    }
+  },
+  "env": {
+    "builtin": true
+  },
+  "globals": {},
+  "overrides": [
+    {
+      "files": [
+        "**/*.test.ts"
+      ],
+      "env": null,
+      "globals": null,
+      "plugins": null,
+      "rules": {
+        "no-debugger": "deny"
+      }
+    }
+  ],
+  "ignorePatterns": []
+}
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/print_config_js_config_extends/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/print_config_js_config_extends/oxlint.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "#oxlint";
+
+import base from "./base.ts";
+
+export default defineConfig({
+  categories: {
+    correctness: "off",
+  },
+  extends: [base],
+});

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -583,6 +583,12 @@ impl ConfigStoreBuilder {
             })
             .collect();
 
+        oxlintrc.plugins = Some(self.config.plugins);
+        oxlintrc.settings.clone_from(&self.config.settings);
+        oxlintrc.env.clone_from(&self.config.env);
+        oxlintrc.globals.clone_from(&self.config.globals);
+        oxlintrc.overrides.clone_from(&self.overrides);
+        oxlintrc.options = self.config.options.clone();
         oxlintrc.rules = OxlintRules::new(new_rules);
         serde_json::to_string_pretty(&oxlintrc).unwrap()
     }


### PR DESCRIPTION
Fixes #20863.

`--print-config` previously serialized the original config after replacing only resolved rules, so inherited plugins and overrides from `oxlint.config.ts` object `extends` were missing from the printed output; this now prints the resolved builder state and adds a regression fixture.