### PR TITLE
refactor(linter): extract this expression finder

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_this_in_exported_function.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_this_in_exported_function.rs
@@ -1,17 +1,13 @@
 use oxc_ast::{
     AstKind,
-    ast::{
-        Declaration, ExportDefaultDeclarationKind, Expression, Function, ModuleExportName,
-        PropertyDefinition, StaticBlock, ThisExpression,
-    },
+    ast::{Declaration, ExportDefaultDeclarationKind, Expression, Function, ModuleExportName},
 };
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, context::LintContext, rule::Rule, utils::ThisExpressionFinder};
 
 fn no_this_in_exported_function_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`this` should not be used in exported functions")
@@ -113,39 +109,14 @@ impl Rule for NoThisInExportedFunction {
     }
 }
 
-// Visitor to find `this` expressions within a function body
-struct ThisFinder {
-    found_this_expressions: Vec<Span>,
-}
-
-impl ThisFinder {
-    fn new() -> Self {
-        Self { found_this_expressions: Vec::new() }
-    }
-}
-
-impl<'a> Visit<'a> for ThisFinder {
-    fn visit_this_expression(&mut self, expr: &ThisExpression) {
-        self.found_this_expressions.push(expr.span);
-    }
-    // Don't traverse into nested function declarations - they have their own `this` context
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
-    // Don't traverse into static blocks - `this` refers to the class itself
-    fn visit_static_block(&mut self, _block: &StaticBlock<'a>) {}
-    // For property definitions, only visit the key (for computed properties)
-    // but skip the value since `this` in values refers to the class/instance
-    fn visit_property_definition(&mut self, prop: &PropertyDefinition<'a>) {
-        self.visit_property_key(&prop.key);
-    }
-}
-
 fn check_function_for_this(func: &Function, ctx: &LintContext) {
     let Some(body) = &func.body else { return };
 
-    let mut finder = ThisFinder::new();
+    let mut finder =
+        ThisExpressionFinder::new().skip_static_blocks().skip_property_definition_values();
     finder.visit_function_body(body);
 
-    for span in finder.found_this_expressions {
+    for span in finder.into_spans() {
         ctx.diagnostic(no_this_in_exported_function_diagnostic(span));
     }
 }

--- a/crates/oxc_linter/src/rules/vue/no_this_in_before_route_enter.rs
+++ b/crates/oxc_linter/src/rules/vue/no_this_in_before_route_enter.rs
@@ -1,14 +1,13 @@
 use oxc_ast::{
     AstKind,
-    ast::{ExportDefaultDeclarationKind, Expression, Function, ObjectPropertyKind, ThisExpression},
+    ast::{ExportDefaultDeclarationKind, Expression, ObjectPropertyKind},
 };
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, context::LintContext, rule::Rule, utils::ThisExpressionFinder};
 
 fn no_this_in_before_route_enter_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`beforeRouteEnter` does NOT have access to `this` component instance.")
@@ -90,9 +89,9 @@ impl Rule for NoThisInBeforeRouteEnter {
                 return;
             };
 
-            let mut finder = ThisFinder::new();
+            let mut finder = ThisExpressionFinder::new();
             finder.visit_function_body(function_body);
-            for span in finder.found_this_expressions {
+            for span in finder.into_spans() {
                 ctx.diagnostic(no_this_in_before_route_enter_diagnostic(span));
             }
         }
@@ -101,24 +100,6 @@ impl Rule for NoThisInBeforeRouteEnter {
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
         ctx.file_extension().is_some_and(|ext| ext == "vue")
     }
-}
-
-struct ThisFinder {
-    found_this_expressions: Vec<Span>,
-}
-
-impl ThisFinder {
-    fn new() -> Self {
-        Self { found_this_expressions: Vec::new() }
-    }
-}
-
-impl<'a> Visit<'a> for ThisFinder {
-    fn visit_this_expression(&mut self, expr: &ThisExpression) {
-        self.found_this_expressions.push(expr.span);
-    }
-
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
 }
 
 #[test]

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -21,6 +21,7 @@ mod promise;
 mod react;
 mod react_perf;
 mod regex;
+mod this_expression;
 mod typescript;
 mod unicorn;
 mod url;
@@ -29,7 +30,8 @@ mod vue;
 
 pub use self::{
     comment::*, config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*, react::*,
-    react_perf::*, regex::*, typescript::*, unicorn::*, url::*, vitest::*, vue::*,
+    react_perf::*, regex::*, this_expression::*, typescript::*, unicorn::*, url::*, vitest::*,
+    vue::*,
 };
 
 /// List of Eslint rules that have TypeScript equivalents.

--- a/crates/oxc_linter/src/utils/this_expression.rs
+++ b/crates/oxc_linter/src/utils/this_expression.rs
@@ -1,0 +1,57 @@
+use oxc_ast::ast::{Function, PropertyDefinition, StaticBlock, ThisExpression};
+use oxc_ast_visit::{Visit, walk};
+use oxc_semantic::ScopeFlags;
+use oxc_span::Span;
+
+/// Finds `this` expressions without traversing into nested functions.
+pub struct ThisExpressionFinder {
+    spans: Vec<Span>,
+    skip_static_blocks: bool,
+    skip_property_definition_values: bool,
+}
+
+impl ThisExpressionFinder {
+    pub fn new() -> Self {
+        Self {
+            spans: Vec::new(),
+            skip_static_blocks: false,
+            skip_property_definition_values: false,
+        }
+    }
+
+    pub fn skip_static_blocks(mut self) -> Self {
+        self.skip_static_blocks = true;
+        self
+    }
+
+    pub fn skip_property_definition_values(mut self) -> Self {
+        self.skip_property_definition_values = true;
+        self
+    }
+
+    pub fn into_spans(self) -> Vec<Span> {
+        self.spans
+    }
+}
+
+impl<'a> Visit<'a> for ThisExpressionFinder {
+    fn visit_this_expression(&mut self, expr: &ThisExpression) {
+        self.spans.push(expr.span);
+    }
+
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+
+    fn visit_static_block(&mut self, block: &StaticBlock<'a>) {
+        if !self.skip_static_blocks {
+            walk::walk_static_block(self, block);
+        }
+    }
+
+    fn visit_property_definition(&mut self, prop: &PropertyDefinition<'a>) {
+        if self.skip_property_definition_values {
+            self.visit_property_key(&prop.key);
+        } else {
+            walk::walk_property_definition(self, prop);
+        }
+    }
+}


### PR DESCRIPTION
Extract a shared linter utility for finding `this` expressions while skipping nested functions. This removes duplicated visitors from the OXC and Vue rules while preserving their rule-specific traversal behavior.