### PR TITLE
feat(linter/jest): implement padding-around-before-each-blocks

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2266,6 +2266,13 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner
+    for crate::rules::jest::padding_around_before_each_blocks::PaddingAroundBeforeEachBlocks
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -245,6 +245,7 @@ pub use crate::rules::jest::no_test_return_statement::NoTestReturnStatement as J
 pub use crate::rules::jest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction as JestNoUnneededAsyncExpectFunction;
 pub use crate::rules::jest::no_untyped_mock_factory::NoUntypedMockFactory as JestNoUntypedMockFactory;
 pub use crate::rules::jest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks as JestPaddingAroundAfterAllBlocks;
+pub use crate::rules::jest::padding_around_before_each_blocks::PaddingAroundBeforeEachBlocks as JestPaddingAroundBeforeEachBlocks;
 pub use crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks as JestPaddingAroundTestBlocks;
 pub use crate::rules::jest::prefer_called_with::PreferCalledWith as JestPreferCalledWith;
 pub use crate::rules::jest::prefer_comparison_matcher::PreferComparisonMatcher as JestPreferComparisonMatcher;
@@ -1148,6 +1149,7 @@ pub enum RuleEnum {
     JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction),
     JestNoUntypedMockFactory(JestNoUntypedMockFactory),
     JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks),
+    JestPaddingAroundBeforeEachBlocks(JestPaddingAroundBeforeEachBlocks),
     JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks),
     JestPreferCalledWith(JestPreferCalledWith),
     JestPreferComparisonMatcher(JestPreferComparisonMatcher),
@@ -1980,7 +1982,10 @@ const JEST_NO_TEST_RETURN_STATEMENT_ID: usize = JEST_NO_TEST_PREFIXES_ID + 1usiz
 const JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID: usize = JEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
 const JEST_NO_UNTYPED_MOCK_FACTORY_ID: usize = JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
 const JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID: usize = JEST_NO_UNTYPED_MOCK_FACTORY_ID + 1usize;
-const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const JEST_PADDING_AROUND_BEFORE_EACH_BLOCKS_ID: usize =
+    JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize =
+    JEST_PADDING_AROUND_BEFORE_EACH_BLOCKS_ID + 1usize;
 const JEST_PREFER_CALLED_WITH_ID: usize = JEST_PADDING_AROUND_TEST_BLOCKS_ID + 1usize;
 const JEST_PREFER_COMPARISON_MATCHER_ID: usize = JEST_PREFER_CALLED_WITH_ID + 1usize;
 const JEST_PREFER_EACH_ID: usize = JEST_PREFER_COMPARISON_MATCHER_ID + 1usize;
@@ -2886,6 +2891,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID,
             Self::JestNoUntypedMockFactory(_) => JEST_NO_UNTYPED_MOCK_FACTORY_ID,
             Self::JestPaddingAroundAfterAllBlocks(_) => JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID,
+            Self::JestPaddingAroundBeforeEachBlocks(_) => JEST_PADDING_AROUND_BEFORE_EACH_BLOCKS_ID,
             Self::JestPaddingAroundTestBlocks(_) => JEST_PADDING_AROUND_TEST_BLOCKS_ID,
             Self::JestPreferCalledWith(_) => JEST_PREFER_CALLED_WITH_ID,
             Self::JestPreferComparisonMatcher(_) => JEST_PREFER_COMPARISON_MATCHER_ID,
@@ -3789,6 +3795,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::NAME,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::NAME,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::NAME,
+            Self::JestPaddingAroundBeforeEachBlocks(_) => JestPaddingAroundBeforeEachBlocks::NAME,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::NAME,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::NAME,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::NAME,
@@ -4704,6 +4711,9 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::CATEGORY,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::CATEGORY,
+            Self::JestPaddingAroundBeforeEachBlocks(_) => {
+                JestPaddingAroundBeforeEachBlocks::CATEGORY
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::CATEGORY,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::CATEGORY,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::CATEGORY,
@@ -5628,6 +5638,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::FIX,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::FIX,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::FIX,
+            Self::JestPaddingAroundBeforeEachBlocks(_) => JestPaddingAroundBeforeEachBlocks::FIX,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::FIX,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::FIX,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::FIX,
@@ -6613,6 +6624,9 @@ impl RuleEnum {
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::documentation(),
             Self::JestPaddingAroundAfterAllBlocks(_) => {
                 JestPaddingAroundAfterAllBlocks::documentation()
+            }
+            Self::JestPaddingAroundBeforeEachBlocks(_) => {
+                JestPaddingAroundBeforeEachBlocks::documentation()
             }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::documentation(),
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::documentation(),
@@ -8223,6 +8237,10 @@ impl RuleEnum {
                 JestPaddingAroundAfterAllBlocks::config_schema(generator)
                     .or_else(|| JestPaddingAroundAfterAllBlocks::schema(generator))
             }
+            Self::JestPaddingAroundBeforeEachBlocks(_) => {
+                JestPaddingAroundBeforeEachBlocks::config_schema(generator)
+                    .or_else(|| JestPaddingAroundBeforeEachBlocks::schema(generator))
+            }
             Self::JestPaddingAroundTestBlocks(_) => {
                 JestPaddingAroundTestBlocks::config_schema(generator)
                     .or_else(|| JestPaddingAroundTestBlocks::schema(generator))
@@ -9831,6 +9849,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => "jest",
             Self::JestNoUntypedMockFactory(_) => "jest",
             Self::JestPaddingAroundAfterAllBlocks(_) => "jest",
+            Self::JestPaddingAroundBeforeEachBlocks(_) => "jest",
             Self::JestPaddingAroundTestBlocks(_) => "jest",
             Self::JestPreferCalledWith(_) => "jest",
             Self::JestPreferComparisonMatcher(_) => "jest",
@@ -11401,6 +11420,11 @@ impl RuleEnum {
             Self::JestPaddingAroundAfterAllBlocks(_) => Ok(Self::JestPaddingAroundAfterAllBlocks(
                 JestPaddingAroundAfterAllBlocks::from_configuration(value)?,
             )),
+            Self::JestPaddingAroundBeforeEachBlocks(_) => {
+                Ok(Self::JestPaddingAroundBeforeEachBlocks(
+                    JestPaddingAroundBeforeEachBlocks::from_configuration(value)?,
+                ))
+            }
             Self::JestPaddingAroundTestBlocks(_) => Ok(Self::JestPaddingAroundTestBlocks(
                 JestPaddingAroundTestBlocks::from_configuration(value)?,
             )),
@@ -13146,6 +13170,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.to_configuration(),
             Self::JestNoUntypedMockFactory(rule) => rule.to_configuration(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.to_configuration(),
+            Self::JestPaddingAroundBeforeEachBlocks(rule) => rule.to_configuration(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.to_configuration(),
             Self::JestPreferCalledWith(rule) => rule.to_configuration(),
             Self::JestPreferComparisonMatcher(rule) => rule.to_configuration(),
@@ -13935,6 +13960,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run(node, ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
+            Self::JestPaddingAroundBeforeEachBlocks(rule) => rule.run(node, ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run(node, ctx),
             Self::JestPreferCalledWith(rule) => rule.run(node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run(node, ctx),
@@ -14722,6 +14748,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run_once(ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
+            Self::JestPaddingAroundBeforeEachBlocks(rule) => rule.run_once(ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_once(ctx),
             Self::JestPreferCalledWith(rule) => rule.run_once(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_once(ctx),
@@ -15579,6 +15606,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JestPaddingAroundBeforeEachBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferCalledWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16404,6 +16432,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.should_run(ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.should_run(ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.should_run(ctx),
+            Self::JestPaddingAroundBeforeEachBlocks(rule) => rule.should_run(ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.should_run(ctx),
             Self::JestPreferCalledWith(rule) => rule.should_run(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.should_run(ctx),
@@ -17350,6 +17379,9 @@ impl RuleEnum {
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::IS_TSGOLINT_RULE,
             Self::JestPaddingAroundAfterAllBlocks(_) => {
                 JestPaddingAroundAfterAllBlocks::IS_TSGOLINT_RULE
+            }
+            Self::JestPaddingAroundBeforeEachBlocks(_) => {
+                JestPaddingAroundBeforeEachBlocks::IS_TSGOLINT_RULE
             }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::IS_TSGOLINT_RULE,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::IS_TSGOLINT_RULE,
@@ -18412,6 +18444,9 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::VERSION,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::VERSION,
+            Self::JestPaddingAroundBeforeEachBlocks(_) => {
+                JestPaddingAroundBeforeEachBlocks::VERSION
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::VERSION,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::VERSION,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::VERSION,
@@ -19376,6 +19411,9 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::HAS_CONFIG,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::HAS_CONFIG,
+            Self::JestPaddingAroundBeforeEachBlocks(_) => {
+                JestPaddingAroundBeforeEachBlocks::HAS_CONFIG
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::HAS_CONFIG,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::HAS_CONFIG,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::HAS_CONFIG,
@@ -20251,6 +20289,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.types_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.types_info(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.types_info(),
+            Self::JestPaddingAroundBeforeEachBlocks(rule) => rule.types_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.types_info(),
             Self::JestPreferCalledWith(rule) => rule.types_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.types_info(),
@@ -21038,6 +21077,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.run_info(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_info(),
+            Self::JestPaddingAroundBeforeEachBlocks(rule) => rule.run_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_info(),
             Self::JestPreferCalledWith(rule) => rule.run_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.run_info(),
@@ -21913,6 +21953,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction::default()),
         RuleEnum::JestNoUntypedMockFactory(JestNoUntypedMockFactory::default()),
         RuleEnum::JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks::default()),
+        RuleEnum::JestPaddingAroundBeforeEachBlocks(JestPaddingAroundBeforeEachBlocks::default()),
         RuleEnum::JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks::default()),
         RuleEnum::JestPreferCalledWith(JestPreferCalledWith::default()),
         RuleEnum::JestPreferComparisonMatcher(JestPreferComparisonMatcher::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -360,6 +360,7 @@ pub(crate) mod jest {
     pub mod no_unneeded_async_expect_function;
     pub mod no_untyped_mock_factory;
     pub mod padding_around_after_all_blocks;
+    pub mod padding_around_before_each_blocks;
     pub mod padding_around_test_blocks;
     pub mod prefer_called_with;
     pub mod prefer_comparison_matcher;

--- a/crates/oxc_linter/src/rules/jest/padding_around_before_each_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_before_each_blocks.rs
@@ -1,0 +1,121 @@
+use oxc_ast::AstKind;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
+        report_missing_padding_before_jest_block,
+    },
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct PaddingAroundBeforeEachBlocks;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule enforces a line of padding before and after 1 or more
+    /// `beforeEach` statements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent formatting of code can make the code more difficult to read
+    /// and follow. This rule helps ensure that `beforeEach` blocks are visually
+    /// separated from the rest of the code, making them easier to identify while
+    /// looking through test files.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const thing = 123;
+    /// beforeEach(() => {});
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const thing = 123;
+    ///
+    /// beforeEach(() => {});
+    /// ```
+    PaddingAroundBeforeEachBlocks,
+    jest,
+    style,
+    fix,
+    version = "1.62.0",
+);
+
+impl Rule for PaddingAroundBeforeEachBlocks {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        let node = jest_node.node;
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+        let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, jest_node, ctx) else {
+            return;
+        };
+        let ParsedGeneralJestFnCall { kind, name, .. } = &jest_fn_call;
+        let Some(kind) = kind.to_general() else {
+            return;
+        };
+        if kind != JestGeneralFnKind::Hook {
+            return;
+        }
+        if name != "beforeEach" {
+            return;
+        }
+        report_missing_padding_before_jest_block(node, ctx, name);
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "beforeEach(() => {});",
+        "const thing = 123;\n\nbeforeEach(() => {});",
+        "describe('foo', () => {\nbeforeEach(() => {});\n});",
+        "const thing = 123;\n\n/* one */\n/* two */\nbeforeEach(() => {});",
+        "afterEach(() => {});\n\nbeforeEach(() => {});",
+        "describe('foo', () => {\n  beforeAll(() => {});\n\n  beforeEach(() => {});\n});",
+    ];
+
+    let fail = vec![
+        "const thing = 123;\nbeforeEach(() => {});",
+        "const thing = 123;\n/* one */\n/* two */\nbeforeEach(() => {});",
+        "afterEach(() => {});\nbeforeEach(() => {});",
+        "describe('foo', () => {\n  beforeAll(() => {});\n  beforeEach(() => {});\n});",
+    ];
+
+    let fix = vec![
+        (
+            "const thing = 123;\nbeforeEach(() => {});",
+            "const thing = 123;\n\nbeforeEach(() => {});",
+        ),
+        (
+            "const thing = 123;\n/* one */\n/* two */\nbeforeEach(() => {});",
+            "const thing = 123;\n\n/* one */\n/* two */\nbeforeEach(() => {});",
+        ),
+        (
+            "afterEach(() => {});\nbeforeEach(() => {});",
+            "afterEach(() => {});\n\nbeforeEach(() => {});",
+        ),
+    ];
+
+    Tester::new(
+        PaddingAroundBeforeEachBlocks::NAME,
+        PaddingAroundBeforeEachBlocks::PLUGIN,
+        pass,
+        fail,
+    )
+    .with_jest_plugin(true)
+    .expect_fix(fix)
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_before_each_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_before_each_blocks.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ jest(padding-around-before-each-blocks): Missing padding before beforeEach block
+   ╭─[padding_around_before_each_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ beforeEach(() => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the beforeEach block
+
+  ⚠ jest(padding-around-before-each-blocks): Missing padding before beforeEach block
+   ╭─[padding_around_before_each_blocks.tsx:4:1]
+ 3 │ /* two */
+ 4 │ beforeEach(() => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the beforeEach block
+
+  ⚠ jest(padding-around-before-each-blocks): Missing padding before beforeEach block
+   ╭─[padding_around_before_each_blocks.tsx:2:1]
+ 1 │ afterEach(() => {});
+ 2 │ beforeEach(() => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the beforeEach block
+
+  ⚠ jest(padding-around-before-each-blocks): Missing padding before beforeEach block
+   ╭─[padding_around_before_each_blocks.tsx:3:3]
+ 2 │   beforeAll(() => {});
+ 3 │   beforeEach(() => {});
+   ·   ▲
+ 4 │ });
+   ╰────
+  help: Make sure there is an empty new line before the beforeEach block


### PR DESCRIPTION
## What

Implements the `jest/padding-around-before-each-blocks` rule from
[eslint-plugin-jest][upstream]. Enforces a blank line before every
`beforeEach(...)` call.

Companion to the already-landed `padding-around-after-all-blocks`
(#21034) and `padding-around-test-blocks` (#12985); reuses the shared
`report_missing_padding_before_jest_block` helper.

[upstream]: https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/padding-around-before-each-blocks.md

## AI assistance disclosure

This PR was authored with AI assistance (Claude). Implementation was
reviewed, tested locally, and verified against the upstream ESLint rule
spec. Test cases follow the same shape as the sibling
`padding-around-after-all-blocks` rule plus additional cases covering
hook-to-hook adjacency (`afterEach` → `beforeEach`, `beforeAll` →
`beforeEach`).

## Checklist

- [x] `cargo lintgen` (regenerated rule enum, +1 rule for 784 total)
- [x] `cargo fmt --all`
- [x] `cargo test -p oxc_linter padding_around_before_each_blocks` — green
- [x] Snapshot reviewed and accepted via `cargo insta accept`
- [x] No new dependencies
