### PR TITLE
fix(linter/typescript): remove duplicate rule tests

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -466,14 +466,6 @@ fn test() {
         ),
         (
             r"
-            /* not on the last line
-            * @ts-expect-error
-            */
-        ",
-            None,
-        ),
-        (
-            r"
             /* @ts-ignore
             * not on the last line */
         ",

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -782,13 +782,6 @@ mod test {
         let fail: Vec<(&'static str, Option<Value>)> = vec![
             // line break
             // ("export default () => (true ? () => {} : (): void => {});", None),
-            (
-                "
-            const foo = arg => arg;
-            export default foo;
-            ",
-                None,
-            ),
             // (
             //     "export default () => () => () => 1",
             //     Some(json!([{ "allowHigherOrderFunctions": true }])),


### PR DESCRIPTION
Removes true duplicate test cases from TypeScript linter rule tests while keeping whitespace-sensitive fixture variants intact. The focused TypeScript rule test suite passes after the cleanup.