### PR TITLE
refactor(linter): simplify context sub host options

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -49,48 +49,13 @@ pub struct ContextSubHost<'a> {
 }
 
 impl<'a> ContextSubHost<'a> {
+    /// # Panics
+    /// If `semantic.cfg()` is `None`.
     pub fn new(
         semantic: Semantic<'a>,
         module_record: Arc<ModuleRecord>,
         source_text_offset: u32,
-    ) -> Self {
-        Self::new_with_framework_options(
-            semantic,
-            module_record,
-            source_text_offset,
-            FrameworkOptions::Default,
-            ArenaBox::new_empty_boxed_slice(),
-        )
-    }
-
-    /// # Panics
-    /// If `semantic.cfg()` is `None`.
-    pub fn new_with_framework_options(
-        semantic: Semantic<'a>,
-        module_record: Arc<ModuleRecord>,
-        source_text_offset: u32,
-        frameworks_options: FrameworkOptions,
-        parser_tokens: ArenaBox<'a, [Token]>,
-    ) -> Self {
-        Self::new_with_framework_options_and_directive_support(
-            semantic,
-            module_record,
-            source_text_offset,
-            frameworks_options,
-            parser_tokens,
-            true,
-        )
-    }
-
-    /// # Panics
-    /// If `semantic.cfg()` is `None`.
-    pub(crate) fn new_with_framework_options_and_directive_support(
-        semantic: Semantic<'a>,
-        module_record: Arc<ModuleRecord>,
-        source_text_offset: u32,
-        frameworks_options: FrameworkOptions,
-        parser_tokens: ArenaBox<'a, [Token]>,
-        respect_eslint_disable_directives: bool,
+        options: ContextSubHostOptions<'a>,
     ) -> Self {
         // We should always check for `semantic.cfg()` being `Some` since we depend on it and it is
         // unwrapped without any runtime checks after construction.
@@ -100,7 +65,7 @@ impl<'a> ContextSubHost<'a> {
         );
 
         let disable_directives = DisableDirectivesBuilder::new()
-            .with_respect_eslint_disable_directives(respect_eslint_disable_directives)
+            .with_respect_eslint_disable_directives(options.respect_eslint_disable_directives)
             .build(semantic.source_text(), semantic.comments());
 
         Self {
@@ -108,8 +73,8 @@ impl<'a> ContextSubHost<'a> {
             module_record,
             source_text_offset,
             disable_directives,
-            framework_options: frameworks_options,
-            parser_tokens,
+            framework_options: options.framework_options,
+            parser_tokens: options.parser_tokens,
         }
     }
 
@@ -133,6 +98,23 @@ impl<'a> ContextSubHost<'a> {
     /// Shared reference to the [`FrameworkOptions`]
     pub fn framework_options(&self) -> FrameworkOptions {
         self.framework_options
+    }
+}
+
+#[non_exhaustive]
+pub struct ContextSubHostOptions<'a> {
+    pub framework_options: FrameworkOptions,
+    pub parser_tokens: ArenaBox<'a, [Token]>,
+    pub respect_eslint_disable_directives: bool,
+}
+
+impl Default for ContextSubHostOptions<'_> {
+    fn default() -> Self {
+        Self {
+            framework_options: FrameworkOptions::Default,
+            parser_tokens: ArenaBox::new_empty_boxed_slice(),
+            respect_eslint_disable_directives: true,
+        }
     }
 }
 

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 mod host;
-pub use host::{ContextHost, ContextSubHost};
+pub use host::{ContextHost, ContextSubHost, ContextSubHostOptions};
 
 /// Contains all of the state and context specific to this lint rule.
 ///

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -71,7 +71,7 @@ pub use crate::{
         Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ESLintRule, LintIgnoreMatcher,
         LintPlugins, Oxlintrc, ResolvedLinterState,
     },
-    context::{ContextSubHost, LintContext},
+    context::{ContextSubHost, ContextSubHostOptions, LintContext},
     external_linter::{
         ExternalLinter, ExternalLinterCreateWorkspaceCb, ExternalLinterDestroyWorkspaceCb,
         ExternalLinterLintFileCb, ExternalLinterLoadPluginCb, ExternalLinterSetupRuleConfigsCb,

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -29,7 +29,7 @@ use oxc_str::CompactStr;
 
 use crate::{
     Fixer, Linter, Message, PossibleFixes,
-    context::ContextSubHost,
+    context::{ContextSubHost, ContextSubHostOptions},
     disable_directives::DisableDirectives,
     loader::{JavaScriptSource, LINT_PARTIAL_LOADER_EXTENSIONS, PartialLoader},
     module_record::ModuleRecord,
@@ -619,18 +619,17 @@ impl Runtime {
                             .into_iter()
                             .zip(dep.section_contents.drain(..))
                             .filter_map(|(record_result, section)| match record_result {
-                                Ok(module_record) => {
-                                    Some(
-                                        ContextSubHost::new_with_framework_options_and_directive_support(
-                                            section.semantic.unwrap(),
-                                            Arc::clone(&module_record),
-                                            section.source.start,
-                                            section.source.framework_options,
-                                            section.parser_tokens,
-                                            respect_eslint_disable_directives,
-                                        ),
-                                    )
-                                }
+                                Ok(module_record) => Some(ContextSubHost::new(
+                                    section.semantic.unwrap(),
+                                    Arc::clone(&module_record),
+                                    section.source.start,
+                                    ContextSubHostOptions {
+                                        framework_options: section.source.framework_options,
+                                        parser_tokens: section.parser_tokens,
+                                        respect_eslint_disable_directives,
+                                        ..Default::default()
+                                    },
+                                )),
                                 Err(messages) => {
                                     if !messages.is_empty() {
                                         let diagnostics = DiagnosticService::wrap_diagnostics(
@@ -744,18 +743,17 @@ impl Runtime {
                             .into_iter()
                             .zip(section_contents.drain(..))
                             .filter_map(|(record_result, section)| match record_result {
-                                Ok(module_record) => {
-                                    Some(
-                                        ContextSubHost::new_with_framework_options_and_directive_support(
-                                            section.semantic.unwrap(),
-                                            Arc::clone(&module_record),
-                                            section.source.start,
-                                            section.source.framework_options,
-                                            section.parser_tokens,
-                                            respect_eslint_disable_directives,
-                                        ),
-                                    )
-                                }
+                                Ok(module_record) => Some(ContextSubHost::new(
+                                    section.semantic.unwrap(),
+                                    Arc::clone(&module_record),
+                                    section.source.start,
+                                    ContextSubHostOptions {
+                                        framework_options: section.source.framework_options,
+                                        parser_tokens: section.parser_tokens,
+                                        respect_eslint_disable_directives,
+                                        ..Default::default()
+                                    },
+                                )),
                                 Err(diagnostics) => {
                                     if !diagnostics.is_empty() {
                                         messages.lock().unwrap().extend(
@@ -865,11 +863,18 @@ impl Runtime {
 
         let messages = Mutex::new(Vec::<Message>::new());
         rayon::scope(|scope| {
-            self.resolve_modules(file_system, &paths_set, scope, check_syntax_errors, Some(tx_error), |me, mut module| {
-                module.content.with_dependent_mut(
-                    |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
+            self.resolve_modules(
+                file_system,
+                &paths_set,
+                scope,
+                check_syntax_errors,
+                Some(tx_error),
+                |me, mut module| {
+                    module.content.with_dependent_mut(|allocator_guard, ModuleContentDependent {
+                        source_text: _,
+                        section_contents,
+                    }| {
                         assert_eq!(module.section_module_records.len(), section_contents.len());
-
 
                         let respect_eslint_disable_directives =
                             me.linter.respect_eslint_disable_directives();
@@ -878,25 +883,24 @@ impl Runtime {
                             .into_iter()
                             .zip(section_contents.drain(..))
                             .filter_map(|(record_result, section)| match record_result {
-                                Ok(module_record) => Some(
-                                    ContextSubHost::new_with_framework_options_and_directive_support(
-                                        section.semantic.unwrap(),
-                                        Arc::clone(&module_record),
-                                        section.source.start,
-                                        section.source.framework_options,
-                                        section.parser_tokens,
+                                Ok(module_record) => Some(ContextSubHost::new(
+                                    section.semantic.unwrap(),
+                                    Arc::clone(&module_record),
+                                    section.source.start,
+                                    ContextSubHostOptions {
+                                        framework_options: section.source.framework_options,
+                                        parser_tokens: section.parser_tokens,
                                         respect_eslint_disable_directives,
-                                    ),
-                                ),
+                                        ..Default::default()
+                                    },
+                                )),
                                 Err(errors) => {
                                     if !errors.is_empty() {
-                                        messages
-                                            .lock()
-                                            .unwrap()
-                                            .extend(errors
-                                        .into_iter()
-                                        .map(|err| Message::new(err, PossibleFixes::None))
-                                    );
+                                        messages.lock().unwrap().extend(
+                                            errors.into_iter().map(|err| {
+                                                Message::new(err, PossibleFixes::None)
+                                            }),
+                                        );
                                     }
                                     None
                                 }
@@ -908,16 +912,11 @@ impl Runtime {
                         }
 
                         messages.lock().unwrap().extend(
-                            me.linter.run(
-                                Path::new(&module.path),
-                                context_sub_hosts,
-                                allocator_guard
-                            )
-                            ,
+                            me.linter.run(Path::new(&module.path), context_sub_hosts, allocator_guard),
                         );
-                    },
-                );
-            });
+                    });
+                },
+            );
         });
         messages.into_inner().unwrap()
     }

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -354,7 +354,11 @@ mod test {
     use oxc_semantic::SemanticBuilder;
     use oxc_span::SourceType;
 
-    use crate::{ContextHost, ModuleRecord, context::ContextSubHost, options::LintOptions};
+    use crate::{
+        ContextHost, ModuleRecord,
+        context::{ContextSubHost, ContextSubHostOptions},
+        options::LintOptions,
+    };
 
     #[test]
     fn test_is_jest_file() {
@@ -367,7 +371,12 @@ mod test {
             let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
             Rc::new(ContextHost::new(
                 path,
-                vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 0)],
+                vec![ContextSubHost::new(
+                    semantic,
+                    Arc::new(ModuleRecord::default()),
+                    0,
+                    ContextSubHostOptions::default(),
+                )],
                 LintOptions::default(),
                 Arc::default(),
             ))

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -36,8 +36,8 @@ use oxc_formatter::{
     get_parse_options,
 };
 use oxc_linter::{
-    ConfigStore, ConfigStoreBuilder, ContextSubHost, ExternalPluginStore, LintOptions, Linter,
-    ModuleRecord, Oxlintrc,
+    ConfigStore, ConfigStoreBuilder, ContextSubHost, ContextSubHostOptions, ExternalPluginStore,
+    LintOptions, Linter, ModuleRecord, Oxlintrc,
 };
 use oxc_napi::{Comment, OxcError, convert_utf8_to_utf16};
 use oxc_transformer_plugins::{
@@ -417,7 +417,12 @@ impl Oxc {
             )
             .run(
                 path,
-                vec![ContextSubHost::new(semantic, Arc::clone(module_record), 0)],
+                vec![ContextSubHost::new(
+                    semantic,
+                    Arc::clone(module_record),
+                    0,
+                    ContextSubHostOptions::default(),
+                )],
                 allocator,
             );
             self.diagnostics.extend(linter_ret.into_iter().map(|e| e.error));

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -5,8 +5,8 @@ use rustc_hash::FxHashMap;
 use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_linter::{
-    ConfigStore, ConfigStoreBuilder, ContextSubHost, ExternalPluginStore, FixKind, LintOptions,
-    Linter, ModuleRecord,
+    ConfigStore, ConfigStoreBuilder, ContextSubHost, ContextSubHostOptions, ExternalPluginStore,
+    FixKind, LintOptions, Linter, ModuleRecord,
 };
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
@@ -48,7 +48,12 @@ fn bench_linter(criterion: &mut Criterion) {
                 runner.run(|| {
                     linter.run(
                         path,
-                        vec![ContextSubHost::new(semantic, Arc::clone(&module_record), 0)],
+                        vec![ContextSubHost::new(
+                            semantic,
+                            Arc::clone(&module_record),
+                            0,
+                            ContextSubHostOptions::default(),
+                        )],
                         &allocator,
                     )
                 });


### PR DESCRIPTION
Simplifies ContextSubHost construction by replacing constructor variants with a single options struct.