### PR TITLE
feat(linter): add help text to `agent` formatter

### DIFF
--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -49,12 +49,14 @@ fn format_agent(diagnostic: &Error) -> String {
     };
     let rule = rule_id.map_or_else(String::new, |rule_id| format!(" {rule_id}"));
     let message = compact_message(&diagnostic.to_string());
+    let help = diagnostic
+        .help()
+        .map(|help| format!(" help: {}", compact_message(&help.to_string())))
+        .unwrap_or_default();
+    let location =
+        if start.line == 0 { String::new() } else { format!(":{}:{}", start.line, start.column) };
 
-    if start.line == 0 {
-        format!("{filename}: {severity}{rule}: {message}\n")
-    } else {
-        format!("{filename}:{}:{}: {severity}{rule}: {message}\n", start.line, start.column)
-    }
+    format!("{filename}{location}: {severity}{rule}: {message}{help}\n")
 }
 
 fn compact_message(message: &str) -> String {
@@ -80,6 +82,7 @@ mod test {
         let mut reporter = AgentReporter;
         let error = OxcDiagnostic::warn("error message")
             .with_error_code("eslint", "no-debugger")
+            .with_help("help message")
             .with_label(Span::new(0, 8))
             .with_source_code(NamedSource::new("file://test.ts", "debugger;"));
 
@@ -87,7 +90,7 @@ mod test {
 
         assert_eq!(
             result.unwrap(),
-            "file://test.ts:1:1: warning eslint(no-debugger): error message\n"
+            "file://test.ts:1:1: warning eslint(no-debugger): error message help: help message\n"
         );
     }
 

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent test.js@oxlint.snap
@@ -5,9 +5,9 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=agent test.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-test.js:5:1: error eslint(no-debugger): `debugger` statement is not allowed
-test.js:1:10: warning eslint(no-unused-vars): Function 'foo' is declared but never used.
-test.js:1:17: warning eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
+test.js:5:1: error eslint(no-debugger): `debugger` statement is not allowed help: Remove the debugger statement
+test.js:1:10: warning eslint(no-unused-vars): Function 'foo' is declared but never used. help: Consider removing this declaration.
+test.js:1:17: warning eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'. help: Consider removing this parameter.
 ----------
 CLI result: LintFoundErrors
 ----------


### PR DESCRIPTION
It's more tokens to add the help text, but I think it is worth the additional context in most cases.