### PR TITLE
perf(formatter): sort imports during IR construction

### DIFF
--- a/crates/oxc_formatter/src/formatter/buffer.rs
+++ b/crates/oxc_formatter/src/formatter/buffer.rs
@@ -71,6 +71,15 @@ pub trait Buffer<'ast> {
 
     /// Returns the mutable formatting state relevant for this formatting session.
     fn state_mut(&mut self) -> &mut FormatState<'ast>;
+
+    /// Replaces the elements starting at `start` with `replacement`.
+    ///
+    /// Used by streaming IR transforms (currently `SortImportsTransform`) to splice a reordered
+    /// chunk back into the buffer. Only `VecBuffer` supports this; the wrapper buffers
+    /// (`PreambleBuffer`, `Inspect`, `RemoveSoftLinesBuffer`) are only ever active inside
+    /// inner-expression contexts, never on the call stack while a streaming chunk is being
+    /// flushed, so they implement this as `unreachable!()`.
+    fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]);
 }
 
 /// Implements the `[Buffer]` trait for all mutable references of objects implementing [Buffer].
@@ -93,6 +102,10 @@ impl<'ast, W: Buffer<'ast> + ?Sized> Buffer<'ast> for &mut W {
 
     fn state_mut(&mut self) -> &mut FormatState<'ast> {
         (**self).state_mut()
+    }
+
+    fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
+        (**self).replace_end(start, replacement);
     }
 }
 
@@ -163,6 +176,10 @@ impl<'ast> Buffer<'ast> for VecBuffer<'_, 'ast> {
 
     fn state_mut(&mut self) -> &mut FormatState<'ast> {
         self.state
+    }
+
+    fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
+        self.elements.splice(start.., replacement.iter().cloned());
     }
 }
 
@@ -275,6 +292,10 @@ where
     fn state_mut(&mut self) -> &mut FormatState<'ast> {
         self.inner.state_mut()
     }
+
+    fn replace_end(&mut self, _start: usize, _replacement: &[FormatElement<'ast>]) {
+        unreachable!()
+    }
 }
 
 /// Buffer that allows you inspecting elements as they get written to the formatter.
@@ -308,6 +329,10 @@ where
 
     fn state_mut(&mut self) -> &mut FormatState<'a> {
         self.inner.state_mut()
+    }
+
+    fn replace_end(&mut self, _start: usize, _replacement: &[FormatElement<'a>]) {
+        unreachable!()
     }
 }
 
@@ -534,6 +559,10 @@ impl<'ast> Buffer<'ast> for RemoveSoftLinesBuffer<'_, 'ast> {
 
     fn state_mut(&mut self) -> &mut FormatState<'ast> {
         self.inner.state_mut()
+    }
+
+    fn replace_end(&mut self, _start: usize, _replacement: &[FormatElement<'ast>]) {
+        unreachable!()
     }
 }
 

--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -2217,16 +2217,20 @@ where
         Self { separator, fmt, has_elements: false }
     }
 
+    /// Returns a reference to the formatter.
+    pub fn fmt(&self) -> &Formatter<'buf, 'ast> {
+        self.fmt
+    }
+
+    /// Returns a mutable reference to the formatter.
+    pub fn fmt_mut(&mut self) -> &mut Formatter<'buf, 'ast> {
+        self.fmt
+    }
+
     /// Adds a new node with the specified formatted content to the output, respecting any new lines
     /// that appear before the node in the input source.
     pub fn entry(&mut self, span: Span, content: &dyn Format<'ast>) {
-        if self.has_elements {
-            if self.has_lines_before(span) {
-                write!(self.fmt, empty_line());
-            } else {
-                self.separator.fmt(self.fmt);
-            }
-        }
+        self.separator_no_entry(span);
         self.has_elements = true;
         write!(self.fmt, content);
     }
@@ -2235,6 +2239,17 @@ where
     pub fn entry_no_separator(&mut self, content: &dyn Format<'ast>) {
         self.has_elements = true;
         write!(self.fmt, content);
+    }
+
+    /// Writes a separator for before `span`, without adding an entry.
+    pub fn separator_no_entry(&mut self, span: Span) {
+        if self.has_elements {
+            if self.has_lines_before(span) {
+                write!(self.fmt, empty_line());
+            } else {
+                self.separator.fmt(self.fmt);
+            }
+        }
     }
 
     /// Adds an iterator of entries to the output. Each entry is a `(node, content)` tuple.

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -295,4 +295,8 @@ impl<'ast> Buffer<'ast> for Formatter<'_, 'ast> {
     fn state_mut(&mut self) -> &mut FormatState<'ast> {
         self.buffer.state_mut()
     }
+
+    fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
+        self.buffer.replace_end(start, replacement);
+    }
 }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -9,42 +9,85 @@ mod source_line;
 use oxc_allocator::{Allocator, Vec as ArenaVec};
 
 use crate::{
-    JsLabels, SortImportsOptions,
-    formatter::format_element::{
-        FormatElement, LineMode,
-        document::Document,
-        tag::{LabelId, Tag},
+    Buffer, JsLabels, SortImportsOptions,
+    formatter::{
+        Formatter,
+        format_element::{
+            FormatElement, LineMode,
+            tag::{LabelId, Tag},
+        },
     },
     ir_transform::sort_imports::{
         group_matcher::GroupMatcher, partitioned_chunk::PartitionedChunk, source_line::SourceLine,
     },
 };
 
+/// Sort a chunk of `ImportDeclaration`s and replace the original `FormatElement`s with the sorted ones
+/// in the formatter buffer.
+///
+/// `chunk_start` is the buffer position of the start of the chunk.
+/// i.e. the buffer position recorded just before the first `entry` call for first `ImportDeclaration` in the chunk.
+///
+/// The chunk buffer must contain nothing but the `FormatElement`s generated from `ImportDeclaration`s,
+/// and their preceding/trailing comments, and line breaks.
+///
+/// `SortImportsTransform::transform` expects its input to end with `Line(Hard)` so its line-walker flushes the last import.
+/// We synthesize that terminator here, hand the chunk slice to `transform`, then trim the terminator off the replacement
+/// before splicing. The next `entry` call (or the closing newline emitted by `Program::write`) will write the real
+/// inter-statement separator.
+///
+/// The caller must already have verified that `sort_imports` option is enabled.
+///
+/// # Panics
+/// Panics if `sort_imports` option is not enabled.
+pub fn sort_imports_chunk(formatter: &mut Formatter<'_, '_>, chunk_start: usize) {
+    formatter.write_element(FormatElement::Line(LineMode::Hard));
+
+    let elements = &formatter.elements()[chunk_start..];
+    let options = formatter.options().sort_imports.as_ref().unwrap();
+
+    let sorted_elements = SortImportsTransform::transform(elements, options, formatter.allocator());
+
+    if let Some(sorted_elements) = sorted_elements {
+        debug_assert!(matches!(sorted_elements.last(), Some(FormatElement::Line(LineMode::Hard))));
+        let sorted_elements = &sorted_elements[..sorted_elements.len() - 1];
+        formatter.replace_end(chunk_start, sorted_elements);
+    } else {
+        // `transform` returns `None` only for the legacy whole-document empty-file case,
+        // which can't fire for a streaming chunk (chunks always contain at least one import's content).
+        // Defensive: undo the synthesized terminator so the buffer matches its pre-flush state.
+        debug_assert!(false, "unreachable");
+        formatter.replace_end(formatter.elements().len() - 1, &[]);
+    }
+}
+
 /// An IR transform that sorts import statements according to specified options.
 /// Heavily inspired by ESLint's `@perfectionist/sort-imports` rule.
 /// <https://perfectionist.dev/rules/sort-imports>
-pub struct SortImportsTransform;
+struct SortImportsTransform;
 
 impl SortImportsTransform {
-    /// Transform the given `Document` by sorting import statements according to the specified options.
+    /// Transform the given slice of `FormatElement`s by sorting import statements according
+    /// to the specified options. The slice is one chunk of consecutive `ImportDeclaration`s
+    /// as written to the formatter buffer (delimited by the streaming driver in `FormatProgramBody`).
     ///
-    // NOTE: `Document` and its `FormatElement`s are already well-formatted.
+    // NOTE: The input `FormatElement`s are already well-formatted.
     // It means that:
     // - There is no redundant spaces, no consecutive line breaks, etc...
     // - Last element is always `FormatElement::Line(Hard)`.
-    pub fn transform<'a>(
-        document: &Document<'a>,
+    fn transform<'a>(
+        elements: &[FormatElement<'a>],
         options: &SortImportsOptions,
         allocator: &'a Allocator,
     ) -> Option<ArenaVec<'a, FormatElement<'a>>> {
         // Early return for empty files
-        if document.len() == 1 && matches!(document[0], FormatElement::Line(LineMode::Hard)) {
+        if elements.len() == 1 && matches!(elements[0], FormatElement::Line(LineMode::Hard)) {
             return None;
         }
 
         // Parse string based groups into our internal representation for performance
         let group_matcher = GroupMatcher::new(&options.groups, &options.custom_groups);
-        let prev_elements: &[FormatElement<'a>] = document;
+        let prev_elements: &[FormatElement<'a>] = elements;
 
         // Roughly speaking, sort-imports is a process of swapping lines.
         // Therefore, as a preprocessing, group IR elements into line first.

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -34,11 +34,10 @@ pub use crate::ir_transform::options::*;
 pub use crate::options::*;
 pub use crate::print::{FormatVueBindingParams, FormatVueScriptGeneric};
 pub use crate::service::*;
-use crate::{formatter::FormatContext, ir_transform::SortImportsTransform};
 #[cfg(feature = "detect_code_removal")]
 pub use detect_code_removal::detect_code_removal;
 
-use self::formatter::prelude::tag::Label;
+use self::formatter::{FormatContext, prelude::tag::Label};
 
 pub struct Formatter<'a> {
     allocator: &'a Allocator,
@@ -78,24 +77,10 @@ impl<'a> Formatter<'a> {
             external_callbacks,
         );
 
-        let mut formatted = formatter::format(
+        formatter::format(
             context,
             formatter::Arguments::new(&[formatter::Argument::new(&program_node)]),
-        );
-
-        // Basic formatting and `document.propagate_expand()` are already done here.
-        // Now apply additional transforms if enabled.
-        if let Some(sort_imports_options) = &formatted.context().options().sort_imports
-            && let Some(transformed_elements) = SortImportsTransform::transform(
-                formatted.document(),
-                sort_imports_options,
-                self.allocator,
-            )
-        {
-            formatted.document_mut().replace_elements(transformed_elements);
-        }
-
-        formatted
+        )
     }
 
     /// Formats an arbitrary value that implements `Format` and returns the `Formatted` IR.

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -86,6 +86,7 @@ use self::{
     class::format_grouped_parameters_with_return_type_for_method,
     object_like::ObjectLike,
     object_pattern_like::ObjectPatternLike,
+    program::FormatStatementsWithImports,
     return_or_throw_statement::FormatAdjacentArgument,
     semicolon::OptionalSemicolon,
     type_parameters::{FormatTSTypeParameters, FormatTSTypeParametersOptions},
@@ -1710,7 +1711,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSModuleBlock<'a>> {
         if is_empty_block(&self.body) && directives.is_empty() {
             write!(f, [format_dangling_comments(span).with_block_indent()]);
         } else {
-            write!(f, [block_indent(&format_args!(directives, body))]);
+            // Use `FormatStatementsWithImports` formatter (instead of generic `AstNode<Vec<Statement>>` impl)
+            // so imports inside ambient modules (`declare module "foo" { ... }`) are sorted when sorting is enabled
+            write!(f, [block_indent(&format_args!(directives, FormatStatementsWithImports(body)))]);
         }
         write!(f, "}");
     }

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -9,6 +9,7 @@ use crate::{
     Buffer, Format,
     ast_nodes::AstNode,
     formatter::{prelude::*, trivia::FormatTrailingComments},
+    ir_transform::sort_imports_chunk,
     print::semicolon::OptionalSemicolon,
     utils::string::{FormatLiteralStringToken, StringLiteralParentKind},
     write,
@@ -36,7 +37,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
                     .then_some(text("\u{feff}")),
                 self.hashbang(),
                 self.directives(),
-                FormatProgramBody(self.body()),
+                FormatStatementsWithImports(self.body()),
                 format_trailing_comments,
                 hard_line_break()
             ]
@@ -44,17 +45,20 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
     }
 }
 
-struct FormatProgramBody<'a, 'b>(&'b AstNode<'a, Vec<'a, Statement<'a>>>);
+pub(super) struct FormatStatementsWithImports<'a, 'b>(pub &'b AstNode<'a, Vec<'a, Statement<'a>>>);
 
-impl<'a> Deref for FormatProgramBody<'a, '_> {
+impl<'a> Deref for FormatStatementsWithImports<'a, '_> {
     type Target = AstNode<'a, Vec<'a, Statement<'a>>>;
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 
-impl<'a> Format<'a> for FormatProgramBody<'a, '_> {
+impl<'a> Format<'a> for FormatStatementsWithImports<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let import_sort_enabled = f.options().sort_imports.is_some();
+        let mut imports_chunk_start: Option<usize> = None;
+
         let mut join = f.join_nodes_with_hardline();
         for stmt in
             self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_)))
@@ -88,7 +92,29 @@ impl<'a> Format<'a> for FormatProgramBody<'a, '_> {
                 _ => stmt.span(),
             };
 
+            if import_sort_enabled {
+                if matches!(stmt.as_ref(), Statement::ImportDeclaration(_)) {
+                    if imports_chunk_start.is_none() {
+                        // First import in a chunk. Output inter-statement separator separately
+                        // so `imports_chunk_start` points to start of IR for the `ImportDeclaration` itself.
+                        join.separator_no_entry(span);
+                        imports_chunk_start = Some(join.fmt().elements().len());
+                        join.entry_no_separator(stmt);
+                        continue;
+                    }
+                } else if let Some(chunk_start) = imports_chunk_start.take() {
+                    // Any other statement after an `ImportDeclaration`, or a run of them.
+                    // Sort the chunk of imports.
+                    sort_imports_chunk(join.fmt_mut(), chunk_start);
+                }
+            }
+
             join.entry(span, stmt);
+        }
+
+        // If last statement was an `ImportDeclaration`, sort the chunk of imports
+        if let Some(chunk_start) = imports_chunk_start.take() {
+            sort_imports_chunk(join.fmt_mut(), chunk_start);
         }
     }
 }


### PR DESCRIPTION
Import sorting operates on IR, rather than AST. Previous attempts to make it pre-sort the AST were abandoned primarily due to difficulties with re-ordering the comments attached to the `ImportDeclaration`s, because AST to IR conversion relies on comments being output in source order.

This PR is a "middle way" approach. Import sorting still operates on IR, but happens during AST to IR conversion, rather than in a separate pass after IR for the whole file has been generated.

The main advantages of this approach:

- The sorting transform only has to deal with small sections of IR which contain only import statements (and comments and line breaks surrounding them), rather than searching through the IR for the entire file.
- Now when transform runs on a chunk of IR, it's at the end of the buffer, so replacing the unsorted `FormatElement`s with the newly sorted ones is only a matter of popping the old ones off end of the buffer, and pushing the new ones on. This is much faster than copying the entire IR into a new buffer, which is what we had to do previously in order to shuffle up/down all the following `FormatElements`.

The main disadvantage is that we lose the simplicity and "stand alone" nature of the separate sorting pass. But IMO the perf improvement is probably a good trade off.

In this PR, I've prioritized altering the core sorting logic as little as possible, so that it's easier to review and verify that this change does not alter behavior. The structure of the code is therefore a bit odd (e.g. `SortImportsTransform` struct would better be replaced by just a free function now), and there's other refactoring and further perf improvements that we can make, but I've left them to follow-ups.