### PR TITLE
feat(linter): Auto detect agents from CLI and transition to the agent output format

### DIFF
--- a/apps/oxlint/src/agent_detection.rs
+++ b/apps/oxlint/src/agent_detection.rs
@@ -1,0 +1,168 @@
+use std::ffi::OsString;
+
+use cow_utils::CowUtils;
+
+/// Information about the AI coding agent detected from the environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentInfo {
+    /// The detected AI coding agent name.
+    pub name: Option<String>,
+}
+
+impl AgentInfo {
+    fn none() -> Self {
+        Self { name: None }
+    }
+
+    fn new(name: impl Into<String>) -> Self {
+        Self { name: Some(name.into()) }
+    }
+
+    /// Return `true` when an AI coding agent was detected.
+    pub fn is_agent(&self) -> bool {
+        self.name.is_some()
+    }
+}
+
+/// Detect the current AI coding agent from environment variables.
+///
+/// This mirrors the environment-based detection used by `std-env` while keeping
+/// the logic reusable for Rust CLI entry points.
+pub fn detect_agent() -> AgentInfo {
+    detect_agent_from_env(|key| std::env::var_os(key))
+}
+
+/// Return `true` when the current process appears to be running inside an AI
+/// coding agent.
+pub fn is_agent() -> bool {
+    detect_agent().is_agent()
+}
+
+fn detect_agent_from_env(mut env: impl FnMut(&str) -> Option<OsString>) -> AgentInfo {
+    if let Some(ai_agent) = env_string(&mut env, "AI_AGENT")
+        && !ai_agent.is_empty()
+    {
+        return AgentInfo::new(ai_agent.cow_to_ascii_lowercase().into_owned());
+    }
+
+    if has_any_env(&mut env, &["CLAUDECODE", "CLAUDE_CODE"]) {
+        AgentInfo::new("claude")
+    } else if has_any_env(&mut env, &["REPL_ID"]) {
+        AgentInfo::new("replit")
+    } else if has_any_env(&mut env, &["GEMINI_CLI"]) {
+        AgentInfo::new("gemini")
+    } else if has_any_env(&mut env, &["CODEX_SANDBOX", "CODEX_THREAD_ID"]) {
+        AgentInfo::new("codex")
+    } else if has_any_env(&mut env, &["OPENCODE"]) {
+        AgentInfo::new("opencode")
+    } else if env_contains_path_segment(&mut env, "PATH", ".pi/agent") {
+        AgentInfo::new("pi")
+    } else if has_any_env(&mut env, &["AUGMENT_AGENT"]) {
+        AgentInfo::new("auggie")
+    } else if has_any_env(&mut env, &["GOOSE_PROVIDER"]) {
+        AgentInfo::new("goose")
+    } else if env_contains(&mut env, "EDITOR", "devin") {
+        AgentInfo::new("devin")
+    } else if has_any_env(&mut env, &["CURSOR_AGENT"]) {
+        AgentInfo::new("cursor")
+    } else if env_contains(&mut env, "TERM_PROGRAM", "kiro") {
+        AgentInfo::new("kiro")
+    } else {
+        AgentInfo::none()
+    }
+}
+
+fn has_any_env(env: &mut impl FnMut(&str) -> Option<OsString>, keys: &[&str]) -> bool {
+    keys.iter().any(|key| env(key).is_some_and(|value| !value.is_empty()))
+}
+
+fn env_string(env: &mut impl FnMut(&str) -> Option<OsString>, key: &str) -> Option<String> {
+    env(key).filter(|value| !value.is_empty()).map(|value| value.to_string_lossy().into_owned())
+}
+
+fn env_contains(env: &mut impl FnMut(&str) -> Option<OsString>, key: &str, needle: &str) -> bool {
+    env_string(env, key).is_some_and(|value| value.contains(needle))
+}
+
+fn env_contains_path_segment(
+    env: &mut impl FnMut(&str) -> Option<OsString>,
+    key: &str,
+    needle: &str,
+) -> bool {
+    env_string(env, key).is_some_and(|value| {
+        let windows_needle = needle.cow_replace('/', "\\");
+        value.contains(needle) || value.contains(windows_needle.as_ref())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use rustc_hash::FxHashMap;
+
+    use super::{AgentInfo, detect_agent_from_env};
+
+    fn detect(vars: &[(&str, &str)]) -> AgentInfo {
+        let env = vars
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), OsString::from(value)))
+            .collect::<FxHashMap<_, _>>();
+
+        detect_agent_from_env(|key| env.get(key).cloned())
+    }
+
+    #[test]
+    fn detects_explicit_ai_agent() {
+        assert_eq!(detect(&[("AI_AGENT", "CustomAgent")]).name.as_deref(), Some("customagent"));
+    }
+
+    #[test]
+    fn explicit_ai_agent_takes_precedence() {
+        assert_eq!(
+            detect(&[("AI_AGENT", "custom"), ("CLAUDECODE", "1")]).name.as_deref(),
+            Some("custom")
+        );
+    }
+
+    #[test]
+    fn ignores_empty_env_values() {
+        assert_eq!(detect(&[("AI_AGENT", ""), ("CLAUDECODE", "")]).name, None);
+    }
+
+    #[test]
+    fn detects_agent_env_vars() {
+        let cases = [
+            ("claude", "CLAUDECODE"),
+            ("claude", "CLAUDE_CODE"),
+            ("replit", "REPL_ID"),
+            ("gemini", "GEMINI_CLI"),
+            ("codex", "CODEX_SANDBOX"),
+            ("codex", "CODEX_THREAD_ID"),
+            ("opencode", "OPENCODE"),
+            ("auggie", "AUGMENT_AGENT"),
+            ("goose", "GOOSE_PROVIDER"),
+            ("cursor", "CURSOR_AGENT"),
+        ];
+
+        for (agent, env_key) in cases {
+            assert_eq!(detect(&[(env_key, "1")]).name.as_deref(), Some(agent));
+        }
+    }
+
+    #[test]
+    fn detects_agent_env_matchers() {
+        assert_eq!(
+            detect(&[("PATH", "/usr/bin:/home/me/.pi/agent/bin")]).name.as_deref(),
+            Some("pi")
+        );
+        assert_eq!(detect(&[("PATH", r"C:\Users\me\.pi\agent\bin")]).name.as_deref(), Some("pi"));
+        assert_eq!(detect(&[("EDITOR", "devin")]).name.as_deref(), Some("devin"));
+        assert_eq!(detect(&[("TERM_PROGRAM", "kiro")]).name.as_deref(), Some("kiro"));
+    }
+
+    #[test]
+    fn returns_none_without_agent_env() {
+        assert_eq!(detect(&[]).name, None);
+    }
+}

--- a/apps/oxlint/src/agent_detection.rs
+++ b/apps/oxlint/src/agent_detection.rs
@@ -4,88 +4,78 @@ use cow_utils::CowUtils;
 
 /// Information about the AI coding agent detected from the environment.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentInfo {
-    /// The detected AI coding agent name.
-    pub name: Option<String>,
-}
-
-impl AgentInfo {
-    fn none() -> Self {
-        Self { name: None }
-    }
-
-    fn new(name: impl Into<String>) -> Self {
-        Self { name: Some(name.into()) }
-    }
-
-    /// Return `true` when an AI coding agent was detected.
-    pub fn is_agent(&self) -> bool {
-        self.name.is_some()
-    }
+pub enum AgentInfo {
+    Claude,
+    Replit,
+    Gemini,
+    Codex,
+    Copilot,
+    OpenCode,
+    Pi,
+    Devin,
+    Cursor,
+    Kiro,
+    Other(String),
 }
 
 /// Detect the current AI coding agent from environment variables.
 ///
 /// This mirrors the environment-based detection used by `std-env` while keeping
 /// the logic reusable for Rust CLI entry points.
-pub fn detect_agent() -> AgentInfo {
+pub fn detect_agent() -> Option<AgentInfo> {
     detect_agent_from_env(|key| std::env::var_os(key))
 }
 
 /// Return `true` when the current process appears to be running inside an AI
 /// coding agent.
 pub fn is_agent() -> bool {
-    detect_agent().is_agent()
+    detect_agent().is_some()
 }
 
-fn detect_agent_from_env(mut env: impl FnMut(&str) -> Option<OsString>) -> AgentInfo {
-    if let Some(ai_agent) = env_string(&mut env, "AI_AGENT")
-        && !ai_agent.is_empty()
-    {
-        return AgentInfo::new(ai_agent.cow_to_ascii_lowercase().into_owned());
+fn detect_agent_from_env(env: impl Fn(&str) -> Option<OsString>) -> Option<AgentInfo> {
+    if let Some(ai_agent) = env_string(&env, "AI_AGENT") {
+        return Some(AgentInfo::Other(ai_agent.cow_to_ascii_lowercase().into_owned()));
     }
 
-    if has_any_env(&mut env, &["CLAUDECODE", "CLAUDE_CODE"]) {
-        AgentInfo::new("claude")
-    } else if has_any_env(&mut env, &["REPL_ID"]) {
-        AgentInfo::new("replit")
-    } else if has_any_env(&mut env, &["GEMINI_CLI"]) {
-        AgentInfo::new("gemini")
-    } else if has_any_env(&mut env, &["CODEX_SANDBOX", "CODEX_THREAD_ID"]) {
-        AgentInfo::new("codex")
-    } else if has_any_env(&mut env, &["OPENCODE"]) {
-        AgentInfo::new("opencode")
-    } else if env_contains_path_segment(&mut env, "PATH", ".pi/agent") {
-        AgentInfo::new("pi")
-    } else if has_any_env(&mut env, &["AUGMENT_AGENT"]) {
-        AgentInfo::new("auggie")
-    } else if has_any_env(&mut env, &["GOOSE_PROVIDER"]) {
-        AgentInfo::new("goose")
-    } else if env_contains(&mut env, "EDITOR", "devin") {
-        AgentInfo::new("devin")
-    } else if has_any_env(&mut env, &["CURSOR_AGENT"]) {
-        AgentInfo::new("cursor")
-    } else if env_contains(&mut env, "TERM_PROGRAM", "kiro") {
-        AgentInfo::new("kiro")
+    if has_any_env(&env, &["CLAUDECODE", "CLAUDE_CODE"]) {
+        Some(AgentInfo::Claude)
+    } else if has_any_env(&env, &["REPL_ID"]) {
+        Some(AgentInfo::Replit)
+    } else if has_any_env(&env, &["GEMINI_CLI"]) {
+        Some(AgentInfo::Gemini)
+    } else if has_any_env(&env, &["CODEX_SANDBOX", "CODEX_THREAD_ID"]) {
+        Some(AgentInfo::Codex)
+    } else if has_any_env(&env, &["COPILOT_CLI"]) {
+        Some(AgentInfo::Copilot)
+    } else if has_any_env(&env, &["OPENCODE"]) {
+        Some(AgentInfo::OpenCode)
+    } else if env_contains_path_segment(&env, "PATH", ".pi/agent") {
+        Some(AgentInfo::Pi)
+    } else if env_contains(&env, "EDITOR", "devin") {
+        Some(AgentInfo::Devin)
+    } else if has_any_env(&env, &["CURSOR_AGENT"]) {
+        Some(AgentInfo::Cursor)
+    } else if env_contains(&env, "TERM_PROGRAM", "kiro") {
+        Some(AgentInfo::Kiro)
     } else {
-        AgentInfo::none()
+        None
     }
 }
 
-fn has_any_env(env: &mut impl FnMut(&str) -> Option<OsString>, keys: &[&str]) -> bool {
+fn has_any_env(env: &impl Fn(&str) -> Option<OsString>, keys: &[&str]) -> bool {
     keys.iter().any(|key| env(key).is_some_and(|value| !value.is_empty()))
 }
 
-fn env_string(env: &mut impl FnMut(&str) -> Option<OsString>, key: &str) -> Option<String> {
+fn env_string(env: &impl Fn(&str) -> Option<OsString>, key: &str) -> Option<String> {
     env(key).filter(|value| !value.is_empty()).map(|value| value.to_string_lossy().into_owned())
 }
 
-fn env_contains(env: &mut impl FnMut(&str) -> Option<OsString>, key: &str, needle: &str) -> bool {
+fn env_contains(env: &impl Fn(&str) -> Option<OsString>, key: &str, needle: &str) -> bool {
     env_string(env, key).is_some_and(|value| value.contains(needle))
 }
 
 fn env_contains_path_segment(
-    env: &mut impl FnMut(&str) -> Option<OsString>,
+    env: &impl Fn(&str) -> Option<OsString>,
     key: &str,
     needle: &str,
 ) -> bool {
@@ -103,7 +93,7 @@ mod tests {
 
     use super::{AgentInfo, detect_agent_from_env};
 
-    fn detect(vars: &[(&str, &str)]) -> AgentInfo {
+    fn detect(vars: &[(&str, &str)]) -> Option<AgentInfo> {
         let env = vars
             .iter()
             .map(|(key, value)| ((*key).to_string(), OsString::from(value)))
@@ -114,55 +104,54 @@ mod tests {
 
     #[test]
     fn detects_explicit_ai_agent() {
-        assert_eq!(detect(&[("AI_AGENT", "CustomAgent")]).name.as_deref(), Some("customagent"));
+        assert_eq!(
+            detect(&[("AI_AGENT", "CustomAgent")]),
+            Some(AgentInfo::Other("customagent".into()))
+        );
     }
 
     #[test]
     fn explicit_ai_agent_takes_precedence() {
         assert_eq!(
-            detect(&[("AI_AGENT", "custom"), ("CLAUDECODE", "1")]).name.as_deref(),
-            Some("custom")
+            detect(&[("AI_AGENT", "custom"), ("CLAUDECODE", "1")]),
+            Some(AgentInfo::Other("custom".into()))
         );
     }
 
     #[test]
     fn ignores_empty_env_values() {
-        assert_eq!(detect(&[("AI_AGENT", ""), ("CLAUDECODE", "")]).name, None);
+        assert_eq!(detect(&[("AI_AGENT", ""), ("CLAUDECODE", "")]), None);
     }
 
     #[test]
     fn detects_agent_env_vars() {
         let cases = [
-            ("claude", "CLAUDECODE"),
-            ("claude", "CLAUDE_CODE"),
-            ("replit", "REPL_ID"),
-            ("gemini", "GEMINI_CLI"),
-            ("codex", "CODEX_SANDBOX"),
-            ("codex", "CODEX_THREAD_ID"),
-            ("opencode", "OPENCODE"),
-            ("auggie", "AUGMENT_AGENT"),
-            ("goose", "GOOSE_PROVIDER"),
-            ("cursor", "CURSOR_AGENT"),
+            (AgentInfo::Claude, "CLAUDECODE"),
+            (AgentInfo::Claude, "CLAUDE_CODE"),
+            (AgentInfo::Replit, "REPL_ID"),
+            (AgentInfo::Gemini, "GEMINI_CLI"),
+            (AgentInfo::Codex, "CODEX_SANDBOX"),
+            (AgentInfo::Codex, "CODEX_THREAD_ID"),
+            (AgentInfo::Copilot, "COPILOT_CLI"),
+            (AgentInfo::OpenCode, "OPENCODE"),
+            (AgentInfo::Cursor, "CURSOR_AGENT"),
         ];
 
         for (agent, env_key) in cases {
-            assert_eq!(detect(&[(env_key, "1")]).name.as_deref(), Some(agent));
+            assert_eq!(detect(&[(env_key, "1")]), Some(agent));
         }
     }
 
     #[test]
     fn detects_agent_env_matchers() {
-        assert_eq!(
-            detect(&[("PATH", "/usr/bin:/home/me/.pi/agent/bin")]).name.as_deref(),
-            Some("pi")
-        );
-        assert_eq!(detect(&[("PATH", r"C:\Users\me\.pi\agent\bin")]).name.as_deref(), Some("pi"));
-        assert_eq!(detect(&[("EDITOR", "devin")]).name.as_deref(), Some("devin"));
-        assert_eq!(detect(&[("TERM_PROGRAM", "kiro")]).name.as_deref(), Some("kiro"));
+        assert_eq!(detect(&[("PATH", "/usr/bin:/home/me/.pi/agent/bin")]), Some(AgentInfo::Pi));
+        assert_eq!(detect(&[("PATH", r"C:\Users\me\.pi\agent\bin")]), Some(AgentInfo::Pi));
+        assert_eq!(detect(&[("EDITOR", "devin")]), Some(AgentInfo::Devin));
+        assert_eq!(detect(&[("TERM_PROGRAM", "kiro")]), Some(AgentInfo::Kiro));
     }
 
     #[test]
     fn returns_none_without_agent_env() {
-        assert_eq!(detect(&[]).name, None);
+        assert_eq!(detect(&[]), None);
     }
 }

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -341,12 +341,26 @@ impl FromStr for DebugOptions {
 
 #[expect(clippy::unnecessary_wraps)]
 fn default_output_format() -> Result<OutputFormat, std::convert::Infallible> {
-    if cfg!(debug_assertions) {
-        Ok(OutputFormat::Default)
-    } else if std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true") {
-        Ok(OutputFormat::Github)
+    let is_agent = !cfg!(test) && crate::agent_detection::is_agent();
+    let is_github_actions =
+        std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true");
+
+    Ok(default_output_format_for(is_agent, cfg!(debug_assertions), is_github_actions))
+}
+
+fn default_output_format_for(
+    is_agent: bool,
+    is_debug: bool,
+    is_github_actions: bool,
+) -> OutputFormat {
+    if is_debug {
+        OutputFormat::Default
+    } else if is_agent {
+        OutputFormat::Agent
+    } else if is_github_actions {
+        OutputFormat::Github
     } else {
-        Ok(OutputFormat::Default)
+        OutputFormat::Default
     }
 }
 
@@ -611,7 +625,10 @@ mod lint_options {
 
     use oxc_linter::AllowWarnDeny;
 
-    use super::{DebugOption, DebugOptions, LintCommand, OutputFormat, lint_command};
+    use super::{
+        DebugOption, DebugOptions, LintCommand, OutputFormat, default_output_format_for,
+        lint_command,
+    };
 
     fn get_lint_options(arg: &str) -> LintCommand {
         let args = arg.split(' ').map(std::string::ToString::to_string).collect::<Vec<_>>();
@@ -708,6 +725,15 @@ mod lint_options {
             result.is_err_and(|err| err.unwrap_stderr()
                 == "couldn't parse `foo`: 'foo' is not a known debug option")
         );
+    }
+
+    #[test]
+    fn default_format_prefers_debug_then_agent_output() {
+        assert_eq!(default_output_format_for(true, true, true), OutputFormat::Default);
+        assert_eq!(default_output_format_for(true, false, false), OutputFormat::Agent);
+        assert_eq!(default_output_format_for(false, true, true), OutputFormat::Default);
+        assert_eq!(default_output_format_for(false, false, true), OutputFormat::Github);
+        assert_eq!(default_output_format_for(false, false, false), OutputFormat::Default);
     }
 
     #[test]

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -341,26 +341,14 @@ impl FromStr for DebugOptions {
 
 #[expect(clippy::unnecessary_wraps)]
 fn default_output_format() -> Result<OutputFormat, std::convert::Infallible> {
-    let is_agent = !cfg!(test) && crate::agent_detection::is_agent();
-    let is_github_actions =
-        std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true");
-
-    Ok(default_output_format_for(is_agent, cfg!(debug_assertions), is_github_actions))
-}
-
-fn default_output_format_for(
-    is_agent: bool,
-    is_debug: bool,
-    is_github_actions: bool,
-) -> OutputFormat {
-    if is_debug {
-        OutputFormat::Default
-    } else if is_agent {
-        OutputFormat::Agent
-    } else if is_github_actions {
-        OutputFormat::Github
+    if cfg!(debug_assertions) {
+        Ok(OutputFormat::Default)
+    } else if !cfg!(test) && crate::agent_detection::is_agent() {
+        Ok(OutputFormat::Agent)
+    } else if std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true") {
+        Ok(OutputFormat::Github)
     } else {
-        OutputFormat::Default
+        Ok(OutputFormat::Default)
     }
 }
 
@@ -625,10 +613,7 @@ mod lint_options {
 
     use oxc_linter::AllowWarnDeny;
 
-    use super::{
-        DebugOption, DebugOptions, LintCommand, OutputFormat, default_output_format_for,
-        lint_command,
-    };
+    use super::{DebugOption, DebugOptions, LintCommand, OutputFormat, lint_command};
 
     fn get_lint_options(arg: &str) -> LintCommand {
         let args = arg.split(' ').map(std::string::ToString::to_string).collect::<Vec<_>>();
@@ -725,15 +710,6 @@ mod lint_options {
             result.is_err_and(|err| err.unwrap_stderr()
                 == "couldn't parse `foo`: 'foo' is not a known debug option")
         );
-    }
-
-    #[test]
-    fn default_format_prefers_debug_then_agent_output() {
-        assert_eq!(default_output_format_for(true, true, true), OutputFormat::Default);
-        assert_eq!(default_output_format_for(true, false, false), OutputFormat::Agent);
-        assert_eq!(default_output_format_for(false, true, true), OutputFormat::Default);
-        assert_eq!(default_output_format_for(false, false, true), OutputFormat::Github);
-        assert_eq!(default_output_format_for(false, false, false), OutputFormat::Default);
     }
 
     #[test]

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -1,6 +1,7 @@
 // Ignore dead code warnings when building `tasks/website`, which disables `napi` Cargo feature
 #![cfg_attr(not(feature = "napi"), allow(dead_code))]
 
+mod agent_detection;
 mod command;
 mod config_loader;
 mod init;


### PR DESCRIPTION
## Summary

We start auto-detecting agents running the linter through environment variables, when we see an agent is running the linter we transition to using the agent output format to save tokens.

The logic is mirrored from https://github.com/unjs/std-env/blob/main/src/agents.ts which is used by vitest and others.

Follow up to https://github.com/oxc-project/oxc/pull/21955