### PR TITLE
fix(linter): treat adjacent fixes as overlapping

### DIFF
--- a/apps/oxlint/test/fixtures/fixes/fix.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fix.snap.md
@@ -51,6 +51,20 @@
   | File path: <fixture>/files/range_start_too_large.js
   | Invalid range: 0..0
 
+  x fixes-plugin(fixes): Replace "a" with "daddy"
+   ,-[files/bom_remove.js:1:4]
+ 1 | ﻿a = c;
+   : ^
+ 2 | d = b
+   `----
+
+  x fixes-plugin(fixes): Replace "a" with "daddy"
+   ,-[files/bom_remove2.js:1:4]
+ 1 | ﻿a = c;
+   : ^
+ 2 | d = b
+   `----
+
   x fixes-plugin(fixes): end negative
    ,-[files/range_end_negative.js:1:5]
  1 | let x;
@@ -123,7 +137,7 @@
    :     ^
    `----
 
-Found 0 warnings and 24 errors.
+Found 0 warnings and 26 errors.
 Finished in Xms on 12 files with 1 rules using X threads.
 ```
 
@@ -146,13 +160,13 @@ rage = abacus
 
 # File altered: files/bom_remove.js
 ```
-daddy = magic;
+a = magic;
 damned = abacus
 ```
 
 # File altered: files/bom_remove2.js
 ```
-daddy = magic;
+a = magic;
 damned = abacus
 ```
 

--- a/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
@@ -51,6 +51,20 @@
   | File path: <fixture>/files/range_start_too_large.js
   | Invalid range: 0..0
 
+  x suggestions-plugin(suggestions): Replace "a" with "daddy"
+   ,-[files/bom_remove.js:1:4]
+ 1 | ﻿a = c;
+   : ^
+ 2 | d = b
+   `----
+
+  x suggestions-plugin(suggestions): Replace "a" with "daddy"
+   ,-[files/bom_remove2.js:1:4]
+ 1 | ﻿a = c;
+   : ^
+ 2 | d = b
+   `----
+
   x suggestions-plugin(suggestions): end negative
    ,-[files/range_end_negative.js:1:5]
  1 | let x;
@@ -123,7 +137,7 @@
    :     ^
    `----
 
-Found 0 warnings and 24 errors.
+Found 0 warnings and 26 errors.
 Finished in Xms on 12 files with 1 rules using X threads.
 ```
 
@@ -146,13 +160,13 @@ rage = abacus
 
 # File altered: files/bom_remove.js
 ```
-daddy = magic;
+a = magic;
 damned = abacus
 ```
 
 # File altered: files/bom_remove2.js
 ```
-daddy = magic;
+a = magic;
 damned = abacus
 ```
 

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -321,7 +321,8 @@ pub struct Fixer<'a> {
 
     /// When `true`, boundary-adjacent fixes (e.g. `[0,5]` and `[5,10]`) are considered
     /// overlapping, matching ESLint's `SourceCodeFixer` behavior.
-    /// When `false` (default), only truly overlapping fixes are skipped.
+    /// When `false`, only truly overlapping fixes are skipped.
+    /// Defaults to `true`.
     eslint_compat: bool,
 
     #[cfg(debug_assertions)]
@@ -340,7 +341,7 @@ impl<'a> Fixer<'a> {
             source_text,
             messages,
             fix_index: 0,
-            eslint_compat: false,
+            eslint_compat: true,
             #[cfg(debug_assertions)]
             source_type,
         }
@@ -401,8 +402,8 @@ impl<'a> Fixer<'a> {
 
             // Skip fixes that overlap with a previously applied fix.
             //
-            // In standard mode, boundary-adjacent fixes (e.g. [0, 5] and [5, 10]) are not considered overlapping.
-            // In ESLint compat mode, they *are* considered overlapping (like ESLint does).
+            // In ESLint-compatible mode, boundary-adjacent fixes (e.g. [0, 5] and [5, 10]) are
+            // considered overlapping. The legacy Oxlint mode only skips truly overlapping fixes.
             //
             // Never consider the first fix overlapping, because there's no previous fix to overlap with.
             // This extra check is required because `last_pos` is 0 initially, so a fix starting at offset 0
@@ -729,32 +730,30 @@ mod test {
         assert!(result.fixed);
     }
 
-    // In normal mode, fixes that share a boundary (end of one == start of next)
-    // are not treated as overlapping. Both fixes are applied.
     #[test]
-    fn apply_two_fix_when_the_start_the_same_as_the_previous_end() {
+    fn apply_one_fix_when_the_start_the_same_as_the_previous_end() {
         let result = get_fix_result(vec![
             create_message(remove_start(), PossibleFixes::Single(REMOVE_START)),
             create_message(replace_id(), PossibleFixes::Single(REPLACE_ID)),
         ]);
-        assert_eq!(result.fixed_code, TEST_CODE.cow_replace("var answer", "foo"));
-        assert_eq!(result.messages.len(), 0);
+        assert_eq!(result.fixed_code, TEST_CODE.cow_replace("var ", ""));
+        assert_eq!(result.messages.len(), 1);
         assert!(result.fixed);
     }
 
-    // In ESLint compat mode, fixes that share a boundary (end of one == start of next)
-    // are treated as overlapping. Only the first fix is applied.
+    // In legacy Oxlint mode, fixes that share a boundary (end of one == start of next)
+    // are not treated as overlapping. Both fixes are applied.
     #[test]
-    fn apply_one_fix_when_the_start_the_same_as_the_previous_end_in_eslint_compat_mode() {
+    fn apply_two_fix_when_the_start_the_same_as_the_previous_end_in_legacy_mode() {
         let messages = vec![
             create_message(remove_start(), PossibleFixes::Single(REMOVE_START)),
             create_message(replace_id(), PossibleFixes::Single(REPLACE_ID)),
         ];
         let result = Fixer::new(TEST_CODE, messages, Some(SourceType::default()))
-            .with_eslint_compat(true)
+            .with_eslint_compat(false)
             .fix();
-        assert_eq!(result.fixed_code, TEST_CODE.cow_replace("var ", ""));
-        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.fixed_code, TEST_CODE.cow_replace("var answer", "foo"));
+        assert_eq!(result.messages.len(), 0);
         assert!(result.fixed);
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -469,13 +469,13 @@ fn test_vars_destructure() {
         ("let [f,\u{a0}a]=p", "let [,a]=p", None, FixKind::DangerousSuggestion),
         (
             "const [a, b, c, d, e] = arr; f(a, e)",
-            "const [a, ,,,e] = arr; f(a, e)",
+            "const [a, ,c, ,e] = arr; f(a, e)",
             None,
             FixKind::DangerousSuggestion,
         ),
         (
             "const [a, b, c, d, e, f] = arr; fn(a, e)",
-            "const [a, ,,,e] = arr; fn(a, e)",
+            "const [a, ,c, ,e] = arr; fn(a, e)",
             None,
             FixKind::DangerousSuggestion,
         ),

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -710,7 +710,7 @@ fn test() {
         ("var foo = '\\#';", "var foo = '#';", None),
         ("var foo = '\\$';", "var foo = '$';", None),
         ("var foo = '\\p';", "var foo = 'p';", None),
-        ("var foo = '\\p\\a\\@';", "var foo = 'pa@';", None),
+        ("var foo = '\\p\\a\\@';", "var foo = 'p\\a@';", None),
         ("<foo attr={\"\\d\"}/>", "<foo attr={\"d\"}/>", None),
         ("var foo = '\\`';", "var foo = '`';", None),
         ("var foo = `\\\"`;", "var foo = `\"`;", None),
@@ -763,7 +763,7 @@ fn test() {
         (
             // https://github.com/oxc-project/oxc/issues/5227
             r"const regex = /(https?:\/\/github\.com\/(([^\s]+)\/([^\s]+))\/([^\s]+\/)?(issues|pull)\/([0-9]+))|(([^\s]+)\/([^\s]+))?#([1-9][0-9]*)($|[\s\:\;\-\(\=])/;",
-            r"const regex = /(https?:\/\/github\.com\/(([^\s]+)\/([^\s]+))\/([^\s]+\/)?(issues|pull)\/([0-9]+))|(([^\s]+)\/([^\s]+))?#([1-9][0-9]*)($|[\s:;\-(=])/;",
+            r"const regex = /(https?:\/\/github\.com\/(([^\s]+)\/([^\s]+))\/([^\s]+\/)?(issues|pull)\/([0-9]+))|(([^\s]+)\/([^\s]+))?#([1-9][0-9]*)($|[\s:\;\-(\=])/;",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -154,7 +154,7 @@ fn test() {
                   ",
             "
             const foo: { bar: number } | null = null;
-            const bar = foo!.bar;
+            const bar = foo!!.bar;
                   ",
         ),
         (


### PR DESCRIPTION
Treat boundary-adjacent autofixes as overlapping by default to match ESLint's conservative fixer behavior.
Resolves #19160.