### PR TITLE
refactor(linter): remove fixer eslint compat option

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -41,7 +41,7 @@ export declare const enum Severity {
  *
  * Fix ranges are converted from UTF-16 code units to UTF-8 bytes.
  */
-export declare function applyFixes(sourceText: string, fixesJson: string, eslintCompat: boolean): string | null
+export declare function applyFixes(sourceText: string, fixesJson: string): string | null
 
 /**
  * Get offset within a `Uint8Array` which is aligned on `BLOCK_ALIGN`.

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -118,7 +118,6 @@ interface Config {
    *
    * If `true`:
    * - Column offsets in diagnostics are incremented by 1.
-   * - Fixes which are adjacent to each other are considered overlapping, and only the first fix is applied.
    * - Defaults `sourceType` to "module" if not provided (otherwise default is "unambiguous").
    * - Disallows `sourceType: "unambiguous"`.
    * - Allows `null` as property value for `globals`.
@@ -674,9 +673,7 @@ function assertInvalidTestCasePasses(test: InvalidTestCase, plugin: Plugin, conf
 
   // Test output after fixes
   const { code } = test;
-  const eslintCompat = test.eslintCompat === true;
-
-  let fixedCode = runFixes(diagnostics, code, eslintCompat);
+  let fixedCode = runFixes(diagnostics, code);
   if (fixedCode === null) fixedCode = code;
 
   // Re-lint and re-fix for additional passes if `recursive` option used
@@ -687,7 +684,7 @@ function assertInvalidTestCasePasses(test: InvalidTestCase, plugin: Plugin, conf
   if (extraPassCount > 0 && fixedCode !== code) {
     for (let pass = 0; pass < extraPassCount; pass++) {
       const diagnostics = lint({ ...test, code: fixedCode }, plugin);
-      const newFixedCode = runFixes(diagnostics, fixedCode, eslintCompat);
+      const newFixedCode = runFixes(diagnostics, fixedCode);
       if (newFixedCode === null) break;
       fixedCode = newFixedCode;
     }
@@ -719,14 +716,14 @@ function assertInvalidTestCasePasses(test: InvalidTestCase, plugin: Plugin, conf
  * @returns Fixed code, or `null` if no fixes to apply
  * @throws {Error} If error when applying fixes
  */
-function runFixes(diagnostics: Diagnostic[], code: string, eslintCompat: boolean): string | null {
+function runFixes(diagnostics: Diagnostic[], code: string): string | null {
   const fixGroups: FixReport[][] = [];
   for (const diagnostic of diagnostics) {
     if (diagnostic.fixes !== null) fixGroups.push(diagnostic.fixes);
   }
   if (fixGroups.length === 0) return null;
 
-  const fixedCode = applyFixes(code, JSON.stringify(fixGroups), eslintCompat);
+  const fixedCode = applyFixes(code, JSON.stringify(fixGroups));
   if (fixedCode === null) throw new Error("Failed to apply fixes");
 
   return fixedCode;
@@ -936,8 +933,6 @@ function assertSuggestionsAreCorrect(
       `Instead found ${actualSuggestions.length} suggestion${actualSuggestions.length > 1 ? "s" : ""}.`,
   );
 
-  const eslintCompat = test.eslintCompat === true;
-
   for (let i = 0; i < expectedSuggestions.length; i++) {
     const actual = actualSuggestions[i]!;
     const expected = expectedSuggestions[i]!;
@@ -949,7 +944,7 @@ function assertSuggestionsAreCorrect(
     // Validate output
     assert(Object.hasOwn(expected, "output"), `${prefix}: \`output\` property is required`);
 
-    const suggestedCode = applyFixes(test.code, JSON.stringify([actual.fixes]), eslintCompat);
+    const suggestedCode = applyFixes(test.code, JSON.stringify([actual.fixes]));
     assert(suggestedCode !== null, `${prefix}: Failed to apply suggestion fix`);
 
     assert.strictEqual(

--- a/apps/oxlint/src/js_plugins/fix.rs
+++ b/apps/oxlint/src/js_plugins/fix.rs
@@ -23,7 +23,7 @@ const BOM_LEN: u32 = BOM.len() as u32;
 /// Fix ranges are converted from UTF-16 code units to UTF-8 bytes.
 #[napi]
 #[allow(dead_code, clippy::needless_pass_by_value, clippy::allow_attributes)]
-pub fn apply_fixes(source_text: String, fixes_json: String, eslint_compat: bool) -> Option<String> {
+pub fn apply_fixes(source_text: String, fixes_json: String) -> Option<String> {
     // Deserialize fixes JSON
     let fix_groups: Vec<Vec<JsFix>> = serde_json::from_str(&fixes_json).ok()?;
 
@@ -47,11 +47,7 @@ pub fn apply_fixes(source_text: String, fixes_json: String, eslint_compat: bool)
         .collect::<Option<Vec<_>>>()?;
 
     // Apply all the fixes
-    let fixed_code = Fixer::new(&source_text, messages, None)
-        .with_eslint_compat(eslint_compat)
-        .fix()
-        .fixed_code
-        .into_owned();
+    let fixed_code = Fixer::new(&source_text, messages, None).fix().fixed_code.into_owned();
 
     Some(fixed_code)
 }

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1151,9 +1151,7 @@ describe("RuleTester", () => {
         // Fix 1 replaces `a` (first char), fix 2 replaces `b` (second char).
         // End of fix 1's range === start of fix 2's range.
         //
-        // In standard mode, adjacent fixes are not considered overlapping, so both apply.
-        // In ESLint compat mode, adjacent fixes are considered overlapping (matching ESLint),
-        // so only the first fix applies.
+        // Adjacent fixes are considered overlapping, matching ESLint, so only the first fix applies.
         const adjacentFixesRule: Rule = {
           meta: {
             fixable: "code",
@@ -1185,22 +1183,7 @@ describe("RuleTester", () => {
           },
         };
 
-        it("adjacent fixes applied in standard mode", () => {
-          const tester = new RuleTester();
-          tester.run("adjacent-fixes", adjacentFixesRule, {
-            valid: [],
-            invalid: [
-              {
-                code: "let ab;",
-                output: "let xy;",
-                errors: 2,
-              },
-            ],
-          });
-          expect(runCases()).toEqual([null]);
-        });
-
-        it("only first adjacent fix applied in ESLint compat mode", () => {
+        it("only first adjacent fix applied", () => {
           const tester = new RuleTester();
           tester.run("adjacent-fixes", adjacentFixesRule, {
             valid: [],
@@ -1208,7 +1191,6 @@ describe("RuleTester", () => {
               {
                 code: "let ab;",
                 output: "let xb;",
-                eslintCompat: true,
                 errors: 2,
               },
             ],

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -319,12 +319,6 @@ pub struct Fixer<'a> {
     // The behavior is oriented by `oxlint` where only one PossibleFixes is applied.
     fix_index: u8,
 
-    /// When `true`, boundary-adjacent fixes (e.g. `[0,5]` and `[5,10]`) are considered
-    /// overlapping, matching ESLint's `SourceCodeFixer` behavior.
-    /// When `false`, only truly overlapping fixes are skipped.
-    /// Defaults to `true`.
-    eslint_compat: bool,
-
     #[cfg(debug_assertions)]
     source_type: Option<SourceType>,
 }
@@ -341,7 +335,6 @@ impl<'a> Fixer<'a> {
             source_text,
             messages,
             fix_index: 0,
-            eslint_compat: true,
             #[cfg(debug_assertions)]
             source_type,
         }
@@ -351,12 +344,6 @@ impl<'a> Fixer<'a> {
     #[must_use]
     pub fn with_fix_index(mut self, fix_index: u8) -> Self {
         self.fix_index = fix_index;
-        self
-    }
-
-    #[must_use]
-    pub fn with_eslint_compat(mut self, eslint_compat: bool) -> Self {
-        self.eslint_compat = eslint_compat;
         self
     }
 
@@ -375,7 +362,6 @@ impl<'a> Fixer<'a> {
         let mut fixed = false;
         let mut output = String::with_capacity(source_text.len());
         let mut last_pos: u32 = 0;
-        let eslint_compat = self.eslint_compat;
 
         // only keep messages that were not fixed
         let mut filtered_messages = Vec::with_capacity(self.messages.len());
@@ -400,16 +386,12 @@ impl<'a> Fixer<'a> {
                 continue;
             }
 
-            // Skip fixes that overlap with a previously applied fix.
-            //
-            // In ESLint-compatible mode, boundary-adjacent fixes (e.g. [0, 5] and [5, 10]) are
-            // considered overlapping. The legacy Oxlint mode only skips truly overlapping fixes.
-            //
+            // Skip fixes that overlap with a previously applied fix. Boundary-adjacent fixes
+            // (e.g. [0, 5] and [5, 10]) are considered overlapping to match ESLint's behavior.
             // Never consider the first fix overlapping, because there's no previous fix to overlap with.
             // This extra check is required because `last_pos` is 0 initially, so a fix starting at offset 0
-            // would incorrectly be considered as overlapping when `eslint_compat` is `true`.
-            let overlaps =
-                if eslint_compat && fixed { last_pos >= start } else { last_pos > start };
+            // would incorrectly be considered as overlapping.
+            let overlaps = fixed && last_pos >= start;
             if overlaps {
                 filtered_messages.push(m);
                 continue;
@@ -738,22 +720,6 @@ mod test {
         ]);
         assert_eq!(result.fixed_code, TEST_CODE.cow_replace("var ", ""));
         assert_eq!(result.messages.len(), 1);
-        assert!(result.fixed);
-    }
-
-    // In legacy Oxlint mode, fixes that share a boundary (end of one == start of next)
-    // are not treated as overlapping. Both fixes are applied.
-    #[test]
-    fn apply_two_fix_when_the_start_the_same_as_the_previous_end_in_legacy_mode() {
-        let messages = vec![
-            create_message(remove_start(), PossibleFixes::Single(REMOVE_START)),
-            create_message(replace_id(), PossibleFixes::Single(REPLACE_ID)),
-        ];
-        let result = Fixer::new(TEST_CODE, messages, Some(SourceType::default()))
-            .with_eslint_compat(false)
-            .fix();
-        assert_eq!(result.fixed_code, TEST_CODE.cow_replace("var answer", "foo"));
-        assert_eq!(result.messages.len(), 0);
         assert!(result.fixed);
     }
 


### PR DESCRIPTION
Remove the now-redundant fixer eslint_compat option now that ESLint-compatible adjacent-fix handling is the only behavior.

follow on from #22071 