### PR TITLE
perf(formatter): process `ImportDeclaration`s in a run

### DIFF
--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -57,12 +57,22 @@ impl<'a> Deref for FormatStatementsWithImports<'a, '_> {
 impl<'a> Format<'a> for FormatStatementsWithImports<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let import_sort_enabled = f.options().sort_imports.is_some();
-        let mut imports_chunk_start: Option<usize> = None;
 
         let mut join = f.join_nodes_with_hardline();
-        for stmt in
-            self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_)))
-        {
+
+        let mut stmts_iter =
+            self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_)));
+        while let Some(mut stmt) = stmts_iter.next() {
+            // If import sort is enabled, and current statement is an `ImportDeclaration`,
+            // collect consecutive `ImportDeclaration`s starting with `stmt`, sort them, and output them
+            if import_sort_enabled && matches!(stmt.as_ref(), Statement::ImportDeclaration(_)) {
+                let next_stmt = format_import_decls_with_sort(stmt, &mut stmts_iter, &mut join);
+                match next_stmt {
+                    Some(next_stmt) => stmt = next_stmt,
+                    None => break,
+                }
+            }
+
             let span = match stmt.as_ref() {
                 // `@decorator export class A {}`
                 // Get the span of the decorator.
@@ -92,31 +102,55 @@ impl<'a> Format<'a> for FormatStatementsWithImports<'a, '_> {
                 _ => stmt.span(),
             };
 
-            if import_sort_enabled {
-                if matches!(stmt.as_ref(), Statement::ImportDeclaration(_)) {
-                    if imports_chunk_start.is_none() {
-                        // First import in a chunk. Output inter-statement separator separately
-                        // so `imports_chunk_start` points to start of IR for the `ImportDeclaration` itself.
-                        join.separator_no_entry(span);
-                        imports_chunk_start = Some(join.fmt().elements().len());
-                        join.entry_no_separator(stmt);
-                        continue;
-                    }
-                } else if let Some(chunk_start) = imports_chunk_start.take() {
-                    // Any other statement after an `ImportDeclaration`, or a run of them.
-                    // Sort the chunk of imports.
-                    sort_imports_chunk(join.fmt_mut(), chunk_start);
-                }
-            }
-
             join.entry(span, stmt);
         }
+    }
+}
 
-        // If last statement was an `ImportDeclaration`, sort the chunk of imports
-        if let Some(chunk_start) = imports_chunk_start.take() {
-            sort_imports_chunk(join.fmt_mut(), chunk_start);
+/// Collect a run of consecutive `ImportDeclaration`s from `stmts_iter`, format them using `join`,
+/// then sort them in place.
+///
+/// Returns the next statement after the run of `ImportDeclaration`s, or `None` if there are no more statements.
+///
+/// The caller must already have verified that `sort_imports` option is enabled.
+///
+/// # Panics
+/// Panics if `sort_imports` option is not enabled.
+//
+// `#[cold]` because most statements aren't `ImportDeclaration`s.
+// Also, when there *are* lots of `ImportDeclaration`s, they tend to all be grouped together.
+// This function consumes the whole run, so is unlikely to be called more than once, even in files with lots of imports.
+#[cold]
+fn format_import_decls_with_sort<'a, 'iter>(
+    stmt: &AstNode<'a, Statement<'a>>,
+    stmts_iter: &mut impl Iterator<Item = &'iter AstNode<'a, Statement<'a>>>,
+    join: &mut JoinNodesBuilder<'_, '_, 'a, Line>,
+) -> Option<&'iter AstNode<'a, Statement<'a>>> {
+    // Output inter-statement separator separately, so `chunk_start` points
+    // to start of IR for the `ImportDeclaration` itself
+    join.separator_no_entry(stmt.span());
+    let chunk_start = join.fmt().elements().len();
+
+    // Output first `ImportDeclaration`
+    join.entry_no_separator(stmt);
+
+    // Output all following `ImportDeclaration`s
+    let mut next_stmt = None;
+    for stmt in stmts_iter {
+        if let Statement::ImportDeclaration(decl) = stmt.as_ref() {
+            join.entry(decl.span, stmt);
+        } else {
+            // Some other statement or end of statements
+            next_stmt = Some(stmt);
+            break;
         }
     }
+
+    // Sort the run of `ImportDeclaration`s
+    sort_imports_chunk(join.fmt_mut(), chunk_start);
+
+    // Return the next statement (which isn't an `ImportDeclaration`)
+    next_stmt
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {


### PR DESCRIPTION
Follow-on after #22065. Small perf optimization to collecting `ImportDeclaration`s for sorting.

Previously, `FormatStatementsWithImports::fmt` had a loop where it checked each statement for whether it's an `ImportDeclaration`, and also checked every _other_ statement to see if it's the first statement _after_ an `ImportDeclaration`.

`ImportDeclaration`s comprise a minority of the statements in a file. So instead have 2 nested loops:

1. Main loop over `Statement`s.
2. Inner loop which consumes a run of `ImportDeclaration`s, before yielding back to the main loop.

This has the following effects:

- Avoids the "am I the first statement after an `ImportDeclaration`?" check on all other statements.
- Makes the flow more predictable for the branch predictor.
- Moves processing a chunk of `ImportDeclaration`s into its own function, making the logic clearer.

We could build on this new structure, if we chose, by:

1. Skipping sorting imports if there's only 1 import in a chunk.
2. Collecting info about imports (e.g. specifiers) at AST level, instead of the sorting transform having to figure it out by sifting through the IR.
3. Doing first-pass formatting of imports into a temporary buffer, so that sorted imports can be output directly into the main buffer, avoiding copying them all twice, which is what we do now (format into buffer, copy into temp `Vec`, copy back into buffer).