### PR TITLE
perf(linter/require-returns): avoid jsdoc tag vec allocation

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -219,15 +219,14 @@ impl Rule for RequireReturns {
                 continue;
             }
 
-            let jsdoc_tags = jsdoc.tags().iter().collect::<Vec<_>>();
             let resolved_returns_tag_name = settings.resolve_tag_name("returns");
 
-            if is_missing_special_tag(&jsdoc_tags, resolved_returns_tag_name) {
+            if is_missing_special_tag(jsdoc.tags(), resolved_returns_tag_name) {
                 ctx.diagnostic(missing_returns_diagnostic(*func_span));
                 continue;
             }
 
-            if let Some(span) = is_duplicated_special_tag(&jsdoc_tags, resolved_returns_tag_name) {
+            if let Some(span) = is_duplicated_special_tag(jsdoc.tags(), resolved_returns_tag_name) {
                 ctx.diagnostic(duplicate_returns_diagnostic(span));
             }
         }

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -154,7 +154,7 @@ impl Rule for RequireYields {
                 // Without this option, need to check `yield` value.
                 // Check will be performed in `YieldExpression` branch.
                 if self.force_require_yields
-                    && is_missing_special_tag(&jsdoc_tags, resolved_yields_tag_name)
+                    && is_missing_special_tag(jsdoc_tags.iter().copied(), resolved_yields_tag_name)
                 {
                     ctx.diagnostic(missing_yields(func.span));
                     return;
@@ -162,7 +162,8 @@ impl Rule for RequireYields {
 
                 // Other checks are always performed
 
-                if let Some(span) = is_duplicated_special_tag(&jsdoc_tags, resolved_yields_tag_name)
+                if let Some(span) =
+                    is_duplicated_special_tag(jsdoc_tags.iter().copied(), resolved_yields_tag_name)
                 {
                     ctx.diagnostic(duplicate_yields(span));
                     return;
@@ -243,7 +244,7 @@ impl Rule for RequireYields {
                 let jsdoc_tags = jsdocs.iter().flat_map(JSDoc::tags).collect::<Vec<_>>();
                 let resolved_yields_tag_name = settings.resolve_tag_name("yields");
 
-                if is_missing_special_tag(&jsdoc_tags, resolved_yields_tag_name) {
+                if is_missing_special_tag(jsdoc_tags.iter().copied(), resolved_yields_tag_name) {
                     ctx.diagnostic(missing_yields(generator_func.span));
                 }
             }

--- a/crates/oxc_linter/src/utils/jsdoc.rs
+++ b/crates/oxc_linter/src/utils/jsdoc.rs
@@ -16,14 +16,23 @@ pub fn should_ignore_as_custom_skip(jsdoc: &JSDoc) -> bool {
     jsdoc.tags().iter().any(|tag| CUSTOM_SKIP_TAG_NAMES.contains(&tag.kind.parsed()))
 }
 
-pub fn is_missing_special_tag(jsdoc_tags: &[&JSDocTag], resolved_tag_name: &str) -> bool {
-    jsdoc_tags.iter().all(|tag| tag.kind.parsed() != resolved_tag_name)
+pub fn is_missing_special_tag<'a, 'b>(
+    jsdoc_tags: impl IntoIterator<Item = &'b JSDocTag<'a>>,
+    resolved_tag_name: &str,
+) -> bool
+where
+    'a: 'b,
+{
+    jsdoc_tags.into_iter().all(|tag| tag.kind.parsed() != resolved_tag_name)
 }
 
-pub fn is_duplicated_special_tag(
-    jsdoc_tags: &Vec<&JSDocTag>,
+pub fn is_duplicated_special_tag<'a, 'b>(
+    jsdoc_tags: impl IntoIterator<Item = &'b JSDocTag<'a>>,
     resolved_returns_tag_name: &str,
-) -> Option<Span> {
+) -> Option<Span>
+where
+    'a: 'b,
+{
     let mut returns_found = false;
     for tag in jsdoc_tags {
         if tag.kind.parsed() == resolved_returns_tag_name {


### PR DESCRIPTION
Avoid allocating a `Vec` when `jsdoc/require-returns` checks return tags by letting the shared JSDoc helpers accept tag iterators.

Follow-up to https://github.com/oxc-project/oxc/pull/22077.