### PR TITLE
docs(oxlint/lsp): auto generate docs for LSP options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc-miette",
+ "oxc-schemars",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -51,6 +51,7 @@ tracing = { workspace = true }
 napi-derive = { workspace = true, optional = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
+schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -5,7 +5,7 @@ mod command;
 mod config_loader;
 mod init;
 mod lint;
-mod lsp;
+pub mod lsp;
 mod mode;
 mod output_formatter;
 mod result;
@@ -16,7 +16,7 @@ mod tester;
 
 /// Re-exported CLI-related items for use in `tasks/website`.
 pub mod cli {
-    pub use super::{command::*, init::*, lint::CliRunner, lsp::run_lsp, result::CliRunResult};
+    pub use super::{command::*, init::*, lint::CliRunner, result::CliRunResult};
 }
 
 // Only include code to run linter when the `napi` feature is enabled.

--- a/apps/oxlint/src/lsp/mod.rs
+++ b/apps/oxlint/src/lsp/mod.rs
@@ -10,11 +10,12 @@ mod code_actions;
 mod commands;
 mod error_with_position;
 mod lsp_file_system;
-mod options;
 mod server_linter;
 #[cfg(test)]
 mod tester;
 mod utils;
+
+pub mod options;
 
 /// Run the language server
 pub async fn run_lsp(

--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -1,10 +1,11 @@
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, de::Error};
 use serde_json::Value;
 
 use oxc_linter::FixKind;
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum UnusedDisableDirectives {
     #[default]
@@ -13,7 +14,7 @@ pub enum UnusedDisableDirectives {
     Deny,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Run {
     OnSave,
@@ -21,21 +22,76 @@ pub enum Run {
     OnType,
 }
 
-#[derive(Debug, Default, Serialize, PartialEq, Eq, Clone)]
+/// LSP Options for linting, which can be defined for each workspace folder separately.
+///
+/// It can be sent by the client in `initialize` or `workspace/didChangeConfiguration` requests.
+/// If the client supports `workspace/configuration`, the server will request the options from the client.
+///
+/// ## Example
+///
+/// Example of `initialize` request:
+/// ```json
+/// {
+///   "processId": 123,
+///   "rootUri": null,
+///   "workspaceFolders": [],
+///   "capabilities": {},
+///   "initializationOptions": [
+///     {
+///       "workspaceUri": "file:///home/user/project",
+///       "options": {
+///         "unusedDisableDirectives": "deny",
+///         "typeAware": true
+///       }
+///     }
+///   ]
+/// }
+/// ```
+///
+/// Example of `workspace/didChangeConfiguration` request:
+/// ```json
+/// {
+///   "settings": [
+///     {
+///       "workspaceUri": "file:///home/user/project",
+///       "options": {
+///         "unusedDisableDirectives": "deny",
+///         "disableNestedConfig": true
+///       }
+///     }
+///   ]
+/// }
+/// ```
+#[derive(Debug, Default, Serialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LintOptions {
+    /// If your editor does not support `textDocument/diagnostic`,
+    /// this option handles when diagnostics are sent to the client.
+    #[schemars(with = "Option<Run>")]
     pub run: Run,
+    /// Path to the config file. Similar to `--config` CLI option.
+    /// If set, it disables searching for config files.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config_path: Option<String>,
+    /// Path to the tsconfig file. Similar to `--tsconfig` CLI option.
+    /// If set, it disables auto discovery for tsconfig files.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ts_config_path: Option<String>,
+    /// How to handle unused disable directives. By default, they are allowed and ignored.
     pub unused_disable_directives: Option<UnusedDisableDirectives>,
+    /// Whether to enable/disable type-aware linting.
+    /// It will override the root config's `typeAware` option if set.
     pub type_aware: Option<bool>,
+    /// Whether to disable nested config support. Similar to `--disable-nested-config` CLI option.
+    /// It gets automatically enabled when `configPath` is set.
+    #[schemars(with = "Option<bool>")]
     pub disable_nested_config: bool,
+    /// What kind of fixes to generate for code actions.
+    #[schemars(with = "Option<LintFixKindFlag>")]
     pub fix_kind: LintFixKindFlag,
 }
 
-#[derive(Debug, Default, Serialize, PartialEq, Eq, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, PartialEq, Eq, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum LintFixKindFlag {
     SafeFix,

--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -1,6 +1,9 @@
 use std::io::BufWriter;
 
-use oxlint::cli::{CliRunResult, CliRunner, init_miette, init_tracing, lint_command, run_lsp};
+use oxlint::{
+    cli::{CliRunResult, CliRunner, init_miette, init_tracing, lint_command},
+    lsp::run_lsp,
+};
 
 #[tokio::main]
 async fn main() -> CliRunResult {

--- a/justfile
+++ b/justfile
@@ -279,6 +279,7 @@ website path:
   cargo run -p website_linter rules --rules-json {{path}}/.vitepress/data/rules.json --rule-docs {{path}}/src/docs/guide/usage/linter/rules --git-ref $(git rev-parse HEAD) --rule-count {{path}}/src/docs/guide/usage
   cargo run -p website_linter cli > {{path}}/src/docs/guide/usage/linter/generated-cli.md
   cargo run -p website_linter schema-markdown > {{path}}/src/docs/guide/usage/linter/generated-config.md
+  cargo run -p website_linter schema-markdown-lsp > {{path}}/src/docs/guide/usage/linter/generated-lsp-config.md
   cargo run -p website_formatter cli > {{path}}/src/docs/guide/usage/formatter/generated-cli.md
   cargo run -p website_formatter schema-markdown > {{path}}/src/docs/guide/usage/formatter/generated-config.md
 

--- a/tasks/website_common/src/schema_markdown.rs
+++ b/tasks/website_common/src/schema_markdown.rs
@@ -529,15 +529,24 @@ impl Section {
 }
 
 fn sanitize(s: &mut String) {
+    let mut cursor = 0;
     let marker = "```json";
-    let Some(start) = s.find(marker) else { return };
-    let start = start + marker.len();
-    let Some(end) = s[start..].find("```") else { return };
-    let json_str = &s[start..start + end];
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(json_str.trim()) else { return };
-    let json = serde_json::to_string_pretty(&json).unwrap();
-    let json = format!("\n{json}\n");
-    s.replace_range(start..start + end, &json);
+
+    while let Some(start) = s[cursor..].find(marker) {
+        let start = cursor + start + marker.len();
+        let Some(end) = s[start..].find("```") else { break };
+        let end = start + end;
+        let json_str = &s[start..end];
+
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(json_str.trim()) {
+            let json = serde_json::to_string_pretty(&json).unwrap();
+            let replacement = format!("\n{json}\n");
+            s.replace_range(start..end, &replacement);
+            cursor = start + replacement.len() + 3;
+        } else {
+            cursor = end + 3;
+        }
+    }
 }
 
 fn as_mapped_type(schema: &SchemaObject) -> Option<&SchemaObject> {

--- a/tasks/website_linter/src/json_schema.rs
+++ b/tasks/website_linter/src/json_schema.rs
@@ -1,4 +1,5 @@
 use oxc_linter::Oxlintrc;
+use oxlint::lsp::options::LintOptions;
 use schemars::schema_for;
 use website_common::{Renderer, generate_schema_json};
 
@@ -31,9 +32,22 @@ fn test_schema_markdown() {
     });
 }
 
+#[test]
+fn test_schema_markdown_lsp() {
+    let snapshot = Renderer::new(schema_for!(LintOptions)).render();
+    insta::with_settings!({ prepend_module_to_snapshot => false }, {
+        insta::assert_snapshot!(snapshot);
+    });
+}
+
 #[expect(clippy::print_stdout)]
 pub fn print_schema_markdown() {
     println!("{}", generate_schema_markdown());
+}
+
+#[expect(clippy::print_stdout)]
+pub fn print_schema_markdown_lsp() {
+    println!("{}", Renderer::new(schema_for!(LintOptions)).render());
 }
 
 fn generate_schema_markdown() -> String {

--- a/tasks/website_linter/src/main.rs
+++ b/tasks/website_linter/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
     match task {
         "schema-json" => json_schema::print_schema_json(),
         "schema-markdown" => json_schema::print_schema_markdown(),
+        "schema-markdown-lsp" => json_schema::print_schema_markdown_lsp(),
         "cli" => cli::print_cli(),
         "rules" => rules::print_rules(args),
         _ => eprintln!("Missing task command."),

--- a/tasks/website_linter/src/snapshots/schema_markdown_lsp.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown_lsp.snap
@@ -1,0 +1,109 @@
+---
+source: tasks/website_linter/src/json_schema.rs
+expression: snapshot
+---
+---
+search: false
+---
+
+# LSP Options for linting, which can be defined for each workspace folder separately.
+
+It can be sent by the client in `initialize` or `workspace/didChangeConfiguration` requests.
+If the client supports `workspace/configuration`, the server will request the options from the client.
+
+## Example
+
+Example of `initialize` request:
+```json
+{
+  "processId": 123,
+  "rootUri": null,
+  "workspaceFolders": [],
+  "capabilities": {},
+  "initializationOptions": [
+    {
+      "workspaceUri": "file:///home/user/project",
+      "options": {
+        "unusedDisableDirectives": "deny",
+        "typeAware": true
+      }
+    }
+  ]
+}
+```
+
+Example of `workspace/didChangeConfiguration` request:
+```json
+{
+  "settings": [
+    {
+      "workspaceUri": "file:///home/user/project",
+      "options": {
+        "unusedDisableDirectives": "deny",
+        "disableNestedConfig": true
+      }
+    }
+  ]
+}
+```
+
+
+## configPath
+
+type: `string`
+
+
+Path to the config file. Similar to `--config` CLI option.
+If set, it disables searching for config files.
+
+
+## disableNestedConfig
+
+type: `boolean`
+
+
+Whether to disable nested config support. Similar to `--disable-nested-config` CLI option.
+It gets automatically enabled when `configPath` is set.
+
+
+## fixKind
+
+type: `"safe_fix" | "safe_fix_or_suggestion" | "dangerous_fix" | "dangerous_fix_or_suggestion" | "none" | "all"`
+
+
+What kind of fixes to generate for code actions.
+
+
+## run
+
+type: `"onSave" | "onType"`
+
+
+If your editor does not support `textDocument/diagnostic`,
+this option handles when diagnostics are sent to the client.
+
+
+## tsConfigPath
+
+type: `string`
+
+
+Path to the tsconfig file. Similar to `--tsconfig` CLI option.
+If set, it disables auto discovery for tsconfig files.
+
+
+## typeAware
+
+type: `boolean`
+
+
+Whether to enable/disable type-aware linting.
+It will override the root config's `typeAware` option if set.
+
+
+## unusedDisableDirectives
+
+type: `"allow" | "warn" | "deny"`
+
+
+How to handle unused disable directives. By default, they are allowed and ignored.


### PR DESCRIPTION
> ## Pull request overview

> This PR adds automated generation of website documentation for oxlint’s LSP linting options by exposing the LSP options schema, rendering it to markdown, and snapshot-testing the output.

An PR on `oxc-project/website` is needed. Will wait for the next release to improve the LSP & Editor docs too :) 