### PR TITLE
refactor(allocator): add `Allocator::new_fixed_size` method

### DIFF
--- a/crates/oxc_allocator/src/arena/fixed_size.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size.rs
@@ -1,0 +1,106 @@
+//! [`Arena::new_fixed_size`]
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    ptr::NonNull,
+};
+
+use crate::generated::fixed_size_constants::{BLOCK_ALIGN, BLOCK_SIZE};
+
+use super::{Arena, CHUNK_ALIGN, CHUNK_FOOTER_SIZE};
+
+const TWO_GIB: usize = 1 << 31;
+const FOUR_GIB: usize = 1 << 32;
+
+// What we ideally want is an allocation 2 GiB in size, aligned on 4 GiB.
+// But system allocator on Mac OS refuses allocations with 4 GiB alignment.
+// https://github.com/rust-lang/rust/blob/556d20a834126d2d0ac20743b9792b8474d6d03c/library/std/src/sys/alloc/unix.rs#L16-L27
+// https://github.com/rust-lang/rust/issues/30170
+//
+// So we instead allocate 4 GiB with 2 GiB alignment, and then use either the 1st or 2nd half
+// of the allocation, one of which is guaranteed to be on a 4 GiB boundary.
+//
+// TODO: We could use this workaround only on Mac OS, and just allocate what we actually want on Linux.
+// Windows OS allocator also doesn't support high alignment allocations, so Rust contains a workaround
+// which over-allocates (6 GiB in this case).
+// https://github.com/rust-lang/rust/blob/556d20a834126d2d0ac20743b9792b8474d6d03c/library/std/src/sys/alloc/windows.rs#L120-L137
+// Could just use that built-in workaround, rather than implementing our own, or allocate a 6 GiB chunk
+// with alignment 16, to skip Rust's built-in workaround.
+// Note: Rust's workaround will likely commit a whole page of memory, just to store the real pointer.
+const ALLOC_SIZE: usize = BLOCK_SIZE + TWO_GIB;
+const ALLOC_ALIGN: usize = TWO_GIB;
+
+/// Layout of backing allocations for fixed-size allocators.
+const ALLOC_LAYOUT: Layout = match Layout::from_size_align(ALLOC_SIZE, ALLOC_ALIGN) {
+    Ok(layout) => layout,
+    Err(_) => unreachable!(),
+};
+
+const _: () = {
+    // `ChunkFooter` lives in the last `CHUNK_FOOTER_SIZE` bytes of the block and must be aligned on `CHUNK_ALIGN` (16).
+    // `BLOCK_SIZE` and `CHUNK_FOOTER_SIZE` are both multiples of `CHUNK_ALIGN`.
+    assert!(BLOCK_SIZE > 0);
+    assert!(BLOCK_SIZE.is_multiple_of(CHUNK_ALIGN));
+    assert!(BLOCK_SIZE >= CHUNK_FOOTER_SIZE);
+    assert!(CHUNK_FOOTER_SIZE.is_multiple_of(CHUNK_ALIGN));
+};
+
+impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
+    /// Construct a static-sized [`Arena`] backed by an allocation made via the [`System`] allocator.
+    ///
+    /// The returned [`Arena`] uses a single chunk of `BLOCK_SIZE` bytes, aligned on `BLOCK_ALIGN`.
+    /// It cannot grow.
+    ///
+    /// Allocation is made via [`System`] allocator, bypassing any registered alternative global allocator
+    /// (e.g. Mimalloc in linter). Mimalloc complains that it cannot serve allocations with high alignment,
+    /// and presumably it's pointless to try to obtain such large allocations from a thread-local heap,
+    /// so better to go direct to the system allocator anyway.
+    ///
+    /// The backing allocation is freed via the global allocator (NOT [`System`]) when the [`Arena`] is dropped.
+    /// Because the allocation here is made via [`System`], the returned [`Arena`] MUST NOT be dropped,
+    /// or [`dealloc`] will try to free the allocation via the wrong allocator.
+    ///
+    /// Returns `None` if the allocation fails.
+    ///
+    /// # SAFETY
+    ///
+    /// The returned [`Arena`] must not be dropped.
+    /// Caller must wrap it in [`ManuallyDrop`] and free the backing allocation manually via [`System::dealloc`],
+    /// using the [`Layout`] stored in the [`Arena`]'s `ChunkFooter`.
+    ///
+    /// [`dealloc`]: std::alloc::dealloc
+    /// [`ManuallyDrop`]: std::mem::ManuallyDrop
+    pub unsafe fn new_fixed_size() -> Option<Self> {
+        // Allocate block of memory.
+        // SAFETY: `ALLOC_LAYOUT` does not have zero size.
+        let alloc_ptr = unsafe { System.alloc(ALLOC_LAYOUT) };
+        let alloc_ptr = NonNull::new(alloc_ptr)?;
+
+        // Get pointer to use for allocator chunk, aligned to 4 GiB.
+        // `alloc_ptr` is aligned on 2 GiB, so `alloc_ptr % FOUR_GIB` is either 0 or `TWO_GIB`.
+        //
+        // * If allocation is already aligned on 4 GiB, `offset == 0`.
+        //   Chunk occupies 1st half of the allocation.
+        // * If allocation is not aligned on 4 GiB, `offset == TWO_GIB`.
+        //   Adding `offset` to `alloc_ptr` brings it up to 4 GiB alignment.
+        //   Chunk occupies 2nd half of the allocation.
+        //
+        // Either way, `chunk_ptr` is aligned on 4 GiB.
+        let offset = alloc_ptr.as_ptr() as usize % FOUR_GIB;
+        // SAFETY: We allocated 4 GiB of memory, so adding `offset` to `alloc_ptr` is in bounds
+        let chunk_ptr = unsafe { alloc_ptr.add(offset) };
+
+        debug_assert!(chunk_ptr.addr().get().is_multiple_of(BLOCK_ALIGN));
+
+        // The `Arena`'s chunk fills the whole `BLOCK_SIZE` block.
+        // `ChunkFooter` sits in the last `CHUNK_FOOTER_SIZE` bytes of the block.
+        //
+        // SAFETY:
+        // * Region starting at `chunk_ptr` with `BLOCK_SIZE` bytes is within the allocation we just made.
+        // * `chunk_ptr` has high alignment (4 GiB).
+        // * `BLOCK_SIZE` is large and a multiple of 16.
+        // * `chunk_ptr` has permission for writes.
+        let arena = unsafe { Self::from_raw_parts(chunk_ptr, BLOCK_SIZE, alloc_ptr, ALLOC_LAYOUT) };
+        Some(arena)
+    }
+}

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -23,6 +23,8 @@ mod utils;
 pub use bumpalo_alloc::AllocErr;
 use create::DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER;
 
+#[cfg(all(feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
+mod fixed_size;
 #[cfg(feature = "from_raw_parts")]
 mod from_raw_parts;
 

--- a/crates/oxc_allocator/src/fixed_size.rs
+++ b/crates/oxc_allocator/src/fixed_size.rs
@@ -1,0 +1,38 @@
+//! [`Allocator::new_fixed_size`]
+
+use crate::{Allocator, arena::Arena};
+
+impl Allocator {
+    /// Construct a static-sized [`Allocator`] backed by an allocation made via the [`System`] allocator.
+    ///
+    /// The returned [`Allocator`] uses a single chunk of `BLOCK_SIZE` bytes, aligned on `BLOCK_ALIGN`.
+    /// It cannot grow.
+    ///
+    /// Allocation is made via [`System`] allocator, bypassing any registered alternative global allocator
+    /// (e.g. Mimalloc in linter). Mimalloc complains that it cannot serve allocations with high alignment,
+    /// and presumably it's pointless to try to obtain such large allocations from a thread-local heap,
+    /// so better to go direct to the system allocator anyway.
+    ///
+    /// The backing allocation is freed via the global allocator (NOT [`System`]) when the [`Allocator`]
+    /// is dropped. Because the allocation here is made via [`System`], the returned [`Allocator`]
+    /// MUST NOT be dropped, or [`dealloc`] will try to free the allocation via the wrong allocator.
+    ///
+    /// Returns `None` if the allocation fails.
+    ///
+    /// # SAFETY
+    ///
+    /// The returned [`Allocator`] must not be dropped.
+    /// Caller must wrap it in [`ManuallyDrop`] and free the backing allocation manually via [`System::dealloc`],
+    /// using the [`Layout`] stored in the inner `Arena`'s `ChunkFooter`.
+    ///
+    /// [`System`]: std::alloc::System
+    /// [`dealloc`]: std::alloc::dealloc
+    /// [`System::dealloc`]: std::alloc::GlobalAlloc::dealloc
+    /// [`Layout`]: std::alloc::Layout
+    /// [`ManuallyDrop`]: std::mem::ManuallyDrop
+    pub unsafe fn new_fixed_size() -> Option<Self> {
+        // SAFETY: Safety requirements of `Arena::new_fixed_size` are the same as for this method.
+        let arena = unsafe { Arena::new_fixed_size() }?;
+        Some(Self::from_arena(arena))
+    }
+}

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -46,6 +46,8 @@ mod bitset;
 mod boxed;
 mod clone_in;
 mod convert;
+#[cfg(all(feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
+mod fixed_size;
 #[cfg(feature = "from_raw_parts")]
 mod from_raw_parts;
 pub mod hash_map;

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -1,5 +1,5 @@
 use std::{
-    alloc::{GlobalAlloc, Layout, System},
+    alloc::{GlobalAlloc, System},
     mem::{self, ManuallyDrop},
     ptr::NonNull,
     sync::{
@@ -18,13 +18,10 @@ use crate::{
     Allocator,
     arena::{CHUNK_FOOTER_SIZE, ChunkFooter},
     generated::fixed_size_constants::{
-        ACTIVE_SIZE, BLOCK_ALIGN, BLOCK_SIZE, BUFFER_SIZE, CURSOR_MIN_ALIGN, RAW_METADATA_ALIGN,
+        ACTIVE_SIZE, BLOCK_SIZE, BUFFER_SIZE, CURSOR_MIN_ALIGN, RAW_METADATA_ALIGN,
         RAW_METADATA_SIZE,
     },
 };
-
-const TWO_GIB: usize = 1 << 31;
-const FOUR_GIB: usize = 1 << 32;
 
 /// A thread-safe pool for reusing [`Allocator`] instances, that uses fixed-size allocators,
 /// suitable for use with raw transfer.
@@ -277,30 +274,6 @@ pub struct FixedSizeAllocatorMetadata {
     pub is_double_owned: AtomicBool,
 }
 
-// What we ideally want is an allocation 2 GiB in size, aligned on 4 GiB.
-// But system allocator on Mac OS refuses allocations with 4 GiB alignment.
-// https://github.com/rust-lang/rust/blob/556d20a834126d2d0ac20743b9792b8474d6d03c/library/std/src/sys/alloc/unix.rs#L16-L27
-// https://github.com/rust-lang/rust/issues/30170
-//
-// So we instead allocate 4 GiB with 2 GiB alignment, and then use either the 1st or 2nd half
-// of the allocation, one of which is guaranteed to be on a 4 GiB boundary.
-//
-// TODO: We could use this workaround only on Mac OS, and just allocate what we actually want on Linux.
-// Windows OS allocator also doesn't support high alignment allocations, so Rust contains a workaround
-// which over-allocates (6 GiB in this case).
-// https://github.com/rust-lang/rust/blob/556d20a834126d2d0ac20743b9792b8474d6d03c/library/std/src/sys/alloc/windows.rs#L120-L137
-// Could just use that built-in workaround, rather than implementing our own, or allocate a 6 GiB chunk
-// with alignment 16, to skip Rust's built-in workaround.
-// Note: Rust's workaround will likely commit a whole page of memory, just to store the real pointer.
-const ALLOC_SIZE: usize = BLOCK_SIZE + TWO_GIB;
-const ALLOC_ALIGN: usize = TWO_GIB;
-
-/// Layout of backing allocations for fixed-size allocators.
-const ALLOC_LAYOUT: Layout = match Layout::from_size_align(ALLOC_SIZE, ALLOC_ALIGN) {
-    Ok(layout) => layout,
-    Err(_) => unreachable!(),
-};
-
 /// Size of `FixedSizeAllocatorMetadata`.
 const FIXED_METADATA_SIZE: usize = size_of::<FixedSizeAllocatorMetadata>();
 
@@ -402,41 +375,16 @@ impl FixedSizeAllocator {
             panic!("`FixedSizeAllocator` is not supported on big-endian systems.");
         }
 
-        // Allocate block of memory.
-        // SAFETY: `ALLOC_LAYOUT` does not have zero size.
-        let alloc_ptr = unsafe { System.alloc(ALLOC_LAYOUT) };
-        let alloc_ptr = NonNull::new(alloc_ptr).ok_or(())?;
-
-        // All code in the rest of this function is infallible, so the allocation will always end up
-        // owned by a `FixedSizeAllocator`, which takes care of freeing the memory correctly on drop
-
-        // Get pointer to use for allocator chunk, aligned to 4 GiB.
-        // `alloc_ptr` is aligned on 2 GiB, so `alloc_ptr % FOUR_GIB` is either 0 or `TWO_GIB`.
-        //
-        // * If allocation is already aligned on 4 GiB, `offset == 0`.
-        //   Chunk occupies 1st half of the allocation.
-        // * If allocation is not aligned on 4 GiB, `offset == TWO_GIB`.
-        //   Adding `offset` to `alloc_ptr` brings it up to 4 GiB alignment.
-        //   Chunk occupies 2nd half of the allocation.
-        //
-        // Either way, `chunk_ptr` is aligned on 4 GiB.
-        let offset = alloc_ptr.as_ptr() as usize % FOUR_GIB;
-        // SAFETY: We allocated 4 GiB of memory, so adding `offset` to `alloc_ptr` is in bounds
-        let chunk_ptr = unsafe { alloc_ptr.add(offset) };
-
-        debug_assert!(chunk_ptr.addr().get().is_multiple_of(BLOCK_ALIGN));
-
-        // The `Allocator` chunk fills the whole block. `ChunkFooter` sits in the last `CHUNK_FOOTER_SIZE`
-        // bytes of the block. `FixedSizeAllocatorMetadata` and `RawTransferMetadata` are written into the
-        // chunk just before `ChunkFooter`. We later set the cursor to before `RawTransferMetadata` so
-        // allocations don't overwrite the metadata regions.
-        //
-        // SAFETY: Memory region starting at `chunk_ptr` with `BLOCK_SIZE` bytes is within the allocation
-        // we just made. `chunk_ptr` has high alignment (4 GiB). `BLOCK_SIZE` is large and a multiple of 16.
-        // `chunk_ptr` has permission for writes.
-        let allocator =
-            unsafe { Allocator::from_raw_parts(chunk_ptr, BLOCK_SIZE, alloc_ptr, ALLOC_LAYOUT) };
+        // Allocate the backing memory and create the `Allocator`.
+        // SAFETY: `Allocator` is wrapped in `ManuallyDrop` immediately, and `FixedSizeAllocator`'s
+        // `Drop` impl frees the backing allocation via `System.dealloc` (in `free_fixed_size_allocator`).
+        let allocator = unsafe { Allocator::new_fixed_size() }.ok_or(())?;
         let allocator = ManuallyDrop::new(allocator);
+
+        // Pointer to the start of the chunk. `data_end_ptr` is the start of the `ChunkFooter`,
+        // which sits at the end of the chunk, `BLOCK_SIZE - CHUNK_FOOTER_SIZE` bytes after `chunk_ptr`.
+        // SAFETY: `BLOCK_SIZE > CHUNK_FOOTER_SIZE`, and the resulting pointer is within the chunk.
+        let chunk_ptr = unsafe { allocator.data_end_ptr().sub(BLOCK_SIZE - CHUNK_FOOTER_SIZE) };
 
         // Check `CURSOR_MIN_ALIGN` is accurate. This check will be const-folded out.
         assert!(


### PR DESCRIPTION
Add a method `new_fixed_size` to `Arena` and `Allocator`. This moves logic for creating fixed-size allocators out of `FixedSizeAllocatorPool` and into core `Arena` implementation.

This is starting point for making fixed-size allocators safer, managing their own memory, and having platform-specific behavior for creation and drop (moving towards fixing the Windows OOM bug in Oxlint and `napi/parser` raw transfer).