### PR TITLE
refactor(allocator): fixed size allocators handle their own deallocation

### DIFF
--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -435,6 +435,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
                 layout,
                 previous_chunk_footer_ptr: Cell::new(previous_chunk_footer_ptr),
                 cursor_ptr: Cell::new(cursor_ptr),
+                is_fixed_size: false,
             });
         }
 

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -1,6 +1,9 @@
 //! `Drop` implementation for `Arena`, and `reset` method.
 
-use std::{alloc, ptr::NonNull};
+use std::{
+    alloc::{self, GlobalAlloc, System},
+    ptr::NonNull,
+};
 
 use super::{Arena, ChunkFooter, utils::is_pointer_aligned_to};
 
@@ -89,7 +92,6 @@ impl<const MIN_ALIGN: usize> Drop for Arena<MIN_ALIGN> {
 /// Deallocate all chunks in linked list, starting with the chunk whose footer is pointed to by `footer_ptr`.
 ///
 /// # SAFETY
-///
 /// `footer_ptr` must point to a valid `ChunkFooter`.
 #[inline]
 unsafe fn dealloc_chunk_list(footer_ptr: Option<NonNull<ChunkFooter>>) {
@@ -98,15 +100,36 @@ unsafe fn dealloc_chunk_list(footer_ptr: Option<NonNull<ChunkFooter>>) {
     while let Some(footer_ptr) = next_footer_ptr {
         // Create `&ChunkFooter` reference to within a block, to ensure the reference is not live
         // when we deallocate the chunk's memory (which includes the `ChunkFooter`)
-        let (backing_alloc_ptr, layout) = {
+        {
             // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
-            let footer = unsafe { footer_ptr.as_ref() };
-            next_footer_ptr = footer.previous_chunk_footer_ptr.get();
-            (footer.backing_alloc_ptr, footer.layout)
-        };
+            next_footer_ptr = unsafe { footer_ptr.as_ref() }.previous_chunk_footer_ptr.get();
+        }
 
-        // SAFETY: Each `ChunkFooter`'s `start_ptr` and `layout` describe its backing allocation,
-        // which was allocated from the global allocator
-        unsafe { alloc::dealloc(backing_alloc_ptr.as_ptr(), layout) };
+        // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
+        unsafe { dealloc_arena_chunk(footer_ptr) };
+    }
+}
+
+/// Deallocate the chunk whose footer is pointed to by `footer_ptr`.
+///
+/// # SAFETY
+/// `footer_ptr` must point to a valid `ChunkFooter`.
+pub unsafe fn dealloc_arena_chunk(footer_ptr: NonNull<ChunkFooter>) {
+    // Create `&ChunkFooter` reference to within a block, to ensure the reference is not live
+    // when we deallocate the chunk's memory (which includes the `ChunkFooter`)
+    let (backing_alloc_ptr, layout, is_fixed_size) = {
+        // SAFETY: Caller guarantees that `footer_ptr` points to a valid `ChunkFooter`
+        let footer = unsafe { footer_ptr.as_ref() };
+        (footer.backing_alloc_ptr.as_ptr(), footer.layout, footer.is_fixed_size)
+    };
+
+    if is_fixed_size {
+        // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
+        // `is_fixed_size` is `true`, so backing allocation was made via `System` allocator.
+        unsafe { System.dealloc(backing_alloc_ptr, layout) };
+    } else {
+        // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
+        // `is_fixed_size` is `false`, so backing allocation was made via global allocator.
+        unsafe { alloc::dealloc(backing_alloc_ptr, layout) };
     }
 }

--- a/crates/oxc_allocator/src/arena/fixed_size.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size.rs
@@ -56,21 +56,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// and presumably it's pointless to try to obtain such large allocations from a thread-local heap,
     /// so better to go direct to the system allocator anyway.
     ///
-    /// The backing allocation is freed via the global allocator (NOT [`System`]) when the [`Arena`] is dropped.
-    /// Because the allocation here is made via [`System`], the returned [`Arena`] MUST NOT be dropped,
-    /// or [`dealloc`] will try to free the allocation via the wrong allocator.
-    ///
     /// Returns `None` if the allocation fails.
-    ///
-    /// # SAFETY
-    ///
-    /// The returned [`Arena`] must not be dropped.
-    /// Caller must wrap it in [`ManuallyDrop`] and free the backing allocation manually via [`System::dealloc`],
-    /// using the [`Layout`] stored in the [`Arena`]'s `ChunkFooter`.
-    ///
-    /// [`dealloc`]: std::alloc::dealloc
-    /// [`ManuallyDrop`]: std::mem::ManuallyDrop
-    pub unsafe fn new_fixed_size() -> Option<Self> {
+    pub fn new_fixed_size() -> Option<Self> {
         // Allocate block of memory.
         // SAFETY: `ALLOC_LAYOUT` does not have zero size.
         let alloc_ptr = unsafe { System.alloc(ALLOC_LAYOUT) };

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -19,7 +19,7 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// `backing_alloc_ptr` and `layout`.
     ///
     /// The [`Arena`] which is returned takes ownership of the backing allocation, and it will be freed
-    /// via the global allocator (using `backing_alloc_ptr` and `layout`) when the `Arena` is dropped.
+    /// via the [`System`] allocator (using `backing_alloc_ptr` and `layout`) when the `Arena` is dropped.
     /// If caller wishes to prevent that happening, they must wrap the `Arena` in `ManuallyDrop`.
     ///
     /// The [`Arena`] returned by this function cannot grow.
@@ -33,9 +33,11 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     ///   the allocation described by `backing_alloc_ptr` and `layout`
     ///   (i.e. `start_ptr >= backing_alloc_ptr` and `start_ptr + size <= backing_alloc_ptr + layout.size()`).
     /// * The allocation described by `backing_alloc_ptr` and `layout` must have been allocated from
-    ///   the global allocator with that same `layout` (or caller must wrap the `Arena` in `ManuallyDrop`
+    ///   the [`System`] allocator with that same `layout` (or caller must wrap the `Arena` in `ManuallyDrop`
     ///   and ensure the backing memory is freed correctly themselves).
     /// * `start_ptr` and `backing_alloc_ptr` must have permission for writes.
+    ///
+    /// [`System`]: std::alloc::System
     pub unsafe fn from_raw_parts(
         start_ptr: NonNull<u8>,
         size: usize,
@@ -62,14 +64,20 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // * `start_ptr` is the start of a region of `size` bytes within the backing allocation.
         // * `size` is `>= CHUNK_FOOTER_SIZE` - so `size - CHUNK_FOOTER_SIZE` cannot wrap around.
         let chunk_footer_ptr = unsafe { start_ptr.add(size_without_footer) }.cast::<ChunkFooter>();
+
         // Initial cursor sits at the footer, which is the end of the allocatable region.
         // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
+        //
+        // Set `is_fixed_size` to `true` so `Drop` impl for `Arena` will free the backing memory via `System` allocator.
+        // `Arena::reset` only resets the cursor pointer, and doesn't deallocate the chunk,
+        // so `is_fixed_size` will remain permanently `true` for this `Arena`, even across `reset` calls.
         let cursor_ptr = chunk_footer_ptr.cast::<u8>();
         let chunk_footer = ChunkFooter {
             backing_alloc_ptr,
             layout,
             previous_chunk_footer_ptr: Cell::new(None),
             cursor_ptr: Cell::new(cursor_ptr),
+            is_fixed_size: true,
         };
         // SAFETY: If caller has upheld safety requirements, `chunk_footer_ptr` is `CHUNK_FOOTER_SIZE` bytes
         // from the end of the chunk region, and aligned on `CHUNK_ALIGN`.

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -22,6 +22,8 @@ mod utils;
 #[cfg(feature = "testing")]
 pub use bumpalo_alloc::AllocErr;
 use create::DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER;
+#[cfg(feature = "fixed_size")]
+pub(crate) use drop::dealloc_arena_chunk;
 
 #[cfg(all(feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
 mod fixed_size;
@@ -272,7 +274,8 @@ unsafe impl<const MIN_ALIGN: usize> Send for Arena<MIN_ALIGN> {}
 pub(crate) struct ChunkFooter {
     /// Pointer to the start of the allocation backing this chunk.
     ///
-    /// This pointer is passed to `alloc::dealloc` when deallocating the chunk.
+    /// This pointer is passed to `alloc::dealloc` (or `System.dealloc` if `is_fixed_size` is `true`)
+    /// when deallocating the chunk.
     backing_alloc_ptr: NonNull<u8>,
 
     /// The layout of this chunk's backing allocation.
@@ -288,18 +291,16 @@ pub(crate) struct ChunkFooter {
     /// Allocation methods use `Arena::cursor_ptr` instead, which is the authoritative pointer for current chunk.
     /// This field is only used in `ChunkIter` and `ChunkRawIter` iterators, and `used_bytes` method.
     cursor_ptr: Cell<NonNull<u8>>,
-}
 
-#[cfg(feature = "fixed_size")]
-impl ChunkFooter {
-    /// Get the backing allocation pointer and layout for this chunk.
+    /// `true` if backing allocation was made via [`System`] allocator (rather than the global allocator).
     ///
-    /// Together these identify the underlying allocation owned by the chunk.
-    /// Used by callers which manage their own deallocation (e.g. `FixedSizeAllocator`).
-    #[inline]
-    pub(crate) fn backing_alloc_info(&self) -> (NonNull<u8>, Layout) {
-        (self.backing_alloc_ptr, self.layout)
-    }
+    /// `Arena`'s [`Drop`] impl uses this to know whether to free the backing allocation via [`System`]
+    /// or the global allocator.
+    ///
+    /// Set to `true` for chunks created via [`Arena::from_raw_parts`], `false` otherwise.
+    ///
+    /// [`System`]: std::alloc::System
+    is_fixed_size: bool,
 }
 
 /// We only support alignments of up to 16 bytes for `iter_allocated_chunks`.

--- a/crates/oxc_allocator/src/fixed_size.rs
+++ b/crates/oxc_allocator/src/fixed_size.rs
@@ -13,26 +13,11 @@ impl Allocator {
     /// and presumably it's pointless to try to obtain such large allocations from a thread-local heap,
     /// so better to go direct to the system allocator anyway.
     ///
-    /// The backing allocation is freed via the global allocator (NOT [`System`]) when the [`Allocator`]
-    /// is dropped. Because the allocation here is made via [`System`], the returned [`Allocator`]
-    /// MUST NOT be dropped, or [`dealloc`] will try to free the allocation via the wrong allocator.
-    ///
     /// Returns `None` if the allocation fails.
     ///
-    /// # SAFETY
-    ///
-    /// The returned [`Allocator`] must not be dropped.
-    /// Caller must wrap it in [`ManuallyDrop`] and free the backing allocation manually via [`System::dealloc`],
-    /// using the [`Layout`] stored in the inner `Arena`'s `ChunkFooter`.
-    ///
     /// [`System`]: std::alloc::System
-    /// [`dealloc`]: std::alloc::dealloc
-    /// [`System::dealloc`]: std::alloc::GlobalAlloc::dealloc
-    /// [`Layout`]: std::alloc::Layout
-    /// [`ManuallyDrop`]: std::mem::ManuallyDrop
-    pub unsafe fn new_fixed_size() -> Option<Self> {
-        // SAFETY: Safety requirements of `Arena::new_fixed_size` are the same as for this method.
-        let arena = unsafe { Arena::new_fixed_size() }?;
+    pub fn new_fixed_size() -> Option<Self> {
+        let arena = Arena::new_fixed_size()?;
         Some(Self::from_arena(arena))
     }
 }

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -1,5 +1,4 @@
 use std::{
-    alloc::{GlobalAlloc, System},
     mem::{self, ManuallyDrop},
     ptr::NonNull,
     sync::{
@@ -16,7 +15,7 @@ use oxc_data_structures::stack::Stack;
 
 use crate::{
     Allocator,
-    arena::{CHUNK_FOOTER_SIZE, ChunkFooter},
+    arena::{CHUNK_FOOTER_SIZE, ChunkFooter, dealloc_arena_chunk},
     generated::fixed_size_constants::{
         ACTIVE_SIZE, BLOCK_SIZE, BUFFER_SIZE, CURSOR_MIN_ALIGN, RAW_METADATA_ALIGN,
         RAW_METADATA_SIZE,
@@ -376,9 +375,9 @@ impl FixedSizeAllocator {
         }
 
         // Allocate the backing memory and create the `Allocator`.
-        // SAFETY: `Allocator` is wrapped in `ManuallyDrop` immediately, and `FixedSizeAllocator`'s
-        // `Drop` impl frees the backing allocation via `System.dealloc` (in `free_fixed_size_allocator`).
-        let allocator = unsafe { Allocator::new_fixed_size() }.ok_or(())?;
+        // Wrap `Allocator` in `ManuallyDrop` so that we can control whether it's dropped in `FixedSizeAllocator`'s
+        // `Drop` impl, depending on whether the buffer is currently shared with JS.
+        let allocator = Allocator::new_fixed_size().ok_or(())?;
         let allocator = ManuallyDrop::new(allocator);
 
         // Pointer to the start of the chunk. `data_end_ptr` is the start of the `ChunkFooter`,
@@ -469,18 +468,12 @@ impl Drop for FixedSizeAllocator {
 ///
 /// `metadata_ptr` must point to a valid `FixedSizeAllocatorMetadata` belonging to a `FixedSizeAllocator`.
 /// The `FixedSizeAllocator`'s `ChunkFooter`, which sits immediately after the `FixedSizeAllocatorMetadata`,
-/// must contain a `backing_alloc_ptr` and `layout` describing a backing allocation made via [`System::alloc`].
+/// must contain a `backing_alloc_ptr`, `layout`, and `is_fixed_size` describing the chunk's backing allocation.
 pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocatorMetadata>) {
-    // The `ChunkFooter` sits immediately after `FixedSizeAllocatorMetadata` in memory.
-    // SAFETY: Caller guarantees `metadata_ptr` points to a `FixedSizeAllocatorMetadata` belonging to
-    // a `FixedSizeAllocator`, so the `ChunkFooter` is at a fixed offset after it within the same allocation.
-    let chunk_footer_ptr =
-        unsafe { metadata_ptr.byte_add(FIXED_METADATA_SIZE).cast::<ChunkFooter>() };
-
     // Read `is_double_owned` flag in a block, so the `&FixedSizeAllocatorMetadata` reference is not live
     // during the deallocation below (the `FixedSizeAllocatorMetadata` lives in the memory we're about to free).
     {
-        // SAFETY: Caller guarantees `metadata_ptr` points to a valid `FixedSizeAllocatorMetadata`.
+        // SAFETY: Caller guarantees `metadata_ptr` points to a valid `FixedSizeAllocatorMetadata`
         let metadata = unsafe { metadata_ptr.as_ref() };
 
         // * If `is_double_owned` is already `false`, then one of:
@@ -502,19 +495,13 @@ pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocator
         }
     }
 
-    // Read backing allocation info from the `ChunkFooter`.
-    // Read in a block so the `&ChunkFooter` reference is not live during the deallocation below
-    // (the `ChunkFooter` lives in the memory we're about to free).
-    let (backing_alloc_ptr, layout) = {
-        // SAFETY: `chunk_footer_ptr` points to a valid `ChunkFooter` (caller guarantees the `FixedSizeAllocator`
-        // was created in the standard layout, with the `ChunkFooter` at this offset)
-        let footer = unsafe { chunk_footer_ptr.as_ref() };
-        footer.backing_alloc_info()
-    };
-
-    // Deallocate the memory backing the `FixedSizeAllocator`.
-    // SAFETY: Caller guarantees the backing allocation was made via `System` allocator with `layout`.
-    unsafe { System.dealloc(backing_alloc_ptr.as_ptr(), layout) }
+    // The `ChunkFooter` sits immediately after `FixedSizeAllocatorMetadata` in memory.
+    // SAFETY: Caller guarantees `metadata_ptr` points to a `FixedSizeAllocatorMetadata` belonging to
+    // a `FixedSizeAllocator`, so a valid `ChunkFooter` is at a fixed offset after it within the same allocation.
+    unsafe {
+        let footer_ptr = metadata_ptr.byte_add(FIXED_METADATA_SIZE).cast::<ChunkFooter>();
+        dealloc_arena_chunk(footer_ptr);
+    }
 }
 
 impl Allocator {


### PR DESCRIPTION
`Arena`'s chunks already store the pointer and layout of their backing allocations in their `ChunkFooter`s.

However, it still wasn't safe for them to handle `Drop` themselves, because fixed-size `Arena`s obtain backing memory direct from the `System` allocator, bypassing the usual global allocator (which can be switched to e.g. Mimalloc). Therefore, special handling was required to ensure the backing memory was also freed via `System` allocator - unlike normal `Arena`s.

Fix that by storing an `is_fixed_size` flag in `ChunkFooter`. This flag is set in `Arena`s created by `Arena::from_raw_parts` (and so, by extension, by `Arena::new_fixed_size`). When `is_fixed_size` flag is set on a chunk, the `Arena` correctly frees the chunk's backing memory via `System` allocator. When it's not set (normal `Arena`s), global allocator is used as usual.

`Arena`s created with `from_raw_parts` / `new_fixed_size` can now manage the entire lifecycle of the memory they own. `Arena::new_fixed_size` therefore doesn't need to be an unsafe method any more.

All deallocation now goes through `dealloc_arena_chunk` which `Arena` provides, which correctly checks the `is_fixed_size `flag to determine which allocator to return the backing memory to.