### PR TITLE
refactor(allocator): remove `can_grow` field from `Arena`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -329,11 +329,13 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Called when there isn't enough room in our current chunk, so need to allocate a new chunk.
     fn try_alloc_layout_slow_impl(&self, layout: Layout) -> Option<NonNull<u8>> {
         unsafe {
-            if !self.can_grow {
+            let current_footer_ptr = self.current_chunk_footer_ptr.get();
+
+            // Fixed-size arenas (e.g. those created via `Arena::from_raw_parts`) cannot grow.
+            // SAFETY: If `current_footer_ptr` is `Some`, it points to a valid `ChunkFooter`.
+            if current_footer_ptr.is_some_and(|footer_ptr| footer_ptr.as_ref().is_fixed_size) {
                 return None;
             }
-
-            let current_footer_ptr = self.current_chunk_footer_ptr.get();
 
             // Get a new chunk from the global allocator.
             // By default, we want our new chunk to be about twice as big as the previous chunk.

--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -308,7 +308,6 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             cursor_ptr: Cell::new(cursor_ptr),
             current_chunk_footer_ptr: Cell::new(chunk_footer_ptr),
             start_ptr: Cell::new(start_ptr),
-            can_grow: true,
             #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
             stats: AllocationStats::default(),
         }

--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -69,6 +69,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // The footer is aligned on `CHUNK_ALIGN`, which is `>= MIN_ALIGN`, so this is already aligned to `MIN_ALIGN`.
         //
         // Set `is_fixed_size` to `true` so `Drop` impl for `Arena` will free the backing memory via `System` allocator.
+        // `is_fixed_size: true` also prevents the `Arena` from ever getting any further chunks
+        // (enforced in allocation slow path `try_alloc_layout_slow_impl`).
         // `Arena::reset` only resets the cursor pointer, and doesn't deallocate the chunk,
         // so `is_fixed_size` will remain permanently `true` for this `Arena`, even across `reset` calls.
         let cursor_ptr = chunk_footer_ptr.cast::<u8>();
@@ -84,12 +86,8 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // Therefore `chunk_footer_ptr` is valid for writing a `ChunkFooter`.
         unsafe { chunk_footer_ptr.write(chunk_footer) };
 
-        // Create `Arena` and set `can_grow` to `false`. This means that the memory chunk we've just created
-        // will remain its only chunk. Therefore it can never be deallocated, until the `Arena` is dropped.
-        // `Arena::reset` would only reset the "cursor" pointer, not deallocate the memory.
-        let mut arena = Self::new_impl(start_ptr, cursor_ptr, Some(chunk_footer_ptr));
-        arena.can_grow = false;
-        arena
+        // Create `Arena`
+        Self::new_impl(start_ptr, cursor_ptr, Some(chunk_footer_ptr))
     }
 
     /// Get the current cursor pointer for this [`Arena`]'s current chunk.

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -170,6 +170,10 @@ mod tests_alloc;
 // `current_chunk_footer_ptr` is placed between the two hot pointers so they sit at offsets 0 and 16,
 // forcing LLVM to emit two independent 8-byte `ldr`s, each of which forwards cleanly.
 // More background here: https://eme64.github.io/blog/2024/06/24/Auto-Vectorization-and-Store-to-Load-Forwarding.html
+#[cfg_attr(
+    not(all(feature = "track_allocations", not(feature = "disable_track_allocations"))),
+    expect(clippy::struct_field_names)
+)]
 #[repr(C)]
 #[derive(Debug)]
 pub struct Arena<const MIN_ALIGN: usize = 1> {
@@ -201,9 +205,6 @@ pub struct Arena<const MIN_ALIGN: usize = 1> {
     ///
     /// This field is duplicated in `ChunkFooter`.
     start_ptr: Cell<NonNull<u8>>,
-
-    /// Whether this `Arena` is allowed to allocate additional chunks when the current one is full.
-    can_grow: bool,
 
     /// Used to track number of allocations made in this `Arena` when `track_allocations` feature is enabled.
     #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]

--- a/crates/oxc_allocator/src/arena/tests_alloc.rs
+++ b/crates/oxc_allocator/src/arena/tests_alloc.rs
@@ -46,7 +46,6 @@ impl<const MIN_ALIGN: usize> TestArena<MIN_ALIGN> {
             cursor_ptr: Cell::new(cursor_ptr),
             current_chunk_footer_ptr: Cell::new(Some(cursor_ptr.cast::<ChunkFooter>())),
             start_ptr: Cell::new(start_ptr),
-            can_grow: false,
             #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
             stats: crate::tracking::AllocationStats::default(),
         };


### PR DESCRIPTION
Remove `can_grow` flag from `Arena`. Instead refuse to grow the `Arena` with a new chunk if `ChunkFooter::is_fixed_size` (introduced in #22085) is `true`. This flag is set for fixed-size allocators, so it performs the same purpose as the old `can_grow` flag.