### PR TITLE
docs(allocator): correct doc comment for `Allocator::from_raw_parts`

### DIFF
--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -29,7 +29,7 @@ impl Allocator {
     /// `backing_alloc_ptr` and `layout`.
     ///
     /// The [`Allocator`] which is returned takes ownership of the backing allocation, and it will be freed
-    /// via the global allocator (using `backing_alloc_ptr` and `layout`) when the `Allocator` is dropped.
+    /// via the [`System`] allocator (using `backing_alloc_ptr` and `layout`) when the `Allocator` is dropped.
     /// If caller wishes to prevent that happening, they must wrap the `Allocator` in `ManuallyDrop`.
     ///
     /// The [`Allocator`] returned by this function cannot grow.
@@ -43,10 +43,11 @@ impl Allocator {
     ///   the allocation described by `backing_alloc_ptr` and `layout`
     ///   (i.e. `start_ptr >= backing_alloc_ptr` and `start_ptr + size <= backing_alloc_ptr + layout.size()`).
     /// * The allocation described by `backing_alloc_ptr` and `layout` must have been allocated from
-    ///   the global allocator with that same `layout` (or caller must wrap the `Allocator` in `ManuallyDrop`
+    ///   the [`System`] allocator with that same `layout` (or caller must wrap the `Allocator` in `ManuallyDrop`
     ///   and ensure the backing memory is freed correctly themselves).
     /// * `start_ptr` and `backing_alloc_ptr` must have permission for writes.
     ///
+    /// [`System`]: std::alloc::System
     /// [`RAW_MIN_ALIGN`]: Self::RAW_MIN_ALIGN
     /// [`RAW_MIN_SIZE`]: Self::RAW_MIN_SIZE
     pub unsafe fn from_raw_parts(


### PR DESCRIPTION
Comments-only change. #22085 altered the docs for `Arena::from_raw_parts` to reflect that arena chunk created by this method will be deallocated via `System` allocator by default, but neglected to update docs for `Allocator::from_raw_parts`. Update the doc comment for this method to bring it into sync.