### PR TITLE
feat(linter/eslint): implement `require-unicode-regexp` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1325,6 +1325,15 @@ impl RuleRunner for crate::rules::eslint::require_await::RequireAwait {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::require_unicode_regexp::RequireUnicodeRegexp {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::NewExpression,
+        AstType::RegExpLiteral,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::require_yield::RequireYield {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::Function]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -174,6 +174,7 @@ pub use crate::rules::eslint::prefer_template::PreferTemplate as EslintPreferTem
 pub use crate::rules::eslint::preserve_caught_error::PreserveCaughtError as EslintPreserveCaughtError;
 pub use crate::rules::eslint::radix::Radix as EslintRadix;
 pub use crate::rules::eslint::require_await::RequireAwait as EslintRequireAwait;
+pub use crate::rules::eslint::require_unicode_regexp::RequireUnicodeRegexp as EslintRequireUnicodeRegexp;
 pub use crate::rules::eslint::require_yield::RequireYield as EslintRequireYield;
 pub use crate::rules::eslint::sort_imports::SortImports as EslintSortImports;
 pub use crate::rules::eslint::sort_keys::SortKeys as EslintSortKeys;
@@ -997,6 +998,7 @@ pub enum RuleEnum {
     EslintPreserveCaughtError(EslintPreserveCaughtError),
     EslintRadix(EslintRadix),
     EslintRequireAwait(EslintRequireAwait),
+    EslintRequireUnicodeRegexp(EslintRequireUnicodeRegexp),
     EslintRequireYield(EslintRequireYield),
     EslintSortImports(EslintSortImports),
     EslintSortKeys(EslintSortKeys),
@@ -1784,7 +1786,8 @@ const ESLINT_PREFER_TEMPLATE_ID: usize = ESLINT_PREFER_SPREAD_ID + 1usize;
 const ESLINT_PRESERVE_CAUGHT_ERROR_ID: usize = ESLINT_PREFER_TEMPLATE_ID + 1usize;
 const ESLINT_RADIX_ID: usize = ESLINT_PRESERVE_CAUGHT_ERROR_ID + 1usize;
 const ESLINT_REQUIRE_AWAIT_ID: usize = ESLINT_RADIX_ID + 1usize;
-const ESLINT_REQUIRE_YIELD_ID: usize = ESLINT_REQUIRE_AWAIT_ID + 1usize;
+const ESLINT_REQUIRE_UNICODE_REGEXP_ID: usize = ESLINT_REQUIRE_AWAIT_ID + 1usize;
+const ESLINT_REQUIRE_YIELD_ID: usize = ESLINT_REQUIRE_UNICODE_REGEXP_ID + 1usize;
 const ESLINT_SORT_IMPORTS_ID: usize = ESLINT_REQUIRE_YIELD_ID + 1usize;
 const ESLINT_SORT_KEYS_ID: usize = ESLINT_SORT_IMPORTS_ID + 1usize;
 const ESLINT_SORT_VARS_ID: usize = ESLINT_SORT_KEYS_ID + 1usize;
@@ -2668,6 +2671,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => ESLINT_PRESERVE_CAUGHT_ERROR_ID,
             Self::EslintRadix(_) => ESLINT_RADIX_ID,
             Self::EslintRequireAwait(_) => ESLINT_REQUIRE_AWAIT_ID,
+            Self::EslintRequireUnicodeRegexp(_) => ESLINT_REQUIRE_UNICODE_REGEXP_ID,
             Self::EslintRequireYield(_) => ESLINT_REQUIRE_YIELD_ID,
             Self::EslintSortImports(_) => ESLINT_SORT_IMPORTS_ID,
             Self::EslintSortKeys(_) => ESLINT_SORT_KEYS_ID,
@@ -3572,6 +3576,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => EslintPreserveCaughtError::NAME,
             Self::EslintRadix(_) => EslintRadix::NAME,
             Self::EslintRequireAwait(_) => EslintRequireAwait::NAME,
+            Self::EslintRequireUnicodeRegexp(_) => EslintRequireUnicodeRegexp::NAME,
             Self::EslintRequireYield(_) => EslintRequireYield::NAME,
             Self::EslintSortImports(_) => EslintSortImports::NAME,
             Self::EslintSortKeys(_) => EslintSortKeys::NAME,
@@ -4468,6 +4473,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => EslintPreserveCaughtError::CATEGORY,
             Self::EslintRadix(_) => EslintRadix::CATEGORY,
             Self::EslintRequireAwait(_) => EslintRequireAwait::CATEGORY,
+            Self::EslintRequireUnicodeRegexp(_) => EslintRequireUnicodeRegexp::CATEGORY,
             Self::EslintRequireYield(_) => EslintRequireYield::CATEGORY,
             Self::EslintSortImports(_) => EslintSortImports::CATEGORY,
             Self::EslintSortKeys(_) => EslintSortKeys::CATEGORY,
@@ -5409,6 +5415,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => EslintPreserveCaughtError::FIX,
             Self::EslintRadix(_) => EslintRadix::FIX,
             Self::EslintRequireAwait(_) => EslintRequireAwait::FIX,
+            Self::EslintRequireUnicodeRegexp(_) => EslintRequireUnicodeRegexp::FIX,
             Self::EslintRequireYield(_) => EslintRequireYield::FIX,
             Self::EslintSortImports(_) => EslintSortImports::FIX,
             Self::EslintSortKeys(_) => EslintSortKeys::FIX,
@@ -6332,6 +6339,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => EslintPreserveCaughtError::documentation(),
             Self::EslintRadix(_) => EslintRadix::documentation(),
             Self::EslintRequireAwait(_) => EslintRequireAwait::documentation(),
+            Self::EslintRequireUnicodeRegexp(_) => EslintRequireUnicodeRegexp::documentation(),
             Self::EslintRequireYield(_) => EslintRequireYield::documentation(),
             Self::EslintSortImports(_) => EslintSortImports::documentation(),
             Self::EslintSortKeys(_) => EslintSortKeys::documentation(),
@@ -7737,6 +7745,10 @@ impl RuleEnum {
             }
             Self::EslintRequireAwait(_) => EslintRequireAwait::config_schema(generator)
                 .or_else(|| EslintRequireAwait::schema(generator)),
+            Self::EslintRequireUnicodeRegexp(_) => {
+                EslintRequireUnicodeRegexp::config_schema(generator)
+                    .or_else(|| EslintRequireUnicodeRegexp::schema(generator))
+            }
             Self::EslintRequireYield(_) => EslintRequireYield::config_schema(generator)
                 .or_else(|| EslintRequireYield::schema(generator)),
             Self::EslintSortImports(_) => EslintSortImports::config_schema(generator)
@@ -9672,6 +9684,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => "eslint",
             Self::EslintRadix(_) => "eslint",
             Self::EslintRequireAwait(_) => "eslint",
+            Self::EslintRequireUnicodeRegexp(_) => "eslint",
             Self::EslintRequireYield(_) => "eslint",
             Self::EslintSortImports(_) => "eslint",
             Self::EslintSortKeys(_) => "eslint",
@@ -10855,6 +10868,9 @@ impl RuleEnum {
             Self::EslintRequireAwait(_) => {
                 Ok(Self::EslintRequireAwait(EslintRequireAwait::from_configuration(value)?))
             }
+            Self::EslintRequireUnicodeRegexp(_) => Ok(Self::EslintRequireUnicodeRegexp(
+                EslintRequireUnicodeRegexp::from_configuration(value)?,
+            )),
             Self::EslintRequireYield(_) => {
                 Ok(Self::EslintRequireYield(EslintRequireYield::from_configuration(value)?))
             }
@@ -12981,6 +12997,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(rule) => rule.to_configuration(),
             Self::EslintRadix(rule) => rule.to_configuration(),
             Self::EslintRequireAwait(rule) => rule.to_configuration(),
+            Self::EslintRequireUnicodeRegexp(rule) => rule.to_configuration(),
             Self::EslintRequireYield(rule) => rule.to_configuration(),
             Self::EslintSortImports(rule) => rule.to_configuration(),
             Self::EslintSortKeys(rule) => rule.to_configuration(),
@@ -13771,6 +13788,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(rule) => rule.run(node, ctx),
             Self::EslintRadix(rule) => rule.run(node, ctx),
             Self::EslintRequireAwait(rule) => rule.run(node, ctx),
+            Self::EslintRequireUnicodeRegexp(rule) => rule.run(node, ctx),
             Self::EslintRequireYield(rule) => rule.run(node, ctx),
             Self::EslintSortImports(rule) => rule.run(node, ctx),
             Self::EslintSortKeys(rule) => rule.run(node, ctx),
@@ -14557,6 +14575,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(rule) => rule.run_once(ctx),
             Self::EslintRadix(rule) => rule.run_once(ctx),
             Self::EslintRequireAwait(rule) => rule.run_once(ctx),
+            Self::EslintRequireUnicodeRegexp(rule) => rule.run_once(ctx),
             Self::EslintRequireYield(rule) => rule.run_once(ctx),
             Self::EslintSortImports(rule) => rule.run_once(ctx),
             Self::EslintSortKeys(rule) => rule.run_once(ctx),
@@ -15347,6 +15366,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintRadix(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintRequireAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintRequireUnicodeRegexp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintRequireYield(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintSortImports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintSortKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16237,6 +16257,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(rule) => rule.should_run(ctx),
             Self::EslintRadix(rule) => rule.should_run(ctx),
             Self::EslintRequireAwait(rule) => rule.should_run(ctx),
+            Self::EslintRequireUnicodeRegexp(rule) => rule.should_run(ctx),
             Self::EslintRequireYield(rule) => rule.should_run(ctx),
             Self::EslintSortImports(rule) => rule.should_run(ctx),
             Self::EslintSortKeys(rule) => rule.should_run(ctx),
@@ -17055,6 +17076,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => EslintPreserveCaughtError::IS_TSGOLINT_RULE,
             Self::EslintRadix(_) => EslintRadix::IS_TSGOLINT_RULE,
             Self::EslintRequireAwait(_) => EslintRequireAwait::IS_TSGOLINT_RULE,
+            Self::EslintRequireUnicodeRegexp(_) => EslintRequireUnicodeRegexp::IS_TSGOLINT_RULE,
             Self::EslintRequireYield(_) => EslintRequireYield::IS_TSGOLINT_RULE,
             Self::EslintSortImports(_) => EslintSortImports::IS_TSGOLINT_RULE,
             Self::EslintSortKeys(_) => EslintSortKeys::IS_TSGOLINT_RULE,
@@ -18159,6 +18181,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => EslintPreserveCaughtError::VERSION,
             Self::EslintRadix(_) => EslintRadix::VERSION,
             Self::EslintRequireAwait(_) => EslintRequireAwait::VERSION,
+            Self::EslintRequireUnicodeRegexp(_) => EslintRequireUnicodeRegexp::VERSION,
             Self::EslintRequireYield(_) => EslintRequireYield::VERSION,
             Self::EslintSortImports(_) => EslintSortImports::VERSION,
             Self::EslintSortKeys(_) => EslintSortKeys::VERSION,
@@ -19112,6 +19135,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(_) => EslintPreserveCaughtError::HAS_CONFIG,
             Self::EslintRadix(_) => EslintRadix::HAS_CONFIG,
             Self::EslintRequireAwait(_) => EslintRequireAwait::HAS_CONFIG,
+            Self::EslintRequireUnicodeRegexp(_) => EslintRequireUnicodeRegexp::HAS_CONFIG,
             Self::EslintRequireYield(_) => EslintRequireYield::HAS_CONFIG,
             Self::EslintSortImports(_) => EslintSortImports::HAS_CONFIG,
             Self::EslintSortKeys(_) => EslintSortKeys::HAS_CONFIG,
@@ -20080,6 +20104,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(rule) => rule.types_info(),
             Self::EslintRadix(rule) => rule.types_info(),
             Self::EslintRequireAwait(rule) => rule.types_info(),
+            Self::EslintRequireUnicodeRegexp(rule) => rule.types_info(),
             Self::EslintRequireYield(rule) => rule.types_info(),
             Self::EslintSortImports(rule) => rule.types_info(),
             Self::EslintSortKeys(rule) => rule.types_info(),
@@ -20866,6 +20891,7 @@ impl RuleEnum {
             Self::EslintPreserveCaughtError(rule) => rule.run_info(),
             Self::EslintRadix(rule) => rule.run_info(),
             Self::EslintRequireAwait(rule) => rule.run_info(),
+            Self::EslintRequireUnicodeRegexp(rule) => rule.run_info(),
             Self::EslintRequireYield(rule) => rule.run_info(),
             Self::EslintSortImports(rule) => rule.run_info(),
             Self::EslintSortKeys(rule) => rule.run_info(),
@@ -21674,6 +21700,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintPreserveCaughtError(EslintPreserveCaughtError::default()),
         RuleEnum::EslintRadix(EslintRadix::default()),
         RuleEnum::EslintRequireAwait(EslintRequireAwait::default()),
+        RuleEnum::EslintRequireUnicodeRegexp(EslintRequireUnicodeRegexp::default()),
         RuleEnum::EslintRequireYield(EslintRequireYield::default()),
         RuleEnum::EslintSortImports(EslintSortImports::default()),
         RuleEnum::EslintSortKeys(EslintSortKeys::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -206,6 +206,7 @@ pub(crate) mod eslint {
     pub mod preserve_caught_error;
     pub mod radix;
     pub mod require_await;
+    pub mod require_unicode_regexp;
     pub mod require_yield;
     pub mod sort_imports;
     pub mod sort_keys;

--- a/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
@@ -148,7 +148,7 @@ declare_oxc_lint!(
     /// ```
     RequireUnicodeRegexp,
     eslint,
-    nursery,
+    pedantic,
     pending,
     config = RequireUnicodeRegexp,
     version = "next",

--- a/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
@@ -139,7 +139,7 @@ declare_oxc_lint!(
     /// const e = /aaa/v
     /// const f = /bbb/giv
     /// const g = new RegExp("ccc", "v")
-    /// const h = new RegExp("ddd", "giv")
+    /// const h = new RegExp("ddd", "gv")
     ///
     /// // This rule ignores RegExp calls if the flags could not be evaluated to a static value.
     /// function i(flags) {
@@ -162,7 +162,7 @@ impl Rule for RequireUnicodeRegexp {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::RegExpLiteral(regexp_lit) => {
-                let flags = &regexp_lit.regex.flags;
+                let flags = regexp_lit.regex.flags;
 
                 let is_missing_flag = self.check_flags(flags);
 
@@ -175,7 +175,7 @@ impl Rule for RequireUnicodeRegexp {
             }
             AstKind::NewExpression(new_expr) if is_regexp_callee(&new_expr.callee, ctx) => {
                 if let Some(flags) = extract_regex_flags(&new_expr.arguments, ctx)
-                    && self.check_flags(&flags)
+                    && self.check_flags(flags)
                 {
                     ctx.diagnostic(require_unicode_regexp_diagnostic(
                         node.span(),
@@ -185,7 +185,7 @@ impl Rule for RequireUnicodeRegexp {
             }
             AstKind::CallExpression(call_expr) if is_regexp_callee(&call_expr.callee, ctx) => {
                 if let Some(flags) = extract_regex_flags(&call_expr.arguments, ctx)
-                    && self.check_flags(&flags)
+                    && self.check_flags(flags)
                 {
                     ctx.diagnostic(require_unicode_regexp_diagnostic(
                         node.span(),
@@ -199,7 +199,7 @@ impl Rule for RequireUnicodeRegexp {
 }
 
 impl RequireUnicodeRegexp {
-    fn check_flags(&self, flags: &RegExpFlags) -> bool {
+    fn check_flags(&self, flags: RegExpFlags) -> bool {
         match &self.0.require_flag {
             Some(flag) => {
                 let regexp_flag = match flag {
@@ -326,6 +326,11 @@ fn resolve_static_index(expr: &Expression) -> Option<usize> {
         Expression::NumericLiteral(lit)
             if lit.value.is_finite() && lit.value >= 0.0 && lit.value.fract() == 0.0 =>
         {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "value is checked to be finite non-negative and integral"
+            )]
             Some(lit.value as usize)
         }
         _ => None,

--- a/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
@@ -1,0 +1,430 @@
+use oxc_allocator::Vec;
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression, IdentifierReference, RegExpFlags, TemplateLiteral},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    ast_util::get_declaration_of_variable,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::is_regexp_callee,
+};
+
+fn require_unicode_regexp_diagnostic(
+    span: Span,
+    require_flag: Option<&RequireFlag>,
+) -> OxcDiagnostic {
+    let (msg, help_msg) = if matches!(require_flag, Some(RequireFlag::V)) {
+        ("Use the 'v' flag.", "Add the 'v' flag.")
+    } else {
+        ("Use the 'u' flag.", "Add the 'u' flag.")
+    };
+
+    OxcDiagnostic::warn(msg).with_help(help_msg).with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct RequireUnicodeRegexpConfig {
+    /// The `u` flag may be preferred in environments that do not support the `v` flag.
+    ///
+    /// Examples of **incorrect** code for this rule with the `{ "requireFlag": "u" }` option:
+    /// ```js
+    /// const fooEmpty = /foo/;
+    /// const fooEmptyRegexp = new RegExp('foo');
+    /// const foo = /foo/v;
+    /// const fooRegexp = new RegExp('foo', 'v');
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the `{ "requireFlag": "u" }` option:
+    /// ```js
+    /// const foo = /foo/u;
+    /// const fooRegexp = new RegExp('foo', 'u');
+    /// ```
+    ///
+    /// The `v` flag may be a better choice when it is supported because it has more features than the `u` flag (e.g., the ability to test Unicode properties of strings).
+    /// It does have a stricter syntax, however (e.g., the need to escape certain characters within character classes).
+    ///
+    /// Examples of **incorrect** code for this rule with the `{ "requireFlag": "v" }` option:
+    /// ```js
+    /// const fooEmpty = /foo/;
+    /// const fooEmptyRegexp = new RegExp('foo');
+    /// const foo = /foo/u;
+    /// const fooRegexp = new RegExp('foo', 'u');
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the `{ "requireFlag": "v" }` option:
+    /// ```js
+    /// const foo = /foo/v;
+    /// const fooRegexp = new RegExp('foo', 'v');
+    /// ```
+    require_flag: Option<RequireFlag>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+enum RequireFlag {
+    U,
+    V,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct RequireUnicodeRegexp(RequireUnicodeRegexpConfig);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce the use of `u` or `v` flag on regular expressions.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// RegExp `u` flag has two effects:
+    ///  1. Make the regular expression handling UTF-16 surrogate pairs correctly.
+    /// ```js
+    /// /^[👍]$/.test("👍") //→ false
+    /// /^[👍]$/u.test("👍") //→ true
+    /// ```
+    ///
+    /// 2. Make the regular expression throwing syntax errors early as disabling [Annex B extensions](https://262.ecma-international.org/6.0/#sec-regular-expressions-patterns).
+    /// Because of historical reason, JavaScript regular expressions are tolerant of syntax errors.
+    /// For example, `/\w{1, 2/` is a syntax error, but JavaScript doesn’t throw the error. It matches strings such as `"a{1, 2"` instead. Such a recovering logic is defined in Annex B.
+    ///
+    /// The RegExp `v` flag, introduced in ECMAScript 2024, is a superset of the `u` flag, and offers two more features:
+    /// 1. Unicode properties of strings
+    /// ```js
+    /// const re = /^\p{RGI_Emoji}$/v;
+    ///
+    /// // Match an emoji that consists of just 1 code point:
+    /// re.test('⚽'); // '\u26BD'
+    /// // → true ✅
+    ///
+    /// // Match an emoji that consists of multiple code points:
+    /// re.test('👨🏾‍⚕️'); // '\u{1F468}\u{1F3FE}\u200D\u2695\uFE0F'
+    /// // → true ✅
+    /// ```
+    ///
+    /// 2. Set notation
+    /// It allows for set operations between character classes:
+    /// ```js
+    /// const re = /[\p{White_Space}&&\p{ASCII}]/v;
+    /// re.test('\n'); // → true
+    /// re.test('\u2028'); // → false
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const a = /aaa/
+    /// const b = /bbb/gi
+    /// const c = new RegExp("ccc")
+    /// const d = new RegExp("ddd", "gi")
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const a = /aaa/u
+    /// const b = /bbb/giu
+    /// const c = new RegExp("ccc", "u")
+    /// const d = new RegExp("ddd", "giu")
+    ///
+    /// const e = /aaa/v
+    /// const f = /bbb/giv
+    /// const g = new RegExp("ccc", "v")
+    /// const h = new RegExp("ddd", "giv")
+    ///
+    /// // This rule ignores RegExp calls if the flags could not be evaluated to a static value.
+    /// function i(flags) {
+    ///     return new RegExp("eee", flags)
+    /// }
+    /// ```
+    RequireUnicodeRegexp,
+    eslint,
+    nursery,
+    pending,
+    config = RequireUnicodeRegexp,
+    version = "next",
+);
+
+impl Rule for RequireUnicodeRegexp {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::RegExpLiteral(regexp_lit) => {
+                let flags = &regexp_lit.regex.flags;
+
+                let is_missing_flag = self.check_flags(flags);
+
+                if is_missing_flag {
+                    ctx.diagnostic(require_unicode_regexp_diagnostic(
+                        node.span(),
+                        self.0.require_flag.as_ref(),
+                    ));
+                }
+            }
+            AstKind::NewExpression(new_expr) if is_regexp_callee(&new_expr.callee, ctx) => {
+                if let Some(flags) = extract_regex_flags(&new_expr.arguments, ctx)
+                    && self.check_flags(&flags)
+                {
+                    ctx.diagnostic(require_unicode_regexp_diagnostic(
+                        node.span(),
+                        self.0.require_flag.as_ref(),
+                    ));
+                }
+            }
+            AstKind::CallExpression(call_expr) if is_regexp_callee(&call_expr.callee, ctx) => {
+                if let Some(flags) = extract_regex_flags(&call_expr.arguments, ctx)
+                    && self.check_flags(&flags)
+                {
+                    ctx.diagnostic(require_unicode_regexp_diagnostic(
+                        node.span(),
+                        self.0.require_flag.as_ref(),
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl RequireUnicodeRegexp {
+    fn check_flags(&self, flags: &RegExpFlags) -> bool {
+        match &self.0.require_flag {
+            Some(flag) => {
+                let regexp_flag = match flag {
+                    RequireFlag::U => RegExpFlags::U,
+                    RequireFlag::V => RegExpFlags::V,
+                };
+
+                !flags.contains(regexp_flag)
+            }
+            None => !flags.contains(RegExpFlags::U) && !flags.contains(RegExpFlags::V),
+        }
+    }
+}
+
+fn extract_regex_flags<'a>(
+    args: &'a Vec<'a, Argument<'a>>,
+    ctx: &LintContext<'a>,
+) -> Option<RegExpFlags> {
+    if args.iter().any(oxc_ast::ast::Argument::is_spread) {
+        return None;
+    }
+    if args.len() <= 1 {
+        return Some(RegExpFlags::empty());
+    }
+
+    let flags_arg = args[1].as_expression()?.get_inner_expression();
+
+    resolve_flags(flags_arg, ctx, true)
+}
+
+fn parse_flags(flags_text: &str) -> RegExpFlags {
+    flags_text.chars().filter_map(|ch| RegExpFlags::try_from(ch).ok()).collect()
+}
+
+fn resolve_flags<'a>(
+    expr: &'a Expression<'a>,
+    ctx: &LintContext<'a>,
+    follow_identifier: bool,
+) -> Option<RegExpFlags> {
+    let expr = expr.get_inner_expression();
+    let expr = if follow_identifier && let Expression::Identifier(ident) = expr {
+        resolve_const_initializer(ident, ctx)?.get_inner_expression()
+    } else {
+        expr
+    };
+
+    match expr {
+        Expression::StringLiteral(lit) => Some(parse_flags(lit.value.as_str())),
+        Expression::TemplateLiteral(template) => resolve_template_flags(template, ctx),
+        Expression::BooleanLiteral(lit) => {
+            Some(if lit.value { RegExpFlags::U } else { RegExpFlags::empty() })
+        }
+        Expression::NullLiteral(_) => Some(RegExpFlags::U),
+        Expression::NumericLiteral(_) => Some(RegExpFlags::empty()),
+        Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
+            let left = resolve_flags(&binary.left, ctx, true)?;
+            let right = resolve_flags(&binary.right, ctx, true)?;
+            Some(left | right)
+        }
+        Expression::ComputedMemberExpression(member) => {
+            let object = resolve_static_string(&member.object, ctx)?;
+            let index = resolve_static_index(&member.expression)?;
+            let ch = object.chars().nth(index)?;
+            Some(RegExpFlags::try_from(ch).unwrap_or_else(|_| RegExpFlags::empty()))
+        }
+        Expression::SequenceExpression(sequence) => {
+            resolve_flags(sequence.expressions.last()?, ctx, true)
+        }
+        Expression::AssignmentExpression(assignment)
+            if assignment.operator == AssignmentOperator::Assign =>
+        {
+            resolve_flags(&assignment.right, ctx, true)
+        }
+        _ => None,
+    }
+}
+
+fn resolve_template_flags<'a>(
+    template: &'a TemplateLiteral<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<RegExpFlags> {
+    let mut flags = RegExpFlags::empty();
+
+    for (index, expression) in template.expressions.iter().enumerate() {
+        flags |= parse_flags(template.quasis.get(index)?.value.cooked?.as_str());
+        flags |= resolve_flags(expression, ctx, true)?;
+    }
+
+    flags |= parse_flags(template.quasis.last()?.value.cooked?.as_str());
+    Some(flags)
+}
+
+fn resolve_static_string<'a>(expr: &'a Expression<'a>, ctx: &LintContext<'a>) -> Option<&'a str> {
+    match expr.get_inner_expression() {
+        Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+        Expression::TemplateLiteral(template) => Some(template.single_quasi()?.as_str()),
+        Expression::Identifier(ident) => {
+            match resolve_const_initializer(ident, ctx)?.get_inner_expression() {
+                Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+                Expression::TemplateLiteral(template) => Some(template.single_quasi()?.as_str()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn resolve_const_initializer<'a>(
+    ident: &IdentifierReference<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<&'a Expression<'a>> {
+    let declaration = get_declaration_of_variable(ident, ctx.semantic())?;
+    let AstKind::VariableDeclarator(decl) = declaration.kind() else { return None };
+
+    if !decl.kind.is_const() || !decl.id.is_binding_identifier() {
+        return None;
+    }
+
+    decl.init.as_ref()
+}
+
+fn resolve_static_index(expr: &Expression) -> Option<usize> {
+    match expr.get_inner_expression() {
+        Expression::NumericLiteral(lit)
+            if lit.value.is_finite() && lit.value >= 0.0 && lit.value.fract() == 0.0 =>
+        {
+            Some(lit.value as usize)
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("/foo/u", None),
+        ("/foo/gimuy", None),
+        ("RegExp('', 'u')", None),
+        ("RegExp('', `u`)", None),
+        ("new RegExp('', 'u')", None),
+        ("RegExp('', 'gimuy')", None),
+        ("RegExp('', `gimuy`)", None),
+        ("RegExp(...patternAndFlags)", None),
+        ("new RegExp('', 'gimuy')", None),
+        ("const flags = 'u'; new RegExp('', flags)", None),
+        ("const flags = 'g'; new RegExp('', flags + 'u')", None),
+        ("const flags = 'gimu'; new RegExp('foo', flags[3])", None),
+        ("new RegExp('', flags)", None),
+        ("function f(flags) { return new RegExp('', flags) }", None),
+        ("function f(RegExp) { return new RegExp('foo') }", None),
+        ("function f(patternAndFlags) { return new RegExp(...patternAndFlags) }", None),
+        ("new globalThis.RegExp('foo', 'u')", None), // { "ecmaVersion": 2020 },
+        ("globalThis.RegExp('foo', 'u')", None),     // { "ecmaVersion": 2020 },
+        ("const flags = 'u'; new globalThis.RegExp('', flags)", None), // { "ecmaVersion": 2020 },
+        ("const flags = 'g'; new globalThis.RegExp('', flags + 'u')", None), // { "ecmaVersion": 2020 },
+        ("const flags = 'gimu'; new globalThis.RegExp('foo', flags[3])", None), // { "ecmaVersion": 2020 },
+        ("class C { #RegExp; foo() { new globalThis.#RegExp('foo') } }", None), // { "ecmaVersion": 2022 },
+        ("/foo/u", Some(serde_json::json!([{ "requireFlag": "u" }]))),
+        ("new RegExp('foo', 'u')", Some(serde_json::json!([{ "requireFlag": "u" }]))),
+        ("/foo/v", None),                  // { "ecmaVersion": 2024 },
+        ("/foo/gimvy", None),              // { "ecmaVersion": 2024 },
+        ("RegExp('', 'v')", None),         // { "ecmaVersion": 2024 },
+        ("RegExp('', `v`)", None),         // { "ecmaVersion": 2024 },
+        ("new RegExp('', 'v')", None),     // { "ecmaVersion": 2024 },
+        ("RegExp('', 'gimvy')", None),     // { "ecmaVersion": 2024 },
+        ("RegExp('', `gimvy`)", None),     // { "ecmaVersion": 2024 },
+        ("new RegExp('', 'gimvy')", None), // { "ecmaVersion": 2024 },
+        ("const flags = 'v'; new RegExp('', flags)", None), // { "ecmaVersion": 2024 },
+        ("const flags = 'g'; new RegExp('', flags + 'v')", None), // { "ecmaVersion": 2024 },
+        ("const flags = 'gimv'; new RegExp('foo', flags[3])", None), // { "ecmaVersion": 2024 },
+        ("/foo/v", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        ("new RegExp('foo', 'v')", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 }
+    ];
+
+    let fail = vec![
+        (r"/\a/", None),
+        ("/foo/", None),
+        ("/foo/gimy", None),
+        ("RegExp()", None),
+        ("RegExp('foo')", None),
+        (r"RegExp('\\a')", None),
+        ("RegExp('foo', '')", None),
+        ("RegExp('foo', 'gimy')", None),
+        ("RegExp('foo', `gimy`)", None),
+        ("new RegExp('foo')", None),
+        ("new RegExp('foo',)", None), // { "ecmaVersion": 2017, },
+        ("new RegExp('foo', false)", None),
+        ("new RegExp('foo', 1)", None),
+        ("new RegExp('foo', '')", None),
+        ("new RegExp('foo', 'gimy')", None),
+        ("new RegExp(('foo'))", None),
+        ("new RegExp(('unrelated', 'foo'))", None),
+        ("const flags = 'gi'; new RegExp('foo', flags)", None),
+        ("const flags = 'gi'; new RegExp('foo', ('unrelated', flags))", None),
+        ("let flags; new RegExp('foo', flags = 'g')", None),
+        ("const flags = `gi`; new RegExp(`foo`, (`unrelated`, flags))", None),
+        ("const flags = 'gimu'; new RegExp('foo', flags[0])", None),
+        ("new window.RegExp('foo')", None), // { "globals": globals.browser },
+        ("new global.RegExp('foo')", None), // { "sourceType": "commonjs" },
+        ("new globalThis.RegExp('foo')", None), // { "ecmaVersion": 2020 },
+        ("/foo/", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        ("/foo/u", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        ("/foo/u", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 6 },
+        ("/[[a]/u", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        ("new RegExp('foo', 'u')", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        ("new RegExp('[[a]', 'u')", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        (r#"new RegExp("foo", "\u0067")"#, Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        (r#"new RegExp("foo", `\u0067`)"#, Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        (r#"new RegExp("foo", "\u0075")"#, Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        (r#"new RegExp("foo", `\u0075`)"#, Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        (
+            r#"const regularFlags = "sm"; new RegExp("foo", `${regularFlags}g`)"#,
+            Some(serde_json::json!([{ "requireFlag": "v" }])),
+        ), // { "ecmaVersion": 2024 },
+        (
+            r#"const regularFlags = "smu"; new RegExp("foo", `${regularFlags}g`)"#,
+            Some(serde_json::json!([{ "requireFlag": "v" }])),
+        ), // { "ecmaVersion": 2024 },
+        ("/foo/v", Some(serde_json::json!([{ "requireFlag": "u" }]))), // { "ecmaVersion": 2024 },
+        ("new RegExp('foo')", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
+        ("new RegExp('foo', 'v')", Some(serde_json::json!([{ "requireFlag": "u" }]))), // { "ecmaVersion": 2024 }
+    ];
+
+    Tester::new(RequireUnicodeRegexp::NAME, RequireUnicodeRegexp::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_allocator::Vec;
 use oxc_ast::{
     AstKind,
@@ -7,8 +10,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -28,7 +29,10 @@ fn require_unicode_regexp_diagnostic(
         ("Use the 'u' flag.", "Add the 'u' flag.")
     };
 
-    OxcDiagnostic::warn(msg).with_help(help_msg).with_label(span)
+    OxcDiagnostic::warn(msg)
+        .with_note("The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.")
+        .with_help(help_msg)
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
@@ -227,36 +227,42 @@ fn extract_regex_flags<'a>(
 
     let flags_arg = args[1].as_expression()?.get_inner_expression();
 
-    resolve_flags(flags_arg, ctx, true)
+    resolve_flags(flags_arg, ctx, true, 0)
 }
 
 fn parse_flags(flags_text: &str) -> RegExpFlags {
     flags_text.chars().filter_map(|ch| RegExpFlags::try_from(ch).ok()).collect()
 }
 
+const MAX_RESOLVE_DEPTH: usize = 8;
+
 fn resolve_flags<'a>(
     expr: &'a Expression<'a>,
     ctx: &LintContext<'a>,
     follow_identifier: bool,
+    depth: usize,
 ) -> Option<RegExpFlags> {
+    if depth > MAX_RESOLVE_DEPTH {
+        return None;
+    }
+
+    let next_depth = depth + 1;
     let expr = expr.get_inner_expression();
-    let expr = if follow_identifier && let Expression::Identifier(ident) = expr {
-        resolve_const_initializer(ident, ctx)?.get_inner_expression()
-    } else {
-        expr
-    };
+    if follow_identifier && let Expression::Identifier(ident) = expr {
+        return resolve_flags(resolve_const_initializer(ident, ctx)?, ctx, true, next_depth);
+    }
 
     match expr {
         Expression::StringLiteral(lit) => Some(parse_flags(lit.value.as_str())),
-        Expression::TemplateLiteral(template) => resolve_template_flags(template, ctx),
+        Expression::TemplateLiteral(template) => resolve_template_flags(template, ctx, next_depth),
         Expression::BooleanLiteral(lit) => {
             Some(if lit.value { RegExpFlags::U } else { RegExpFlags::empty() })
         }
         Expression::NullLiteral(_) => Some(RegExpFlags::U),
         Expression::NumericLiteral(_) => Some(RegExpFlags::empty()),
         Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
-            let left = resolve_flags(&binary.left, ctx, true)?;
-            let right = resolve_flags(&binary.right, ctx, true)?;
+            let left = resolve_flags(&binary.left, ctx, true, next_depth)?;
+            let right = resolve_flags(&binary.right, ctx, true, next_depth)?;
             Some(left | right)
         }
         Expression::ComputedMemberExpression(member) => {
@@ -266,12 +272,12 @@ fn resolve_flags<'a>(
             Some(RegExpFlags::try_from(ch).unwrap_or_else(|_| RegExpFlags::empty()))
         }
         Expression::SequenceExpression(sequence) => {
-            resolve_flags(sequence.expressions.last()?, ctx, true)
+            resolve_flags(sequence.expressions.last()?, ctx, true, next_depth)
         }
         Expression::AssignmentExpression(assignment)
             if assignment.operator == AssignmentOperator::Assign =>
         {
-            resolve_flags(&assignment.right, ctx, true)
+            resolve_flags(&assignment.right, ctx, true, next_depth)
         }
         _ => None,
     }
@@ -280,12 +286,13 @@ fn resolve_flags<'a>(
 fn resolve_template_flags<'a>(
     template: &'a TemplateLiteral<'a>,
     ctx: &LintContext<'a>,
+    depth: usize,
 ) -> Option<RegExpFlags> {
     let mut flags = RegExpFlags::empty();
 
     for (index, expression) in template.expressions.iter().enumerate() {
         flags |= parse_flags(template.quasis.get(index)?.value.cooked?.as_str());
-        flags |= resolve_flags(expression, ctx, true)?;
+        flags |= resolve_flags(expression, ctx, true, depth)?;
     }
 
     flags |= parse_flags(template.quasis.last()?.value.cooked?.as_str());
@@ -354,6 +361,9 @@ fn test() {
         ("const flags = 'u'; new RegExp('', flags)", None),
         ("const flags = 'g'; new RegExp('', flags + 'u')", None),
         ("const flags = 'gimu'; new RegExp('foo', flags[3])", None),
+        ("const flags = flags; new RegExp('foo', flags)", None),
+        ("const flags = `${flags}`; new RegExp('foo', flags)", None),
+        ("const flags = other; const other = flags; new RegExp('foo', flags)", None),
         ("new RegExp('', flags)", None),
         ("function f(flags) { return new RegExp('', flags) }", None),
         ("function f(RegExp) { return new RegExp('foo') }", None),
@@ -428,6 +438,7 @@ fn test() {
         ("/foo/v", Some(serde_json::json!([{ "requireFlag": "u" }]))), // { "ecmaVersion": 2024 },
         ("new RegExp('foo')", Some(serde_json::json!([{ "requireFlag": "v" }]))), // { "ecmaVersion": 2024 },
         ("new RegExp('foo', 'v')", Some(serde_json::json!([{ "requireFlag": "u" }]))), // { "ecmaVersion": 2024 }
+        ("const a = 'g'; const b = a; new RegExp('x', b)", None),
     ];
 
     Tester::new(RequireUnicodeRegexp::NAME, RequireUnicodeRegexp::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_require_unicode_regexp.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_require_unicode_regexp.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -36,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -50,6 +56,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -57,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -64,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -71,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -78,6 +88,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -85,6 +96,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -92,6 +104,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -99,6 +112,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -106,6 +120,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -113,6 +128,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -120,6 +136,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:21]
@@ -127,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:21]
@@ -134,6 +152,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:12]
@@ -141,6 +160,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ──────────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:21]
@@ -148,6 +168,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:23]
@@ -155,6 +176,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ───────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -162,6 +184,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -169,6 +192,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -176,6 +200,7 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -183,6 +208,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -190,6 +216,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -197,6 +224,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -204,6 +232,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -211,6 +240,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -218,6 +248,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -225,6 +256,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -232,6 +264,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -239,6 +272,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -246,6 +280,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:28]
@@ -253,6 +288,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─────────────────────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:29]
@@ -260,6 +296,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─────────────────────────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -267,6 +304,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -274,6 +312,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────
    ╰────
   help: Add the 'v' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:1]
@@ -281,6 +320,7 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.
 
   ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
    ╭─[require_unicode_regexp.tsx:1:29]
@@ -288,3 +328,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──────────────────
    ╰────
   help: Add the 'u' flag.
+  note: The 'u' and 'v' flags enable Unicode-aware regular expression behavior and stricter pattern parsing.

--- a/crates/oxc_linter/src/snapshots/eslint_require_unicode_regexp.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_require_unicode_regexp.snap
@@ -281,3 +281,10 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────
    ╰────
   help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:29]
+ 1 │ const a = 'g'; const b = a; new RegExp('x', b)
+   ·                             ──────────────────
+   ╰────
+  help: Add the 'u' flag.

--- a/crates/oxc_linter/src/snapshots/eslint_require_unicode_regexp.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_require_unicode_regexp.snap
@@ -1,0 +1,283 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /\a/
+   · ────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /foo/
+   · ─────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /foo/gimy
+   · ─────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ RegExp()
+   · ────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ RegExp('foo')
+   · ─────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ RegExp('\\a')
+   · ─────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ RegExp('foo', '')
+   · ─────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ RegExp('foo', 'gimy')
+   · ─────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ RegExp('foo', `gimy`)
+   · ─────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo')
+   · ─────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo',)
+   · ──────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo', false)
+   · ────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo', 1)
+   · ────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo', '')
+   · ─────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo', 'gimy')
+   · ─────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp(('foo'))
+   · ───────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp(('unrelated', 'foo'))
+   · ────────────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:21]
+ 1 │ const flags = 'gi'; new RegExp('foo', flags)
+   ·                     ────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:21]
+ 1 │ const flags = 'gi'; new RegExp('foo', ('unrelated', flags))
+   ·                     ───────────────────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:12]
+ 1 │ let flags; new RegExp('foo', flags = 'g')
+   ·            ──────────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:21]
+ 1 │ const flags = `gi`; new RegExp(`foo`, (`unrelated`, flags))
+   ·                     ───────────────────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:23]
+ 1 │ const flags = 'gimu'; new RegExp('foo', flags[0])
+   ·                       ───────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new window.RegExp('foo')
+   · ────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new global.RegExp('foo')
+   · ────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new globalThis.RegExp('foo')
+   · ────────────────────────────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /foo/
+   · ─────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /foo/u
+   · ──────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /foo/u
+   · ──────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /[[a]/u
+   · ───────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo', 'u')
+   · ──────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('[[a]', 'u')
+   · ───────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp("foo", "\u0067")
+   · ───────────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp("foo", `\u0067`)
+   · ───────────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp("foo", "\u0075")
+   · ───────────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp("foo", `\u0075`)
+   · ───────────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:28]
+ 1 │ const regularFlags = "sm"; new RegExp("foo", `${regularFlags}g`)
+   ·                            ─────────────────────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:29]
+ 1 │ const regularFlags = "smu"; new RegExp("foo", `${regularFlags}g`)
+   ·                             ─────────────────────────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ /foo/v
+   · ──────
+   ╰────
+  help: Add the 'u' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'v' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo')
+   · ─────────────────
+   ╰────
+  help: Add the 'v' flag.
+
+  ⚠ eslint(require-unicode-regexp): Use the 'u' flag.
+   ╭─[require_unicode_regexp.tsx:1:1]
+ 1 │ new RegExp('foo', 'v')
+   · ──────────────────────
+   ╰────
+  help: Add the 'u' flag.

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -93,16 +93,18 @@ where
     }
 }
 
-// Accepts both RegExp and globalThis.RegExp
-fn is_regexp_callee<'a>(callee: &'a Expression<'a>, ctx: &'a LintContext<'_>) -> bool {
+// Accepts global RegExp constructors like `RegExp`, `globalThis.RegExp`, `window.RegExp`,
+// and `global.RegExp`.
+pub fn is_regexp_callee<'a>(callee: &'a Expression<'a>, ctx: &'a LintContext<'_>) -> bool {
     if callee.is_global_reference_name(static_ident!("RegExp"), ctx.semantic().scoping()) {
         return true;
     }
-    // Check for globalThis.RegExp (StaticMemberExpression)
     if let Expression::StaticMemberExpression(member) = callee
         && let Expression::Identifier(obj) = &member.object
-        && obj.is_global_reference_name(static_ident!("globalThis"), ctx.semantic().scoping())
         && member.property.name == "RegExp"
+        && (obj.is_global_reference_name(static_ident!("globalThis"), ctx.semantic().scoping())
+            || obj.is_global_reference_name(static_ident!("window"), ctx.semantic().scoping())
+            || obj.is_global_reference_name(static_ident!("global"), ctx.semantic().scoping()))
     {
         return true;
     }


### PR DESCRIPTION
this PR implements `eslint/require-unicode-regexp`, passes all upstream tests

issue #479

