### PR TITLE
perf(ci): use filter blob:none for release metadata checkout

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -655,6 +655,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0 # for changelog
+          filter: blob:none
           persist-credentials: true
 
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16


### PR DESCRIPTION
## Summary

Use `filter: blob:none` for checkout in `release_apps.yml`.

This workflow builds release artifacts across many targets, so it still needs the working tree at `HEAD`. The goal here is not to avoid checking out source files, but to avoid downloading unnecessary historical blobs during checkout.

## Why

The release workflow checks out the repository in several jobs before building oxlint artifacts. A blobless partial clone keeps commits and trees available while omitting blobs that are not needed unless a later Git operation asks for them.

This should reduce checkout transfer size without changing the build behavior.

## Notes

- The working tree for `HEAD` is still available.
- If a later step needs a missing blob from history, Git can fetch it lazily.
- No functional change intended.

## Verification

- Release workflow checkout succeeds.
- Build steps continue to run against the checked-out source tree.

## AI Disclosure

This change was identified using my CI analysis tool:
https://github.com/yoshi-taka/ci-perf-lint

The patch and reasoning were validated manually.

Parts of this PR description were assisted by AI.