### PR TITLE
refactor(allocator): reduce scope of `unsafe` blocks in `Arena::try_alloc_layout_slow_impl`

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -328,70 +328,74 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Slow path for allocation, shared between `alloc_layout` and `try_alloc_layout`.
     /// Called when there isn't enough room in our current chunk, so need to allocate a new chunk.
     fn try_alloc_layout_slow_impl(&self, layout: Layout) -> Option<NonNull<u8>> {
-        unsafe {
-            let current_footer_ptr = self.current_chunk_footer_ptr.get();
+        let current_footer_ptr = self.current_chunk_footer_ptr.get();
 
-            // Fixed-size arenas (e.g. those created via `Arena::from_raw_parts`) cannot grow.
-            // SAFETY: If `current_footer_ptr` is `Some`, it points to a valid `ChunkFooter`.
-            if current_footer_ptr.is_some_and(|footer_ptr| footer_ptr.as_ref().is_fixed_size) {
+        // Fixed-size arenas (those created via `Arena::from_raw_parts`) cannot grow
+        if let Some(footer_ptr) = current_footer_ptr {
+            // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
+            let footer = unsafe { footer_ptr.as_ref() };
+            if footer.is_fixed_size {
                 return None;
             }
+        }
 
-            // Get a new chunk from the global allocator.
-            // By default, we want our new chunk to be about twice as big as the previous chunk.
-            // If the global allocator refuses it, we try to divide it by half until it works for `layout`
-            // or the requested size is smaller than the default chunk size.
-            let min_new_chunk_size = max(layout.size(), DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
+        // Get a new chunk from the global allocator.
+        // By default, we want our new chunk to be about twice as big as the previous chunk.
+        // If the global allocator refuses it, we try to divide it by half until it works for `layout`
+        // or the requested size is smaller than the default chunk size.
+        let min_new_chunk_size = max(layout.size(), DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
 
-            let mut size = match current_footer_ptr {
-                // Double the size of the current chunk, but not less than `min_new_chunk_size`
-                Some(footer_ptr) => {
-                    let current_size_without_footer =
-                        footer_ptr.as_ref().layout.size() - CHUNK_FOOTER_SIZE;
-                    // `current_size_without_footer * 2` cannot overflow because `Layout::size()` is always `<= isize::MAX`
-                    max(current_size_without_footer * 2, min_new_chunk_size)
-                }
-                // No existing chunks, so just use `min_new_chunk_size`
-                None => min_new_chunk_size,
-            };
+        let mut size = match current_footer_ptr {
+            // Double the size of the current chunk, but not less than `min_new_chunk_size`
+            Some(footer_ptr) => {
+                // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
+                let footer = unsafe { footer_ptr.as_ref() };
+                let current_size_without_footer = footer.layout.size() - CHUNK_FOOTER_SIZE;
+                // `current_size_without_footer * 2` cannot overflow because `Layout::size()` is always `<= isize::MAX`
+                max(current_size_without_footer * 2, min_new_chunk_size)
+            }
+            // No existing chunks, so just use `min_new_chunk_size`
+            None => min_new_chunk_size,
+        };
 
-            let (new_start_ptr, new_footer_ptr) = loop {
-                // Try to allocate a chunk of `size` bytes (plus footer and rounding).
-                // SAFETY: `current_footer_ptr` points to a valid `ChunkFooter` for a chunk in this `Arena`,
-                // or it's `None`.
-                if let Some(new_chunk) = Self::new_chunk(size, layout, current_footer_ptr) {
-                    break new_chunk;
-                }
-
-                // Failed. Halve size and try again.
-                // TODO: Before admitting defeat, try one last time with minimum size required to service the request.
-                // This can be a value somewhere between `size` and `size / 2`.
-                size /= 2;
-                if size < min_new_chunk_size {
-                    return None;
-                }
-            };
-
-            debug_assert!(is_pointer_aligned_to(new_start_ptr, layout.align()));
-
-            // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
-            // can read its final cursor position later. Skip this if there was no current chunk.
-            if let Some(current_footer_ptr) = current_footer_ptr {
-                current_footer_ptr.as_ref().cursor_ptr.set(self.cursor_ptr.get());
+        let (new_start_ptr, new_footer_ptr) = loop {
+            // Try to allocate a chunk of `size` bytes (plus footer and rounding).
+            // SAFETY: `current_footer_ptr` points to a valid `ChunkFooter` for a chunk in this `Arena`, or it's `None`.
+            let new_chunk = unsafe { Self::new_chunk(size, layout, current_footer_ptr) };
+            if let Some(new_chunk) = new_chunk {
+                break new_chunk;
             }
 
-            // Set the new chunk as our new current chunk, and sync `start_ptr` and `cursor_ptr` accordingly.
-            // Initial cursor sits at the footer (end of the allocatable region).
-            // The footer is aligned on `CHUNK_ALIGN >= MIN_ALIGN`, so no rounding is needed.
-            self.start_ptr.set(new_start_ptr);
-            self.cursor_ptr.set(new_footer_ptr.cast::<u8>());
-            self.current_chunk_footer_ptr.set(Some(new_footer_ptr));
+            // Failed. Halve size and try again.
+            // TODO: Before admitting defeat, try one last time with minimum size required to service the request.
+            // This can be a value somewhere between `size` and `size / 2`.
+            size /= 2;
+            if size < min_new_chunk_size {
+                return None;
+            }
+        };
 
-            // And then we can rely on `try_alloc_layout_fast` to allocate space within this chunk
-            let ptr = self.try_alloc_layout_fast(layout);
-            debug_assert!(ptr.is_some());
-            ptr
+        debug_assert!(is_pointer_aligned_to(new_start_ptr, layout.align()));
+
+        // Sync `Arena::cursor_ptr` back to the retiring chunk's footer so iteration over chunks
+        // can read its final cursor position later. Skip this if there was no current chunk.
+        if let Some(footer_ptr) = current_footer_ptr {
+            // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
+            let footer = unsafe { footer_ptr.as_ref() };
+            footer.cursor_ptr.set(self.cursor_ptr.get());
         }
+
+        // Set the new chunk as our new current chunk, and sync `start_ptr` and `cursor_ptr` accordingly.
+        // Initial cursor sits at the footer (end of the allocatable region).
+        // The footer is aligned on `CHUNK_ALIGN >= MIN_ALIGN`, so no rounding is needed.
+        self.start_ptr.set(new_start_ptr);
+        self.cursor_ptr.set(new_footer_ptr.cast::<u8>());
+        self.current_chunk_footer_ptr.set(Some(new_footer_ptr));
+
+        // And then we can rely on `try_alloc_layout_fast` to allocate space within this chunk
+        let ptr = self.try_alloc_layout_fast(layout);
+        debug_assert!(ptr.is_some());
+        ptr
     }
 
     #[inline]


### PR DESCRIPTION
Refactor. `Arena::try_alloc_layout_slow_impl` was a single large `unsafe { ... }` block. Remove that block, and scope `unsafe { ... }` to just the operations that need it. Document the safety of each.