### PR TITLE
fix(ci/release-apps): skip validate rule versions if no new release

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -42,6 +42,7 @@ jobs:
           file-url: https://unpkg.com/oxlint@latest/package.json
 
       - name: Validate rule versions
+        if: steps.oxlint.outputs.version_changed == 'true'
         env:
           OXLINT_VERSION: ${{ steps.oxlint.outputs.version }}
         run: |


### PR DESCRIPTION
`Validate rule versions` now runs only when the oxlint package version changed. This avoids running oxlint rule-version validation for releases that only update other app packages.

This should pervent failures such as https://github.com/oxc-project/oxc/actions/runs/25299302016/job/74163331967