### PR TITLE
fix(linter/no-single-promise-in-promise-methods): avoid unused array fix

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -114,12 +114,14 @@ impl Rule for NoSinglePromiseInPromiseMethods {
         }
 
         if is_fixable(node.id(), ctx) {
+            let promise_all_result_unused =
+                method_name == "all" && is_await_value_discarded(node.id(), ctx);
             ctx.diagnostic_with_fix(diagnostic, |fixer| {
                 let elem_text = fixer.source_range(first.span());
                 let call_span = call_expr.span;
 
                 if let Some(await_span) = await_expr_span {
-                    if method_name == "all" {
+                    if method_name == "all" && !promise_all_result_unused {
                         fixer.replace(await_span, format!("[await {elem_text}]"))
                     } else {
                         fixer.replace(call_span, elem_text.to_owned())
@@ -166,6 +168,22 @@ fn is_fixable(call_node_id: NodeId, ctx: &LintContext<'_>) -> bool {
         }
     }
     true
+}
+
+fn is_await_value_discarded(call_node_id: NodeId, ctx: &LintContext<'_>) -> bool {
+    let mut seen_await = false;
+
+    for parent in ctx.nodes().ancestors(call_node_id) {
+        match parent.kind() {
+            AstKind::AwaitExpression(_) => seen_await = true,
+            kind if is_ignorable_kind(&kind) => {}
+            AstKind::ExpressionStatement(_) if seen_await => return true,
+            _ if seen_await => return false,
+            _ => {}
+        }
+    }
+
+    false
 }
 
 /// We want to skip:
@@ -296,15 +314,23 @@ fn test() {
         "Promise.all([x as const]).then()",
         "Promise.all([x!]).then()",
         "Promise.all(['one']).then(something);",
+        "
+        async function run() {
+            await Promise.all([
+                new Promise((resolve) => resolve(true)),
+            ]);
+        }
+        ",
     ];
 
     let fix = vec![
         ("Promise.race([null]).then()", "Promise.resolve(null).then()", None),
         // Promise.all returns an array, so we preserve the array structure
-        // `await Promise.all([x])` -> `[await x]`
-        ("await Promise.all([x]);", "[await x];", None),
-        ("await Promise.all([x as Promise<number>]);", "[await x as Promise<number>];", None),
-        ("while(true) { await Promise.all([x]); }", "while(true) { [await x]; }", None),
+        // when the result is used, but avoid creating an unread array when
+        // `await Promise.all([x])` is used as an expression statement.
+        ("await Promise.all([x]);", "await x;", None),
+        ("await Promise.all([x as Promise<number>]);", "await x as Promise<number>;", None),
+        ("while(true) { await Promise.all([x]); }", "while(true) { await x; }", None),
         // Promise.any and Promise.race return a single value, not an array
         ("await Promise.any([x]);", "await x;", None),
         ("await Promise.race([x]);", "await x;", None),
@@ -316,11 +342,31 @@ fn test() {
             "function foo () { return Promise.all([x]); }",
             None,
         ),
+        (
+            "async function foo () { return await Promise.all([x]); }",
+            "async function foo () { return await Promise.all([x]); }",
+            None,
+        ),
         ("const foo = () => Promise.race([x])", "const foo = () => Promise.resolve(x)", None),
         ("foo = await Promise.race([x])", "foo = await Promise.race([x])", None),
         (
             "Promise.all(['one']).then((result) => result[0]);",
             "Promise.all(['one']).then((result) => result[0]);",
+            None,
+        ),
+        (
+            "
+            async function run() {
+                await Promise.all([
+                    new Promise((resolve) => resolve(true)),
+                ]);
+            }
+            ",
+            "
+            async function run() {
+                await new Promise((resolve) => resolve(true));
+            }
+            ",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
@@ -476,3 +476,12 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:3:27]
+ 2 │         async function run() {
+ 3 │             await Promise.all([
+   ·                           ───
+ 4 │                 new Promise((resolve) => resolve(true)),
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/22114.

Updates the fixer so `await Promise.all([value])` used as an expression statement becomes `await value` instead of `[await value]`, while preserving the array wrapper when the result is consumed.

Original report: https://github.com/oxc-project/oxc/issues/22114