### PR TITLE
refactor(allocator): per-platform implementation of freeing fixed-size chunks

### DIFF
--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -1,9 +1,6 @@
 //! `Drop` implementation for `Arena`, and `reset` method.
 
-use std::{
-    alloc::{self, GlobalAlloc, System},
-    ptr::NonNull,
-};
+use std::{alloc, ptr::NonNull};
 
 use super::{Arena, ChunkFooter, utils::is_pointer_aligned_to};
 
@@ -106,7 +103,7 @@ unsafe fn dealloc_chunk_list(footer_ptr: Option<NonNull<ChunkFooter>>) {
         }
 
         // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
-        unsafe { dealloc_arena_chunk(footer_ptr) };
+        unsafe { dealloc_chunk(footer_ptr) };
     }
 }
 
@@ -114,7 +111,7 @@ unsafe fn dealloc_chunk_list(footer_ptr: Option<NonNull<ChunkFooter>>) {
 ///
 /// # SAFETY
 /// `footer_ptr` must point to a valid `ChunkFooter`.
-pub unsafe fn dealloc_arena_chunk(footer_ptr: NonNull<ChunkFooter>) {
+unsafe fn dealloc_chunk(footer_ptr: NonNull<ChunkFooter>) {
     // Create `&ChunkFooter` reference within a block, to ensure the reference is not live
     // when we deallocate the chunk's memory (which includes the `ChunkFooter`)
     let (backing_alloc_ptr, layout, is_fixed_size) = {
@@ -123,13 +120,36 @@ pub unsafe fn dealloc_arena_chunk(footer_ptr: NonNull<ChunkFooter>) {
         (footer.backing_alloc_ptr.as_ptr(), footer.layout, footer.is_fixed_size)
     };
 
+    // If is a fixed-size allocator, delegate to `dealloc_fixed_size_arena_chunk`
     if is_fixed_size {
-        // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
-        // `is_fixed_size` is `true`, so backing allocation was made via `System` allocator.
-        unsafe { System.dealloc(backing_alloc_ptr, layout) };
-    } else {
-        // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
-        // `is_fixed_size` is `false`, so backing allocation was made via global allocator.
-        unsafe { alloc::dealloc(backing_alloc_ptr, layout) };
+        #[cfg(all(feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
+        {
+            // SAFETY: Caller guarantees that `footer_ptr` points to a valid `ChunkFooter`,
+            // and `is_fixed_size` indicates that the chunk is fixed-size
+            unsafe { super::fixed_size::dealloc_fixed_size_arena_chunk(footer_ptr) };
+            return;
+        }
+
+        // Note: `napi/parser` and Oxlint's `RuleTester` create `Arena`s with `is_fixed_size: true`,
+        // but in both cases the memory backing the `Arena` is owned by JS, and they prevent the `Arena`
+        // from being dropped, by wrapping it in `ManuallyDrop`. So this code is unreachable in those cases.
+        //
+        // Using `debug_assert!` not `panic!` here means this whole `if is_fixed_size { ... }` block
+        // is dead code in release builds where `fixed_size` feature is not enabled.
+        #[cfg(not(all(
+            feature = "fixed_size",
+            target_pointer_width = "64",
+            target_endian = "little"
+        )))]
+        {
+            debug_assert!(
+                false,
+                "`is_fixed_size` should be `false` when `fixed_size` feature is disabled"
+            );
+        }
     }
+
+    // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
+    // `is_fixed_size` is `false`, so backing allocation was made via global allocator.
+    unsafe { alloc::dealloc(backing_alloc_ptr, layout) };
 }

--- a/crates/oxc_allocator/src/arena/fixed_size/mod.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size/mod.rs
@@ -46,6 +46,10 @@ const _: () = {
 
 #[cfg(target_os = "windows")]
 mod windows;
+#[cfg(target_os = "windows")]
+pub use windows::dealloc_fixed_size_arena_chunk;
 
 #[cfg(not(target_os = "windows"))]
 mod unix;
+#[cfg(not(target_os = "windows"))]
+pub use unix::dealloc_fixed_size_arena_chunk;

--- a/crates/oxc_allocator/src/arena/fixed_size/unix.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size/unix.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::generated::fixed_size_constants::{BLOCK_ALIGN, BLOCK_SIZE};
 
-use super::super::Arena;
+use super::super::{Arena, ChunkFooter};
 
 // System allocator on Mac OS refuses allocations with 4 GiB alignment, so we over-allocate
 // `BLOCK_SIZE + TWO_GIB` (4 GiB - 16) bytes with 2 GiB alignment, and then use either the 1st or 2nd half
@@ -83,4 +83,33 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         Some(arena)
     }
+}
+
+/// Deallocate the chunk whose footer is pointed to by `footer_ptr`, when the chunk is fixed size
+/// (created via `Arena::from_raw_parts` or `Arena::new_fixed_size`).
+///
+/// `dealloc_chunk` in `drop` module delegates to this function when chunk's `is_fixed_size` flag is set.
+/// `free_fixed_size_allocator` in `pool/fixed_size.rs` also uses this function for deallocation.
+///
+/// # SAFETY
+///
+/// * `footer_ptr` must point to a valid `ChunkFooter`.
+/// * `ChunkFooter` must be for a fixed size chunk (created via `Arena::from_raw_parts` or `Arena::new_fixed_size`).
+pub unsafe fn dealloc_fixed_size_arena_chunk(footer_ptr: NonNull<ChunkFooter>) {
+    // Create `&ChunkFooter` reference within a block, to ensure the reference is not live
+    // when we deallocate the chunk's memory (which includes the `ChunkFooter`)
+    let (backing_alloc_ptr, layout, is_fixed_size) = {
+        // SAFETY: Caller guarantees that `footer_ptr` points to a valid `ChunkFooter`
+        let footer = unsafe { footer_ptr.as_ref() };
+        (footer.backing_alloc_ptr, footer.layout, footer.is_fixed_size)
+    };
+
+    debug_assert!(
+        is_fixed_size,
+        "Only fixed-size allocators should be passed to `dealloc_fixed_size_arena_chunk` to deallocate"
+    );
+
+    // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
+    // Caller guarantees `is_fixed_size` is `true`, so backing allocation was made via `System` allocator.
+    unsafe { System.dealloc(backing_alloc_ptr.as_ptr(), layout) };
 }

--- a/crates/oxc_allocator/src/arena/fixed_size/windows.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size/windows.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::generated::fixed_size_constants::{BLOCK_ALIGN, BLOCK_SIZE};
 
-use super::super::Arena;
+use super::super::{Arena, ChunkFooter};
 
 // Windows system allocator doesn't support high alignment allocations directly.
 //
@@ -82,4 +82,33 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         Some(arena)
     }
+}
+
+/// Deallocate the chunk whose footer is pointed to by `footer_ptr`, when the chunk is fixed size
+/// (created via `Arena::from_raw_parts` or `Arena::new_fixed_size`).
+///
+/// `dealloc_chunk` in `drop` module delegates to this function when chunk's `is_fixed_size` flag is set.
+/// `free_fixed_size_allocator` in `pool/fixed_size.rs` also uses this function for deallocation.
+///
+/// # SAFETY
+///
+/// * `footer_ptr` must point to a valid `ChunkFooter`.
+/// * `ChunkFooter` must be for a fixed size chunk (created via `Arena::from_raw_parts` or `Arena::new_fixed_size`).
+pub unsafe fn dealloc_fixed_size_arena_chunk(footer_ptr: NonNull<ChunkFooter>) {
+    // Create `&ChunkFooter` reference within a block, to ensure the reference is not live
+    // when we deallocate the chunk's memory (which includes the `ChunkFooter`)
+    let (backing_alloc_ptr, layout, is_fixed_size) = {
+        // SAFETY: Caller guarantees that `footer_ptr` points to a valid `ChunkFooter`
+        let footer = unsafe { footer_ptr.as_ref() };
+        (footer.backing_alloc_ptr, footer.layout, footer.is_fixed_size)
+    };
+
+    debug_assert!(
+        is_fixed_size,
+        "Only fixed-size allocators should be passed to `dealloc_fixed_size_arena_chunk` to deallocate"
+    );
+
+    // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
+    // Caller guarantees `is_fixed_size` is `true`, so backing allocation was made via `System` allocator.
+    unsafe { System.dealloc(backing_alloc_ptr.as_ptr(), layout) };
 }

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -22,11 +22,10 @@ mod utils;
 #[cfg(feature = "testing")]
 pub use bumpalo_alloc::AllocErr;
 use create::DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER;
-#[cfg(feature = "fixed_size")]
-pub(crate) use drop::dealloc_arena_chunk;
 
 #[cfg(all(feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
-mod fixed_size;
+pub(crate) mod fixed_size;
+
 #[cfg(feature = "from_raw_parts")]
 mod from_raw_parts;
 

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -15,7 +15,7 @@ use oxc_data_structures::stack::Stack;
 
 use crate::{
     Allocator,
-    arena::{CHUNK_FOOTER_SIZE, ChunkFooter, dealloc_arena_chunk},
+    arena::{CHUNK_FOOTER_SIZE, ChunkFooter, fixed_size::dealloc_fixed_size_arena_chunk},
     generated::fixed_size_constants::{
         ACTIVE_SIZE, BLOCK_SIZE, BUFFER_SIZE, CURSOR_MIN_ALIGN, RAW_METADATA_ALIGN,
         RAW_METADATA_SIZE,
@@ -500,7 +500,7 @@ pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocator
     // a `FixedSizeAllocator`, so a valid `ChunkFooter` is at a fixed offset after it within the same allocation.
     unsafe {
         let footer_ptr = metadata_ptr.byte_add(FIXED_METADATA_SIZE).cast::<ChunkFooter>();
-        dealloc_arena_chunk(footer_ptr);
+        dealloc_fixed_size_arena_chunk(footer_ptr);
     }
 }
 


### PR DESCRIPTION
Add per-platform implementations of `dealloc_fixed_size_arena_chunk`, and delegate to them when dropping an `Arena` which has fixed-size chunks.

Currently, all the implementations are identical - they just deallocate the memory with `System` allocator. But this prepares the way for #22124, which alters the Windows impl to use `VirtualFree` instead.