### PR TITLE
refactor(allocator): add `Arena::grow_fixed_size_chunk` method

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -335,6 +335,36 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
             let footer = unsafe { footer_ptr.as_ref() };
             if footer.is_fixed_size {
+                // Attempt to grow the chunk in place to accommodate the allocation
+                #[cfg(all(
+                    feature = "fixed_size",
+                    target_pointer_width = "64",
+                    target_endian = "little"
+                ))]
+                {
+                    // SAFETY: Allocating `layout` within current chunk is not possible.
+                    // If it was, then `try_alloc_layout_fast` would have succeeded,
+                    // and this method wouldn't have been called.
+                    // `is_fixed_size` is `true`, so it's a fixed-size chunk.
+                    let new_ptr = unsafe { self.grow_fixed_size_chunk(layout) };
+                    if let Some(new_ptr) = new_ptr {
+                        debug_assert!(new_ptr >= self.start_ptr.get());
+                        debug_assert!(new_ptr < self.cursor_ptr.get());
+                        debug_assert!(
+                            self.cursor_ptr.get().addr().get() - new_ptr.addr().get()
+                                >= layout.size()
+                        );
+                        debug_assert!(is_pointer_aligned_to(new_ptr, layout.align()));
+                        debug_assert!(is_pointer_aligned_to(new_ptr, MIN_ALIGN));
+
+                        // Update cursor and return pointer where `layout` can be allocated
+                        self.cursor_ptr.set(new_ptr);
+                        return Some(new_ptr);
+                    }
+                }
+
+                // Could not grow the chunk in place enough to accommodate allocating `layout`.
+                // Fixed-size arenas cannot add more chunks, so allocation fails.
                 return None;
             }
         }

--- a/crates/oxc_allocator/src/arena/fixed_size/unix.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size/unix.rs
@@ -83,6 +83,42 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         Some(arena)
     }
+
+    /// Attempt to grow the [`Arena`]'s current chunk in place to accommodate an allocation of `Layout`.
+    ///
+    /// If the chunk can be grown in place to accommodate the request:
+    /// * Returns `Some(new_ptr)`, where `new_ptr` is the pointer to write the layout at.
+    /// * Updates `start_ptr`.
+    /// * Does NOT update `cursor_ptr` - that is left to the caller.
+    ///
+    /// If the chunk could not be grown in place to accommodate the request, returns `None`.
+    ///
+    /// On Linux and Mac OS, fixed size chunks cannot currently be grown in place, so always returns `None`.
+    ///
+    /// # SAFETY
+    ///
+    /// * `Arena` must be fixed-size (created via `Arena::new_fixed_size`).
+    /// * Arena must not be able to accommodate an allocation of `layout` within current chunk, prior to growing it.
+    #[expect(unused_variables)]
+    #[cfg_attr(not(debug_assertions), expect(clippy::unused_self))]
+    #[inline(always)] // Because it's a no-op
+    pub(in super::super) unsafe fn grow_fixed_size_chunk(
+        &self,
+        layout: Layout,
+    ) -> Option<NonNull<u8>> {
+        #[cfg(debug_assertions)]
+        {
+            let footer_ptr = self.current_chunk_footer_ptr.get().expect("Arena has no chunks");
+            // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
+            let footer = unsafe { footer_ptr.as_ref() };
+            assert!(
+                footer.is_fixed_size,
+                "Only fixed-size allocators should be passed to `Arena::grow_fixed_size_chunk`"
+            );
+        }
+
+        None
+    }
 }
 
 /// Deallocate the chunk whose footer is pointed to by `footer_ptr`, when the chunk is fixed size

--- a/crates/oxc_allocator/src/arena/fixed_size/windows.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size/windows.rs
@@ -82,6 +82,42 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
 
         Some(arena)
     }
+
+    /// Attempt to grow the [`Arena`]'s current chunk in place to accommodate an allocation of `Layout`.
+    ///
+    /// If the chunk can be grown in place to accommodate the request:
+    /// * Returns `Some(new_ptr)`, where `new_ptr` is the pointer to write the layout at.
+    /// * Updates `start_ptr`.
+    /// * Does NOT update `cursor_ptr` - that is left to the caller.
+    ///
+    /// If the chunk could not be grown in place to accommodate the request, returns `None`.
+    ///
+    /// On Windows, fixed size chunks cannot currently be grown in place, so always returns `None`.
+    ///
+    /// # SAFETY
+    ///
+    /// * `Arena` must be fixed-size (created via `Arena::new_fixed_size`).
+    /// * Arena must not be able to accommodate an allocation of `layout` within current chunk, prior to growing it.
+    #[expect(unused_variables)]
+    #[cfg_attr(not(debug_assertions), expect(clippy::unused_self))]
+    #[inline(always)] // Because it's a no-op
+    pub(in super::super) unsafe fn grow_fixed_size_chunk(
+        &self,
+        layout: Layout,
+    ) -> Option<NonNull<u8>> {
+        #[cfg(debug_assertions)]
+        {
+            let footer_ptr = self.current_chunk_footer_ptr.get().expect("Arena has no chunks");
+            // SAFETY: `footer_ptr` always points to a valid `ChunkFooter`
+            let footer = unsafe { footer_ptr.as_ref() };
+            assert!(
+                footer.is_fixed_size,
+                "Only fixed-size allocators should be passed to `Arena::grow_fixed_size_chunk`"
+            );
+        }
+
+        None
+    }
 }
 
 /// Deallocate the chunk whose footer is pointed to by `footer_ptr`, when the chunk is fixed size


### PR DESCRIPTION
Add a private method `Arena::grow_fixed_size_chunk` which attempts to grow a fixed-size `Arena` chunk in place.

Similar to #22122, there's multiple implementations for different platforms, but all are currently the same - all return `None` to indicate "could not grow". This is preparatory work for #22124, which adds a Windows-specific implementation.