### PR TITLE
chore(linter): For sarif tests, scrub the version number to avoid breaking snapshots

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -13,8 +13,8 @@ working directory: fixtures/cli/output_formatter_diagnostic
       "tool": {
         "driver": {
           "name": "oxlint",
-          "version": "1.62.0",
-          "semanticVersion": "1.62.0",
+          "version": "<variable>",
+          "semanticVersion": "<variable>",
           "informationUri": "https://oxc.rs/docs/guide/usage/linter.html",
           "rules": [
             {

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif ok.js@oxlint.snap
@@ -13,8 +13,8 @@ working directory: fixtures/cli/output_formatter_diagnostic
       "tool": {
         "driver": {
           "name": "oxlint",
-          "version": "1.62.0",
-          "semanticVersion": "1.62.0",
+          "version": "<variable>",
+          "semanticVersion": "<variable>",
           "informationUri": "https://oxc.rs/docs/guide/usage/linter.html",
           "rules": []
         }

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif parser-error.js@oxlint.snap
@@ -13,8 +13,8 @@ working directory: fixtures/cli/output_formatter_diagnostic
       "tool": {
         "driver": {
           "name": "oxlint",
-          "version": "1.62.0",
-          "semanticVersion": "1.62.0",
+          "version": "<variable>",
+          "semanticVersion": "<variable>",
           "informationUri": "https://oxc.rs/docs/guide/usage/linter.html",
           "rules": [
             {

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif test.js@oxlint.snap
@@ -13,8 +13,8 @@ working directory: fixtures/cli/output_formatter_diagnostic
       "tool": {
         "driver": {
           "name": "oxlint",
-          "version": "1.62.0",
-          "semanticVersion": "1.62.0",
+          "version": "<variable>",
+          "semanticVersion": "<variable>",
           "informationUri": "https://oxc.rs/docs/guide/usage/linter.html",
           "rules": [
             {

--- a/apps/oxlint/src/tester.rs
+++ b/apps/oxlint/src/tester.rs
@@ -124,6 +124,21 @@ impl Tester {
         let output_string = regex.replace_all(output_string, "<variable>ms").into_owned();
         let regex = Regex::new(r#""start_time": \d+\.\d+"#).unwrap();
         let output_string = regex.replace_all(&output_string, r#""start_time": <variable>"#);
+        // Censor the oxlint version in SARIF output so snapshots survive version bumps.
+        let is_sarif = multiple_args
+            .iter()
+            .flat_map(|args| args.iter())
+            .any(|arg| *arg == "--format=sarif" || *arg == "sarif");
+        let output_string = if is_sarif {
+            let regex =
+                Regex::new(r#""version":\s*"[^"]+",(\s+)"semanticVersion":\s*"[^"]+""#).unwrap();
+            regex.replace_all(
+                &output_string,
+                r#""version": "<variable>",${1}"semanticVersion": "<variable>""#,
+            )
+        } else {
+            output_string
+        };
 
         // do not output the current working directory, each machine has a different one
         let cwd_string = current_cwd.to_str().unwrap();


### PR DESCRIPTION
This probably isn't the best way to do it, but *shrug* it works. I considered skipping the is_sarif check but it seems better than running the regex on every test snapshot.

Generated with Claude Code, reviewed by me.