### PR TITLE
docs(linter): Fix jest settings docs.

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -560,7 +560,8 @@ export interface JestPluginSettings {
    * Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
    * storing only the major version.
    * ::: warning
-   * Using this config will override the `no-deprecated-functions`' config set.
+   * Using this config will override the `no-deprecated-functions` config set.
+   * :::
    */
   version?: JestVersionSchema;
   [k: string]: unknown;

--- a/crates/oxc_linter/src/config/settings/jest.rs
+++ b/crates/oxc_linter/src/config/settings/jest.rs
@@ -13,7 +13,8 @@ pub struct JestPluginSettings {
     /// Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
     /// storing only the major version.
     /// ::: warning
-    /// Using this config will override the `no-deprecated-functions`' config set.
+    /// Using this config will override the `no-deprecated-functions` config set.
+    /// :::
     #[serde(default, deserialize_with = "jest_version_deserialize")]
     #[schemars(with = "Option<JestVersionSchema>")]
     pub version: Option<usize>,

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -384,14 +384,14 @@
       "type": "object",
       "properties": {
         "version": {
-          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set.",
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions` config set.\n:::",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/JestVersionSchema"
             }
           ],
-          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set."
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions` config set.\n:::"
         }
       },
       "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -388,14 +388,14 @@ expression: json
       "type": "object",
       "properties": {
         "version": {
-          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set.",
+          "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions` config set.\n:::",
           "default": null,
           "allOf": [
             {
               "$ref": "#/definitions/JestVersionSchema"
             }
           ],
-          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions`' config set."
+          "markdownDescription": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions` config set.\n:::"
         }
       },
       "markdownDescription": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference."

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -667,7 +667,8 @@ default: `null`
 Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
 storing only the major version.
 ::: warning
-Using this config will override the `no-deprecated-functions`' config set.
+Using this config will override the `no-deprecated-functions` config set.
+:::
 
 
 ### settings.jsdoc


### PR DESCRIPTION
This was unclosed and broke the config reference page.

Previously:

<img width="762" height="702" alt="Screenshot 2026-05-04 at 9 15 59 PM" src="https://github.com/user-attachments/assets/2e435c6b-d053-48ef-b87f-a0ce46782eab" />
