### PR TITLE
fix(linter): update docs for no_alias_methods rule to be Vitest-specific and add toThrowError alias

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -1,16 +1,62 @@
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
-    context::LintContext,
-    rule::Rule,
-    rules::shared::no_alias_methods::{DOCUMENTATION, run_on_jest_node},
+    context::LintContext, rule::Rule, rules::shared::no_alias_methods::run_on_jest_node,
     utils::PossibleJestNode,
 };
 
 #[derive(Debug, Default, Clone)]
 pub struct NoAliasMethods;
 
-declare_oxc_lint!(NoAliasMethods, jest, style, fix, docs = DOCUMENTATION, version = "0.0.12",);
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces Jest's canonical matcher names instead of aliases.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Jest matcher aliases are deprecated and are going to be removed in the next major version of Jest.
+    /// See [jestjs/jest#13164](https://github.com/jestjs/jest/issues/13164) for more.
+    ///
+    /// This rule makes it easier to search for all occurrences of a matcher and ensures consistency among matcher names.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// expect(a).toBeCalled()
+    /// expect(a).toBeCalledTimes()
+    /// expect(a).toBeCalledWith()
+    /// expect(a).lastCalledWith()
+    /// expect(a).nthCalledWith()
+    /// expect(a).toReturn()
+    /// expect(a).toReturnTimes()
+    /// expect(a).toReturnWith()
+    /// expect(a).lastReturnedWith()
+    /// expect(a).nthReturnedWith()
+    /// expect(a).toThrowError()
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// expect(a).toHaveBeenCalled()
+    /// expect(a).toHaveBeenCalledTimes()
+    /// expect(a).toHaveBeenCalledWith()
+    /// expect(a).toHaveBeenLastCalledWith()
+    /// expect(a).toHaveBeenNthCalledWith()
+    /// expect(a).toHaveReturned()
+    /// expect(a).toHaveReturnedTimes()
+    /// expect(a).toHaveReturnedWith()
+    /// expect(a).toHaveLastReturnedWith()
+    /// expect(a).toHaveNthReturnedWith()
+    /// expect(a).toThrow()
+    /// ```
+    NoAliasMethods,
+    jest,
+    style,
+    fix,
+    version = "0.0.12",
+);
 
 impl Rule for NoAliasMethods {
     fn run_on_jest_node<'a, 'c>(

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_alias_methods.rs
@@ -13,73 +13,6 @@ fn no_alias_methods_diagnostic(name: &str, canonical_name: &str, span: Span) -> 
         .with_label(span)
 }
 
-// TODO: This rule's documentation should be genericized to apply to Vitest as well, probably?
-pub const DOCUMENTATION: &str = r#"### What it does
-
-This rule ensures that only the canonical name as used in the Jest documentation is used in the code.
-
-### Why is this bad?
-
-These aliases are going to be removed in the next major version of Jest - see [jestjs/jest#13164](https://github.com/jestjs/jest/issues/13164) for more.
-This rule will make it easier to search for all occurrences of the method within code, and it ensures consistency among the method names used.
-
-### Examples
-
-Examples of **incorrect** code for this rule:
-```javascript
-expect(a).toBeCalled()
-expect(a).toBeCalledTimes()
-expect(a).toBeCalledWith()
-expect(a).lastCalledWith()
-expect(a).nthCalledWith()
-expect(a).toReturn()
-expect(a).toReturnTimes()
-expect(a).toReturnWith()
-expect(a).lastReturnedWith()
-expect(a).nthReturnedWith()
-expect(a).toThrowError()
-```
-
-Examples of **correct** code for this rule:
-```javascript
-expect(a).toHaveBeenCalled()
-expect(a).toHaveBeenCalledTimes()
-expect(a).toHaveBeenCalledWith()
-expect(a).toHaveBeenLastCalledWith()
-expect(a).toHaveBeenNthCalledWith()
-expect(a).toHaveReturned()
-expect(a).toHaveReturnedTimes()
-expect(a).toHaveReturnedWith()
-expect(a).toHaveLastReturnedWith()
-expect(a).toHaveNthReturnedWith()
-expect(a).toThrow()
-```
-
-Examples of **incorrect** code for this rule with vitest:
-```javascript
-expect(a).toBeCalled()
-expect(a).toBeCalledTimes()
-expect(a).not["toThrowError"]()
-```
-
-Examples of **correct** code for this rule with vitest:
-```javascript
-expect(a).toHaveBeenCalled()
-expect(a).toHaveBeenCalledTimes()
-expect(a).toHaveBeenCalledWith()
-expect(a).toHaveBeenLastCalledWith()
-expect(a).toHaveBeenNthCalledWith()
-expect(a).toHaveReturned()
-expect(a).toHaveReturnedTimes()
-expect(a).toHaveReturnedWith()
-expect(a).toHaveLastReturnedWith()
-expect(a).toHaveNthReturnedWith()
-expect(a).toThrow()
-expect(a).rejects
-expect(a)
-```
-"#;
-
 pub fn run_on_jest_node<'a, 'c>(jest_node: &PossibleJestNode<'a, 'c>, ctx: &'c LintContext<'a>) {
     let node = jest_node.node;
     let AstKind::CallExpression(call_expr) = node.kind() else {
@@ -101,8 +34,7 @@ pub fn run_on_jest_node<'a, 'c>(jest_node: &PossibleJestNode<'a, 'c>, ctx: &'c L
     let (name, canonical_name) = method_name.name_with_canonical();
 
     let mut span = matcher.span;
-    // expect(a).not['toThrowError']()
-    // matcher is the node of `toThrowError`, we only what to replace the content in the quotes.
+    // For quoted matchers, replace only the method name inside the quotes.
     if matcher.element.is_string_literal() {
         span.start += 1;
         span.end -= 1;

--- a/crates/oxc_linter/src/rules/vitest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_alias_methods.rs
@@ -1,16 +1,60 @@
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
-    context::LintContext,
-    rule::Rule,
-    rules::shared::no_alias_methods::{DOCUMENTATION, run_on_jest_node},
+    context::LintContext, rule::Rule, rules::shared::no_alias_methods::run_on_jest_node,
     utils::PossibleJestNode,
 };
 
 #[derive(Debug, Default, Clone)]
 pub struct NoAliasMethods;
 
-declare_oxc_lint!(NoAliasMethods, vitest, style, fix, docs = DOCUMENTATION, version = "0.0.12",);
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces Vitest's canonical matcher names instead of aliases.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Vitest matcher aliases are discouraged because they make matcher usage inconsistent.
+    /// This rule makes it easier to search for all occurrences of a matcher and ensures consistency among matcher names.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// expect(a).toBeCalled()
+    /// expect(a).toBeCalledTimes()
+    /// expect(a).toBeCalledWith()
+    /// expect(a).lastCalledWith()
+    /// expect(a).nthCalledWith()
+    /// expect(a).toReturn()
+    /// expect(a).toReturnTimes()
+    /// expect(a).toReturnWith()
+    /// expect(a).lastReturnedWith()
+    /// expect(a).nthReturnedWith()
+    /// expect(a).toThrowError()
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// expect(a).toHaveBeenCalled()
+    /// expect(a).toHaveBeenCalledTimes()
+    /// expect(a).toHaveBeenCalledWith()
+    /// expect(a).toHaveBeenLastCalledWith()
+    /// expect(a).toHaveBeenNthCalledWith()
+    /// expect(a).toHaveReturned()
+    /// expect(a).toHaveReturnedTimes()
+    /// expect(a).toHaveReturnedWith()
+    /// expect(a).toHaveLastReturnedWith()
+    /// expect(a).toHaveNthReturnedWith()
+    /// expect(a).toThrow()
+    /// ```
+    NoAliasMethods,
+    vitest,
+    style,
+    fix,
+    version = "0.0.12",
+);
 
 impl Rule for NoAliasMethods {
     fn run_on_jest_node<'a, 'c>(


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/16306

Makes the docs accurate for the Vitest version of the rule