### PR TITLE
feat(linter/react): implement destructuring-assignment rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -152,6 +152,10 @@ export type RadixType = "always" | "as-needed";
 export type NativeAllowList = AllKeyword | string[];
 export type AllKeyword = "all";
 /**
+ * Controls whether destructuring assignments are required or forbidden in function signatures.
+ */
+export type DestructureInSignature = "always" | "ignore";
+/**
  * A forbidden prop, either as a plain prop name string or with options.
  */
 export type ForbidItem = string | ForbidItemObject;
@@ -1150,6 +1154,11 @@ export interface DummyRuleMap {
     | AllowWarnDeny
     | [AllowWarnDeny]
     | [AllowWarnDeny, CheckedRequiresOnchangeOrReadonly];
+  "react/destructuring-assignment"?:
+    | AllowWarnDeny
+    | [AllowWarnDeny]
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, AlwaysNever, DestructuringAssignmentOptions];
   "react/display-name"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DisplayNameConfig];
   "react/exhaustive-deps"?: DummyRule;
   "react/forbid-component-props"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ForbidComponentPropsConfig];
@@ -3906,6 +3915,16 @@ export interface CheckedRequiresOnchangeOrReadonly {
    * Ignore the requirement to provide either `onChange` or `readOnly` when the `checked` prop is present.
    */
   ignoreMissingProperties?: boolean;
+}
+export interface DestructuringAssignmentOptions {
+  /**
+   * Whether to ignore destructuring in function signature.
+   */
+  destructureInSignature?: DestructureInSignature;
+  /**
+   * Whether to ignore class fields when destructuring.
+   */
+  ignoreClassFields?: boolean;
 }
 export interface DisplayNameConfig {
   /**

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -337,6 +337,44 @@ impl GetSpan for Message {
     }
 }
 
+/// Expand a statement's span to include surrounding whitespace so that deleting
+/// the span does not leave behind blank lines or extra spaces.
+///
+/// - Leading horizontal whitespace (spaces/tabs) is consumed if preceded by a newline.
+/// - Trailing whitespace up to and including one newline is consumed.
+#[expect(clippy::cast_possible_truncation)]
+pub fn expand_span_to_statement_boundaries(source_text: &str, statement_span: Span) -> Span {
+    let mut start = statement_span.start as usize;
+    let mut end = statement_span.end as usize;
+    let bytes = source_text.as_bytes();
+
+    let mut candidate_start = start;
+    while candidate_start > 0 {
+        let ch = bytes[candidate_start - 1];
+        if matches!(ch, b' ' | b'\t') {
+            candidate_start -= 1;
+            continue;
+        }
+        if matches!(ch, b'\n' | b'\r') {
+            start = candidate_start;
+        }
+        break;
+    }
+
+    if end < bytes.len() && bytes[end] == b' ' {
+        end += 1;
+    }
+
+    let rest = bytes.get(end..).unwrap_or(&[]);
+    if rest.starts_with(b"\r\n") {
+        end += 2;
+    } else if rest.starts_with(b"\r") || rest.starts_with(b"\n") {
+        end += 1;
+    }
+
+    Span::new(start as u32, end as u32)
+}
+
 /// The fixer of the code.
 /// Note that our parser has handled the BOM, so we don't need to port the BOM test cases from `ESLint`.
 pub struct Fixer<'a> {

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2509,6 +2509,15 @@ impl RuleRunner for crate::rules::react::checked_requires_onchange_or_readonly::
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::destructuring_assignment::DestructuringAssignment {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::FormalParameter,
+        AstType::ObjectPattern,
+        AstType::StaticMemberExpression,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::display_name::DisplayName {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2510,12 +2510,8 @@ impl RuleRunner for crate::rules::react::checked_requires_onchange_or_readonly::
 }
 
 impl RuleRunner for crate::rules::react::destructuring_assignment::DestructuringAssignment {
-    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
-        AstType::FormalParameter,
-        AstType::ObjectPattern,
-        AstType::StaticMemberExpression,
-    ]));
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
 impl RuleRunner for crate::rules::react::display_name::DisplayName {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -417,6 +417,7 @@ pub use crate::rules::promise::spec_only::SpecOnly as PromiseSpecOnly;
 pub use crate::rules::promise::valid_params::ValidParams as PromiseValidParams;
 pub use crate::rules::react::button_has_type::ButtonHasType as ReactButtonHasType;
 pub use crate::rules::react::checked_requires_onchange_or_readonly::CheckedRequiresOnchangeOrReadonly as ReactCheckedRequiresOnchangeOrReadonly;
+pub use crate::rules::react::destructuring_assignment::DestructuringAssignment as ReactDestructuringAssignment;
 pub use crate::rules::react::display_name::DisplayName as ReactDisplayName;
 pub use crate::rules::react::exhaustive_deps::ExhaustiveDeps as ReactExhaustiveDeps;
 pub use crate::rules::react::forbid_component_props::ForbidComponentProps as ReactForbidComponentProps;
@@ -1240,6 +1241,7 @@ pub enum RuleEnum {
     JestValidTitle(JestValidTitle),
     ReactButtonHasType(ReactButtonHasType),
     ReactCheckedRequiresOnchangeOrReadonly(ReactCheckedRequiresOnchangeOrReadonly),
+    ReactDestructuringAssignment(ReactDestructuringAssignment),
     ReactDisplayName(ReactDisplayName),
     ReactExhaustiveDeps(ReactExhaustiveDeps),
     ReactForbidComponentProps(ReactForbidComponentProps),
@@ -2124,7 +2126,9 @@ const JEST_VALID_EXPECT_IN_PROMISE_ID: usize = JEST_VALID_EXPECT_ID + 1usize;
 const JEST_VALID_TITLE_ID: usize = JEST_VALID_EXPECT_IN_PROMISE_ID + 1usize;
 const REACT_BUTTON_HAS_TYPE_ID: usize = JEST_VALID_TITLE_ID + 1usize;
 const REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID: usize = REACT_BUTTON_HAS_TYPE_ID + 1usize;
-const REACT_DISPLAY_NAME_ID: usize = REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID + 1usize;
+const REACT_DESTRUCTURING_ASSIGNMENT_ID: usize =
+    REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID + 1usize;
+const REACT_DISPLAY_NAME_ID: usize = REACT_DESTRUCTURING_ASSIGNMENT_ID + 1usize;
 const REACT_EXHAUSTIVE_DEPS_ID: usize = REACT_DISPLAY_NAME_ID + 1usize;
 const REACT_FORBID_COMPONENT_PROPS_ID: usize = REACT_EXHAUSTIVE_DEPS_ID + 1usize;
 const REACT_FORBID_DOM_PROPS_ID: usize = REACT_FORBID_COMPONENT_PROPS_ID + 1usize;
@@ -3084,6 +3088,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID
             }
+            Self::ReactDestructuringAssignment(_) => REACT_DESTRUCTURING_ASSIGNMENT_ID,
             Self::ReactDisplayName(_) => REACT_DISPLAY_NAME_ID,
             Self::ReactExhaustiveDeps(_) => REACT_EXHAUSTIVE_DEPS_ID,
             Self::ReactForbidComponentProps(_) => REACT_FORBID_COMPONENT_PROPS_ID,
@@ -4039,6 +4044,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::NAME
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::NAME,
             Self::ReactDisplayName(_) => ReactDisplayName::NAME,
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::NAME,
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::NAME,
@@ -5006,6 +5012,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::CATEGORY
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::CATEGORY,
             Self::ReactDisplayName(_) => ReactDisplayName::CATEGORY,
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::CATEGORY,
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::CATEGORY,
@@ -5984,6 +5991,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::FIX
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::FIX,
             Self::ReactDisplayName(_) => ReactDisplayName::FIX,
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::FIX,
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::FIX,
@@ -7034,6 +7042,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::documentation()
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::documentation(),
             Self::ReactDisplayName(_) => ReactDisplayName::documentation(),
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::documentation(),
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::documentation(),
@@ -8789,6 +8798,10 @@ impl RuleEnum {
                 ReactCheckedRequiresOnchangeOrReadonly::config_schema(generator)
                     .or_else(|| ReactCheckedRequiresOnchangeOrReadonly::schema(generator))
             }
+            Self::ReactDestructuringAssignment(_) => {
+                ReactDestructuringAssignment::config_schema(generator)
+                    .or_else(|| ReactDestructuringAssignment::schema(generator))
+            }
             Self::ReactDisplayName(_) => ReactDisplayName::config_schema(generator)
                 .or_else(|| ReactDisplayName::schema(generator)),
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::config_schema(generator)
@@ -10450,6 +10463,7 @@ impl RuleEnum {
             Self::JestValidTitle(_) => "jest",
             Self::ReactButtonHasType(_) => "react",
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => "react",
+            Self::ReactDestructuringAssignment(_) => "react",
             Self::ReactDisplayName(_) => "react",
             Self::ReactExhaustiveDeps(_) => "react",
             Self::ReactForbidComponentProps(_) => "react",
@@ -12154,6 +12168,9 @@ impl RuleEnum {
                     ReactCheckedRequiresOnchangeOrReadonly::from_configuration(value)?,
                 ))
             }
+            Self::ReactDestructuringAssignment(_) => Ok(Self::ReactDestructuringAssignment(
+                ReactDestructuringAssignment::from_configuration(value)?,
+            )),
             Self::ReactDisplayName(_) => {
                 Ok(Self::ReactDisplayName(ReactDisplayName::from_configuration(value)?))
             }
@@ -13961,6 +13978,7 @@ impl RuleEnum {
             Self::JestValidTitle(rule) => rule.to_configuration(),
             Self::ReactButtonHasType(rule) => rule.to_configuration(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.to_configuration(),
+            Self::ReactDestructuringAssignment(rule) => rule.to_configuration(),
             Self::ReactDisplayName(rule) => rule.to_configuration(),
             Self::ReactExhaustiveDeps(rule) => rule.to_configuration(),
             Self::ReactForbidComponentProps(rule) => rule.to_configuration(),
@@ -14804,6 +14822,7 @@ impl RuleEnum {
                 Self::JestValidTitle(rule) => rule.run(node, ctx),
                 Self::ReactButtonHasType(rule) => rule.run(node, ctx),
                 Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run(node, ctx),
+                Self::ReactDestructuringAssignment(rule) => rule.run(node, ctx),
                 Self::ReactDisplayName(rule) => rule.run(node, ctx),
                 Self::ReactExhaustiveDeps(rule) => rule.run(node, ctx),
                 Self::ReactForbidComponentProps(rule) => rule.run(node, ctx),
@@ -15640,6 +15659,7 @@ impl RuleEnum {
                 Self::JestValidTitle(rule) => rule.run(node, ctx),
                 Self::ReactButtonHasType(rule) => rule.run(node, ctx),
                 Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run(node, ctx),
+                Self::ReactDestructuringAssignment(rule) => rule.run(node, ctx),
                 Self::ReactDisplayName(rule) => rule.run(node, ctx),
                 Self::ReactExhaustiveDeps(rule) => rule.run(node, ctx),
                 Self::ReactForbidComponentProps(rule) => rule.run(node, ctx),
@@ -16483,6 +16503,7 @@ impl RuleEnum {
                 Self::JestValidTitle(rule) => rule.run_once(ctx),
                 Self::ReactButtonHasType(rule) => rule.run_once(ctx),
                 Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_once(ctx),
+                Self::ReactDestructuringAssignment(rule) => rule.run_once(ctx),
                 Self::ReactDisplayName(rule) => rule.run_once(ctx),
                 Self::ReactExhaustiveDeps(rule) => rule.run_once(ctx),
                 Self::ReactForbidComponentProps(rule) => rule.run_once(ctx),
@@ -17319,6 +17340,7 @@ impl RuleEnum {
                 Self::JestValidTitle(rule) => rule.run_once(ctx),
                 Self::ReactButtonHasType(rule) => rule.run_once(ctx),
                 Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_once(ctx),
+                Self::ReactDestructuringAssignment(rule) => rule.run_once(ctx),
                 Self::ReactDisplayName(rule) => rule.run_once(ctx),
                 Self::ReactExhaustiveDeps(rule) => rule.run_once(ctx),
                 Self::ReactForbidComponentProps(rule) => rule.run_once(ctx),
@@ -18287,6 +18309,7 @@ impl RuleEnum {
                 Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::ReactDestructuringAssignment(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactDisplayName(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactExhaustiveDeps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactForbidComponentProps(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19379,6 +19402,7 @@ impl RuleEnum {
                 Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::ReactDestructuringAssignment(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactDisplayName(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactExhaustiveDeps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactForbidComponentProps(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20347,6 +20371,7 @@ impl RuleEnum {
             Self::JestValidTitle(rule) => rule.should_run(ctx),
             Self::ReactButtonHasType(rule) => rule.should_run(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.should_run(ctx),
+            Self::ReactDestructuringAssignment(rule) => rule.should_run(ctx),
             Self::ReactDisplayName(rule) => rule.should_run(ctx),
             Self::ReactExhaustiveDeps(rule) => rule.should_run(ctx),
             Self::ReactForbidComponentProps(rule) => rule.should_run(ctx),
@@ -21354,6 +21379,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::IS_TSGOLINT_RULE
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::IS_TSGOLINT_RULE,
             Self::ReactDisplayName(_) => ReactDisplayName::IS_TSGOLINT_RULE,
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::IS_TSGOLINT_RULE,
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::IS_TSGOLINT_RULE,
@@ -22479,6 +22505,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::VERSION
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::VERSION,
             Self::ReactDisplayName(_) => ReactDisplayName::VERSION,
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::VERSION,
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::VERSION,
@@ -23497,6 +23524,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::HAS_CONFIG
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::HAS_CONFIG,
             Self::ReactDisplayName(_) => ReactDisplayName::HAS_CONFIG,
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::HAS_CONFIG,
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::HAS_CONFIG,
@@ -24498,6 +24526,7 @@ impl RuleEnum {
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::INFO
             }
+            Self::ReactDestructuringAssignment(_) => ReactDestructuringAssignment::INFO,
             Self::ReactDisplayName(_) => ReactDisplayName::INFO,
             Self::ReactExhaustiveDeps(_) => ReactExhaustiveDeps::INFO,
             Self::ReactForbidComponentProps(_) => ReactForbidComponentProps::INFO,
@@ -25378,6 +25407,7 @@ impl RuleEnum {
             Self::JestValidTitle(rule) => rule.types_info(),
             Self::ReactButtonHasType(rule) => rule.types_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.types_info(),
+            Self::ReactDestructuringAssignment(rule) => rule.types_info(),
             Self::ReactDisplayName(rule) => rule.types_info(),
             Self::ReactExhaustiveDeps(rule) => rule.types_info(),
             Self::ReactForbidComponentProps(rule) => rule.types_info(),
@@ -26211,6 +26241,7 @@ impl RuleEnum {
             Self::JestValidTitle(rule) => rule.run_info(),
             Self::ReactButtonHasType(rule) => rule.run_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_info(),
+            Self::ReactDestructuringAssignment(rule) => rule.run_info(),
             Self::ReactDisplayName(rule) => rule.run_info(),
             Self::ReactExhaustiveDeps(rule) => rule.run_info(),
             Self::ReactForbidComponentProps(rule) => rule.run_info(),
@@ -27134,6 +27165,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactCheckedRequiresOnchangeOrReadonly(
             ReactCheckedRequiresOnchangeOrReadonly::default(),
         ),
+        RuleEnum::ReactDestructuringAssignment(ReactDestructuringAssignment::default()),
         RuleEnum::ReactDisplayName(ReactDisplayName::default()),
         RuleEnum::ReactExhaustiveDeps(ReactExhaustiveDeps::default()),
         RuleEnum::ReactForbidComponentProps(ReactForbidComponentProps::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -410,6 +410,7 @@ pub(crate) mod jest {
 pub(crate) mod react {
     pub mod button_has_type;
     pub mod checked_requires_onchange_or_readonly;
+    pub mod destructuring_assignment;
     pub mod display_name;
     pub mod exhaustive_deps;
     pub mod forbid_component_props;

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -18,12 +18,6 @@ use crate::{
     utils::{FunctionLike, get_parent_component, get_parent_stateless_component},
 };
 
-//   noDestructPropsInSFCArg: 'Must never use destructuring props assignment in SFC argument',
-// noDestructContextInSFCArg: 'Must never use destructuring context assignment in SFC argument',
-// noDestructAssignment: 'Must never use destructuring {{type}} assignment',
-// useDestructAssignment: 'Must use destructuring {{type}} assignment',
-// destructureInSignature: 'Must destructure props in the function signature.',
-
 fn no_destruct_props_in_sfc_arg_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Must never use destructuring props assignment in SFC argument.")
         .with_label(span)

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -1,0 +1,1239 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, StaticMemberExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::NodeId;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::expand_span_to_statement_boundaries,
+    rule::{Rule, TupleRuleConfig},
+    rules::ContextHost,
+    utils::{FunctionLike, get_parent_component, get_parent_stateless_component},
+};
+
+//   noDestructPropsInSFCArg: 'Must never use destructuring props assignment in SFC argument',
+// noDestructContextInSFCArg: 'Must never use destructuring context assignment in SFC argument',
+// noDestructAssignment: 'Must never use destructuring {{type}} assignment',
+// useDestructAssignment: 'Must use destructuring {{type}} assignment',
+// destructureInSignature: 'Must destructure props in the function signature.',
+
+fn no_destruct_props_in_sfc_arg_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Must never use destructuring props assignment in SFC argument.")
+        .with_label(span)
+}
+
+fn no_destruct_context_in_sfc_arg_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Must never use destructuring context assignment in SFC argument.")
+        .with_label(span)
+}
+
+fn no_destruct_assignment_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Must never use destructuring {name} assignment.")).with_label(span)
+}
+
+fn use_destruct_assignment_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Must use destructuring {name} assignment.")).with_label(span)
+}
+
+fn destructure_in_signature_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Must destructure props in the function signature.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Mode {
+    #[default]
+    Always,
+    Never,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum DestructureInSignature {
+    Always,
+    #[default]
+    Ignore,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct DestructuringAssignmentOptions {
+    // Whether to ignore class fields when destructuring.
+    ignore_class_fields: bool,
+    // Whether to ignore destructuring in function signature.
+    destructure_in_signature: DestructureInSignature,
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(default)]
+pub struct DestructuringAssignmentTupleConfig(Mode, DestructuringAssignmentOptions);
+
+#[derive(Debug, Clone)]
+pub struct DestructuringAssignmentConfig {
+    apply_never: bool,
+    apply_to_class_fields: bool,
+    apply_to_signature: bool,
+}
+
+impl From<DestructuringAssignmentTupleConfig> for DestructuringAssignmentConfig {
+    fn from(value: DestructuringAssignmentTupleConfig) -> Self {
+        let DestructuringAssignmentTupleConfig(mode, options) = value;
+
+        DestructuringAssignmentConfig {
+            apply_never: matches!(mode, Mode::Never),
+            apply_to_class_fields: !options.ignore_class_fields,
+            apply_to_signature: matches!(
+                options.destructure_in_signature,
+                DestructureInSignature::Always
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DestructuringAssignment(Box<DestructuringAssignmentConfig>);
+
+impl std::ops::Deref for DestructuringAssignment {
+    type Target = DestructuringAssignmentConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for DestructuringAssignment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let config = DestructuringAssignmentTupleConfig::deserialize(deserializer)?;
+        Ok(Self(Box::new(config.into())))
+    }
+}
+
+impl Default for DestructuringAssignmentConfig {
+    fn default() -> Self {
+        Self { apply_never: false, apply_to_class_fields: true, apply_to_signature: false }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce consistent usage of destructuring assignment of props, state, and context.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Destructuring can make it easier to read and understand what properties are being used in a component.
+    ///
+    /// ### Options
+    ///
+    /// This rule takes one string and one optional object as arguments:
+    ///
+    /// ```jsonc
+    /// {
+    ///   "rules": {
+    ///     "react/destructuring-assignment": [
+    ///       "error",
+    ///       "always", // or "never"
+    ///       {
+    ///         "ignoreClassFields": false,
+    ///         "destructureInSignature": "ignore" // or "always"
+    ///       }
+    ///     ]
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// - `"always"` (default): enforce destructuring of `props`, `state`, and `context`.
+    /// - `"never"`: forbid destructuring of `props`, `state`, and `context`.
+    /// - `ignoreClassFields` (default `false`): when `true`, ignore class field
+    ///   declarations such as `bar = this.props.bar`.
+    /// - `destructureInSignature` (default `"ignore"`): when set to `"always"`,
+    ///   require props destructuring to happen in the function signature.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule, when configured with `"always"` (the default):
+    ///
+    /// ```jsx
+    /// const MyComponent = (props) => {
+    ///   return (<div id={props.id} />)
+    /// };
+    /// ```
+    ///
+    /// ```jsx
+    /// const Foo = class extends React.PureComponent {
+    ///   render() {
+    ///     return <div>{this.context.foo}</div>;
+    ///   }
+    /// };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule, when configured with `"always"` (the default):
+    ///
+    /// ```jsx
+    /// const MyComponent = ({id}) => {
+    ///   return (<div id={id} />)
+    /// };
+    /// ```
+    ///
+    /// ```jsx
+    /// const MyComponent = (props, context) => {
+    ///   const { id } = props;
+    ///   return (<div id={id} />)
+    /// };
+    /// ```
+    ///
+    /// ```jsx
+    /// const Foo = class extends React.PureComponent {
+    ///   render() {
+    ///     const { title } = this.context;
+    ///     return <div>{title}</div>;
+    ///   }
+    /// };
+    /// ```
+    ///
+    /// Examples of **incorrect** code for this rule, when configured with `"never"`:
+    ///
+    /// ```jsx
+    /// const MyComponent = ({id}) => {
+    ///   return (<div id={id} />)
+    /// };
+    /// ```
+    ///
+    /// ```jsx
+    /// const MyComponent = (props) => {
+    ///   const { id } = props;
+    ///   return (<div id={id} />)
+    /// };
+    /// ```
+    ///
+    /// ```jsx
+    /// const Foo = class extends React.PureComponent {
+    ///   render() {
+    ///     const { title } = this.state;
+    ///     return <div>{title}</div>;
+    ///   }
+    /// };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule, when configured with `"never"`:
+    ///
+    /// ```jsx
+    /// const MyComponent = (props) => {
+    ///   return (<div id={props.id} />)
+    /// };
+    /// ```
+    ///
+    /// ```jsx
+    /// const Foo = class extends React.PureComponent {
+    ///   render() {
+    ///     return <div>{this.state.title}</div>;
+    ///   }
+    /// };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule, when configured with `["always", { "ignoreClassFields": true }]`:
+    ///
+    /// ```jsx
+    /// class Foo extends React.PureComponent {
+    ///   bar = this.props.bar
+    /// }
+    /// ```
+    ///
+    /// Examples of **incorrect** code for this rule, when configured with `["always", { "destructureInSignature": "always" }]`:
+    ///
+    /// ```jsx
+    /// function Foo(props) {
+    ///   const {a} = props;
+    ///   return <>{a}</>
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule, when configured with `["always", { "destructureInSignature": "always" }]`:
+    ///
+    /// ```jsx
+    /// function Foo({a}) {
+    ///   return <>{a}</>
+    /// }
+    /// ```
+    ///
+    /// ```jsx
+    /// // Ignores when props is used elsewhere
+    /// function Foo(props) {
+    ///   const {a} = props;
+    ///   useProps(props); // NOTE: it is a bad practice to pass the props object anywhere else!
+    ///   return <Goo a={a}/>
+    /// }
+    /// ```
+    DestructuringAssignment,
+    react,
+    style,
+    fix,
+    config = DestructuringAssignmentTupleConfig,
+    version = "next",
+);
+
+impl DestructuringAssignment {
+    fn handle_object_pattern(
+        &self,
+        node_id: NodeId,
+        ctx: &LintContext,
+    ) -> Option<(Span, Span, Span)> {
+        for ancestor in ctx.nodes().ancestors(node_id) {
+            let node = ctx.nodes().get_node(node_id);
+            match ancestor.kind() {
+                AstKind::VariableDeclarator(decl) => {
+                    let Some(init) = &decl.init else {
+                        break;
+                    };
+
+                    if let Some(prop_name) = get_this_member_name(init) {
+                        if get_parent_component(node, ctx).is_some() {
+                            ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, prop_name));
+                        }
+                        break;
+                    }
+
+                    let Some(id_ref) = init.get_identifier_reference() else {
+                        break;
+                    };
+                    let Some(parent) = get_parent_stateless_component(node, ctx) else {
+                        break;
+                    };
+                    let obj_name = id_ref.name.as_str();
+                    let params = parent.params();
+                    let Some(param) = params.items.iter().find(|p| {
+                        p.pattern
+                            .get_binding_identifier()
+                            .is_some_and(|id| id.name.as_str() == obj_name)
+                    }) else {
+                        break;
+                    };
+
+                    if self.apply_never {
+                        ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, obj_name));
+                    } else if self.apply_to_signature {
+                        let binding = param.pattern.get_binding_identifier().unwrap();
+                        let used_more_than_once = ctx
+                            .scoping()
+                            .get_resolved_references(binding.symbol_id())
+                            .filter(|reference| !reference.is_type())
+                            .count()
+                            > 1;
+                        if !used_more_than_once {
+                            let object_pattern_span = node.span();
+                            let declaration_span = ctx.nodes().parent_node(decl.node_id()).span();
+                            let param_span = param.pattern.span();
+                            return Some((object_pattern_span, declaration_span, param_span));
+                        }
+                    }
+                    break;
+                }
+                AstKind::FormalParameter(_) | AstKind::FormalParameters(_) => break,
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn should_skip_member(&self, node: &AstNode, ctx: &LintContext) -> bool {
+        match ctx.nodes().parent_kind(node.id()) {
+            AstKind::AssignmentExpression(_) => true,
+            AstKind::PropertyDefinition(_) => !self.apply_to_class_fields,
+            AstKind::TemplateLiteral(_) => {
+                !self.apply_to_class_fields
+                    && matches!(
+                        ctx.nodes().parent_kind(ctx.nodes().parent_id(node.id())),
+                        AstKind::PropertyDefinition(_)
+                    )
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Rule for DestructuringAssignment {
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::StaticMemberExpression(member) => {
+                if self.should_skip_member(node, ctx) || self.apply_never {
+                    return;
+                }
+                if let Some(parent) = get_parent_stateless_component(node, ctx) {
+                    handle_function_component_usage(member, ctx, &parent);
+                } else if get_parent_component(node, ctx).is_some() {
+                    handle_class_component_usage(member, ctx);
+                }
+            }
+            AstKind::FormalParameter(param)
+                if param.pattern.is_object_pattern() && self.apply_never =>
+            {
+                if let Some(parent) = get_parent_stateless_component(node, ctx) {
+                    let params = parent.params();
+                    if params.items[0].span == param.span {
+                        ctx.diagnostic(no_destruct_props_in_sfc_arg_diagnostic(param.span));
+                    } else if params.items[1].span == param.span {
+                        ctx.diagnostic(no_destruct_context_in_sfc_arg_diagnostic(param.span));
+                    }
+                }
+            }
+            AstKind::ObjectPattern(_) if self.apply_never || self.apply_to_signature => {
+                let Some((object_pattern_span, decl_span, param_span)) =
+                    self.handle_object_pattern(node.id(), ctx)
+                else {
+                    return;
+                };
+                ctx.diagnostic_with_fix(destructure_in_signature_diagnostic(decl_span), |fixer| {
+                    let mut fix = fixer.new_fix_with_capacity(2);
+                    fix.push(
+                        fixer.replace(
+                            param_span,
+                            fixer.source_range(object_pattern_span).to_string(),
+                        ),
+                    );
+                    let expanded_decl_span =
+                        expand_span_to_statement_boundaries(fixer.source_text(), decl_span);
+                    fix.push(fixer.delete_range(expanded_decl_span));
+                    fix.with_message("Replace object pattern with destructuring in signature")
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+fn handle_class_component_usage<'a>(node: &StaticMemberExpression<'a>, ctx: &LintContext<'a>) {
+    let Some(prop_name) = get_this_member_name(&node.object) else {
+        return;
+    };
+    ctx.diagnostic(use_destruct_assignment_diagnostic(node.span, prop_name));
+}
+
+fn handle_function_component_usage<'a>(
+    node: &StaticMemberExpression<'a>,
+    ctx: &LintContext<'a>,
+    parent: &FunctionLike<'a>,
+) {
+    let params = parent.params();
+    let Some(id_ref) = node.object.get_identifier_reference() else {
+        return;
+    };
+    let obj_name = id_ref.name.as_str();
+    let matched_name = params.items.iter().find_map(|param| {
+        let param_id = param.pattern.get_binding_identifier()?;
+        let param_name = param_id.name.as_str();
+        (obj_name == param_name).then_some(param_name)
+    });
+    if let Some(name) = matched_name {
+        ctx.diagnostic(use_destruct_assignment_diagnostic(node.span, name));
+    }
+}
+
+fn get_this_member_name<'a>(expr: &Expression<'a>) -> Option<&'a str> {
+    let Expression::StaticMemberExpression(member) = expr else { return None };
+    let Expression::ThisExpression(_) = &member.object else { return None };
+    let prop_name = member.property.name.as_str(); // "props", "context", or "state"
+    matches!(prop_name, "props" | "context" | "state").then_some(prop_name)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                    export const revisionStates2 = {
+                        [A.b]: props => {
+                          return props.editor !== null
+                            ? 'xyz'
+                            : 'abc'
+                        },
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export function hof(namespace) {
+                      const initialState = {
+                        bounds: null,
+                        search: false,
+                      };
+                      return (props) => {
+                        const {x, y} = props
+                        if (y) {
+                          return <span>{y}</span>;
+                        }
+                        return <span>{x}</span>
+                      };
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export function hof(namespace) {
+                      const initialState = {
+                        bounds: null,
+                        search: false,
+                      };
+
+                      return (state = initialState, action) => {
+                        if (action.type === 'ABC') {
+                          return {...state, bounds: stuff ? action.x : null};
+                        }
+
+                        if (action.namespace !== namespace) {
+                          return state;
+                        }
+
+                        return null
+                      };
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const MyComponent = ({ id, className }) => (
+                      <div id={id} className={className} />
+                    );
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const MyComponent = ({ id, className }) => (
+                      <div id={id} className={className} />
+                    );
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const { id, className } = props;
+                      return <div id={id} className={className} />
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const { id, className } = props;
+                      return <div id={id} className={className} />
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => (
+                      <div id={id} props={props} />
+                    );
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => (
+                      <div id={id} props={props} />
+                    );
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props, { color }) => (
+                      <div id={id} props={props} color={color} />
+                    );
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props, { color }) => (
+                      <div id={id} props={props} color={color} />
+                    );
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        return <div>{this.props.foo}</div>;
+                      }
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    class Foo extends React.Component {
+                      doStuff() {}
+                      render() {
+                        return <div>{this.props.foo}</div>;
+                      }
+                    }
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        const { foo } = this.props;
+                        return <div>{foo}</div>;
+                      }
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        const { foo } = this.props;
+                        return <div>{foo}</div>;
+                      }
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const { h, i } = hi;
+                      return <div id={props.id} className={props.className} />
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      constructor() {
+                        this.state = {};
+                        this.state.foo = 'bar';
+                      }
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const div = styled.div`
+                      & .button {
+                        border-radius: ${props => props.borderRadius}px;
+                      }
+                    `
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export default (context: $Context) => ({
+                      foo: context.bar
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    class Foo {
+                      bar(context) {
+                        return context.baz;
+                      }
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    class Foo {
+                      bar(props) {
+                        return props.baz;
+                      }
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    class Foo extends React.Component {
+                      bar = this.props.bar
+                    }
+                  ",
+            Some(serde_json::json!(["always", { "ignoreClassFields": true }])),
+            None,
+        ),
+        (
+            "
+                    class Input extends React.Component {
+                      id = `${this.props.name}`;
+                      render() {
+                        return <div />;
+                      }
+                    }
+                  ",
+            Some(serde_json::json!(["always", { "ignoreClassFields": true }])),
+            None,
+        ),
+        (
+            "
+                    function Foo({ context }) {
+                      const d = context.describe();
+                      return <div>{d}</div>;
+                    }
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const obj = {
+                      foo(arg) {
+                        const a = arg.func();
+                        return null;
+                      },
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const columns = [
+                      {
+                        render: (val) => {
+                          if (val.url) {
+                            return (
+                              <a href={val.url}>
+                                {val.test}
+                              </a>
+                            );
+                          }
+                          return null;
+                        },
+                      },
+                    ];
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const columns = [
+                      {
+                        render: val => <span>{val}</span>,
+                      },
+                      {
+                        someRenderFunc: function(val) {
+                          if (val.url) {
+                            return (
+                              <a href={val.url}>
+                                {val.test}
+                              </a>
+                            );
+                          }
+                          return null;
+                        },
+                      },
+                    ];
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export default (fileName) => {
+                      const match = fileName.match(/some expression/);
+                      if (match) {
+                        return fn;
+                      }
+                      return null;
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    class C extends React.Component {
+                      componentDidMount() {
+                        const { forwardRef } = this.props;
+
+                        this.ref.current.focus();
+
+                        if (typeof forwardRef === 'function') {
+                          forwardRef(this.ref);
+                        }
+                      }
+                      render() {
+                        return <div />;
+                      }
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    function Foo(props) {
+                      const {a} = props;
+                      return <Goo {...props}>{a}</Goo>;
+                    }
+                  ",
+            Some(serde_json::json!(["always", { "destructureInSignature": "always" }])),
+            None,
+        ),
+        (
+            "
+                    function Foo(props) {
+                      const {a} = props;
+                      return <Goo f={() => props}>{a}</Goo>;
+                    }
+                  ",
+            Some(serde_json::json!(["always", { "destructureInSignature": "always" }])),
+            None,
+        ),
+        (
+            "
+                    import { useContext } from 'react';
+
+                    const MyComponent = (props) => {
+                      const {foo} = useContext(aContext);
+                      return <div>{foo}</div>
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.9.0" } } })),
+        ),
+        (
+            "
+                    import { useContext } from 'react';
+
+                    const MyComponent = (props) => {
+                      const foo = useContext(aContext);
+                      return <div>{foo.test}</div>
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.9.0" } } })),
+        ),
+        (
+            "
+                    import { useContext } from 'react';
+
+                    const MyComponent = (props) => {
+                      const foo = useContext(aContext);
+                      return <div>{foo.test}</div>
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.9.0" } } })),
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const foo = useContext(aContext);
+                      return <div>{foo.test}</div>
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.8.999" } } })),
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const {foo} = useContext(aContext);
+                      return <div>{foo}</div>
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.8.999" } } })),
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const {foo} = useContext(aContext);
+                      return <div>{foo}</div>
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.8.999" } } })),
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const foo = useContext(aContext);
+                      return <div>{foo.test}</div>
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.8.999" } } })),
+        ),
+        (
+            "
+                    import { useContext } from 'react';
+
+                    const MyComponent = (props) => {
+                      const foo = useContext(aContext);
+                      return <div>{foo?.test}</div>
+                    };
+                  ",
+            None,
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                    const MyComponent = (props) => {
+                      return (<div id={props.id} />)
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const MyComponent = ({ id, className }) => (
+                      <div id={id} className={className} />
+                    );
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props, { color }) => (
+                      <div id={props.id} className={props.className} />
+                    );
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        return <div>{this.props.foo}</div>;
+                      }
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        return <div>{this.state.foo}</div>;
+                      }
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        return <div>{this.context.foo}</div>;
+                      }
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    class Foo extends React.Component {
+                      render() { return this.foo(); }
+                      foo() {
+                        return this.props.children;
+                      }
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    var Hello = createReactClass({
+                      render: function() {
+                        return <Text>{this.props.foo}</Text>;
+                      }
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    module.exports = {
+                      Foo(props) {
+                        return <p>{props.a}</p>;
+                      }
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export default function Foo(props) {
+                      return <p>{props.a}</p>;
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    function hof() {
+                      return (props) => <p>{props.a}</p>;
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        const foo = this.props.foo;
+                        return <div>{foo}</div>;
+                      }
+                    };
+                    ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        const { foo } = this.props;
+                        return <div>{foo}</div>;
+                      }
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      const { id, className } = props;
+                      return <div id={id} className={className} />
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    const Foo = class extends React.PureComponent {
+                      render() {
+                        const { foo } = this.state;
+                        return <div>{foo}</div>;
+                      }
+                    };
+                  ",
+            Some(serde_json::json!(["never"])),
+            None,
+        ),
+        (
+            "
+                    const columns = [
+                      {
+                        CustomComponentName: function(props) {
+                          if (props.url) {
+                            return (
+                              <a href={props.url}>
+                                {props.test}
+                              </a>
+                            );
+                          }
+                          return null;
+                        },
+                      },
+                    ];
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    function Foo(props, context) {
+                      const d = context.describe();
+                      return <div>{d}</div>;
+                    }
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    export default (props) => {
+                      const match = props.str.match(/some expression/);
+                      if (match) {
+                        return <span>jsx</span>;
+                      }
+                      return null;
+                    };
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    import React from 'react';
+
+                    const TestComp = (props) => {
+                      props.onClick3102();
+
+                      return (
+                        <div
+                          onClick={(evt) => {
+                            if (props.onClick3102) {
+                              props.onClick3102(evt);
+                            }
+                          }}
+                        >
+                          <div />
+                        </div>
+                      );
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export const revisionStates2 = {
+                        [A.b]: props => {
+                          return props.editor !== null
+                            ? <span>{props.editor}</span>
+                            : null
+                        },
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export function hof(namespace) {
+                      const initialState = {
+                        bounds: null,
+                        search: false,
+                      };
+                      return (props) => {
+                        if (props.y) {
+                          return <span>{props.y}</span>;
+                        }
+                        return <span>{props.x}</span>
+                      };
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    type Props = { text: string };
+                    export const MyComponent: React.FC<Props> = (props) => {
+                      type MyType = typeof props.text;
+                      return <div>{props.text as MyType}</div>;
+                    };
+                  ",
+            Some(serde_json::json!(["always", { "destructureInSignature": "always" }])),
+            None,
+        ),
+        (
+            "
+                    type Props = { text: string };
+                    export const MyOtherComponent: React.FC<Props> = (props) => {
+                      const { text } = props;
+                      type MyType = typeof props.text;
+                      return <div>{text as MyType}</div>;
+                    };
+                  ",
+            Some(serde_json::json!(["always", { "destructureInSignature": "always" }])),
+            None,
+        ),
+        (
+            "
+                    function C(props: Props) {
+                      void props.a
+                      typeof props.b
+                      return <div />
+                    }
+                  ",
+            Some(serde_json::json!(["always"])),
+            None,
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "function Foo(props) { const {a} = props; return <>{a}</> }",
+            "function Foo({a}) { return <>{a}</> }",
+            Some(serde_json::json!(["always", { "destructureInSignature": "always" }])),
+        ),
+        (
+            "function Foo(props: FooProps) { const {a} = props; return <>{a}</> }",
+            "function Foo({a}: FooProps) { return <>{a}</> }",
+            Some(serde_json::json!(["always", { "destructureInSignature": "always" }])),
+        ),
+    ];
+
+    Tester::new(DestructuringAssignment::NAME, DestructuringAssignment::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -314,21 +314,13 @@ impl DestructuringAssignment {
             return None;
         }
 
-        let Some(id_ref) = init.get_identifier_reference() else {
-            return None;
-        };
-        let Some(parent) =
-            get_parent_stateless_component_cached(node, ctx, stateless_component_cache)
-        else {
-            return None;
-        };
+        let id_ref = init.get_identifier_reference()?;
+        let parent = get_parent_stateless_component_cached(node, ctx, stateless_component_cache)?;
         let obj_name = id_ref.name.as_str();
         let params = parent.params();
-        let Some(param) = params.items.iter().find(|p| {
+        let param = params.items.iter().find(|p| {
             p.pattern.get_binding_identifier().is_some_and(|id| id.name.as_str() == obj_name)
-        }) else {
-            return None;
-        };
+        })?;
 
         if self.apply_never() {
             ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, obj_name));

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -1,9 +1,11 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use rustc_hash::FxHashMap;
+
 use oxc_ast::{
-    AstKind,
-    ast::{Expression, StaticMemberExpression},
+    AstKind, AstType,
+    ast::{Expression, StaticMemberExpression, VariableDeclarator},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -16,7 +18,10 @@ use crate::{
     fixer::expand_span_to_statement_boundaries,
     rule::{Rule, TupleRuleConfig},
     rules::ContextHost,
-    utils::{AlwaysNever, FunctionLike, get_parent_component, get_parent_stateless_component},
+    utils::{
+        AlwaysNever, FunctionLike, function_like_returns_jsx, get_parent_component,
+        is_react_component_name,
+    },
 };
 
 fn no_destruct_props_in_sfc_arg_diagnostic(span: Span) -> OxcDiagnostic {
@@ -64,6 +69,14 @@ struct DestructuringAssignmentOptions {
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(default)]
 pub struct DestructuringAssignment(AlwaysNever, DestructuringAssignmentOptions);
+
+const NEEDED_NODE_TYPES: &oxc_semantic::AstTypesBitset =
+    &oxc_semantic::AstTypesBitset::from_types(&[
+        AstType::ArrowFunctionExpression,
+        AstType::Function,
+        AstType::StaticMemberExpression,
+        AstType::VariableDeclarator,
+    ]);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -202,123 +215,138 @@ impl Rule for DestructuringAssignment {
         serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        match node.kind() {
-            AstKind::StaticMemberExpression(member) => {
-                if self.should_skip_member(node, ctx) || self.apply_never() {
-                    return;
-                }
+    fn run_once(&self, ctx: &LintContext) {
+        let apply_never = self.apply_never();
+        let apply_to_signature = self.apply_to_signature();
+        let mut stateless_component_cache = FxHashMap::default();
 
-                if is_parameter_member_object(member, ctx) {
-                    if let Some(parent) = get_parent_stateless_component(node, ctx) {
+        for node in ctx.nodes() {
+            match node.kind() {
+                AstKind::StaticMemberExpression(member) => {
+                    if self.should_skip_member(node, ctx) || apply_never {
+                        continue;
+                    }
+
+                    if let Some(parent) = get_parent_stateless_component_cached(
+                        node,
+                        ctx,
+                        &mut stateless_component_cache,
+                    ) {
                         handle_function_component_usage(member, ctx, &parent);
-                    }
-                } else if let Some(prop_name) = get_this_member_name(&member.object)
-                    && get_parent_component(node, ctx).is_some()
-                {
-                    ctx.diagnostic(use_destruct_assignment_diagnostic(member.span, prop_name));
-                }
-            }
-            AstKind::FormalParameter(param)
-                if param.pattern.is_object_pattern() && self.apply_never() =>
-            {
-                if let Some(parent) = get_parent_stateless_component(node, ctx) {
-                    let params = parent.params();
-                    if params.items[0].span == param.span {
-                        ctx.diagnostic(no_destruct_props_in_sfc_arg_diagnostic(param.span));
-                    } else if params.items[1].span == param.span {
-                        ctx.diagnostic(no_destruct_context_in_sfc_arg_diagnostic(param.span));
+                    } else if let Some(prop_name) = get_this_member_name(&member.object)
+                        && get_parent_component(node, ctx).is_some()
+                    {
+                        ctx.diagnostic(use_destruct_assignment_diagnostic(member.span, prop_name));
                     }
                 }
-            }
-            AstKind::ObjectPattern(_) if self.apply_never() || self.apply_to_signature() => {
-                let Some((object_pattern_span, decl_span, param_span)) =
-                    self.handle_object_pattern(node.id(), node.span(), ctx)
-                else {
-                    return;
-                };
-                ctx.diagnostic_with_fix(destructure_in_signature_diagnostic(decl_span), |fixer| {
-                    let mut fix = fixer.new_fix_with_capacity(2);
-                    fix.push(
-                        fixer.replace(
-                            param_span,
-                            fixer.source_range(object_pattern_span).to_string(),
-                        ),
+                AstKind::Function(func) if apply_never => {
+                    handle_function_component_parameters(
+                        FunctionLike::Function(func),
+                        node,
+                        ctx,
+                        &mut stateless_component_cache,
                     );
-                    let expanded_decl_span =
-                        expand_span_to_statement_boundaries(fixer.source_text(), decl_span);
-                    fix.push(fixer.delete_range(expanded_decl_span));
-                    fix.with_message("Replace object pattern with destructuring in signature")
-                });
+                }
+                AstKind::ArrowFunctionExpression(arrow) if apply_never => {
+                    handle_function_component_parameters(
+                        FunctionLike::Arrow(arrow),
+                        node,
+                        ctx,
+                        &mut stateless_component_cache,
+                    );
+                }
+                AstKind::VariableDeclarator(decl)
+                    if decl.id.is_object_pattern() && (apply_never || apply_to_signature) =>
+                {
+                    let Some((object_pattern_span, decl_span, param_span)) = self
+                        .handle_variable_declarator(
+                            decl,
+                            node,
+                            ctx,
+                            &mut stateless_component_cache,
+                        )
+                    else {
+                        continue;
+                    };
+                    ctx.diagnostic_with_fix(
+                        destructure_in_signature_diagnostic(decl_span),
+                        |fixer| {
+                            let mut fix = fixer.new_fix_with_capacity(2);
+                            fix.push(fixer.replace(
+                                param_span,
+                                fixer.source_range(object_pattern_span).to_string(),
+                            ));
+                            let expanded_decl_span =
+                                expand_span_to_statement_boundaries(fixer.source_text(), decl_span);
+                            fix.push(fixer.delete_range(expanded_decl_span));
+                            fix.with_message(
+                                "Replace object pattern with destructuring in signature",
+                            )
+                        },
+                    );
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
+        ctx.source_type().is_jsx() && ctx.semantic().nodes().contains_any(NEEDED_NODE_TYPES)
     }
 }
 
 impl DestructuringAssignment {
-    fn handle_object_pattern(
+    fn handle_variable_declarator<'a>(
         &self,
-        node_id: NodeId,
-        object_pattern_span: Span,
-        ctx: &LintContext,
+        decl: &VariableDeclarator<'a>,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+        stateless_component_cache: &mut FxHashMap<NodeId, bool>,
     ) -> Option<(Span, Span, Span)> {
-        for ancestor in ctx.nodes().ancestors(node_id) {
-            match ancestor.kind() {
-                AstKind::VariableDeclarator(decl) => {
-                    let Some(init) = &decl.init else {
-                        break;
-                    };
+        let Some(init) = &decl.init else {
+            return None;
+        };
 
-                    if let Some(prop_name) = get_this_member_name(init) {
-                        if get_parent_component(ancestor, ctx).is_some() {
-                            ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, prop_name));
-                        }
-                        break;
-                    }
+        if let Some(prop_name) = get_this_member_name(init) {
+            if get_parent_component(node, ctx).is_some() {
+                ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, prop_name));
+            }
+            return None;
+        }
 
-                    let Some(id_ref) = init.get_identifier_reference() else {
-                        break;
-                    };
-                    let Some(parent) = get_parent_stateless_component(ancestor, ctx) else {
-                        break;
-                    };
-                    let obj_name = id_ref.name.as_str();
-                    let params = parent.params();
-                    let Some(param) = params.items.iter().find(|p| {
-                        p.pattern
-                            .get_binding_identifier()
-                            .is_some_and(|id| id.name.as_str() == obj_name)
-                    }) else {
-                        break;
-                    };
+        let Some(id_ref) = init.get_identifier_reference() else {
+            return None;
+        };
+        let Some(parent) =
+            get_parent_stateless_component_cached(node, ctx, stateless_component_cache)
+        else {
+            return None;
+        };
+        let obj_name = id_ref.name.as_str();
+        let params = parent.params();
+        let Some(param) = params.items.iter().find(|p| {
+            p.pattern.get_binding_identifier().is_some_and(|id| id.name.as_str() == obj_name)
+        }) else {
+            return None;
+        };
 
-                    if self.apply_never() {
-                        ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, obj_name));
-                    } else if self.apply_to_signature() {
-                        let binding = param.pattern.get_binding_identifier().unwrap();
-                        let used_more_than_once = ctx
-                            .scoping()
-                            .get_resolved_references(binding.symbol_id())
-                            .filter(|reference| !reference.is_type())
-                            .count()
-                            > 1;
-                        if !used_more_than_once {
-                            let declaration_span = ctx.nodes().parent_node(decl.node_id()).span();
-                            let param_span = param.pattern.span();
-                            return Some((object_pattern_span, declaration_span, param_span));
-                        }
-                    }
-                    break;
-                }
-                AstKind::FormalParameter(_) | AstKind::FormalParameters(_) => break,
-                _ => {}
+        if self.apply_never() {
+            ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, obj_name));
+        } else if self.apply_to_signature() {
+            let binding = param.pattern.get_binding_identifier().unwrap();
+            let used_more_than_once = ctx
+                .scoping()
+                .get_resolved_references(binding.symbol_id())
+                .filter(|reference| !reference.is_type())
+                .count()
+                > 1;
+            if !used_more_than_once {
+                let declaration_span = ctx.nodes().parent_node(decl.node_id()).span();
+                let param_span = param.pattern.span();
+                return Some((decl.id.span(), declaration_span, param_span));
             }
         }
+
         None
     }
 
@@ -350,6 +378,21 @@ impl DestructuringAssignment {
     }
 }
 
+fn get_parent_stateless_component_cached<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    cache: &mut FxHashMap<NodeId, bool>,
+) -> Option<FunctionLike<'a>> {
+    ctx.nodes().ancestors(node.id()).find_map(|ancestor_node| {
+        let function = FunctionLike::from_ast_kind(ancestor_node.kind())?;
+        let is_stateless_component = cache
+            .entry(ancestor_node.id())
+            .or_insert_with(|| is_stateless_component_function(function, ancestor_node, ctx));
+
+        (*is_stateless_component).then_some(function)
+    })
+}
+
 fn handle_function_component_usage<'a>(
     node: &StaticMemberExpression<'a>,
     ctx: &LintContext<'a>,
@@ -370,11 +413,50 @@ fn handle_function_component_usage<'a>(
     }
 }
 
-fn is_parameter_member_object(node: &StaticMemberExpression, ctx: &LintContext) -> bool {
-    let Some(id_ref) = node.object.get_identifier_reference() else { return false };
-    let reference = ctx.scoping().get_reference(id_ref.reference_id());
-    let Some(symbol_id) = reference.symbol_id() else { return false };
-    matches!(ctx.semantic().symbol_declaration(symbol_id).kind(), AstKind::FormalParameter(_))
+fn handle_function_component_parameters<'a>(
+    function: FunctionLike<'a>,
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    cache: &mut FxHashMap<NodeId, bool>,
+) {
+    let is_stateless_component = cache
+        .entry(node.id())
+        .or_insert_with(|| is_stateless_component_function(function, node, ctx));
+    if !*is_stateless_component {
+        return;
+    }
+
+    let params = function.params();
+    if let Some(param) = params.items.first()
+        && param.pattern.is_object_pattern()
+    {
+        ctx.diagnostic(no_destruct_props_in_sfc_arg_diagnostic(param.span));
+    }
+
+    if let Some(param) = params.items.get(1)
+        && param.pattern.is_object_pattern()
+    {
+        ctx.diagnostic(no_destruct_context_in_sfc_arg_diagnostic(param.span));
+    }
+}
+
+fn is_stateless_component_function<'a>(
+    function: FunctionLike<'a>,
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    if !function_like_returns_jsx(function) {
+        return false;
+    }
+
+    match ctx.nodes().parent_kind(node.id()) {
+        AstKind::ObjectProperty(prop) => {
+            let name = prop.key.name();
+            name.is_none_or(|n| is_react_component_name(&n))
+        }
+        AstKind::ArrayExpression(_) | AstKind::MethodDefinition(_) => false,
+        _ => true,
+    }
 }
 
 fn get_this_member_name<'a>(expr: &Expression<'a>) -> Option<&'a str> {

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -16,7 +16,7 @@ use crate::{
     fixer::expand_span_to_statement_boundaries,
     rule::{Rule, TupleRuleConfig},
     rules::ContextHost,
-    utils::{FunctionLike, get_parent_component, get_parent_stateless_component},
+    utils::{AlwaysNever, FunctionLike, get_parent_component, get_parent_stateless_component},
 };
 
 fn no_destruct_props_in_sfc_arg_diagnostic(span: Span) -> OxcDiagnostic {
@@ -41,18 +41,13 @@ fn destructure_in_signature_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Must destructure props in the function signature.").with_label(span)
 }
 
-#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub enum Mode {
-    #[default]
-    Always,
-    Never,
-}
-
+/// Controls whether destructuring assignments are required or forbidden in function signatures.
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum DestructureInSignature {
+    /// Require destructuring in the function signature when props are only used for destructuring.
     Always,
+    /// Allow destructuring in either the function signature or function body.
     #[default]
     Ignore,
 }
@@ -60,15 +55,15 @@ pub enum DestructureInSignature {
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct DestructuringAssignmentOptions {
-    // Whether to ignore class fields when destructuring.
+    /// Whether to ignore class fields when destructuring.
     ignore_class_fields: bool,
-    // Whether to ignore destructuring in function signature.
+    /// Whether to ignore destructuring in function signature.
     destructure_in_signature: DestructureInSignature,
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(default)]
-pub struct DestructuringAssignment(Mode, DestructuringAssignmentOptions);
+pub struct DestructuringAssignment(AlwaysNever, DestructuringAssignmentOptions);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -365,7 +360,7 @@ impl DestructuringAssignment {
     }
 
     fn apply_never(&self) -> bool {
-        matches!(&self.0, Mode::Never)
+        matches!(&self.0, AlwaysNever::Never)
     }
 
     fn apply_to_class_fields(&self) -> bool {

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -400,7 +400,7 @@ impl DestructuringAssignment {
 
     fn should_skip_member(&self, node: &AstNode, ctx: &LintContext) -> bool {
         match ctx.nodes().parent_kind(node.id()) {
-            AstKind::AssignmentExpression(_) => true,
+            AstKind::AssignmentExpression(assignment) => assignment.left.span() == node.span(),
             AstKind::PropertyDefinition(_) => !self.apply_to_class_fields,
             AstKind::TemplateLiteral(_) => {
                 !self.apply_to_class_fields
@@ -563,6 +563,16 @@ fn test() {
                     );
                   ",
             Some(serde_json::json!(["always"])),
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      props.id = 'id';
+                      return <div />;
+                    };
+                  ",
+            None,
             None,
         ),
         (
@@ -1175,6 +1185,17 @@ fn test() {
                         return <span>{props.x}</span>
                       };
                     }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const MyComponent = (props) => {
+                      let id;
+                      id = props.id;
+                      return <div>{id}</div>;
+                    };
                   ",
             None,
             None,

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -208,10 +208,15 @@ impl Rule for DestructuringAssignment {
                 if self.should_skip_member(node, ctx) || self.apply_never() {
                     return;
                 }
-                if let Some(parent) = get_parent_stateless_component(node, ctx) {
-                    handle_function_component_usage(member, ctx, &parent);
-                } else if get_parent_component(node, ctx).is_some() {
-                    handle_class_component_usage(member, ctx);
+
+                if is_parameter_member_object(member, ctx) {
+                    if let Some(parent) = get_parent_stateless_component(node, ctx) {
+                        handle_function_component_usage(member, ctx, &parent);
+                    }
+                } else if let Some(prop_name) = get_this_member_name(&member.object)
+                    && get_parent_component(node, ctx).is_some()
+                {
+                    ctx.diagnostic(use_destruct_assignment_diagnostic(member.span, prop_name));
                 }
             }
             AstKind::FormalParameter(param)
@@ -345,13 +350,6 @@ impl DestructuringAssignment {
     }
 }
 
-fn handle_class_component_usage<'a>(node: &StaticMemberExpression<'a>, ctx: &LintContext<'a>) {
-    let Some(prop_name) = get_this_member_name(&node.object) else {
-        return;
-    };
-    ctx.diagnostic(use_destruct_assignment_diagnostic(node.span, prop_name));
-}
-
 fn handle_function_component_usage<'a>(
     node: &StaticMemberExpression<'a>,
     ctx: &LintContext<'a>,
@@ -370,6 +368,13 @@ fn handle_function_component_usage<'a>(
     if let Some(name) = matched_name {
         ctx.diagnostic(use_destruct_assignment_diagnostic(node.span, name));
     }
+}
+
+fn is_parameter_member_object(node: &StaticMemberExpression, ctx: &LintContext) -> bool {
+    let Some(id_ref) = node.object.get_identifier_reference() else { return false };
+    let reference = ctx.scoping().get_reference(id_ref.reference_id());
+    let Some(symbol_id) = reference.symbol_id() else { return false };
+    matches!(ctx.semantic().symbol_declaration(symbol_id).kind(), AstKind::FormalParameter(_))
 }
 
 fn get_this_member_name<'a>(expr: &Expression<'a>) -> Option<&'a str> {

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -254,7 +254,7 @@ impl Rule for DestructuringAssignment {
             }
             AstKind::ObjectPattern(_) if self.apply_never() || self.apply_to_signature() => {
                 let Some((object_pattern_span, decl_span, param_span)) =
-                    self.handle_object_pattern(node.id(), ctx)
+                    self.handle_object_pattern(node.id(), node.span(), ctx)
                 else {
                     return;
                 };
@@ -285,10 +285,10 @@ impl DestructuringAssignment {
     fn handle_object_pattern(
         &self,
         node_id: NodeId,
+        object_pattern_span: Span,
         ctx: &LintContext,
     ) -> Option<(Span, Span, Span)> {
         for ancestor in ctx.nodes().ancestors(node_id) {
-            let node = ctx.nodes().get_node(node_id);
             match ancestor.kind() {
                 AstKind::VariableDeclarator(decl) => {
                     let Some(init) = &decl.init else {
@@ -296,7 +296,7 @@ impl DestructuringAssignment {
                     };
 
                     if let Some(prop_name) = get_this_member_name(init) {
-                        if get_parent_component(node, ctx).is_some() {
+                        if get_parent_component(ancestor, ctx).is_some() {
                             ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, prop_name));
                         }
                         break;
@@ -305,7 +305,7 @@ impl DestructuringAssignment {
                     let Some(id_ref) = init.get_identifier_reference() else {
                         break;
                     };
-                    let Some(parent) = get_parent_stateless_component(node, ctx) else {
+                    let Some(parent) = get_parent_stateless_component(ancestor, ctx) else {
                         break;
                     };
                     let obj_name = id_ref.name.as_str();
@@ -329,7 +329,6 @@ impl DestructuringAssignment {
                             .count()
                             > 1;
                         if !used_more_than_once {
-                            let object_pattern_span = node.span();
                             let declaration_span = ctx.nodes().parent_node(decl.node_id()).span();
                             let param_span = param.pattern.span();
                             return Some((object_pattern_span, declaration_span, param_span));

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -74,32 +74,6 @@ declare_oxc_lint!(
     ///
     /// Destructuring can make it easier to read and understand what properties are being used in a component.
     ///
-    /// ### Options
-    ///
-    /// This rule takes one string and one optional object as arguments:
-    ///
-    /// ```jsonc
-    /// {
-    ///   "rules": {
-    ///     "react/destructuring-assignment": [
-    ///       "error",
-    ///       "always", // or "never"
-    ///       {
-    ///         "ignoreClassFields": false,
-    ///         "destructureInSignature": "ignore" // or "always"
-    ///       }
-    ///     ]
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// - `"always"` (default): enforce destructuring of `props`, `state`, and `context`.
-    /// - `"never"`: forbid destructuring of `props`, `state`, and `context`.
-    /// - `ignoreClassFields` (default `false`): when `true`, ignore class field
-    ///   declarations such as `bar = this.props.bar`.
-    /// - `destructureInSignature` (default `"ignore"`): when set to `"always"`,
-    ///   require props destructuring to happen in the function signature.
-    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule, when configured with `"always"` (the default):

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{Expression, StaticMemberExpression},
@@ -6,8 +9,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,
@@ -276,6 +277,64 @@ declare_oxc_lint!(
     version = "next",
 );
 
+impl Rule for DestructuringAssignment {
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::StaticMemberExpression(member) => {
+                if self.should_skip_member(node, ctx) || self.apply_never {
+                    return;
+                }
+                if let Some(parent) = get_parent_stateless_component(node, ctx) {
+                    handle_function_component_usage(member, ctx, &parent);
+                } else if get_parent_component(node, ctx).is_some() {
+                    handle_class_component_usage(member, ctx);
+                }
+            }
+            AstKind::FormalParameter(param)
+                if param.pattern.is_object_pattern() && self.apply_never =>
+            {
+                if let Some(parent) = get_parent_stateless_component(node, ctx) {
+                    let params = parent.params();
+                    if params.items[0].span == param.span {
+                        ctx.diagnostic(no_destruct_props_in_sfc_arg_diagnostic(param.span));
+                    } else if params.items[1].span == param.span {
+                        ctx.diagnostic(no_destruct_context_in_sfc_arg_diagnostic(param.span));
+                    }
+                }
+            }
+            AstKind::ObjectPattern(_) if self.apply_never || self.apply_to_signature => {
+                let Some((object_pattern_span, decl_span, param_span)) =
+                    self.handle_object_pattern(node.id(), ctx)
+                else {
+                    return;
+                };
+                ctx.diagnostic_with_fix(destructure_in_signature_diagnostic(decl_span), |fixer| {
+                    let mut fix = fixer.new_fix_with_capacity(2);
+                    fix.push(
+                        fixer.replace(
+                            param_span,
+                            fixer.source_range(object_pattern_span).to_string(),
+                        ),
+                    );
+                    let expanded_decl_span =
+                        expand_span_to_statement_boundaries(fixer.source_text(), decl_span);
+                    fix.push(fixer.delete_range(expanded_decl_span));
+                    fix.with_message("Replace object pattern with destructuring in signature")
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
 impl DestructuringAssignment {
     fn handle_object_pattern(
         &self,
@@ -351,64 +410,6 @@ impl DestructuringAssignment {
                     )
             }
             _ => false,
-        }
-    }
-}
-
-impl Rule for DestructuringAssignment {
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
-    }
-
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
-    }
-
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        match node.kind() {
-            AstKind::StaticMemberExpression(member) => {
-                if self.should_skip_member(node, ctx) || self.apply_never {
-                    return;
-                }
-                if let Some(parent) = get_parent_stateless_component(node, ctx) {
-                    handle_function_component_usage(member, ctx, &parent);
-                } else if get_parent_component(node, ctx).is_some() {
-                    handle_class_component_usage(member, ctx);
-                }
-            }
-            AstKind::FormalParameter(param)
-                if param.pattern.is_object_pattern() && self.apply_never =>
-            {
-                if let Some(parent) = get_parent_stateless_component(node, ctx) {
-                    let params = parent.params();
-                    if params.items[0].span == param.span {
-                        ctx.diagnostic(no_destruct_props_in_sfc_arg_diagnostic(param.span));
-                    } else if params.items[1].span == param.span {
-                        ctx.diagnostic(no_destruct_context_in_sfc_arg_diagnostic(param.span));
-                    }
-                }
-            }
-            AstKind::ObjectPattern(_) if self.apply_never || self.apply_to_signature => {
-                let Some((object_pattern_span, decl_span, param_span)) =
-                    self.handle_object_pattern(node.id(), ctx)
-                else {
-                    return;
-                };
-                ctx.diagnostic_with_fix(destructure_in_signature_diagnostic(decl_span), |fixer| {
-                    let mut fix = fixer.new_fix_with_capacity(2);
-                    fix.push(
-                        fixer.replace(
-                            param_span,
-                            fixer.source_range(object_pattern_span).to_string(),
-                        ),
-                    );
-                    let expanded_decl_span =
-                        expand_span_to_statement_boundaries(fixer.source_text(), decl_span);
-                    fix.push(fixer.delete_range(expanded_decl_span));
-                    fix.with_message("Replace object pattern with destructuring in signature")
-                });
-            }
-            _ => {}
         }
     }
 }

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -68,46 +68,7 @@ struct DestructuringAssignmentOptions {
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(default)]
-pub struct DestructuringAssignmentTupleConfig(Mode, DestructuringAssignmentOptions);
-
-#[derive(Debug, Clone)]
-pub struct DestructuringAssignmentConfig {
-    apply_never: bool,
-    apply_to_class_fields: bool,
-    apply_to_signature: bool,
-}
-
-impl From<DestructuringAssignmentTupleConfig> for DestructuringAssignmentConfig {
-    fn from(value: DestructuringAssignmentTupleConfig) -> Self {
-        let DestructuringAssignmentTupleConfig(mode, options) = value;
-
-        DestructuringAssignmentConfig {
-            apply_never: matches!(mode, Mode::Never),
-            apply_to_class_fields: !options.ignore_class_fields,
-            apply_to_signature: matches!(
-                options.destructure_in_signature,
-                DestructureInSignature::Always
-            ),
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct DestructuringAssignment(Box<DestructuringAssignmentConfig>);
-
-impl std::ops::Deref for DestructuringAssignment {
-    type Target = DestructuringAssignmentConfig;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Default for DestructuringAssignmentConfig {
-    fn default() -> Self {
-        Self { apply_never: false, apply_to_class_fields: true, apply_to_signature: false }
-    }
-}
+pub struct DestructuringAssignment(Mode, DestructuringAssignmentOptions);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -263,20 +224,19 @@ declare_oxc_lint!(
     react,
     style,
     fix,
-    config = DestructuringAssignmentTupleConfig,
+    config = DestructuringAssignment,
     version = "next",
 );
 
 impl Rule for DestructuringAssignment {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<TupleRuleConfig<DestructuringAssignmentTupleConfig>>(value)
-            .map(|config| Self(Box::new(config.into_inner().into())))
+        serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::StaticMemberExpression(member) => {
-                if self.should_skip_member(node, ctx) || self.apply_never {
+                if self.should_skip_member(node, ctx) || self.apply_never() {
                     return;
                 }
                 if let Some(parent) = get_parent_stateless_component(node, ctx) {
@@ -286,7 +246,7 @@ impl Rule for DestructuringAssignment {
                 }
             }
             AstKind::FormalParameter(param)
-                if param.pattern.is_object_pattern() && self.apply_never =>
+                if param.pattern.is_object_pattern() && self.apply_never() =>
             {
                 if let Some(parent) = get_parent_stateless_component(node, ctx) {
                     let params = parent.params();
@@ -297,7 +257,7 @@ impl Rule for DestructuringAssignment {
                     }
                 }
             }
-            AstKind::ObjectPattern(_) if self.apply_never || self.apply_to_signature => {
+            AstKind::ObjectPattern(_) if self.apply_never() || self.apply_to_signature() => {
                 let Some((object_pattern_span, decl_span, param_span)) =
                     self.handle_object_pattern(node.id(), ctx)
                 else {
@@ -363,9 +323,9 @@ impl DestructuringAssignment {
                         break;
                     };
 
-                    if self.apply_never {
+                    if self.apply_never() {
                         ctx.diagnostic(no_destruct_assignment_diagnostic(decl.span, obj_name));
-                    } else if self.apply_to_signature {
+                    } else if self.apply_to_signature() {
                         let binding = param.pattern.get_binding_identifier().unwrap();
                         let used_more_than_once = ctx
                             .scoping()
@@ -392,9 +352,9 @@ impl DestructuringAssignment {
     fn should_skip_member(&self, node: &AstNode, ctx: &LintContext) -> bool {
         match ctx.nodes().parent_kind(node.id()) {
             AstKind::AssignmentExpression(assignment) => assignment.left.span() == node.span(),
-            AstKind::PropertyDefinition(_) => !self.apply_to_class_fields,
+            AstKind::PropertyDefinition(_) => !self.apply_to_class_fields(),
             AstKind::TemplateLiteral(_) => {
-                !self.apply_to_class_fields
+                !self.apply_to_class_fields()
                     && matches!(
                         ctx.nodes().parent_kind(ctx.nodes().parent_id(node.id())),
                         AstKind::PropertyDefinition(_)
@@ -402,6 +362,18 @@ impl DestructuringAssignment {
             }
             _ => false,
         }
+    }
+
+    fn apply_never(&self) -> bool {
+        matches!(&self.0, Mode::Never)
+    }
+
+    fn apply_to_class_fields(&self) -> bool {
+        !self.1.ignore_class_fields
+    }
+
+    fn apply_to_signature(&self) -> bool {
+        matches!(&self.1.destructure_in_signature, DestructureInSignature::Always)
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -103,16 +103,6 @@ impl std::ops::Deref for DestructuringAssignment {
     }
 }
 
-impl<'de> Deserialize<'de> for DestructuringAssignment {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let config = DestructuringAssignmentTupleConfig::deserialize(deserializer)?;
-        Ok(Self(Box::new(config.into())))
-    }
-}
-
 impl Default for DestructuringAssignmentConfig {
     fn default() -> Self {
         Self { apply_never: false, apply_to_class_fields: true, apply_to_signature: false }
@@ -279,7 +269,8 @@ declare_oxc_lint!(
 
 impl Rule for DestructuringAssignment {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
+        serde_json::from_value::<TupleRuleConfig<DestructuringAssignmentTupleConfig>>(value)
+            .map(|config| Self(Box::new(config.into_inner().into())))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
+++ b/crates/oxc_linter/src/rules/react/destructuring_assignment.rs
@@ -278,10 +278,6 @@ declare_oxc_lint!(
 );
 
 impl Rule for DestructuringAssignment {
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
-    }
-
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
         serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
     }
@@ -332,6 +328,10 @@ impl Rule for DestructuringAssignment {
             }
             _ => {}
         }
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
@@ -10,7 +10,9 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::node::NodeId;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode, context::LintContext, fixer::expand_span_to_statement_boundaries, rule::Rule,
+};
 
 fn prefer_default_parameters_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer default parameters over reassignment for '{name}'."))
@@ -233,7 +235,7 @@ fn check_expression<'a>(
         replace_span = params.span;
     }
 
-    let delete_span = expand_statement_delete_span(ctx.source_text(), statement_span);
+    let delete_span = expand_span_to_statement_boundaries(ctx.source_text(), statement_span);
 
     ctx.diagnostic_with_fix(prefer_default_parameters_diagnostic(stmt_span, param_name), |fixer| {
         let fixer = fixer.for_multifix();
@@ -242,39 +244,6 @@ fn check_expression<'a>(
         fix.push(fixer.delete_range(delete_span));
         fix.with_message("Prefer default parameters over reassignment.")
     });
-}
-
-#[expect(clippy::cast_possible_truncation)]
-fn expand_statement_delete_span(source_text: &str, statement_span: Span) -> Span {
-    let mut start = statement_span.start as usize;
-    let mut end = statement_span.end as usize;
-    let bytes = source_text.as_bytes();
-
-    let mut candidate_start = start;
-    while candidate_start > 0 {
-        let ch = bytes[candidate_start - 1];
-        if matches!(ch, b' ' | b'\t') {
-            candidate_start -= 1;
-            continue;
-        }
-        if matches!(ch, b'\n' | b'\r') {
-            start = candidate_start;
-        }
-        break;
-    }
-
-    if end < bytes.len() && bytes[end] == b' ' {
-        end += 1;
-    }
-
-    let rest = bytes.get(end..).unwrap_or(&[]);
-    if rest.starts_with(b"\r\n") {
-        end += 2;
-    } else if rest.starts_with(b"\r") || rest.starts_with(b"\n") {
-        end += 1;
-    }
-
-    Span::new(start as u32, end as u32)
 }
 
 fn find_enclosing_function<'a>(

--- a/crates/oxc_linter/src/snapshots/react_destructuring_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/react_destructuring_assignment.snap
@@ -1,0 +1,260 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:3:40]
+ 2 │                     const MyComponent = (props) => {
+ 3 │                       return (<div id={props.id} />)
+   ·                                        ────────
+ 4 │                     };
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring props assignment in SFC argument.
+   ╭─[destructuring_assignment.tsx:2:42]
+ 1 │ 
+ 2 │                     const MyComponent = ({ id, className }) => (
+   ·                                          ─────────────────
+ 3 │                       <div id={id} className={className} />
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring context assignment in SFC argument.
+   ╭─[destructuring_assignment.tsx:2:49]
+ 1 │ 
+ 2 │                     const MyComponent = (props, { color }) => (
+   ·                                                 ─────────
+ 3 │                       <div id={props.id} className={props.className} />
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:38]
+ 3 │                       render() {
+ 4 │                         return <div>{this.props.foo}</div>;
+   ·                                      ──────────────
+ 5 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring state assignment.
+   ╭─[destructuring_assignment.tsx:4:38]
+ 3 │                       render() {
+ 4 │                         return <div>{this.state.foo}</div>;
+   ·                                      ──────────────
+ 5 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring context assignment.
+   ╭─[destructuring_assignment.tsx:4:38]
+ 3 │                       render() {
+ 4 │                         return <div>{this.context.foo}</div>;
+   ·                                      ────────────────
+ 5 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:5:32]
+ 4 │                       foo() {
+ 5 │                         return this.props.children;
+   ·                                ───────────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:39]
+ 3 │                       render: function() {
+ 4 │                         return <Text>{this.props.foo}</Text>;
+   ·                                       ──────────────
+ 5 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:36]
+ 3 │                       Foo(props) {
+ 4 │                         return <p>{props.a}</p>;
+   ·                                    ───────
+ 5 │                       }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:3:34]
+ 2 │                     export default function Foo(props) {
+ 3 │                       return <p>{props.a}</p>;
+   ·                                  ───────
+ 4 │                     }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:3:45]
+ 2 │                     function hof() {
+ 3 │                       return (props) => <p>{props.a}</p>;
+   ·                                             ───────
+ 4 │                     }
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:37]
+ 3 │                       render() {
+ 4 │                         const foo = this.props.foo;
+   ·                                     ──────────────
+ 5 │                         return <div>{foo}</div>;
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:31]
+ 3 │                       render() {
+ 4 │                         const { foo } = this.props;
+   ·                               ────────────────────
+ 5 │                         return <div>{foo}</div>;
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:3:29]
+ 2 │                     const MyComponent = (props) => {
+ 3 │                       const { id, className } = props;
+   ·                             ─────────────────────────
+ 4 │                       return <div id={id} className={className} />
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring state assignment.
+   ╭─[destructuring_assignment.tsx:4:31]
+ 3 │                       render() {
+ 4 │                         const { foo } = this.state;
+   ·                               ────────────────────
+ 5 │                         return <div>{foo}</div>;
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:5:31]
+ 4 │                         CustomComponentName: function(props) {
+ 5 │                           if (props.url) {
+   ·                               ─────────
+ 6 │                             return (
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:7:40]
+ 6 │                             return (
+ 7 │                               <a href={props.url}>
+   ·                                        ─────────
+ 8 │                                 {props.test}
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:8:34]
+ 7 │                               <a href={props.url}>
+ 8 │                                 {props.test}
+   ·                                  ──────────
+ 9 │                               </a>
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring context assignment.
+   ╭─[destructuring_assignment.tsx:3:33]
+ 2 │                     function Foo(props, context) {
+ 3 │                       const d = context.describe();
+   ·                                 ────────────────
+ 4 │                       return <div>{d}</div>;
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:3:37]
+ 2 │                     export default (props) => {
+ 3 │                       const match = props.str.match(/some expression/);
+   ·                                     ─────────
+ 4 │                       if (match) {
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:5:23]
+ 4 │                     const TestComp = (props) => {
+ 5 │                       props.onClick3102();
+   ·                       ─────────────────
+ 6 │ 
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+    ╭─[destructuring_assignment.tsx:10:33]
+  9 │                           onClick={(evt) => {
+ 10 │                             if (props.onClick3102) {
+    ·                                 ─────────────────
+ 11 │                               props.onClick3102(evt);
+    ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+    ╭─[destructuring_assignment.tsx:11:31]
+ 10 │                             if (props.onClick3102) {
+ 11 │                               props.onClick3102(evt);
+    ·                               ─────────────────
+ 12 │                             }
+    ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:34]
+ 3 │                         [A.b]: props => {
+ 4 │                           return props.editor !== null
+   ·                                  ────────────
+ 5 │                             ? <span>{props.editor}</span>
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:5:38]
+ 4 │                           return props.editor !== null
+ 5 │                             ? <span>{props.editor}</span>
+   ·                                      ────────────
+ 6 │                             : null
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:8:29]
+ 7 │                       return (props) => {
+ 8 │                         if (props.y) {
+   ·                             ───────
+ 9 │                           return <span>{props.y}</span>;
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+    ╭─[destructuring_assignment.tsx:9:41]
+  8 │                         if (props.y) {
+  9 │                           return <span>{props.y}</span>;
+    ·                                         ───────
+ 10 │                         }
+    ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+    ╭─[destructuring_assignment.tsx:11:39]
+ 10 │                         }
+ 11 │                         return <span>{props.x}</span>
+    ·                                       ───────
+ 12 │                       };
+    ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:5:36]
+ 4 │                       type MyType = typeof props.text;
+ 5 │                       return <div>{props.text as MyType}</div>;
+   ·                                    ──────────
+ 6 │                     };
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must destructure props in the function signature.
+   ╭─[destructuring_assignment.tsx:4:23]
+ 3 │                     export const MyOtherComponent: React.FC<Props> = (props) => {
+ 4 │                       const { text } = props;
+   ·                       ───────────────────────
+ 5 │                       type MyType = typeof props.text;
+   ╰────
+  help: Replace object pattern with destructuring in signature
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:3:28]
+ 2 │                     function C(props: Props) {
+ 3 │                       void props.a
+   ·                            ───────
+ 4 │                       typeof props.b
+   ╰────
+
+  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:30]
+ 3 │                       void props.a
+ 4 │                       typeof props.b
+   ·                              ───────
+ 5 │                       return <div />
+   ╰────

--- a/crates/oxc_linter/src/snapshots/react_destructuring_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/react_destructuring_assignment.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:3:40]
  2 │                     const MyComponent = (props) => {
  3 │                       return (<div id={props.id} />)
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     };
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring props assignment in SFC argument.
+  ⚠ react(destructuring-assignment): Must never use destructuring props assignment in SFC argument.
    ╭─[destructuring_assignment.tsx:2:42]
  1 │ 
  2 │                     const MyComponent = ({ id, className }) => (
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │                       <div id={id} className={className} />
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring context assignment in SFC argument.
+  ⚠ react(destructuring-assignment): Must never use destructuring context assignment in SFC argument.
    ╭─[destructuring_assignment.tsx:2:49]
  1 │ 
  2 │                     const MyComponent = (props, { color }) => (
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │                       <div id={props.id} className={props.className} />
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:4:38]
  3 │                       render() {
  4 │                         return <div>{this.props.foo}</div>;
@@ -34,7 +34,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                       }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring state assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring state assignment.
    ╭─[destructuring_assignment.tsx:4:38]
  3 │                       render() {
  4 │                         return <div>{this.state.foo}</div>;
@@ -42,7 +42,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                       }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring context assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring context assignment.
    ╭─[destructuring_assignment.tsx:4:38]
  3 │                       render() {
  4 │                         return <div>{this.context.foo}</div>;
@@ -50,7 +50,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                       }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:5:32]
  4 │                       foo() {
  5 │                         return this.props.children;
@@ -58,7 +58,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │                       }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:4:39]
  3 │                       render: function() {
  4 │                         return <Text>{this.props.foo}</Text>;
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                       }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:4:36]
  3 │                       Foo(props) {
  4 │                         return <p>{props.a}</p>;
@@ -74,7 +74,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                       }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:3:34]
  2 │                     export default function Foo(props) {
  3 │                       return <p>{props.a}</p>;
@@ -82,7 +82,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:3:45]
  2 │                     function hof() {
  3 │                       return (props) => <p>{props.a}</p>;
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     }
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:4:37]
  3 │                       render() {
  4 │                         const foo = this.props.foo;
@@ -98,7 +98,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                         return <div>{foo}</div>;
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must never use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:4:31]
  3 │                       render() {
  4 │                         const { foo } = this.props;
@@ -106,7 +106,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                         return <div>{foo}</div>;
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must never use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:3:29]
  2 │                     const MyComponent = (props) => {
  3 │                       const { id, className } = props;
@@ -114,7 +114,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                       return <div id={id} className={className} />
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must never use destructuring state assignment.
+  ⚠ react(destructuring-assignment): Must never use destructuring state assignment.
    ╭─[destructuring_assignment.tsx:4:31]
  3 │                       render() {
  4 │                         const { foo } = this.state;
@@ -122,7 +122,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                         return <div>{foo}</div>;
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:5:31]
  4 │                         CustomComponentName: function(props) {
  5 │                           if (props.url) {
@@ -130,7 +130,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │                             return (
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:7:40]
  6 │                             return (
  7 │                               <a href={props.url}>
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │                                 {props.test}
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:8:34]
  7 │                               <a href={props.url}>
  8 │                                 {props.test}
@@ -146,7 +146,7 @@ source: crates/oxc_linter/src/tester.rs
  9 │                               </a>
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring context assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring context assignment.
    ╭─[destructuring_assignment.tsx:3:33]
  2 │                     function Foo(props, context) {
  3 │                       const d = context.describe();
@@ -154,7 +154,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                       return <div>{d}</div>;
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:3:37]
  2 │                     export default (props) => {
  3 │                       const match = props.str.match(/some expression/);
@@ -162,7 +162,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                       if (match) {
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:5:23]
  4 │                     const TestComp = (props) => {
  5 │                       props.onClick3102();
@@ -170,7 +170,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ 
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
     ╭─[destructuring_assignment.tsx:10:33]
   9 │                           onClick={(evt) => {
  10 │                             if (props.onClick3102) {
@@ -178,7 +178,7 @@ source: crates/oxc_linter/src/tester.rs
  11 │                               props.onClick3102(evt);
     ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
     ╭─[destructuring_assignment.tsx:11:31]
  10 │                             if (props.onClick3102) {
  11 │                               props.onClick3102(evt);
@@ -186,7 +186,7 @@ source: crates/oxc_linter/src/tester.rs
  12 │                             }
     ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:4:34]
  3 │                         [A.b]: props => {
  4 │                           return props.editor !== null
@@ -194,7 +194,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                             ? <span>{props.editor}</span>
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:5:38]
  4 │                           return props.editor !== null
  5 │                             ? <span>{props.editor}</span>
@@ -202,7 +202,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │                             : null
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:8:29]
  7 │                       return (props) => {
  8 │                         if (props.y) {
@@ -210,7 +210,7 @@ source: crates/oxc_linter/src/tester.rs
  9 │                           return <span>{props.y}</span>;
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
     ╭─[destructuring_assignment.tsx:9:41]
   8 │                         if (props.y) {
   9 │                           return <span>{props.y}</span>;
@@ -218,7 +218,7 @@ source: crates/oxc_linter/src/tester.rs
  10 │                         }
     ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
     ╭─[destructuring_assignment.tsx:11:39]
  10 │                         }
  11 │                         return <span>{props.x}</span>
@@ -226,7 +226,15 @@ source: crates/oxc_linter/src/tester.rs
  12 │                       };
     ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
+   ╭─[destructuring_assignment.tsx:4:28]
+ 3 │                       let id;
+ 4 │                       id = props.id;
+   ·                            ────────
+ 5 │                       return <div>{id}</div>;
+   ╰────
+
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:5:36]
  4 │                       type MyType = typeof props.text;
  5 │                       return <div>{props.text as MyType}</div>;
@@ -234,7 +242,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │                     };
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must destructure props in the function signature.
+  ⚠ react(destructuring-assignment): Must destructure props in the function signature.
    ╭─[destructuring_assignment.tsx:4:23]
  3 │                     export const MyOtherComponent: React.FC<Props> = (props) => {
  4 │                       const { text } = props;
@@ -243,7 +251,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace object pattern with destructuring in signature
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:3:28]
  2 │                     function C(props: Props) {
  3 │                       void props.a
@@ -251,7 +259,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                       typeof props.b
    ╰────
 
-  ⚠ eslint-plugin-react(destructuring-assignment): Must use destructuring props assignment.
+  ⚠ react(destructuring-assignment): Must use destructuring props assignment.
    ╭─[destructuring_assignment.tsx:4:30]
  3 │                       void props.a
  4 │                       typeof props.b

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -644,32 +644,6 @@ pub fn function_like_returns_jsx(f: FunctionLike) -> bool {
     }
 }
 
-pub fn get_parent_stateless_component<'a, 'b>(
-    node: &'b AstNode<'a>,
-    ctx: &'b LintContext<'a>,
-) -> Option<FunctionLike<'a>> {
-    ctx.nodes().ancestors(node.id()).find_map(|ancestor_node| {
-        let f = FunctionLike::from_ast_kind(ancestor_node.kind())?;
-        if !function_like_returns_jsx(f) {
-            return None;
-        }
-
-        let parent_kind = ctx.nodes().parent_kind(ancestor_node.id());
-        match parent_kind {
-            AstKind::ObjectProperty(prop) => {
-                let name = prop.key.name();
-                if name.is_some_and(|n| !is_react_component_name(&n)) {
-                    return None; // lowercase → not a component, skip
-                }
-            }
-            AstKind::ArrayExpression(_) | AstKind::MethodDefinition(_) => return None,
-            _ => {}
-        }
-
-        Some(f)
-    })
-}
-
 fn get_jsx_mem_expr_name<'a>(jsx_mem_expr: &JSXMemberExpression) -> Cow<'a, str> {
     let prefix = match &jsx_mem_expr.object {
         JSXMemberExpressionObject::IdentifierReference(id) => Cow::Borrowed(id.name.as_str()),

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -3,10 +3,10 @@ use std::borrow::Cow;
 use oxc_ast::{
     AstKind,
     ast::{
-        ArrowFunctionExpression, CallExpression, Expression, Function, FunctionBody,
-        JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
+        ArrowFunctionExpression, CallExpression, Expression, FormalParameters, Function,
+        FunctionBody, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
         JSXElementName, JSXExpression, JSXFragment, JSXMemberExpression, JSXMemberExpressionObject,
-        JSXOpeningElement, Statement, StaticMemberExpression,
+        JSXOpeningElement, ReturnStatement, Statement, StaticMemberExpression,
     },
 };
 use oxc_ast_visit::{Visit, walk};
@@ -595,6 +595,81 @@ pub fn get_parent_component<'a, 'b>(
     ctx.nodes().ancestors(node.id()).find(|node| is_es5_component(node) || is_es6_component(node))
 }
 
+#[derive(Clone, Copy)]
+pub enum FunctionLike<'a> {
+    Function(&'a Function<'a>),
+    Arrow(&'a ArrowFunctionExpression<'a>),
+}
+
+impl<'a> FunctionLike<'a> {
+    pub fn from_ast_kind(kind: AstKind<'a>) -> Option<Self> {
+        match kind {
+            AstKind::Function(func) => Some(Self::Function(func)),
+            AstKind::ArrowFunctionExpression(arrow) => Some(Self::Arrow(arrow)),
+            _ => None,
+        }
+    }
+
+    pub fn params(&self) -> &FormalParameters<'a> {
+        match self {
+            Self::Function(func) => &func.params,
+            Self::Arrow(arrow) => &arrow.params,
+        }
+    }
+}
+
+pub fn function_like_returns_jsx(f: FunctionLike) -> bool {
+    match f {
+        FunctionLike::Arrow(arrow) if arrow.expression => {
+            arrow.get_expression().is_some_and(|expr| {
+                let mut visitor = JsxFinder::new();
+                visitor.visit_expression(expr);
+                visitor.found
+            })
+        }
+        FunctionLike::Arrow(arrow) => {
+            let mut visitor = JsxReturnFinder::new();
+            visitor.visit_function_body(&arrow.body);
+            visitor.found
+        }
+        FunctionLike::Function(func) => {
+            if let Some(body) = &func.body {
+                let mut visitor = JsxReturnFinder::new();
+                visitor.visit_function_body(body);
+                visitor.found
+            } else {
+                false
+            }
+        }
+    }
+}
+
+pub fn get_parent_stateless_component<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<FunctionLike<'a>> {
+    ctx.nodes().ancestors(node.id()).find_map(|ancestor_node| {
+        let f = FunctionLike::from_ast_kind(ancestor_node.kind())?;
+        if !function_like_returns_jsx(f) {
+            return None;
+        }
+
+        let parent_kind = ctx.nodes().parent_kind(ancestor_node.id());
+        match parent_kind {
+            AstKind::ObjectProperty(prop) => {
+                let name = prop.key.name();
+                if name.is_some_and(|n| !is_react_component_name(&n)) {
+                    return None; // lowercase → not a component, skip
+                }
+            }
+            AstKind::ArrayExpression(_) | AstKind::MethodDefinition(_) => return None,
+            _ => {}
+        }
+
+        Some(f)
+    })
+}
+
 fn get_jsx_mem_expr_name<'a>(jsx_mem_expr: &JSXMemberExpression) -> Cow<'a, str> {
     let prefix = match &jsx_mem_expr.object {
         JSXMemberExpressionObject::IdentifierReference(id) => Cow::Borrowed(id.name.as_str()),
@@ -920,6 +995,31 @@ pub fn expression_contains_jsx(expr: &Expression) -> bool {
         }
         _ => false,
     }
+}
+
+struct JsxReturnFinder {
+    found: bool,
+}
+
+impl JsxReturnFinder {
+    fn new() -> Self {
+        Self { found: false }
+    }
+}
+
+impl<'a> Visit<'a> for JsxReturnFinder {
+    fn visit_return_statement(&mut self, ret: &ReturnStatement<'a>) {
+        if let Some(arg) = &ret.argument {
+            let mut jsx_finder = JsxFinder::new();
+            jsx_finder.visit_expression(arg);
+            if jsx_finder.found {
+                self.found = true;
+            }
+        }
+    }
+
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+    fn visit_arrow_function_expression(&mut self, _arrow: &ArrowFunctionExpression<'a>) {}
 }
 
 #[cfg(test)]

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1290,6 +1290,28 @@
         }
       ]
     },
+    "DestructureInSignature": {
+      "description": "Controls whether destructuring assignments are required or forbidden in function signatures.",
+      "oneOf": [
+        {
+          "description": "Require destructuring in the function signature when props are only used for destructuring.",
+          "type": "string",
+          "enum": [
+            "always"
+          ],
+          "markdownDescription": "Require destructuring in the function signature when props are only used for destructuring."
+        },
+        {
+          "description": "Allow destructuring in either the function signature or function body.",
+          "type": "string",
+          "enum": [
+            "ignore"
+          ],
+          "markdownDescription": "Allow destructuring in either the function signature or function body."
+        }
+      ],
+      "markdownDescription": "Controls whether destructuring assignments are required or forbidden in function signatures."
+    },
     "Destructuring": {
       "oneOf": [
         {
@@ -1309,6 +1331,40 @@
           "markdownDescription": "Only warn if all variables in a destructuring assignment should be `const`. Otherwise, ignore them."
         }
       ]
+    },
+    "DestructuringAssignment": {
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/AlwaysNever"
+        },
+        {
+          "$ref": "#/definitions/DestructuringAssignmentOptions"
+        }
+      ],
+      "maxItems": 2,
+      "minItems": 2
+    },
+    "DestructuringAssignmentOptions": {
+      "type": "object",
+      "properties": {
+        "destructureInSignature": {
+          "description": "Whether to ignore destructuring in function signature.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DestructureInSignature"
+            }
+          ],
+          "markdownDescription": "Whether to ignore destructuring in function signature."
+        },
+        "ignoreClassFields": {
+          "description": "Whether to ignore class fields when destructuring.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "Whether to ignore class fields when destructuring."
+        }
+      },
+      "additionalProperties": false
     },
     "DisplayNameConfig": {
       "type": "object",
@@ -5101,6 +5157,29 @@
                 }
               ],
               "maxItems": 2,
+              "minItems": 1
+            }
+          ]
+        },
+        "react/destructuring-assignment": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/AlwaysNever"
+                },
+                {
+                  "$ref": "#/definitions/DestructuringAssignmentOptions"
+                }
+              ],
+              "maxItems": 3,
               "minItems": 1
             }
           ]

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1294,6 +1294,28 @@ expression: json
         }
       ]
     },
+    "DestructureInSignature": {
+      "description": "Controls whether destructuring assignments are required or forbidden in function signatures.",
+      "oneOf": [
+        {
+          "description": "Require destructuring in the function signature when props are only used for destructuring.",
+          "type": "string",
+          "enum": [
+            "always"
+          ],
+          "markdownDescription": "Require destructuring in the function signature when props are only used for destructuring."
+        },
+        {
+          "description": "Allow destructuring in either the function signature or function body.",
+          "type": "string",
+          "enum": [
+            "ignore"
+          ],
+          "markdownDescription": "Allow destructuring in either the function signature or function body."
+        }
+      ],
+      "markdownDescription": "Controls whether destructuring assignments are required or forbidden in function signatures."
+    },
     "Destructuring": {
       "oneOf": [
         {
@@ -1313,6 +1335,40 @@ expression: json
           "markdownDescription": "Only warn if all variables in a destructuring assignment should be `const`. Otherwise, ignore them."
         }
       ]
+    },
+    "DestructuringAssignment": {
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/AlwaysNever"
+        },
+        {
+          "$ref": "#/definitions/DestructuringAssignmentOptions"
+        }
+      ],
+      "maxItems": 2,
+      "minItems": 2
+    },
+    "DestructuringAssignmentOptions": {
+      "type": "object",
+      "properties": {
+        "destructureInSignature": {
+          "description": "Whether to ignore destructuring in function signature.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DestructureInSignature"
+            }
+          ],
+          "markdownDescription": "Whether to ignore destructuring in function signature."
+        },
+        "ignoreClassFields": {
+          "description": "Whether to ignore class fields when destructuring.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "Whether to ignore class fields when destructuring."
+        }
+      },
+      "additionalProperties": false
     },
     "DisplayNameConfig": {
       "type": "object",
@@ -5105,6 +5161,29 @@ expression: json
                 }
               ],
               "maxItems": 2,
+              "minItems": 1
+            }
+          ]
+        },
+        "react/destructuring-assignment": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/AlwaysNever"
+                },
+                {
+                  "$ref": "#/definitions/DestructuringAssignmentOptions"
+                }
+              ],
+              "maxItems": 3,
               "minItems": 1
             }
           ]


### PR DESCRIPTION
Implement [react/destructuring-assignment](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md) as tracked in #1022 

AI was used to help understand the language, codebase, and errors I ran into.

As I lack experience with Rust, feedback and changes are very welcome.