### PR TITLE
fix(tasks/lint-rules): use eslint v9 to satisfy peer peps

### DIFF
--- a/tasks/lint_rules/package.json
+++ b/tasks/lint_rules/package.json
@@ -7,7 +7,7 @@
     "@next/eslint-plugin-next": "latest",
     "@typescript-eslint/eslint-plugin": "latest",
     "@vitest/eslint-plugin": "latest",
-    "eslint": "^10.0.0",
+    "eslint": "^9.13.0",
     "eslint-plugin-import": "latest",
     "eslint-plugin-jest": "latest",
     "eslint-plugin-jsdoc": "latest",


### PR DESCRIPTION
fixes failing CI job:

https://github.com/oxc-project/oxc/actions/runs/25342053393/job/74301572269