### PR TITLE
feat(ci): require full insta snapshot match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
+env:
+  INSTA_REQUIRE_FULL_MATCH: 1
+
 jobs:
   test-ubuntu:
     name: Test Linux


### PR DESCRIPTION
this prevents the old format of the insta snapshot from being merged as a PR, and enforces that only the newer version is supported.

This should prevent unecessary diffs and prevent PRs such as #22135.

~Note: it's expected that the CI will fail on this PR until #22135 is merged~