### PR TITLE
chore(cargo): move `oxc_config_discovery` to `publish: false` section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_config_discovery"
-version = "0.127.0"
+version = "0.0.0"
 dependencies = [
  "oxc_diagnostics",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,6 @@ oxc_ast_visit = { version = "0.129.0", path = "crates/oxc_ast_visit" } # AST vis
 oxc_cfg = { version = "0.129.0", path = "crates/oxc_cfg" } # Control flow graph
 oxc_codegen = { version = "0.129.0", path = "crates/oxc_codegen", default-features = false } # Code generation
 oxc_compat = { version = "0.129.0", path = "crates/oxc_compat" } # Browser compatibility
-oxc_config_discovery = { version = "0.127.0", path = "crates/oxc_config_discovery" } # Config discovery
 oxc_data_structures = { version = "0.129.0", path = "crates/oxc_data_structures" } # Shared data structures
 oxc_diagnostics = { version = "0.129.0", path = "crates/oxc_diagnostics" } # Error reporting
 oxc_ecmascript = { version = "0.129.0", path = "crates/oxc_ecmascript" } # ECMAScript operations
@@ -144,6 +143,7 @@ oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting
 oxc_language_server = { path = "crates/oxc_language_server", default-features = false } # Language server
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
+oxc_config_discovery = { path = "crates/oxc_config_discovery" } # Config discovery
 oxc_tasks_common = { path = "tasks/common" } # Task utilities
 oxc_tasks_transform_checker = { path = "tasks/transform_checker" } # Transform validation
 oxlint = { path = "apps/oxlint" } # Linter CLI

--- a/crates/oxc_config_discovery/Cargo.toml
+++ b/crates/oxc_config_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_config_discovery"
-version = "0.127.0"
+version = "0.0.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Move `oxc_config_discovery` to the unpublished workspace dependency group because it is an internal config-discovery crate and should not be treated as part of the published crate set.