### PR TITLE
refactor(oxfmt): use shared GlobSet for overrides

### DIFF
--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -4,12 +4,13 @@ use editorconfig_parser::{
     EditorConfig, EditorConfigProperties, EditorConfigProperty, EndOfLine, IndentStyle,
     MaxLineLength, QuoteType,
 };
-use fast_glob::glob_match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use serde_json::Value;
 use tracing::instrument;
 
-use oxc_config::{ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path};
+use oxc_config::{
+    ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, GlobSet, is_js_config_path,
+};
 #[cfg(feature = "napi")]
 use oxc_formatter::FormatOptions;
 
@@ -513,26 +514,13 @@ struct OxfmtrcOverrides {
 
 impl OxfmtrcOverrides {
     fn new(overrides: Vec<OxfmtOverrideConfig>, base_dir: Option<PathBuf>) -> Self {
-        // Normalize glob patterns by adding `**/` prefix to patterns without `/`.
-        // This matches ESLint/Prettier behavior.
-        let normalize_patterns = |patterns: Vec<String>| {
-            patterns
-                .into_iter()
-                // This may be problematic if user writes glob patterns with `\` as separator on Windows.
-                // But fine for now since:
-                // - `fast_glob::glob_match()` supports both `/` and `\`
-                // - Glob patterns are usually written with `/` even on Windows
-                .map(|pat| if pat.contains('/') { pat } else { format!("**/{pat}") })
-                .collect()
-        };
-
         Self {
             base_dir,
             entries: overrides
                 .into_iter()
                 .map(|o| OxfmtrcOverrideEntry {
-                    files: normalize_patterns(o.files),
-                    exclude_files: o.exclude_files.map(normalize_patterns).unwrap_or_default(),
+                    files: o.files,
+                    exclude_files: o.exclude_files,
                     options: o.options,
                 })
                 .collect(),
@@ -563,8 +551,7 @@ impl OxfmtrcOverrides {
     }
 
     fn is_entry_match(entry: &OxfmtrcOverrideEntry, relative: &str) -> bool {
-        entry.files.iter().any(|glob| glob_match(glob, relative))
-            && !entry.exclude_files.iter().any(|glob| glob_match(glob, relative))
+        entry.files.is_match(relative) && !entry.exclude_files.is_match(relative)
     }
 }
 
@@ -572,8 +559,8 @@ impl OxfmtrcOverrides {
 /// NOTE: Written path patterns are glob patterns; use `/` as the path separator on all platforms.
 #[derive(Debug)]
 struct OxfmtrcOverrideEntry {
-    files: Vec<String>,
-    exclude_files: Vec<String>,
+    files: GlobSet,
+    exclude_files: GlobSet,
     options: FormatConfig,
 }
 

--- a/apps/oxfmt/src/core/options/to_prettier.rs
+++ b/apps/oxfmt/src/core/options/to_prettier.rs
@@ -235,6 +235,8 @@ pub fn inject_oxfmt_plugin_payload(opts: &mut Value, config: &FormatConfig, path
 
 #[cfg(test)]
 mod tests_overrides_parsing {
+    use oxc_config::GlobSet;
+
     use crate::core::oxfmtrc::Oxfmtrc;
 
     #[test]
@@ -261,13 +263,13 @@ mod tests_overrides_parsing {
         assert_eq!(overrides.len(), 2);
 
         // First override: single file pattern
-        assert_eq!(overrides[0].files, vec!["*.test.js"]);
-        assert!(overrides[0].exclude_files.is_none());
+        assert_eq!(overrides[0].files, GlobSet::new(["*.test.js"]));
+        assert_eq!(overrides[0].exclude_files, GlobSet::default());
         assert_eq!(overrides[0].options.tab_width, Some(4));
 
         // Second override: multiple file patterns with exclude
-        assert_eq!(overrides[1].files, vec!["*.md", "*.html"]);
-        assert_eq!(overrides[1].exclude_files, Some(vec!["*.min.js".to_string()]));
+        assert_eq!(overrides[1].files, GlobSet::new(["*.md", "*.html"]));
+        assert_eq!(overrides[1].exclude_files, GlobSet::new(["*.min.js"]));
         assert_eq!(overrides[1].options.print_width, Some(80));
     }
 }

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -4,6 +4,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use oxc_config::GlobSet;
+
 use crate::core::utils;
 
 /// Configuration options for the Oxfmt.
@@ -36,10 +38,10 @@ pub struct Oxfmtrc {
 pub struct OxfmtOverrideConfig {
     /// Glob patterns to match files for this override.
     /// All patterns are relative to the Oxfmt configuration file.
-    pub files: Vec<String>,
+    pub files: GlobSet,
     /// Glob patterns to exclude from this override.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclude_files: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "GlobSet::is_empty")]
+    pub exclude_files: GlobSet,
     /// Format options to apply for matched files.
     #[serde(default)]
     pub options: FormatConfig,

--- a/crates/oxc_config/src/glob_set.rs
+++ b/crates/oxc_config/src/glob_set.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// A set of glob patterns.
-#[derive(Debug, Default, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, JsonSchema)]
 pub struct GlobSet(Vec<String>);
 
 impl<'de> Deserialize<'de> for GlobSet {

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -418,6 +418,14 @@
         }
       }
     },
+    "GlobSet": {
+      "description": "A set of glob patterns.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "markdownDescription": "A set of glob patterns."
+    },
     "HtmlWhitespaceSensitivityConfig": {
       "type": "string",
       "enum": [
@@ -524,18 +532,20 @@
       "properties": {
         "excludeFiles": {
           "description": "Glob patterns to exclude from this override.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
           "markdownDescription": "Glob patterns to exclude from this override."
         },
         "files": {
           "description": "Glob patterns to match files for this override.\nAll patterns are relative to the Oxfmt configuration file.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
           "markdownDescription": "Glob patterns to match files for this override.\nAll patterns are relative to the Oxfmt configuration file."
         },
         "options": {

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -422,6 +422,14 @@ expression: json
         }
       }
     },
+    "GlobSet": {
+      "description": "A set of glob patterns.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "markdownDescription": "A set of glob patterns."
+    },
     "HtmlWhitespaceSensitivityConfig": {
       "type": "string",
       "enum": [
@@ -528,18 +536,20 @@ expression: json
       "properties": {
         "excludeFiles": {
           "description": "Glob patterns to exclude from this override.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
           "markdownDescription": "Glob patterns to exclude from this override."
         },
         "files": {
           "description": "Glob patterns to match files for this override.\nAll patterns are relative to the Oxfmt configuration file.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
           "markdownDescription": "Glob patterns to match files for this override.\nAll patterns are relative to the Oxfmt configuration file."
         },
         "options": {

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -280,7 +280,7 @@ type: `object`
 type: `string[]`
 
 
-Glob patterns to exclude from this override.
+A set of glob patterns.
 
 
 #### overrides[n].files
@@ -288,8 +288,7 @@ Glob patterns to exclude from this override.
 type: `string[]`
 
 
-Glob patterns to match files for this override.
-All patterns are relative to the Oxfmt configuration file.
+A set of glob patterns.
 
 
 #### overrides[n].options


### PR DESCRIPTION
uses oxlint's `GlobSet` for overrides over `Vec<String>`.

This helpe move out some shared normalization code from oxlint and oxfmt to the shared config crate.


Hopefully this change is ok for you @leaysgur  - I was originally hoping to share somethign else, but it seems trickier than I expected, so I just moved this out instead, which feels to me a good change