### PR TITLE
docs(linter): Improve the `react/jsx-key` rule docs.

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -81,12 +81,12 @@ impl Deref for JsxKey {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce `key` prop for elements in array.
+    /// Enforce `key` prop for elements in an array.
     ///
     /// ### Why is this bad?
     ///
-    /// React requires a `key` prop for elements in an array to help identify which
-    /// items have changed, are added, or are removed.
+    /// React [requires a `key` prop](https://react.dev/learn/rendering-lists#rendering-data-from-arrays)
+    /// for elements in an array to help identify which items have changed, are added, or are removed.
     ///
     /// ### Examples
     ///


### PR DESCRIPTION
Grammar fix and add a link to the relevant React docs.