### PR TITLE
perf(linter/no-this-in-sfc): reorder cheap name check, avoid String allocation

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_this_in_sfc.rs
+++ b/crates/oxc_linter/src/rules/react/no_this_in_sfc.rs
@@ -78,6 +78,10 @@ impl Rule for NoThisInSfc {
 
         let Some(component_node) = get_parent_function(node, ctx) else { return };
 
+        if !is_potential_react_component(component_node, ctx) {
+            return;
+        }
+
         if ctx
             .nodes()
             .ancestors(component_node.id())
@@ -87,10 +91,6 @@ impl Rule for NoThisInSfc {
         }
 
         if is_in_nested_this_context(node, component_node, ctx) {
-            return;
-        }
-
-        if !is_potential_react_component(component_node, ctx) {
             return;
         }
 
@@ -132,26 +132,21 @@ fn is_in_nested_this_context<'a>(
 }
 
 fn is_potential_react_component<'a>(function_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
-    let function_name = get_function_name(function_node, ctx);
-
-    if let Some(name) = function_name
-        && is_react_component_name(&name)
-    {
-        return true;
-    }
-
-    false
+    get_function_name(function_node, ctx).is_some_and(is_react_component_name)
 }
 
-fn get_function_name<'a>(function_node: &AstNode<'a>, ctx: &LintContext<'a>) -> Option<String> {
+fn get_function_name<'a, 'b>(
+    function_node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b str> {
     match function_node.kind() {
-        AstKind::Function(func) => func.id.as_ref().map(|id| id.name.to_string()),
+        AstKind::Function(func) => func.id.as_ref().map(|id| id.name.as_str()),
         AstKind::ArrowFunctionExpression(_) => {
             let parent = ctx.nodes().parent_node(function_node.id());
             if let AstKind::VariableDeclarator(declarator) = parent.kind()
                 && let BindingPattern::BindingIdentifier(ident) = &declarator.id
             {
-                return Some(ident.name.to_string());
+                return Some(ident.name.as_str());
             }
             None
         }


### PR DESCRIPTION
This was generated and benchmarked using Claude Code, reviewed and tested by me.

Ultimately, this is basically micro-benching, but I've made sure the benchmarks show this is a pretty universal improvement and the change is simple enough that I think it's also a code improvement/simplification regardless.

Two simple changes:

- Move `is_potential_react_component` ahead of other checks to avoid the more expensive checks on non-component functions.
- Return `&str` instead of String to drop a few allocations.

Claude's summary is below.

---

Two small changes to `react/no-this-in-sfc`:

  1. Move `is_potential_react_component` — a first-char ASCII uppercase test — ahead of the ES5/ES6 ancestor walk and the nested-`this` walk. Non-PascalCase functions (the common case for `this` in JSX files: class methods, jQuery-style helpers, validation callbacks) now skip both walks.
  2. Return `&str` from `get_function_name` instead of `String`. The only caller passes the result straight to `is_react_component_name(&str)`, so the `to_string()` was pure overhead per `this` expression.

  Behavior is unchanged. Full JSON diagnostic output is byte-identical to `main` on the benchmark fixtures (only `start_time` differs).

  ### Benchmark

  Paired-sample interleaved bench (N=80, 8 warmup) against `main`, `--silent`, on synthetic JSX fixtures:

  | Fixture | main | patch | Δ | t-stat |
  |---|---|---|---|---|
  | Combined (~136K LoC) | 47.9 ms | 46.4 ms | **−3.2%** | +7.76 |
  | Non-PascalCase helpers (worst case for main) | 21.4 ms | 19.8 ms | **−8.2%** | +14.4 |
  | Class methods | 25.6 ms | 24.9 ms | −2.8% | +5.29 |
  | Pascal SFCs (diagnostic-firing) | 44.7 ms | 44.0 ms | −1.5% | +4.12 |
  | Parse-only differential | 25.2 ms | 25.0 ms | −0.9% | +1.68 (n.s.) |

  Rule-attributable share on the combined fixture: **−1.3 ms (−5.7% of the rule's own cost)**. Parse-only differential is not significant, so the wall-clock signal isn't binary-layout drift.

TL;DR −3.2% on combined fixture, −8.2% on worst case, parity confirmed.