### PR TITLE
perf(linter/getter-return): remove unnecessary Vec collect in CFG edge traversal

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -237,8 +237,7 @@ impl GetterReturn {
                     match event {
                         // We only need to check paths that are normal or jump.
                         DfsEvent::TreeEdge(a, b) => {
-                            let edges = graph.edges_connecting(a, b).collect::<Vec<_>>();
-                            if edges.iter().any(|e| {
+                            if graph.edges_connecting(a, b).any(|e| {
                                 matches!(
                                     e.weight(),
                                     EdgeType::Normal


### PR DESCRIPTION
This is a simple change with no real downside that I can see, just a minor performance/memory usage win for the rule.

Below is Claude's summary

----

## Summary

- Remove unnecessary `.collect::<Vec<_>>()` in the `getter_return` rule's CFG DFS traversal, calling `.any()` directly on the iterator instead.
- This allocation fires on every `TreeEdge` during depth-first search, so avoiding it is measurable.

## Benchmark results

Paired interleaved benchmark on a 51,499-line synthetic fixture with ~3,000 getter definitions:

```
=== GETTER_RETURN RULE (paired analysis) ===
N = 60
Baseline mean:  17.91 ms (sd=0.69)
Optimized mean: 16.62 ms (sd=0.62)
Paired diff:    1.293 ms (sd=0.891)
t-stat:         11.25
Win/Loss/Tie:   54/6/0

=== PARSE-ONLY CONTROL (paired analysis) ===
Paired diff:          0.058 ms (sd=1.079)
t-stat:               0.41

=== RULE-ATTRIBUTABLE DELTA ===
Rule delta: 1.235 ms
```

- **~36% reduction in rule cost** (from ~3.4ms to ~2.2ms after subtracting parse-only baseline)
- Parse-only control confirms no binary-layout effect (t=0.41, well below significance threshold)
- Behavioral parity confirmed via identical `--format=json` output

## Test plan

- [x] Existing `getter_return` tests pass (`cargo test -p oxc_linter -- getter_return`)
- [x] Behavioral parity confirmed (identical `--format=json` output between baseline and optimized binaries)
- [x] Benchmarked with paired interleaved methodology (parse-only control shows no binary-layout effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)