### PR TITLE
perf(linter): remove unnecessary Vec collect in CFG edge traversal

### DIFF
--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -321,8 +321,7 @@ fn has_no_return_code_path(node: &AstNode, ctx: &LintContext) -> bool {
         match event {
             // We only need to check paths that are normal or jump.
             DfsEvent::TreeEdge(a, b) => {
-                let edges = graph.edges_connecting(a, b).collect::<Vec<_>>();
-                if edges.iter().any(|e| {
+                if graph.edges_connecting(a, b).any(|e| {
                     matches!(
                         e.weight(),
                         EdgeType::Normal

--- a/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
+++ b/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
@@ -470,14 +470,13 @@ impl<'a, 'b> MultipleResolvedChecker<'a, 'b> {
         set_depth_first_search::<_, _, _, Control<()>, _>(graph, Some(start_block_id), |event| {
             match event {
                 DfsEvent::TreeEdge(a, b) => {
-                    let edges = graph.edges_connecting(a, b).collect::<Vec<_>>();
-                    for edge in &edges {
+                    for edge in graph.edges_connecting(a, b) {
                         if matches!(edge.weight(), EdgeType::NewFunction) {
                             self.check(edge.target());
                             return Control::Prune;
                         }
                     }
-                    if edges.iter().any(|edge| {
+                    if graph.edges_connecting(a, b).any(|edge| {
                         matches!(edge.weight(), EdgeType::Backedge)
                             && graph
                                 .edges_directed(edge.target(), Direction::Outgoing)

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -268,8 +268,7 @@ fn definitely_returns_in_all_codepaths(
     let output =
         set_depth_first_search(graph, Some(ctx.nodes().cfg_id(node.id())), |event| match event {
             DfsEvent::TreeEdge(a, b) => {
-                let edges = graph.edges_connecting(a, b).collect::<Vec<_>>();
-                if edges.iter().any(|e| {
+                if graph.edges_connecting(a, b).any(|e| {
                     matches!(
                         e.weight(),
                         EdgeType::Normal


### PR DESCRIPTION
Same idea as #22166, the pattern was reused elsewhere so this fixes those as well. Benchmarked and the change is at worst neutral, at best a decent improvement for these code paths, and pretty consistently saves allocations.

Claude's description is below.

---

## Summary

Remove unnecessary `.collect::<Vec<_>>()` in CFG DFS traversals for three linter rules:

- `promise/always-return`
- `promise/no-multiple-resolved`
- `vue/return-in-computed-property`

Same optimization as #22166 (`getter-return`). In all cases, `graph.edges_connecting(a, b)` was collected into a `Vec` just to call `.iter().any()` or iterate with `for`. Since `edges_connecting` returns a cheap iterator over the adjacency list, the Vec allocation is pure overhead — and it fires on every `TreeEdge` during DFS, making it the hottest allocation in these rules.

The pattern was introduced in the first CFG-based rule and copy-pasted into the others without deliberate reason (confirmed via git blame — all four sites were present from initial implementation).

## Benchmark results

Paired interleaved benchmarks (N=60, alternating execution order, parse-only control).

### Wall-clock (paired analysis)

| Rule | Baseline mean | Optimized mean | Rule-attributable delta | t-stat | Win/Loss |
|---|---|---|---|---|---|
| `always-return` | 12.12 ms | 11.99 ms | 0.050 ms | 0.88 | 38/22 |
| `no-multiple-resolved` | 283.36 ms | 281.00 ms | 2.262 ms | 2.03 | 36/24 |

- `no-multiple-resolved` shows a borderline-significant improvement (t=2.03, threshold ~2.0), with a clean parse-only control (t=0.63).
- `always-return` is too cheap (~2ms rule cost) for the improvement to register at binary level, but the allocation reduction is real.
- `return-in-computed-property` was not benchmarked (Vue-only rule requiring `.vue` file fixtures), but uses the identical pattern.

### Memory (counting global allocator, rule-attributable = total minus parse-only)

| Rule | Metric | Baseline | Optimized | Saved | % reduction |
|---|---|---|---|---|---|
| `always-return` | alloc count | 66,045 | 60,045 | **6,000** | 9.1% |
| | alloc bytes | 6,115,232 | 5,539,251 | **575,981 (563 KB)** | 9.4% |
| `no-multiple-resolved` | alloc count | 183,041 | 171,041 | **12,000** | 6.6% |
| | alloc bytes | 13,159,807 | 12,007,826 | **1,151,981 (1.1 MB)** | 8.8% |

For reference, the same fix on `getter-return` (#22166) eliminated **77,300 allocations and 7.1 MB** of heap churn (72.7% reduction in rule-attributable allocations).

All fixtures use ~3,000 instances of the pattern each rule checks (promise `.then()` callbacks, `new Promise` constructors, getter definitions).

## Test plan

- [x] All three rules' tests pass (`cargo test -p oxc_linter`)
- [x] Behavioral parity confirmed (identical `--format=json` output between baseline and optimized binaries)
- [x] Parse-only controls confirm no binary-layout effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)