### PR TITLE
perf(linter/aria-role): remove unnecessary string allocations in run method

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -129,13 +129,12 @@ impl Rule for AriaRole {
                     }
                 }
                 Some(JSXAttributeValue::StringLiteral(str)) => {
-                    let words_str = String::from(str.value.as_str());
-                    let words = words_str.split_whitespace();
-                    if words_str.trim().is_empty() {
+                    let value = str.value.as_str();
+                    if value.trim().is_empty() {
                         ctx.diagnostic(aria_role_diagnostic(str.span, ""));
-                    } else if let Some(error_prop) = words.into_iter().find(|word| {
+                    } else if let Some(error_prop) = value.split_whitespace().find(|word| {
                         !VALID_ARIA_ROLES.contains(word)
-                            && !self.allowed_invalid_roles.contains(&(*word).to_string())
+                            && !self.allowed_invalid_roles.iter().any(|s| s == word)
                     }) {
                         ctx.diagnostic(aria_role_diagnostic(
                             str.span,


### PR DESCRIPTION
This is another micro-optimization to remove some unnecessary memory allocations and get a very minor speed improvement/code improvement. In real codebases this'll be basically impossible to detect, but I figure it's worth it regardless.

Below is Claude's summary.

---

## Summary

- Remove `String::from(str.value.as_str())` — `split_whitespace()` works directly on the `&str`, no heap copy needed.
- Replace `allowed_invalid_roles.contains(&word.to_string())` with `.iter().any(|s| s == word)` — avoids a `String` allocation per word comparison.

## Benchmark data

Fixture: 20 synthetic JSX files, 40,000 elements with `role` attributes (mix of valid, invalid, multi-word, and empty roles).

### Wall-clock (paired interleaved, N=60)

| | Baseline | Optimized | Delta |
|---|---|---|---|
| Rule ON | 24.34 ms | 22.74 ms | **-1.61 ms** |
| Parse-only | 8.30 ms | 8.46 ms | -0.16 ms (noise) |

- Paired t-statistic: **7.71** (highly significant, |t| > 2 threshold)
- Win/Loss/Tie: **49/11/0**
- Parse-only shows no significant difference (t = -1.34), confirming the signal is from the rule change, not binary layout effects.

Hyperfine (unpaired, N=50): optimized ran **1.05 ± 0.07x** faster than baseline.

### Allocation counts (counting global allocator)

| Metric | Baseline | Optimized | Saved | Reduction |
|---|---|---|---|---|
| Alloc count (rule-attributable) | 364,208 | 316,209 | **47,999** | **13.2%** |
| Alloc bytes (rule-attributable) | 26.6 MB | 26.2 MB | **434 KB** | **1.6%** |

~48,000 fewer heap allocations. The count reduction is large because both the `String::from()` copy (1 per element) and the `.to_string()` per word per invalid-role check are eliminated. Byte reduction is modest because the role strings are short.

## Test plan

- [x] `cargo test -p oxc_linter aria_role` — all tests pass
- [x] `cargo clippy -p oxc_linter --no-deps -- -D warnings` — clean
- [x] `just fmt` — no changes needed
- [x] Behavioral parity confirmed (JSON output diff shows only `start_time`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)