### PR TITLE
perf(linter/no-useless-escape): drop unnecessary Vec collect

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -262,15 +262,10 @@ fn check_string(string: &str) -> Vec<usize> {
 
     let quote_char = string.chars().next().unwrap();
     let bytes = &string.as_bytes()[1..string.len() - 1];
-    let escapes = memmem::find_iter(bytes, "\\").collect::<Vec<_>>();
-
-    if escapes.is_empty() {
-        return vec![];
-    }
 
     let mut offsets = vec![];
     let mut prev_offset = None; // for checking double escape `\\`
-    for offset in escapes {
+    for offset in memmem::find_iter(bytes, "\\") {
         // Safety:
         // The offset comes from a utf8 checked string
 


### PR DESCRIPTION
Another memory allocation optimization, also simplifies the code a bit.

Below is Claude's summary.

---

## Summary

`check_string` collected `memmem::find_iter(bytes, "\\")` into a `Vec<usize>` just to iterate it once. The `is_empty()` early-return wasn't buying anything either since `vec\![]` doesn't allocate — the existing `offsets = vec\![]` fallthrough already produces the same empty result.

Iterate `find_iter` directly. Eliminates one Vec allocation per string literal that contains a backslash.

## Benchmark

Paired interleaved benchmark (N=60, alternating order, parse-only control). Fixture: 30 files × 2000 string literals, 20% containing backslashes.

### Wall-clock

| | Baseline | Optimized | Δ |
|---|---|---|---|
| Rule on | 11.74 ms | 11.08 ms | **−0.65 ms** |
| Parse-only | 7.93 ms | 7.86 ms | −0.07 ms (noise) |
| Rule-attributable | | | **−0.58 ms** |

- Paired t-statistic: **4.04** (well above |t|>2 threshold)
- Win/Loss/Tie: **41/19/0**
- Parse-only control t=0.53 confirms the signal isn't from binary layout effects.

### Allocations (counting global allocator, rule-attributable = total − parse-only)

| Metric | Baseline | Optimized | Saved | Reduction |
|---|---|---|---|---|
| Alloc count | 78,501 | 66,664 | **11,837** | **15%** |
| Alloc bytes | 5.78 MB | 3.70 MB | **2.08 MB** | **36%** |

## Test plan

- [x] \`cargo test -p oxc_linter no_useless_escape\` — passes
- [x] \`cargo clippy -p oxc_linter --no-deps -- -D warnings\` — clean
- [x] \`just fmt\` — no changes needed
- [x] Behavioral parity confirmed (\`--format=json\` diff shows only \`start_time\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)