### PR TITLE
perf(linter/check-property-names): replace split-collect-pop-join with rfind

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -86,13 +86,9 @@ impl Rule for CheckPropertyNames {
                 let type_name = name_part.parsed();
 
                 // Check property path has a root
-                if type_name.contains('.') {
-                    let mut parts = type_name.split('.').collect::<Vec<_>>();
-                    // `foo[].bar` -> `foo[]`
-                    parts.pop();
-                    let parent_name = parts.join(".");
-                    // `foo[]` -> `foo`
-                    let parent_name = parent_name.trim_end_matches("[]");
+                if let Some(dot_idx) = type_name.rfind('.') {
+                    // `foo[].bar` -> `foo[]` -> `foo`
+                    let parent_name = type_name[..dot_idx].trim_end_matches("[]");
 
                     if !seen.contains_key(&parent_name) {
                         ctx.diagnostic(no_root(name_part.span, type_name));


### PR DESCRIPTION
Another minor optimization + code simplification. Claude's summary is below. As with all of these, the benchmark is based on running the rule on a file with a lot of specific code that isn't likely to occur in real codebases. So the % drops shouldn't be seen as representative of much beyond "this specific code path is faster".

---

## Summary

Two allocations per `@property` JSDoc tag with a dot — the `Vec<&str>` from `split + collect` and the `String` from `join(".")` — collapse to a single slice index using `rfind('.')`.

```rust
// before
if type_name.contains('.') {
    let mut parts = type_name.split('.').collect::<Vec<_>>();
    parts.pop();                                // `foo[].bar` -> `foo[]`
    let parent_name = parts.join(".");
    let parent_name = parent_name.trim_end_matches("[]");
    ...
}

// after
if let Some(dot_idx) = type_name.rfind('.') {
    let parent_name = type_name[..dot_idx].trim_end_matches("[]");  // `foo[].bar` -> `foo[]` -> `foo`
    ...
}
```

`rfind('.')` matches the last dot; the original `split + pop + join` reassembled all-but-the-last segment with `.` as the separator — equivalent.

Same family as #22164/#22166/#22167/#22168.

## Benchmark

Synthetic fixture: 30 JS files × 60 typedef blocks × 16 `@property` tags ≈ **28,800 tags**, ~80% with dots. Counting global allocator (system alloc, no mimalloc) on the rule-on and parse-only configs; rule-attributable = total − parse-only.

### Wall-clock (paired interleaved, N=60)

| | Baseline | Optimized | Δ |
|---|---|---|---|
| Rule ON | 21.564 ms | 20.550 ms | **−1.014 ms** |
| Parse-only | 7.319 ms | 7.326 ms | +0.007 ms (noise) |

- Paired t-stat: **5.02** (rule-on); **−0.05** (parse-only control)
- Win/Loss/Tie: **42 / 18 / 0**
- Parse-only is flat, so the delta isn't a binary-layout artifact.

### Allocations (rule-attributable)

| Metric | Baseline | Optimized | Saved | Reduction |
|---|---|---|---|---|
| Count | 318,002 | 282,603 | **35,399** | **11.1%** |
| Bytes | 30.7 MB | 29.4 MB | **1.32 MB** | **4.3%** |

Saves ~1.5 allocations per dotted tag on this fixture (Vec is sometimes elided when the path is `a.b`, but `String` from `join` always allocates).

## Test plan

- [x] `cargo test -p oxc_linter --lib jsdoc::check_property_names` — passes
- [x] `--format=json` parity confirmed across baseline and optimized binaries on the fixture (only `start_time` differs)
- [x] Parse-only control confirms no binary-layout effect (t = −0.05)
- [x] `just fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)