### PR TITLE
fix(linter/disable-directives): ignore invalid enable suffixes

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -714,7 +714,7 @@ impl DisableDirectivesBuilder {
                         // collect as unused enable (see more at note comments in beginning of this method)
                         unused_enable_directives.push((directive_prefix, None, comment_span));
                     }
-                } else {
+                } else if text.starts_with(char::is_whitespace) {
                     // `eslint-enable rule-name1, rule-name2`
                     Self::get_rule_names(text, rule_name_start, |rule_name, name_span| {
                         if let Some((start, disable_prefix, _, _, _)) =
@@ -1045,7 +1045,14 @@ no-debugger
                 /* {prefix}-disable , ,no-debugger, , */
                 debugger;
             "),
-            format!("debugger;//{prefix}-disable-line")
+            format!("debugger;//{prefix}-disable-line"),
+            format!("
+            /* {prefix}-disable no-debugger, no-console */
+                debugger;
+            /* {prefix}-enablefoo, no-debugger, no-console */
+                debugger;
+            "
+            )
         ];
 
         let fail = vec![


### PR DESCRIPTION
- Ignore malformed enable comments like `eslint-enablefoo` when deciding whether to parse a rule list.
- Add regression coverage for the comma-separated typo form that used to be accepted accidentally.

### Breakage Scenario

A file can contain a disabled rule followed by a typo in an enable directive:

```js
/* eslint-disable no-debugger */
/* eslint-enablefoo, no-debugger */
debugger;
```

`eslint-enablefoo` is not a valid enable directive, so `no-debugger` should remain disabled for the later `debugger` statement. Before this fix, the parser matched the `eslint-enable` prefix and then parsed the trailing `, no-debugger` as a rule list, incorrectly re-enabling `no-debugger`.
