### PR TITLE
fix(minifier): skip folding Array constructors with spread args

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1165,11 +1165,17 @@ impl<'a> PeepholeOptimizations {
                     }
                 } else {
                     // `new Array(1, 2, 3)` -> `[1, 2, 3]`
-                    let elements = ctx.ast.vec_from_iter(
-                        args.iter_mut()
-                            .filter_map(|arg| arg.as_expression_mut())
-                            .map(|arg| ArrayExpressionElement::from(arg.take_in(ctx.ast))),
-                    );
+                    let mut elements = ctx.ast.vec_with_capacity(args.len());
+                    for arg in args.iter_mut() {
+                        elements.push(if let Argument::SpreadElement(spread_el) = arg {
+                            ctx.ast.array_expression_element_spread_element(
+                                spread_el.span,
+                                spread_el.argument.take_in(ctx.ast),
+                            )
+                        } else {
+                            ArrayExpressionElement::from(arg.to_expression_mut().take_in(ctx.ast))
+                        });
+                    }
                     *expr = ctx.ast.expression_array(*span, elements);
                     ctx.state.changed = true;
                 }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1111,6 +1111,12 @@ impl<'a> PeepholeOptimizations {
                 ctx.state.changed = true;
             }
             "Array" => {
+                // A spread can disappear at runtime, turning `Array(x, ...[])` into `Array(x)`.
+                // That changes semantics for numeric `x`, since `Array(1)` creates a holey array.
+                // <https://github.com/oxc-project/oxc/pull/22186#issuecomment-4389606903>
+                if args.iter().any(Argument::is_spread) {
+                    return;
+                }
                 // `new Array` -> `[]`
                 if args.is_empty() {
                     *expr = ctx.ast.expression_array(*span, ctx.ast.vec());
@@ -1165,17 +1171,9 @@ impl<'a> PeepholeOptimizations {
                     }
                 } else {
                     // `new Array(1, 2, 3)` -> `[1, 2, 3]`
-                    let mut elements = ctx.ast.vec_with_capacity(args.len());
-                    for arg in args.iter_mut() {
-                        elements.push(if let Argument::SpreadElement(spread_el) = arg {
-                            ctx.ast.array_expression_element_spread_element(
-                                spread_el.span,
-                                spread_el.argument.take_in(ctx.ast),
-                            )
-                        } else {
-                            ArrayExpressionElement::from(arg.to_expression_mut().take_in(ctx.ast))
-                        });
-                    }
+                    let elements = ctx.ast.vec_from_iter(args.iter_mut().map(|arg| {
+                        ArrayExpressionElement::from(arg.to_expression_mut().take_in(ctx.ast))
+                    }));
                     *expr = ctx.ast.expression_array(*span, elements);
                     ctx.state.changed = true;
                 }

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -196,10 +196,10 @@ fn test_fold_literal_array_constructors() {
     // 1+ arguments
     test("x = new Array(1, 2, 3, 4)", "x = [1, 2, 3, 4]");
     test("x = Array(1, 2, 3, 4)", "x = [1, 2, 3, 4]");
-    test("x = new Array(1, 2, ...x)", "x = [1, 2, ...x]");
-    test("x = Array(1, 2, ...x)", "x = [1, 2, ...x]");
-    test("x = new Array(Foo, ...Bar)", "x = [Foo, ...Bar]");
-    test("x = Array(Foo, ...Bar)", "x = [Foo, ...Bar]");
+    test_same("x = new Array(1, 2, ...x)");
+    test_same("x = Array(1, 2, ...x)");
+    test_same("x = new Array(Foo, ...Bar)");
+    test_same("x = Array(Foo, ...Bar)");
     test("x = new Array('a', 1, 2, 'bc', 3, {}, 'abc')", "x = ['a', 1, 2, 'bc', 3, {}, 'abc']");
     test("x = Array('a', 1, 2, 'bc', 3, {}, 'abc')", "x = ['a', 1, 2, 'bc', 3, {}, 'abc']");
     test("x = new Array(Array(1, '2', 3, '4'))", "x = [[1, '2', 3, '4']]");

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -196,6 +196,10 @@ fn test_fold_literal_array_constructors() {
     // 1+ arguments
     test("x = new Array(1, 2, 3, 4)", "x = [1, 2, 3, 4]");
     test("x = Array(1, 2, 3, 4)", "x = [1, 2, 3, 4]");
+    test("x = new Array(1, 2, ...x)", "x = [1, 2, ...x]");
+    test("x = Array(1, 2, ...x)", "x = [1, 2, ...x]");
+    test("x = new Array(Foo, ...Bar)", "x = [Foo, ...Bar]");
+    test("x = Array(Foo, ...Bar)", "x = [Foo, ...Bar]");
     test("x = new Array('a', 1, 2, 'bc', 3, {}, 'abc')", "x = ['a', 1, 2, 'bc', 3, {}, 'abc']");
     test("x = Array('a', 1, 2, 'bc', 3, {}, 'abc')", "x = ['a', 1, 2, 'bc', 3, {}, 'abc']");
     test("x = new Array(Array(1, '2', 3, '4'))", "x = [[1, '2', 3, '4']]");


### PR DESCRIPTION
fixes #22185


> **AI disclosure**
> used gpt-5.5 (codex) for help in locating the bug and help setting up oxc and figuring out stuff