### PR TITLE
fix(minifier): bail optimizing `Array` with unknown arg count

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1111,6 +1111,10 @@ impl<'a> PeepholeOptimizations {
                 ctx.state.changed = true;
             }
             "Array" => {
+                if args.iter().any(Argument::is_spread) {
+                    return;
+                }
+
                 // `new Array` -> `[]`
                 if args.is_empty() {
                     *expr = ctx.ast.expression_array(*span, ctx.ast.vec());

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -187,15 +187,23 @@ fn test_fold_literal_array_constructors() {
     test("x = new Array(7n)", "x = [7n]");
     test("x = new Array(y)", "x = Array(y)");
     test("x = new Array(foo())", "x = Array(foo())");
+    test_same("x = new Array(...y)");
+    test("x = new Array(...[3])", "x = [,,,]");
     test("x = Array(0)", "x = []");
     test("x = Array(\"a\")", "x = [\"a\"]");
     test_same("x = Array(7)");
     test_same("x = Array(y)");
     test_same("x = Array(foo())");
+    test_same("x = Array(...y)");
+    test("x = Array(...[3])", "x = [,,,]");
 
     // 1+ arguments
     test("x = new Array(1, 2, 3, 4)", "x = [1, 2, 3, 4]");
     test("x = Array(1, 2, 3, 4)", "x = [1, 2, 3, 4]");
+    test_same("x = new Array(foo, ...bar)");
+    test_same("x = Array(foo, ...bar)");
+    test("x = new Array(3, ...[])", "x = [,,,]");
+    test("x = Array(3, ...[])", "x = [,,,]");
     test("x = new Array('a', 1, 2, 'bc', 3, {}, 'abc')", "x = ['a', 1, 2, 'bc', 3, {}, 'abc']");
     test("x = Array('a', 1, 2, 'bc', 3, {}, 'abc')", "x = ['a', 1, 2, 'bc', 3, {}, 'abc']");
     test("x = new Array(Array(1, '2', 3, '4'))", "x = [[1, '2', 3, '4']]");


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/22185

From the ECMAScript Spec:

```
23.1.1.1 Array ( ...values )
This function performs the following steps when called:

1. If NewTarget is undefined, let newTarget be the [active function object](https://tc39.es/ecma262/#active-function-object); else let newTarget be NewTarget.
2. Let proto be ? [GetPrototypeFromConstructor](https://tc39.es/ecma262/#sec-getprototypefromconstructor)(newTarget, "%Array.prototype%").
3. Let numberOfArgs be the number of elements in values.
4. If numberOfArgs = 0, return ! [ArrayCreate](https://tc39.es/ecma262/#sec-arraycreate)(0, proto).
5. If numberOfArgs = 1, then
   a. Let len be values[0].
   b. Let array be ! [ArrayCreate](https://tc39.es/ecma262/#sec-arraycreate)(0, proto).
   c. If len [is not a Number](https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type), then
      i. Perform ! [CreateDataPropertyOrThrow](https://tc39.es/ecma262/#sec-createdatapropertyorthrow)(array, "0", len).
      ii. Let intLen be 1𝔽.
   d. Else,
      i. Let intLen be ! [ToUint32](https://tc39.es/ecma262/#sec-touint32)(len).
      ii. If [SameValueZero](https://tc39.es/ecma262/#sec-samevaluezero)(intLen, len) is false, throw a RangeError exception.
   e. Perform ! [Set](https://tc39.es/ecma262/#sec-set-o-p-v-throw)(array, "length", intLen, true).
   f. Return array.
6. [Assert](https://tc39.es/ecma262/#assert): numberOfArgs ≥ 2.
7. Let array be ? [ArrayCreate](https://tc39.es/ecma262/#sec-arraycreate)(numberOfArgs, proto).
8. Let k be 0.
9. Repeat, while k < numberOfArgs,
   a. Let propertyKey be ! [ToString](https://tc39.es/ecma262/#sec-tostring)([𝔽](https://tc39.es/ecma262/#%F0%9D%94%BD)(k)).
   b. Let itemK be values[k].
   c. Perform ! [CreateDataPropertyOrThrow](https://tc39.es/ecma262/#sec-createdatapropertyorthrow)(array, propertyKey, itemK).
   d. Set k to k + 1.
10. [Assert](https://tc39.es/ecma262/#assert): The [mathematical value of](https://tc39.es/ecma262/#mathematical-value-of) array's "length" property is numberOfArgs.
11. Return array.
```

If there is a spread in the arguments, we cannot statically identify the number of arguments - it it incorrect to assume that the spread-ed entry it non-zero in length.


We could technically improve this approach by realizing if they are >1 non-spread arguments, then it's ok to move this into an `[]`, but i've left it out of scope of this PR