### PR TITLE
fix(tasks/website): Render both prop-level and type-level description

### DIFF
--- a/tasks/website_common/src/schema_markdown.rs
+++ b/tasks/website_common/src/schema_markdown.rs
@@ -212,6 +212,19 @@ impl Renderer {
                     if section.default.is_none() && !subschema.has_type(InstanceType::Object) {
                         section.default = Self::render_default(schema);
                     }
+                    // Schemars' draft-07 visitor wraps a `$ref` in `allOf` when sibling
+                    // properties (e.g. `description`) exist. Combine the property-level
+                    // description (context-specific) with the referenced type's description
+                    // (generic semantics) so neither layer is hidden by the other.
+                    if let Some(outer_desc) =
+                        schema.metadata.as_ref().and_then(|m| m.description.clone())
+                    {
+                        section.description = if section.description.is_empty() {
+                            outer_desc
+                        } else {
+                            format!("{outer_desc}\n\n{}", section.description)
+                        };
+                    }
                     section.sanitize();
                     section
                 })

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -280,6 +280,8 @@ type: `object`
 type: `string[]`
 
 
+Glob patterns to exclude from this override.
+
 A set of glob patterns.
 
 
@@ -287,6 +289,9 @@ A set of glob patterns.
 
 type: `string[]`
 
+
+Glob patterns to match files for this override.
+All patterns are relative to the Oxfmt configuration file.
 
 A set of glob patterns.
 
@@ -296,7 +301,7 @@ A set of glob patterns.
 type: `object`
 
 
-
+Format options to apply for matched files.
 
 
 ##### overrides[n].options.arrowParens

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -327,7 +327,7 @@ Fine-grained auto-fix controls for `no-unused-vars`.
 type: `"off" | "suggestion" | "fix" | "safe-fix"`
 
 
-
+Controls auto-fixes for unused imports.
 
 
 ##### `"off"`
@@ -364,7 +364,7 @@ Only applicable for imports, unavailable for variables.
 type: `"off" | "suggestion" | "fix" | "safe-fix"`
 
 
-
+Controls auto-fixes for unused variables (including catch bindings).
 
 
 ##### `"off"`
@@ -1198,13 +1198,15 @@ Supports four types of specifiers:
 type: `"file"`
 
 
-
+Must be "file"
 
 
 ##### allowForKnownSafeCalls[n].name
 
 type: `array | string`
 
+
+The name(s) of the type or value to match
 
 Name specifier that can be a single string or array of strings
 
@@ -1274,13 +1276,15 @@ Supports four types of specifiers:
 type: `"file"`
 
 
-
+Must be "file"
 
 
 ##### allowForKnownSafePromises[n].name
 
 type: `array | string`
 
+
+The name(s) of the type or value to match
 
 Name specifier that can be a single string or array of strings
 

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -183,6 +183,8 @@ Example
 type: `Record<string, boolean>`
 
 
+Environments enable and disable collections of global variables.
+
 Predefine global variables.
 
 Environments specify what global variables are predefined.
@@ -247,6 +249,8 @@ overriding the previous ones.
 
 type: `Record<string, string>`
 
+
+Enabled or disabled specific global variables.
 
 Add or remove global variables.
 
@@ -399,6 +403,8 @@ Path or package name of the plugin
 type: `object`
 
 
+Oxlint config options.
+
 Options for the linter.
 
 
@@ -475,7 +481,7 @@ Note that this requires the `oxlint-tsgolint` package to be installed.
 type: `array`
 
 
-
+Add, remove, or otherwise reconfigure rules for specific files or groups of files.
 
 
 ### overrides[n]
@@ -499,6 +505,11 @@ Environments enable and disable collections of global variables.
 type: `string[]`
 
 
+A list of glob patterns to override.
+
+## Example
+`[ "*.test.ts", "*.spec.ts" ]`
+
 A set of glob patterns.
 
 
@@ -514,6 +525,14 @@ Enabled or disabled specific global variables.
 
 type: `string[]`
 
+
+A list of glob patterns to exclude from this override.
+
+Files matching these patterns are not globally ignored; this override
+simply does not apply to them.
+
+## Example
+`[ "*.generated.ts", "fixtures/**" ]`
 
 A set of glob patterns.
 
@@ -627,6 +646,29 @@ type: `"eslint" | "react" | "unicorn" | "typescript" | "oxc" | "import" | "jsdoc
 type: `object`
 
 
+Example
+
+`.oxlintrc.json`
+
+```json
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "rules": {
+    "eqeqeq": "warn",
+    "import/no-cycle": "error",
+    "prefer-const": [
+      "error",
+      {
+        "ignoreReadBeforeAssign": true
+      }
+    ]
+  }
+}
+```
+
+See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html) for the list of
+rules.
+
 See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)
 
 
@@ -634,6 +676,10 @@ See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)
 
 type: `object`
 
+
+Plugin-specific configuration for both built-in and custom plugins.
+This includes settings for built-in plugins such as `react` and `jsdoc`
+as well as configuring settings for JS custom plugins loaded via `jsPlugins`.
 
 Configure the behavior of linter plugins.
 
@@ -864,7 +910,22 @@ Configure Next.js plugin rules.
 type: `array | string`
 
 
+The root directory of the Next.js project.
 
+This is particularly useful when you have a monorepo and your Next.js
+project is in a subfolder.
+
+Example:
+
+```json
+{
+  "settings": {
+    "next": {
+      "rootDir": "apps/dashboard/"
+    }
+  }
+}
+```
 
 
 ##### settings.next.rootDir[n]


### PR DESCRIPTION
When a property references a type via `$ref` and both have doc comments, the markdown renderer was dropping the property-level description.

```rs
/// A set of glob patterns.                                // ← type-level
pub struct GlobSet(Vec<String>);
```
```rs
pub struct OxfmtOverrideConfig {
    /// Glob patterns to match files for this override.    // ← property-level
    pub files: GlobSet,
}
```

Before:

```
#### overrides[n].files

A set of glob patterns.
```

After:

```
#### overrides[n].files

Glob patterns to match files for this override.

A set of glob patterns.
```

At present, some definitions may seem redundant, but since unifying them at the prop-level seemed inconvenient for linter use cases, I decided to provide both.

The intended convention is generic invariants on the type-level, contextual purpose on the property-level.