### PR TITLE
fix(codegen): emit block/array/object end mapping at close char

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1562,8 +1562,8 @@ impl Gen for ArrayExpression<'_> {
             p.dedent();
             p.print_indent();
         }
-        p.print_ascii_byte(b']');
         p.add_source_mapping_end(self.span);
+        p.print_ascii_byte(b']');
     }
 }
 
@@ -1613,8 +1613,8 @@ impl GenExpr for ObjectExpression<'_> {
             } else if len > 0 {
                 p.print_soft_space();
             }
-            p.print_ascii_byte(b'}');
             p.add_source_mapping_end(self.span);
+            p.print_ascii_byte(b'}');
         });
     }
 }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -570,8 +570,8 @@ impl<'a> Codegen<'a> {
             self.dedent();
             self.print_indent();
         }
-        self.print_ascii_byte(b'}');
         self.add_source_mapping_end(span);
+        self.print_ascii_byte(b'}');
     }
 
     fn print_block_start(&mut self, span: Span) {
@@ -584,8 +584,8 @@ impl<'a> Codegen<'a> {
     fn print_block_end(&mut self, span: Span) {
         self.dedent();
         self.print_indent();
-        self.print_ascii_byte(b'}');
         self.add_source_mapping_end(span);
+        self.print_ascii_byte(b'}');
     }
 
     fn print_body(&mut self, stmt: &Statement<'_>, need_space: bool, ctx: Context) {

--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -235,8 +235,8 @@ fn synthesized_block_closing_braces_are_mapped() {
 
     // The emitted `}` after `if (bar) baz();` maps back to the end of `baz();`.
     assert!(
-        has_mapping(&tokens, pos(2, 9), pos(2, 1)),
-        "expected the generated end position after a synthesized block closing brace to map back to the wrapped if statement",
+        has_mapping(&tokens, pos(2, 9), pos(2, 0)),
+        "expected the synthesized block closing brace to map back to the wrapped if statement",
     );
 }
 
@@ -247,6 +247,41 @@ fn call_end_mapping_lands_at_close_paren() {
     let tokens = sourcemap_tokens("factory()()", SourceType::mjs());
     assert!(has_mapping(&tokens, pos(0, 8), pos(0, 8)), "inner `)`");
     assert!(has_mapping(&tokens, pos(0, 10), pos(0, 10)), "outer `)`");
+}
+
+// `print_block_end`: source `}` → gen `}`, not the `;` that follows.
+#[test]
+fn block_end_mapping_lands_at_close_brace() {
+    let source = "const fn = () => { return 1 }";
+    let src_brace = u32::try_from(source.rfind('}').unwrap()).unwrap();
+    let tokens = sourcemap_tokens(source, SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, src_brace), pos(2, 0)));
+}
+
+// `print_curly_braces` (shared by class body, switch, TS enum/interface/
+// typeliteral/module): pin one to cover the shared helper.
+#[test]
+fn class_body_close_brace_lands_at_close_brace() {
+    let source = "class C { a; }";
+    let src_brace = u32::try_from(source.rfind('}').unwrap()).unwrap();
+    let tokens = sourcemap_tokens(source, SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, src_brace), pos(2, 0)));
+}
+
+#[test]
+fn array_close_bracket_lands_at_close_bracket() {
+    let source = "const a = [1, 2]";
+    let src_bracket = u32::try_from(source.rfind(']').unwrap()).unwrap();
+    let tokens = sourcemap_tokens(source, SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, src_bracket), pos(0, src_bracket)));
+}
+
+#[test]
+fn object_close_brace_lands_at_close_brace() {
+    let source = "const o = { a: 1 }";
+    let src_brace = u32::try_from(source.rfind('}').unwrap()).unwrap();
+    let tokens = sourcemap_tokens(source, SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, src_brace), pos(0, src_brace)));
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #22199.

Extends the same fix shape from #22199 (move `add_source_mapping_end` before the closing `print_ascii_byte`) to the remaining close-delimiter sites: `print_block_end`, `print_curly_braces`, and the `]`/`}` of `ArrayExpression` / `ObjectExpression`.

## Why

#22199 fixed the call's `)`. The same root cause exists for `}` of blocks/objects and `]` of arrays — the end mapping was placed AFTER the close char, putting it at the position of whatever follows. The most visible case: `() => { ... };` — the source `}` mapped to the generated `;` rather than the generated `}`, so source-map consumers viewing this diff saw the `}` "point at the semicolon."

## How

Five sites total, four in this PR (one already in #22199):

| Site | File |
|---|---|
| `print_block_end` (the `}` of `BlockStatement`) | `lib.rs` |
| `print_curly_braces` (shared by class body, switch, TS enum/interface/typeliteral/module) | `lib.rs` |
| `ArrayExpression` (`]`) | `gen.rs` |
| `ObjectExpression` (`}`) | `gen.rs` |

Each: swap `print_ascii_byte; add_source_mapping_end` → `add_source_mapping_end; print_ascii_byte`. The mapping now lands at the gen position OF the close char.

## Visual comparisons

Fixture covering all 5 sites (classes, arrow bodies, arrays, objects, chained calls):

- **Pre-PR vs Full fix** (full picture): https://source-map-viewer.void.app/compare?a=j9GHxMTX&b=UcCYKDih
- **PR-only vs Full fix** (just the changes #22199 + #22200 add): https://source-map-viewer.void.app/compare?a=ngs4XAsh&b=UcCYKDih
- **esbuild vs Full fix** (alignment with esbuild): https://source-map-viewer.void.app/compare?a=26JVF9DI&b=UcCYKDih

## Reference

esbuild (`internal/js_printer/js_printer.go`):

```go
if e.CloseBraceLoc.Start > expr.Loc.Start {
    p.addSourceMapping(e.CloseBraceLoc)
}
p.print("}")
```

(Same pattern as the call's `)` handling — see #22199.)

## Test plan

Each of the 4 modified sites has direct test coverage:

- [x] `block_end_mapping_lands_at_close_brace` — pins `}` of `() => { return 1 }` (exercises `print_block_end`)
- [x] `class_body_close_brace_lands_at_close_brace` — pins `}` of `class C { a; }` (exercises `print_curly_braces` — shared by classes, switch, TS enum/interface/typeliteral/module)
- [x] `array_close_bracket_lands_at_close_bracket` — pins `]` of `const a = [1, 2]` (exercises `ArrayExpression`)
- [x] `object_close_brace_lands_at_close_brace` — pins `}` of `const o = { a: 1 }` (exercises `ObjectExpression`)
- [x] `synthesized_block_closing_braces_are_mapped` (added by #22001) updated to assert `dst (2, 0)` instead of `(2, 1)` — same intent (the synthesized `}` resolves back to the wrapped if's last char), now anchored at the `}` itself
- [x] `cargo test -p oxc_codegen` passes (11 sourcemap tests, 100 integration total)
- [x] `stacktrace_is_correct` snapshot unchanged

Each new test was verified to fail without the corresponding swap and pass with it.
