### PR TITLE
refactor(formatter/sort_imports): Remove `SourceLine::Others` variant

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -226,7 +226,8 @@ fn transform<'a>(
                 current_chunk.add_imports_line(line);
             }
             // This `SourceLine` is a boundary!
-            // Generally, `SourceLine::Others` should always reach here.
+            // Reached only when `partition_by_newline` is true (for `Empty`)
+            // or `partition_by_comment` is true (for `CommentOnly`).
             _ => {
                 // Flush current import chunk
                 if !current_chunk.is_empty() {

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
@@ -26,8 +26,8 @@ pub enum PartitionedChunk<'a> {
     /// and possibly leading/trailing comments or empty lines.
     Imports(Vec<SourceLine<'a>>),
     /// A boundary chunk.
-    /// Always contains `SourceLine::Others`,
-    /// or optionally `SourceLine::Empty|CommentOnly` depending on partition options.
+    /// Contains `SourceLine::Empty` (when `partition_by_newline` is true)
+    /// or `SourceLine::CommentOnly` (when `partition_by_comment` is true).
     Boundary(SourceLine<'a>),
 }
 
@@ -39,11 +39,6 @@ impl Default for PartitionedChunk<'_> {
 
 impl<'a> PartitionedChunk<'a> {
     pub fn add_imports_line(&mut self, line: SourceLine<'a>) {
-        debug_assert!(
-            !matches!(line, SourceLine::Others(..)),
-            "`line` must not be of type `SourceLine::Others`."
-        );
-
         match self {
             Self::Imports(lines) => lines.push(line),
             Self::Boundary(_) => {
@@ -149,11 +144,6 @@ impl<'a> PartitionedChunk<'a> {
                 }
                 SourceLine::CommentOnly(..) => {
                     current_pending.push(line);
-                }
-                SourceLine::Others(..) => {
-                    unreachable!(
-                        "`PartitionedChunk::Imports` must not contain `SourceLine::Others`."
-                    );
                 }
             }
         }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -23,8 +23,6 @@ pub enum SourceLine<'a> {
     /// Line that contains only comment(s).
     /// May be used as a boundary if `options.partition_by_comment` is true.
     CommentOnly(Range<usize>, LineMode),
-    /// Other lines, always a boundary.
-    Others(Range<usize>, LineMode),
 }
 
 impl<'a> SourceLine<'a> {
@@ -131,27 +129,24 @@ impl<'a> SourceLine<'a> {
             }
         }
 
-        if has_import && let Some(source) = source {
-            // TODO: Check line has trailing ignore comment?
-            return SourceLine::Import(
-                range,
-                ImportLineMetadata {
-                    source,
-                    is_side_effect,
-                    is_type_import,
-                    has_default_specifier,
-                    has_namespace_specifier,
-                    has_named_specifier,
-                },
-            );
-        }
+        // The chunk passed to `transform` only contains `ImportDeclaration`s,
+        // their surrounding comments, and line breaks.
+        // So a non-comment-only line must contain an `ImportDeclaration`.
+        debug_assert!(has_import && source.is_some());
+        let source = source.expect("`ImportDeclaration` must have a source");
 
-        // Otherwise, this line is neither of:
-        // - Empty line
-        // - Comment-only line
-        // - Import line
-        // So, it will be a boundary line.
-        SourceLine::Others(range, line_mode)
+        // TODO: Check line has trailing ignore comment?
+        SourceLine::Import(
+            range,
+            ImportLineMetadata {
+                source,
+                is_side_effect,
+                is_type_import,
+                has_default_specifier,
+                has_namespace_specifier,
+                has_named_specifier,
+            },
+        )
     }
 
     pub fn write(
@@ -174,7 +169,7 @@ impl<'a> SourceLine<'a> {
                 // Always use hard line break after import statement.
                 next_elements.push(FormatElement::Line(LineMode::Hard));
             }
-            SourceLine::CommentOnly(range, mode) | SourceLine::Others(range, mode) => {
+            SourceLine::CommentOnly(range, mode) => {
                 for idx in range.clone() {
                     next_elements.push(prev_elements[idx].clone());
                 }


### PR DESCRIPTION
This is no longer necessary, as the target IR now contains nothing but import statements by #22065.