### PR TITLE
fix(codegen): swap mapping/indent order for top-level decls

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -69,8 +69,8 @@ impl Gen for Hashbang<'_> {
 impl Gen for Directive<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_comments_at(self.span.start);
-        p.add_source_mapping(self.span);
         p.print_indent();
+        p.add_source_mapping(self.span);
         // A Use Strict Directive may not contain an EscapeSequence or LineContinuation.
         // So here should print original `directive` value, the `expression` value is escaped str.
         // See https://github.com/babel/babel/blob/v7.26.2/packages/babel-generator/src/generators/base.ts#L64
@@ -849,8 +849,8 @@ impl Gen for FormalParameters<'_> {
 impl Gen for ImportDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_comments_at(self.span.start);
-        p.add_source_mapping(self.span);
         p.print_indent();
+        p.add_source_mapping(self.span);
         p.print_space_before_identifier();
         p.print_str("import");
         if self.import_kind.is_type() {
@@ -1003,8 +1003,8 @@ impl Gen for ExportNamedDeclaration<'_> {
         {
             p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
         }
-        p.add_source_mapping(self.span);
         p.print_indent();
+        p.add_source_mapping(self.span);
         p.print_str("export");
         if let Some(decl) = &self.declaration {
             p.print_hard_space();
@@ -1127,8 +1127,8 @@ impl Gen for ModuleExportName<'_> {
 impl Gen for ExportAllDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_comments_at(self.span.start);
-        p.add_source_mapping(self.span);
         p.print_indent();
+        p.add_source_mapping(self.span);
         p.print_str("export");
         if self.export_kind.is_type() {
             p.print_str(" type ");
@@ -1166,8 +1166,8 @@ impl Gen for ExportDefaultDeclaration<'_> {
         {
             p.print_str(NO_SIDE_EFFECTS_NEW_LINE_COMMENT);
         }
-        p.add_source_mapping(self.span);
         p.print_indent();
+        p.add_source_mapping(self.span);
         p.print_str("export default ");
         self.declaration.print(p, ctx);
     }

--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -176,6 +176,38 @@ fn indented_statement_mappings_start_after_generated_indent() {
     assert_source_maps_after_indent(&tokens, pos(1, 2), pos(1, 0), pos(1, 1));
 }
 
+// `Directive`, `ImportDeclaration`, `ExportNamedDeclaration`,
+// `ExportAllDeclaration`, and `ExportDefaultDeclaration` previously called
+// `add_source_mapping` *before* `print_indent`, anchoring the mapping at
+// gen col 0 (whitespace) instead of the start of the keyword.
+#[test]
+fn top_level_decl_mappings_start_after_generated_indent() {
+    // Wrap the imports/exports in `if (true) { ... }` so the body is
+    // indented, exposing the order of `add_source_mapping` vs `print_indent`.
+    let tokens = sourcemap_tokens(
+        r#"if (true) {
+"use strict";
+import { x } from "x";
+export { x } from "x";
+export * from "x";
+export default 1;
+}"#,
+        SourceType::mjs(),
+    );
+
+    // Directive `"use strict"` source col 0 of line 1 → gen col 1 (after tab),
+    // not gen col 0.
+    assert_source_maps_after_indent(&tokens, pos(1, 0), pos(1, 0), pos(1, 1));
+    // ImportDeclaration
+    assert_source_maps_after_indent(&tokens, pos(2, 0), pos(2, 0), pos(2, 1));
+    // ExportNamedDeclaration
+    assert_source_maps_after_indent(&tokens, pos(3, 0), pos(3, 0), pos(3, 1));
+    // ExportAllDeclaration
+    assert_source_maps_after_indent(&tokens, pos(4, 0), pos(4, 0), pos(4, 1));
+    // ExportDefaultDeclaration
+    assert_source_maps_after_indent(&tokens, pos(5, 0), pos(5, 0), pos(5, 1));
+}
+
 #[test]
 fn class_member_mappings_start_before_member_keys() {
     let tokens = sourcemap_tokens(


### PR DESCRIPTION
Independent of #22199 / #22200. Fixes a separate sourcemap-indent issue.

Five `gen.rs` impls for top-level declarations were calling `add_source_mapping(self.span)` *before* `print_indent()`:

- `Directive`
- `ImportDeclaration`
- `ExportNamedDeclaration`
- `ExportAllDeclaration`
- `ExportDefaultDeclaration`

The mapping then anchored at the line's indent column (col 0) rather than at the actual keyword column. Sourcemap consumers querying the keyword's gen position would land on the leading whitespace.

Every other indented statement in the codebase (`ExpressionStatement`, `IfStatement`, `VariableDeclaration`, etc.) uses the inverse order — `print_indent` first, then `add_source_mapping`. This PR brings the five outliers in line.

## Visual comparison

The bug surfaces when codegen is invoked with non-zero `initial_indent` (a common pattern for bundler callers that nest output in a wrapper). [Before vs After this PR](https://source-map-viewer.void.app/compare?a=5KX8dYtn&b=ZFhNIEAv) on a fixture with all five declaration kinds:

```js
"use strict";
import { x } from "x";
export { y } from "y";
export * from "z";
export default 42;
```

Each declaration's source position now maps to gen col 1 (the keyword) instead of gen col 0 (the leading tab).

## Test plan

- [x] New test `top_level_decl_mappings_start_after_generated_indent` — wraps a `"use strict"`, `import`, three `export` forms inside an indented `if (true) { ... }` block, asserts each maps from `src col 0` to `gen col 1` (after the tab), not `gen col 0`.
- [x] Verified the test fails without the fix.
- [x] All 99 codegen tests pass.
