### PR TITLE
refactor(codegen): extract `consume_pending_indent_space` helper

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -614,10 +614,10 @@ impl Gen for CatchClause<'_> {
         }
         p.print_soft_space();
         p.print_comments_at(self.body.span.start);
-        // Consume the space flag set by comment printing to ensure proper spacing before the opening brace
-        if !p.options.minify && p.print_next_indent_as_space {
-            p.print_hard_space();
-            p.print_next_indent_as_space = false;
+        // Flush the pending-indent-as-space flag so `/* */ {` doesn't
+        // collapse to `/* */{`.
+        if !p.options.minify {
+            p.consume_pending_indent_space();
         }
         p.print_block_statement(&self.body, ctx);
     }
@@ -776,7 +776,7 @@ impl Gen for FunctionBody<'_> {
             // Print trailing statement comments.
             if let Some(comments) = comments_at_end {
                 p.print_comments(&comments);
-                p.print_next_indent_as_space = false;
+                p.clear_pending_indent_space();
             }
         });
         p.needs_semicolon = false;
@@ -1097,7 +1097,7 @@ impl Gen for ExportSpecifier<'_> {
         if let Some(comments) = p.get_comments(self.local.span().start) {
             p.print_comments(&comments);
             p.print_soft_space();
-            p.print_next_indent_as_space = false;
+            p.clear_pending_indent_space();
         }
         self.local.print(p, ctx);
         let local_name = get_module_export_name(&self.local, p);
@@ -1107,7 +1107,7 @@ impl Gen for ExportSpecifier<'_> {
             if let Some(comments) = p.get_comments(self.exported.span().start) {
                 p.print_comments(&comments);
                 p.print_soft_space();
-                p.print_next_indent_as_space = false;
+                p.clear_pending_indent_space();
             }
             self.exported.print(p, ctx);
         }
@@ -1598,10 +1598,7 @@ impl GenExpr for ObjectExpression<'_> {
                     p.print_soft_space();
                     if let Some(comments) = p.get_comments(item.span().start) {
                         p.print_comments(&comments);
-                        if p.print_next_indent_as_space {
-                            p.print_hard_space();
-                            p.print_next_indent_as_space = false;
-                        }
+                        p.consume_pending_indent_space();
                     }
                 }
                 item.print(p, ctx);
@@ -1924,10 +1921,7 @@ impl GenExpr for ConditionalExpression<'_> {
             p.print_soft_space();
             if let Some(comments) = p.get_comments(self.alternate.span().start) {
                 p.print_comments(&comments);
-                if p.print_next_indent_as_space {
-                    p.print_hard_space();
-                    p.print_next_indent_as_space = false;
-                }
+                p.consume_pending_indent_space();
             }
             self.alternate.print_expr(p, Precedence::Yield, ctx & Context::FORBID_IN);
         });

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -518,12 +518,33 @@ impl<'a> Codegen<'a> {
         if self.options.minify {
             return;
         }
-        if self.print_next_indent_as_space {
-            self.print_hard_space();
-            self.print_next_indent_as_space = false;
+        if self.consume_pending_indent_space() {
             return;
         }
         self.code.print_indent(self.indent as usize);
+    }
+
+    /// Comment-printing and inline-statement-body emission set
+    /// `print_next_indent_as_space` so the *next* emit becomes a single
+    /// space instead of indent — keeping `/* … */ stmt` glued together
+    /// and `if (x) bar()` on one line. Returns `true` when a space was
+    /// emitted, so callers that *also* want to print indent can skip it.
+    #[inline]
+    fn consume_pending_indent_space(&mut self) -> bool {
+        if self.print_next_indent_as_space {
+            self.print_hard_space();
+            self.print_next_indent_as_space = false;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Drop the pending-indent-as-space flag without emitting anything. Used
+    /// after manual comment handling that already produced the right spacing.
+    #[inline]
+    fn clear_pending_indent_space(&mut self) {
+        self.print_next_indent_as_space = false;
     }
 
     #[inline]


### PR DESCRIPTION
Stacked on #22206. Pure refactor — no behavior change.

The `print_next_indent_as_space` flag was being read inline at **five** sites in `gen.rs` via copy-pasted `if flag { print_hard_space(); flag = false }` blocks. Two named private helpers replace those:

- `consume_pending_indent_space() -> bool` — emit space + clear flag, returns whether anything was emitted
- `clear_pending_indent_space()` — drop the flag without emitting

`print_indent` continues to call `consume_pending_indent_space` internally, preserving the flag-as-space contract at every existing `print_indent` site.

## Test plan

- [x] `cargo test -p oxc_codegen` passes (100 integration tests, no new tests added since the existing `top_level_decl_mappings_start_after_generated_indent` from #22206 already covers the `Directive` indent path)
- [x] `cargo test -p oxc_isolated_declarations` passes (the namespace / `declare module` snapshot fixtures that already exercise indented import/export decls)
- [x] No snapshot updates needed
