### PR TITLE
fix(linter): undocument override `ignores` option

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -491,16 +491,6 @@ export interface OxlintOverride {
    */
   globals?: OxlintGlobals;
   /**
-   * A list of glob patterns to exclude from this override.
-   *
-   * Files matching these patterns are not globally ignored; this override
-   * simply does not apply to them.
-   *
-   * ## Example
-   * `[ "*.generated.ts", "fixtures/**" ]`
-   */
-  ignores?: GlobSet;
-  /**
    * JS plugins for this override, allows usage of ESLint plugins with Oxlint.
    *
    * Read more about JS plugins in

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -95,6 +95,7 @@ pub struct OxlintOverride {
     /// ## Example
     /// `[ "*.generated.ts", "fixtures/**" ]`
     #[serde(default, skip_serializing_if = "GlobSet::is_empty")]
+    #[schemars(skip)]
     pub ignores: GlobSet,
 
     /// Environments enable and disable collections of global variables.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -596,15 +596,6 @@
           ],
           "markdownDescription": "Enabled or disabled specific global variables."
         },
-        "ignores": {
-          "description": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`",
-          "allOf": [
-            {
-              "$ref": "#/definitions/GlobSet"
-            }
-          ],
-          "markdownDescription": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`"
-        },
         "jsPlugins": {
           "description": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are in alpha and not subject to semver.",
           "anyOf": [

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -600,15 +600,6 @@ expression: json
           ],
           "markdownDescription": "Enabled or disabled specific global variables."
         },
-        "ignores": {
-          "description": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`",
-          "allOf": [
-            {
-              "$ref": "#/definitions/GlobSet"
-            }
-          ],
-          "markdownDescription": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`"
-        },
         "jsPlugins": {
           "description": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are in alpha and not subject to semver.",
           "anyOf": [

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -522,23 +522,6 @@ type: `object`
 Enabled or disabled specific global variables.
 
 
-#### overrides[n].ignores
-
-type: `string[]`
-
-
-A list of glob patterns to exclude from this override.
-
-Files matching these patterns are not globally ignored; this override
-simply does not apply to them.
-
-## Example
-`[ "*.generated.ts", "fixtures/**" ]`
-
-A set of glob patterns.
-Patterns are matched against paths relative to the configuration file's directory.
-
-
 #### overrides[n].jsPlugins
 
 type: `array`


### PR DESCRIPTION
we need some more discussion on this feature, as well as fleshing out naming.

This PR undocuments it so we can make some changes without breaking anyone.