### PR TITLE
docs(formatter): correct comment

### DIFF
--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -143,7 +143,7 @@ fn format_import_decls_with_sort<'a, 'iter>(
             join.entry(decl.span, stmt);
             count += 1;
         } else {
-            // Some other statement or end of statements
+            // Some other statement
             next_stmt = Some(stmt);
             break;
         }


### PR DESCRIPTION
Follow-on after #22079. Just correct a comment which was erroneous (oops, my fault).