### PR TITLE
feat(linter/react): implement `no-deprecated` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -765,6 +765,22 @@ export interface ReactPluginSettings {
    */
   linkComponents?: CustomComponent[];
   /**
+   * React pragma to use for rules that need to recognize the React namespace.
+   *
+   * Example:
+   *
+   * ```jsonc
+   * {
+   * "settings": {
+   * "react": {
+   * "pragma": "Foo"
+   * }
+   * }
+   * }
+   * ```
+   */
+  pragma?: string;
+  /**
    * React version to use for version-specific rules.
    *
    * Accepts semver versions (e.g., "18.2.0", "17.0").

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -32,6 +32,7 @@ working directory:
     "react": {
       "formComponents": [],
       "linkComponents": [],
+      "pragma": null,
       "version": null,
       "componentWrapperFunctions": []
     },

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -25,6 +25,7 @@ working directory: fixtures
     "react": {
       "formComponents": [],
       "linkComponents": [],
+      "pragma": null,
       "version": null,
       "componentWrapperFunctions": []
     },

--- a/apps/oxlint/test/fixtures/print_config_js_config_extends/output.snap.md
+++ b/apps/oxlint/test/fixtures/print_config_js_config_extends/output.snap.md
@@ -28,6 +28,7 @@
     "react": {
       "formComponents": [],
       "linkComponents": [],
+      "pragma": null,
       "version": null,
       "componentWrapperFunctions": []
     },

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize, de};
 
 use oxc_str::CompactStr;
 
-/// Regex to validate React version strings like "18.2.0", "17.0", or "16".
+/// Regex to validate React version strings like "18.2.0", "17.0", "16", or "0.14.0".
 static REACT_VERSION_REGEX: Lazy<Regex> =
-    lazy_regex!(r"^[1-9]\d*(\.(0|[1-9]\d*))?(\.(0|[1-9]\d*))?$");
+    lazy_regex!(r"^(0|[1-9]\d*)(\.(0|[1-9]\d*))?(\.(0|[1-9]\d*))?$");
 
 /// Configure React plugin rules.
 ///
@@ -186,6 +186,12 @@ impl ReactVersion {
         self.patch
     }
 
+    /// Returns `true` if this version is greater than or equal to the provided version.
+    #[inline]
+    pub fn is_at_least(&self, major: u32, minor: u32, patch: u32) -> bool {
+        (self.major, self.minor, self.patch) >= (major, minor, patch)
+    }
+
     /// Checks if the React version supports `UNSAFE_` prefixed lifecycle methods.
     ///
     /// React 16.3 introduced the `UNSAFE_` prefixed lifecycle methods
@@ -194,7 +200,7 @@ impl ReactVersion {
     /// Returns `true` if this version is >= 16.3.
     #[inline]
     pub fn supports_unsafe_lifecycle_prefix(&self) -> bool {
-        self.major > 16 || (self.major == 16 && self.minor >= 3)
+        self.is_at_least(16, 3, 0)
     }
 }
 
@@ -345,7 +351,7 @@ mod test {
     fn test_version_regex() {
         let re = &*REACT_VERSION_REGEX;
 
-        let valid_versions = vec!["18.2.0", "17.0", "16", "1.0.0", "10.20.30", "2.5"];
+        let valid_versions = vec!["18.2.0", "17.0", "16", "1.0.0", "10.20.30", "2.5", "0.14.0"];
         for version in valid_versions {
             assert!(re.is_match(version), "Expected version '{version}' to match regex");
         }

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -62,6 +62,22 @@ pub struct ReactPluginSettings {
     #[serde(rename = "linkComponents")]
     link_components: Vec<CustomComponent>,
 
+    /// React pragma to use for rules that need to recognize the React namespace.
+    ///
+    /// Example:
+    ///
+    /// ```jsonc
+    /// {
+    ///   "settings": {
+    ///     "react": {
+    ///       "pragma": "Foo"
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    #[serde(default)]
+    pub pragma: Option<CompactStr>,
+
     /// React version to use for version-specific rules.
     ///
     /// Accepts semver versions (e.g., "18.2.0", "17.0").

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2647,6 +2647,17 @@ impl RuleRunner for crate::rules::react::no_danger_with_children::NoDangerWithCh
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::no_deprecated::NoDeprecated {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ImportDeclaration,
+        AstType::MethodDefinition,
+        AstType::ObjectProperty,
+        AstType::StaticMemberExpression,
+        AstType::VariableDeclarator,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::no_did_mount_set_state::NoDidMountSetState {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -433,6 +433,7 @@ pub use crate::rules::react::no_children_prop::NoChildrenProp as ReactNoChildren
 pub use crate::rules::react::no_clone_element::NoCloneElement as ReactNoCloneElement;
 pub use crate::rules::react::no_danger::NoDanger as ReactNoDanger;
 pub use crate::rules::react::no_danger_with_children::NoDangerWithChildren as ReactNoDangerWithChildren;
+pub use crate::rules::react::no_deprecated::NoDeprecated as ReactNoDeprecated;
 pub use crate::rules::react::no_did_mount_set_state::NoDidMountSetState as ReactNoDidMountSetState;
 pub use crate::rules::react::no_did_update_set_state::NoDidUpdateSetState as ReactNoDidUpdateSetState;
 pub use crate::rules::react::no_direct_mutation_state::NoDirectMutationState as ReactNoDirectMutationState;
@@ -1220,6 +1221,7 @@ pub enum RuleEnum {
     ReactNoCloneElement(ReactNoCloneElement),
     ReactNoDanger(ReactNoDanger),
     ReactNoDangerWithChildren(ReactNoDangerWithChildren),
+    ReactNoDeprecated(ReactNoDeprecated),
     ReactNoDidMountSetState(ReactNoDidMountSetState),
     ReactNoDidUpdateSetState(ReactNoDidUpdateSetState),
     ReactNoDirectMutationState(ReactNoDirectMutationState),
@@ -2061,7 +2063,8 @@ const REACT_NO_CHILDREN_PROP_ID: usize = REACT_NO_ARRAY_INDEX_KEY_ID + 1usize;
 const REACT_NO_CLONE_ELEMENT_ID: usize = REACT_NO_CHILDREN_PROP_ID + 1usize;
 const REACT_NO_DANGER_ID: usize = REACT_NO_CLONE_ELEMENT_ID + 1usize;
 const REACT_NO_DANGER_WITH_CHILDREN_ID: usize = REACT_NO_DANGER_ID + 1usize;
-const REACT_NO_DID_MOUNT_SET_STATE_ID: usize = REACT_NO_DANGER_WITH_CHILDREN_ID + 1usize;
+const REACT_NO_DEPRECATED_ID: usize = REACT_NO_DANGER_WITH_CHILDREN_ID + 1usize;
+const REACT_NO_DID_MOUNT_SET_STATE_ID: usize = REACT_NO_DEPRECATED_ID + 1usize;
 const REACT_NO_DID_UPDATE_SET_STATE_ID: usize = REACT_NO_DID_MOUNT_SET_STATE_ID + 1usize;
 const REACT_NO_DIRECT_MUTATION_STATE_ID: usize = REACT_NO_DID_UPDATE_SET_STATE_ID + 1usize;
 const REACT_NO_FIND_DOM_NODE_ID: usize = REACT_NO_DIRECT_MUTATION_STATE_ID + 1usize;
@@ -2978,6 +2981,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => REACT_NO_CLONE_ELEMENT_ID,
             Self::ReactNoDanger(_) => REACT_NO_DANGER_ID,
             Self::ReactNoDangerWithChildren(_) => REACT_NO_DANGER_WITH_CHILDREN_ID,
+            Self::ReactNoDeprecated(_) => REACT_NO_DEPRECATED_ID,
             Self::ReactNoDidMountSetState(_) => REACT_NO_DID_MOUNT_SET_STATE_ID,
             Self::ReactNoDidUpdateSetState(_) => REACT_NO_DID_UPDATE_SET_STATE_ID,
             Self::ReactNoDirectMutationState(_) => REACT_NO_DIRECT_MUTATION_STATE_ID,
@@ -3887,6 +3891,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => ReactNoCloneElement::NAME,
             Self::ReactNoDanger(_) => ReactNoDanger::NAME,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::NAME,
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::NAME,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::NAME,
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::NAME,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::NAME,
@@ -4812,6 +4817,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => ReactNoCloneElement::CATEGORY,
             Self::ReactNoDanger(_) => ReactNoDanger::CATEGORY,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::CATEGORY,
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::CATEGORY,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::CATEGORY,
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::CATEGORY,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::CATEGORY,
@@ -5742,6 +5748,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => ReactNoCloneElement::FIX,
             Self::ReactNoDanger(_) => ReactNoDanger::FIX,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::FIX,
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::FIX,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::FIX,
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::FIX,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::FIX,
@@ -6746,6 +6753,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => ReactNoCloneElement::documentation(),
             Self::ReactNoDanger(_) => ReactNoDanger::documentation(),
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::documentation(),
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::documentation(),
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::documentation(),
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::documentation(),
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::documentation(),
@@ -8473,6 +8481,8 @@ impl RuleEnum {
                 ReactNoDangerWithChildren::config_schema(generator)
                     .or_else(|| ReactNoDangerWithChildren::schema(generator))
             }
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::config_schema(generator)
+                .or_else(|| ReactNoDeprecated::schema(generator)),
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::config_schema(generator)
                 .or_else(|| ReactNoDidMountSetState::schema(generator)),
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::config_schema(generator)
@@ -9983,6 +9993,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => "react",
             Self::ReactNoDanger(_) => "react",
             Self::ReactNoDangerWithChildren(_) => "react",
+            Self::ReactNoDeprecated(_) => "react",
             Self::ReactNoDidMountSetState(_) => "react",
             Self::ReactNoDidUpdateSetState(_) => "react",
             Self::ReactNoDirectMutationState(_) => "react",
@@ -11693,6 +11704,9 @@ impl RuleEnum {
             Self::ReactNoDangerWithChildren(_) => Ok(Self::ReactNoDangerWithChildren(
                 ReactNoDangerWithChildren::from_configuration(value)?,
             )),
+            Self::ReactNoDeprecated(_) => {
+                Ok(Self::ReactNoDeprecated(ReactNoDeprecated::from_configuration(value)?))
+            }
             Self::ReactNoDidMountSetState(_) => Ok(Self::ReactNoDidMountSetState(
                 ReactNoDidMountSetState::from_configuration(value)?,
             )),
@@ -13326,6 +13340,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(rule) => rule.to_configuration(),
             Self::ReactNoDanger(rule) => rule.to_configuration(),
             Self::ReactNoDangerWithChildren(rule) => rule.to_configuration(),
+            Self::ReactNoDeprecated(rule) => rule.to_configuration(),
             Self::ReactNoDidMountSetState(rule) => rule.to_configuration(),
             Self::ReactNoDidUpdateSetState(rule) => rule.to_configuration(),
             Self::ReactNoDirectMutationState(rule) => rule.to_configuration(),
@@ -14121,6 +14136,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(rule) => rule.run(node, ctx),
             Self::ReactNoDanger(rule) => rule.run(node, ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.run(node, ctx),
+            Self::ReactNoDeprecated(rule) => rule.run(node, ctx),
             Self::ReactNoDidMountSetState(rule) => rule.run(node, ctx),
             Self::ReactNoDidUpdateSetState(rule) => rule.run(node, ctx),
             Self::ReactNoDirectMutationState(rule) => rule.run(node, ctx),
@@ -14914,6 +14930,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(rule) => rule.run_once(ctx),
             Self::ReactNoDanger(rule) => rule.run_once(ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.run_once(ctx),
+            Self::ReactNoDeprecated(rule) => rule.run_once(ctx),
             Self::ReactNoDidMountSetState(rule) => rule.run_once(ctx),
             Self::ReactNoDidUpdateSetState(rule) => rule.run_once(ctx),
             Self::ReactNoDirectMutationState(rule) => rule.run_once(ctx),
@@ -15779,6 +15796,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDanger(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactNoDeprecated(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDidMountSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDidUpdateSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDirectMutationState(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16610,6 +16628,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(rule) => rule.should_run(ctx),
             Self::ReactNoDanger(rule) => rule.should_run(ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.should_run(ctx),
+            Self::ReactNoDeprecated(rule) => rule.should_run(ctx),
             Self::ReactNoDidMountSetState(rule) => rule.should_run(ctx),
             Self::ReactNoDidUpdateSetState(rule) => rule.should_run(ctx),
             Self::ReactNoDirectMutationState(rule) => rule.should_run(ctx),
@@ -17575,6 +17594,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => ReactNoCloneElement::IS_TSGOLINT_RULE,
             Self::ReactNoDanger(_) => ReactNoDanger::IS_TSGOLINT_RULE,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::IS_TSGOLINT_RULE,
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::IS_TSGOLINT_RULE,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::IS_TSGOLINT_RULE,
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::IS_TSGOLINT_RULE,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::IS_TSGOLINT_RULE,
@@ -18638,6 +18658,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => ReactNoCloneElement::VERSION,
             Self::ReactNoDanger(_) => ReactNoDanger::VERSION,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::VERSION,
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::VERSION,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::VERSION,
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::VERSION,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::VERSION,
@@ -19610,6 +19631,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(_) => ReactNoCloneElement::HAS_CONFIG,
             Self::ReactNoDanger(_) => ReactNoDanger::HAS_CONFIG,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::HAS_CONFIG,
+            Self::ReactNoDeprecated(_) => ReactNoDeprecated::HAS_CONFIG,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::HAS_CONFIG,
             Self::ReactNoDidUpdateSetState(_) => ReactNoDidUpdateSetState::HAS_CONFIG,
             Self::ReactNoDirectMutationState(_) => ReactNoDirectMutationState::HAS_CONFIG,
@@ -20491,6 +20513,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(rule) => rule.types_info(),
             Self::ReactNoDanger(rule) => rule.types_info(),
             Self::ReactNoDangerWithChildren(rule) => rule.types_info(),
+            Self::ReactNoDeprecated(rule) => rule.types_info(),
             Self::ReactNoDidMountSetState(rule) => rule.types_info(),
             Self::ReactNoDidUpdateSetState(rule) => rule.types_info(),
             Self::ReactNoDirectMutationState(rule) => rule.types_info(),
@@ -21284,6 +21307,7 @@ impl RuleEnum {
             Self::ReactNoCloneElement(rule) => rule.run_info(),
             Self::ReactNoDanger(rule) => rule.run_info(),
             Self::ReactNoDangerWithChildren(rule) => rule.run_info(),
+            Self::ReactNoDeprecated(rule) => rule.run_info(),
             Self::ReactNoDidMountSetState(rule) => rule.run_info(),
             Self::ReactNoDidUpdateSetState(rule) => rule.run_info(),
             Self::ReactNoDirectMutationState(rule) => rule.run_info(),
@@ -22167,6 +22191,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactNoCloneElement(ReactNoCloneElement::default()),
         RuleEnum::ReactNoDanger(ReactNoDanger::default()),
         RuleEnum::ReactNoDangerWithChildren(ReactNoDangerWithChildren::default()),
+        RuleEnum::ReactNoDeprecated(ReactNoDeprecated::default()),
         RuleEnum::ReactNoDidMountSetState(ReactNoDidMountSetState::default()),
         RuleEnum::ReactNoDidUpdateSetState(ReactNoDidUpdateSetState::default()),
         RuleEnum::ReactNoDirectMutationState(ReactNoDirectMutationState::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -429,6 +429,7 @@ pub(crate) mod react {
     pub mod no_clone_element;
     pub mod no_danger;
     pub mod no_danger_with_children;
+    pub mod no_deprecated;
     pub mod no_did_mount_set_state;
     pub mod no_did_update_set_state;
     pub mod no_direct_mutation_state;

--- a/crates/oxc_linter/src/rules/react/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/react/no_deprecated.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write;
+use std::{borrow::Cow, fmt::Write};
 
 use oxc_ast::{
     AstKind,
@@ -343,7 +343,9 @@ impl Rule for NoDeprecated {
 
 impl NoDeprecated {
     fn check_deprecation(name: &str, span: Span, ctx: &LintContext<'_>) {
-        let Some(api) = DEPRECATED_APIS.iter().find(|api| api.name == name) else {
+        let normalized_name = normalize_react_pragma_path(name, ctx);
+        let Some(api) = DEPRECATED_APIS.iter().find(|api| api.name == normalized_name.as_ref())
+        else {
             return;
         };
         if is_react_version_at_least(ctx.settings().react.version.as_ref(), api.since) {
@@ -354,6 +356,35 @@ impl NoDeprecated {
 
 fn is_react_version_at_least(version: Option<&ReactVersion>, since: (u32, u32, u32)) -> bool {
     version.is_none_or(|version| version.is_at_least(since.0, since.1, since.2))
+}
+
+fn normalize_react_pragma_path<'a>(name: &'a str, ctx: &LintContext<'_>) -> Cow<'a, str> {
+    let Some(pragma) = jsx_pragma(ctx).or(ctx.settings().react.pragma.as_deref()) else {
+        return Cow::Borrowed(name);
+    };
+
+    if pragma == "React" {
+        return Cow::Borrowed(name);
+    }
+
+    let Some(rest) = name.strip_prefix(pragma).and_then(|rest| rest.strip_prefix('.')) else {
+        return Cow::Borrowed(name);
+    };
+
+    Cow::Owned(format!("React.{rest}"))
+}
+
+fn jsx_pragma<'a>(ctx: &LintContext<'a>) -> Option<&'a str> {
+    for comment in ctx.semantic().comments() {
+        let mut tokens = ctx.source_range(comment.content_span()).split_whitespace();
+        while let Some(token) = tokens.next() {
+            if token == "@jsx" {
+                return tokens.next();
+            }
+        }
+    }
+
+    None
 }
 
 fn canonical_module_name(module_name: &str) -> Option<&'static str> {
@@ -499,6 +530,12 @@ fn test() {
 
     let fail = vec![
         ("React.renderComponent()", None, None),
+        (
+            "Foo.renderComponent()",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "pragma": "Foo" } } })),
+        ),
+        ("/** @jsx Foo */ Foo.renderComponent()", None, None),
         ("this.transferPropsTo()", None, None),
         ("React.addons.TestUtils", None, None),
         ("React.addons.classSet()", None, None),
@@ -508,6 +545,11 @@ fn test() {
         ("React.renderToString(element);", None, None),
         ("React.renderToStaticMarkup(element);", None, None),
         ("React.createClass({});", None, None),
+        (
+            "Foo.createClass({});",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "pragma": "Foo" } } })),
+        ),
         ("React.PropTypes", None, None),
         ("var {createClass} = require('react');", None, None),
         ("var {createClass, PropTypes} = require('react');", None, None),
@@ -530,6 +572,11 @@ fn test() {
         ),
         (
             "class Bar extends PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };",
+            None,
+            None,
+        ),
+        (
+            "class Foo extends React.Component { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }",
             None,
             None,
         ),

--- a/crates/oxc_linter/src/rules/react/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/react/no_deprecated.rs
@@ -279,7 +279,7 @@ impl Rule for NoDeprecated {
         match node.kind() {
             AstKind::StaticMemberExpression(member_expr) => {
                 if let Some(name) = static_member_path(member_expr) {
-                    self.check_deprecation(&name, member_expr.span, ctx);
+                    Self::check_deprecation(&name, member_expr.span, ctx);
                 }
             }
             AstKind::ImportDeclaration(import_decl) => {
@@ -297,7 +297,7 @@ impl Rule for NoDeprecated {
                         continue;
                     };
                     let name = format!("{module_name}.{}", import_specifier.imported.name());
-                    self.check_deprecation(&name, import_specifier.span, ctx);
+                    Self::check_deprecation(&name, import_specifier.span, ctx);
                 }
             }
             AstKind::VariableDeclarator(declarator) => {
@@ -317,7 +317,7 @@ impl Rule for NoDeprecated {
                         continue;
                     };
                     let name = format!("{module_name}.{property_name}");
-                    self.check_deprecation(&name, span, ctx);
+                    Self::check_deprecation(&name, span, ctx);
                 }
             }
             AstKind::MethodDefinition(method_def) => {
@@ -325,7 +325,7 @@ impl Rule for NoDeprecated {
                     return;
                 };
                 if get_parent_component(node, ctx).is_some() {
-                    self.check_deprecation(name.as_ref(), method_def.key.span(), ctx);
+                    Self::check_deprecation(name.as_ref(), method_def.key.span(), ctx);
                 }
             }
             AstKind::ObjectProperty(obj_prop) => {
@@ -333,7 +333,7 @@ impl Rule for NoDeprecated {
                     return;
                 };
                 if ctx.nodes().ancestors(node.id()).any(is_es5_component) {
-                    self.check_deprecation(name.as_ref(), obj_prop.key.span(), ctx);
+                    Self::check_deprecation(name.as_ref(), obj_prop.key.span(), ctx);
                 }
             }
             _ => {}
@@ -342,7 +342,7 @@ impl Rule for NoDeprecated {
 }
 
 impl NoDeprecated {
-    fn check_deprecation(&self, name: &str, span: Span, ctx: &LintContext<'_>) {
+    fn check_deprecation(name: &str, span: Span, ctx: &LintContext<'_>) {
         let Some(api) = DEPRECATED_APIS.iter().find(|api| api.name == name) else {
             return;
         };

--- a/crates/oxc_linter/src/rules/react/no_deprecated.rs
+++ b/crates/oxc_linter/src/rules/react/no_deprecated.rs
@@ -1,0 +1,569 @@
+use std::fmt::Write;
+
+use oxc_ast::{
+    AstKind,
+    ast::{
+        BindingPattern, Expression, ImportDeclarationSpecifier, PropertyKey, StaticMemberExpression,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    config::ReactVersion,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_parent_component, is_es5_component},
+};
+
+#[derive(Debug, Clone, Copy)]
+struct DeprecatedApi {
+    name: &'static str,
+    since: (u32, u32, u32),
+    replacement: Option<&'static str>,
+    reference: Option<&'static str>,
+}
+
+const DEPRECATED_APIS: &[DeprecatedApi] = &[
+    DeprecatedApi {
+        name: "React.renderComponent",
+        since: (0, 12, 0),
+        replacement: Some("React.render"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.renderComponentToString",
+        since: (0, 12, 0),
+        replacement: Some("React.renderToString"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.renderComponentToStaticMarkup",
+        since: (0, 12, 0),
+        replacement: Some("React.renderToStaticMarkup"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.isValidComponent",
+        since: (0, 12, 0),
+        replacement: Some("React.isValidElement"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.PropTypes.component",
+        since: (0, 12, 0),
+        replacement: Some("React.PropTypes.element"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.PropTypes.renderable",
+        since: (0, 12, 0),
+        replacement: Some("React.PropTypes.node"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.isValidClass",
+        since: (0, 12, 0),
+        replacement: None,
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "this.transferPropsTo",
+        since: (0, 12, 0),
+        replacement: Some("spread operator ({...})"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.addons.classSet",
+        since: (0, 13, 0),
+        replacement: Some("the npm module classnames"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.addons.cloneWithProps",
+        since: (0, 13, 0),
+        replacement: Some("React.cloneElement"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.render",
+        since: (0, 14, 0),
+        replacement: Some("ReactDOM.render"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.unmountComponentAtNode",
+        since: (0, 14, 0),
+        replacement: Some("ReactDOM.unmountComponentAtNode"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.findDOMNode",
+        since: (0, 14, 0),
+        replacement: Some("ReactDOM.findDOMNode"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.renderToString",
+        since: (0, 14, 0),
+        replacement: Some("ReactDOMServer.renderToString"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.renderToStaticMarkup",
+        since: (0, 14, 0),
+        replacement: Some("ReactDOMServer.renderToStaticMarkup"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.addons.LinkedStateMixin",
+        since: (15, 0, 0),
+        replacement: None,
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "ReactPerf.printDOM",
+        since: (15, 0, 0),
+        replacement: Some("ReactPerf.printOperations"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "Perf.printDOM",
+        since: (15, 0, 0),
+        replacement: Some("Perf.printOperations"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "ReactPerf.getMeasurementsSummaryMap",
+        since: (15, 0, 0),
+        replacement: Some("ReactPerf.getWasted"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "Perf.getMeasurementsSummaryMap",
+        since: (15, 0, 0),
+        replacement: Some("Perf.getWasted"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.createClass",
+        since: (15, 5, 0),
+        replacement: Some("the npm module create-react-class"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.addons.TestUtils",
+        since: (15, 5, 0),
+        replacement: Some("ReactDOM.TestUtils"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.PropTypes",
+        since: (15, 5, 0),
+        replacement: Some("the npm module prop-types"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "React.DOM",
+        since: (15, 6, 0),
+        replacement: Some("the npm module react-dom-factories"),
+        reference: None,
+    },
+    DeprecatedApi {
+        name: "componentWillMount",
+        since: (16, 9, 0),
+        replacement: Some("UNSAFE_componentWillMount"),
+        reference: Some(
+            "https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.",
+        ),
+    },
+    DeprecatedApi {
+        name: "componentWillReceiveProps",
+        since: (16, 9, 0),
+        replacement: Some("UNSAFE_componentWillReceiveProps"),
+        reference: Some(
+            "https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.",
+        ),
+    },
+    DeprecatedApi {
+        name: "componentWillUpdate",
+        since: (16, 9, 0),
+        replacement: Some("UNSAFE_componentWillUpdate"),
+        reference: Some(
+            "https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.",
+        ),
+    },
+    DeprecatedApi {
+        name: "ReactDOM.render",
+        since: (18, 0, 0),
+        replacement: Some("createRoot"),
+        reference: Some("https://reactjs.org/link/switch-to-createroot"),
+    },
+    DeprecatedApi {
+        name: "ReactDOM.hydrate",
+        since: (18, 0, 0),
+        replacement: Some("hydrateRoot"),
+        reference: Some("https://reactjs.org/link/switch-to-createroot"),
+    },
+    DeprecatedApi {
+        name: "ReactDOM.unmountComponentAtNode",
+        since: (18, 0, 0),
+        replacement: Some("root.unmount"),
+        reference: Some("https://reactjs.org/link/switch-to-createroot"),
+    },
+    DeprecatedApi {
+        name: "ReactDOMServer.renderToNodeStream",
+        since: (18, 0, 0),
+        replacement: Some("renderToPipeableStream"),
+        reference: Some("https://reactjs.org/docs/react-dom-server.html#rendertonodestream"),
+    },
+];
+
+fn no_deprecated_diagnostic(api: &DeprecatedApi, span: Span) -> OxcDiagnostic {
+    let mut message = format!(
+        "{} is deprecated since React {}.{}.{}",
+        api.name, api.since.0, api.since.1, api.since.2
+    );
+    if let Some(replacement) = api.replacement {
+        write!(message, ", use {replacement} instead").unwrap();
+    }
+
+    let diagnostic = OxcDiagnostic::warn(message).with_label(span);
+    if let Some(reference) = api.reference {
+        diagnostic.with_help(format!("See {reference}"))
+    } else {
+        diagnostic
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDeprecated;
+
+// <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md>
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows usage of APIs deprecated by React.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Deprecated React APIs may be removed in future React releases and often have
+    /// safer or better-supported replacements.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// React.render(<MyComponent />, root);
+    /// React.createClass({});
+    /// ReactDOM.render(<div />, container);
+    /// componentWillMount() {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// import { createRoot } from 'react-dom/client';
+    /// const root = createRoot(container);
+    /// UNSAFE_componentWillMount() {}
+    /// ```
+    NoDeprecated,
+    react,
+    correctness,
+    version = "1.63.0",
+);
+
+impl Rule for NoDeprecated {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::StaticMemberExpression(member_expr) => {
+                if let Some(name) = static_member_path(member_expr) {
+                    self.check_deprecation(&name, member_expr.span, ctx);
+                }
+            }
+            AstKind::ImportDeclaration(import_decl) => {
+                let Some(module_name) = canonical_module_name(import_decl.source.value.as_str())
+                else {
+                    return;
+                };
+                let Some(specifiers) = &import_decl.specifiers else {
+                    return;
+                };
+
+                for specifier in specifiers {
+                    let ImportDeclarationSpecifier::ImportSpecifier(import_specifier) = specifier
+                    else {
+                        continue;
+                    };
+                    let name = format!("{module_name}.{}", import_specifier.imported.name());
+                    self.check_deprecation(&name, import_specifier.span, ctx);
+                }
+            }
+            AstKind::VariableDeclarator(declarator) => {
+                let BindingPattern::ObjectPattern(pattern) = &declarator.id else {
+                    return;
+                };
+                let Some(init) = &declarator.init else {
+                    return;
+                };
+                let Some(module_name) = initializer_module_name(init) else {
+                    return;
+                };
+
+                for property in &pattern.properties {
+                    let Some((property_name, span)) = property_key_name_and_span(&property.key)
+                    else {
+                        continue;
+                    };
+                    let name = format!("{module_name}.{property_name}");
+                    self.check_deprecation(&name, span, ctx);
+                }
+            }
+            AstKind::MethodDefinition(method_def) => {
+                let Some(name) = method_def.key.static_name() else {
+                    return;
+                };
+                if get_parent_component(node, ctx).is_some() {
+                    self.check_deprecation(name.as_ref(), method_def.key.span(), ctx);
+                }
+            }
+            AstKind::ObjectProperty(obj_prop) => {
+                let Some(name) = obj_prop.key.static_name() else {
+                    return;
+                };
+                if ctx.nodes().ancestors(node.id()).any(is_es5_component) {
+                    self.check_deprecation(name.as_ref(), obj_prop.key.span(), ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl NoDeprecated {
+    fn check_deprecation(&self, name: &str, span: Span, ctx: &LintContext<'_>) {
+        let Some(api) = DEPRECATED_APIS.iter().find(|api| api.name == name) else {
+            return;
+        };
+        if is_react_version_at_least(ctx.settings().react.version.as_ref(), api.since) {
+            ctx.diagnostic(no_deprecated_diagnostic(api, span));
+        }
+    }
+}
+
+fn is_react_version_at_least(version: Option<&ReactVersion>, since: (u32, u32, u32)) -> bool {
+    version.is_none_or(|version| version.is_at_least(since.0, since.1, since.2))
+}
+
+fn canonical_module_name(module_name: &str) -> Option<&'static str> {
+    match module_name {
+        "react" => Some("React"),
+        "react-addons-perf" => Some("ReactPerf"),
+        "react-dom" => Some("ReactDOM"),
+        "react-dom/server" => Some("ReactDOMServer"),
+        _ => None,
+    }
+}
+
+fn canonical_object_name(name: &str) -> Option<&'static str> {
+    match name {
+        "React" => Some("React"),
+        "ReactPerf" => Some("ReactPerf"),
+        "Perf" => Some("Perf"),
+        "ReactDOM" => Some("ReactDOM"),
+        "ReactDOMServer" => Some("ReactDOMServer"),
+        _ => None,
+    }
+}
+
+fn initializer_module_name(init: &Expression<'_>) -> Option<&'static str> {
+    match init.without_parentheses() {
+        Expression::Identifier(ident) => canonical_object_name(ident.name.as_str()),
+        Expression::CallExpression(call) => {
+            canonical_module_name(call.common_js_require()?.value.as_str())
+        }
+        _ => None,
+    }
+}
+
+fn static_member_path(member_expr: &StaticMemberExpression<'_>) -> Option<String> {
+    let object = expression_path(member_expr.object.without_parentheses())?;
+    Some(format!("{object}.{}", member_expr.property.name))
+}
+
+fn expression_path(expr: &Expression<'_>) -> Option<String> {
+    match expr {
+        Expression::Identifier(ident) => Some(ident.name.to_string()),
+        Expression::ThisExpression(_) => Some("this".to_string()),
+        Expression::StaticMemberExpression(member_expr) => static_member_path(member_expr),
+        Expression::ParenthesizedExpression(paren) => expression_path(&paren.expression),
+        Expression::ChainExpression(chain) => match &chain.expression {
+            oxc_ast::ast::ChainElement::StaticMemberExpression(member_expr) => {
+                static_member_path(member_expr)
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn property_key_name_and_span<'a>(key: &'a PropertyKey<'a>) -> Option<(&'a str, Span)> {
+    match key {
+        PropertyKey::Identifier(ident) => Some((ident.name.as_str(), ident.span)),
+        PropertyKey::StaticIdentifier(ident) => Some((ident.name.as_str(), ident.span)),
+        _ => None,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var element = React.createElement('p', {}, null);", None, None),
+        ("var clone = React.cloneElement(element);", None, None),
+        ("ReactDOM.cloneElement(child, container);", None, None),
+        (
+            "ReactDOM.findDOMNode(instance);",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "version": "17.0.0" } } })),
+        ),
+        ("ReactDOM.createPortal(child, container);", None, None),
+        ("ReactDOMServer.renderToString(element);", None, None),
+        ("ReactDOMServer.renderToStaticMarkup(element);", None, None),
+        ("var Foo = createReactClass({ render: function() {} })", None, None),
+        (
+            "var Foo = createReactClassNonReact({ componentWillMount: function() {}, componentWillReceiveProps: function() {}, componentWillUpdate: function() {} });",
+            None,
+            None,
+        ),
+        (
+            "var Foo = { componentWillMount: function() {}, componentWillReceiveProps: function() {}, componentWillUpdate: function() {} };",
+            None,
+            None,
+        ),
+        (
+            "class Foo { constructor() {} componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }",
+            None,
+            None,
+        ),
+        (
+            "React.renderComponent()",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "version": "0.11.0" } } })),
+        ),
+        (
+            "React.createClass()",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "version": "15.4.0" } } })),
+        ),
+        (
+            "React.PropTypes",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "version": "15.4.0" } } })),
+        ),
+        (
+            "class Foo extends React.Component { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "version": "16.8.0" } } })),
+        ),
+        (
+            "import React from 'react'; let { default: defaultReactExport, ...allReactExports } = React;",
+            None,
+            None,
+        ),
+        (
+            "import { render, hydrate } from 'react-dom'; import { renderToNodeStream } from 'react-dom/server'; ReactDOM.render(element, container); ReactDOM.unmountComponentAtNode(container); ReactDOMServer.renderToNodeStream(element);",
+            None,
+            Some(serde_json::json!({ "settings": { "react": { "version": "17.999.999" } } })),
+        ),
+        (
+            "import ReactDOM, { createRoot } from 'react-dom/client'; ReactDOM.createRoot(container); const root = createRoot(container); root.unmount();",
+            None,
+            None,
+        ),
+        (
+            "import ReactDOM, { hydrateRoot } from 'react-dom/client'; ReactDOM.hydrateRoot(container, <App/>); hydrateRoot(container, <App/>);",
+            None,
+            None,
+        ),
+        (
+            "import ReactDOMServer, { renderToPipeableStream } from 'react-dom/server'; ReactDOMServer.renderToPipeableStream(<App />, {}); renderToPipeableStream(<App />, {});",
+            None,
+            None,
+        ),
+        ("import { renderToString } from 'react-dom/server';", None, None),
+        ("const { renderToString } = require('react-dom/server');", None, None),
+    ];
+
+    let fail = vec![
+        ("React.renderComponent()", None, None),
+        ("this.transferPropsTo()", None, None),
+        ("React.addons.TestUtils", None, None),
+        ("React.addons.classSet()", None, None),
+        ("React.render(element, container);", None, None),
+        ("React.unmountComponentAtNode(container);", None, None),
+        ("React.findDOMNode(instance);", None, None),
+        ("React.renderToString(element);", None, None),
+        ("React.renderToStaticMarkup(element);", None, None),
+        ("React.createClass({});", None, None),
+        ("React.PropTypes", None, None),
+        ("var {createClass} = require('react');", None, None),
+        ("var {createClass, PropTypes} = require('react');", None, None),
+        ("import {createClass} from 'react';", None, None),
+        ("import {createClass, PropTypes} from 'react';", None, None),
+        ("import React from 'react'; const {createClass, PropTypes} = React;", None, None),
+        ("import {printDOM} from 'react-addons-perf';", None, None),
+        ("import ReactPerf from 'react-addons-perf'; const {printDOM} = ReactPerf;", None, None),
+        ("const {printDOM} = Perf;", None, None),
+        ("React.DOM.div", None, None),
+        (
+            "class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };",
+            None,
+            None,
+        ),
+        (
+            "function Foo() { return class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }; }",
+            None,
+            None,
+        ),
+        (
+            "class Bar extends PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };",
+            None,
+            None,
+        ),
+        (
+            "class Foo extends React.Component { constructor() {} componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }",
+            None,
+            None,
+        ),
+        (
+            "var Foo = createReactClass({ componentWillMount: function() {}, componentWillReceiveProps: function() {}, componentWillUpdate: function() {} })",
+            None,
+            None,
+        ),
+        (
+            "import { render } from 'react-dom'; ReactDOM.render(<div></div>, container);",
+            None,
+            None,
+        ),
+        (
+            "import { hydrate } from 'react-dom'; ReactDOM.hydrate(<div></div>, container);",
+            None,
+            None,
+        ),
+        (
+            "import { unmountComponentAtNode } from 'react-dom'; ReactDOM.unmountComponentAtNode(container);",
+            None,
+            None,
+        ),
+        (
+            "import { renderToNodeStream } from 'react-dom/server'; ReactDOMServer.renderToNodeStream(element);",
+            None,
+            None,
+        ),
+    ];
+
+    Tester::new(NoDeprecated::NAME, NoDeprecated::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_no_deprecated.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_deprecated.snap
@@ -1,0 +1,302 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ react(no-deprecated): React.renderComponent is deprecated since React 0.12.0, use React.render instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.renderComponent()
+   · ─────────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): this.transferPropsTo is deprecated since React 0.12.0, use spread operator ({...}) instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ this.transferPropsTo()
+   · ────────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.addons.TestUtils is deprecated since React 15.5.0, use ReactDOM.TestUtils instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.addons.TestUtils
+   · ──────────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.addons.classSet is deprecated since React 0.13.0, use the npm module classnames instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.addons.classSet()
+   · ─────────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.render is deprecated since React 0.14.0, use ReactDOM.render instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.render(element, container);
+   · ────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.unmountComponentAtNode is deprecated since React 0.14.0, use ReactDOM.unmountComponentAtNode instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.unmountComponentAtNode(container);
+   · ────────────────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.findDOMNode is deprecated since React 0.14.0, use ReactDOM.findDOMNode instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.findDOMNode(instance);
+   · ─────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.renderToString is deprecated since React 0.14.0, use ReactDOMServer.renderToString instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.renderToString(element);
+   · ────────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.renderToStaticMarkup is deprecated since React 0.14.0, use ReactDOMServer.renderToStaticMarkup instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.renderToStaticMarkup(element);
+   · ──────────────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.createClass({});
+   · ─────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.PropTypes is deprecated since React 15.5.0, use the npm module prop-types instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.PropTypes
+   · ───────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead
+   ╭─[no_deprecated.tsx:1:6]
+ 1 │ var {createClass} = require('react');
+   ·      ───────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead
+   ╭─[no_deprecated.tsx:1:6]
+ 1 │ var {createClass, PropTypes} = require('react');
+   ·      ───────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.PropTypes is deprecated since React 15.5.0, use the npm module prop-types instead
+   ╭─[no_deprecated.tsx:1:19]
+ 1 │ var {createClass, PropTypes} = require('react');
+   ·                   ─────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead
+   ╭─[no_deprecated.tsx:1:9]
+ 1 │ import {createClass} from 'react';
+   ·         ───────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead
+   ╭─[no_deprecated.tsx:1:9]
+ 1 │ import {createClass, PropTypes} from 'react';
+   ·         ───────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.PropTypes is deprecated since React 15.5.0, use the npm module prop-types instead
+   ╭─[no_deprecated.tsx:1:22]
+ 1 │ import {createClass, PropTypes} from 'react';
+   ·                      ─────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead
+   ╭─[no_deprecated.tsx:1:35]
+ 1 │ import React from 'react'; const {createClass, PropTypes} = React;
+   ·                                   ───────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.PropTypes is deprecated since React 15.5.0, use the npm module prop-types instead
+   ╭─[no_deprecated.tsx:1:48]
+ 1 │ import React from 'react'; const {createClass, PropTypes} = React;
+   ·                                                ─────────
+   ╰────
+
+  ⚠ react(no-deprecated): ReactPerf.printDOM is deprecated since React 15.0.0, use ReactPerf.printOperations instead
+   ╭─[no_deprecated.tsx:1:9]
+ 1 │ import {printDOM} from 'react-addons-perf';
+   ·         ────────
+   ╰────
+
+  ⚠ react(no-deprecated): ReactPerf.printDOM is deprecated since React 15.0.0, use ReactPerf.printOperations instead
+   ╭─[no_deprecated.tsx:1:51]
+ 1 │ import ReactPerf from 'react-addons-perf'; const {printDOM} = ReactPerf;
+   ·                                                   ────────
+   ╰────
+
+  ⚠ react(no-deprecated): Perf.printDOM is deprecated since React 15.0.0, use Perf.printOperations instead
+   ╭─[no_deprecated.tsx:1:8]
+ 1 │ const {printDOM} = Perf;
+   ·        ────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.DOM is deprecated since React 15.6.0, use the npm module react-dom-factories instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ React.DOM.div
+   · ─────────
+   ╰────
+
+  ⚠ react(no-deprecated): componentWillMount is deprecated since React 16.9.0, use UNSAFE_componentWillMount instead
+   ╭─[no_deprecated.tsx:1:41]
+ 1 │ class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };
+   ·                                         ──────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead
+   ╭─[no_deprecated.tsx:1:65]
+ 1 │ class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };
+   ·                                                                 ─────────────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillUpdate is deprecated since React 16.9.0, use UNSAFE_componentWillUpdate instead
+   ╭─[no_deprecated.tsx:1:96]
+ 1 │ class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };
+   ·                                                                                                ───────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillMount is deprecated since React 16.9.0, use UNSAFE_componentWillMount instead
+   ╭─[no_deprecated.tsx:1:65]
+ 1 │ function Foo() { return class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }; }
+   ·                                                                 ──────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead
+   ╭─[no_deprecated.tsx:1:89]
+ 1 │ function Foo() { return class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }; }
+   ·                                                                                         ─────────────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillUpdate is deprecated since React 16.9.0, use UNSAFE_componentWillUpdate instead
+   ╭─[no_deprecated.tsx:1:120]
+ 1 │ function Foo() { return class Bar extends React.PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }; }
+   ·                                                                                                                        ───────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillMount is deprecated since React 16.9.0, use UNSAFE_componentWillMount instead
+   ╭─[no_deprecated.tsx:1:35]
+ 1 │ class Bar extends PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };
+   ·                                   ──────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead
+   ╭─[no_deprecated.tsx:1:59]
+ 1 │ class Bar extends PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };
+   ·                                                           ─────────────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillUpdate is deprecated since React 16.9.0, use UNSAFE_componentWillUpdate instead
+   ╭─[no_deprecated.tsx:1:90]
+ 1 │ class Bar extends PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };
+   ·                                                                                          ───────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillMount is deprecated since React 16.9.0, use UNSAFE_componentWillMount instead
+   ╭─[no_deprecated.tsx:1:54]
+ 1 │ class Foo extends React.Component { constructor() {} componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }
+   ·                                                      ──────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead
+   ╭─[no_deprecated.tsx:1:78]
+ 1 │ class Foo extends React.Component { constructor() {} componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }
+   ·                                                                              ─────────────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillUpdate is deprecated since React 16.9.0, use UNSAFE_componentWillUpdate instead
+   ╭─[no_deprecated.tsx:1:109]
+ 1 │ class Foo extends React.Component { constructor() {} componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }
+   ·                                                                                                             ───────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillMount is deprecated since React 16.9.0, use UNSAFE_componentWillMount instead
+   ╭─[no_deprecated.tsx:1:30]
+ 1 │ var Foo = createReactClass({ componentWillMount: function() {}, componentWillReceiveProps: function() {}, componentWillUpdate: function() {} })
+   ·                              ──────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead
+   ╭─[no_deprecated.tsx:1:65]
+ 1 │ var Foo = createReactClass({ componentWillMount: function() {}, componentWillReceiveProps: function() {}, componentWillUpdate: function() {} })
+   ·                                                                 ─────────────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillUpdate is deprecated since React 16.9.0, use UNSAFE_componentWillUpdate instead
+   ╭─[no_deprecated.tsx:1:107]
+ 1 │ var Foo = createReactClass({ componentWillMount: function() {}, componentWillReceiveProps: function() {}, componentWillUpdate: function() {} })
+   ·                                                                                                           ───────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): ReactDOM.render is deprecated since React 18.0.0, use createRoot instead
+   ╭─[no_deprecated.tsx:1:10]
+ 1 │ import { render } from 'react-dom'; ReactDOM.render(<div></div>, container);
+   ·          ──────
+   ╰────
+  help: See https://reactjs.org/link/switch-to-createroot
+
+  ⚠ react(no-deprecated): ReactDOM.render is deprecated since React 18.0.0, use createRoot instead
+   ╭─[no_deprecated.tsx:1:37]
+ 1 │ import { render } from 'react-dom'; ReactDOM.render(<div></div>, container);
+   ·                                     ───────────────
+   ╰────
+  help: See https://reactjs.org/link/switch-to-createroot
+
+  ⚠ react(no-deprecated): ReactDOM.hydrate is deprecated since React 18.0.0, use hydrateRoot instead
+   ╭─[no_deprecated.tsx:1:10]
+ 1 │ import { hydrate } from 'react-dom'; ReactDOM.hydrate(<div></div>, container);
+   ·          ───────
+   ╰────
+  help: See https://reactjs.org/link/switch-to-createroot
+
+  ⚠ react(no-deprecated): ReactDOM.hydrate is deprecated since React 18.0.0, use hydrateRoot instead
+   ╭─[no_deprecated.tsx:1:38]
+ 1 │ import { hydrate } from 'react-dom'; ReactDOM.hydrate(<div></div>, container);
+   ·                                      ────────────────
+   ╰────
+  help: See https://reactjs.org/link/switch-to-createroot
+
+  ⚠ react(no-deprecated): ReactDOM.unmountComponentAtNode is deprecated since React 18.0.0, use root.unmount instead
+   ╭─[no_deprecated.tsx:1:10]
+ 1 │ import { unmountComponentAtNode } from 'react-dom'; ReactDOM.unmountComponentAtNode(container);
+   ·          ──────────────────────
+   ╰────
+  help: See https://reactjs.org/link/switch-to-createroot
+
+  ⚠ react(no-deprecated): ReactDOM.unmountComponentAtNode is deprecated since React 18.0.0, use root.unmount instead
+   ╭─[no_deprecated.tsx:1:53]
+ 1 │ import { unmountComponentAtNode } from 'react-dom'; ReactDOM.unmountComponentAtNode(container);
+   ·                                                     ───────────────────────────────
+   ╰────
+  help: See https://reactjs.org/link/switch-to-createroot
+
+  ⚠ react(no-deprecated): ReactDOMServer.renderToNodeStream is deprecated since React 18.0.0, use renderToPipeableStream instead
+   ╭─[no_deprecated.tsx:1:10]
+ 1 │ import { renderToNodeStream } from 'react-dom/server'; ReactDOMServer.renderToNodeStream(element);
+   ·          ──────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-dom-server.html#rendertonodestream
+
+  ⚠ react(no-deprecated): ReactDOMServer.renderToNodeStream is deprecated since React 18.0.0, use renderToPipeableStream instead
+   ╭─[no_deprecated.tsx:1:56]
+ 1 │ import { renderToNodeStream } from 'react-dom/server'; ReactDOMServer.renderToNodeStream(element);
+   ·                                                        ─────────────────────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-dom-server.html#rendertonodestream

--- a/crates/oxc_linter/src/snapshots/react_no_deprecated.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_deprecated.snap
@@ -8,6 +8,18 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────
    ╰────
 
+  ⚠ react(no-deprecated): React.renderComponent is deprecated since React 0.12.0, use React.render instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ Foo.renderComponent()
+   · ───────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.renderComponent is deprecated since React 0.12.0, use React.render instead
+   ╭─[no_deprecated.tsx:1:17]
+ 1 │ /** @jsx Foo */ Foo.renderComponent()
+   ·                 ───────────────────
+   ╰────
+
   ⚠ react(no-deprecated): this.transferPropsTo is deprecated since React 0.12.0, use spread operator ({...}) instead
    ╭─[no_deprecated.tsx:1:1]
  1 │ this.transferPropsTo()
@@ -60,6 +72,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_deprecated.tsx:1:1]
  1 │ React.createClass({});
    · ─────────────────
+   ╰────
+
+  ⚠ react(no-deprecated): React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead
+   ╭─[no_deprecated.tsx:1:1]
+ 1 │ Foo.createClass({});
+   · ───────────────
    ╰────
 
   ⚠ react(no-deprecated): React.PropTypes is deprecated since React 15.5.0, use the npm module prop-types instead
@@ -200,6 +218,27 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_deprecated.tsx:1:90]
  1 │ class Bar extends PureComponent { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} };
    ·                                                                                          ───────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillMount is deprecated since React 16.9.0, use UNSAFE_componentWillMount instead
+   ╭─[no_deprecated.tsx:1:37]
+ 1 │ class Foo extends React.Component { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }
+   ·                                     ──────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead
+   ╭─[no_deprecated.tsx:1:61]
+ 1 │ class Foo extends React.Component { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }
+   ·                                                             ─────────────────────────
+   ╰────
+  help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
+
+  ⚠ react(no-deprecated): componentWillUpdate is deprecated since React 16.9.0, use UNSAFE_componentWillUpdate instead
+   ╭─[no_deprecated.tsx:1:92]
+ 1 │ class Foo extends React.Component { componentWillMount() {} componentWillReceiveProps() {} componentWillUpdate() {} }
+   ·                                                                                            ───────────────────
    ╰────
   help: See https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -124,6 +124,7 @@
         "react": {
           "formComponents": [],
           "linkComponents": [],
+          "pragma": null,
           "version": null,
           "componentWrapperFunctions": []
         },
@@ -700,6 +701,7 @@
           "default": {
             "formComponents": [],
             "linkComponents": [],
+            "pragma": null,
             "version": null,
             "componentWrapperFunctions": []
           },
@@ -752,6 +754,12 @@
             "$ref": "#/definitions/CustomComponent"
           },
           "markdownDescription": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```"
+        },
+        "pragma": {
+          "description": "React pragma to use for rules that need to recognize the React namespace.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"pragma\": \"Foo\"\n}\n}\n}\n```",
+          "default": null,
+          "type": "string",
+          "markdownDescription": "React pragma to use for rules that need to recognize the React namespace.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"pragma\": \"Foo\"\n}\n}\n}\n```"
         },
         "version": {
           "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -757,7 +757,7 @@
           "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",
           "default": null,
           "type": "string",
-          "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
+          "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
           "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
         }
       },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -761,7 +761,7 @@ expression: json
           "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",
           "default": null,
           "type": "string",
-          "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
+          "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
           "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
         }
       },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -128,6 +128,7 @@ expression: json
         "react": {
           "formComponents": [],
           "linkComponents": [],
+          "pragma": null,
           "version": null,
           "componentWrapperFunctions": []
         },
@@ -704,6 +705,7 @@ expression: json
           "default": {
             "formComponents": [],
             "linkComponents": [],
+            "pragma": null,
             "version": null,
             "componentWrapperFunctions": []
           },
@@ -756,6 +758,12 @@ expression: json
             "$ref": "#/definitions/CustomComponent"
           },
           "markdownDescription": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```"
+        },
+        "pragma": {
+          "description": "React pragma to use for rules that need to recognize the React namespace.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"pragma\": \"Foo\"\n}\n}\n}\n```",
+          "default": null,
+          "type": "string",
+          "markdownDescription": "React pragma to use for rules that need to recognize the React namespace.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"pragma\": \"Foo\"\n}\n}\n}\n```"
         },
         "version": {
           "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -1055,6 +1055,27 @@ type: `string`
 
 
 
+#### settings.react.pragma
+
+type: `string`
+
+default: `null`
+
+React pragma to use for rules that need to recognize the React namespace.
+
+Example:
+
+```jsonc
+{
+"settings": {
+"react": {
+"pragma": "Foo"
+}
+}
+}
+```
+
+
 #### settings.react.version
 
 type: `string`


### PR DESCRIPTION
Contributes to https://github.com/oxc-project/oxc/issues/1022

This implements the [react/no-deprecated](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-deprecated.md) rule.

I had to change the `version_regex` as it wasn't accounting for the pre-v1 versioning policy i.e. 0.12 which was the first where certain parts of the API surface got deprecated.

> [!NOTE]
> This PR was authored by an LLM (GPT5.5) and reviewed by me