### PR TITLE
fix(minifier): fold optional chains by base nullishness

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -75,13 +75,14 @@ impl<'a> PeepholeOptimizations {
     pub fn fold_chain_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::ChainExpression(e) = expr else { return };
         let span = e.span;
-        match try_fold_chain_at_element(&mut e.expression, ctx) {
+        let search = try_fold_chain_at_element(&mut e.expression, ctx);
+        match search.result {
             None => {}
-            Some(ChainFoldResult::Flipped { has_optional }) => {
+            Some(ChainFoldResult::Flipped) => {
                 // Unwrap the `ChainExpression` only if no optionals remain.
                 // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
                 // outer `?.bar` keeps the wrapper alive.
-                if !has_optional {
+                if !search.has_optional {
                     *expr = Expression::from(e.expression.take_in(ctx.ast));
                 }
                 ctx.state.changed = true;
@@ -773,7 +774,7 @@ enum ChainFoldResult<'a> {
     /// The deepest optional was statically non-nullish; its `optional` flag
     /// was flipped to `false`. Caller should unwrap the surrounding
     /// `ChainExpression` if no other optionals remain.
-    Flipped { has_optional: bool },
+    Flipped,
     /// The deepest optional was statically nullish; the chain short-circuits
     /// to `void 0`. `base` carries the (taken-out) base expression so the
     /// caller can preserve any side effects via a sequence expression.
@@ -795,14 +796,7 @@ impl<'a> ChainFoldSearch<'a> {
     }
 
     fn add_optional(&mut self, optional: bool) {
-        if !optional {
-            return;
-        }
-        // Optionals above a folded node belong to the fold result; optionals
-        // seen before any fold are carried by the ongoing search.
-        if let Some(ChainFoldResult::Flipped { has_optional }) = &mut self.result {
-            *has_optional = true;
-        } else {
+        if optional {
             self.has_optional = true;
         }
     }
@@ -818,7 +812,7 @@ impl<'a> ChainFoldSearch<'a> {
 fn try_fold_chain_at_element<'a>(
     elem: &mut ChainElement<'a>,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldResult<'a>> {
+) -> ChainFoldSearch<'a> {
     match elem {
         ChainElement::CallExpression(c) => try_fold_call_expression(c, ctx),
         match_member_expression!(ChainElement) => {
@@ -826,7 +820,6 @@ fn try_fold_chain_at_element<'a>(
         }
         ChainElement::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
     }
-    .result
 }
 
 fn try_fold_chain_at_expr<'a>(
@@ -921,7 +914,7 @@ fn try_fold_at_optional<'a>(
     }
     if !ty.is_undetermined() {
         *optional = false;
-        return Some(ChainFoldResult::Flipped { has_optional });
+        return Some(ChainFoldResult::Flipped);
     }
     None
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -75,26 +75,25 @@ impl<'a> PeepholeOptimizations {
     pub fn fold_chain_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::ChainExpression(e) = expr else { return };
         let span = e.span;
-        let search = try_fold_chain_at_element(&mut e.expression, ctx);
-        match search.result {
-            None => {}
-            Some(ChainFoldResult::Flipped) => {
-                // Unwrap the `ChainExpression` only if no optionals remain.
+        match try_fold_chain_at_element(&mut e.expression, ctx) {
+            ChainFold::Unfolded { .. } => {}
+            ChainFold::Flipped { has_optional } => {
                 // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
                 // outer `?.bar` keeps the wrapper alive.
-                if !search.has_optional {
+                if !has_optional {
                     *expr = Expression::from(e.expression.take_in(ctx.ast));
                 }
                 ctx.state.changed = true;
             }
-            Some(ChainFoldResult::Collapse { base }) => {
-                // Always emit `(base, void 0)`. A side-effect-free base is
-                // dropped from the sequence by a later pass (the same one
-                // that reduces e.g. `(0, 1).foo` to `1 .foo`).
-                *expr = ctx.ast.expression_sequence(
-                    span,
-                    ctx.ast.vec_from_array([base, ctx.ast.void_0(span)]),
-                );
+            ChainFold::Collapse { base, base_has_side_effects } => {
+                *expr = if base_has_side_effects {
+                    ctx.ast.expression_sequence(
+                        span,
+                        ctx.ast.vec_from_array([base, ctx.ast.void_0(span)]),
+                    )
+                } else {
+                    ctx.value_to_expr(span, ConstantValue::Undefined)
+                };
                 ctx.state.changed = true;
             }
         }
@@ -769,41 +768,25 @@ impl<'a> PeepholeOptimizations {
     }
 }
 
-/// Outcome of attempting to fold an optional-chain access at the deepest
-/// optional position in a chain.
-enum ChainFoldResult<'a> {
-    /// The deepest optional was statically non-nullish; its `optional` flag
-    /// was flipped to `false`.
-    Flipped,
-    /// The deepest optional was statically nullish; the chain short-circuits
-    /// to `void 0`. `base` carries the (taken-out) base expression.
-    Collapse { base: Expression<'a> },
-}
-
-/// State carried up the chain while searching for the deepest optional to
-/// fold.
-struct ChainFoldSearch<'a> {
-    /// the outcome once a fold fires
-    result: Option<ChainFoldResult<'a>>,
-    /// tracks whether any `?.` was seen along the way and decides whether the
-    /// outer `ChainExpression` wrapper is still needed
-    has_optional: bool,
-}
-
-impl<'a> ChainFoldSearch<'a> {
-    fn none() -> Self {
-        Self { result: None, has_optional: false }
-    }
-
-    fn folded(result: ChainFoldResult<'a>) -> Self {
-        Self { result: Some(result), has_optional: false }
-    }
-
-    fn add_optional(&mut self, optional: bool) {
-        if optional {
-            self.has_optional = true;
-        }
-    }
+/// Outcome of folding an optional-chain at the deepest optional position.
+///
+/// `has_optional` carries the same notion in both `Unfolded` and `Flipped`:
+/// whether any unresolved `?.` exists in the chain segment seen so far —
+/// below the current level while still searching, above the fold point
+/// after firing. It gates outer fold attempts and the wrapper unwrap.
+enum ChainFold<'a> {
+    Unfolded {
+        has_optional: bool,
+    },
+    Flipped {
+        has_optional: bool,
+    },
+    /// `base_has_side_effects` is computed here so the caller doesn't walk
+    /// the base subtree a second time.
+    Collapse {
+        base: Expression<'a>,
+        base_has_side_effects: bool,
+    },
 }
 
 /// Try folding the *deepest* (= leftmost in source order) optional in a
@@ -816,7 +799,7 @@ impl<'a> ChainFoldSearch<'a> {
 fn try_fold_chain_at_element<'a>(
     elem: &mut ChainElement<'a>,
     ctx: &TraverseCtx<'a>,
-) -> ChainFoldSearch<'a> {
+) -> ChainFold<'a> {
     match elem {
         ChainElement::CallExpression(c) => try_fold_call_expression(c, ctx),
         match_member_expression!(ChainElement) => {
@@ -826,58 +809,48 @@ fn try_fold_chain_at_element<'a>(
     }
 }
 
-fn try_fold_chain_at_expr<'a>(
-    expr: &mut Expression<'a>,
-    ctx: &TraverseCtx<'a>,
-) -> ChainFoldSearch<'a> {
-    match expr {
+fn try_fold_chain_at_expr<'a>(expr: &mut Expression<'a>, ctx: &TraverseCtx<'a>) -> ChainFold<'a> {
+    match expr.get_inner_expression_mut() {
         Expression::CallExpression(c) => try_fold_call_expression(c, ctx),
         match_member_expression!(Expression) => {
             try_fold_member_expression(expr.to_member_expression_mut(), ctx)
         }
-        Expression::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
-        Expression::ParenthesizedExpression(p) => try_fold_chain_at_expr(&mut p.expression, ctx),
-        _ => ChainFoldSearch::none(),
+        _ => ChainFold::Unfolded { has_optional: false },
     }
 }
 
 fn try_fold_call_expression<'a>(
     call: &mut CallExpression<'a>,
     ctx: &TraverseCtx<'a>,
-) -> ChainFoldSearch<'a> {
-    let mut search = try_fold_chain_at_expr(&mut call.callee, ctx);
-    if search.result.is_some() {
-        search.add_optional(call.optional);
-        return search;
+) -> ChainFold<'a> {
+    match try_fold_chain_at_expr(&mut call.callee, ctx) {
+        ChainFold::Flipped { has_optional } => {
+            ChainFold::Flipped { has_optional: has_optional || call.optional }
+        }
+        collapse @ ChainFold::Collapse { .. } => collapse,
+        ChainFold::Unfolded { has_optional } => {
+            try_fold_at_optional(&mut call.optional, &mut call.callee, has_optional, ctx)
+                .unwrap_or(ChainFold::Unfolded { has_optional: has_optional || call.optional })
+        }
     }
-
-    if let Some(result) =
-        try_fold_at_optional(&mut call.optional, &mut call.callee, search.has_optional, ctx)
-    {
-        return ChainFoldSearch::folded(result);
-    }
-
-    search.add_optional(call.optional);
-    search
 }
 
 fn try_fold_member_expression<'a>(
     member: &mut MemberExpression<'a>,
     ctx: &TraverseCtx<'a>,
-) -> ChainFoldSearch<'a> {
-    let mut search = try_fold_chain_at_expr(member.object_mut(), ctx);
-    if search.result.is_some() {
-        search.add_optional(member.optional());
-        return search;
+) -> ChainFold<'a> {
+    let (optional_mut, object) = member_expression_optional_and_object_mut(member);
+    let optional = *optional_mut;
+    match try_fold_chain_at_expr(object, ctx) {
+        ChainFold::Flipped { has_optional } => {
+            ChainFold::Flipped { has_optional: has_optional || optional }
+        }
+        collapse @ ChainFold::Collapse { .. } => collapse,
+        ChainFold::Unfolded { has_optional } => {
+            try_fold_at_optional(optional_mut, object, has_optional, ctx)
+                .unwrap_or(ChainFold::Unfolded { has_optional: has_optional || optional })
+        }
     }
-
-    let (optional, object) = member_expression_optional_and_object_mut(member);
-    if let Some(result) = try_fold_at_optional(optional, object, search.has_optional, ctx) {
-        return ChainFoldSearch::folded(result);
-    }
-
-    search.add_optional(member.optional());
-    search
 }
 
 fn member_expression_optional_and_object_mut<'a, 'b>(
@@ -904,19 +877,20 @@ fn try_fold_at_optional<'a>(
     base: &mut Expression<'a>,
     has_optional: bool,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldResult<'a>> {
+) -> Option<ChainFold<'a>> {
     if !*optional || has_optional {
         return None;
     }
     match base.value_type(ctx) {
         ValueType::Null | ValueType::Undefined => {
+            let base_has_side_effects = base.may_have_side_effects(ctx);
             let taken = base.take_in(ctx.ast);
-            Some(ChainFoldResult::Collapse { base: taken })
+            Some(ChainFold::Collapse { base: taken, base_has_side_effects })
         }
         ValueType::Undetermined => None,
         _ => {
             *optional = false;
-            Some(ChainFoldResult::Flipped)
+            Some(ChainFold::Flipped { has_optional: false })
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -74,30 +74,20 @@ impl<'a> PeepholeOptimizations {
 
     pub fn fold_chain_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::ChainExpression(e) = expr else { return };
-        let span = e.span;
-        match try_fold_chain_at_element(&mut e.expression, ctx) {
-            None => {}
-            Some(ChainFoldResult::Flipped { has_optional }) => {
-                // Unwrap the `ChainExpression` only if no optionals remain.
-                // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
-                // outer `?.bar` keeps the wrapper alive.
-                if !has_optional {
-                    *expr = Expression::from(e.expression.take_in(ctx.ast));
-                }
-                ctx.state.changed = true;
-            }
-            Some(ChainFoldResult::Collapse { base, has_side_effects }) => {
-                *expr = if has_side_effects {
-                    ctx.ast.expression_sequence(
-                        span,
-                        ctx.ast.vec_from_array([base, ctx.ast.void_0(span)]),
-                    )
-                } else {
-                    ctx.value_to_expr(span, ConstantValue::Undefined)
-                };
-                ctx.state.changed = true;
-            }
+        let search = try_fold_chain_at_element(&mut e.expression, ctx);
+        if !search.folded {
+            return;
         }
+
+        if let Some(replacement) = search.replacement {
+            *expr = replacement;
+        } else if !search.has_optional {
+            // Unwrap the `ChainExpression` only if no optionals remain.
+            // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
+            // outer `?.bar` keeps the wrapper alive.
+            *expr = Expression::from(e.expression.take_in(ctx.ast));
+        }
+        ctx.state.changed = true;
     }
 
     /// Try to fold a AND / OR node.
@@ -769,44 +759,30 @@ impl<'a> PeepholeOptimizations {
     }
 }
 
-/// Outcome of attempting to fold an optional-chain access at the deepest
-/// optional position in a chain.
-enum ChainFoldResult<'a> {
-    /// The deepest optional was statically non-nullish; its `optional` flag
-    /// was flipped to `false`. Caller should unwrap the surrounding
-    /// `ChainExpression` if no other optionals remain.
-    Flipped { has_optional: bool },
-    /// The deepest optional was statically nullish; the chain short-circuits
-    /// to `void 0`. `base` carries the (taken-out) base expression so the
-    /// caller can preserve any side effects via a sequence expression.
-    Collapse { base: Expression<'a>, has_side_effects: bool },
-}
-
 struct ChainFoldSearch<'a> {
-    result: Option<ChainFoldResult<'a>>,
+    folded: bool,
     has_optional: bool,
+    replacement: Option<Expression<'a>>,
 }
 
 impl<'a> ChainFoldSearch<'a> {
     fn none() -> Self {
-        Self { result: None, has_optional: false }
+        Self { folded: false, has_optional: false, replacement: None }
     }
 
-    fn folded(result: ChainFoldResult<'a>) -> Self {
-        Self { result: Some(result), has_optional: false }
+    fn folded() -> Self {
+        Self { folded: true, has_optional: false, replacement: None }
+    }
+
+    fn collapsed(replacement: Expression<'a>) -> Self {
+        Self { folded: true, has_optional: false, replacement: Some(replacement) }
     }
 
     fn add_optional(&mut self, optional: bool) {
         if !optional {
             return;
         }
-        // Optionals above a folded node belong to the fold result; optionals
-        // seen before any fold are carried by the ongoing search.
-        if let Some(ChainFoldResult::Flipped { has_optional }) = &mut self.result {
-            *has_optional = true;
-        } else {
-            self.has_optional = true;
-        }
+        self.has_optional = true;
     }
 }
 
@@ -820,7 +796,7 @@ impl<'a> ChainFoldSearch<'a> {
 fn try_fold_chain_at_element<'a>(
     elem: &mut ChainElement<'a>,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldResult<'a>> {
+) -> ChainFoldSearch<'a> {
     match elem {
         ChainElement::CallExpression(c) => try_fold_call_expression(c, ctx),
         match_member_expression!(ChainElement) => {
@@ -828,7 +804,6 @@ fn try_fold_chain_at_element<'a>(
         }
         ChainElement::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
     }
-    .result
 }
 
 fn try_fold_chain_at_expr<'a>(
@@ -851,15 +826,19 @@ fn try_fold_call_expression<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> ChainFoldSearch<'a> {
     let mut search = try_fold_chain_at_expr(&mut call.callee, ctx);
-    if search.result.is_some() {
+    if search.folded {
         search.add_optional(call.optional);
         return search;
     }
 
-    if let Some(result) =
-        try_fold_at_optional(&mut call.optional, &mut call.callee, search.has_optional, ctx)
-    {
-        return ChainFoldSearch::folded(result);
+    if let Some(search) = try_fold_at_optional(
+        &mut call.optional,
+        &mut call.callee,
+        call.span,
+        search.has_optional,
+        ctx,
+    ) {
+        return search;
     }
 
     search.add_optional(call.optional);
@@ -871,14 +850,15 @@ fn try_fold_member_expression<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> ChainFoldSearch<'a> {
     let mut search = try_fold_chain_at_expr(member.object_mut(), ctx);
-    if search.result.is_some() {
+    if search.folded {
         search.add_optional(member.optional());
         return search;
     }
 
+    let span = member.span();
     let (optional, object) = member_expression_optional_and_object_mut(member);
-    if let Some(result) = try_fold_at_optional(optional, object, search.has_optional, ctx) {
-        return ChainFoldSearch::folded(result);
+    if let Some(search) = try_fold_at_optional(optional, object, span, search.has_optional, ctx) {
+        return search;
     }
 
     search.add_optional(member.optional());
@@ -907,9 +887,10 @@ fn member_expression_optional_and_object_mut<'a, 'b>(
 fn try_fold_at_optional<'a>(
     optional: &mut bool,
     base: &mut Expression<'a>,
+    span: Span,
     has_optional: bool,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldResult<'a>> {
+) -> Option<ChainFoldSearch<'a>> {
     if !*optional {
         return None;
     }
@@ -918,13 +899,15 @@ fn try_fold_at_optional<'a>(
     }
     let ty = base.value_type(ctx);
     if ty.is_null() || ty.is_undefined() {
-        let has_side_effects = base.may_have_side_effects(ctx);
         let taken = base.take_in(ctx.ast);
-        return Some(ChainFoldResult::Collapse { base: taken, has_side_effects });
+        let replacement = ctx
+            .ast
+            .expression_sequence(span, ctx.ast.vec_from_array([taken, ctx.ast.void_0(span)]));
+        return Some(ChainFoldSearch::collapsed(replacement));
     }
     if !ty.is_undetermined() {
         *optional = false;
-        return Some(ChainFoldResult::Flipped { has_optional });
+        return Some(ChainFoldSearch::folded());
     }
     None
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -784,46 +784,53 @@ enum ChainFoldResult<'a> {
     Collapse { base: Expression<'a>, has_side_effects: bool },
 }
 
+/// Whether a `ValueType` is statically known to be non-nullish — i.e. a
+/// member access or call on it cannot short-circuit through `?.`. The
+/// transform's correctness depends on this exact set, so it lives in a
+/// named helper rather than an inline `matches!` to avoid accidental
+/// weakening (e.g. adding `Undetermined`).
+fn is_known_non_nullish(ty: ValueType) -> bool {
+    matches!(
+        ty,
+        ValueType::Number
+            | ValueType::String
+            | ValueType::Boolean
+            | ValueType::BigInt
+            | ValueType::Object
+    )
+}
+
+/// Recurse into a `Member`/`Call` node's `.object`/`.callee` and, if no
+/// deeper optional was folded, attempt the fold at this level. Used by
+/// both `try_fold_chain_at_element` and `try_fold_chain_at_expr` to keep
+/// the recurse-then-check shape in one place.
+macro_rules! recurse_then_fold {
+    ($boxed:expr, $base_field:ident, $ctx:expr) => {{
+        let n = &mut **$boxed;
+        let inner = try_fold_chain_at_expr(&mut n.$base_field, $ctx);
+        if !matches!(inner, ChainFoldResult::None) {
+            return inner;
+        }
+        try_fold_at_optional(&mut n.optional, &mut n.$base_field, $ctx)
+    }};
+}
+
 /// Try folding the *deepest* (= leftmost in source order) optional in a
 /// chain. Recurses inward through `.object` / `.callee` first so the
 /// short-circuit point is found before any outer access.
+///
+/// Nested `ChainExpression`s (e.g. `(a?.b)?.c`) are not descended into —
+/// the compressor's separate flattening pass merges them into a single
+/// chain on a later iteration, after which this fold fires.
 fn try_fold_chain_at_element<'a>(
     elem: &mut ChainElement<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> ChainFoldResult<'a> {
     match elem {
-        ChainElement::CallExpression(c) => {
-            let c = &mut **c;
-            let inner = try_fold_chain_at_expr(&mut c.callee, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut c.optional, &mut c.callee, ctx)
-        }
-        ChainElement::StaticMemberExpression(m) => {
-            let m = &mut **m;
-            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
-        }
-        ChainElement::ComputedMemberExpression(m) => {
-            let m = &mut **m;
-            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
-        }
-        ChainElement::PrivateFieldExpression(m) => {
-            let m = &mut **m;
-            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
-        }
+        ChainElement::CallExpression(c) => recurse_then_fold!(c, callee, ctx),
+        ChainElement::StaticMemberExpression(m) => recurse_then_fold!(m, object, ctx),
+        ChainElement::ComputedMemberExpression(m) => recurse_then_fold!(m, object, ctx),
+        ChainElement::PrivateFieldExpression(m) => recurse_then_fold!(m, object, ctx),
         ChainElement::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
     }
 }
@@ -833,42 +840,12 @@ fn try_fold_chain_at_expr<'a>(
     ctx: &mut TraverseCtx<'a>,
 ) -> ChainFoldResult<'a> {
     match expr {
-        Expression::CallExpression(c) => {
-            let c = &mut **c;
-            let inner = try_fold_chain_at_expr(&mut c.callee, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut c.optional, &mut c.callee, ctx)
-        }
-        Expression::StaticMemberExpression(m) => {
-            let m = &mut **m;
-            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
-        }
-        Expression::ComputedMemberExpression(m) => {
-            let m = &mut **m;
-            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
-        }
-        Expression::PrivateFieldExpression(m) => {
-            let m = &mut **m;
-            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
-            if !matches!(inner, ChainFoldResult::None) {
-                return inner;
-            }
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
-        }
+        Expression::CallExpression(c) => recurse_then_fold!(c, callee, ctx),
+        Expression::StaticMemberExpression(m) => recurse_then_fold!(m, object, ctx),
+        Expression::ComputedMemberExpression(m) => recurse_then_fold!(m, object, ctx),
+        Expression::PrivateFieldExpression(m) => recurse_then_fold!(m, object, ctx),
         Expression::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
         Expression::ParenthesizedExpression(p) => try_fold_chain_at_expr(&mut p.expression, ctx),
-        // Stop at nested `ChainExpression`s — a separate pass flattens
-        // `(a?.b)?.c` into a single chain, after which folding can fire.
         _ => ChainFoldResult::None,
     }
 }
@@ -876,7 +853,7 @@ fn try_fold_chain_at_expr<'a>(
 fn try_fold_at_optional<'a>(
     optional: &mut bool,
     base: &mut Expression<'a>,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> ChainFoldResult<'a> {
     if !*optional {
         return ChainFoldResult::None;
@@ -887,20 +864,19 @@ fn try_fold_at_optional<'a>(
         let taken = base.take_in(ctx.ast);
         return ChainFoldResult::Collapse { base: taken, has_side_effects };
     }
-    if matches!(
-        ty,
-        ValueType::Number
-            | ValueType::String
-            | ValueType::Boolean
-            | ValueType::BigInt
-            | ValueType::Object
-    ) {
+    if is_known_non_nullish(ty) {
         *optional = false;
         return ChainFoldResult::Flipped;
     }
     ChainFoldResult::None
 }
 
+/// Whether any access in this chain is still marked `optional: true`. Used
+/// after a `Flipped` fold to decide if the surrounding `ChainExpression`
+/// can be unwrapped. The chain-element layer immediately delegates to the
+/// expression layer because every `ChainElement` member variant inherits
+/// from `MemberExpression` and shares its underlying struct with
+/// `Expression`'s counterparts.
 fn chain_element_has_optional(elem: &ChainElement<'_>) -> bool {
     match elem {
         ChainElement::CallExpression(c) => c.optional || expression_has_chain_optional(&c.callee),

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -76,8 +76,8 @@ impl<'a> PeepholeOptimizations {
         let Expression::ChainExpression(e) = expr else { return };
         let span = e.span;
         match try_fold_chain_at_element(&mut e.expression, ctx) {
-            ChainFoldResult::None => {}
-            ChainFoldResult::Flipped => {
+            None => {}
+            Some(ChainFoldResult::Flipped) => {
                 // Unwrap the `ChainExpression` only if no optionals remain.
                 // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
                 // outer `?.bar` keeps the wrapper alive.
@@ -86,7 +86,7 @@ impl<'a> PeepholeOptimizations {
                 }
                 ctx.state.changed = true;
             }
-            ChainFoldResult::Collapse { base, has_side_effects } => {
+            Some(ChainFoldResult::Collapse { base, has_side_effects }) => {
                 *expr = if has_side_effects {
                     ctx.ast.expression_sequence(
                         span,
@@ -772,8 +772,6 @@ impl<'a> PeepholeOptimizations {
 /// Outcome of attempting to fold an optional-chain access at the deepest
 /// optional position in a chain.
 enum ChainFoldResult<'a> {
-    /// No fold applied — keep the chain as-is.
-    None,
     /// The deepest optional was statically non-nullish; its `optional` flag
     /// was flipped to `false`. Caller should unwrap the surrounding
     /// `ChainExpression` if no other optionals remain.
@@ -800,21 +798,6 @@ fn is_known_non_nullish(ty: ValueType) -> bool {
     )
 }
 
-/// Recurse into a `Member`/`Call` node's `.object`/`.callee` and, if no
-/// deeper optional was folded, attempt the fold at this level. Used by
-/// both `try_fold_chain_at_element` and `try_fold_chain_at_expr` to keep
-/// the recurse-then-check shape in one place.
-macro_rules! recurse_then_fold {
-    ($boxed:expr, $base_field:ident, $ctx:expr) => {{
-        let n = &mut **$boxed;
-        let inner = try_fold_chain_at_expr(&mut n.$base_field, $ctx);
-        if !matches!(inner, ChainFoldResult::None) {
-            return inner;
-        }
-        try_fold_at_optional(&mut n.optional, &mut n.$base_field, $ctx)
-    }};
-}
-
 /// Try folding the *deepest* (= leftmost in source order) optional in a
 /// chain. Recurses inward through `.object` / `.callee` first so the
 /// short-circuit point is found before any outer access.
@@ -824,29 +807,60 @@ macro_rules! recurse_then_fold {
 /// chain on a later iteration, after which this fold fires.
 fn try_fold_chain_at_element<'a>(
     elem: &mut ChainElement<'a>,
-    ctx: &mut TraverseCtx<'a>,
-) -> ChainFoldResult<'a> {
+    ctx: &TraverseCtx<'a>,
+) -> Option<ChainFoldResult<'a>> {
     match elem {
-        ChainElement::CallExpression(c) => recurse_then_fold!(c, callee, ctx),
-        ChainElement::StaticMemberExpression(m) => recurse_then_fold!(m, object, ctx),
-        ChainElement::ComputedMemberExpression(m) => recurse_then_fold!(m, object, ctx),
-        ChainElement::PrivateFieldExpression(m) => recurse_then_fold!(m, object, ctx),
+        ChainElement::CallExpression(c) => try_fold_call_expression(c, ctx),
+        match_member_expression!(ChainElement) => {
+            try_fold_member_expression(elem.to_member_expression_mut(), ctx)
+        }
         ChainElement::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
     }
 }
 
 fn try_fold_chain_at_expr<'a>(
     expr: &mut Expression<'a>,
-    ctx: &mut TraverseCtx<'a>,
-) -> ChainFoldResult<'a> {
+    ctx: &TraverseCtx<'a>,
+) -> Option<ChainFoldResult<'a>> {
     match expr {
-        Expression::CallExpression(c) => recurse_then_fold!(c, callee, ctx),
-        Expression::StaticMemberExpression(m) => recurse_then_fold!(m, object, ctx),
-        Expression::ComputedMemberExpression(m) => recurse_then_fold!(m, object, ctx),
-        Expression::PrivateFieldExpression(m) => recurse_then_fold!(m, object, ctx),
+        Expression::CallExpression(c) => try_fold_call_expression(c, ctx),
+        match_member_expression!(Expression) => {
+            try_fold_member_expression(expr.to_member_expression_mut(), ctx)
+        }
         Expression::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
         Expression::ParenthesizedExpression(p) => try_fold_chain_at_expr(&mut p.expression, ctx),
-        _ => ChainFoldResult::None,
+        _ => None,
+    }
+}
+
+fn try_fold_call_expression<'a>(
+    call: &mut CallExpression<'a>,
+    ctx: &TraverseCtx<'a>,
+) -> Option<ChainFoldResult<'a>> {
+    try_fold_chain_at_expr(&mut call.callee, ctx)
+        .or_else(|| try_fold_at_optional(&mut call.optional, &mut call.callee, ctx))
+}
+
+fn try_fold_member_expression<'a>(
+    member: &mut MemberExpression<'a>,
+    ctx: &TraverseCtx<'a>,
+) -> Option<ChainFoldResult<'a>> {
+    if let Some(result) = try_fold_chain_at_expr(member.object_mut(), ctx) {
+        return Some(result);
+    }
+    match member {
+        MemberExpression::StaticMemberExpression(m) => {
+            let m = &mut **m;
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        MemberExpression::ComputedMemberExpression(m) => {
+            let m = &mut **m;
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        MemberExpression::PrivateFieldExpression(m) => {
+            let m = &mut **m;
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
     }
 }
 
@@ -854,21 +868,21 @@ fn try_fold_at_optional<'a>(
     optional: &mut bool,
     base: &mut Expression<'a>,
     ctx: &TraverseCtx<'a>,
-) -> ChainFoldResult<'a> {
+) -> Option<ChainFoldResult<'a>> {
     if !*optional {
-        return ChainFoldResult::None;
+        return None;
     }
     let ty = base.value_type(ctx);
     if ty.is_null() || ty.is_undefined() {
         let has_side_effects = base.may_have_side_effects(ctx);
         let taken = base.take_in(ctx.ast);
-        return ChainFoldResult::Collapse { base: taken, has_side_effects };
+        return Some(ChainFoldResult::Collapse { base: taken, has_side_effects });
     }
     if is_known_non_nullish(ty) {
         *optional = false;
-        return ChainFoldResult::Flipped;
+        return Some(ChainFoldResult::Flipped);
     }
-    ChainFoldResult::None
+    None
 }
 
 /// Whether any access in this chain is still marked `optional: true`. Used
@@ -879,15 +893,9 @@ fn try_fold_at_optional<'a>(
 /// `Expression`'s counterparts.
 fn chain_element_has_optional(elem: &ChainElement<'_>) -> bool {
     match elem {
-        ChainElement::CallExpression(c) => c.optional || expression_has_chain_optional(&c.callee),
-        ChainElement::StaticMemberExpression(m) => {
-            m.optional || expression_has_chain_optional(&m.object)
-        }
-        ChainElement::ComputedMemberExpression(m) => {
-            m.optional || expression_has_chain_optional(&m.object)
-        }
-        ChainElement::PrivateFieldExpression(m) => {
-            m.optional || expression_has_chain_optional(&m.object)
+        ChainElement::CallExpression(c) => call_expression_has_chain_optional(c),
+        match_member_expression!(ChainElement) => {
+            member_expression_has_chain_optional(elem.to_member_expression())
         }
         ChainElement::TSNonNullExpression(t) => expression_has_chain_optional(&t.expression),
     }
@@ -895,18 +903,20 @@ fn chain_element_has_optional(elem: &ChainElement<'_>) -> bool {
 
 fn expression_has_chain_optional(expr: &Expression<'_>) -> bool {
     match expr {
-        Expression::CallExpression(c) => c.optional || expression_has_chain_optional(&c.callee),
-        Expression::StaticMemberExpression(m) => {
-            m.optional || expression_has_chain_optional(&m.object)
-        }
-        Expression::ComputedMemberExpression(m) => {
-            m.optional || expression_has_chain_optional(&m.object)
-        }
-        Expression::PrivateFieldExpression(m) => {
-            m.optional || expression_has_chain_optional(&m.object)
+        Expression::CallExpression(c) => call_expression_has_chain_optional(c),
+        match_member_expression!(Expression) => {
+            member_expression_has_chain_optional(expr.to_member_expression())
         }
         Expression::TSNonNullExpression(t) => expression_has_chain_optional(&t.expression),
         Expression::ParenthesizedExpression(p) => expression_has_chain_optional(&p.expression),
         _ => false,
     }
+}
+
+fn call_expression_has_chain_optional(call: &CallExpression<'_>) -> bool {
+    call.optional || expression_has_chain_optional(&call.callee)
+}
+
+fn member_expression_has_chain_optional(member: &MemberExpression<'_>) -> bool {
+    member.optional() || expression_has_chain_optional(member.object())
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -75,62 +75,28 @@ impl<'a> PeepholeOptimizations {
     pub fn fold_chain_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::ChainExpression(e) = expr else { return };
         let span = e.span;
-        let left_expr = match &mut e.expression {
-            match_member_expression!(ChainElement) => {
-                let member_expr = e.expression.to_member_expression_mut();
-                if !member_expr.optional() {
-                    return;
+        match try_fold_chain_at_element(&mut e.expression, ctx) {
+            ChainFoldResult::None => {}
+            ChainFoldResult::Flipped => {
+                // Unwrap the `ChainExpression` only if no optionals remain.
+                // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
+                // outer `?.bar` keeps the wrapper alive.
+                if !chain_element_has_optional(&e.expression) {
+                    *expr = Expression::from(e.expression.take_in(ctx.ast));
                 }
-                member_expr.object_mut()
+                ctx.state.changed = true;
             }
-            ChainElement::CallExpression(call_expr) => {
-                if !call_expr.optional {
-                    return;
-                }
-                &mut call_expr.callee
+            ChainFoldResult::Collapse { base, has_side_effects } => {
+                *expr = if has_side_effects {
+                    ctx.ast.expression_sequence(
+                        span,
+                        ctx.ast.vec_from_array([base, ctx.ast.void_0(span)]),
+                    )
+                } else {
+                    ctx.value_to_expr(span, ConstantValue::Undefined)
+                };
+                ctx.state.changed = true;
             }
-            ChainElement::TSNonNullExpression(_) => return,
-        };
-        let ty = left_expr.value_type(ctx);
-        if ty.is_null() || ty.is_undefined() {
-            *expr = if left_expr.may_have_side_effects(ctx) {
-                ctx.ast.expression_sequence(
-                    span,
-                    ctx.ast.vec_from_array([left_expr.take_in(ctx.ast), ctx.ast.void_0(span)]),
-                )
-            } else {
-                ctx.value_to_expr(span, ConstantValue::Undefined)
-            };
-            ctx.state.changed = true;
-            return;
-        }
-        // Drop the outermost `?.` when the base is statically non-nullish.
-        // Only the outermost level is handled here, matching the structure of the
-        // nullish branch above. Multi-level chains like `a?.b.c` (where `?.` is
-        // not on the outermost element) are intentionally left for a follow-up.
-        if matches!(
-            ty,
-            ValueType::Number
-                | ValueType::String
-                | ValueType::Boolean
-                | ValueType::BigInt
-                | ValueType::Object
-        ) {
-            match &mut e.expression {
-                ChainElement::StaticMemberExpression(m) => m.optional = false,
-                ChainElement::ComputedMemberExpression(m) => m.optional = false,
-                ChainElement::PrivateFieldExpression(m) => m.optional = false,
-                ChainElement::CallExpression(c) => c.optional = false,
-                ChainElement::TSNonNullExpression(_) => unreachable!(),
-            }
-            // Unwrap the `ChainExpression` only if no nested optionals remain.
-            // A case like `Number?.POSITIVE_INFINITY?.foo` enters this branch
-            // (the inner static member resolves to `ValueType::Number`), but
-            // the inner `?.` must keep its `ChainExpression` shell.
-            if !chain_element_has_optional(&e.expression) {
-                *expr = Expression::from(e.expression.take_in(ctx.ast));
-            }
-            ctx.state.changed = true;
         }
     }
 
@@ -801,6 +767,138 @@ impl<'a> PeepholeOptimizations {
 
         ctx.state.changed = true;
     }
+}
+
+/// Outcome of attempting to fold an optional-chain access at the deepest
+/// optional position in a chain.
+enum ChainFoldResult<'a> {
+    /// No fold applied — keep the chain as-is.
+    None,
+    /// The deepest optional was statically non-nullish; its `optional` flag
+    /// was flipped to `false`. Caller should unwrap the surrounding
+    /// `ChainExpression` if no other optionals remain.
+    Flipped,
+    /// The deepest optional was statically nullish; the chain short-circuits
+    /// to `void 0`. `base` carries the (taken-out) base expression so the
+    /// caller can preserve any side effects via a sequence expression.
+    Collapse { base: Expression<'a>, has_side_effects: bool },
+}
+
+/// Try folding the *deepest* (= leftmost in source order) optional in a
+/// chain. Recurses inward through `.object` / `.callee` first so the
+/// short-circuit point is found before any outer access.
+fn try_fold_chain_at_element<'a>(
+    elem: &mut ChainElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) -> ChainFoldResult<'a> {
+    match elem {
+        ChainElement::CallExpression(c) => {
+            let c = &mut **c;
+            let inner = try_fold_chain_at_expr(&mut c.callee, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut c.optional, &mut c.callee, ctx)
+        }
+        ChainElement::StaticMemberExpression(m) => {
+            let m = &mut **m;
+            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        ChainElement::ComputedMemberExpression(m) => {
+            let m = &mut **m;
+            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        ChainElement::PrivateFieldExpression(m) => {
+            let m = &mut **m;
+            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        ChainElement::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
+    }
+}
+
+fn try_fold_chain_at_expr<'a>(
+    expr: &mut Expression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) -> ChainFoldResult<'a> {
+    match expr {
+        Expression::CallExpression(c) => {
+            let c = &mut **c;
+            let inner = try_fold_chain_at_expr(&mut c.callee, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut c.optional, &mut c.callee, ctx)
+        }
+        Expression::StaticMemberExpression(m) => {
+            let m = &mut **m;
+            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        Expression::ComputedMemberExpression(m) => {
+            let m = &mut **m;
+            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        Expression::PrivateFieldExpression(m) => {
+            let m = &mut **m;
+            let inner = try_fold_chain_at_expr(&mut m.object, ctx);
+            if !matches!(inner, ChainFoldResult::None) {
+                return inner;
+            }
+            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+        }
+        Expression::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
+        Expression::ParenthesizedExpression(p) => try_fold_chain_at_expr(&mut p.expression, ctx),
+        // Stop at nested `ChainExpression`s — a separate pass flattens
+        // `(a?.b)?.c` into a single chain, after which folding can fire.
+        _ => ChainFoldResult::None,
+    }
+}
+
+fn try_fold_at_optional<'a>(
+    optional: &mut bool,
+    base: &mut Expression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) -> ChainFoldResult<'a> {
+    if !*optional {
+        return ChainFoldResult::None;
+    }
+    let ty = base.value_type(ctx);
+    if ty.is_null() || ty.is_undefined() {
+        let has_side_effects = base.may_have_side_effects(ctx);
+        let taken = base.take_in(ctx.ast);
+        return ChainFoldResult::Collapse { base: taken, has_side_effects };
+    }
+    if matches!(
+        ty,
+        ValueType::Number
+            | ValueType::String
+            | ValueType::Boolean
+            | ValueType::BigInt
+            | ValueType::Object
+    ) {
+        *optional = false;
+        return ChainFoldResult::Flipped;
+    }
+    ChainFoldResult::None
 }
 
 fn chain_element_has_optional(elem: &ChainElement<'_>) -> bool {

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -89,7 +89,8 @@ impl<'a> PeepholeOptimizations {
             }
             Some(ChainFoldResult::Collapse { base }) => {
                 // Always emit `(base, void 0)`. A side-effect-free base is
-                // folded away by a later pass (e.g. `(0, 1).foo` → `1 .foo`).
+                // dropped from the sequence by a later pass (the same one
+                // that reduces e.g. `(0, 1).foo` to `1 .foo`).
                 *expr = ctx.ast.expression_sequence(
                     span,
                     ctx.ast.vec_from_array([base, ctx.ast.void_0(span)]),
@@ -772,17 +773,20 @@ impl<'a> PeepholeOptimizations {
 /// optional position in a chain.
 enum ChainFoldResult<'a> {
     /// The deepest optional was statically non-nullish; its `optional` flag
-    /// was flipped to `false`. Caller should unwrap the surrounding
-    /// `ChainExpression` if no other optionals remain.
+    /// was flipped to `false`.
     Flipped,
     /// The deepest optional was statically nullish; the chain short-circuits
-    /// to `void 0`. `base` carries the (taken-out) base expression so the
-    /// caller can preserve any side effects via a sequence expression.
+    /// to `void 0`. `base` carries the (taken-out) base expression.
     Collapse { base: Expression<'a> },
 }
 
+/// State carried up the chain while searching for the deepest optional to
+/// fold.
 struct ChainFoldSearch<'a> {
+    /// the outcome once a fold fires
     result: Option<ChainFoldResult<'a>>,
+    /// tracks whether any `?.` was seen along the way and decides whether the
+    /// outer `ChainExpression` wrapper is still needed
     has_optional: bool,
 }
 
@@ -901,20 +905,18 @@ fn try_fold_at_optional<'a>(
     has_optional: bool,
     ctx: &TraverseCtx<'a>,
 ) -> Option<ChainFoldResult<'a>> {
-    if !*optional {
+    if !*optional || has_optional {
         return None;
     }
-    if has_optional {
-        return None;
+    match base.value_type(ctx) {
+        ValueType::Null | ValueType::Undefined => {
+            let taken = base.take_in(ctx.ast);
+            Some(ChainFoldResult::Collapse { base: taken })
+        }
+        ValueType::Undetermined => None,
+        _ => {
+            *optional = false;
+            Some(ChainFoldResult::Flipped)
+        }
     }
-    let ty = base.value_type(ctx);
-    if ty.is_null() || ty.is_undefined() {
-        let taken = base.take_in(ctx.ast);
-        return Some(ChainFoldResult::Collapse { base: taken });
-    }
-    if !ty.is_undetermined() {
-        *optional = false;
-        return Some(ChainFoldResult::Flipped);
-    }
-    None
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -782,22 +782,6 @@ enum ChainFoldResult<'a> {
     Collapse { base: Expression<'a>, has_side_effects: bool },
 }
 
-/// Whether a `ValueType` is statically known to be non-nullish — i.e. a
-/// member access or call on it cannot short-circuit through `?.`. The
-/// transform's correctness depends on this exact set, so it lives in a
-/// named helper rather than an inline `matches!` to avoid accidental
-/// weakening (e.g. adding `Undetermined`).
-fn is_known_non_nullish(ty: ValueType) -> bool {
-    matches!(
-        ty,
-        ValueType::Number
-            | ValueType::String
-            | ValueType::Boolean
-            | ValueType::BigInt
-            | ValueType::Object
-    )
-}
-
 /// Try folding the *deepest* (= leftmost in source order) optional in a
 /// chain. Recurses inward through `.object` / `.callee` first so the
 /// short-circuit point is found before any outer access.
@@ -878,7 +862,7 @@ fn try_fold_at_optional<'a>(
         let taken = base.take_in(ctx.ast);
         return Some(ChainFoldResult::Collapse { base: taken, has_side_effects });
     }
-    if is_known_non_nullish(ty) {
+    if !ty.is_undetermined() {
         *optional = false;
         return Some(ChainFoldResult::Flipped);
     }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -800,6 +800,8 @@ impl<'a> ChainFoldSearch<'a> {
         if !optional {
             return;
         }
+        // Optionals above a folded node belong to the fold result; optionals
+        // seen before any fold are carried by the ongoing search.
         if let Some(ChainFoldResult::Flipped { has_optional }) = &mut self.result {
             *has_optional = true;
         } else {
@@ -874,35 +876,32 @@ fn try_fold_member_expression<'a>(
         return search;
     }
 
-    match member {
-        MemberExpression::StaticMemberExpression(m) => {
-            let m = &mut **m;
-            if let Some(result) =
-                try_fold_at_optional(&mut m.optional, &mut m.object, search.has_optional, ctx)
-            {
-                return ChainFoldSearch::folded(result);
-            }
-        }
-        MemberExpression::ComputedMemberExpression(m) => {
-            let m = &mut **m;
-            if let Some(result) =
-                try_fold_at_optional(&mut m.optional, &mut m.object, search.has_optional, ctx)
-            {
-                return ChainFoldSearch::folded(result);
-            }
-        }
-        MemberExpression::PrivateFieldExpression(m) => {
-            let m = &mut **m;
-            if let Some(result) =
-                try_fold_at_optional(&mut m.optional, &mut m.object, search.has_optional, ctx)
-            {
-                return ChainFoldSearch::folded(result);
-            }
-        }
+    let (optional, object) = member_expression_optional_and_object_mut(member);
+    if let Some(result) = try_fold_at_optional(optional, object, search.has_optional, ctx) {
+        return ChainFoldSearch::folded(result);
     }
 
     search.add_optional(member.optional());
     search
+}
+
+fn member_expression_optional_and_object_mut<'a, 'b>(
+    member: &'b mut MemberExpression<'a>,
+) -> (&'b mut bool, &'b mut Expression<'a>) {
+    match member {
+        MemberExpression::StaticMemberExpression(m) => {
+            let m = &mut **m;
+            (&mut m.optional, &mut m.object)
+        }
+        MemberExpression::ComputedMemberExpression(m) => {
+            let m = &mut **m;
+            (&mut m.optional, &mut m.object)
+        }
+        MemberExpression::PrivateFieldExpression(m) => {
+            let m = &mut **m;
+            (&mut m.optional, &mut m.object)
+        }
+    }
 }
 
 fn try_fold_at_optional<'a>(

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -77,11 +77,11 @@ impl<'a> PeepholeOptimizations {
         let span = e.span;
         match try_fold_chain_at_element(&mut e.expression, ctx) {
             None => {}
-            Some(ChainFoldResult::Flipped) => {
+            Some(ChainFoldResult::Flipped { has_optional }) => {
                 // Unwrap the `ChainExpression` only if no optionals remain.
                 // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
                 // outer `?.bar` keeps the wrapper alive.
-                if !chain_element_has_optional(&e.expression) {
+                if !has_optional {
                     *expr = Expression::from(e.expression.take_in(ctx.ast));
                 }
                 ctx.state.changed = true;
@@ -775,11 +775,37 @@ enum ChainFoldResult<'a> {
     /// The deepest optional was statically non-nullish; its `optional` flag
     /// was flipped to `false`. Caller should unwrap the surrounding
     /// `ChainExpression` if no other optionals remain.
-    Flipped,
+    Flipped { has_optional: bool },
     /// The deepest optional was statically nullish; the chain short-circuits
     /// to `void 0`. `base` carries the (taken-out) base expression so the
     /// caller can preserve any side effects via a sequence expression.
     Collapse { base: Expression<'a>, has_side_effects: bool },
+}
+
+struct ChainFoldSearch<'a> {
+    result: Option<ChainFoldResult<'a>>,
+    has_optional: bool,
+}
+
+impl<'a> ChainFoldSearch<'a> {
+    fn none() -> Self {
+        Self { result: None, has_optional: false }
+    }
+
+    fn folded(result: ChainFoldResult<'a>) -> Self {
+        Self { result: Some(result), has_optional: false }
+    }
+
+    fn add_optional(&mut self, optional: bool) {
+        if !optional {
+            return;
+        }
+        if let Some(ChainFoldResult::Flipped { has_optional }) = &mut self.result {
+            *has_optional = true;
+        } else {
+            self.has_optional = true;
+        }
+    }
 }
 
 /// Try folding the *deepest* (= leftmost in source order) optional in a
@@ -800,12 +826,13 @@ fn try_fold_chain_at_element<'a>(
         }
         ChainElement::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
     }
+    .result
 }
 
 fn try_fold_chain_at_expr<'a>(
     expr: &mut Expression<'a>,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldResult<'a>> {
+) -> ChainFoldSearch<'a> {
     match expr {
         Expression::CallExpression(c) => try_fold_call_expression(c, ctx),
         match_member_expression!(Expression) => {
@@ -813,47 +840,81 @@ fn try_fold_chain_at_expr<'a>(
         }
         Expression::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
         Expression::ParenthesizedExpression(p) => try_fold_chain_at_expr(&mut p.expression, ctx),
-        _ => None,
+        _ => ChainFoldSearch::none(),
     }
 }
 
 fn try_fold_call_expression<'a>(
     call: &mut CallExpression<'a>,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldResult<'a>> {
-    try_fold_chain_at_expr(&mut call.callee, ctx)
-        .or_else(|| try_fold_at_optional(&mut call.optional, &mut call.callee, ctx))
+) -> ChainFoldSearch<'a> {
+    let mut search = try_fold_chain_at_expr(&mut call.callee, ctx);
+    if search.result.is_some() {
+        search.add_optional(call.optional);
+        return search;
+    }
+
+    if let Some(result) =
+        try_fold_at_optional(&mut call.optional, &mut call.callee, search.has_optional, ctx)
+    {
+        return ChainFoldSearch::folded(result);
+    }
+
+    search.add_optional(call.optional);
+    search
 }
 
 fn try_fold_member_expression<'a>(
     member: &mut MemberExpression<'a>,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldResult<'a>> {
-    if let Some(result) = try_fold_chain_at_expr(member.object_mut(), ctx) {
-        return Some(result);
+) -> ChainFoldSearch<'a> {
+    let mut search = try_fold_chain_at_expr(member.object_mut(), ctx);
+    if search.result.is_some() {
+        search.add_optional(member.optional());
+        return search;
     }
+
     match member {
         MemberExpression::StaticMemberExpression(m) => {
             let m = &mut **m;
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+            if let Some(result) =
+                try_fold_at_optional(&mut m.optional, &mut m.object, search.has_optional, ctx)
+            {
+                return ChainFoldSearch::folded(result);
+            }
         }
         MemberExpression::ComputedMemberExpression(m) => {
             let m = &mut **m;
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+            if let Some(result) =
+                try_fold_at_optional(&mut m.optional, &mut m.object, search.has_optional, ctx)
+            {
+                return ChainFoldSearch::folded(result);
+            }
         }
         MemberExpression::PrivateFieldExpression(m) => {
             let m = &mut **m;
-            try_fold_at_optional(&mut m.optional, &mut m.object, ctx)
+            if let Some(result) =
+                try_fold_at_optional(&mut m.optional, &mut m.object, search.has_optional, ctx)
+            {
+                return ChainFoldSearch::folded(result);
+            }
         }
     }
+
+    search.add_optional(member.optional());
+    search
 }
 
 fn try_fold_at_optional<'a>(
     optional: &mut bool,
     base: &mut Expression<'a>,
+    has_optional: bool,
     ctx: &TraverseCtx<'a>,
 ) -> Option<ChainFoldResult<'a>> {
     if !*optional {
+        return None;
+    }
+    if has_optional {
         return None;
     }
     let ty = base.value_type(ctx);
@@ -864,43 +925,7 @@ fn try_fold_at_optional<'a>(
     }
     if !ty.is_undetermined() {
         *optional = false;
-        return Some(ChainFoldResult::Flipped);
+        return Some(ChainFoldResult::Flipped { has_optional });
     }
     None
-}
-
-/// Whether any access in this chain is still marked `optional: true`. Used
-/// after a `Flipped` fold to decide if the surrounding `ChainExpression`
-/// can be unwrapped. The chain-element layer immediately delegates to the
-/// expression layer because every `ChainElement` member variant inherits
-/// from `MemberExpression` and shares its underlying struct with
-/// `Expression`'s counterparts.
-fn chain_element_has_optional(elem: &ChainElement<'_>) -> bool {
-    match elem {
-        ChainElement::CallExpression(c) => call_expression_has_chain_optional(c),
-        match_member_expression!(ChainElement) => {
-            member_expression_has_chain_optional(elem.to_member_expression())
-        }
-        ChainElement::TSNonNullExpression(t) => expression_has_chain_optional(&t.expression),
-    }
-}
-
-fn expression_has_chain_optional(expr: &Expression<'_>) -> bool {
-    match expr {
-        Expression::CallExpression(c) => call_expression_has_chain_optional(c),
-        match_member_expression!(Expression) => {
-            member_expression_has_chain_optional(expr.to_member_expression())
-        }
-        Expression::TSNonNullExpression(t) => expression_has_chain_optional(&t.expression),
-        Expression::ParenthesizedExpression(p) => expression_has_chain_optional(&p.expression),
-        _ => false,
-    }
-}
-
-fn call_expression_has_chain_optional(call: &CallExpression<'_>) -> bool {
-    call.optional || expression_has_chain_optional(&call.callee)
-}
-
-fn member_expression_has_chain_optional(member: &MemberExpression<'_>) -> bool {
-    member.optional() || expression_has_chain_optional(member.object())
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -74,20 +74,28 @@ impl<'a> PeepholeOptimizations {
 
     pub fn fold_chain_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::ChainExpression(e) = expr else { return };
-        let search = try_fold_chain_at_element(&mut e.expression, ctx);
-        if !search.folded {
-            return;
+        let span = e.span;
+        match try_fold_chain_at_element(&mut e.expression, ctx) {
+            None => {}
+            Some(ChainFoldResult::Flipped { has_optional }) => {
+                // Unwrap the `ChainExpression` only if no optionals remain.
+                // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
+                // outer `?.bar` keeps the wrapper alive.
+                if !has_optional {
+                    *expr = Expression::from(e.expression.take_in(ctx.ast));
+                }
+                ctx.state.changed = true;
+            }
+            Some(ChainFoldResult::Collapse { base }) => {
+                // Always emit `(base, void 0)`. A side-effect-free base is
+                // folded away by a later pass (e.g. `(0, 1).foo` → `1 .foo`).
+                *expr = ctx.ast.expression_sequence(
+                    span,
+                    ctx.ast.vec_from_array([base, ctx.ast.void_0(span)]),
+                );
+                ctx.state.changed = true;
+            }
         }
-
-        if let Some(replacement) = search.replacement {
-            *expr = replacement;
-        } else if !search.has_optional {
-            // Unwrap the `ChainExpression` only if no optionals remain.
-            // For `(known_obj)?.foo?.bar` the inner `?.` flips, but the
-            // outer `?.bar` keeps the wrapper alive.
-            *expr = Expression::from(e.expression.take_in(ctx.ast));
-        }
-        ctx.state.changed = true;
     }
 
     /// Try to fold a AND / OR node.
@@ -759,30 +767,44 @@ impl<'a> PeepholeOptimizations {
     }
 }
 
+/// Outcome of attempting to fold an optional-chain access at the deepest
+/// optional position in a chain.
+enum ChainFoldResult<'a> {
+    /// The deepest optional was statically non-nullish; its `optional` flag
+    /// was flipped to `false`. Caller should unwrap the surrounding
+    /// `ChainExpression` if no other optionals remain.
+    Flipped { has_optional: bool },
+    /// The deepest optional was statically nullish; the chain short-circuits
+    /// to `void 0`. `base` carries the (taken-out) base expression so the
+    /// caller can preserve any side effects via a sequence expression.
+    Collapse { base: Expression<'a> },
+}
+
 struct ChainFoldSearch<'a> {
-    folded: bool,
+    result: Option<ChainFoldResult<'a>>,
     has_optional: bool,
-    replacement: Option<Expression<'a>>,
 }
 
 impl<'a> ChainFoldSearch<'a> {
     fn none() -> Self {
-        Self { folded: false, has_optional: false, replacement: None }
+        Self { result: None, has_optional: false }
     }
 
-    fn folded() -> Self {
-        Self { folded: true, has_optional: false, replacement: None }
-    }
-
-    fn collapsed(replacement: Expression<'a>) -> Self {
-        Self { folded: true, has_optional: false, replacement: Some(replacement) }
+    fn folded(result: ChainFoldResult<'a>) -> Self {
+        Self { result: Some(result), has_optional: false }
     }
 
     fn add_optional(&mut self, optional: bool) {
         if !optional {
             return;
         }
-        self.has_optional = true;
+        // Optionals above a folded node belong to the fold result; optionals
+        // seen before any fold are carried by the ongoing search.
+        if let Some(ChainFoldResult::Flipped { has_optional }) = &mut self.result {
+            *has_optional = true;
+        } else {
+            self.has_optional = true;
+        }
     }
 }
 
@@ -796,7 +818,7 @@ impl<'a> ChainFoldSearch<'a> {
 fn try_fold_chain_at_element<'a>(
     elem: &mut ChainElement<'a>,
     ctx: &TraverseCtx<'a>,
-) -> ChainFoldSearch<'a> {
+) -> Option<ChainFoldResult<'a>> {
     match elem {
         ChainElement::CallExpression(c) => try_fold_call_expression(c, ctx),
         match_member_expression!(ChainElement) => {
@@ -804,6 +826,7 @@ fn try_fold_chain_at_element<'a>(
         }
         ChainElement::TSNonNullExpression(t) => try_fold_chain_at_expr(&mut t.expression, ctx),
     }
+    .result
 }
 
 fn try_fold_chain_at_expr<'a>(
@@ -826,19 +849,15 @@ fn try_fold_call_expression<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> ChainFoldSearch<'a> {
     let mut search = try_fold_chain_at_expr(&mut call.callee, ctx);
-    if search.folded {
+    if search.result.is_some() {
         search.add_optional(call.optional);
         return search;
     }
 
-    if let Some(search) = try_fold_at_optional(
-        &mut call.optional,
-        &mut call.callee,
-        call.span,
-        search.has_optional,
-        ctx,
-    ) {
-        return search;
+    if let Some(result) =
+        try_fold_at_optional(&mut call.optional, &mut call.callee, search.has_optional, ctx)
+    {
+        return ChainFoldSearch::folded(result);
     }
 
     search.add_optional(call.optional);
@@ -850,15 +869,14 @@ fn try_fold_member_expression<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> ChainFoldSearch<'a> {
     let mut search = try_fold_chain_at_expr(member.object_mut(), ctx);
-    if search.folded {
+    if search.result.is_some() {
         search.add_optional(member.optional());
         return search;
     }
 
-    let span = member.span();
     let (optional, object) = member_expression_optional_and_object_mut(member);
-    if let Some(search) = try_fold_at_optional(optional, object, span, search.has_optional, ctx) {
-        return search;
+    if let Some(result) = try_fold_at_optional(optional, object, search.has_optional, ctx) {
+        return ChainFoldSearch::folded(result);
     }
 
     search.add_optional(member.optional());
@@ -887,10 +905,9 @@ fn member_expression_optional_and_object_mut<'a, 'b>(
 fn try_fold_at_optional<'a>(
     optional: &mut bool,
     base: &mut Expression<'a>,
-    span: Span,
     has_optional: bool,
     ctx: &TraverseCtx<'a>,
-) -> Option<ChainFoldSearch<'a>> {
+) -> Option<ChainFoldResult<'a>> {
     if !*optional {
         return None;
     }
@@ -900,14 +917,11 @@ fn try_fold_at_optional<'a>(
     let ty = base.value_type(ctx);
     if ty.is_null() || ty.is_undefined() {
         let taken = base.take_in(ctx.ast);
-        let replacement = ctx
-            .ast
-            .expression_sequence(span, ctx.ast.vec_from_array([taken, ctx.ast.void_0(span)]));
-        return Some(ChainFoldSearch::collapsed(replacement));
+        return Some(ChainFoldResult::Collapse { base: taken });
     }
     if !ty.is_undetermined() {
         *optional = false;
-        return Some(ChainFoldSearch::folded());
+        return Some(ChainFoldResult::Flipped { has_optional });
     }
     None
 }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -102,6 +102,35 @@ impl<'a> PeepholeOptimizations {
                 ctx.value_to_expr(span, ConstantValue::Undefined)
             };
             ctx.state.changed = true;
+            return;
+        }
+        // Drop the outermost `?.` when the base is statically non-nullish.
+        // Only the outermost level is handled here, matching the structure of the
+        // nullish branch above. Multi-level chains like `a?.b.c` (where `?.` is
+        // not on the outermost element) are intentionally left for a follow-up.
+        if matches!(
+            ty,
+            ValueType::Number
+                | ValueType::String
+                | ValueType::Boolean
+                | ValueType::BigInt
+                | ValueType::Object
+        ) {
+            match &mut e.expression {
+                ChainElement::StaticMemberExpression(m) => m.optional = false,
+                ChainElement::ComputedMemberExpression(m) => m.optional = false,
+                ChainElement::PrivateFieldExpression(m) => m.optional = false,
+                ChainElement::CallExpression(c) => c.optional = false,
+                ChainElement::TSNonNullExpression(_) => unreachable!(),
+            }
+            // Unwrap the `ChainExpression` only if no nested optionals remain.
+            // A case like `Number?.POSITIVE_INFINITY?.foo` enters this branch
+            // (the inner static member resolves to `ValueType::Number`), but
+            // the inner `?.` must keep its `ChainExpression` shell.
+            if !chain_element_has_optional(&e.expression) {
+                *expr = Expression::from(e.expression.take_in(ctx.ast));
+            }
+            ctx.state.changed = true;
         }
     }
 
@@ -771,5 +800,39 @@ impl<'a> PeepholeOptimizations {
         }
 
         ctx.state.changed = true;
+    }
+}
+
+fn chain_element_has_optional(elem: &ChainElement<'_>) -> bool {
+    match elem {
+        ChainElement::CallExpression(c) => c.optional || expression_has_chain_optional(&c.callee),
+        ChainElement::StaticMemberExpression(m) => {
+            m.optional || expression_has_chain_optional(&m.object)
+        }
+        ChainElement::ComputedMemberExpression(m) => {
+            m.optional || expression_has_chain_optional(&m.object)
+        }
+        ChainElement::PrivateFieldExpression(m) => {
+            m.optional || expression_has_chain_optional(&m.object)
+        }
+        ChainElement::TSNonNullExpression(t) => expression_has_chain_optional(&t.expression),
+    }
+}
+
+fn expression_has_chain_optional(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::CallExpression(c) => c.optional || expression_has_chain_optional(&c.callee),
+        Expression::StaticMemberExpression(m) => {
+            m.optional || expression_has_chain_optional(&m.object)
+        }
+        Expression::ComputedMemberExpression(m) => {
+            m.optional || expression_has_chain_optional(&m.object)
+        }
+        Expression::PrivateFieldExpression(m) => {
+            m.optional || expression_has_chain_optional(&m.object)
+        }
+        Expression::TSNonNullExpression(t) => expression_has_chain_optional(&t.expression),
+        Expression::ParenthesizedExpression(p) => expression_has_chain_optional(&p.expression),
+        _ => false,
     }
 }

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -584,4 +584,8 @@ fn drop_optional_chain_on_non_nullish_base() {
     test("({})?.foo;", "({}).foo;");
     // Side effects on the base are preserved when the `?.` is dropped.
     test("export const v = (foo(), {})?.bar", "export const v = (foo(), {}).bar");
+    // Nested: the optional is on the inner access, the outer access is
+    // non-optional. Both folds (collapse + drop) reach the deepest `?.`.
+    test("export const v = null?.foo.bar", "export const v = void 0");
+    test("export const v = []?.foo.bar", "export const v = [].foo.bar");
 }

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -575,3 +575,13 @@ fn preserve_pure_iife_in_used_position_for_downstream_treeshake() {
 
     test("export const x = /* @__PURE__ */ (() => 42)();", "export const x = 42;");
 }
+
+#[test]
+fn drop_optional_chain_on_non_nullish_base() {
+    // https://github.com/oxc-project/oxc/issues/21923
+    // ObjectExpression at statement start needs to stay parenthesised; codegen
+    // already handles that, so the fold is safe in statement position.
+    test("({})?.foo;", "({}).foo;");
+    // Side effects on the base are preserved when the `?.` is dropped.
+    test("export const v = (foo(), {})?.bar", "export const v = (foo(), {}).bar");
+}

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -690,6 +690,7 @@ fn test_fold_opt_chain() {
     // Nested: nullish base short-circuits the entire chain even when the
     // optional is not on the outermost element.
     fold("x = null?.foo.bar", "x = void 0");
+    fold("x = ((null))?.foo", "x = void 0");
     fold("x = null?.foo()", "x = void 0");
     fold("x = null?.foo.bar.baz()", "x = void 0");
     fold("x = (foo(), null)?.bar.baz", "x = (foo(), void 0)");
@@ -748,6 +749,7 @@ fn test_fold_opt_chain_non_nullish_base() {
 
     // Inner `?.` flips, outer `?.` keeps the chain wrapped.
     fold("x = ({})?.foo?.bar", "x = ({}).foo?.bar");
+    fold("x = (() => 0)?.foo?.()", "x = (() => 0).foo?.()");
 
     // Nested ChainExpressions are flattened by a separate pass before this
     // fold sees the inner optional on a later compression iteration.

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -689,6 +689,37 @@ fn test_fold_opt_chain() {
 }
 
 #[test]
+fn test_fold_opt_chain_non_nullish_base() {
+    // https://github.com/oxc-project/oxc/issues/21923
+    // Drop `?.` when the base is statically non-nullish.
+    fold(r#"x = ("")?.foo"#, r#"x = ("").foo"#);
+    fold("x = (1)?.foo", "x = (1).foo");
+    fold("x = (1n)?.foo", "x = (1n).foo");
+    fold("x = ({})?.foo", "x = ({}).foo");
+    fold("x = ([])?.foo", "x = ([]).foo");
+    fold("x = (() => 0)?.foo", "x = (() => 0).foo");
+    fold("x = (function () {})?.foo", "x = (function () {}).foo");
+    fold("x = (class {})?.foo", "x = (class {}).foo");
+    fold("x = /a/?.flags", "x = /a/.flags");
+    // Computed and optional-call forms.
+    fold(r#"x = ({})?.["foo"]"#, "x = ({}).foo");
+    // Fold chains with the IIFE inliner: (() => 0)?.() -> (() => 0)() -> 0
+    fold("x = (() => 0)?.()", "x = 0");
+
+    // Side effects on the base must be preserved.
+    fold("x = (foo(), {})?.bar", "x = (foo(), {}).bar");
+
+    // `Number.POSITIVE_INFINITY` resolves to `Number`, so the outer `?.` flips,
+    // but the inner `?.` keeps the chain wrapped.
+    fold("x = Number?.POSITIVE_INFINITY?.foo", "x = Number?.POSITIVE_INFINITY.foo");
+
+    // Unknown bases are left alone.
+    fold_same("x = b?.foo");
+    fold_same("x = foo()?.bar");
+    fold_same("x = new Foo()?.bar");
+}
+
+#[test]
 fn test_fold_bitwise_op() {
     fold("x = 1 & 1", "x = 1");
     fold("x = 1 & 2", "x = 0");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -716,10 +716,23 @@ fn test_fold_opt_chain_non_nullish_base() {
     // Side effects on the base must be preserved.
     fold("x = (foo(), {})?.bar", "x = (foo(), {}).bar");
 
-    // Outer flips because `Number.POSITIVE_INFINITY` has a resolved
-    // `value_type` of `Number`. Inner stays optional because the free
-    // identifier `Number` resolves to `Undetermined`.
-    fold("x = Number?.POSITIVE_INFINITY?.foo", "x = Number?.POSITIVE_INFINITY.foo");
+    // The outer `?.foo` cannot be dropped while the base still contains an
+    // unresolved optional. `Number` may be shadowed by a primitive, in which
+    // case `Number?.POSITIVE_INFINITY.foo` would throw.
+    fold_same("x = Number?.POSITIVE_INFINITY?.foo");
+    fold_same("x = Number?.NEGATIVE_INFINITY?.foo");
+    test(
+        "const Number = 1; x = Number?.POSITIVE_INFINITY?.foo",
+        "const Number = 1; x = 1 .POSITIVE_INFINITY?.foo",
+    );
+    test(
+        "const Number = 1; x = Number?.POSITIVE_INFINITY?.[foo()]",
+        "const Number = 1; x = 1 .POSITIVE_INFINITY?.[foo()]",
+    );
+    test(
+        "const Number = 1; x = Number?.POSITIVE_INFINITY?.(foo())",
+        "const Number = 1; x = 1 .POSITIVE_INFINITY?.(foo())",
+    );
 
     // Unknown bases are left alone.
     fold_same("x = b?.foo");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -716,8 +716,9 @@ fn test_fold_opt_chain_non_nullish_base() {
     // Side effects on the base must be preserved.
     fold("x = (foo(), {})?.bar", "x = (foo(), {}).bar");
 
-    // `Number.POSITIVE_INFINITY` resolves to `Number`, so the outer `?.` flips,
-    // but the inner `?.` keeps the chain wrapped.
+    // Outer flips because `Number.POSITIVE_INFINITY` has a resolved
+    // `value_type` of `Number`. Inner stays optional because the free
+    // identifier `Number` resolves to `Undetermined`.
     fold("x = Number?.POSITIVE_INFINITY?.foo", "x = Number?.POSITIVE_INFINITY.foo");
 
     // Unknown bases are left alone.

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -686,6 +686,13 @@ fn test_fold_opt_chain() {
     fold("x = null?.()", "x = void 0");
     fold("x = (foo(), null)?.y", "x = (foo(), void 0)");
     fold("x = (foo(), null)?.()", "x = (foo(), void 0)");
+
+    // Nested: nullish base short-circuits the entire chain even when the
+    // optional is not on the outermost element.
+    fold("x = null?.foo.bar", "x = void 0");
+    fold("x = null?.foo()", "x = void 0");
+    fold("x = null?.foo.bar.baz()", "x = void 0");
+    fold("x = (foo(), null)?.bar.baz", "x = (foo(), void 0)");
 }
 
 #[test]
@@ -717,6 +724,16 @@ fn test_fold_opt_chain_non_nullish_base() {
     fold_same("x = b?.foo");
     fold_same("x = foo()?.bar");
     fold_same("x = new Foo()?.bar");
+
+    // Nested chains: drop the inner `?.` when its base is non-nullish, even
+    // when the outermost element is non-optional.
+    fold("x = []?.foo.bar", "x = [].foo.bar");
+    fold(r#"x = ("")?.foo.bar"#, r#"x = ("").foo.bar"#);
+    fold("x = ({})?.foo()", "x = ({}).foo()");
+    fold(r#"x = /a/?.test("a")"#, r#"x = /a/.test("a")"#);
+
+    // Inner `?.` flips, outer `?.` keeps the chain wrapped.
+    fold("x = ({})?.foo?.bar", "x = ({}).foo?.bar");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -734,6 +734,10 @@ fn test_fold_opt_chain_non_nullish_base() {
 
     // Inner `?.` flips, outer `?.` keeps the chain wrapped.
     fold("x = ({})?.foo?.bar", "x = ({}).foo?.bar");
+
+    // Nested ChainExpressions are flattened by a separate pass before this
+    // fold sees the inner optional on a later compression iteration.
+    fold("x = (({})?.foo)?.bar", "x = ({}).foo?.bar");
 }
 
 #[test]


### PR DESCRIPTION
`fold_chain_expr` only operated on the outermost element of a `ChainExpression` and only handled the *nullish* case, leaving two gaps:

* Non-nullish bases like `({})?.foo` were not folded. This isn't fixed by #21923
* Multi-level chains like `null?.foo.bar` and `[]?.foo.bar` kept their `?.` because the optional is on an inner element, not the outermost. This it the focus for this PR.

The implemented fix rewrites the fold to walk inward to the *deepest* (= leftmost in source) optional and act there. A small `ChainFoldResult` enum encodes the three outcomes:

- `None`: no fold applies.
- `Flipped`: non-nullish base; `optional` flag was set to `false`. Caller unwraps the `ChainExpression` if no other optionals remain.
- `Collapse { base, has_side_effects }`: nullish base; the chain short-circuits to `void 0`. The base is taken out so its side effects can be preserved via a sequence expression.

### Cases now covered

| Input | Output |
|---|---|
| `null?.foo` | `void 0` (worked before) |
| `null?.foo.bar` | `void 0` (new — nested nullish) |
| `null?.foo()` | `void 0` (new) |
| `(foo(), null)?.bar.baz` | `(foo(), void 0)` (new, side effects preserved) |
| `({})?.foo` | `({}).foo` (new — #21923) |
| `(\"\")?.foo` | `(\"\").foo` (new) |
| `[]?.foo.bar` | `[].foo.bar` (new, nested non-nullish) |
| `(() => 0)?.()` | `0` (chains with IIFE inliner) |
| `({})?.foo?.bar` | `({}).foo?.bar` (inner flips, outer keeps the chain wrapped) |
| `Number?.POSITIVE_INFINITY?.foo` | `Number?.POSITIVE_INFINITY.foo` |
| `b?.foo`, `foo()?.bar`, `new Foo()?.bar` | unchanged (unknown bases) |

Closes #21923