### PR TITLE
fix(minifier): keep function / class names if direct eval is present in the scope

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1479,7 +1479,9 @@ impl<'a> PeepholeOptimizations {
         if ctx.options().keep_names.function {
             return;
         }
-        if func.id.as_ref().is_some_and(|id| ctx.scoping().symbol_is_unused(id.symbol_id())) {
+        if func.id.as_ref().is_some_and(|id| ctx.scoping().symbol_is_unused(id.symbol_id()))
+            && !ctx.scoping().scope_flags(func.scope_id()).contains_direct_eval()
+        {
             func.id = None;
             ctx.state.changed = true;
         }
@@ -1495,7 +1497,9 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        if class.id.as_ref().is_some_and(|id| ctx.scoping().symbol_is_unused(id.symbol_id())) {
+        if class.id.as_ref().is_some_and(|id| ctx.scoping().symbol_is_unused(id.symbol_id()))
+            && !ctx.scoping().scope_flags(class.scope_id()).contains_direct_eval()
+        {
             class.id = None;
             ctx.state.changed = true;
         }

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -1447,7 +1447,7 @@ fn test_flatten_values() {
     test("return a.x !== undefined && a.x !== null", "return a.x !== void 0 && a.x !== null;");
     test("x = function y() {}", "x = function() {};");
     test("x = function y() { return y }", "x = function y() { return y;};");
-    // test("x = function y() { return eval('y') }", "x = function y() { return eval('y');};");
+    test("x = function y() { return eval('y') }", "x = function y() { return eval('y');};");
     test("x = function y() { if (0) return y }", "x = function() {};");
     test("class x {['y'] = z}", "class x { y = z;}");
     test("class x {['y']() {}}", "class x { y() { }}");

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -803,9 +803,11 @@ fn optional_catch_binding() {
 fn test_remove_name_from_expressions() {
     test("var a = function f() {}", "var a = function () {}");
     test_same("var a = function f() { return f; }");
+    test_same("var a = function f() { return eval('f'); }");
 
     test("var a = class C {}", "var a = class {}");
     test_same("var a = class C { foo() { return C } }");
+    test_same("var a = class C { foo() { return eval('C') } }");
 
     let options = CompressOptions {
         keep_names: CompressOptionsKeepNames::function_only(),


### PR DESCRIPTION
Keep names correctly for cases like:
```js
var a = function f() { return eval('f'); }
```
```js
var a = class C { foo() { return eval('C') } }
```