### PR TITLE
fix(ci): Run extra pnpm install for Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,11 @@ jobs:
           babel: false
           prettier: false
           node-compat-table: false
+      # `setup-node` already runs `pnpm install`, but its `node_modules` is invalidated by `setup-dev-drive` workspace copy, so reinstall here.
+      - if: steps.filter.outputs.changed == 'true'
+        name: Install deps on dev drive
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - if: steps.filter.outputs.changed == 'true'
         name: Run tests
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
@@ -372,6 +377,11 @@ jobs:
         with:
           cache-key: napi
           save-cache: ${{ github.ref_name == 'main' }}
+      # `setup-node` already runs `pnpm install`, but its `node_modules` is invalidated by `setup-dev-drive` workspace copy, so reinstall here.
+      - if: steps.filter.outputs.changed == 'true'
+        name: Install deps on dev drive
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - if: steps.filter.outputs.changed == 'true'
         name: Run tests
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
@@ -412,6 +422,11 @@ jobs:
         with:
           cache-key: napi
           save-cache: ${{ github.ref_name == 'main' }}
+      # `setup-node` already runs `pnpm install`, but its `node_modules` is invalidated by `setup-dev-drive` workspace copy, so reinstall here.
+      - if: steps.filter.outputs.changed == 'true'
+        name: Install deps on dev drive
+        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - if: steps.filter.outputs.changed == 'true'
         name: Run tests
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}


### PR DESCRIPTION
> https://github.com/oxc-project/oxc/actions/runs/25534858980/job/74950578795

Windows CI fails with `ERR_PNPM_IGNORED_BUILDS` because `setup-dev-drive` copies the workspace to a different drive, invalidating the `node_modules` created by `setup-node`. The next pnpm command then re-installs without `--ignore-scripts` and trips pnpm v11's build script policy.

Fix by explicitly running `pnpm install --frozen-lockfile --ignore-scripts` on the dev drive before tests.

