### PR TITLE
fix(ci): Migrate to pnpm@11 allowBuilds syntax

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,9 +23,9 @@ catalog:
   vitest: 4.1.5
 
 allowBuilds:
-  '@vscode/vsce-sign@2.0.8': true
+  "@vscode/vsce-sign@2.0.8": true
   esbuild@0.27.7: true
   esbuild@0.28.0: true
-  '@nestjs/core@11.1.9': false
+  "@nestjs/core@11.1.9": false
 
 verifyDepsBeforeRun: install

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,12 +22,10 @@ catalog:
   tsdown: 0.22.0
   vitest: 4.1.5
 
-onlyBuiltDependencies:
-  - "@vscode/vsce-sign@2.0.8"
-  - esbuild@0.27.7
-  - esbuild@0.28.0
-
-ignoredBuiltDependencies:
-  - "@nestjs/core@11.1.9"
+allowBuilds:
+  '@vscode/vsce-sign@2.0.8': true
+  esbuild@0.27.7: true
+  esbuild@0.28.0: true
+  '@nestjs/core@11.1.9': false
 
 verifyDepsBeforeRun: install


### PR DESCRIPTION
> https://pnpm.io/blog/releases/11.0#allowbuilds-replaces-the-old-build-settings

Changes made by:

```
pnpx codemod run pnpm-v10-to-v11
```

Hopefully fixes Windows CI failure.
