### PR TITLE
feat(linter): implement react no-unstable-nested-components

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -949,6 +949,7 @@ export interface DummyRuleMap {
   "react/no-unescaped-entities"?: DummyRule;
   "react/no-unknown-property"?: DummyRule;
   "react/no-unsafe"?: DummyRule;
+  "react/no-unstable-nested-components"?: DummyRule;
   "react/no-will-update-set-state"?: DummyRule;
   "react/only-export-components"?: DummyRule;
   "react/prefer-es6-class"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2745,6 +2745,11 @@ impl RuleRunner for crate::rules::react::no_unsafe::NoUnsafe {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::no_unstable_nested_components::NoUnstableNestedComponents {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::no_will_update_set_state::NoWillUpdateSetState {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2746,7 +2746,12 @@ impl RuleRunner for crate::rules::react::no_unsafe::NoUnsafe {
 }
 
 impl RuleRunner for crate::rules::react::no_unstable_nested_components::NoUnstableNestedComponents {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ArrowFunctionExpression,
+        AstType::CallExpression,
+        AstType::Class,
+        AstType::Function,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -455,6 +455,7 @@ pub use crate::rules::react::no_this_in_sfc::NoThisInSfc as ReactNoThisInSfc;
 pub use crate::rules::react::no_unescaped_entities::NoUnescapedEntities as ReactNoUnescapedEntities;
 pub use crate::rules::react::no_unknown_property::NoUnknownProperty as ReactNoUnknownProperty;
 pub use crate::rules::react::no_unsafe::NoUnsafe as ReactNoUnsafe;
+pub use crate::rules::react::no_unstable_nested_components::NoUnstableNestedComponents as ReactNoUnstableNestedComponents;
 pub use crate::rules::react::no_will_update_set_state::NoWillUpdateSetState as ReactNoWillUpdateSetState;
 pub use crate::rules::react::only_export_components::OnlyExportComponents as ReactOnlyExportComponents;
 pub use crate::rules::react::prefer_es6_class::PreferEs6Class as ReactPreferEs6Class;
@@ -1245,6 +1246,7 @@ pub enum RuleEnum {
     ReactNoUnescapedEntities(ReactNoUnescapedEntities),
     ReactNoUnknownProperty(ReactNoUnknownProperty),
     ReactNoUnsafe(ReactNoUnsafe),
+    ReactNoUnstableNestedComponents(ReactNoUnstableNestedComponents),
     ReactNoWillUpdateSetState(ReactNoWillUpdateSetState),
     ReactOnlyExportComponents(ReactOnlyExportComponents),
     ReactPreferEs6Class(ReactPreferEs6Class),
@@ -2095,7 +2097,8 @@ const REACT_NO_THIS_IN_SFC_ID: usize = REACT_NO_STRING_REFS_ID + 1usize;
 const REACT_NO_UNESCAPED_ENTITIES_ID: usize = REACT_NO_THIS_IN_SFC_ID + 1usize;
 const REACT_NO_UNKNOWN_PROPERTY_ID: usize = REACT_NO_UNESCAPED_ENTITIES_ID + 1usize;
 const REACT_NO_UNSAFE_ID: usize = REACT_NO_UNKNOWN_PROPERTY_ID + 1usize;
-const REACT_NO_WILL_UPDATE_SET_STATE_ID: usize = REACT_NO_UNSAFE_ID + 1usize;
+const REACT_NO_UNSTABLE_NESTED_COMPONENTS_ID: usize = REACT_NO_UNSAFE_ID + 1usize;
+const REACT_NO_WILL_UPDATE_SET_STATE_ID: usize = REACT_NO_UNSTABLE_NESTED_COMPONENTS_ID + 1usize;
 const REACT_ONLY_EXPORT_COMPONENTS_ID: usize = REACT_NO_WILL_UPDATE_SET_STATE_ID + 1usize;
 const REACT_PREFER_ES_6_CLASS_ID: usize = REACT_ONLY_EXPORT_COMPONENTS_ID + 1usize;
 const REACT_PREFER_FUNCTION_COMPONENT_ID: usize = REACT_PREFER_ES_6_CLASS_ID + 1usize;
@@ -3021,6 +3024,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => REACT_NO_UNESCAPED_ENTITIES_ID,
             Self::ReactNoUnknownProperty(_) => REACT_NO_UNKNOWN_PROPERTY_ID,
             Self::ReactNoUnsafe(_) => REACT_NO_UNSAFE_ID,
+            Self::ReactNoUnstableNestedComponents(_) => REACT_NO_UNSTABLE_NESTED_COMPONENTS_ID,
             Self::ReactNoWillUpdateSetState(_) => REACT_NO_WILL_UPDATE_SET_STATE_ID,
             Self::ReactOnlyExportComponents(_) => REACT_ONLY_EXPORT_COMPONENTS_ID,
             Self::ReactPreferEs6Class(_) => REACT_PREFER_ES_6_CLASS_ID,
@@ -3940,6 +3944,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::NAME,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::NAME,
             Self::ReactNoUnsafe(_) => ReactNoUnsafe::NAME,
+            Self::ReactNoUnstableNestedComponents(_) => ReactNoUnstableNestedComponents::NAME,
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::NAME,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::NAME,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::NAME,
@@ -4875,6 +4880,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::CATEGORY,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::CATEGORY,
             Self::ReactNoUnsafe(_) => ReactNoUnsafe::CATEGORY,
+            Self::ReactNoUnstableNestedComponents(_) => ReactNoUnstableNestedComponents::CATEGORY,
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::CATEGORY,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::CATEGORY,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::CATEGORY,
@@ -5815,6 +5821,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::FIX,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::FIX,
             Self::ReactNoUnsafe(_) => ReactNoUnsafe::FIX,
+            Self::ReactNoUnstableNestedComponents(_) => ReactNoUnstableNestedComponents::FIX,
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::FIX,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::FIX,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::FIX,
@@ -6829,6 +6836,9 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::documentation(),
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::documentation(),
             Self::ReactNoUnsafe(_) => ReactNoUnsafe::documentation(),
+            Self::ReactNoUnstableNestedComponents(_) => {
+                ReactNoUnstableNestedComponents::documentation()
+            }
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::documentation(),
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::documentation(),
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::documentation(),
@@ -8591,6 +8601,10 @@ impl RuleEnum {
             Self::ReactNoUnsafe(_) => {
                 ReactNoUnsafe::config_schema(generator).or_else(|| ReactNoUnsafe::schema(generator))
             }
+            Self::ReactNoUnstableNestedComponents(_) => {
+                ReactNoUnstableNestedComponents::config_schema(generator)
+                    .or_else(|| ReactNoUnstableNestedComponents::schema(generator))
+            }
             Self::ReactNoWillUpdateSetState(_) => {
                 ReactNoWillUpdateSetState::config_schema(generator)
                     .or_else(|| ReactNoWillUpdateSetState::schema(generator))
@@ -10096,6 +10110,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => "react",
             Self::ReactNoUnknownProperty(_) => "react",
             Self::ReactNoUnsafe(_) => "react",
+            Self::ReactNoUnstableNestedComponents(_) => "react",
             Self::ReactNoWillUpdateSetState(_) => "react",
             Self::ReactOnlyExportComponents(_) => "react",
             Self::ReactPreferEs6Class(_) => "react",
@@ -11850,6 +11865,9 @@ impl RuleEnum {
             Self::ReactNoUnsafe(_) => {
                 Ok(Self::ReactNoUnsafe(ReactNoUnsafe::from_configuration(value)?))
             }
+            Self::ReactNoUnstableNestedComponents(_) => Ok(Self::ReactNoUnstableNestedComponents(
+                ReactNoUnstableNestedComponents::from_configuration(value)?,
+            )),
             Self::ReactNoWillUpdateSetState(_) => Ok(Self::ReactNoWillUpdateSetState(
                 ReactNoWillUpdateSetState::from_configuration(value)?,
             )),
@@ -13467,6 +13485,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(rule) => rule.to_configuration(),
             Self::ReactNoUnknownProperty(rule) => rule.to_configuration(),
             Self::ReactNoUnsafe(rule) => rule.to_configuration(),
+            Self::ReactNoUnstableNestedComponents(rule) => rule.to_configuration(),
             Self::ReactNoWillUpdateSetState(rule) => rule.to_configuration(),
             Self::ReactOnlyExportComponents(rule) => rule.to_configuration(),
             Self::ReactPreferEs6Class(rule) => rule.to_configuration(),
@@ -14276,6 +14295,7 @@ impl RuleEnum {
                 Self::ReactNoUnescapedEntities(rule) => rule.run(node, ctx),
                 Self::ReactNoUnknownProperty(rule) => rule.run(node, ctx),
                 Self::ReactNoUnsafe(rule) => rule.run(node, ctx),
+                Self::ReactNoUnstableNestedComponents(rule) => rule.run(node, ctx),
                 Self::ReactNoWillUpdateSetState(rule) => rule.run(node, ctx),
                 Self::ReactOnlyExportComponents(rule) => rule.run(node, ctx),
                 Self::ReactPreferEs6Class(rule) => rule.run(node, ctx),
@@ -15078,6 +15098,7 @@ impl RuleEnum {
                 Self::ReactNoUnescapedEntities(rule) => rule.run(node, ctx),
                 Self::ReactNoUnknownProperty(rule) => rule.run(node, ctx),
                 Self::ReactNoUnsafe(rule) => rule.run(node, ctx),
+                Self::ReactNoUnstableNestedComponents(rule) => rule.run(node, ctx),
                 Self::ReactNoWillUpdateSetState(rule) => rule.run(node, ctx),
                 Self::ReactOnlyExportComponents(rule) => rule.run(node, ctx),
                 Self::ReactPreferEs6Class(rule) => rule.run(node, ctx),
@@ -15887,6 +15908,7 @@ impl RuleEnum {
                 Self::ReactNoUnescapedEntities(rule) => rule.run_once(ctx),
                 Self::ReactNoUnknownProperty(rule) => rule.run_once(ctx),
                 Self::ReactNoUnsafe(rule) => rule.run_once(ctx),
+                Self::ReactNoUnstableNestedComponents(rule) => rule.run_once(ctx),
                 Self::ReactNoWillUpdateSetState(rule) => rule.run_once(ctx),
                 Self::ReactOnlyExportComponents(rule) => rule.run_once(ctx),
                 Self::ReactPreferEs6Class(rule) => rule.run_once(ctx),
@@ -16689,6 +16711,7 @@ impl RuleEnum {
                 Self::ReactNoUnescapedEntities(rule) => rule.run_once(ctx),
                 Self::ReactNoUnknownProperty(rule) => rule.run_once(ctx),
                 Self::ReactNoUnsafe(rule) => rule.run_once(ctx),
+                Self::ReactNoUnstableNestedComponents(rule) => rule.run_once(ctx),
                 Self::ReactNoWillUpdateSetState(rule) => rule.run_once(ctx),
                 Self::ReactOnlyExportComponents(rule) => rule.run_once(ctx),
                 Self::ReactPreferEs6Class(rule) => rule.run_once(ctx),
@@ -17627,6 +17650,9 @@ impl RuleEnum {
                 Self::ReactNoUnescapedEntities(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoUnknownProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoUnsafe(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::ReactNoUnstableNestedComponents(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::ReactNoWillUpdateSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactOnlyExportComponents(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactPreferEs6Class(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18677,6 +18703,9 @@ impl RuleEnum {
                 Self::ReactNoUnescapedEntities(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoUnknownProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoUnsafe(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::ReactNoUnstableNestedComponents(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::ReactNoWillUpdateSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactOnlyExportComponents(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactPreferEs6Class(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19599,6 +19628,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(rule) => rule.should_run(ctx),
             Self::ReactNoUnknownProperty(rule) => rule.should_run(ctx),
             Self::ReactNoUnsafe(rule) => rule.should_run(ctx),
+            Self::ReactNoUnstableNestedComponents(rule) => rule.should_run(ctx),
             Self::ReactNoWillUpdateSetState(rule) => rule.should_run(ctx),
             Self::ReactOnlyExportComponents(rule) => rule.should_run(ctx),
             Self::ReactPreferEs6Class(rule) => rule.should_run(ctx),
@@ -20572,6 +20602,9 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::IS_TSGOLINT_RULE,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::IS_TSGOLINT_RULE,
             Self::ReactNoUnsafe(_) => ReactNoUnsafe::IS_TSGOLINT_RULE,
+            Self::ReactNoUnstableNestedComponents(_) => {
+                ReactNoUnstableNestedComponents::IS_TSGOLINT_RULE
+            }
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::IS_TSGOLINT_RULE,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::IS_TSGOLINT_RULE,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::IS_TSGOLINT_RULE,
@@ -21647,6 +21680,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::VERSION,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::VERSION,
             Self::ReactNoUnsafe(_) => ReactNoUnsafe::VERSION,
+            Self::ReactNoUnstableNestedComponents(_) => ReactNoUnstableNestedComponents::VERSION,
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::VERSION,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::VERSION,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::VERSION,
@@ -22629,6 +22663,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(_) => ReactNoUnescapedEntities::HAS_CONFIG,
             Self::ReactNoUnknownProperty(_) => ReactNoUnknownProperty::HAS_CONFIG,
             Self::ReactNoUnsafe(_) => ReactNoUnsafe::HAS_CONFIG,
+            Self::ReactNoUnstableNestedComponents(_) => ReactNoUnstableNestedComponents::HAS_CONFIG,
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::HAS_CONFIG,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::HAS_CONFIG,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::HAS_CONFIG,
@@ -23518,6 +23553,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(rule) => rule.types_info(),
             Self::ReactNoUnknownProperty(rule) => rule.types_info(),
             Self::ReactNoUnsafe(rule) => rule.types_info(),
+            Self::ReactNoUnstableNestedComponents(rule) => rule.types_info(),
             Self::ReactNoWillUpdateSetState(rule) => rule.types_info(),
             Self::ReactOnlyExportComponents(rule) => rule.types_info(),
             Self::ReactPreferEs6Class(rule) => rule.types_info(),
@@ -24317,6 +24353,7 @@ impl RuleEnum {
             Self::ReactNoUnescapedEntities(rule) => rule.run_info(),
             Self::ReactNoUnknownProperty(rule) => rule.run_info(),
             Self::ReactNoUnsafe(rule) => rule.run_info(),
+            Self::ReactNoUnstableNestedComponents(rule) => rule.run_info(),
             Self::ReactNoWillUpdateSetState(rule) => rule.run_info(),
             Self::ReactOnlyExportComponents(rule) => rule.run_info(),
             Self::ReactPreferEs6Class(rule) => rule.run_info(),
@@ -25208,6 +25245,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactNoUnescapedEntities(ReactNoUnescapedEntities::default()),
         RuleEnum::ReactNoUnknownProperty(ReactNoUnknownProperty::default()),
         RuleEnum::ReactNoUnsafe(ReactNoUnsafe::default()),
+        RuleEnum::ReactNoUnstableNestedComponents(ReactNoUnstableNestedComponents::default()),
         RuleEnum::ReactNoWillUpdateSetState(ReactNoWillUpdateSetState::default()),
         RuleEnum::ReactOnlyExportComponents(ReactOnlyExportComponents::default()),
         RuleEnum::ReactPreferEs6Class(ReactPreferEs6Class::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -447,6 +447,7 @@ pub(crate) mod react {
     pub mod no_unescaped_entities;
     pub mod no_unknown_property;
     pub mod no_unsafe;
+    pub mod no_unstable_nested_components;
     pub mod no_will_update_set_state;
     pub mod only_export_components;
     pub mod prefer_es6_class;

--- a/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
+++ b/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
@@ -1,0 +1,1794 @@
+use fast_glob::glob_match;
+use oxc_ast::{
+    AstKind,
+    ast::{
+        Argument, ArrowFunctionExpression, CallExpression, Class, Expression, Function,
+        JSXAttributeName, JSXExpression, JSXExpressionContainer, ObjectProperty, PropertyKey,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_str::CompactStr;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::{DefaultRuleConfig, Rule},
+    utils::{
+        expression_contains_jsx, function_body_contains_jsx, function_contains_jsx,
+        is_create_element_call, is_hoc_call, is_react_component_name, is_react_hook,
+    },
+};
+
+const COMPONENT_AS_PROPS_INFO: &str =
+    " If you want to allow component creation in props, set `allowAsProps` option to true.";
+
+fn no_unstable_nested_components_diagnostic(
+    span: Span,
+    parent_name: Option<&str>,
+    is_component_in_prop: bool,
+) -> OxcDiagnostic {
+    let parent = parent_name.map_or(String::new(), |name| format!(" `{name}`"));
+    let mut help = format!(
+        "Move this component definition out of the parent component{parent} and pass data as props."
+    );
+    if is_component_in_prop {
+        help.push_str(COMPONENT_AS_PROPS_INFO);
+    }
+
+    OxcDiagnostic::warn("Do not define components during render.").with_help(help).with_label(span)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct NoUnstableNestedComponentsConfig {
+    /// Allow component definitions in props.
+    allow_as_props: bool,
+    /// Optional custom propTypes validators accepted for eslint-plugin-react compatibility.
+    custom_validators: Vec<CompactStr>,
+    /// Glob pattern for render-prop names that may receive inline component definitions.
+    prop_name_pattern: CompactStr,
+}
+
+impl Default for NoUnstableNestedComponentsConfig {
+    fn default() -> Self {
+        Self {
+            allow_as_props: false,
+            custom_validators: Vec::new(),
+            prop_name_pattern: CompactStr::new("render*"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NoUnstableNestedComponents(Box<NoUnstableNestedComponentsConfig>);
+
+impl Default for NoUnstableNestedComponents {
+    fn default() -> Self {
+        Self(Box::new(NoUnstableNestedComponentsConfig::default()))
+    }
+}
+
+impl From<NoUnstableNestedComponentsConfig> for NoUnstableNestedComponents {
+    fn from(config: NoUnstableNestedComponentsConfig) -> Self {
+        Self(Box::new(config))
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows defining React components inside other components.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// React compares element types by reference during reconciliation. A component defined during
+    /// render gets a new identity on every render, so React remounts the entire nested subtree and
+    /// destroys its DOM nodes and state.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// function Component() {
+    ///   function UnstableNestedComponent() {
+    ///     return <div />;
+    ///   }
+    ///
+    ///   return <UnstableNestedComponent />;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// function StableComponent() {
+    ///   return <div />;
+    /// }
+    ///
+    /// function Component() {
+    ///   return <StableComponent />;
+    /// }
+    /// ```
+    NoUnstableNestedComponents,
+    react,
+    suspicious,
+    none,
+    config = NoUnstableNestedComponentsConfig,
+    version = "next",
+);
+
+impl Rule for NoUnstableNestedComponents {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<NoUnstableNestedComponentsConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(Self::from)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let Some(candidate) = self.component_candidate(node, ctx) else {
+            return;
+        };
+
+        if self.should_ignore_candidate(node, ctx, candidate.is_component_in_prop) {
+            return;
+        }
+
+        let Some(parent_name) = find_parent_component_name(node, ctx) else {
+            return;
+        };
+
+        ctx.diagnostic(no_unstable_nested_components_diagnostic(
+            candidate.span,
+            parent_name.as_deref(),
+            candidate.is_component_in_prop && !self.0.allow_as_props,
+        ));
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ComponentCandidate {
+    span: Span,
+    is_component_in_prop: bool,
+}
+
+impl NoUnstableNestedComponents {
+    fn component_candidate<'a>(
+        &self,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+    ) -> Option<ComponentCandidate> {
+        match node.kind() {
+            AstKind::Function(func) => self.function_candidate(func, node, ctx),
+            AstKind::ArrowFunctionExpression(arrow) => self.arrow_candidate(arrow, node, ctx),
+            AstKind::Class(class) => class_candidate(class, node, ctx),
+            AstKind::CallExpression(call) => hoc_call_candidate(call, node, ctx),
+            _ => None,
+        }
+    }
+
+    fn function_candidate<'a>(
+        &self,
+        func: &Function<'a>,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+    ) -> Option<ComponentCandidate> {
+        if is_first_argument_of_hoc_call(node, ctx) {
+            return None;
+        }
+
+        let is_component_in_prop = is_component_declared_in_prop(node, ctx);
+        if is_component_in_prop {
+            if function_contains_jsx(func) {
+                return Some(ComponentCandidate { span: func.span, is_component_in_prop });
+            }
+            return None;
+        }
+
+        let name = function_name(func, node, ctx)?;
+        if is_react_component_name(&name) && function_contains_jsx(func) {
+            Some(ComponentCandidate { span: func.span, is_component_in_prop: false })
+        } else {
+            None
+        }
+    }
+
+    fn arrow_candidate<'a>(
+        &self,
+        arrow: &ArrowFunctionExpression<'a>,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+    ) -> Option<ComponentCandidate> {
+        if is_first_argument_of_hoc_call(node, ctx) {
+            return None;
+        }
+
+        let contains_jsx = function_body_contains_jsx(&arrow.body);
+        if !contains_jsx {
+            return None;
+        }
+
+        let is_component_in_prop = is_component_declared_in_prop(node, ctx);
+        if is_component_in_prop {
+            return Some(ComponentCandidate { span: arrow.span, is_component_in_prop });
+        }
+
+        let name = function_like_name(node, ctx)?;
+        if is_react_component_name(&name) {
+            Some(ComponentCandidate { span: arrow.span, is_component_in_prop: false })
+        } else {
+            None
+        }
+    }
+
+    fn should_ignore_candidate<'a>(
+        &self,
+        node: &AstNode<'a>,
+        ctx: &LintContext<'a>,
+        is_component_in_prop: bool,
+    ) -> bool {
+        is_map_callback(node, ctx)
+            || is_return_statement_of_hook(node, ctx)
+            || is_allowed_render_prop(node, ctx, &self.0.prop_name_pattern)
+            || (is_component_in_prop && self.0.allow_as_props)
+    }
+}
+
+fn class_candidate<'a>(
+    class: &Class<'a>,
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<ComponentCandidate> {
+    if !is_es6_component_class(class) {
+        return None;
+    }
+
+    let name = class_name(class, node, ctx)?;
+    if is_react_component_name(&name) {
+        Some(ComponentCandidate { span: class.span, is_component_in_prop: false })
+    } else {
+        None
+    }
+}
+
+fn hoc_call_candidate<'a>(
+    call: &CallExpression<'a>,
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<ComponentCandidate> {
+    let name = function_like_name(node, ctx)?;
+    if !is_react_component_name(&name) || !is_hoc_component_call(call, ctx) {
+        return None;
+    }
+    Some(ComponentCandidate { span: call.span, is_component_in_prop: false })
+}
+
+fn find_parent_component_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Option<String>> {
+    for ancestor_id in ctx.nodes().ancestor_ids(node.id()).filter(|&id| id != node.id()) {
+        let ancestor = ctx.nodes().get_node(ancestor_id);
+        match ancestor.kind() {
+            AstKind::Function(func) => {
+                if is_first_argument_of_hoc_call(ancestor, ctx) {
+                    continue;
+                }
+                if !function_contains_jsx(func) {
+                    continue;
+                }
+
+                if let Some(name) = function_name(func, ancestor, ctx) {
+                    if is_react_component_name(&name) {
+                        return Some(Some(name));
+                    }
+                    continue;
+                }
+
+                if is_anonymous_default_export(ancestor, ctx) {
+                    return Some(None);
+                }
+            }
+            AstKind::ArrowFunctionExpression(arrow) => {
+                if is_first_argument_of_hoc_call(ancestor, ctx)
+                    || !function_body_contains_jsx(&arrow.body)
+                {
+                    continue;
+                }
+
+                if let Some(name) = function_like_name(ancestor, ctx) {
+                    if is_react_component_name(&name) {
+                        return Some(Some(name));
+                    }
+                    continue;
+                }
+
+                if is_anonymous_default_export(ancestor, ctx) {
+                    return Some(None);
+                }
+            }
+            AstKind::Class(class) => {
+                if is_es6_component_class(class)
+                    && let Some(name) = class_name(class, ancestor, ctx)
+                    && is_react_component_name(&name)
+                {
+                    return Some(Some(name));
+                }
+            }
+            AstKind::CallExpression(call) => {
+                if is_hoc_component_call(call, ctx)
+                    && let Some(name) = function_like_name(ancestor, ctx)
+                    && is_react_component_name(&name)
+                {
+                    return Some(Some(name));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn function_name(func: &Function<'_>, node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    func.id.as_ref().map(|id| id.name.to_string()).or_else(|| function_like_name(node, ctx))
+}
+
+fn function_like_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    let parent = ctx.nodes().parent_node(node.id());
+    match parent.kind() {
+        AstKind::VariableDeclarator(decl) => {
+            decl.id.get_identifier_name().map(|name| name.to_string())
+        }
+        AstKind::ObjectProperty(prop) => static_property_name(prop).map(ToString::to_string),
+        _ => None,
+    }
+}
+
+fn class_name(class: &Class<'_>, node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    class.id.as_ref().map(|id| id.name.to_string()).or_else(|| function_like_name(node, ctx))
+}
+
+fn static_property_name<'a>(prop: &'a ObjectProperty<'a>) -> Option<&'a str> {
+    match &prop.key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+        _ => None,
+    }
+}
+
+fn is_anonymous_default_export(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    matches!(ctx.nodes().parent_node(node.id()).kind(), AstKind::ExportDefaultDeclaration(_))
+}
+
+fn is_component_declared_in_prop(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let parent = ctx.nodes().parent_node(node.id());
+
+    if matches!(parent.kind(), AstKind::ObjectProperty(_)) {
+        return true;
+    }
+
+    if is_in_jsx_attribute_expression(node, ctx) {
+        return true;
+    }
+
+    is_inside_create_element_props_object(node, ctx)
+}
+
+fn is_in_jsx_attribute_expression(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let mut previous_id = node.id();
+    for ancestor_id in ctx.nodes().ancestor_ids(node.id()).filter(|&id| id != node.id()) {
+        let ancestor = ctx.nodes().get_node(ancestor_id);
+        match ancestor.kind() {
+            AstKind::JSXExpressionContainer(_) => {
+                let parent = ctx.nodes().parent_node(ancestor.id());
+                return matches!(parent.kind(), AstKind::JSXAttribute(_));
+            }
+            AstKind::JSXElement(_) | AstKind::JSXFragment(_) => return false,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+                if ancestor.id() != previous_id =>
+            {
+                return false;
+            }
+            _ => {}
+        }
+        previous_id = ancestor.id();
+    }
+    false
+}
+
+fn is_inside_create_element_props_object(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    for ancestor_id in ctx.nodes().ancestor_ids(node.id()).filter(|&id| id != node.id()) {
+        let ancestor = ctx.nodes().get_node(ancestor_id);
+        if let AstKind::ObjectExpression(obj) = ancestor.kind() {
+            let parent = ctx.nodes().parent_node(ancestor.id());
+            let AstKind::CallExpression(call) = parent.kind() else {
+                continue;
+            };
+            if !is_create_element_call(call) {
+                continue;
+            }
+            return call
+                .arguments
+                .get(1)
+                .is_some_and(|arg| matches!(arg, Argument::ObjectExpression(arg_obj) if arg_obj.span == obj.span));
+        }
+    }
+    false
+}
+
+fn is_allowed_render_prop(node: &AstNode<'_>, ctx: &LintContext<'_>, pattern: &str) -> bool {
+    if is_direct_jsx_child_render_prop(node, ctx) {
+        return true;
+    }
+
+    if let Some(prop_name) = nearest_jsx_attribute_name(node, ctx) {
+        return prop_name == "children" || glob_match(pattern, &prop_name);
+    }
+
+    if let Some(prop_name) = direct_object_property_name(node, ctx) {
+        return prop_name == "children" || glob_match(pattern, &prop_name);
+    }
+
+    false
+}
+
+fn nearest_jsx_attribute_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    for ancestor_id in ctx.nodes().ancestor_ids(node.id()).filter(|&id| id != node.id()) {
+        let ancestor = ctx.nodes().get_node(ancestor_id);
+        if let AstKind::JSXExpressionContainer(_) = ancestor.kind() {
+            let parent = ctx.nodes().parent_node(ancestor.id());
+            let AstKind::JSXAttribute(attr) = parent.kind() else {
+                return None;
+            };
+            return match &attr.name {
+                JSXAttributeName::Identifier(id) => Some(id.name.to_string()),
+                JSXAttributeName::NamespacedName(_) => None,
+            };
+        }
+        if matches!(ancestor.kind(), AstKind::JSXElement(_) | AstKind::JSXFragment(_)) {
+            return None;
+        }
+    }
+    None
+}
+
+fn direct_object_property_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
+    let parent = ctx.nodes().parent_node(node.id());
+    let AstKind::ObjectProperty(prop) = parent.kind() else {
+        return None;
+    };
+    static_property_name(prop).map(ToString::to_string)
+}
+
+fn is_direct_jsx_child_render_prop(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let parent = ctx.nodes().parent_node(node.id());
+    let AstKind::JSXExpressionContainer(JSXExpressionContainer { expression, .. }) = parent.kind()
+    else {
+        return false;
+    };
+
+    if !jsx_expression_matches_node(expression, node.kind().span()) {
+        return false;
+    }
+
+    matches!(ctx.nodes().parent_node(parent.id()).kind(), AstKind::JSXElement(_))
+}
+
+fn jsx_expression_matches_node(expression: &JSXExpression<'_>, span: Span) -> bool {
+    match expression {
+        JSXExpression::ArrowFunctionExpression(arrow) => arrow.span == span,
+        JSXExpression::FunctionExpression(func) => func.span == span,
+        _ => false,
+    }
+}
+
+fn is_map_callback(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let parent = ctx.nodes().parent_node(node.id());
+    let AstKind::CallExpression(call) = parent.kind() else {
+        return false;
+    };
+
+    if call.callee.as_member_expression().and_then(|member| member.static_property_name())
+        != Some("map")
+    {
+        return false;
+    }
+
+    call.arguments.first().is_some_and(|arg| argument_span(arg) == Some(node.kind().span()))
+}
+
+fn argument_span(arg: &Argument<'_>) -> Option<Span> {
+    match arg {
+        Argument::FunctionExpression(func) => Some(func.span),
+        Argument::ArrowFunctionExpression(arrow) => Some(arrow.span),
+        Argument::ClassExpression(class) => Some(class.span),
+        Argument::CallExpression(call) => Some(call.span),
+        _ => arg.as_expression().map(GetSpan::span),
+    }
+}
+
+fn is_return_statement_of_hook(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let parent = ctx.nodes().parent_node(node.id());
+    if !matches!(parent.kind(), AstKind::ReturnStatement(_)) {
+        return false;
+    }
+
+    for ancestor_id in ctx.nodes().ancestor_ids(node.id()).filter(|&id| id != node.id()) {
+        let ancestor = ctx.nodes().get_node(ancestor_id);
+        if let AstKind::CallExpression(call) = ancestor.kind() {
+            return is_react_hook(&call.callee);
+        }
+    }
+    false
+}
+
+fn is_first_argument_of_hoc_call(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let parent = ctx.nodes().parent_node(node.id());
+    let AstKind::CallExpression(call) = parent.kind() else {
+        return false;
+    };
+    is_hoc_component_call(call, ctx)
+        && call.arguments.first().is_some_and(|arg| argument_span(arg) == Some(node.kind().span()))
+}
+
+fn is_hoc_component_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
+    get_hoc_callee_name(call).is_some_and(|name| is_hoc_call(&name, ctx))
+        && call.arguments.first().is_some_and(argument_contains_jsx)
+}
+
+fn get_hoc_callee_name(call: &CallExpression<'_>) -> Option<String> {
+    call.callee_name().map(ToString::to_string)
+}
+
+fn argument_contains_jsx(arg: &Argument<'_>) -> bool {
+    match arg {
+        Argument::FunctionExpression(func) => function_contains_jsx(func),
+        Argument::ArrowFunctionExpression(arrow) => function_body_contains_jsx(&arrow.body),
+        _ => arg.as_expression().is_some_and(expression_contains_jsx),
+    }
+}
+
+fn is_es6_component_class(class: &Class<'_>) -> bool {
+    class.super_class.as_ref().is_some_and(|super_class| {
+        if let Some(member_expr) = super_class.as_member_expression()
+            && let Expression::Identifier(ident) = member_expr.object()
+            && ident.name == "React"
+        {
+            return member_expr
+                .static_property_name()
+                .is_some_and(|name| matches!(name, "Component" | "PureComponent"));
+        }
+        super_class
+            .get_identifier_reference()
+            .is_some_and(|id| matches!(id.name.as_str(), "Component" | "PureComponent"))
+    })
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <div>
+                          <OutsideDefinedFunctionComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(OutsideDefinedFunctionComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <SomeComponent
+                          footer={<OutsideDefinedComponent />}
+                          header={<div />}
+                          />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      return React.createElement(SomeComponent, {
+                        footer: React.createElement(OutsideDefinedComponent, null),
+                        header: React.createElement("div", null)
+                      });
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const MemoizedNestedComponent = React.useCallback(() => <div />, []);
+            
+                      return (
+                        <div>
+                          <MemoizedNestedComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      const MemoizedNestedComponent = React.useCallback(
+                        () => React.createElement("div", null),
+                        []
+                      );
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(MemoizedNestedComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const MemoizedNestedFunctionComponent = React.useCallback(
+                        function () {
+                          return <div />;
+                        },
+                        []
+                      );
+            
+                      return (
+                        <div>
+                          <MemoizedNestedFunctionComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      const MemoizedNestedFunctionComponent = React.useCallback(
+                        function () {
+                          return React.createElement("div", null);
+                        },
+                        []
+                      );
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(MemoizedNestedFunctionComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent(props) {
+                      // Should not interfere handler declarations
+                      function onClick(event) {
+                        props.onClick(event.target.value);
+                      }
+            
+                      const onKeyPress = () => null;
+            
+                      function getOnHover() {
+                        return function onHover(event) {
+                          props.onHover(event.target);
+                        }
+                      }
+            
+                      return (
+                        <div>
+                          <button
+                            onClick={onClick}
+                            onKeyPress={onKeyPress}
+                            onHover={getOnHover()}
+            
+                            // These should not be considered as components
+                            maybeComponentOrHandlerNull={() => null}
+                            maybeComponentOrHandlerUndefined={() => undefined}
+                            maybeComponentOrHandlerBlank={() => ''}
+                            maybeComponentOrHandlerString={() => 'hello-world'}
+                            maybeComponentOrHandlerNumber={() => 42}
+                            maybeComponentOrHandlerArray={() => []}
+                            maybeComponentOrHandlerObject={() => {}} />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      function getComponent() {
+                        return <div />;
+                      }
+            
+                      return (
+                        <div>
+                          {getComponent()}
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      function getComponent() {
+                        return React.createElement("div", null);
+                      }
+            
+                      return React.createElement("div", null, getComponent());
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                        return (
+                          <RenderPropComponent>
+                            {() => <div />}
+                          </RenderPropComponent>
+                        );
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                        return (
+                          <RenderPropComponent children={() => <div />} />
+                        );
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <ComplexRenderPropComponent
+                          listRenderer={data.map((items, index) => (
+                            <ul>
+                              {items[index].map((item) =>
+                                <li>
+                                  {item}
+                                </li>
+                              )}
+                            </ul>
+                          ))
+                          }
+                        />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      return React.createElement(
+                          RenderPropComponent,
+                          null,
+                          () => React.createElement("div", null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent(props) {
+                      return (
+                        <ul>
+                          {props.items.map(item => (
+                            <li key={item.id}>
+                              {item.name}
+                            </li>
+                          ))}
+                        </ul>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent(props) {
+                      return (
+                        <List items={props.items.map(item => {
+                          return (
+                            <li key={item.id}>
+                              {item.name}
+                            </li>
+                          );
+                        })}
+                        />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent(props) {
+                      return React.createElement(
+                        "ul",
+                        null,
+                        props.items.map(() =>
+                          React.createElement(
+                            "li",
+                            { key: item.id },
+                            item.name
+                          )
+                        )
+                      )
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent(props) {
+                      return (
+                        <ul>
+                          {props.items.map(function Item(item) {
+                            return (
+                              <li key={item.id}>
+                                {item.name}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent(props) {
+                      return React.createElement(
+                        "ul",
+                        null,
+                        props.items.map(function Item() {
+                          return React.createElement(
+                            "li",
+                            { key: item.id },
+                            item.name
+                          );
+                        })
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function createTestComponent(props) {
+                      return (
+                        <div />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function createTestComponent(props) {
+                      return React.createElement("div", null);
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <ComponentWithProps footer={() => <div />} />
+                      );
+                    }
+                  ",
+            Some(serde_json::json!([{ "allowAsProps": true }])),
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      return React.createElement(ComponentWithProps, {
+                        footer: () => React.createElement("div", null)
+                      });
+                    }
+                  "#,
+            Some(serde_json::json!([{ "allowAsProps": true }])),
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <SomeComponent item={{ children: () => <div /> }} />
+                      )
+                    }
+                  ",
+            Some(serde_json::json!([{ "allowAsProps": true }])),
+        ),
+        (
+            "
+                  function ParentComponent() {
+                    return (
+                      <SomeComponent>
+                        {
+                          thing.match({
+                            renderLoading: () => <div />,
+                            renderSuccess: () => <div />,
+                            renderFailure: () => <div />,
+                          })
+                        }
+                      </SomeComponent>
+                    )
+                  }
+                  ",
+            None,
+        ),
+        (
+            "
+                  function ParentComponent() {
+                    const thingElement = thing.match({
+                      renderLoading: () => <div />,
+                      renderSuccess: () => <div />,
+                      renderFailure: () => <div />,
+                    });
+                    return (
+                      <SomeComponent>
+                        {thingElement}
+                      </SomeComponent>
+                    )
+                  }
+                  ",
+            None,
+        ),
+        (
+            "
+                  function ParentComponent() {
+                    return (
+                      <SomeComponent>
+                        {
+                          thing.match({
+                            loading: () => <div />,
+                            success: () => <div />,
+                            failure: () => <div />,
+                          })
+                        }
+                      </SomeComponent>
+                    )
+                  }
+                  ",
+            Some(serde_json::json!([{ "allowAsProps": true, }])),
+        ),
+        (
+            "
+                  function ParentComponent() {
+                    const thingElement = thing.match({
+                      loading: () => <div />,
+                      success: () => <div />,
+                      failure: () => <div />,
+                    });
+                    return (
+                      <SomeComponent>
+                        {thingElement}
+                      </SomeComponent>
+                    )
+                  }
+                  ",
+            Some(serde_json::json!([{ "allowAsProps": true, }])),
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <ComponentForProps renderFooter={() => <div />} />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      return React.createElement(ComponentForProps, {
+                        renderFooter: () => React.createElement("div", null)
+                      });
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      useEffect(() => {
+                        return () => null;
+                      });
+            
+                      return <div />;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <SomeComponent renderers={{ Header: () => <div /> }} />
+                      )
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <SomeComponent renderMenu={() => (
+                          <RenderPropComponent>
+                            {items.map(item => (
+                              <li key={item}>{item}</li>
+                            ))}
+                          </RenderPropComponent>
+                        )} />
+                      )
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    const ParentComponent = () => (
+                      <SomeComponent
+                        components={[
+                          <ul>
+                            {list.map(item => (
+                              <li key={item}>{item}</li>
+                            ))}
+                          </ul>,
+                        ]}
+                      />
+                    );
+                 ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const rows = [
+                        {
+                          name: 'A',
+                          render: (props) => <Row {...props} />
+                        },
+                      ];
+            
+                      return <Table rows={rows} />;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return <SomeComponent renderers={{ notComponent: () => null }} />;
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    const ParentComponent = createReactClass({
+                      displayName: "ParentComponent",
+                      statics: {
+                        getSnapshotBeforeUpdate: function () {
+                          return null;
+                        },
+                      },
+                      render() {
+                        return <div />;
+                      },
+                    });
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const rows = [
+                        {
+                          name: 'A',
+                          notPrefixedWithRender: (props) => <Row {...props} />
+                        },
+                      ];
+            
+                      return <Table rows={rows} />;
+                    }
+                  ",
+            Some(serde_json::json!([{ "allowAsProps": true, }])),
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return <Table
+                        rowRenderer={(rowData) => <Row data={data} />}
+                      />
+                    }
+                  ",
+            Some(serde_json::json!([{ "propNamePattern": "*Renderer", }])),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                    function ParentComponent() {
+                      function UnstableNestedFunctionComponent() {
+                        return <div />;
+                      }
+            
+                      return (
+                        <div>
+                          <UnstableNestedFunctionComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      function UnstableNestedFunctionComponent() {
+                        return React.createElement("div", null);
+                      }
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedFunctionComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const UnstableNestedVariableComponent = () => {
+                        return <div />;
+                      }
+            
+                      return (
+                        <div>
+                          <UnstableNestedVariableComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      const UnstableNestedVariableComponent = () => {
+                        return React.createElement("div", null);
+                      }
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedVariableComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    const ParentComponent = () => {
+                      function UnstableNestedFunctionComponent() {
+                        return <div />;
+                      }
+            
+                      return (
+                        <div>
+                          <UnstableNestedFunctionComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    const ParentComponent = () => {
+                      function UnstableNestedFunctionComponent() {
+                        return React.createElement("div", null);
+                      }
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedFunctionComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    export default () => {
+                      function UnstableNestedFunctionComponent() {
+                        return <div />;
+                      }
+            
+                      return (
+                        <div>
+                          <UnstableNestedFunctionComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    export default () => {
+                      function UnstableNestedFunctionComponent() {
+                        return React.createElement("div", null);
+                      }
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedFunctionComponent, null)
+                      );
+                    };
+                  "#,
+            None,
+        ),
+        (
+            "
+                    const ParentComponent = () => {
+                      const UnstableNestedVariableComponent = () => {
+                        return <div />;
+                      }
+            
+                      return (
+                        <div>
+                          <UnstableNestedVariableComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    const ParentComponent = () => {
+                      const UnstableNestedVariableComponent = () => {
+                        return React.createElement("div", null);
+                      }
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedVariableComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      class UnstableNestedClassComponent extends React.Component {
+                        render() {
+                          return <div />;
+                        }
+                      };
+            
+                      return (
+                        <div>
+                          <UnstableNestedClassComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      class UnstableNestedClassComponent extends React.Component {
+                        render() {
+                          return React.createElement("div", null);
+                        }
+                      }
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedClassComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    class ParentComponent extends React.Component {
+                      render() {
+                        class UnstableNestedClassComponent extends React.Component {
+                          render() {
+                            return <div />;
+                          }
+                        };
+            
+                        return (
+                          <div>
+                            <UnstableNestedClassComponent />
+                          </div>
+                        );
+                      }
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    class ParentComponent extends React.Component {
+                      render() {
+                        class UnstableNestedClassComponent extends React.Component {
+                          render() {
+                            return React.createElement("div", null);
+                          }
+                        }
+            
+                        return React.createElement(
+                          "div",
+                          null,
+                          React.createElement(UnstableNestedClassComponent, null)
+                        );
+                      }
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    class ParentComponent extends React.Component {
+                      render() {
+                        function UnstableNestedFunctionComponent() {
+                          return <div />;
+                        }
+            
+                        return (
+                          <div>
+                            <UnstableNestedFunctionComponent />
+                          </div>
+                        );
+                      }
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    class ParentComponent extends React.Component {
+                      render() {
+                        function UnstableNestedClassComponent() {
+                          return React.createElement("div", null);
+                        }
+            
+                        return React.createElement(
+                          "div",
+                          null,
+                          React.createElement(UnstableNestedClassComponent, null)
+                        );
+                      }
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    class ParentComponent extends React.Component {
+                      render() {
+                        const UnstableNestedVariableComponent = () => {
+                          return <div />;
+                        }
+            
+                        return (
+                          <div>
+                            <UnstableNestedVariableComponent />
+                          </div>
+                        );
+                      }
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    class ParentComponent extends React.Component {
+                      render() {
+                        const UnstableNestedClassComponent = () => {
+                          return React.createElement("div", null);
+                        }
+            
+                        return React.createElement(
+                          "div",
+                          null,
+                          React.createElement(UnstableNestedClassComponent, null)
+                        );
+                      }
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      function getComponent() {
+                        function NestedUnstableFunctionComponent() {
+                          return <div />;
+                        };
+            
+                        return <NestedUnstableFunctionComponent />;
+                      }
+            
+                      return (
+                        <div>
+                          {getComponent()}
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      function getComponent() {
+                        function NestedUnstableFunctionComponent() {
+                          return React.createElement("div", null);
+                        }
+            
+                        return React.createElement(NestedUnstableFunctionComponent, null);
+                      }
+            
+                      return React.createElement("div", null, getComponent());
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ComponentWithProps(props) {
+                      return <div />;
+                    }
+            
+                    function ParentComponent() {
+                      return (
+                        <ComponentWithProps
+                          footer={
+                            function SomeFooter() {
+                              return <div />;
+                            }
+                          } />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ComponentWithProps(props) {
+                      return React.createElement("div", null);
+                    }
+            
+                    function ParentComponent() {
+                      return React.createElement(ComponentWithProps, {
+                        footer: function SomeFooter() {
+                          return React.createElement("div", null);
+                        }
+                      });
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ComponentWithProps(props) {
+                      return <div />;
+                    }
+            
+                    function ParentComponent() {
+                        return (
+                          <ComponentWithProps footer={() => <div />} />
+                        );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ComponentWithProps(props) {
+                      return React.createElement("div", null);
+                    }
+            
+                    function ParentComponent() {
+                      return React.createElement(ComponentWithProps, {
+                        footer: () => React.createElement("div", null)
+                      });
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                        return (
+                          <RenderPropComponent>
+                            {() => {
+                              function UnstableNestedComponent() {
+                                return <div />;
+                              }
+            
+                              return (
+                                <div>
+                                  <UnstableNestedComponent />
+                                </div>
+                              );
+                            }}
+                          </RenderPropComponent>
+                        );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function RenderPropComponent(props) {
+                      return props.render({});
+                    }
+            
+                    function ParentComponent() {
+                      return React.createElement(
+                        RenderPropComponent,
+                        null,
+                        () => {
+                          function UnstableNestedComponent() {
+                            return React.createElement("div", null);
+                          }
+            
+                          return React.createElement(
+                            "div",
+                            null,
+                            React.createElement(UnstableNestedComponent, null)
+                          );
+                        }
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ComponentForProps(props) {
+                      return <div />;
+                    }
+            
+                    function ParentComponent() {
+                      return (
+                        <ComponentForProps notPrefixedWithRender={() => <div />} />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ComponentForProps(props) {
+                      return React.createElement("div", null);
+                    }
+            
+                    function ParentComponent() {
+                      return React.createElement(ComponentForProps, {
+                        notPrefixedWithRender: () => React.createElement("div", null)
+                      });
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <ComponentForProps someMap={{ Header: () => <div /> }} />
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    class ParentComponent extends React.Component {
+                      render() {
+                        const List = (props) => {
+                          const items = props.items
+                            .map((item) => (
+                              <li key={item.key}>
+                                <span>{item.name}</span>
+                              </li>
+                            ));
+            
+                          return <ul>{items}</ul>;
+                        };
+            
+                        return <List {...this.props} />;
+                      }
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                  function ParentComponent() {
+                    return (
+                      <SomeComponent>
+                        {
+                          thing.match({
+                            loading: () => <div />,
+                            success: () => <div />,
+                            failure: () => <div />,
+                          })
+                        }
+                      </SomeComponent>
+                    )
+                  }
+                  ",
+            None,
+        ),
+        (
+            "
+                  function ParentComponent() {
+                    const thingElement = thing.match({
+                      loading: () => <div />,
+                      success: () => <div />,
+                      failure: () => <div />,
+                    });
+                    return (
+                      <SomeComponent>
+                        {thingElement}
+                      </SomeComponent>
+                    )
+                  }
+                  ",
+            None,
+        ),
+        (
+            "
+                  function ParentComponent() {
+                    const rows = [
+                      {
+                        name: 'A',
+                        notPrefixedWithRender: (props) => <Row {...props} />
+                      },
+                    ];
+            
+                    return <Table rows={rows} />;
+                  }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const UnstableNestedComponent = React.memo(() => {
+                        return <div />;
+                      });
+            
+                      return (
+                        <div>
+                          <UnstableNestedComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      const UnstableNestedComponent = React.memo(
+                        () => React.createElement("div", null),
+                      );
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const UnstableNestedComponent = React.memo(
+                        function () {
+                          return <div />;
+                        }
+                      );
+            
+                      return (
+                        <div>
+                          <UnstableNestedComponent />
+                        </div>
+                      );
+                    }
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    function ParentComponent() {
+                      const UnstableNestedComponent = React.memo(
+                        function () {
+                          return React.createElement("div", null);
+                        }
+                      );
+            
+                      return React.createElement(
+                        "div",
+                        null,
+                        React.createElement(UnstableNestedComponent, null)
+                      );
+                    }
+                  "#,
+            None,
+        ),
+    ];
+
+    Tester::new(NoUnstableNestedComponents::NAME, NoUnstableNestedComponents::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
+++ b/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
@@ -63,14 +63,8 @@ impl Default for NoUnstableNestedComponentsConfig {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct NoUnstableNestedComponents(Box<NoUnstableNestedComponentsConfig>);
-
-impl Default for NoUnstableNestedComponents {
-    fn default() -> Self {
-        Self(Box::new(NoUnstableNestedComponentsConfig::default()))
-    }
-}
 
 impl From<NoUnstableNestedComponentsConfig> for NoUnstableNestedComponents {
     fn from(config: NoUnstableNestedComponentsConfig) -> Self {
@@ -128,7 +122,7 @@ impl Rule for NoUnstableNestedComponents {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let Some(candidate) = self.component_candidate(node, ctx) else {
+        let Some(candidate) = Self::component_candidate(node, ctx) else {
             return;
         };
 
@@ -160,13 +154,12 @@ struct ComponentCandidate {
 
 impl NoUnstableNestedComponents {
     fn component_candidate<'a>(
-        &self,
         node: &AstNode<'a>,
         ctx: &LintContext<'a>,
     ) -> Option<ComponentCandidate> {
         match node.kind() {
-            AstKind::Function(func) => self.function_candidate(func, node, ctx),
-            AstKind::ArrowFunctionExpression(arrow) => self.arrow_candidate(arrow, node, ctx),
+            AstKind::Function(func) => Self::function_candidate(func, node, ctx),
+            AstKind::ArrowFunctionExpression(arrow) => Self::arrow_candidate(arrow, node, ctx),
             AstKind::Class(class) => class_candidate(class, node, ctx),
             AstKind::CallExpression(call) => hoc_call_candidate(call, node, ctx),
             _ => None,
@@ -174,7 +167,6 @@ impl NoUnstableNestedComponents {
     }
 
     fn function_candidate<'a>(
-        &self,
         func: &Function<'a>,
         node: &AstNode<'a>,
         ctx: &LintContext<'a>,
@@ -200,7 +192,6 @@ impl NoUnstableNestedComponents {
     }
 
     fn arrow_candidate<'a>(
-        &self,
         arrow: &ArrowFunctionExpression<'a>,
         node: &AstNode<'a>,
         ctx: &LintContext<'a>,
@@ -269,7 +260,24 @@ fn hoc_call_candidate<'a>(
     Some(ComponentCandidate { span: call.span, is_component_in_prop: false })
 }
 
-fn find_parent_component_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Option<String>> {
+enum ParentComponentName {
+    Named(String),
+    Anonymous,
+}
+
+impl ParentComponentName {
+    fn as_deref(&self) -> Option<&str> {
+        match self {
+            Self::Named(name) => Some(name),
+            Self::Anonymous => None,
+        }
+    }
+}
+
+fn find_parent_component_name(
+    node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+) -> Option<ParentComponentName> {
     for ancestor_id in ctx.nodes().ancestor_ids(node.id()).filter(|&id| id != node.id()) {
         let ancestor = ctx.nodes().get_node(ancestor_id);
         match ancestor.kind() {
@@ -283,13 +291,13 @@ fn find_parent_component_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Opti
 
                 if let Some(name) = function_name(func, ancestor, ctx) {
                     if is_react_component_name(&name) {
-                        return Some(Some(name));
+                        return Some(ParentComponentName::Named(name));
                     }
                     continue;
                 }
 
                 if is_anonymous_default_export(ancestor, ctx) {
-                    return Some(None);
+                    return Some(ParentComponentName::Anonymous);
                 }
             }
             AstKind::ArrowFunctionExpression(arrow) => {
@@ -301,13 +309,13 @@ fn find_parent_component_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Opti
 
                 if let Some(name) = function_like_name(ancestor, ctx) {
                     if is_react_component_name(&name) {
-                        return Some(Some(name));
+                        return Some(ParentComponentName::Named(name));
                     }
                     continue;
                 }
 
                 if is_anonymous_default_export(ancestor, ctx) {
-                    return Some(None);
+                    return Some(ParentComponentName::Anonymous);
                 }
             }
             AstKind::Class(class) => {
@@ -315,7 +323,7 @@ fn find_parent_component_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Opti
                     && let Some(name) = class_name(class, ancestor, ctx)
                     && is_react_component_name(&name)
                 {
-                    return Some(Some(name));
+                    return Some(ParentComponentName::Named(name));
                 }
             }
             AstKind::CallExpression(call) => {
@@ -323,7 +331,7 @@ fn find_parent_component_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Opti
                     && let Some(name) = function_like_name(ancestor, ctx)
                     && is_react_component_name(&name)
                 {
-                    return Some(Some(name));
+                    return Some(ParentComponentName::Named(name));
                 }
             }
             _ => {}
@@ -491,7 +499,10 @@ fn is_map_callback(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
         return false;
     };
 
-    if call.callee.as_member_expression().and_then(|member| member.static_property_name())
+    if call
+        .callee
+        .as_member_expression()
+        .and_then(oxc_ast::ast::MemberExpression::static_property_name)
         != Some("map")
     {
         return false;

--- a/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
+++ b/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
@@ -2,8 +2,9 @@ use fast_glob::glob_match;
 use oxc_ast::{
     AstKind,
     ast::{
-        Argument, ArrowFunctionExpression, CallExpression, Class, Expression, Function,
-        JSXAttributeName, JSXExpression, JSXExpressionContainer, ObjectProperty, PropertyKey,
+        Argument, ArrowFunctionExpression, AssignmentTarget, CallExpression, Class, Expression,
+        Function, JSXAttributeName, JSXExpression, JSXExpressionContainer, ObjectProperty,
+        PropertyKey,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -240,6 +241,11 @@ fn class_candidate<'a>(
         return None;
     }
 
+    let is_component_in_prop = is_component_declared_in_prop(node, ctx);
+    if is_component_in_prop {
+        return Some(ComponentCandidate { span: class.span, is_component_in_prop });
+    }
+
     let name = class_name(class, node, ctx)?;
     if is_react_component_name(&name) {
         Some(ComponentCandidate { span: class.span, is_component_in_prop: false })
@@ -253,11 +259,14 @@ fn hoc_call_candidate<'a>(
     node: &AstNode<'a>,
     ctx: &LintContext<'a>,
 ) -> Option<ComponentCandidate> {
-    let name = function_like_name(node, ctx)?;
-    if !is_react_component_name(&name) || !is_hoc_component_call(call, ctx) {
+    if is_first_argument_of_hoc_call(node, ctx) || !is_hoc_component_call(call, ctx) {
         return None;
     }
-    Some(ComponentCandidate { span: call.span, is_component_in_prop: false })
+
+    Some(ComponentCandidate {
+        span: call.span,
+        is_component_in_prop: is_component_declared_in_prop(node, ctx),
+    })
 }
 
 enum ParentComponentName {
@@ -327,12 +336,24 @@ fn find_parent_component_name(
                 }
             }
             AstKind::CallExpression(call) => {
-                if is_hoc_component_call(call, ctx)
-                    && let Some(name) = function_like_name(ancestor, ctx)
+                if is_first_argument_of_hoc_call(ancestor, ctx) || !is_hoc_component_call(call, ctx)
+                {
+                    continue;
+                }
+
+                if let Some(name) = function_like_name(ancestor, ctx)
                     && is_react_component_name(&name)
                 {
                     return Some(ParentComponentName::Named(name));
                 }
+
+                if let Some(name) = hoc_first_argument_name(call)
+                    && is_react_component_name(&name)
+                {
+                    return Some(ParentComponentName::Named(name));
+                }
+
+                return Some(ParentComponentName::Anonymous);
             }
             _ => {}
         }
@@ -351,6 +372,24 @@ fn function_like_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Strin
             decl.id.get_identifier_name().map(|name| name.to_string())
         }
         AstKind::ObjectProperty(prop) => static_property_name(prop).map(ToString::to_string),
+        AstKind::AssignmentExpression(assign) => assignment_target_name(&assign.left),
+        _ => None,
+    }
+}
+
+fn assignment_target_name(target: &AssignmentTarget<'_>) -> Option<String> {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(ident) => Some(ident.name.to_string()),
+        AssignmentTarget::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        _ => None,
+    }
+}
+
+fn hoc_first_argument_name(call: &CallExpression<'_>) -> Option<String> {
+    let first_arg = call.arguments.first()?;
+    match first_arg {
+        Argument::FunctionExpression(func) => func.id.as_ref().map(|id| id.name.to_string()),
+        Argument::CallExpression(call) => hoc_first_argument_name(call),
         _ => None,
     }
 }
@@ -395,7 +434,7 @@ fn is_in_jsx_attribute_expression(node: &AstNode<'_>, ctx: &LintContext<'_>) -> 
                 return matches!(parent.kind(), AstKind::JSXAttribute(_));
             }
             AstKind::JSXElement(_) | AstKind::JSXFragment(_) => return false,
-            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) | AstKind::Class(_)
                 if ancestor.id() != previous_id =>
             {
                 return false;
@@ -547,17 +586,18 @@ fn is_first_argument_of_hoc_call(node: &AstNode<'_>, ctx: &LintContext<'_>) -> b
 
 fn is_hoc_component_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
     get_hoc_callee_name(call).is_some_and(|name| is_hoc_call(&name, ctx))
-        && call.arguments.first().is_some_and(argument_contains_jsx)
+        && call.arguments.first().is_some_and(|arg| argument_contains_jsx(arg, ctx))
 }
 
 fn get_hoc_callee_name(call: &CallExpression<'_>) -> Option<String> {
     call.callee_name().map(ToString::to_string)
 }
 
-fn argument_contains_jsx(arg: &Argument<'_>) -> bool {
+fn argument_contains_jsx(arg: &Argument<'_>, ctx: &LintContext<'_>) -> bool {
     match arg {
         Argument::FunctionExpression(func) => function_contains_jsx(func),
         Argument::ArrowFunctionExpression(arrow) => function_body_contains_jsx(&arrow.body),
+        Argument::CallExpression(call) => is_hoc_component_call(call, ctx),
         _ => arg.as_expression().is_some_and(expression_contains_jsx),
     }
 }
@@ -1162,6 +1202,30 @@ fn test() {
                     }
                   ",
             Some(serde_json::json!([{ "propNamePattern": "*Renderer", }])),
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return <SomeComponent footer={React.memo(() => <div />)} />;
+                    }
+                  ",
+            Some(serde_json::json!([{ "allowAsProps": true, }])),
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <SomeComponent
+                          footer={class Footer extends React.Component {
+                            render() {
+                              return <div />;
+                            }
+                          }}
+                        />
+                      );
+                    }
+                  ",
+            Some(serde_json::json!([{ "allowAsProps": true, }])),
         ),
     ];
 
@@ -1796,6 +1860,57 @@ fn test() {
                       );
                     }
                   "#,
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      NestedComponent = () => <div />;
+                      return <NestedComponent />;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      const UnstableNestedComponent = React.memo(React.forwardRef(() => <div />));
+                      return <UnstableNestedComponent />;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    export default React.forwardRef(function ParentComponent() {
+                      const UnstableNestedComponent = () => <div />;
+                      return <UnstableNestedComponent />;
+                    });
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return <SomeComponent footer={React.memo(() => <div />)} />;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    function ParentComponent() {
+                      return (
+                        <SomeComponent
+                          footer={class Footer extends React.Component {
+                            render() {
+                              return <div />;
+                            }
+                          }}
+                        />
+                      );
+                    }
+                  ",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
+++ b/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
@@ -2,9 +2,8 @@ use fast_glob::glob_match;
 use oxc_ast::{
     AstKind,
     ast::{
-        Argument, ArrowFunctionExpression, AssignmentTarget, CallExpression, Class, Expression,
-        Function, JSXAttributeName, JSXExpression, JSXExpressionContainer, ObjectProperty,
-        PropertyKey,
+        Argument, ArrowFunctionExpression, CallExpression, Class, Function, JSXAttributeName,
+        JSXExpression, JSXExpressionContainer,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -20,7 +19,8 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
     utils::{
         expression_contains_jsx, function_body_contains_jsx, function_contains_jsx,
-        is_create_element_call, is_hoc_call, is_react_component_name, is_react_hook,
+        is_create_element_call, is_es6_component, is_hoc_call, is_react_component_name,
+        is_react_hook,
     },
 };
 
@@ -123,23 +123,29 @@ impl Rule for NoUnstableNestedComponents {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let Some(candidate) = Self::component_candidate(node, ctx) else {
-            return;
-        };
-
-        if self.should_ignore_candidate(node, ctx, candidate.is_component_in_prop) {
-            return;
+        match node.kind() {
+            AstKind::Function(func) => {
+                if let Some(candidate) = Self::function_candidate(func, node, ctx) {
+                    self.report_candidate(node, ctx, candidate);
+                }
+            }
+            AstKind::ArrowFunctionExpression(arrow) => {
+                if let Some(candidate) = Self::arrow_candidate(arrow, node, ctx) {
+                    self.report_candidate(node, ctx, candidate);
+                }
+            }
+            AstKind::Class(class) => {
+                if let Some(candidate) = class_candidate(class, node, ctx) {
+                    self.report_candidate(node, ctx, candidate);
+                }
+            }
+            AstKind::CallExpression(call) => {
+                if let Some(candidate) = hoc_call_candidate(call, node, ctx) {
+                    self.report_candidate(node, ctx, candidate);
+                }
+            }
+            _ => {}
         }
-
-        let Some(parent_name) = find_parent_component_name(node, ctx) else {
-            return;
-        };
-
-        ctx.diagnostic(no_unstable_nested_components_diagnostic(
-            candidate.span,
-            parent_name.as_deref(),
-            candidate.is_component_in_prop && !self.0.allow_as_props,
-        ));
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
@@ -154,17 +160,25 @@ struct ComponentCandidate {
 }
 
 impl NoUnstableNestedComponents {
-    fn component_candidate<'a>(
+    fn report_candidate<'a>(
+        &self,
         node: &AstNode<'a>,
         ctx: &LintContext<'a>,
-    ) -> Option<ComponentCandidate> {
-        match node.kind() {
-            AstKind::Function(func) => Self::function_candidate(func, node, ctx),
-            AstKind::ArrowFunctionExpression(arrow) => Self::arrow_candidate(arrow, node, ctx),
-            AstKind::Class(class) => class_candidate(class, node, ctx),
-            AstKind::CallExpression(call) => hoc_call_candidate(call, node, ctx),
-            _ => None,
+        candidate: ComponentCandidate,
+    ) {
+        if self.should_ignore_candidate(node, ctx, candidate.is_component_in_prop) {
+            return;
         }
+
+        let Some(parent_name) = find_parent_component_name(node, ctx) else {
+            return;
+        };
+
+        ctx.diagnostic(no_unstable_nested_components_diagnostic(
+            candidate.span,
+            parent_name.as_deref(),
+            candidate.is_component_in_prop && !self.0.allow_as_props,
+        ));
     }
 
     fn function_candidate<'a>(
@@ -237,7 +251,7 @@ fn class_candidate<'a>(
     node: &AstNode<'a>,
     ctx: &LintContext<'a>,
 ) -> Option<ComponentCandidate> {
-    if !is_es6_component_class(class) {
+    if !is_es6_component(node) {
         return None;
     }
 
@@ -328,7 +342,7 @@ fn find_parent_component_name(
                 }
             }
             AstKind::Class(class) => {
-                if is_es6_component_class(class)
+                if is_es6_component(ancestor)
                     && let Some(name) = class_name(class, ancestor, ctx)
                     && is_react_component_name(&name)
                 {
@@ -362,7 +376,7 @@ fn find_parent_component_name(
 }
 
 fn function_name(func: &Function<'_>, node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
-    func.id.as_ref().map(|id| id.name.to_string()).or_else(|| function_like_name(node, ctx))
+    func.name().map(|name| name.to_string()).or_else(|| function_like_name(node, ctx))
 }
 
 fn function_like_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
@@ -371,16 +385,10 @@ fn function_like_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Strin
         AstKind::VariableDeclarator(decl) => {
             decl.id.get_identifier_name().map(|name| name.to_string())
         }
-        AstKind::ObjectProperty(prop) => static_property_name(prop).map(ToString::to_string),
-        AstKind::AssignmentExpression(assign) => assignment_target_name(&assign.left),
-        _ => None,
-    }
-}
-
-fn assignment_target_name(target: &AssignmentTarget<'_>) -> Option<String> {
-    match target {
-        AssignmentTarget::AssignmentTargetIdentifier(ident) => Some(ident.name.to_string()),
-        AssignmentTarget::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        AstKind::ObjectProperty(prop) => prop.key.static_name().map(std::borrow::Cow::into_owned),
+        AstKind::AssignmentExpression(assign) => {
+            assign.left.get_identifier_name().map(ToString::to_string)
+        }
         _ => None,
     }
 }
@@ -388,22 +396,14 @@ fn assignment_target_name(target: &AssignmentTarget<'_>) -> Option<String> {
 fn hoc_first_argument_name(call: &CallExpression<'_>) -> Option<String> {
     let first_arg = call.arguments.first()?;
     match first_arg {
-        Argument::FunctionExpression(func) => func.id.as_ref().map(|id| id.name.to_string()),
+        Argument::FunctionExpression(func) => func.name().map(|name| name.to_string()),
         Argument::CallExpression(call) => hoc_first_argument_name(call),
         _ => None,
     }
 }
 
 fn class_name(class: &Class<'_>, node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<String> {
-    class.id.as_ref().map(|id| id.name.to_string()).or_else(|| function_like_name(node, ctx))
-}
-
-fn static_property_name<'a>(prop: &'a ObjectProperty<'a>) -> Option<&'a str> {
-    match &prop.key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
-        PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
-        _ => None,
-    }
+    class.name().map(|name| name.to_string()).or_else(|| function_like_name(node, ctx))
 }
 
 fn is_anonymous_default_export(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
@@ -507,7 +507,7 @@ fn direct_object_property_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Opt
     let AstKind::ObjectProperty(prop) = parent.kind() else {
         return None;
     };
-    static_property_name(prop).map(ToString::to_string)
+    prop.key.static_name().map(std::borrow::Cow::into_owned)
 }
 
 fn is_direct_jsx_child_render_prop(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
@@ -547,17 +547,7 @@ fn is_map_callback(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
         return false;
     }
 
-    call.arguments.first().is_some_and(|arg| argument_span(arg) == Some(node.kind().span()))
-}
-
-fn argument_span(arg: &Argument<'_>) -> Option<Span> {
-    match arg {
-        Argument::FunctionExpression(func) => Some(func.span),
-        Argument::ArrowFunctionExpression(arrow) => Some(arrow.span),
-        Argument::ClassExpression(class) => Some(class.span),
-        Argument::CallExpression(call) => Some(call.span),
-        _ => arg.as_expression().map(GetSpan::span),
-    }
+    call.arguments.first().is_some_and(|arg| arg.span() == node.kind().span())
 }
 
 fn is_return_statement_of_hook(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
@@ -581,16 +571,12 @@ fn is_first_argument_of_hoc_call(node: &AstNode<'_>, ctx: &LintContext<'_>) -> b
         return false;
     };
     is_hoc_component_call(call, ctx)
-        && call.arguments.first().is_some_and(|arg| argument_span(arg) == Some(node.kind().span()))
+        && call.arguments.first().is_some_and(|arg| arg.span() == node.kind().span())
 }
 
 fn is_hoc_component_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
-    get_hoc_callee_name(call).is_some_and(|name| is_hoc_call(&name, ctx))
+    call.callee_name().is_some_and(|name| is_hoc_call(name, ctx))
         && call.arguments.first().is_some_and(|arg| argument_contains_jsx(arg, ctx))
-}
-
-fn get_hoc_callee_name(call: &CallExpression<'_>) -> Option<String> {
-    call.callee_name().map(ToString::to_string)
 }
 
 fn argument_contains_jsx(arg: &Argument<'_>, ctx: &LintContext<'_>) -> bool {
@@ -600,22 +586,6 @@ fn argument_contains_jsx(arg: &Argument<'_>, ctx: &LintContext<'_>) -> bool {
         Argument::CallExpression(call) => is_hoc_component_call(call, ctx),
         _ => arg.as_expression().is_some_and(expression_contains_jsx),
     }
-}
-
-fn is_es6_component_class(class: &Class<'_>) -> bool {
-    class.super_class.as_ref().is_some_and(|super_class| {
-        if let Some(member_expr) = super_class.as_member_expression()
-            && let Expression::Identifier(ident) = member_expr.object()
-            && ident.name == "React"
-        {
-            return member_expr
-                .static_property_name()
-                .is_some_and(|name| matches!(name, "Component" | "PureComponent"));
-        }
-        super_class
-            .get_identifier_reference()
-            .is_some_and(|id| matches!(id.name.as_str(), "Component" | "PureComponent"))
-    })
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
@@ -419,3 +419,51 @@ assertion_line: 490
  8 │                 
    ╰────
   help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:41]
+ 2 │                     function ParentComponent() {
+ 3 │                       NestedComponent = () => <div />;
+   ·                                         ─────────────
+ 4 │                       return <NestedComponent />;
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:55]
+ 2 │                     function ParentComponent() {
+ 3 │                       const UnstableNestedComponent = React.memo(React.forwardRef(() => <div />));
+   ·                                                       ───────────────────────────────────────────
+ 4 │                       return <UnstableNestedComponent />;
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:55]
+ 2 │                     export default React.forwardRef(function ParentComponent() {
+ 3 │                       const UnstableNestedComponent = () => <div />;
+   ·                                                       ─────────────
+ 4 │                       return <UnstableNestedComponent />;
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:53]
+ 2 │                     function ParentComponent() {
+ 3 │                       return <SomeComponent footer={React.memo(() => <div />)} />;
+   ·                                                     ─────────────────────────
+ 4 │                     }
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+    ╭─[no_unstable_nested_components.tsx:5:35]
+  4 │                             <SomeComponent
+  5 │ ╭─▶                           footer={class Footer extends React.Component {
+  6 │ │                               render() {
+  7 │ │                                 return <div />;
+  8 │ │                               }
+  9 │ ╰─▶                           }}
+ 10 │                             />
+    ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

--- a/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
@@ -1,0 +1,421 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       function UnstableNestedFunctionComponent() {
+ 4 │ │                           return <div />;
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       function UnstableNestedFunctionComponent() {
+ 4 │ │                           return React.createElement("div", null);
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:63]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       const UnstableNestedVariableComponent = () => {
+ 4 │ │                           return <div />;
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:63]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       const UnstableNestedVariableComponent = () => {
+ 4 │ │                           return React.createElement("div", null);
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         const ParentComponent = () => {
+ 3 │ ╭─▶                       function UnstableNestedFunctionComponent() {
+ 4 │ │                           return <div />;
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         const ParentComponent = () => {
+ 3 │ ╭─▶                       function UnstableNestedFunctionComponent() {
+ 4 │ │                           return React.createElement("div", null);
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         export default () => {
+ 3 │ ╭─▶                       function UnstableNestedFunctionComponent() {
+ 4 │ │                           return <div />;
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         export default () => {
+ 3 │ ╭─▶                       function UnstableNestedFunctionComponent() {
+ 4 │ │                           return React.createElement("div", null);
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:63]
+ 2 │                         const ParentComponent = () => {
+ 3 │ ╭─▶                       const UnstableNestedVariableComponent = () => {
+ 4 │ │                           return <div />;
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:63]
+ 2 │                         const ParentComponent = () => {
+ 3 │ ╭─▶                       const UnstableNestedVariableComponent = () => {
+ 4 │ │                           return React.createElement("div", null);
+ 5 │ ╰─▶                       }
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       class UnstableNestedClassComponent extends React.Component {
+ 4 │ │                           render() {
+ 5 │ │                             return <div />;
+ 6 │ │                           }
+ 7 │ ╰─▶                       };
+ 8 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:23]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       class UnstableNestedClassComponent extends React.Component {
+ 4 │ │                           render() {
+ 5 │ │                             return React.createElement("div", null);
+ 6 │ │                           }
+ 7 │ ╰─▶                       }
+ 8 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:25]
+ 3 │                           render() {
+ 4 │ ╭─▶                         class UnstableNestedClassComponent extends React.Component {
+ 5 │ │                             render() {
+ 6 │ │                               return <div />;
+ 7 │ │                             }
+ 8 │ ╰─▶                         };
+ 9 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:25]
+ 3 │                           render() {
+ 4 │ ╭─▶                         class UnstableNestedClassComponent extends React.Component {
+ 5 │ │                             render() {
+ 6 │ │                               return React.createElement("div", null);
+ 7 │ │                             }
+ 8 │ ╰─▶                         }
+ 9 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:25]
+ 3 │                           render() {
+ 4 │ ╭─▶                         function UnstableNestedFunctionComponent() {
+ 5 │ │                             return <div />;
+ 6 │ ╰─▶                         }
+ 7 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:25]
+ 3 │                           render() {
+ 4 │ ╭─▶                         function UnstableNestedClassComponent() {
+ 5 │ │                             return React.createElement("div", null);
+ 6 │ ╰─▶                         }
+ 7 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:65]
+ 3 │                           render() {
+ 4 │ ╭─▶                         const UnstableNestedVariableComponent = () => {
+ 5 │ │                             return <div />;
+ 6 │ ╰─▶                         }
+ 7 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:62]
+ 3 │                           render() {
+ 4 │ ╭─▶                         const UnstableNestedClassComponent = () => {
+ 5 │ │                             return React.createElement("div", null);
+ 6 │ ╰─▶                         }
+ 7 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:25]
+ 3 │                           function getComponent() {
+ 4 │ ╭─▶                         function NestedUnstableFunctionComponent() {
+ 5 │ │                             return <div />;
+ 6 │ ╰─▶                         };
+ 7 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:25]
+ 3 │                           function getComponent() {
+ 4 │ ╭─▶                         function NestedUnstableFunctionComponent() {
+ 5 │ │                             return React.createElement("div", null);
+ 6 │ ╰─▶                         }
+ 7 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+    ╭─[no_unstable_nested_components.tsx:10:29]
+  9 │                               footer={
+ 10 │ ╭─▶                             function SomeFooter() {
+ 11 │ │                                 return <div />;
+ 12 │ ╰─▶                             }
+ 13 │                               } />
+    ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+    ╭─[no_unstable_nested_components.tsx:8:33]
+  7 │                           return React.createElement(ComponentWithProps, {
+  8 │ ╭─▶                         footer: function SomeFooter() {
+  9 │ │                             return React.createElement("div", null);
+ 10 │ ╰─▶                         }
+ 11 │                           });
+    ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:8:55]
+ 7 │                         return (
+ 8 │                           <ComponentWithProps footer={() => <div />} />
+   ·                                                       ─────────────
+ 9 │                         );
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:8:33]
+ 7 │                       return React.createElement(ComponentWithProps, {
+ 8 │                         footer: () => React.createElement("div", null)
+   ·                                 ──────────────────────────────────────
+ 9 │                       });
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:6:31]
+ 5 │                                 {() => {
+ 6 │ ╭─▶                               function UnstableNestedComponent() {
+ 7 │ │                                   return <div />;
+ 8 │ ╰─▶                               }
+ 9 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+    ╭─[no_unstable_nested_components.tsx:11:27]
+ 10 │                             () => {
+ 11 │ ╭─▶                           function UnstableNestedComponent() {
+ 12 │ │                               return React.createElement("div", null);
+ 13 │ ╰─▶                           }
+ 14 │                 
+    ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:8:67]
+ 7 │                       return (
+ 8 │                         <ComponentForProps notPrefixedWithRender={() => <div />} />
+   ·                                                                   ─────────────
+ 9 │                       );
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:8:48]
+ 7 │                       return React.createElement(ComponentForProps, {
+ 8 │                         notPrefixedWithRender: () => React.createElement("div", null)
+   ·                                                ──────────────────────────────────────
+ 9 │                       });
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:63]
+ 3 │                       return (
+ 4 │                         <ComponentForProps someMap={{ Header: () => <div /> }} />
+   ·                                                               ─────────────
+ 5 │                       );
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+    ╭─[no_unstable_nested_components.tsx:4:38]
+  3 │                           render() {
+  4 │ ╭─▶                         const List = (props) => {
+  5 │ │                             const items = props.items
+  6 │ │                               .map((item) => (
+  7 │ │                                 <li key={item.key}>
+  8 │ │                                   <span>{item.name}</span>
+  9 │ │                                 </li>
+ 10 │ │                               ));
+ 11 │ │               
+ 12 │ │                             return <ul>{items}</ul>;
+ 13 │ ╰─▶                         };
+ 14 │                 
+    ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:7:38]
+ 6 │                           thing.match({
+ 7 │                             loading: () => <div />,
+   ·                                      ─────────────
+ 8 │                             success: () => <div />,
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:8:38]
+ 7 │                             loading: () => <div />,
+ 8 │                             success: () => <div />,
+   ·                                      ─────────────
+ 9 │                             failure: () => <div />,
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+    ╭─[no_unstable_nested_components.tsx:9:38]
+  8 │                             success: () => <div />,
+  9 │                             failure: () => <div />,
+    ·                                      ─────────────
+ 10 │                           })
+    ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:4:32]
+ 3 │                     const thingElement = thing.match({
+ 4 │                       loading: () => <div />,
+   ·                                ─────────────
+ 5 │                       success: () => <div />,
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:5:32]
+ 4 │                       loading: () => <div />,
+ 5 │                       success: () => <div />,
+   ·                                ─────────────
+ 6 │                       failure: () => <div />,
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:6:32]
+ 5 │                       success: () => <div />,
+ 6 │                       failure: () => <div />,
+   ·                                ─────────────
+ 7 │                     });
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:6:48]
+ 5 │                         name: 'A',
+ 6 │                         notPrefixedWithRender: (props) => <Row {...props} />
+   ·                                                ─────────────────────────────
+ 7 │                       },
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:55]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       const UnstableNestedComponent = React.memo(() => {
+ 4 │ │                           return <div />;
+ 5 │ ╰─▶                       });
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:55]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       const UnstableNestedComponent = React.memo(
+ 4 │ │                           () => React.createElement("div", null),
+ 5 │ ╰─▶                       );
+ 6 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:55]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       const UnstableNestedComponent = React.memo(
+ 4 │ │                           function () {
+ 5 │ │                             return <div />;
+ 6 │ │                           }
+ 7 │ ╰─▶                       );
+ 8 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:3:55]
+ 2 │                         function ParentComponent() {
+ 3 │ ╭─▶                       const UnstableNestedComponent = React.memo(
+ 4 │ │                           function () {
+ 5 │ │                             return React.createElement("div", null);
+ 6 │ │                           }
+ 7 │ ╰─▶                       );
+ 8 │                 
+   ╰────
+  help: Move this component definition out of the parent component `ParentComponent` and pass data as props.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1558,6 +1558,9 @@
         "react/no-unsafe": {
           "$ref": "#/definitions/DummyRule"
         },
+        "react/no-unstable-nested-components": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "react/no-will-update-set-state": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1562,6 +1562,9 @@ expression: json
         "react/no-unsafe": {
           "$ref": "#/definitions/DummyRule"
         },
+        "react/no-unstable-nested-components": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "react/no-will-update-set-state": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
Contributes to https://github.com/oxc-project/oxc/issues/1022

This implements the [react/no-unstable-nested-components](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unstable-nested-components.nd) rule.

> [!NOTE]
> This PR was authored by an LLM (GPT5.5) and reviewed by me