### PR TITLE
chore(tasks): enable `enum_eval` for transformer-fed semantic builders

### DIFF
--- a/tasks/benchmark/benches/codegen.rs
+++ b/tasks/benchmark/benches/codegen.rs
@@ -19,7 +19,8 @@ fn bench_codegen(criterion: &mut Criterion) {
         assert!(parser_ret.errors.is_empty());
         let mut program = parser_ret.program;
 
-        let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+        let scoping =
+            SemanticBuilder::new().with_enum_eval(true).build(&program).semantic.into_scoping();
 
         let transform_options = TransformOptions::enable_all();
         let transformer_ret =

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -29,7 +29,11 @@ fn bench_minifier(criterion: &mut Criterion) {
 
                 // Create fresh AST + semantic data for each iteration
                 let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+                let scoping = SemanticBuilder::new()
+                    .with_enum_eval(true)
+                    .build(&program)
+                    .semantic
+                    .into_scoping();
 
                 // Minifier only works on esnext.
                 let transform_options = TransformOptions::from_target("esnext").unwrap();

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -43,6 +43,7 @@ fn bench_pipeline(criterion: &mut Criterion) {
                     // Semantic
                     let scoping = SemanticBuilder::new()
                         .with_excess_capacity(2.0)
+                        .with_enum_eval(true)
                         .build(&program)
                         .semantic
                         .into_scoping();

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -36,6 +36,7 @@ fn bench_transformer(criterion: &mut Criterion) {
                 let scoping = SemanticBuilder::new()
                     // Estimate transformer will triple scopes, symbols, references
                     .with_excess_capacity(2.0)
+                    .with_enum_eval(true)
                     .build(&program)
                     .semantic
                     .into_scoping();

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -153,7 +153,11 @@ pub fn run() -> Result<(), io::Error> {
         assert!(parsed.errors.is_empty());
 
         // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
-        let scoping = SemanticBuilder::new().build(&parsed.program).semantic.into_scoping();
+        let scoping = SemanticBuilder::new()
+            .with_enum_eval(true)
+            .build(&parsed.program)
+            .semantic
+            .into_scoping();
         let transform_options = TransformOptions::from_target("esnext").unwrap();
         let _ =
             Transformer::new(&allocator, std::path::Path::new(&file.file_name), &transform_options)
@@ -194,7 +198,11 @@ pub fn run() -> Result<(), io::Error> {
         ));
 
         let (scoping, semantic_stats) = record_stats_in(&allocator, || {
-            SemanticBuilder::new().build(&parsed.program).semantic.into_scoping()
+            SemanticBuilder::new()
+                .with_enum_eval(true)
+                .build(&parsed.program)
+                .semantic
+                .into_scoping()
         });
 
         semantic_out.push_str(&format_table_row(


### PR DESCRIPTION
Pre-requisite for #22252.

## Why

#22252 adds a `debug_assert!` in the transformer that requires `Scoping` to be built with `SemanticBuilder::with_enum_eval(true)` whenever a `TSEnumDeclaration` reaches the transform pass. The internal `Compiler` (`crates/oxc/src/compiler.rs`) and the playground already enable it; the CI run on #22252 surfaced a few internal callers that don't.

Land that fix on its own first, so the assert PR doesn't trip CI on these tasks.

## Sites updated

Every `SemanticBuilder` site that feeds `Transformer::build_with_scoping`:

- `tasks/track_memory_allocations/src/lib.rs` — both call sites (`cargo allocs`).
- `tasks/benchmark/benches/transformer.rs`
- `tasks/benchmark/benches/pipeline.rs`
- `tasks/benchmark/benches/minifier.rs`
- `tasks/benchmark/benches/codegen.rs`

Other semantic builders in these files that feed only the minifier / codegen / compressor are left alone — they don't go through enum lowering.

## Test plan

- [x] `cargo check -p oxc_track_memory_allocations` — clean
- [x] `cargo check --benches -p oxc_benchmark` — clean
