### PR TITLE
docs(linter/forbid-dom-props): escape jsx examples in lint rule docs

### DIFF
--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -113,7 +113,7 @@ pub struct ForbidDomPropsConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule prevents passing of props to elements. This rule only applies to DOM Nodes (e.g. <div />) and not Components (e.g. <Component />). The list of forbidden props can be customized with the forbid option.
+    /// This rule prevents passing of props to elements. This rule only applies to DOM Nodes (e.g. `<div />`) and not Components (e.g. `<Component />`). The list of forbidden props can be customized with the forbid option.
     ///
     /// ### Why is this bad?
     ///

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -1572,7 +1572,7 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 
 ### What it does
 
-This rule prevents passing of props to elements. This rule only applies to DOM Nodes (e.g. <div />) and not Components (e.g. <Component />). The list of forbidden props can be customized with the forbid option.
+This rule prevents passing of props to elements. This rule only applies to DOM Nodes (e.g. `<div />`) and not Components (e.g. `<Component />`). The list of forbidden props can be customized with the forbid option.
 
 ### Why is this bad?
 


### PR DESCRIPTION
## [Before](https://oxc.rs/docs/guide/usage/linter/rules/react/forbid-dom-props)

<img width="1076" height="426" alt="image" src="https://github.com/user-attachments/assets/d7a509db-2088-4d2a-a970-cb5005b47537" />

## After

<img width="1085" height="334" alt="image" src="https://github.com/user-attachments/assets/9989b55d-2fdd-4913-b524-6092e4aa08be" />