### PR TITLE
fix(linter): move `no-debugger` fix to suggestion

### DIFF
--- a/apps/oxlint/fixtures/cli/fix_argument/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/fix_argument/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "categories": {
+    "correctness": "off",
+  },
+  "rules": {
+    "no-new-wrappers": "error",
+    "no-debugger": "error",
+  }
+}

--- a/apps/oxlint/fixtures/cli/fix_argument/fix.js
+++ b/apps/oxlint/fixtures/cli/fix_argument/fix.js
@@ -1,1 +1,1 @@
-debugger
+var x = new String('Hello world');

--- a/apps/oxlint/fixtures/cli/fix_argument/fix.vue
+++ b/apps/oxlint/fixtures/cli/fix_argument/fix.vue
@@ -1,2 +1,2 @@
-<script>debugger;</script>
-<script>debugger;</script>
+<script>var x = new String('Hello world');</script>
+<script>var y = new String('Hello world');</script>

--- a/apps/oxlint/fixtures/cli/fix_argument/skip_suggestion.js
+++ b/apps/oxlint/fixtures/cli/fix_argument/skip_suggestion.js
@@ -1,0 +1,1 @@
+debugger

--- a/apps/oxlint/fixtures/cli/fix_argument/skip_suggestion.vue
+++ b/apps/oxlint/fixtures/cli/fix_argument/skip_suggestion.vue
@@ -1,0 +1,2 @@
+<script>debugger;</script>
+<script>debugger;</script>

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1081,12 +1081,26 @@ mod test {
 
     #[test]
     fn test_fix() {
-        Tester::test_fix("fixtures/cli/fix_argument/fix.js", "debugger\n", "\n");
-        Tester::test_fix(
-            "fixtures/cli/fix_argument/fix.vue",
-            "<script>debugger;</script>\n<script>debugger;</script>\n",
-            "<script></script>\n<script></script>\n",
+        let tester = Tester::new().with_cwd("fixtures/cli/fix_argument".into());
+        tester.test_fix(
+            "fix.js",
+            "var x = new String('Hello world');\n",
+            "var x = 'Hello world';\n",
         );
+        tester.test_fix(
+            "fix.vue",
+            "<script>var x = new String('Hello world');</script>\n<script>var y = new String('Hello world');</script>\n",
+            "<script>var x = 'Hello world';</script>\n<script>var y = 'Hello world';</script>\n",
+        );
+    }
+
+    #[test]
+    fn test_fix_skip_suggestion() {
+        let tester = Tester::new().with_cwd("fixtures/cli/fix_argument".into());
+        let test_1 = "debugger\n";
+        tester.test_fix("skip_suggestion.js", test_1, test_1);
+        let test_2 = "<script>debugger;</script>\n<script>debugger;</script>\n";
+        tester.test_fix("skip_suggestion.vue", test_2, test_2);
     }
 
     #[test]
@@ -1676,7 +1690,7 @@ mod test {
     #[test]
     #[cfg(all(not(target_os = "windows"), not(target_endian = "big")))]
     fn test_tsgolint_fix() {
-        Tester::test_fix_with_args(
+        Tester::new().test_fix_with_args(
             "fixtures/cli/tsgolint_fix/fix.ts",
             "// This file has a fixable tsgolint error: no-unnecessary-type-assertion
 // The type assertion `as string` is unnecessary because str is already a string

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=sarif test.js@oxlint.snap
@@ -24,7 +24,7 @@ working directory: fixtures/cli/output_formatter_diagnostic
               "properties": {
                 "category": "correctness",
                 "plugin": "eslint",
-                "fix": "fixable_fix"
+                "fix": "fixable_suggestion"
               }
             },
             {

--- a/apps/oxlint/src/tester.rs
+++ b/apps/oxlint/src/tester.rs
@@ -54,36 +54,38 @@ impl Tester {
         String::from_utf8(output).unwrap()
     }
 
-    pub fn test_fix(file: &str, before: &str, after: &str) {
-        Self::test_fix_with_args(file, before, after, &[]);
+    pub fn test_fix(&self, file: &str, before: &str, after: &str) {
+        self.test_fix_with_args(file, before, after, &[]);
     }
 
     /// Test fix with additional CLI arguments (e.g., `--type-aware` for tsgolint)
-    pub fn test_fix_with_args(file: &str, before: &str, after: &str, extra_args: &[&str]) {
+    pub fn test_fix_with_args(&self, file: &str, before: &str, after: &str, extra_args: &[&str]) {
         use std::fs;
+        let path = self.cwd.join(file);
+
         #[expect(clippy::disallowed_methods)]
-        let content_original = fs::read_to_string(file).unwrap().replace("\r\n", "\n");
+        let content_original = fs::read_to_string(&path).unwrap().replace("\r\n", "\n");
         assert_eq!(content_original, before);
 
         let mut args = vec!["--fix"];
         args.extend(extra_args);
         args.push(file);
-        Tester::new().test(&args);
+        self.test(&args);
 
         #[expect(clippy::disallowed_methods)]
-        let new_content = fs::read_to_string(file).unwrap().replace("\r\n", "\n");
+        let new_content = fs::read_to_string(&path).unwrap().replace("\r\n", "\n");
         assert_eq!(new_content, after);
 
-        Tester::new().test(&args);
+        self.test(&args);
 
         // File should not be modified if no fix is applied.
         let modified_before: std::time::SystemTime =
-            fs::metadata(file).unwrap().modified().unwrap();
-        let modified_after = fs::metadata(file).unwrap().modified().unwrap();
+            fs::metadata(&path).unwrap().modified().unwrap();
+        let modified_after = fs::metadata(&path).unwrap().modified().unwrap();
         assert_eq!(modified_before, modified_after);
 
         // Write the file back.
-        fs::write(file, before).unwrap();
+        fs::write(&path, before).unwrap();
     }
 
     pub fn test_and_snapshot(&self, args: &[&str]) {

--- a/apps/oxlint/test/lsp/code_action/__snapshots__/code_action.test.ts.snap
+++ b/apps/oxlint/test/lsp/code_action/__snapshots__/code_action.test.ts.snap
@@ -281,11 +281,5 @@ debugger;
 
 --- Code Actions ---------
 
-Title : fix all fixable oxlint issues
-Preferred: Yes
-Resulting Content:
-
-
-
 --------------------"
 `;

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -45,14 +45,15 @@ declare_oxc_lint!(
     NoDebugger,
     eslint,
     correctness,
-    fix,
+    suggestion,
     version = "0.0.3",
 );
 
 impl Rule for NoDebugger {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::DebuggerStatement(stmt) = node.kind() {
-            ctx.diagnostic_with_fix(no_debugger_diagnostic(stmt.span), |fixer| {
+            // mark the fix as a suggestion, so that it won't be applied automatically by the editor auto-fix on save feature
+            ctx.diagnostic_with_suggestion(no_debugger_diagnostic(stmt.span), |fixer| {
                 let Some(parent) = ctx
                     .nodes()
                     .ancestors(node.id())


### PR DESCRIPTION
`console.log` and `debugger;` are utils while developing. 
`console.log` is already a suggestion (aligned with ESLint), but `no-debugger` would be autofixed too.
ESLint does not have a fixer for his rule, but we do.

This is a part of #22195, where do not autofix suggestions on the editor side, aligning with ESLint.
`debugger;` should not be autofixed on save. 