### PR TITLE
perf(oxfmt)!: Avoid config pre-scan

### DIFF
--- a/apps/oxfmt/src/cli/resolve.rs
+++ b/apps/oxfmt/src/cli/resolve.rs
@@ -1,10 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
-#[cfg(feature = "napi")]
-use crate::core::JsConfigLoaderCb;
-use crate::core::{ConfigResolver, utils::normalize_relative_path};
+use crate::core::{ConfigResolver, DiscoveryCtx, utils::normalize_relative_path};
 
 /// Resolve ignore file paths from CLI args or defaults.
 ///
@@ -107,34 +108,29 @@ pub(super) fn is_ignored(
     false
 }
 
-/// Resolve the nearest config scope for a file target.
-/// Returns `None` if the file belongs to the root scope.
+/// Resolve the nearest config scope for an explicit file target. Falls back to root.
+///
+/// Reaching `root_config_resolver.config_dir()` returns the pre-built root
+/// resolver directly — re-loading via the shared cache would create a
+/// duplicate `Arc` and (for JS root configs) re-invoke the NAPI loader.
 pub(super) fn resolve_file_scope_config(
     file: &Path,
-    root_config_dir: Option<&Path>,
-    editorconfig_path: Option<&Path>,
-    #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
-) -> Result<Option<ConfigResolver>, String> {
+    root_config_resolver: &Arc<ConfigResolver>,
+    ctx: &DiscoveryCtx,
+) -> Result<Arc<ConfigResolver>, String> {
     let Some(parent) = file.parent() else {
-        return Ok(None);
+        return Ok(Arc::clone(root_config_resolver));
     };
+    let root_config_dir = root_config_resolver.config_dir();
 
-    let mut resolver = ConfigResolver::from_config(
-        parent,
-        None,
-        editorconfig_path,
-        #[cfg(feature = "napi")]
-        js_config_loader,
-    )
-    .map_err(|err| format!("Failed to load config for {}: {err}", file.display()))?;
-
-    // No config found, or same as root → belongs to root scope
-    if resolver.config_dir().is_none() || resolver.config_dir() == root_config_dir {
-        return Ok(None);
+    for dir in parent.ancestors() {
+        if Some(dir) == root_config_dir {
+            return Ok(Arc::clone(root_config_resolver));
+        }
+        if let Some(r) = ctx.probe_dir(dir)? {
+            return Ok(r);
+        }
     }
 
-    resolver
-        .build_and_validate()
-        .map_err(|err| format!("Failed to parse config for {}: {err}", file.display()))?;
-    Ok(Some(resolver))
+    Ok(Arc::clone(root_config_resolver))
 }

--- a/apps/oxfmt/src/cli/stdin_runner.rs
+++ b/apps/oxfmt/src/cli/stdin_runner.rs
@@ -12,8 +12,8 @@ use super::{
     },
 };
 use crate::core::{
-    ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, ResolveOutcome,
-    SourceFormatter, classify_file_kind, resolve_editorconfig_path, utils,
+    ConfigResolver, DiscoveryCtx, ExternalFormatter, FormatResult, JsConfigLoaderCb,
+    ResolveOutcome, SourceFormatter, classify_file_kind, resolve_editorconfig_path, utils,
 };
 
 pub struct StdinRunner {
@@ -99,19 +99,19 @@ impl StdinRunner {
         // Resolve filepath to absolute for nested config resolution
         let filepath = utils::normalize_relative_path(&cwd, &filepath);
 
-        // Resolve nested config based on filepath's parent directory
-        // (same as CLI direct file path behavior)
+        // Wrap root config in `Arc` so the on-demand discovery API can short-circuit
+        // when the file's ancestor walk reaches `root_config_dir`.
+        let root_config_resolver = Arc::new(config_resolver);
+
         let detect_nested =
             config_options.config.is_none() && !config_options.disable_nested_config;
-        if detect_nested {
-            match resolve_file_scope_config(
-                &filepath,
-                config_resolver.config_dir(),
-                editorconfig_path.as_deref(),
-                Some(&self.js_config_loader),
-            ) {
-                Ok(Some(nested)) => config_resolver = nested,
-                Ok(None) => {} // No nested config or same as root — use root
+        let config_resolver = if detect_nested {
+            let ctx = DiscoveryCtx::new(
+                editorconfig_path.as_deref().map(Arc::from),
+                Some(Arc::clone(&self.js_config_loader)),
+            );
+            match resolve_file_scope_config(&filepath, &root_config_resolver, &ctx) {
+                Ok(resolved) => resolved,
                 Err(err) => {
                     utils::print_and_flush(
                         stderr,
@@ -120,7 +120,9 @@ impl StdinRunner {
                     return CliRunResult::InvalidOptionConfig;
                 }
             }
-        }
+        } else {
+            Arc::clone(&root_config_resolver)
+        };
 
         // Check if the file is ignored by global ignores or config's `ignorePatterns`
         let global_matchers = match resolve_ignore_paths(&cwd, &ignore_options.ignore_path)

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -16,7 +16,7 @@ use super::resolve::{build_global_ignore_matchers, is_ignored, resolve_file_scop
 #[cfg(feature = "napi")]
 use crate::core::JsConfigLoaderCb;
 use crate::core::{
-    ConfigResolver, FormatStrategy, ResolveOutcome, classify_file_kind, config_discovery,
+    ConfigResolver, DiscoveryCtx, FormatStrategy, ResolveOutcome, classify_file_kind,
 };
 
 /// Orchestrates file discovery with nested config and ignore handling.
@@ -34,31 +34,50 @@ use crate::core::{
 /// # Walk phases
 /// - Phase 1: Classify CLI positional PATHs into directory targets, file targets, and globs
 /// - Phase 2: File targets are processed directly (no walk)
-///   - Scope is resolved upward from the file's parent, O(depth) per unique parent
+///   - Scope is resolved by walking `file.parent().ancestors()` and probing each
+///     dir via `get_or_load_direct_config` (shared cache). The first hit wins;
+///     reaching `root_config_dir` returns the pre-built root resolver without
+///     re-loading.
 ///   - This helps with performance when many file targets are specified like with `husky`
-///     - Processed even when nested detection is disabled (no pre-scan, no child scopes loaded)
-/// - Phase 3: Directory targets are walked via a flat single-walk architecture
-///   - 3-1. Pre-scan: walk entries to discover nested config file locations
-///     - Required to build the scope map before streaming walk begins (see `prescan_config_locations()`)
-///     - Cost: O(entries), but avoids per-directory config-file metadata probes; skipped when `--config` is given
-///   - 3-2. Load child scopes: load all discovered configs into a scope map
-///   - 3-3. Build ancestor set (only when any scope has `ignorePatterns`):
-///     - Records which directories have a config descendant,
-///       so `filter_entry()` can safely skip `ignorePatterns` matches without hiding nested configs
-///   - 3-4. Parallel walk: a single `WalkBuilder` walk processes all files
+///     (the shared cache deduplicates loads across siblings).
+/// - Phase 3: Directory targets are walked via a single parallel walk
+///   - Discovery is **entry-based**: `filter_entry` lets config-looking files
+///     pass file-level global ignore so `visit()` can register them in
+///     `scope_by_dir` (the walk-wide shared scope map).
+///   - Non-config file `visit()` resolves scope by ancestor lookup against
+///     `scope_by_dir` + the visitor-local `scope_cache`, with a race-rescue
+///     `get_or_load_direct_config` probe across `visited` (closer-first) so
+///     `nearest-config-wins` holds even when a closer config has not yet been
+///     registered by another visitor.
+///   - All loads (JSON / JSONC / JS / Vite) go through `config_load_cache`
+///     (`OnceLock` per dir) so each directory's config is loaded **at most
+///     once walk-wide**, including across Phase 2 / Phase 3.
 ///
 /// # Ignore model
-/// Three layers, checked in `filter_entry()` (directories) and `visit()` (files).
+/// Three layers, checked in `filter_entry()` and `visit()`.
 ///
 /// - (1) Hardcoded skips: `.git`, `.svn`, `node_modules`, etc
 ///   - Always skipped in `filter_entry()`, cannot be overridden by ignore files or patterns
 /// - (2) Global ignores: `.prettierignore`, `--ignore-path`, CLI `"!path"`
-///   - Block both directories and files across all scopes
+///   - Block both directories and files across all scopes.
+///   - **Exception**: `filter_entry` lets config-looking files (`.oxfmtrc.json`
+///     etc.) bypass file-level global ignore so discovery can register their
+///     scope. `visit()` re-applies global ignore to those entries before
+///     deciding format eligibility.
 /// - (3) Scope-local `ignorePatterns`: each scope's config can define patterns
-///   - Directories (`filter_entry`): scope is resolved per-directory, then that scope's `ignorePatterns` are checked
-///     - The directory is skipped only when the pre-scan ancestor set confirms no config descendant exists
-///   - Files (`visit`): scope is resolved per-parent-directory (cached), then that scope's `ignorePatterns` are checked
-///     - This handles file-specific patterns (e.g. `*.generated.js`) and files inside directories that couldn't be skipped (config descendants).
+///   - Applied per-file in `visit()` against the file's resolved scope. Inner
+///     scopes' `ignorePatterns` correctly override outer ones because each
+///     file resolves to its nearest config.
+///
+/// # Atomicity on broken nested config
+///
+/// Nested configs are loaded lazily during the walk. When one fails to parse,
+/// the walk reports the error via `fatal_error` and stops, but format workers
+/// run concurrently and may have already written files in unaffected scopes
+/// to disk. Format is idempotent — the recommended recovery is to fix the
+/// failing config and re-run. Buffering writes until walk completion would
+/// give all-or-nothing semantics but at the cost of holding all formatted
+/// outputs in memory, which doesn't scale to very large monorepos.
 pub struct ScopedWalker {
     cwd: PathBuf,
     paths: Vec<PathBuf>,
@@ -175,41 +194,34 @@ impl ScopedWalker {
             (dirs, files)
         };
 
-        // Phase 2: Process file targets directly (no walk needed)
+        // Walk-wide shared discovery state. Cloning `DiscoveryCtx` is cheap
+        // (each field is `Arc` / `Copy`); the underlying caches and signals
+        // are shared across Phase 2, Phase 3, and across all parallel visitors.
+        let discovery_ctx = DiscoveryCtx::new(
+            editorconfig_path.map(Arc::from),
+            #[cfg(feature = "napi")]
+            js_config_loader.cloned(),
+        );
+        let fatal_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        // Phase 2: Process file targets directly (no walk needed).
         let mut directly_processed: FxHashSet<PathBuf> = FxHashSet::default();
         if !file_targets.is_empty() {
-            // Cache scope resolution results by parent directory to avoid redundant lookups
-            type ScopeEntry = Option<Arc<ConfigResolver>>;
-
-            let mut scope_cache: FxHashMap<&Path, ScopeEntry> = FxHashMap::default();
+            let mut scope_cache: FxHashMap<&Path, Arc<ConfigResolver>> = FxHashMap::default();
             for file in &file_targets {
                 // Skip non-existent files (WalkBuilder naturally skips these via error entries)
                 if !file.is_file() {
                     continue;
                 }
 
-                // Resolve which scope (config) this file belongs to
                 let file_config = if detect_nested {
                     let parent = file.parent().unwrap();
                     if !scope_cache.contains_key(parent) {
-                        let cached = resolve_file_scope_config(
-                            file,
-                            root_config_resolver.config_dir(),
-                            editorconfig_path,
-                            #[cfg(feature = "napi")]
-                            js_config_loader,
-                        )?
-                        .map(Arc::from);
-                        scope_cache.insert(parent, cached);
+                        let resolved =
+                            resolve_file_scope_config(file, &root_config_resolver, &discovery_ctx)?;
+                        scope_cache.insert(parent, resolved);
                     }
-
-                    match &scope_cache[parent] {
-                        Some(resolver) => {
-                            any_config_used = true;
-                            Arc::clone(resolver)
-                        }
-                        None => Arc::clone(&root_config_resolver),
-                    }
+                    Arc::clone(&scope_cache[parent])
                 } else {
                     Arc::clone(&root_config_resolver)
                 };
@@ -218,7 +230,6 @@ impl ScopedWalker {
                     continue;
                 }
 
-                // Not a formatting target (e.g. unsupported extension) — skip silently
                 let Some(kind) = classify_file_kind(Arc::from(file.as_path())) else {
                     continue;
                 };
@@ -238,7 +249,7 @@ impl ScopedWalker {
             }
         }
 
-        // Phase 3: Walk directory targets
+        // Phase 3: Walk directory targets.
         let directly_processed: Arc<FxHashSet<PathBuf>> = Arc::new(directly_processed);
 
         // Build the glob matcher once for walk-time filtering.
@@ -248,49 +259,8 @@ impl ScopedWalker {
             Arc::new(GlobMatcher::new(self.cwd.clone(), self.glob_patterns.clone(), &walk_targets))
         });
 
-        // Compute once and share across both walks (pre-scan and main).
         let has_vcs_boundary = all_paths_have_vcs_boundary(&walk_targets, &self.cwd);
-
-        // Pre-scan: discover nested config file locations
-        let config_dirs = if detect_nested {
-            prescan_config_locations(
-                &walk_targets,
-                has_vcs_boundary,
-                &ignore_file_matchers,
-                with_node_modules,
-            )
-        } else {
-            vec![]
-        };
-
-        let (child_scope_map, config_ancestors) = if config_dirs.is_empty() {
-            // No nested configs, = only root scope
-            (Arc::new(FxHashMap::default()), None)
-        } else {
-            // Load all child configs upfront into a scope map
-            let (map, has_children) = resolve_child_scope_configs(
-                &config_dirs,
-                root_config_resolver.config_dir(),
-                editorconfig_path,
-                #[cfg(feature = "napi")]
-                js_config_loader,
-            )?;
-            if has_children {
-                any_config_used = true;
-            }
-
-            // Build ancestor set for directory-level `ignorePatterns` skipping,
-            // only when any scope (root or child) has `ignorePatterns`.
-            let ancestors = if root_config_resolver.has_ignore_patterns()
-                || map.values().any(|r| r.has_ignore_patterns())
-            {
-                Some(build_config_ancestors(&config_dirs))
-            } else {
-                None
-            };
-
-            (Arc::new(map), ancestors)
-        };
+        let walk_target_roots: Arc<[PathBuf]> = Arc::from(walk_targets.clone());
 
         walk_and_stream(
             &self.cwd,
@@ -301,11 +271,23 @@ impl ScopedWalker {
             glob_matcher.as_ref(),
             &root_config_resolver,
             &directly_processed,
-            config_ancestors.as_ref(),
-            &child_scope_map,
+            discovery_ctx.clone(),
+            detect_nested,
+            walk_target_roots,
+            Arc::clone(&fatal_error),
             sender,
             tx_error,
         );
+
+        // Surface any fatal error encountered inside the parallel walk.
+        let fatal = fatal_error.lock().expect("fatal_error mutex poisoned").take();
+        if let Some(err) = fatal {
+            return Err(err);
+        }
+
+        if discovery_ctx.config_found() {
+            any_config_used = true;
+        }
 
         Ok(any_config_used)
     }
@@ -376,181 +358,6 @@ impl GlobMatcher {
 
 // ---
 
-/// Pre-scan directories within walk targets to discover nested config file locations.
-///
-/// A separate pass is required because the flat single-walk needs all configs
-/// loaded into a scope map before `visit()` can resolve file scopes.
-///
-/// This also preserves the streaming architecture (walk → channel → format workers),
-/// which keeps format workers busy sooner.
-/// This is critical because current bottleneck is non-JS file formatting via external JS runtime.
-///
-/// The returned directories are used to:
-/// 1. Load child scope configs (`resolve_child_scope_configs()`)
-/// 2. Build an ancestor set for `filter_entry()` directory skipping
-///
-/// Uses a parallel walk and only performs metadata checks for entries
-/// whose file names match supported config files.
-/// This avoids probing every directory for every possible config filename.
-#[instrument(level = "debug", name = "oxfmt::walk::prescan_config_locations", skip_all)]
-fn prescan_config_locations(
-    target_paths: &[PathBuf],
-    has_vcs_boundary: bool,
-    ignore_file_matchers: &Arc<[Gitignore]>,
-    with_node_modules: bool,
-) -> Vec<PathBuf> {
-    let Some(first) = target_paths.first() else {
-        return vec![];
-    };
-
-    let mut builder = ignore::WalkBuilder::new(first);
-    for path in target_paths.iter().skip(1) {
-        builder.add(path);
-    }
-
-    let matchers = Arc::clone(ignore_file_matchers);
-    let discovery = config_discovery();
-    builder.filter_entry(move |entry| {
-        let Some(file_type) = entry.file_type() else {
-            return false;
-        };
-        if file_type.is_dir() {
-            return !is_walk_excluded_dir(entry, &matchers, with_node_modules);
-        }
-        // Do not apply file-level global ignores here.
-        // The previous directory probe checked config files by path,
-        // so file-level ignore patterns did not hide nested configs.
-        // Only keep config-looking file entries
-        // so the visitor can confirm they are files (including symlinks to files).
-        discovery.discover_config_file(entry.path()).is_some()
-    });
-
-    let (sender, receiver) = mpsc::channel::<Vec<PathBuf>>();
-    let mut visitor = ConfigPrescanVisitorBuilder { sender };
-    configure_oxfmt_walk_builder(&mut builder, has_vcs_boundary)
-        .build_parallel()
-        .visit(&mut visitor);
-    drop(visitor);
-
-    let mut seen = FxHashSet::default();
-    let mut config_dirs = vec![];
-    for dir in receiver.into_iter().flatten() {
-        if seen.insert(dir.clone()) {
-            config_dirs.push(dir);
-        }
-    }
-    config_dirs.sort_unstable();
-
-    config_dirs
-}
-
-struct ConfigPrescanVisitorBuilder {
-    sender: mpsc::Sender<Vec<PathBuf>>,
-}
-
-impl<'s> ignore::ParallelVisitorBuilder<'s> for ConfigPrescanVisitorBuilder {
-    fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
-        Box::new(ConfigPrescanVisitor { config_dirs: vec![], sender: self.sender.clone() })
-    }
-}
-
-struct ConfigPrescanVisitor {
-    config_dirs: Vec<PathBuf>,
-    sender: mpsc::Sender<Vec<PathBuf>>,
-}
-
-impl Drop for ConfigPrescanVisitor {
-    fn drop(&mut self) {
-        let config_dirs = std::mem::take(&mut self.config_dirs);
-        let _ = self.sender.send(config_dirs);
-    }
-}
-
-impl ignore::ParallelVisitor for ConfigPrescanVisitor {
-    fn visit(&mut self, entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
-        match entry {
-            Ok(entry) => {
-                if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                    return ignore::WalkState::Continue;
-                }
-
-                let path = entry.path();
-                if path.is_file()
-                    && let Some(parent) = path.parent()
-                {
-                    self.config_dirs.push(parent.to_path_buf());
-                }
-
-                ignore::WalkState::Continue
-            }
-            Err(_) => ignore::WalkState::Skip,
-        }
-    }
-}
-
-// ---
-
-/// Load all child scope configs discovered by pre-scan.
-///
-/// Returns the scope map and a flag indicating whether any child scope had a config.
-/// Skips directories whose resolved config matches the root config dir
-/// (they belong to the root scope, not a child scope).
-#[instrument(level = "debug", name = "oxfmt::walk::load_child_scopes", skip_all)]
-fn resolve_child_scope_configs(
-    config_dirs: &[PathBuf],
-    root_config_dir: Option<&Path>,
-    editorconfig_path: Option<&Path>,
-    #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
-) -> Result<(FxHashMap<PathBuf, Arc<ConfigResolver>>, bool), String> {
-    let mut map = FxHashMap::default();
-    let mut has_children = false;
-    for config_dir in config_dirs {
-        let mut resolver = ConfigResolver::from_config(
-            config_dir,
-            // NOTE: Let it auto-discover (not a direct path) config,
-            // so that `discover_config()` can skip invalid candidates
-            // (e.g. `vite.config.ts` without a `.fmt` field)
-            // and continue searching upward.
-            None,
-            editorconfig_path,
-            #[cfg(feature = "napi")]
-            js_config_loader,
-        )
-        .map_err(|err| format!("Failed to load config in {}: {err}", config_dir.display()))?;
-
-        // No config found, or same as root → belongs to root scope
-        if resolver.config_dir().is_none() || resolver.config_dir() == root_config_dir {
-            continue;
-        }
-
-        resolver
-            .build_and_validate()
-            .map_err(|err| format!("Failed to parse config in {}: {err}", config_dir.display()))?;
-
-        has_children = true;
-        map.insert(config_dir.clone(), Arc::from(resolver));
-    }
-
-    Ok((map, has_children))
-}
-
-/// Build the ancestor set from discovered config directories.
-/// Enables O(1) "has config descendant?" lookups in `filter_entry()`,
-/// allowing `ignorePatterns` directories to be skipped when no nested config exists beneath them.
-fn build_config_ancestors(config_dirs: &[PathBuf]) -> Arc<FxHashSet<PathBuf>> {
-    let mut ancestors = FxHashSet::default();
-    for config_dir in config_dirs {
-        for ancestor in config_dir.ancestors() {
-            if !ancestors.insert(ancestor.to_path_buf()) {
-                break;
-            }
-        }
-    }
-    Arc::new(ancestors)
-}
-
-// ---
-
 /// Build a Walk, stream entries to the shared channel.
 #[expect(clippy::needless_pass_by_value)] // Arcs are moved into closures/structs
 fn walk_and_stream(
@@ -562,8 +369,10 @@ fn walk_and_stream(
     glob_matcher: Option<&Arc<GlobMatcher>>,
     root_config_resolver: &Arc<ConfigResolver>,
     directly_processed: &Arc<FxHashSet<PathBuf>>,
-    config_ancestors: Option<&Arc<FxHashSet<PathBuf>>>,
-    child_scope_map: &Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
+    discovery_ctx: DiscoveryCtx,
+    detect_nested: bool,
+    walk_target_roots: Arc<[PathBuf]>,
+    fatal_error: Arc<Mutex<Option<String>>>,
     sender: &mpsc::Sender<FormatStrategy>,
     tx_error: &DiagnosticSender,
 ) {
@@ -577,10 +386,7 @@ fn walk_and_stream(
     }
 
     let filter_global = Arc::clone(&ignore_file_matchers);
-    let filter_root_resolver = Arc::clone(root_config_resolver);
-    let filter_ancestors = config_ancestors.cloned();
-    let filter_child_scopes = Arc::clone(child_scope_map);
-    // NOTE: If return `false` here, it will not be `visit()`ed at all
+    let filter_discovery = discovery_ctx.discovery;
     inner.filter_entry(move |entry| {
         let Some(file_type) = entry.file_type() else {
             return false;
@@ -590,29 +396,23 @@ fn walk_and_stream(
         if is_dir && is_walk_excluded_dir(entry, &filter_global, with_node_modules) {
             return false;
         }
-        // Global ignores also apply to files (e.g. `*.test.js` in .prettierignore)
-        if !is_dir && is_ignored(&filter_global, entry.path(), false, false) {
+        // File-level global ignores apply, EXCEPT for config-looking files —
+        // those must reach `visit()` so entry-based discovery can register
+        // them in `scope_by_dir`. Whether they get formatted is decided
+        // separately in `visit()` by re-checking global ignore.
+        if !is_dir
+            && filter_discovery.discover_config_file(entry.path()).is_none()
+            && is_ignored(&filter_global, entry.path(), false, false)
+        {
             return false;
         }
-        // Check scope-specific `ignorePatterns` for directories.
-        // Resolves which scope (root or child) this directory belongs to,
-        // then checks that scope's ignorePatterns.
-        // Safe to skip when pre-scan confirms no config descendant exists beneath.
-        if is_dir && filter_ancestors.as_ref().is_some_and(|a| !a.contains(entry.path())) {
-            let resolver: &ConfigResolver = entry
-                .path()
-                .ancestors()
-                .find_map(|a| filter_child_scopes.get(a).map(AsRef::as_ref))
-                .unwrap_or(&filter_root_resolver);
-            if resolver.is_path_ignored(entry.path(), true) {
-                return false;
-            }
-        }
 
-        // NOTE: Glob pattern matching is NOT done here in `filter_entry()`.
-        // Glob patterns like `**/*.js` cannot be used to skip directories,
-        // since any directory could contain matching files at any depth.
-        // Glob filtering is instead done per-file in the visitor `visit()` below.
+        // Scope-local `ignorePatterns` are checked per-file in `visit()`
+        // against the file's resolved scope, which correctly handles the
+        // "inner config wins over outer" rule.
+        //
+        // Glob pattern matching is also done per-file in `visit()` since
+        // patterns like `**/*.js` cannot reliably skip directories.
         true
     });
 
@@ -622,8 +422,12 @@ fn walk_and_stream(
         tx_error: tx_error.clone(),
         root_config_resolver: Arc::clone(root_config_resolver),
         glob_matcher: glob_matcher.cloned(),
-        child_scope_map: Arc::clone(child_scope_map),
         directly_processed: Arc::clone(directly_processed),
+        discovery_ctx,
+        detect_nested,
+        walk_target_roots,
+        fatal_error,
+        filter_global: Arc::clone(&ignore_file_matchers),
     };
 
     configure_oxfmt_walk_builder(&mut inner, has_vcs_boundary).build_parallel().visit(&mut builder);
@@ -651,9 +455,14 @@ struct WalkVisitorBuilder {
     tx_error: DiagnosticSender,
     root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
-    child_scope_map: Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
-    /// Files already processed as direct file targets (for dedup with walk results).
     directly_processed: Arc<FxHashSet<PathBuf>>,
+    discovery_ctx: DiscoveryCtx,
+    detect_nested: bool,
+    walk_target_roots: Arc<[PathBuf]>,
+    fatal_error: Arc<Mutex<Option<String>>>,
+    /// Needed in `visit()` to gate format eligibility for config-looking files
+    /// that bypass `filter_entry`.
+    filter_global: Arc<[Gitignore]>,
 }
 
 impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkVisitorBuilder {
@@ -664,8 +473,12 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkVisitorBuilder {
             tx_error: self.tx_error.clone(),
             root_config_resolver: Arc::clone(&self.root_config_resolver),
             glob_matcher: self.glob_matcher.clone(),
-            child_scope_map: Arc::clone(&self.child_scope_map),
             directly_processed: Arc::clone(&self.directly_processed),
+            discovery_ctx: self.discovery_ctx.clone(),
+            detect_nested: self.detect_nested,
+            walk_target_roots: Arc::clone(&self.walk_target_roots),
+            fatal_error: Arc::clone(&self.fatal_error),
+            filter_global: Arc::clone(&self.filter_global),
             scope_cache: FxHashMap::default(),
         })
     }
@@ -677,113 +490,225 @@ struct WalkVisitor {
     tx_error: DiagnosticSender,
     root_config_resolver: Arc<ConfigResolver>,
     glob_matcher: Option<Arc<GlobMatcher>>,
-    child_scope_map: Arc<FxHashMap<PathBuf, Arc<ConfigResolver>>>,
     directly_processed: Arc<FxHashSet<PathBuf>>,
-    /// Cache: parent dir → (resolved config, parent_ignored flag).
+    discovery_ctx: DiscoveryCtx,
+    detect_nested: bool,
+    walk_target_roots: Arc<[PathBuf]>,
+    fatal_error: Arc<Mutex<Option<String>>>,
+    filter_global: Arc<[Gitignore]>,
+    /// Visitor-local cache: parent dir → (resolved scope, parent_ignored flag).
+    /// Entries are direct-probe-confirmed; under static-FS they stay valid
+    /// for this visitor's lifetime.
     scope_cache: FxHashMap<PathBuf, (Arc<ConfigResolver>, bool)>,
 }
 
 impl WalkVisitor {
-    /// Ensure the scope for `parent` is cached, resolving it if needed.
+    /// Record the first fatal error seen by any visitor.
+    fn record_fatal(&self, err: String) {
+        let mut guard = self.fatal_error.lock().expect("fatal_error mutex poisoned");
+        if guard.is_none() {
+            *guard = Some(err);
+        }
+    }
+
+    /// Resolve and cache `parent`'s scope.
     ///
-    /// Walks `parent.ancestors()` to find the nearest child scope in the pre-loaded map.
-    /// Falls back to root scope if no child scope is found.
-    /// Caches the resolved scope and pre-computed `parent_ignored` flag.
-    fn ensure_scope_cached(&mut self, parent: &Path) {
+    /// Phase 1 walks `parent.ancestors()`, accumulating dirs without cache hit
+    /// into `visited`. Phase 2 race-probes every dir in `visited` (closer-first)
+    /// — even when Phase 1 hit an outer ancestor, this protects `nearest-config-wins`
+    /// against parallel visitors that may register a closer config concurrently.
+    fn ensure_scope_cached(&mut self, parent: &Path) -> Result<(), String> {
         if self.scope_cache.contains_key(parent) {
-            return;
+            return Ok(());
         }
 
-        // PERF: Skip ancestors traversal when no child scopes exist (e.g. `--disable-nested-config`)
-        let resolver = if self.child_scope_map.is_empty() {
-            Arc::clone(&self.root_config_resolver)
-        } else {
-            parent
-                .ancestors()
-                .find_map(|a| self.child_scope_map.get(a))
-                .cloned()
-                .unwrap_or_else(|| Arc::clone(&self.root_config_resolver))
+        // detect_nested off → root scope only.
+        if !self.detect_nested {
+            let parent_ignored = self.root_config_resolver.is_path_ignored(parent, true);
+            self.scope_cache.insert(
+                parent.to_path_buf(),
+                (Arc::clone(&self.root_config_resolver), parent_ignored),
+            );
+            return Ok(());
+        }
+
+        let probe_root: Option<&Path> = self
+            .walk_target_roots
+            .iter()
+            .map(PathBuf::as_path)
+            .filter(|t| parent.starts_with(t))
+            .max_by_key(|t| t.components().count());
+        let root_config_dir = self.root_config_resolver.config_dir();
+
+        // Phase 1: cheap ancestor lookup (no probe).
+        let mut visited: Vec<PathBuf> = vec![];
+        let mut hit_via_lookup: Option<Arc<ConfigResolver>> = None;
+
+        'lookup: for dir in parent.ancestors() {
+            if let Some((r, _)) = self.scope_cache.get(dir) {
+                hit_via_lookup = Some(Arc::clone(r));
+                break 'lookup;
+            }
+
+            if Some(dir) == root_config_dir {
+                hit_via_lookup = Some(Arc::clone(&self.root_config_resolver));
+                break 'lookup;
+            }
+
+            let hit = {
+                let guard =
+                    self.discovery_ctx.scope_by_dir.read().expect("scope_by_dir rwlock poisoned");
+                guard.get(dir).cloned()
+            };
+            if let Some(r) = hit {
+                hit_via_lookup = Some(r);
+                break 'lookup;
+            }
+
+            visited.push(dir.to_path_buf());
+            if Some(dir) == probe_root {
+                break;
+            }
+        }
+
+        // Phase 2: race-rescue probe across `visited`, closer-first.
+        let mut found_closer: Option<(PathBuf, Arc<ConfigResolver>)> = None;
+        for dir in &visited {
+            if let Some(loaded) = self.discovery_ctx.probe_dir(dir)? {
+                found_closer = Some((dir.clone(), loaded));
+                break;
+            }
+        }
+
+        let (resolved_scope_dir, resolver) = match (found_closer, hit_via_lookup) {
+            (Some((dir, loaded)), _) => (Some(dir), loaded),
+            (None, Some(r)) => (None, r),
+            (None, None) => (None, Arc::clone(&self.root_config_resolver)),
         };
 
-        let parent_ignored = resolver.is_path_ignored(parent, true);
-        self.scope_cache.insert(parent.to_path_buf(), (resolver, parent_ignored));
+        // Cache: (1) the dir that owns the resolved scope, (2) negative-cached
+        // probed dirs, (3) `parent` itself if not yet covered.
+        if let Some(scope_dir) = resolved_scope_dir
+            && !self.scope_cache.contains_key(&scope_dir)
+        {
+            let parent_ignored = resolver.is_path_ignored(&scope_dir, true);
+            self.scope_cache.insert(scope_dir, (Arc::clone(&resolver), parent_ignored));
+        }
+        for dir in visited {
+            if self.scope_cache.contains_key(&dir) {
+                continue;
+            }
+            let parent_ignored = resolver.is_path_ignored(&dir, true);
+            self.scope_cache.insert(dir, (Arc::clone(&resolver), parent_ignored));
+        }
+        if !self.scope_cache.contains_key(parent) {
+            let parent_ignored = resolver.is_path_ignored(parent, true);
+            self.scope_cache.insert(parent.to_path_buf(), (resolver, parent_ignored));
+        }
+
+        Ok(())
     }
 }
 
 impl ignore::ParallelVisitor for WalkVisitor {
     fn visit(&mut self, entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
-        match entry {
-            Ok(entry) => {
-                let Some(file_type) = entry.file_type() else {
-                    return ignore::WalkState::Continue;
-                };
-                if file_type.is_dir() {
-                    return ignore::WalkState::Continue;
-                }
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_err) => return ignore::WalkState::Skip,
+        };
 
-                // Use `is_file()` to detect symlinks to the directory named `.js`
-                #[expect(clippy::filetype_is_file)]
-                if file_type.is_file() {
-                    let path = entry.into_path();
-
-                    // Skip files already processed as direct file targets
-                    if self.directly_processed.contains(&path) {
-                        return ignore::WalkState::Continue;
-                    }
-
-                    // Resolve this file's scope (cached per parent directory)
-                    let parent = path.parent().expect("walk yields absolute paths");
-                    self.ensure_scope_cached(parent);
-                    let (resolver, parent_ignored) = &self.scope_cache[parent];
-
-                    // Check scope's `ignorePatterns` per-file.
-                    //
-                    // Two-level check:
-                    // 1. Parent directory (cached): catches directory patterns like "lib" that match all files under lib/.
-                    //    Uses check_ancestors so "lib" also catches files under lib/packages/.
-                    // 2. File-level: catches file-specific patterns like "temp.js".
-                    if *parent_ignored || resolver.is_path_ignored(&path, false) {
-                        return ignore::WalkState::Continue;
-                    }
-
-                    // When glob matcher is active,
-                    // only accept files that match glob patterns or explicitly specified concrete paths.
-                    if let Some(glob_matcher) = &self.glob_matcher
-                        && !glob_matcher.matches(&path)
-                    {
-                        return ignore::WalkState::Continue;
-                    }
-
-                    // Tier 1 = `.js`, `.tsx`, etc: JS/TS files supported by `oxc_formatter`
-                    // Tier 2 = `.toml`, etc: Some files supported by `oxfmt` directly
-                    // Tier 3 = `.html`, `.json`, etc: Other files supported by Prettier
-                    // (Tier 4 = `.astro`, `.svelte`, etc: Other files supported by Prettier plugins)
-                    // Everything else: Ignored
-                    // Not a formatting target (e.g. unsupported extension) — skip silently
-                    let path: Arc<Path> = Arc::from(path);
-                    let Some(kind) = classify_file_kind(Arc::clone(&path)) else {
-                        return ignore::WalkState::Continue;
-                    };
-                    let strategy = match resolver.resolve(kind) {
-                        Ok(ResolveOutcome::Format(strategy)) => strategy,
-                        Ok(ResolveOutcome::MissingPlugin(_)) => {
-                            return ignore::WalkState::Continue;
-                        }
-                        Err(err) => {
-                            report_resolve_error(&self.tx_error, &self.cwd, &path, err);
-                            return ignore::WalkState::Continue;
-                        }
-                    };
-
-                    if self.sender.send(strategy).is_err() {
-                        return ignore::WalkState::Quit;
-                    }
-                }
-
-                ignore::WalkState::Continue
-            }
-            Err(_err) => ignore::WalkState::Skip,
+        let Some(file_type) = entry.file_type() else {
+            return ignore::WalkState::Continue;
+        };
+        if file_type.is_dir() {
+            // No per-dir probe in the discovery path — entry-based discovery
+            // happens via `visit(config-looking file)` below.
+            return ignore::WalkState::Continue;
         }
+
+        // Skip non-regular entries (symlinks of any kind, sockets, etc.) to
+        // match the walker's `follow_links(false)` behavior.
+        #[expect(clippy::filetype_is_file)]
+        if !file_type.is_file() {
+            return ignore::WalkState::Continue;
+        }
+
+        let path = entry.into_path();
+
+        // Skip files already processed as direct file targets.
+        if self.directly_processed.contains(&path) {
+            return ignore::WalkState::Continue;
+        }
+
+        let parent = path.parent().expect("walk yields absolute paths");
+
+        // Identify config-looking files. Needed regardless of `detect_nested`
+        // because (B) re-applies global ignore for them: `filter_entry`
+        // exempts config files from file-level global ignore so discovery
+        // can see them, and (B) restores that filter for format eligibility.
+        let is_config_file = self.discovery_ctx.discovery.discover_config_file(&path).is_some();
+
+        // (A) Discovery: register the parent dir's scope (nested-detection only).
+        if is_config_file
+            && self.detect_nested
+            && let Err(err) = self.discovery_ctx.probe_dir(parent)
+        {
+            self.record_fatal(err);
+            return ignore::WalkState::Quit;
+        }
+
+        // (B) Re-apply file-level global ignore for config-looking files.
+        if is_config_file && is_ignored(&self.filter_global, &path, false, false) {
+            return ignore::WalkState::Continue;
+        }
+
+        // (C) Resolve scope for this file (cached per parent directory).
+        if let Err(err) = self.ensure_scope_cached(parent) {
+            self.record_fatal(err);
+            return ignore::WalkState::Quit;
+        }
+        let (resolver, parent_ignored) = &self.scope_cache[parent];
+
+        // Scope-local `ignorePatterns` check.
+        //
+        // Two-level: parent dir (cached) catches directory patterns like
+        // `lib`; file-level catches patterns like `temp.js`.
+        if *parent_ignored || resolver.is_path_ignored(&path, false) {
+            return ignore::WalkState::Continue;
+        }
+
+        // Glob filter (when active).
+        if let Some(glob_matcher) = &self.glob_matcher
+            && !glob_matcher.matches(&path)
+        {
+            return ignore::WalkState::Continue;
+        }
+
+        // Tier 1 = `.js`, `.tsx`, etc: JS/TS files supported by `oxc_formatter`
+        // Tier 2 = `.toml`, etc: Some files supported by `oxfmt` directly
+        // Tier 3 = `.html`, `.json`, etc: Other files supported by Prettier
+        // (Tier 4 = `.astro`, `.svelte`, etc: Prettier plugins)
+        // Anything else is silently skipped.
+        let path: Arc<Path> = Arc::from(path);
+        let Some(kind) = classify_file_kind(Arc::clone(&path)) else {
+            return ignore::WalkState::Continue;
+        };
+        let strategy = match resolver.resolve(kind) {
+            Ok(ResolveOutcome::Format(strategy)) => strategy,
+            Ok(ResolveOutcome::MissingPlugin(_)) => {
+                return ignore::WalkState::Continue;
+            }
+            Err(err) => {
+                report_resolve_error(&self.tx_error, &self.cwd, &path, err);
+                return ignore::WalkState::Continue;
+            }
+        };
+
+        if self.sender.send(strategy).is_err() {
+            return ignore::WalkState::Quit;
+        }
+
+        ignore::WalkState::Continue
     }
 }
 

--- a/apps/oxfmt/src/cli/walk_runner.rs
+++ b/apps/oxfmt/src/cli/walk_runner.rs
@@ -188,7 +188,17 @@ impl WalkRunner {
             Err(err) => {
                 drop(tx_entry);
                 drop(tx_error);
-                utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
+                let mut msg = format!("Failed to parse configuration.\n{err}\n");
+                // Nested configs are loaded lazily during the walk, so by the
+                // time a load failure surfaces some files in unaffected scopes
+                // may already have been written. Format is idempotent — fix
+                // the offending config and re-run.
+                if matches!(format_mode, OutputMode::Write) {
+                    msg.push_str(
+                        "Files in unaffected scopes may have already been written; re-run after fixing the config.\n",
+                    );
+                }
+                utils::print_and_flush(stderr, &msg);
                 return CliRunResult::InvalidOptionConfig;
             }
         };

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -1,15 +1,23 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex, OnceLock, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use editorconfig_parser::{
     EditorConfig, EditorConfigProperties, EditorConfigProperty, EndOfLine, IndentStyle,
     MaxLineLength, QuoteType,
 };
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use rustc_hash::FxHashMap;
 use serde_json::Value;
 use tracing::instrument;
 
 use oxc_config::{
-    ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, GlobSet, is_js_config_path,
+    ConfigConflict, ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, GlobSet,
+    is_js_config_path,
 };
 #[cfg(feature = "napi")]
 use oxc_formatter::FormatOptions;
@@ -36,6 +44,265 @@ pub fn config_discovery() -> ConfigDiscovery {
         OXFMT_CONFIG_FILE_NAMES,
         cfg!(feature = "napi") && utils::vp_version().is_some(),
     )
+}
+
+/// Find the unique config file directly inside `dir` using a single `read_dir`.
+///
+/// Unlike `ConfigDiscovery::find_unique_config_in_directory` which calls
+/// `is_file()` per candidate name, this issues one `read_dir` and matches
+/// entry names — no extra `stat` syscalls.
+///
+/// Only regular files are considered: directories and symlinks (regardless of
+/// target) are skipped. This matches the walker's `follow_links(false)`
+/// behavior so config discovery and file traversal stay consistent.
+///
+/// Returns `Ok(None)` when `dir` is unreadable; the caller can decide whether
+/// that warrants a diagnostic.
+pub fn find_unique_config_by_readdir(
+    dir: &Path,
+) -> Result<Option<DiscoveredConfigFile>, ConfigConflict> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(None);
+    };
+
+    let discovery = config_discovery();
+    // Cache the supported names once; the iteration body needs only name comparison.
+    let config_names = discovery.config_file_names();
+    let mut matches = Vec::new();
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if !config_names.iter().any(|n| name == *n) {
+            continue;
+        }
+
+        let Ok(file_type) = entry.file_type() else { continue };
+        // Intentional: skip directories, symlinks, sockets, ... — only
+        // regular files are considered configs (matches walker's
+        // `follow_links(false)`).
+        #[expect(clippy::filetype_is_file)]
+        if !file_type.is_file() {
+            continue;
+        }
+
+        if let Some(config) = discovery.discover_config_file(&entry.path()) {
+            matches.push(config);
+        }
+    }
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.into_iter().next()),
+        _ => Err(ConfigConflict::new(dir.to_path_buf(), matches)),
+    }
+}
+
+// ---
+// Shared on-demand config discovery infrastructure.
+//
+// Discovery state is centralized in `DiscoveryCtx` so Phase 2 (direct file
+// targets), Phase 3 (parallel walk), and the stdin path all share one cache
+// (each load runs at most once walk-wide) and one signal (`any_config_found`).
+
+/// Result of loading a direct config in a single directory.
+pub type ConfigLoadResult = Result<Option<Arc<ConfigResolver>>, String>;
+
+/// Walk-wide shared cache for direct-config loads.
+///
+/// Each entry's `OnceLock` ensures the underlying load runs at most once per
+/// directory across all visitors and across phases.
+pub type ConfigLoadCache = Arc<Mutex<FxHashMap<PathBuf, Arc<OnceLock<ConfigLoadResult>>>>>;
+
+/// Walk-wide shared map of "directory has a direct config" entries.
+///
+/// **Lock discipline**: never hold this lock across a `ConfigLoadCache` load.
+/// Acquire the read/write lock, do the lookup or insert, release immediately.
+pub type ScopeByDir = Arc<RwLock<FxHashMap<PathBuf, Arc<ConfigResolver>>>>;
+
+/// Shared discovery context: cached `ConfigDiscovery` + load cache + scope map +
+/// loader inputs (`editorconfig_path`, `js_config_loader`) + the
+/// `any_config_found` signal.
+///
+/// Cloning is shallow (each field is already `Arc` / `Copy`).
+#[derive(Clone)]
+pub struct DiscoveryCtx {
+    pub discovery: ConfigDiscovery,
+    pub editorconfig_path: Option<Arc<Path>>,
+    #[cfg(feature = "napi")]
+    pub js_config_loader: Option<JsConfigLoaderCb>,
+    pub any_config_found: Arc<AtomicBool>,
+    pub scope_by_dir: ScopeByDir,
+    pub config_load_cache: ConfigLoadCache,
+}
+
+impl DiscoveryCtx {
+    pub fn new(
+        editorconfig_path: Option<Arc<Path>>,
+        #[cfg(feature = "napi")] js_config_loader: Option<JsConfigLoaderCb>,
+    ) -> Self {
+        Self {
+            discovery: config_discovery(),
+            editorconfig_path,
+            #[cfg(feature = "napi")]
+            js_config_loader,
+            any_config_found: Arc::new(AtomicBool::new(false)),
+            scope_by_dir: Arc::new(RwLock::new(FxHashMap::default())),
+            config_load_cache: Arc::new(Mutex::new(FxHashMap::default())),
+        }
+    }
+
+    /// Get-or-compute the direct-config load result for `dir`, dedupe walk-wide.
+    ///
+    /// `OnceLock::get_or_init` blocks concurrent callers for the same `dir`
+    /// until the first init completes. `Ok(Some(_))` / `Ok(None)` / `Err(_)`
+    /// are all cached, so broken configs are not retried and "no config in
+    /// this dir" lookups stay O(1).
+    pub fn get_or_load_direct_config(&self, dir: &Path) -> ConfigLoadResult {
+        // Acquire (or insert) the cell, then drop the outer mutex immediately.
+        let cell = {
+            let mut guard =
+                self.config_load_cache.lock().expect("config_load_cache mutex poisoned");
+            let entry = guard.entry(dir.to_path_buf()).or_insert_with(|| Arc::new(OnceLock::new()));
+            Arc::clone(entry)
+        };
+
+        cell.get_or_init(|| {
+            load_direct_config_in_dir(
+                dir,
+                self.editorconfig_path.as_deref(),
+                #[cfg(feature = "napi")]
+                self.js_config_loader.as_ref(),
+            )
+        })
+        .clone()
+    }
+
+    /// Mark that a nested config was discovered. Idempotent.
+    pub fn mark_config_found(&self) {
+        self.any_config_found.store(true, Ordering::Relaxed);
+    }
+
+    pub fn config_found(&self) -> bool {
+        self.any_config_found.load(Ordering::Relaxed)
+    }
+
+    /// Read `scope_by_dir` for `dir`; on miss, probe via the load cache and
+    /// register the result.
+    ///
+    /// Returns:
+    /// - `Ok(Some(_))` — `dir` has a direct config (registered).
+    /// - `Ok(None)` — `dir` has no direct config, or Vite+ `.fmt` missing.
+    /// - `Err(_)` — load / parse / validate failure.
+    ///
+    /// On a successful load, `mark_config_found()` is called and the resolver
+    /// is inserted into `scope_by_dir` (only the first writer wins per dir).
+    pub fn probe_dir(&self, dir: &Path) -> Result<Option<Arc<ConfigResolver>>, String> {
+        let hit = {
+            let guard = self.scope_by_dir.read().expect("scope_by_dir rwlock poisoned");
+            guard.get(dir).cloned()
+        };
+        if hit.is_some() {
+            return Ok(hit);
+        }
+
+        match self.get_or_load_direct_config(dir)? {
+            Some(loaded) => {
+                self.mark_config_found();
+                let mut guard = self.scope_by_dir.write().expect("scope_by_dir rwlock poisoned");
+                guard.entry(dir.to_path_buf()).or_insert_with(|| Arc::clone(&loaded));
+                Ok(Some(loaded))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+/// Load and validate a config file located **directly** inside `dir`.
+///
+/// Returns `Ok(None)` when `dir` has no supported config file, or when a
+/// `vite.config.ts` is present but lacks a `.fmt` field (Vite+ mode). This
+/// matches `discover_config`'s "skip and continue" semantics applied at a
+/// single-dir scope.
+fn load_direct_config_in_dir(
+    dir: &Path,
+    editorconfig_path: Option<&Path>,
+    #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
+) -> Result<Option<Arc<ConfigResolver>>, String> {
+    let Some(config_file) = find_unique_config_by_readdir(dir)
+        .map_err(|e| Into::<oxc_diagnostics::OxcDiagnostic>::into(e).to_string())?
+    else {
+        return Ok(None);
+    };
+
+    let editorconfig = load_editorconfig(dir, editorconfig_path)?;
+    let load_err = |err: String| format!("Failed to load config in {}: {err}", dir.display());
+
+    let Some(mut resolver) = build_resolver_from_discovered(
+        config_file,
+        editorconfig,
+        #[cfg(feature = "napi")]
+        js_config_loader,
+    )
+    .map_err(load_err)?
+    else {
+        return Ok(None);
+    };
+
+    resolver.build_and_validate().map_err(load_err)?;
+    Ok(Some(Arc::new(resolver)))
+}
+
+/// Build a `ConfigResolver` from a single discovered config file (no ancestor walk,
+/// no `build_and_validate`).
+///
+/// Returns `Ok(None)` for the Vite+ "missing `.fmt`" case so callers can decide
+/// whether to skip-and-continue (ancestor walk) or treat it as "no config in this dir".
+fn build_resolver_from_discovered(
+    config_file: DiscoveredConfigFile,
+    editorconfig: Option<EditorConfig>,
+    #[cfg(feature = "napi")] js_config_loader: Option<&JsConfigLoaderCb>,
+) -> Result<Option<ConfigResolver>, String> {
+    match config_file {
+        DiscoveredConfigFile::Json(path) | DiscoveredConfigFile::Jsonc(path) => {
+            ConfigResolver::from_json_config(Some(&path), editorconfig).map(Some)
+        }
+        #[cfg(not(feature = "napi"))]
+        DiscoveredConfigFile::Js(path) | DiscoveredConfigFile::Vite(path) => Err(format!(
+            "JS/TS config file ({}) is not supported in pure Rust CLI.\nUse JSON/JSONC instead.",
+            path.display()
+        )),
+        #[cfg(feature = "napi")]
+        DiscoveredConfigFile::Js(path) => {
+            // Non-Vite JS config: `loadJsConfig` never returns `null`; failures bubble up as `Err`.
+            let raw_config = load_js_config(
+                js_config_loader
+                    .expect("JS config loader must be set when `napi` feature is enabled"),
+                &path,
+            )?
+            .expect("loadJsConfig never returns null for non-Vite JS config");
+            Ok(Some(ConfigResolver::new(
+                raw_config,
+                path.parent().map(Path::to_path_buf),
+                editorconfig,
+            )))
+        }
+        #[cfg(feature = "napi")]
+        DiscoveredConfigFile::Vite(path) => {
+            let Some(raw_config) = load_js_config(
+                js_config_loader
+                    .expect("JS config loader must be set when `napi` feature is enabled"),
+                &path,
+            )?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(ConfigResolver::new(
+                raw_config,
+                path.parent().map(Path::to_path_buf),
+                editorconfig,
+            )))
+        }
+    }
 }
 
 pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
@@ -169,11 +436,6 @@ impl ConfigResolver {
         self.config_dir.as_deref()
     }
 
-    /// Returns `true` if this config has any `ignorePatterns`.
-    pub fn has_ignore_patterns(&self) -> bool {
-        self.ignore_glob.is_some()
-    }
-
     /// Returns `true` if the given path should be ignored by this config's `ignorePatterns`.
     pub fn is_path_ignored(&self, path: &Path, is_dir: bool) -> bool {
         self.ignore_glob.as_ref().is_some_and(|glob| {
@@ -269,53 +531,14 @@ impl ConfigResolver {
                 continue;
             };
 
-            match config_file {
-                DiscoveredConfigFile::Json(path) | DiscoveredConfigFile::Jsonc(path) => {
-                    return Self::from_json_config(Some(&path), editorconfig);
-                }
-                #[cfg(not(feature = "napi"))]
-                DiscoveredConfigFile::Js(path) | DiscoveredConfigFile::Vite(path) => {
-                    return Err(format!(
-                        "JS/TS config file ({}) is not supported in pure Rust CLI.\nUse JSON/JSONC instead.",
-                        path.display()
-                    ));
-                }
+            // Vite+ with `.fmt` missing returns `None` → keep searching upwards.
+            if let Some(resolver) = build_resolver_from_discovered(
+                config_file,
+                editorconfig.clone(),
                 #[cfg(feature = "napi")]
-                DiscoveredConfigFile::Js(path) => {
-                    // JS `loadJsConfig()` (non-Vite+ mode) never returns `null`,
-                    // failures are raised as errors by `load_js_config()`.
-                    let raw_config = load_js_config(
-                        js_config_loader
-                            .expect("JS config loader must be set when `napi` feature is enabled"),
-                        &path,
-                    )?
-                    .expect("loadJsConfig never returns null for non-Vite JS config");
-
-                    return Ok(Self::new(
-                        raw_config,
-                        path.parent().map(Path::to_path_buf),
-                        editorconfig,
-                    ));
-                }
-                #[cfg(feature = "napi")]
-                DiscoveredConfigFile::Vite(path) => {
-                    // JS `loadVitePlusConfig()` (Vite+ mode) returns `null`
-                    // when `.fmt` is missing, skip and continue searching upwards.
-                    let Some(raw_config) = load_js_config(
-                        js_config_loader
-                            .expect("JS config loader must be set when `napi` feature is enabled"),
-                        &path,
-                    )?
-                    else {
-                        continue;
-                    };
-
-                    return Ok(Self::new(
-                        raw_config,
-                        path.parent().map(Path::to_path_buf),
-                        editorconfig,
-                    ));
-                }
+                js_config_loader,
+            )? {
+                return Ok(resolver);
             }
         }
 

--- a/apps/oxfmt/src/core/js_config.rs
+++ b/apps/oxfmt/src/core/js_config.rs
@@ -29,18 +29,28 @@ pub type JsConfigLoaderCb = Arc<dyn Fn(String) -> Result<Value, String> + Send +
 ///
 /// The returned function blocks the current thread until the JS callback resolves.
 ///
-/// NOTE: Unlike `ExternalFormatter` which uses `napi::bindgen_prelude::block_on`
-/// and relies on call sites to wrap with `block_in_place()`,
-/// this uses `block_in_place` + `Handle::block_on` internally because
-/// it is called from both rayon worker threads (CLI) and async contexts (stdin, LSP)
-/// via `ConfigResolver::from_config()`, where adding per-call-site wrapping is impractical.
+/// The loader can be invoked from any thread, including:
+/// - rayon worker threads (Phase 3 walk visitors during on-demand discovery)
+/// - Tokio worker threads (Phase 2 direct file resolution, stdin, LSP)
+/// - bare threads (any other context that obtained a `JsConfigLoaderCb`)
+///
+/// We capture a `tokio::runtime::Handle` at creation time so the awaiting
+/// machinery does not depend on `Handle::current()` at call time. We then
+/// branch on the calling context:
+/// - inside a Tokio runtime, wrap with `block_in_place` so the Tokio worker
+///   can be reused for other tasks while we block on the NAPI promise
+/// - outside a Tokio runtime, drive the future directly via the captured handle
 pub fn create_js_config_loader(cb: JsLoadJsConfigCb) -> JsConfigLoaderCb {
+    let handle = tokio::runtime::Handle::current();
     Arc::new(move |path: String| {
         let cb = &cb;
-        let res = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(async move { cb.call_async(path).await?.into_future().await })
-        });
+        let handle = handle.clone();
+        let fut = async move { cb.call_async(path).await?.into_future().await };
+        let res = if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::task::block_in_place(|| handle.block_on(fut))
+        } else {
+            handle.block_on(fut)
+        };
         res.map_err(|e| e.reason.clone())
     })
 }

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -10,7 +10,10 @@ mod external_formatter;
 #[cfg(feature = "napi")]
 mod js_config;
 
-pub use config::{ConfigResolver, ResolveOutcome, config_discovery, resolve_editorconfig_path};
+pub use config::{ConfigResolver, DiscoveryCtx, ResolveOutcome, resolve_editorconfig_path};
+// `config_discovery` is consumed only by LSP code paths (napi-gated).
+#[cfg(feature = "napi")]
+pub use config::config_discovery;
 #[cfg(feature = "napi")]
 pub use config::{resolve_for_api, resolve_for_embedded_js};
 pub use format::{FormatResult, FormatStrategy, SourceFormatter};


### PR DESCRIPTION
Fixes #22250 

> I'm benchmarking oxfmt on a big repo with around 50k directories.
> https://github.com/oxc-project/oxc/issues/22225
>
> The changes in this PR improve the times from 3.4s -> 2.8s, so 600ms savings 🎉
> https://github.com/oxc-project/oxc/pull/22258#issuecomment-4406579633

When I tested this on a local repo of about 20k, I didn't see as much improvement as reported, but there was definitely an improvement.

---

> [!WARNING]
> This PR changes the CLI behavior in the following nitch cases.

- When you have nested configs,
- and one of which is invalid,
- and you run it in "write" mode

Previously, the CLI would pre-scan the all config files, so an error would be reported immediately and no files would be formatted at all.

With this PR, while it will still report an error and abort upon finding an invalid config file, it will now proceed to format the files for any parts where a valid config can be applied.

In other words, it is highly unlikely that you will encounter this change.