### PR TITLE
fix(formatter): fix erroneous formatting inside a template literal with parentheses

### DIFF
--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -363,7 +363,9 @@ impl<'a> Format<'a> for FormatTemplateExpression<'a, '_> {
         let format_expression = format_once(|f| match self.expression {
             TemplateExpression::Expression(e) => {
                 let leading_comments = f.context().comments().comments_before(e.span().start);
-                FormatLeadingComments::Comments(leading_comments).fmt(f);
+                // Let the expression formatter place leading comments. JSX may insert wrap-on-break
+                // parentheses around itself, and pre-printing comments here would move line-sensitive
+                // directives outside those parentheses.
                 FormatNodeWithoutTrailingComments(e).fmt(f);
                 let trailing_comments =
                     f.context().comments().comments_before_character(e.span().start, b'}');

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-leading-comments.tsx
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-leading-comments.tsx
@@ -1,0 +1,15 @@
+const plain = `value ${
+  // leading comment stays attached to identifier
+  value
+}`;
+
+const call = `value ${
+  // leading comment stays attached to call expression
+  call()
+}`;
+
+const inlineBlock = `value ${/* leading block */ value}`;
+
+const trailing = `value ${
+  value // trailing comment stays before interpolation end
+}`;

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-leading-comments.tsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-leading-comments.tsx.snap
@@ -1,0 +1,60 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const plain = `value ${
+  // leading comment stays attached to identifier
+  value
+}`;
+
+const call = `value ${
+  // leading comment stays attached to call expression
+  call()
+}`;
+
+const inlineBlock = `value ${/* leading block */ value}`;
+
+const trailing = `value ${
+  value // trailing comment stays before interpolation end
+}`;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const plain = `value ${
+  // leading comment stays attached to identifier
+  value
+}`;
+
+const call = `value ${
+  // leading comment stays attached to call expression
+  call()
+}`;
+
+const inlineBlock = `value ${/* leading block */ value}`;
+
+const trailing = `value ${
+  value // trailing comment stays before interpolation end
+}`;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const plain = `value ${
+  // leading comment stays attached to identifier
+  value
+}`;
+
+const call = `value ${
+  // leading comment stays attached to call expression
+  call()
+}`;
+
+const inlineBlock = `value ${/* leading block */ value}`;
+
+const trailing = `value ${
+  value // trailing comment stays before interpolation end
+}`;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-parenthesized-jsx-directive.tsx
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-parenthesized-jsx-directive.tsx
@@ -1,0 +1,10 @@
+const doc = md`
+${
+	(
+		// eslint-disable-next-line @atlaskit/ui-styling-standard/enforce-style-prop -- reason
+		<div style={{ marginTop: token('space.100') }}>
+			<Child />
+		</div>
+	)
+}
+`;

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-parenthesized-jsx-directive.tsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/template-interpolation-parenthesized-jsx-directive.tsx.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const doc = md`
+${
+	(
+		// eslint-disable-next-line @atlaskit/ui-styling-standard/enforce-style-prop -- reason
+		<div style={{ marginTop: token('space.100') }}>
+			<Child />
+		</div>
+	)
+}
+`;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const doc = md`
+${
+  (
+    // eslint-disable-next-line @atlaskit/ui-styling-standard/enforce-style-prop -- reason
+    <div style={{ marginTop: token("space.100") }}>
+      <Child />
+    </div>
+  )
+}
+`;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const doc = md`
+${
+  (
+    // eslint-disable-next-line @atlaskit/ui-styling-standard/enforce-style-prop -- reason
+    <div style={{ marginTop: token("space.100") }}>
+      <Child />
+    </div>
+  )
+}
+`;
+
+===================== End =====================


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/21941

Looks like we were mainly breaking this with `FormatLeadingComments::Comments(leading_comments).fmt(f);` this mainly caused us to print the interpolation at the wrong layer.

1. FormatTemplateExpression saw the directive as a leading comment for the JSX element                                                                                                   
2. It printed that comment immediately                                                                                              
3. Then the JSX formatter printed its reconstructed (

I copied the tests verbatim from the issue