### PR TITLE
fix(linter): `valid-title`: detect `String.raw` strings

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
@@ -4,7 +4,7 @@ use cow_utils::CowUtils;
 use lazy_regex::Regex;
 use oxc_ast::{
     AstKind,
-    ast::{Argument, BinaryExpression, Expression},
+    ast::{Argument, BinaryExpression, Expression, TaggedTemplateExpression},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
@@ -229,6 +229,25 @@ impl ValidTitleConfig {
                     &jest_fn_call.name,
                     ctx,
                 );
+            }
+            // Handle String.raw`foo`
+            Argument::TaggedTemplateExpression(tagged_template) => {
+                if !is_string_raw_tagged_template(tagged_template) {
+                    if need_report_name {
+                        ctx.diagnostic(title_must_be_string_diagnostic(arg.span()));
+                    }
+                    return;
+                }
+
+                if let Some(quasi) = tagged_template.quasi.single_quasi() {
+                    validate_title(
+                        quasi.as_str(),
+                        tagged_template.span,
+                        config,
+                        &jest_fn_call.name,
+                        ctx,
+                    );
+                }
             }
             Argument::TemplateLiteral(template_literal) => {
                 if let Some(quasi) = template_literal.single_quasi() {
@@ -464,4 +483,19 @@ fn does_binary_expression_contain_string_node(expr: &BinaryExpression) -> bool {
         Expression::BinaryExpression(left) => does_binary_expression_contain_string_node(left),
         _ => false,
     }
+}
+
+fn is_string_raw_tagged_template(tagged_template: &TaggedTemplateExpression) -> bool {
+    let Expression::StaticMemberExpression(static_member) =
+        tagged_template.tag.get_inner_expression()
+    else {
+        return false;
+    };
+    if static_member.property.name != "raw" {
+        return false;
+    }
+    let Some(identifier) = static_member.object.get_identifier_reference() else {
+        return false;
+    };
+    identifier.name == "String"
 }

--- a/crates/oxc_linter/src/rules/vitest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/valid_title.rs
@@ -222,6 +222,8 @@ fn test() {
             test('', () => {})",
             None,
         ),
+        // https://github.com/oxc-project/oxc/issues/22268
+        ("it(String.raw`foo`, () => {})", None),
     ];
 
     let fail = vec![
@@ -566,6 +568,9 @@ fn test() {
         ("it(abc, function () {})", None),
         // Vitest-specific fail test with allowArguments: false
         ("test(bar, () => {});", Some(serde_json::json!([{ "allowArguments": false }]))),
+        // https://github.com/oxc-project/oxc/issues/22268
+        ("it(Object.raw`foo`, () => {})", None),
+        ("it(String.raw(`foo`), () => {})", None),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/vitest_valid_title.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_valid_title.snap
@@ -582,3 +582,17 @@ source: crates/oxc_linter/src/tester.rs
    ·      ───
    ╰────
   help: Replace your title with a string
+
+  ⚠ vitest(valid-title): Title must be a string
+   ╭─[valid_title.tsx:1:4]
+ 1 │ it(Object.raw`foo`, () => {})
+   ·    ───────────────
+   ╰────
+  help: Replace your title with a string
+
+  ⚠ vitest(valid-title): Title must be a string
+   ╭─[valid_title.tsx:1:4]
+ 1 │ it(String.raw(`foo`), () => {})
+   ·    ─────────────────
+   ╰────
+  help: Replace your title with a string


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/22268

The upstream tests did not check for `String.raw`, so it is possible not respected there too. (Did not test it).
But I think the rule should detect them and do not report on them.