### PR TITLE
fix(oxlint/cli): load root config by searching up parent directories

### DIFF
--- a/apps/oxlint/fixtures/cli/root_config_ancestor/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/root_config_ancestor/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-debugger": "off"
+  }
+}

--- a/apps/oxlint/fixtures/cli/root_config_ancestor/cwd/test.ts
+++ b/apps/oxlint/fixtures/cli/root_config_ancestor/cwd/test.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -509,24 +509,8 @@ impl<'a> ConfigLoader<'a> {
         }
     }
 
-    pub(crate) fn load_root_config(
-        &self,
-        cwd: &Path,
-        config_path: Option<&PathBuf>,
-    ) -> Result<Oxlintrc, OxcDiagnostic> {
-        if let Some(config_path) = config_path {
-            return self.load_explicit_config(cwd, config_path);
-        }
-
-        match self.try_load_config_from_dir(cwd)? {
-            Some(config) => Ok(config),
-            None => Ok(Oxlintrc::default()),
-        }
-    }
-
     /// Load root config by searching up parent directories.
     ///
-    /// This is used by the LSP when a workspace folder is nested (e.g., `apps/app1`).
     /// It searches from the current directory up to parent directories to find a config file.
     ///
     /// # Arguments
@@ -535,7 +519,7 @@ impl<'a> ConfigLoader<'a> {
     ///
     /// # Returns
     /// The first config found when searching up the directory tree, or default if none found.
-    pub(crate) fn load_root_config_with_ancestor_search(
+    pub(crate) fn load_root_config(
         &self,
         cwd: &Path,
         config_path: Option<&PathBuf>,
@@ -835,7 +819,7 @@ mod test {
         // Uses fixture: ancestor_search/apps/app1 -> should find ancestor_search/.oxlintrc.json
         let nested_dir = cwd.join("apps/oxlint/fixtures/cli/ancestor_search/apps/app1");
         if nested_dir.exists() {
-            let result = loader.load_root_config_with_ancestor_search(&nested_dir, None);
+            let result = loader.load_root_config(&nested_dir, None);
             assert!(result.is_ok(), "Expected ancestor search to find config or return default");
 
             // Verify the config was actually found (not just default)
@@ -852,13 +836,13 @@ mod test {
         // Uses dedicated fixture with .oxlintrc.json
         let valid_config =
             PathBuf::from("fixtures/cli/ancestor_search_explicit_config/.oxlintrc.json");
-        let result = loader.load_root_config_with_ancestor_search(&cwd, Some(&valid_config));
+        let result = loader.load_root_config(&cwd, Some(&valid_config));
         assert!(result.is_ok(), "Expected config lookup to succeed with explicit path");
 
         // Test case 3: When no config exists in any ancestor, should return default
         let temp_dir = std::env::temp_dir().join("oxc_test_no_config");
         std::fs::create_dir_all(&temp_dir).expect("Failed to create temporary test directory");
-        let result = loader.load_root_config_with_ancestor_search(&temp_dir, None);
+        let result = loader.load_root_config(&temp_dir, None);
         assert!(result.is_ok(), "Expected default config when no config found");
         std::fs::remove_dir_all(&temp_dir).expect("Failed to cleanup temporary test directory");
     }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1292,6 +1292,13 @@ mod test {
     }
 
     #[test]
+    fn test_root_config_ancestor() {
+        Tester::new()
+            .with_cwd("fixtures/cli/root_config_ancestor/cwd".into())
+            .test_and_snapshot(&[]);
+    }
+
+    #[test]
     fn test_nested_config() {
         let args = &[];
         Tester::new().with_cwd("fixtures/cli/nested_config".into()).test_and_snapshot(args);

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -105,14 +105,13 @@ impl ServerLinterBuilder {
         #[cfg(feature = "napi")]
         let loader = loader.with_js_config_loader(self.js_config_loader.as_ref());
 
-        let oxlintrc =
-            match loader.load_root_config_with_ancestor_search(&root_path, config_path.as_ref()) {
-                Ok(config) => config,
-                Err(e) => {
-                    warn!("Failed to load config: {e}");
-                    Oxlintrc::default()
-                }
-            };
+        let oxlintrc = match loader.load_root_config(&root_path, config_path.as_ref()) {
+            Ok(config) => config,
+            Err(e) => {
+                warn!("Failed to load config: {e}");
+                Oxlintrc::default()
+            }
+        };
 
         let mut nested_ignore_patterns = Vec::new();
         let mut extended_paths = FxHashSet::default();

--- a/apps/oxlint/src/snapshots/fixtures__cli__root_config_ancestor__cwd_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__root_config_ancestor__cwd_@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/cli/root_config_ancestor/cwd
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/test/fixtures/vite_config_monorepo/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_config_monorepo/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr


### PR DESCRIPTION
Allow users to run `oxlint` in a sub package, when the monorepo has a base config.

Example:
`cd project/packages/pack-a && oxlint`

Now it detects the config from `project/.oxlintrc.json`, aligning how the LSP side works.
Aligns too how oxfmt searches config path.

closes https://github.com/oxc-project/oxc/issues/21533
found in https://github.com/voidzero-dev/vite-plus/pull/1378#discussion_r3078146663