### PR TITLE
fix(linter): add missing vitest/valid-describe-callback functionality

### DIFF
--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -3,7 +3,7 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::valid_describe_callback::{DOCUMENTATION, run},
+    rules::shared::valid_describe_callback::{ValidDescribeCallbackOptions, run},
     utils::PossibleJestNode,
 };
 
@@ -11,10 +11,43 @@ use crate::{
 pub struct ValidDescribeCallback;
 
 declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule validates that the second parameter of a `describe()` function is a
+    /// callback function. This callback function:
+    /// - should not be
+    ///   [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
+    /// - should not contain any parameters
+    /// - should not contain any `return` statements
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using an improper `describe()` callback function can lead to unexpected test
+    /// errors.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// // Async callback functions are not allowed
+    /// describe('myFunction()', async () => {
+    ///   // ...
+    /// });
+    ///
+    /// // Callback function parameters are not allowed
+    /// describe('myFunction()', done => {
+    ///   // ...
+    /// });
+    ///
+    /// // Returning a value from a describe block is not allowed
+    /// describe('myFunction', () =>
+    ///   it('returns a truthy value', () => {
+    ///     expect(myFunction()).toBeTruthy();
+    /// }));
+    /// ```
     ValidDescribeCallback,
     jest,
     correctness,
-    docs = DOCUMENTATION,
     version = "0.0.8",
 );
 
@@ -24,7 +57,7 @@ impl Rule for ValidDescribeCallback {
         jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
-        run(jest_node, ctx);
+        run(jest_node, ctx, ValidDescribeCallbackOptions::JEST);
     }
 }
 

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_describe_callback.rs
@@ -18,43 +18,25 @@ fn valid_describe_callback_diagnostic(
     OxcDiagnostic::warn(x1).with_help(x2).with_label(span3)
 }
 
-pub const DOCUMENTATION: &str = r"### What it does
+#[derive(Clone, Copy)]
+pub struct ValidDescribeCallbackOptions {
+    allow_async_describe_callback: bool,
+    allow_describe_options_argument: bool,
+}
 
-This rule validates that the second parameter of a `describe()` function is a
-callback function. This callback function:
-- should not be
-[async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
-- should not contain any parameters
-- should not contain any `return` statements
+impl ValidDescribeCallbackOptions {
+    pub const JEST: Self =
+        Self { allow_async_describe_callback: false, allow_describe_options_argument: false };
 
-### Why is this bad?
+    pub const VITEST: Self =
+        Self { allow_async_describe_callback: true, allow_describe_options_argument: true };
+}
 
-Using an improper `describe()` callback function can lead to unexpected test
-errors.
-
-### Examples
-
-Examples of **incorrect** code for this rule:
-```javascript
-// Async callback functions are not allowed
-describe('myFunction()', async () => {
-  // ...
-});
-
-// Callback function parameters are not allowed
-describe('myFunction()', done => {
-  // ...
-});
-
-// Returning a value from a describe block is not allowed
-describe('myFunction', () =>
-  it('returns a truthy value', () => {
-    expect(myFunction()).toBeTruthy();
-}));
-```
-";
-
-pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+pub fn run<'a>(
+    possible_jest_node: &PossibleJestNode<'a, '_>,
+    ctx: &LintContext<'a>,
+    options: ValidDescribeCallbackOptions,
+) {
     let node = possible_jest_node.node;
     let AstKind::CallExpression(call_expr) = node.kind() else {
         return;
@@ -92,14 +74,26 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
         return;
     }
 
-    match &call_expr.arguments[1] {
+    let callback = if options.allow_describe_options_argument
+        && let Some(callback) = call_expr.arguments.get(2)
+        && !is_function_argument(&call_expr.arguments[1])
+        && is_function_argument(callback)
+    {
+        callback
+    } else {
+        &call_expr.arguments[1]
+    };
+
+    match callback {
         Argument::FunctionExpression(fn_expr) => {
-            if fn_expr.r#async {
+            if fn_expr.r#async && !options.allow_async_describe_callback {
                 diagnostic(ctx, fn_expr.span, Message::NoAsyncDescribeCallback);
             }
-            let no_each_fields =
-                jest_fn_call.members.iter().all(|member| member.is_name_unequal("each"));
-            if no_each_fields && fn_expr.params.parameters_count() > 0 {
+            let no_parameterized_fields = jest_fn_call
+                .members
+                .iter()
+                .all(|member| member.is_name_unequal("each") && member.is_name_unequal("for"));
+            if no_parameterized_fields && fn_expr.params.parameters_count() > 0 {
                 diagnostic(ctx, fn_expr.span, Message::UnexpectedDescribeArgument);
             }
 
@@ -111,12 +105,14 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
             }
         }
         Argument::ArrowFunctionExpression(arrow_expr) => {
-            if arrow_expr.r#async {
+            if arrow_expr.r#async && !options.allow_async_describe_callback {
                 diagnostic(ctx, arrow_expr.span, Message::NoAsyncDescribeCallback);
             }
-            let no_each_fields =
-                jest_fn_call.members.iter().all(|member| member.is_name_unequal("each"));
-            if no_each_fields && arrow_expr.params.parameters_count() > 0 {
+            let no_parameterized_fields = jest_fn_call
+                .members
+                .iter()
+                .all(|member| member.is_name_unequal("each") && member.is_name_unequal("for"));
+            if no_parameterized_fields && arrow_expr.params.parameters_count() > 0 {
                 diagnostic(ctx, arrow_expr.span, Message::UnexpectedDescribeArgument);
             }
 
@@ -136,6 +132,10 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
         }
         callback => diagnostic(ctx, callback.span(), Message::SecondArgumentMustBeFunction),
     }
+}
+
+fn is_function_argument(arg: &Argument) -> bool {
+    matches!(arg, Argument::FunctionExpression(_) | Argument::ArrowFunctionExpression(_))
 }
 
 fn find_first_return_stmt_span(function_body: &FunctionBody) -> Option<Span> {

--- a/crates/oxc_linter/src/rules/vitest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/vitest/valid_describe_callback.rs
@@ -3,7 +3,7 @@ use oxc_macros::declare_oxc_lint;
 use crate::{
     context::LintContext,
     rule::Rule,
-    rules::shared::valid_describe_callback::{DOCUMENTATION, run},
+    rules::shared::valid_describe_callback::{ValidDescribeCallbackOptions, run},
     utils::PossibleJestNode,
 };
 
@@ -11,10 +11,38 @@ use crate::{
 pub struct ValidDescribeCallback;
 
 declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule validates that the second parameter of a `describe()` function is a
+    /// callback function. This callback function:
+    /// - should not contain any parameters
+    /// - should not contain any `return` statements
+    ///
+    /// Vitest supports async `describe()` callbacks, so this rule allows them.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using an improper `describe()` callback function can lead to unexpected test
+    /// errors.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// // Callback function parameters are not allowed
+    /// describe('myFunction()', done => {
+    ///   // ...
+    /// });
+    ///
+    /// // Returning a value from a describe block is not allowed
+    /// describe('myFunction', () =>
+    ///   it('returns a truthy value', () => {
+    ///     expect(myFunction()).toBeTruthy();
+    /// }));
+    /// ```
     ValidDescribeCallback,
     vitest,
     correctness,
-    docs = DOCUMENTATION,
     version = "0.0.8",
 );
 
@@ -24,7 +52,7 @@ impl Rule for ValidDescribeCallback {
         jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
-        run(jest_node, ctx);
+        run(jest_node, ctx, ValidDescribeCallbackOptions::VITEST);
     }
 }
 
@@ -88,26 +116,6 @@ fn test() {
         ("describe('foo')", None),
         ("describe('foo', 'foo2')", None),
         ("describe()", None),
-        ("describe('foo', async () => {})", None),
-        ("describe('foo', async function () {})", None),
-        ("describe.only('foo', async function () {})", None),
-        ("describe.skip('foo', async function () {})", None),
-        (
-            "
-            describe('sample case', () => {
-                it('works', () => {
-                    expect(true).toEqual(true);
-                });
-                describe('async', async () => {
-                    await new Promise(setImmediate);
-                    it('breaks', () => {
-                        throw new Error('Fail');
-                    });
-                });
-            });
-            ",
-            None,
-        ),
         (
             "
             describe('foo', function () {
@@ -164,6 +172,7 @@ fn test() {
 
     let pass_vitest = vec![
         ("describe.each([1, 2, 3])(\"%s\", (a, b) => {});", None),
+        ("describe.for([1, 2, 3])(\"%s\", (a, b) => {});", None),
         ("describe(\"foo\", function() {})", None),
         ("describe(\"foo\", () => {})", None),
         ("describe(`foo`, () => {})", None),
@@ -171,6 +180,7 @@ fn test() {
         ("fdescribe(\"foo\", () => {})", None),
         ("describe.only(\"foo\", () => {})", None),
         ("describe.skip(\"foo\", () => {})", None),
+        ("describe.todo(\"runPrettierFormat\");", None),
         (
             "
                 import { describe } from 'vitest';
@@ -195,6 +205,71 @@ fn test() {
                 describe('foo', () => {
                     it('bar', async () => {
                         expect(await Promise.resolve(42)).toBe(42)
+                    })
+                })
+            ",
+            None,
+        ),
+        ("describe(\"foo\", async () => {})", None),
+        ("describe(\"foo\", async function () {})", None),
+        ("xdescribe(\"foo\", async function () {})", None),
+        ("fdescribe(\"foo\", async function () {})", None),
+        ("describe.only(\"foo\", async function () {})", None),
+        ("describe.skip(\"foo\", async function () {})", None),
+        (
+            "
+                describe('sample case', () => {
+                    it('works', () => {
+                        expect(true).toEqual(true);
+                    });
+                    describe('async', async () => {
+                        await new Promise(setImmediate);
+                        it('works', () => {
+                            expect(true).toEqual(true);
+                        });
+                    });
+                });
+            ",
+            None,
+        ),
+        (
+            "
+                describe('sample case', () => {
+                    it('works', () => {
+                        expect(true).toEqual(true);
+                    });
+                    describe('async', () => {
+                        it('works', async () => {
+                            await new Promise(setImmediate);
+                            expect(true).toEqual(true);
+                        });
+                    });
+                });
+            ",
+            None,
+        ),
+        (
+            "
+                describe('FixtureTest', async () => {
+                    const files = collectTsFiles('./tests/fixtures');
+                    for (const file of files) {
+                        const { config } = await import(file);
+
+                        test(file, async () => {
+                            await runFixtureTest(config);
+                        });
+                    }
+                });
+            ",
+            None,
+        ),
+        (
+            "
+                describe('foo', { only: true }, () => {
+                    it('bar', () => {
+                        return Promise.resolve(42).then(value => {
+                            expect(value).toBe(42)
+                        })
                     })
                 })
             ",
@@ -231,26 +306,6 @@ fn test() {
         ("describe(\"foo\")", None),
         ("describe(\"foo\", \"foo2\")", None),
         ("describe()", None),
-        ("describe(\"foo\", async () => {})", None),
-        ("describe(\"foo\", async function () {})", None),
-        ("describe.only(\"foo\", async function () {})", None),
-        ("describe.skip(\"foo\", async function () {})", None),
-        (
-            "
-                describe('sample case', () => {
-                    it('works', () => {
-                        expect(true).toEqual(true);
-                    });
-                    describe('async', async () => {
-                        await new Promise(setImmediate);
-                        it('breaks', () => {
-                            throw new Error('Fail');
-                        });
-                    });
-                });
-            ",
-            None,
-        ),
         (
             "
                 describe('foo', function () {
@@ -306,10 +361,38 @@ fn test() {
             ",
             None,
         ),
+        (
+            "
+                describe('foo', { only: true }, () =>
+                    test('bar', () => {})
+                )
+            ",
+            None,
+        ),
+        (
+            "
+                describe('foo', { only: true }, () => {
+                    return Promise.resolve().then(() => {
+                        it('breaks', () => {
+                            throw new Error('Fail')
+                        })
+                    })
+                    describe('nested', () => {
+                        return Promise.resolve().then(() => {
+                            it('breaks', () => {
+                                throw new Error('Fail')
+                            })
+                        })
+                    })
+                })
+            ",
+            None,
+        ),
         ("describe(\"foo\", done => {})", None),
         ("describe(\"foo\", function (done) {})", None),
         ("describe(\"foo\", function (one, two, three) {})", None),
         ("describe(\"foo\", async function (done) {})", None),
+        ("describe(\"foo\", { only: true }, done => {})", None),
     ];
 
     pass.extend(pass_vitest);

--- a/crates/oxc_linter/src/snapshots/vitest_valid_describe_callback.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_valid_describe_callback.snap
@@ -86,47 +86,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:17]
- 1 │ describe('foo', async () => {})
-   ·                 ──────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:17]
- 1 │ describe('foo', async function () {})
-   ·                 ────────────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:22]
- 1 │ describe.only('foo', async function () {})
-   ·                      ────────────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:22]
- 1 │ describe.skip('foo', async function () {})
-   ·                      ────────────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-    ╭─[valid_describe_callback.tsx:6:35]
-  5 │                     });
-  6 │ ╭─▶                 describe('async', async () => {
-  7 │ │                       await new Promise(setImmediate);
-  8 │ │                       it('breaks', () => {
-  9 │ │                           throw new Error('Fail');
- 10 │ │                       });
- 11 │ ╰─▶                 });
- 12 │                 });
-    ╰────
-  help: Remove `async` keyword
-
   ⚠ vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:17]
  2 │                 describe('foo', function () {
@@ -162,24 +121,6 @@ source: crates/oxc_linter/src/tester.rs
  14 │                     })
     ╰────
   help: Remove return statement in your describe callback
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-    ╭─[valid_describe_callback.tsx:2:29]
-  1 │     
-  2 │ ╭─▶             describe('foo', async () => {
-  3 │ │                   await something()
-  4 │ │                   it('does something')
-  5 │ │                   describe('nested', () => {
-  6 │ │                       return Promise.resolve().then(() => {
-  7 │ │                           it('breaks', () => {
-  8 │ │                               throw new Error('Fail')
-  9 │ │                           })
- 10 │ │                       })
- 11 │ │                   })
- 12 │ ╰─▶             })
- 13 │                 
-    ╰────
-  help: Remove `async` keyword
 
   ⚠ vitest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:6:21]
@@ -220,13 +161,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─────────────────────────────
    ╰────
   help: Remove argument(s) of describe callback
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:17]
- 1 │ describe('foo', async function (done) {})
-   ·                 ────────────────────────
-   ╰────
-  help: Remove `async` keyword
 
   ⚠ vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
@@ -319,47 +253,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add name as first argument and callback as second argument
 
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:17]
- 1 │ describe("foo", async () => {})
-   ·                 ──────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:17]
- 1 │ describe("foo", async function () {})
-   ·                 ────────────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:22]
- 1 │ describe.only("foo", async function () {})
-   ·                      ────────────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:22]
- 1 │ describe.skip("foo", async function () {})
-   ·                      ────────────────────
-   ╰────
-  help: Remove `async` keyword
-
-  ⚠ vitest(valid-describe-callback): No async describe callback
-    ╭─[valid_describe_callback.tsx:6:39]
-  5 │                         });
-  6 │ ╭─▶                     describe('async', async () => {
-  7 │ │                           await new Promise(setImmediate);
-  8 │ │                           it('breaks', () => {
-  9 │ │                               throw new Error('Fail');
- 10 │ │                           });
- 11 │ ╰─▶                     });
- 12 │                     });
-    ╰────
-  help: Remove `async` keyword
-
   ⚠ vitest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                     describe('foo', function () {
@@ -396,24 +289,6 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Remove return statement in your describe callback
 
-  ⚠ vitest(valid-describe-callback): No async describe callback
-    ╭─[valid_describe_callback.tsx:2:33]
-  1 │     
-  2 │ ╭─▶                 describe('foo', async () => {
-  3 │ │                       await something()
-  4 │ │                       it('does something')
-  5 │ │                       describe('nested', () => {
-  6 │ │                           return Promise.resolve().then(() => {
-  7 │ │                               it('breaks', () => {
-  8 │ │                                   throw new Error('Fail')
-  9 │ │                               })
- 10 │ │                           })
- 11 │ │                       })
- 12 │ ╰─▶                 })
- 13 │                 
-    ╰────
-  help: Remove `async` keyword
-
   ⚠ vitest(valid-describe-callback): Unexpected return statement in describe callback
     ╭─[valid_describe_callback.tsx:6:25]
   5 │                         describe('nested', () => {
@@ -433,6 +308,39 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─────────────────────
  4 │                 )
    ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ vitest(valid-describe-callback): Unexpected return statement in describe callback
+   ╭─[valid_describe_callback.tsx:3:21]
+ 2 │                 describe('foo', { only: true }, () =>
+ 3 │                     test('bar', () => {})
+   ·                     ─────────────────────
+ 4 │                 )
+   ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ vitest(valid-describe-callback): Unexpected return statement in describe callback
+   ╭─[valid_describe_callback.tsx:3:21]
+ 2 │                     describe('foo', { only: true }, () => {
+ 3 │ ╭─▶                     return Promise.resolve().then(() => {
+ 4 │ │                           it('breaks', () => {
+ 5 │ │                               throw new Error('Fail')
+ 6 │ │                           })
+ 7 │ ╰─▶                     })
+ 8 │                         describe('nested', () => {
+   ╰────
+  help: Remove return statement in your describe callback
+
+  ⚠ vitest(valid-describe-callback): Unexpected return statement in describe callback
+    ╭─[valid_describe_callback.tsx:9:25]
+  8 │                         describe('nested', () => {
+  9 │ ╭─▶                         return Promise.resolve().then(() => {
+ 10 │ │                               it('breaks', () => {
+ 11 │ │                                   throw new Error('Fail')
+ 12 │ │                               })
+ 13 │ ╰─▶                         })
+ 14 │                         })
+    ╰────
   help: Remove return statement in your describe callback
 
   ⚠ vitest(valid-describe-callback): Unexpected argument(s) in describe callback
@@ -456,16 +364,16 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove argument(s) of describe callback
 
-  ⚠ vitest(valid-describe-callback): No async describe callback
-   ╭─[valid_describe_callback.tsx:1:17]
- 1 │ describe("foo", async function (done) {})
-   ·                 ────────────────────────
-   ╰────
-  help: Remove `async` keyword
-
   ⚠ vitest(valid-describe-callback): Unexpected argument(s) in describe callback
    ╭─[valid_describe_callback.tsx:1:17]
  1 │ describe("foo", async function (done) {})
    ·                 ────────────────────────
+   ╰────
+  help: Remove argument(s) of describe callback
+
+  ⚠ vitest(valid-describe-callback): Unexpected argument(s) in describe callback
+   ╭─[valid_describe_callback.tsx:1:33]
+ 1 │ describe("foo", { only: true }, done => {})
+   ·                                 ──────────
    ╰────
   help: Remove argument(s) of describe callback


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/17643
- closes https://github.com/oxc-project/oxc/issues/9060

Now that this rule has been split into two separate implementations, we can support all of the Vitest specific functionality:

- `async` describe callbacks (not valid in Jest)
- passing an options object to `describe` (not valid in Jest)

This also ports more tests from the upstream rule.