### PR TITLE
fix(linter): allow dialogs and popovers for no_autofocus

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -100,8 +100,7 @@ impl Rule for NoAutofocus {
             return;
         }
 
-        if is_dialog_or_popover(ctx, &jsx_el.opening_element)
-            || ctx.nodes().ancestor_kinds(node.id()).any(|kind| {
+        if ctx.nodes().ancestor_kinds(node.id()).any(|kind| {
                 matches!(kind, AstKind::JSXElement(ancestor) if is_dialog_or_popover(ctx, &ancestor.opening_element))
             })
         {
@@ -206,10 +205,6 @@ fn test() {
         ("<div><div autofocus /></div>", Some(ignore_non_dom_schema()), None),
         ("<Button />", None, Some(components_settings())),
         ("<Button />", Some(ignore_non_dom_schema()), Some(components_settings())),
-        ("<dialog autoFocus />", None, None),
-        (r#"<div role="dialog" autoFocus />"#, None, None),
-        ("<div popover autoFocus />", None, None),
-        (r#"<div popover="auto" autoFocus />"#, None, None),
         ("<dialog><div autoFocus /></dialog>", None, None),
         ("<dialog><input autoFocus /></dialog>", None, None),
         (r#"<div role="dialog"><input autoFocus /></div>"#, None, None),
@@ -239,6 +234,10 @@ fn test() {
         ("<Foo autoFocus />", None, None),
         ("<Button autoFocus />", None, Some(components_settings())),
         ("<Button autoFocus />", Some(ignore_non_dom_schema()), Some(components_settings())),
+        ("<dialog autoFocus />", None, None),
+        (r#"<div role="dialog" autoFocus />"#, None, None),
+        ("<div popover autoFocus />", None, None),
+        (r#"<div popover="auto" autoFocus />"#, None, None),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{Expression, JSXAttributeItem, JSXAttributeValue},
+    ast::{Expression, JSXAttributeItem, JSXAttributeValue, JSXOpeningElement},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -13,7 +13,9 @@ use crate::{
     context::LintContext,
     globals::HTML_TAG,
     rule::{DefaultRuleConfig, Rule},
-    utils::{get_element_type, has_jsx_prop},
+    utils::{
+        get_element_type, get_string_literal_prop_value, has_jsx_prop, has_jsx_prop_ignore_case,
+    },
 };
 
 fn no_autofocus_diagnostic(span: Span) -> OxcDiagnostic {
@@ -42,6 +44,13 @@ declare_oxc_lint!(
     /// without user input and can interfere with assistive technologies.
     /// Users should control when and where focus moves on a page.
     ///
+    /// ### Exceptions
+    ///
+    /// `<dialog>` elements, elements with `role="dialog"`, and elements with the
+    /// `popover` attribute (and their descendants) are exempt, since directing
+    /// focus into them when opened is the expected behavior.
+    /// See [MDN: `<dialog>` accessibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#accessibility).
+    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
@@ -55,6 +64,12 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     /// ```jsx
     /// <div />
+    /// <dialog autoFocus />
+    /// <dialog><input autoFocus /></dialog>
+    /// <div role="dialog" autoFocus />
+    /// <div role="dialog"><input autoFocus /></div>
+    /// <div popover autoFocus />
+    /// <div popover><input autoFocus /></div>
     /// ```
     NoAutofocus,
     jsx_a11y,
@@ -85,6 +100,14 @@ impl Rule for NoAutofocus {
             return;
         }
 
+        if is_dialog_or_popover(ctx, &jsx_el.opening_element)
+            || ctx.nodes().ancestor_kinds(node.id()).any(|kind| {
+                matches!(kind, AstKind::JSXElement(ancestor) if is_dialog_or_popover(ctx, &ancestor.opening_element))
+            })
+        {
+            return;
+        }
+
         if self.ignore_non_dom {
             let element_type = get_element_type(ctx, &jsx_el.opening_element);
 
@@ -100,6 +123,21 @@ impl Rule for NoAutofocus {
             fixer.delete(&attr.span)
         });
     }
+}
+
+fn is_dialog_or_popover<'a>(ctx: &LintContext<'a>, opening: &JSXOpeningElement<'a>) -> bool {
+    if get_element_type(ctx, opening) == "dialog" {
+        return true;
+    }
+    if has_jsx_prop_ignore_case(opening, "popover").is_some() {
+        return true;
+    }
+    if let Some(role_attr) = has_jsx_prop_ignore_case(opening, "role")
+        && get_string_literal_prop_value(role_attr).is_some_and(|value| value == "dialog")
+    {
+        return true;
+    }
+    false
 }
 
 fn is_false_attribute_value(value: &JSXAttributeValue) -> bool {
@@ -168,6 +206,22 @@ fn test() {
         ("<div><div autofocus /></div>", Some(ignore_non_dom_schema()), None),
         ("<Button />", None, Some(components_settings())),
         ("<Button />", Some(ignore_non_dom_schema()), Some(components_settings())),
+        ("<dialog autoFocus />", None, None),
+        (r#"<div role="dialog" autoFocus />"#, None, None),
+        ("<div popover autoFocus />", None, None),
+        (r#"<div popover="auto" autoFocus />"#, None, None),
+        ("<dialog><div autoFocus /></dialog>", None, None),
+        ("<dialog><input autoFocus /></dialog>", None, None),
+        (r#"<div role="dialog"><input autoFocus /></div>"#, None, None),
+        ("<div popover><input autoFocus /></div>", None, None),
+        (r#"<div popover="auto"><input autoFocus /></div>"#, None, None),
+        ("<dialog><div><input autoFocus /></div></dialog>", None, None),
+        (
+            r#"<div role="dialog"><section><div><input autoFocus /></div></section></div>"#,
+            None,
+            None,
+        ),
+        ("<div popover><section><input autoFocus /></section></div>", None, None),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_autofocus.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_autofocus.snap
@@ -92,3 +92,31 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────
    ╰────
   help: Remove the `autoFocus` attribute.
+
+  ⚠ jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
+   ╭─[no_autofocus.tsx:1:9]
+ 1 │ <dialog autoFocus />
+   ·         ─────────
+   ╰────
+  help: Remove the `autoFocus` attribute.
+
+  ⚠ jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
+   ╭─[no_autofocus.tsx:1:20]
+ 1 │ <div role="dialog" autoFocus />
+   ·                    ─────────
+   ╰────
+  help: Remove the `autoFocus` attribute.
+
+  ⚠ jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
+   ╭─[no_autofocus.tsx:1:14]
+ 1 │ <div popover autoFocus />
+   ·              ─────────
+   ╰────
+  help: Remove the `autoFocus` attribute.
+
+  ⚠ jsx-a11y(no-autofocus): The `autoFocus` attribute is found here, which can cause usability issues for sighted and non-sighted users.
+   ╭─[no_autofocus.tsx:1:21]
+ 1 │ <div popover="auto" autoFocus />
+   ·                     ─────────
+   ╰────
+  help: Remove the `autoFocus` attribute.


### PR DESCRIPTION
close https://github.com/oxc-project/oxc/issues/22287

Since we haven't discussed whether this change is appropriate, please let me know if there are any concerns.