### PR TITLE
test(linter/no-param-reassign): cover this computed key assignment

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
@@ -269,6 +269,19 @@ fn test() {
                 serde_json::json!([ { "props": true, "ignorePropertyModificationsForRegex": ["^(foo|bar)$"], "ignorePropertyModificationsFor": ["baz"], }, ]),
             ),
         ),
+        (
+            "function foo(key, value) { this[key] = value; }",
+            Some(serde_json::json!([{ "props": true }])),
+        ),
+        (
+            "function foo(key, value) { this[key] += value; }",
+            Some(serde_json::json!([{ "props": true }])),
+        ),
+        ("function foo(key) { delete this[key]; }", Some(serde_json::json!([{ "props": true }]))),
+        (
+            "function foo<T>(this: Record<PropertyKey, T>, key: PropertyKey, value: T) { this[key] = value; }",
+            Some(serde_json::json!([{ "props": true }])),
+        ),
     ];
 
     let fail = vec![


### PR DESCRIPTION
- add `no-param-reassign` regression cases for assignments through `this[key]`

Stacked on #22302.

Related to https://github.com/oxc-project/oxc/issues/22300