### PR TITLE
fix(codegen): emit newline after legal-comment orphan flush

### DIFF
--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -104,7 +104,13 @@ impl Codegen<'_> {
                 comments.remove(&k);
             }
         }
-        if !legals.is_empty() {
+        if let Some(last) = legals.last_mut() {
+            // Orphans aren't in their original position, so the source's
+            // `followed_by_newline` hint no longer applies. Force it on so
+            // `print_comments` emits a trailing newline instead of setting
+            // `print_next_indent_as_space` — otherwise the next indent (often
+            // before `}`) collapses to a space and pass 2 stops matching.
+            last.set_followed_by_newline(true);
             self.print_comments(&legals);
         }
     }

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -653,6 +653,21 @@ fn test_pure_comment_on_object_idempotency() {
     test_idempotency("export const X = /* @__PURE__ */ { a: 1 };");
 }
 
+// Regression for monitor-oxc codegen idempotency:
+// inline `/*!*/` between expression operands (parsed as a legal block comment
+// because it starts with `!`) used to round-trip non-idempotently — pass 1
+// emitted `\t/*!*/ }` (orphan flushed before `}`, trailing-edge converted
+// the closing-brace indent into a single space) and pass 2 emitted
+// `\t/*!*/}` (the comment now attaches to `}` so `FunctionBody`'s
+// `clear_pending_indent_space()` runs). The fix forces orphan flushes to
+// land on their own line, matching the pass-2 behaviour on pass 1.
+#[test]
+fn test_inline_legal_comment_in_function_body_is_idempotent() {
+    test_idempotency(
+        "function isPunctuator(ch) {\n\treturn ch === 33/*!*/ || ch === 37/*%*/;\n}\n",
+    );
+}
+
 #[test]
 fn test_legal_comment_after_code_minify_with_comments_idempotency() {
     use oxc_codegen::{CodegenOptions, CommentOptions};


### PR DESCRIPTION
`print_legal_orphans_before` carried the source-side `followed_by_newline = false` for inline orphans (e.g. `33/*!*/ ||`) over into the flush position. After printing the orphan, `print_comments` set `print_next_indent_as_space = true`, which then turned the closing-`}` indent into a single space — producing `\t/*!*/ }` on pass 1.

Pass 2 saw the comment at `}`-position, picked it up via `FunctionBody`'s `comments_at_end` branch (which calls `clear_pending_indent_space()`), and emitted `\t/*!*/}` without the space. The two passes diverged and [monitor-oxc's codegen idempotency check](https://github.com/oxc-project/monitor-oxc/actions/runs/25616176953/job/75194649734) failed on every cjs-module-lexer / es-module-lexer build.

Force `followed_by_newline = true` on the last orphan before the flush so `print_comments` takes its existing newline-emitting branch. Orphans now land block-level on both passes — matching the pass-2 `comments_at_end` path that already calls `clear_pending_indent_space()`.

The orphan-preservation behavior added in #21575 (issue #19750) is unaffected: `//! some license` whose anchor is DCE'd is still emitted at the next surviving statement.

## Test plan
- [x] `cargo test -p oxc_codegen` (105 tests, includes new `test_inline_legal_comment_in_function_body_is_idempotent`)
- [x] `cargo test -p oxc_minifier --tests` (492 tests, includes #21575's `preserve_legal_comment_when_dce_removes_anchor`)
- [x] Re-ran codegen idempotency on all 4 originally failing files (`cjs-module-lexer@1.4.3 / @2.2.0`, `es-module-lexer@1.7.0 / @2.0.0`) — all `same = true`.
