### PR TITLE
refactor(traverse): add spanned variants of BoundIdentifier::create_binding_*

### DIFF
--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -59,20 +59,38 @@ impl<'a> BoundIdentifier<'a> {
         MaybeBoundIdentifier::new(self.name, Some(self.symbol_id))
     }
 
-    /// Create `BindingIdentifier` for this binding
+    /// Create `BindingIdentifier` for this binding, with dummy `Span`
     pub fn create_binding_identifier<State>(
         &self,
         ctx: &TraverseCtx<'a, State>,
     ) -> BindingIdentifier<'a> {
-        ctx.ast.binding_identifier_with_symbol_id(SPAN, self.name, self.symbol_id)
+        self.create_spanned_binding_identifier(SPAN, ctx)
     }
 
-    /// Create `BindingPattern` for this binding
+    /// Create `BindingPattern` for this binding, with dummy `Span`
     pub fn create_binding_pattern<State>(
         &self,
         ctx: &TraverseCtx<'a, State>,
     ) -> BindingPattern<'a> {
-        let ident = self.create_binding_identifier(ctx);
+        self.create_spanned_binding_pattern(SPAN, ctx)
+    }
+
+    /// Create `BindingIdentifier` for this binding, with specified `Span`
+    pub fn create_spanned_binding_identifier<State>(
+        &self,
+        span: Span,
+        ctx: &TraverseCtx<'a, State>,
+    ) -> BindingIdentifier<'a> {
+        ctx.ast.binding_identifier_with_symbol_id(span, self.name, self.symbol_id)
+    }
+
+    /// Create `BindingPattern` for this binding, with specified `Span`
+    pub fn create_spanned_binding_pattern<State>(
+        &self,
+        span: Span,
+        ctx: &TraverseCtx<'a, State>,
+    ) -> BindingPattern<'a> {
+        let ident = self.create_spanned_binding_identifier(span, ctx);
         BindingPattern::BindingIdentifier(ctx.alloc(ident))
     }
 


### PR DESCRIPTION
## Summary

Add `create_spanned_binding_identifier(span, ctx)` and `create_spanned_binding_pattern(span, ctx)` on `BoundIdentifier`, mirroring the existing `create_spanned_*` pattern used for references / expressions / assignment targets.

The existing `create_binding_identifier` / `create_binding_pattern` now delegate to the spanned variants with `SPAN`.

## Why

Needed by transforms that lower a class/function declaration to a `var` declarator and want the synthesized `BindingIdentifier` to keep the original `id.span`, so semantic re-analysis of the printed AST agrees with the transformer's symbol-table bookkeeping (`Symbol span mismatch` lines in `transform_conformance` snapshots).

First user lands in a follow-up PR for the explicit-resource-management transform.

## Test plan

- [x] `cargo build -p oxc_traverse`
- [x] `cargo clippy -p oxc_traverse`
