### PR TITLE
fix(transformer/explicit-resource-management): preserve class names

### DIFF
--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -40,7 +40,7 @@ use rustc_hash::FxHashMap;
 use oxc_allocator::{Address, Box as ArenaBox, GetAddress, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
-use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
+use oxc_semantic::{NodeId, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{SPAN, Span};
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -328,8 +328,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                             ExportDefaultDeclarationKind::ClassDeclaration(class_decl)
                                 if class_decl.id.is_some() =>
                             {
-                                let binding = Self::preserve_class_expression_name(class_decl, ctx);
-                                (binding, SPAN)
+                                Self::preserve_class_expression_name(class_decl, ctx)
                             }
                             ExportDefaultDeclarationKind::FunctionDeclaration(_) => {
                                 program_body.push(stmt);
@@ -369,7 +368,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                                 ctx.ast.vec1(ctx.ast.variable_declarator(
                                     span,
                                     VariableDeclarationKind::Var,
-                                    var_id.create_binding_pattern(ctx),
+                                    var_id.create_spanned_binding_pattern(span, ctx),
                                     NONE,
                                     Some(expr),
                                     false,
@@ -882,7 +881,7 @@ impl<'a> ExplicitResourceManagement<'a> {
         mut class_decl: ArenaBox<'a, Class<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let binding = Self::preserve_class_expression_name(&class_decl, ctx);
+        let (binding, original_span) = Self::preserve_class_expression_name(&class_decl, ctx);
 
         class_decl.r#type = ClassType::ClassExpression;
         let class_expr = Expression::ClassExpression(class_decl);
@@ -893,7 +892,7 @@ impl<'a> ExplicitResourceManagement<'a> {
             ctx.ast.vec1(ctx.ast.variable_declarator(
                 SPAN,
                 VariableDeclarationKind::Var,
-                binding.create_binding_pattern(ctx),
+                binding.create_spanned_binding_pattern(original_span, ctx),
                 NONE,
                 Some(class_expr),
                 false,
@@ -905,21 +904,29 @@ impl<'a> ExplicitResourceManagement<'a> {
     /// Move the original class id symbol to a new `var`-style outer binding, and create a fresh
     /// `Class`-flagged symbol in the class scope for the named class expression's inner binding.
     ///
-    /// Returns the outer `BoundIdentifier` (reusing the original symbol id) that the caller should
-    /// use for the surrounding `var` declarator. Mirrors the swap in
+    /// Returns the outer `BoundIdentifier` (reusing the original symbol id) for the surrounding
+    /// `var` declarator, along with the original `id.span` so the caller can emit the outer
+    /// `BindingIdentifier` with the correct span. Mirrors the swap in
     /// `decorator::legacy::transform_class_declaration_with_class_decorators`.
     fn preserve_class_expression_name(
         class_decl: &Class<'a>,
         ctx: &mut TraverseCtx<'a>,
-    ) -> BoundIdentifier<'a> {
+    ) -> (BoundIdentifier<'a>, Span) {
         let id = class_decl.id.as_ref().expect("ClassDeclaration should have an id");
-        let inner_binding =
-            ctx.generate_binding(id.name, class_decl.scope_id(), SymbolFlags::Class);
-        let outer_symbol_id = id
-            .symbol_id
-            .replace(Some(inner_binding.symbol_id))
-            .expect("class always has a symbol id");
-        *ctx.scoping_mut().symbol_flags_mut(outer_symbol_id) = SymbolFlags::FunctionScopedVariable;
-        BoundIdentifier::new(id.name, outer_symbol_id)
+        let original_span = id.span;
+        let class_scope_id = class_decl.scope_id();
+        let scoping = ctx.scoping_mut();
+        let inner_symbol_id = scoping.create_symbol(
+            original_span,
+            id.name,
+            SymbolFlags::Class,
+            class_scope_id,
+            NodeId::DUMMY,
+        );
+        scoping.add_binding(class_scope_id, id.name, inner_symbol_id);
+        let outer_symbol_id =
+            id.symbol_id.replace(Some(inner_symbol_id)).expect("class always has a symbol id");
+        *scoping.symbol_flags_mut(outer_symbol_id) = SymbolFlags::FunctionScopedVariable;
+        (BoundIdentifier::new(id.name, outer_symbol_id), original_span)
     }
 }

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 6402dbbf
 
-Passed: 692/1165
+Passed: 694/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -167,7 +167,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-explicit-resource-management (20/28)
+# babel-plugin-transform-explicit-resource-management (22/28)
 * integration/commonjs-transform/input.js
 x Output mismatch
 
@@ -198,28 +198,6 @@ rebuilt        : SymbolId(5): ScopeId(4)
 
 * transform-sync/named-evaluation/input.js
 x Output mismatch
-
-* transform-top-level/hoisting/input.mjs
-Symbol span mismatch for "A":
-after transform: SymbolId(6): Span { start: 257, end: 258 }
-rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Symbol span mismatch for "A":
-after transform: SymbolId(9): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(8): Span { start: 257, end: 258 }
-Symbol span mismatch for "B":
-after transform: SymbolId(7): Span { start: 275, end: 276 }
-rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
-Symbol span mismatch for "B":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(10): Span { start: 275, end: 276 }
-
-* transform-top-level/hoisting-default-class/input.mjs
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 37, end: 38 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
-Symbol span mismatch for "C":
-after transform: SymbolId(2): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 37, end: 38 }
 
 * transform-top-level/hoisting-mutate-outer-class-binding/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -23,15 +23,9 @@ Passed: 229/377
 
 # babel-plugin-transform-explicit-resource-management (2/4)
 * export-class-name/input.js
-Symbol span mismatch for "C":
-after transform: SymbolId(1): Span { start: 31, end: 32 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(7)]
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(5), ReferenceId(6)]
-Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 31, end: 32 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(3): []
 rebuilt        : SymbolId(3): [ReferenceId(4)]


### PR DESCRIPTION
Stacked on #22305. 

## Why

`class C { static getSelf() { return C } }` lowered by the explicit resource management transform was emitting `var C = class {}` (anonymous), so when the outer `C` is reassigned (`C = 123`), `getSelf()` returns the reassigned value instead of the original class — the exact behaviour the named class expression's inner binding is supposed to protect against. Babel emits `var C = class C {}` for the same input.

## Fix

1. **Emit `var C = class C {}`** for both `class C {}` and `export default class C {}`. Adds a `preserve_class_expression_name` helper that mirrors the swap in `decorator::legacy::transform_class_declaration_with_class_decorators` — generate a fresh `Class`-flagged symbol in the class scope for the inner class id, swap `class_decl.id.symbol_id` (via `Cell::replace`) to the new symbol, and repurpose the original symbol as the outer `var` (flags → `FunctionScopedVariable`). Returns the outer `BoundIdentifier` and the original span so the caller can emit the outer declarator with the correct span.

2. **Carry the original span through both sides of the swap.** The inner symbol is created with the original `id.span` (via `Scoping::create_symbol(span, ...)` + `add_binding`); the outer var's `BindingIdentifier` is emitted with the same span (via `BoundIdentifier::create_spanned_binding_pattern`, added in #22305). This eliminates the `Symbol span mismatch` diffs in:
   - `transform-top-level/hoisting/input.mjs`
   - `transform-top-level/hoisting-default-class/input.mjs`
   - `export-class-name/input.js`

## Comparison with Babel

Babel reuses the *original `id` node* for the outer `var` and clones it for the inner class. This PR does the inverse — reuses the original *symbol id* for the outer `var` and generates a new symbol for the inner class. Given oxc's symbol-aware model, the inversion avoids rewiring every outer-scope reference (`const K = C`, `C = 123`, …): they already point at the original symbol.

## Remaining follow-up

`export-class-name/input.js` still has `Symbol reference IDs mismatch` for `C` — references inside the class body (`return C`) still resolve to the outer symbol in the transformer's bookkeeping. A fresh semantic rebuild over the printed AST correctly resolves them to the inner class symbol, so tools that re-run semantic (rolldown / oxc_minifier on a fresh build) are fine. Tools that trust the transformer's symbol table directly (in-place minification / mangler) will see the stale binding. Rewiring those references is a separate follow-up (`Reference.symbol_id` update + `delete_resolved_reference` / `add_resolved_reference`).

## Conformance impact

- Babel suite: **692 → 694 passing** (+2)
- `transform-top-level/hoisting/input.mjs` ✓
- `transform-top-level/hoisting-default-class/input.mjs` ✓
- `export-class-name/input.js`: 4 span mismatches eliminated; reference-rewiring follow-up remains.

## Test plan

- [x] `cargo run -p oxc_transform_conformance`
- [x] `cargo run -p oxc_transform_conformance -- --exec`
- [x] `cargo test -p oxc_transformer`
