### PR TITLE
refactor(linter/no-map-spread): use `is_scope_descendant_of` api

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -670,11 +670,11 @@ where
                 let declaration_scope = self.ctx.scoping().symbol_scope_id(symbol_id);
 
                 // symbol is not declared within the mapper callback
-                if !self
-                    .ctx
-                    .scoping()
-                    .scope_ancestors(declaration_scope)
-                    .any(|parent_id| parent_id == self.cb_scope_id)
+                if declaration_scope != self.cb_scope_id
+                    && !self
+                        .ctx
+                        .scoping()
+                        .scope_is_descendant_of(declaration_scope, self.cb_scope_id)
                 {
                     return;
                 }


### PR DESCRIPTION
stacked on #22313 