### PR TITLE
test(linter/no-unused-vars): cover decorated parameter renames

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1196,6 +1196,18 @@ fn test_argument_fix() {
             Some(json!([{ "args": "all", "argsIgnorePattern": "^_" }])),
             FixKind::DangerousSuggestion,
         ),
+        (
+            "class Foo { method(@dec unused: string) {} } new Foo().method('x')",
+            "class Foo { method(@dec _unused: string) {} } new Foo().method('x')",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
+        (
+            "const marker = 1; class Foo { method(@dec(marker) unused: string) {} } new Foo().method('x')",
+            "const marker = 1; class Foo { method(@dec(marker) _unused: string) {} } new Foo().method('x')",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail).expect_fix(fix).test();


### PR DESCRIPTION
`no-unused-vars` already renames simple identifier parameters by replacing the binding identifier span. Decorated parameters should be safe for that same path because the replacement leaves the decorator expression, type annotation, and call syntax alone.

For example:

```ts
class Foo {
  method(@dec unused: string) {}
}
```

can be suggested as:

```ts
class Foo {
  method(@dec _unused: string) {}
}
```

This adds coverage for both a bare parameter decorator and a decorator call expression so that support does not regress.