### PR TITLE
test(linter/no-unused-vars): cover parameter rename followups

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1152,13 +1152,9 @@ fn test_arguments() {
 }
 
 #[test]
-fn test_argument_fix() {
-    let pass = vec![];
-    let fail = vec![
-        // Destructuring parameters are intentionally diagnosed
-        // without a fix in this first parameter-renaming phase.
-        ("function foo({ unused }) {} foo()", None),
-    ];
+fn test_argument_parameter_rename_fix() {
+    let pass: Vec<(&str, Option<serde_json::Value>)> = vec![];
+    let fail: Vec<(&str, Option<serde_json::Value>)> = vec![];
     let fix = vec![
         (
             "function foo(unused = 1) {} foo()",
@@ -1249,6 +1245,33 @@ fn test_argument_fix() {
             "const _unused = 1; function foo(_unused0: typeof _unused) {} foo(1)",
             None,
             FixKind::DangerousSuggestion,
+        ),
+        (
+            "const _unused = 1; class Foo { method(@dec unused: string) { return _unused } } new Foo().method('x')",
+            "const _unused = 1; class Foo { method(@dec _unused0: string) { return _unused } } new Foo().method('x')",
+            None,
+            FixKind::DangerousSuggestion,
+        ),
+        // TODO: support renaming destructuring and rest parameters, and generate
+        // names for more `argsIgnorePattern` values.
+        (
+            "function foo({ unused }) {} foo()",
+            "function foo({ unused }) {} foo()",
+            None,
+            FixKind::None,
+        ),
+        ("function foo([unused]) {} foo()", "function foo([unused]) {} foo()", None, FixKind::None),
+        (
+            "function foo(...unused) {} foo()",
+            "function foo(...unused) {} foo()",
+            None,
+            FixKind::None,
+        ),
+        (
+            "function foo(unused) {} foo()",
+            "function foo(unused) {} foo()",
+            Some(json!([{ "argsIgnorePattern": "^ignored" }])),
+            FixKind::None,
         ),
     ];
 


### PR DESCRIPTION
Adds the remaining `no-unused-vars` parameter-rename follow-up coverage now that the default-parameter, decorated-parameter, and capture fixes have landed on `main`.

This keeps the active fix cases together, adds a decorated capture regression, and records the still-unsupported destructuring/rest/custom-pattern cases as `FixKind::None` expectations.