### PR TITLE
fix(linter/import/no-named-as-default): avoid same-binding false positive

### DIFF
--- a/crates/oxc_linter/fixtures/import/local-default-class-and-named.js
+++ b/crates/oxc_linter/fixtures/import/local-default-class-and-named.js
@@ -1,0 +1,4 @@
+class LocalHls {}
+
+export class LocalController {}
+export { LocalHls, LocalHls as default };

--- a/crates/oxc_linter/fixtures/import/node_modules/hls-default-class/index.js
+++ b/crates/oxc_linter/fixtures/import/node_modules/hls-default-class/index.js
@@ -1,0 +1,4 @@
+class Hls {}
+
+export class CMCDController {}
+export { Hls, Hls as default };

--- a/crates/oxc_linter/fixtures/import/node_modules/hls-default-class/package.json
+++ b/crates/oxc_linter/fixtures/import/node_modules/hls-default-class/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "hls-default-class"
+}

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -4,7 +4,9 @@ use oxc_span::Span;
 
 use crate::{
     context::LintContext,
-    module_record::{ExportExportName, ExportImportName, ImportImportName, ModuleRecord},
+    module_record::{
+        ExportEntry, ExportExportName, ExportImportName, ImportImportName, ModuleRecord,
+    },
     rule::Rule,
 };
 
@@ -90,7 +92,7 @@ impl Rule for NoNamedAsDefault {
                 continue;
             }
 
-            if default_and_named_are_same_reexport(&remote_module_record, import_name) {
+            if default_and_named_are_same_export(&remote_module_record, import_name) {
                 continue;
             }
 
@@ -101,6 +103,47 @@ impl Rule for NoNamedAsDefault {
             ));
         }
     }
+}
+
+fn export_name_is(export_entry: &ExportEntry, name: &str) -> bool {
+    match &export_entry.export_name {
+        ExportExportName::Name(n) => n.name() == name,
+        ExportExportName::Default(_) => name == "default",
+        ExportExportName::Null => false,
+    }
+}
+
+fn default_and_named_are_same_export(remote_module_record: &ModuleRecord, name: &str) -> bool {
+    default_and_named_are_same_local_export(remote_module_record, name)
+        || default_and_named_are_same_reexport(remote_module_record, name)
+}
+
+/// Check if the remote module exports both default and the given named export from the same local
+/// binding.
+fn default_and_named_are_same_local_export(
+    remote_module_record: &ModuleRecord,
+    name: &str,
+) -> bool {
+    let Some(default_entry) = remote_module_record
+        .local_export_entries
+        .iter()
+        .find(|entry| export_name_is(entry, "default"))
+    else {
+        return false;
+    };
+
+    let Some(named_entry) =
+        remote_module_record.local_export_entries.iter().find(|entry| export_name_is(entry, name))
+    else {
+        return false;
+    };
+
+    default_entry.local_name.name().is_some_and(|default_local_name| {
+        named_entry
+            .local_name
+            .name()
+            .is_some_and(|named_local_name| default_local_name == named_local_name)
+    })
 }
 
 /// Check if the remote module re-exports both the default and the given named export
@@ -114,9 +157,11 @@ impl Rule for NoNamedAsDefault {
 fn default_and_named_are_same_reexport(remote_module_record: &ModuleRecord, name: &str) -> bool {
     // Find the default re-export entry.
     // Only re-exports like `export { foo as default }` are found here.
-    let Some(default_entry) = remote_module_record.indirect_export_entries.iter().find(
-        |entry| matches!(&entry.export_name, ExportExportName::Name(n) if n.name() == "default"),
-    ) else {
+    let Some(default_entry) = remote_module_record
+        .indirect_export_entries
+        .iter()
+        .find(|entry| export_name_is(entry, "default"))
+    else {
         return false;
     };
 
@@ -124,7 +169,7 @@ fn default_and_named_are_same_reexport(remote_module_record: &ModuleRecord, name
     let Some(named_entry) = remote_module_record
         .indirect_export_entries
         .iter()
-        .find(|entry| matches!(&entry.export_name, ExportExportName::Name(n) if n.name() == name))
+        .find(|entry| export_name_is(entry, name))
     else {
         return false;
     };
@@ -187,6 +232,9 @@ fn test() {
         // Import-then-export of the same named binding as both default and named.
         // Both refer to the same source binding, so this is allowed.
         r#"import userEvent from "./re-export-default-and-named-import-then-export""#,
+        // Bundled packages can export the same local binding as both default and named.
+        r#"import Hls, { CMCDController } from "hls-default-class""#,
+        r#"import LocalHls from "./local-default-class-and-named""#,
     ];
 
     let fail = vec![
@@ -212,4 +260,17 @@ fn test() {
         .change_rule_path("index.js")
         .with_import_plugin(true)
         .test_and_snapshot();
+}
+
+#[test]
+fn test_type_import() {
+    use crate::tester::Tester;
+
+    let pass = vec![r#"import type Hls from "hls-default-class""#];
+    let fail: Vec<&str> = vec![];
+
+    Tester::new(NoNamedAsDefault::NAME, NoNamedAsDefault::PLUGIN, pass, fail)
+        .change_rule_path("index.ts")
+        .with_import_plugin(true)
+        .test();
 }


### PR DESCRIPTION
This fixes a false positive in `import/no-named-as-default` for modules that export the same local binding as both a named export and the default export. Packages built into ESM bundles can emit shapes like `export { Hls, Hls as default }`; before this change, the rule only saw that `Hls` existed in `exported_bindings` and reported `import Hls from "hls.js"` as confusing, even though the default import and named export refer to the same value.

The existing rule already had a carve-out for equivalent same-binding re-export patterns. This extends that logic to local export entries as well, so the rule still reports genuinely misleading default import names but allows package bundle exports where the names resolve to the same binding.

I added fixtures for both a local module and a `node_modules` package-shaped module, including the type-only default import case from the issue.

Fixes #22319
