### PR TITLE
fix(linter): remove bulk supressions commands from CLI help

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -76,11 +76,11 @@ pub struct LintCommand {
 #[derive(Debug, Clone, Bpaf)]
 pub struct SuppressionOptions {
     /// Generate suppressions for all current violations
-    #[bpaf(switch, hide_usage)]
+    #[bpaf(switch, hide)]
     pub suppress_all: bool,
 
     /// Remove entries for violations that no longer exist
-    #[bpaf(switch, hide_usage)]
+    #[bpaf(switch, hide)]
     pub prune_suppressions: bool,
 }
 

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -161,10 +161,6 @@ Arguments:
   Enable rules that require type information
 - **`    --type-check`** &mdash; 
   Enable experimental type checking (includes TypeScript compiler diagnostics)
-- **`    --suppress-all`** &mdash; 
-  Generate suppressions for all current violations
-- **`    --prune-suppressions`** &mdash; 
-  Remove entries for violations that no longer exist
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -102,7 +102,5 @@ Available options:
         --type-aware          Enable rules that require type information
         --type-check          Enable experimental type checking (includes TypeScript compiler
                               diagnostics)
-        --suppress-all        Generate suppressions for all current violations
-        --prune-suppressions  Remove entries for violations that no longer exist
     -h, --help                Prints help information
     -V, --version             Prints version information


### PR DESCRIPTION
we're still having some internal discussion about if this feature should ship.

This PR removes the two flags from the documentation to give us the option to make breaking changes in future.

