### PR TITLE
fix(ci): pin mimalloc-safe to 0.1.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,9 +1363,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys2"
-version = "0.1.55"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a59567f2add52cb5a14b97e11ba4a20239fb93402fa99173347cbb689cd5330"
+checksum = "e8cac9b2d60928163027249a1ebd0ec8e6c58b66dca93cccf58ee618e66fc062"
 dependencies = [
  "cc",
  "cmake",
@@ -1435,9 +1435,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc-safe"
-version = "0.1.59"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9098e05eb52f2e4e14969b26608ccf7704bc8891dcc27a25e5d2d2cf782bed99"
+checksum = "a8bf95a709c09e85ae74e77b2413cbb11a1b8f2f3d11e23b3751382467c9c15c"
 dependencies = [
  "libmimalloc-sys2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ memchr = "2.7.6" # Fast byte searching
 miette = { package = "oxc-miette", version = "2.7.1", features = [
   "fancy-no-syscall",
 ] } # Error reporting
-mimalloc-safe = "0.1.56" # Fast allocator
+mimalloc-safe = "=0.1.58" # Fast allocator
 nodejs-built-in-modules = "1.0.0" # Node.js built-in modules
 nonmax = "0.5.5" # Non-maximum numbers
 num-bigint = "0.4.6" # Big integers


### PR DESCRIPTION
## Summary

Pins the workspace `mimalloc-safe` dependency to `=0.1.58` and updates `Cargo.lock` so `libmimalloc-sys2` is downgraded from `0.1.55` to `0.1.54`.

## Why

The `Build Oxfmt aarch64-pc-windows-msvc` release job started failing after the dependency set moved to `mimalloc-safe 0.1.59` / `libmimalloc-sys2 0.1.55`. The failing log shows clang compiling mimalloc for `aarch64-pc-windows-msvc` and hitting undeclared MSVC ARM64 atomics (`__ldar64` / `__stlr64`). The same workflow target passed on May 5 with `mimalloc-safe 0.1.58` / `libmimalloc-sys2 0.1.54`.

This is intended as a narrow release unblock while the upstream mimalloc-safe regression is handled separately.
