### PR TITLE
fix(ci): unset TARGET_CC for *-pc-windows-msvc targets

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -136,7 +136,10 @@ jobs:
     name: Build Oxlint ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
-      TARGET_CC: clang # for mimalloc
+      # `clang` lacks the `__ldar64`/`__stlr64` MSVC intrinsics that mimalloc's
+      # atomic.h uses on the ARM64 MSVC C path, so leave TARGET_CC unset on
+      # `*-pc-windows-msvc` targets and let cc-rs pick `cl.exe`.
+      TARGET_CC: ${{ !contains(matrix.target, 'pc-windows-msvc') && 'clang' || '' }} # for mimalloc
     defaults:
       run:
         shell: bash
@@ -441,7 +444,10 @@ jobs:
     name: Build Oxfmt ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
-      TARGET_CC: clang # for mimalloc
+      # `clang` lacks the `__ldar64`/`__stlr64` MSVC intrinsics that mimalloc's
+      # atomic.h uses on the ARM64 MSVC C path, so leave TARGET_CC unset on
+      # `*-pc-windows-msvc` targets and let cc-rs pick `cl.exe`.
+      TARGET_CC: ${{ !contains(matrix.target, 'pc-windows-msvc') && 'clang' || '' }} # for mimalloc
     defaults:
       run:
         shell: bash

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -152,7 +152,10 @@ jobs:
         run: ${{ matrix.build }}
         shell: bash
         env:
-          TARGET_CC: clang # for mimalloc
+          # `clang` lacks the `__ldar64`/`__stlr64` MSVC intrinsics that mimalloc's
+          # atomic.h uses on the ARM64 MSVC C path, so leave TARGET_CC unset on
+          # `*-pc-windows-msvc` targets and let cc-rs pick `cl.exe`.
+          TARGET_CC: ${{ !contains(matrix.target, 'pc-windows-msvc') && 'clang' || '' }} # for mimalloc
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

`Build Oxlint/Oxfmt aarch64-pc-windows-msvc` jobs in `Release Apps` have been failing while compiling `libmimalloc-sys2`:

```
c_src/mimalloc/include/mimalloc/atomic.h:230:14: error: call to undeclared function '__ldar64'
c_src/mimalloc/include/mimalloc/atomic.h:252:7:  error: call to undeclared function '__stlr64'
c_src/mimalloc/include/mimalloc/atomic.h:273:14: error: call to undeclared function '__ldar64'
c_src/mimalloc/include/mimalloc/atomic.h:298:7:  error: call to undeclared function '__stlr64'
error: failed to run custom build command for `libmimalloc-sys2 v0.1.55`
```

(see [this run](https://github.com/oxc-project/oxc/actions/runs/25678327792/job/75390244216))

### Root cause

Three workflow files (`release_apps.yml` and `reusable_release_napi.yml`) set `TARGET_CC: clang # for mimalloc` at job level, applying it to *every* matrix entry — including `aarch64-pc-windows-msvc`.

On `aarch64-pc-windows-msvc`:

1. cc-rs picks `clang` (not `cl.exe`, not `clang-cl`).
2. `libmimalloc-sys/build.rs` only flips `cpp(true)` when `is_like_msvc()` is true, which is **false** for plain `clang` — so `static.c` is compiled as C.
3. clang targeting `*-pc-windows-msvc` defines `_MSC_VER` (for Windows SDK header compatibility), so `mimalloc/atomic.h` takes the `#elif defined(_MSC_VER)` branch.
4. That branch's ARM64 path calls `__ldar64`/`__stlr64` — MSVC-only intrinsics that clang does not provide → compile error.

The x86_64/i686 MSVC builds pass because the x86 atomic path uses `__iso_volatile_load`/`__iso_volatile_store`, which clang does provide. Only ARM64 hits the missing intrinsics.

### Fix

Skip `TARGET_CC=clang` on all `*-pc-windows-msvc` targets so cc-rs falls back to `cl.exe`, which:

- has the `__ldar64`/`__stlr64` intrinsics, and
- triggers `libmimalloc-sys/build.rs`'s `is_like_msvc()` check, which switches the C build to C++ — taking the `std::atomic` branch in `atomic.h`.

This matches what [napi-rs/mimalloc-safe's own CI](https://github.com/napi-rs/mimalloc-safe/blob/main/.github/workflows/CI.yml#L208-L217) does: `TARGET_CC=clang` is only set on `*-gnu*` cross builds.

## Test plan

- [ ] `Release Apps` workflow runs successfully on a release that touches `npm/oxlint/package.json` or `npm/oxfmt/package.json`, including the `aarch64-pc-windows-msvc` matrix entries.
- [ ] `Build *-pc-windows-msvc` jobs in the napi reusable workflow pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release CI workflows and alters compiler selection for Windows MSVC matrix entries; while small, it can impact build outputs and release automation if misconfigured.
> 
> **Overview**
> Prevents Windows MSVC (notably ARM64) release builds from forcing `TARGET_CC=clang`, which was breaking `mimalloc` compilation.
> 
> Updates the `Release Apps` (`oxlint`/`oxfmt`) and reusable NAPI release workflows to set `TARGET_CC` to `clang` only for non-`*-pc-windows-msvc` targets, leaving it unset so `cc-rs` falls back to `cl.exe` on MSVC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2cab00b89fb48fea5229bc61951525648b6525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->