### PR TITLE
feat(linter/eslint): implement `consistent-this` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -875,6 +875,7 @@ export interface DummyRuleMap {
   "capitalized-comments"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever] | [AllowWarnDeny, AlwaysNever, OptionsJsonEnum];
   "class-methods-use-this"?: RuleNoConfig | [AllowWarnDeny, ClassMethodsUseThisConfig];
   complexity?: RuleNoConfig | [AllowWarnDeny, ComplexityConfigEnum];
+  "consistent-this"?: RuleNoConfig | [AllowWarnDeny, string, ...string[]];
   "constructor-super"?: RuleNoConfig;
   curly?: RuleNoConfig | [AllowWarnDeny, CurlyType] | [AllowWarnDeny, CurlyType, CurlyConsistent];
   "default-case"?: RuleNoConfig | [AllowWarnDeny, DefaultCaseConfig];

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -901,6 +901,7 @@ export interface DummyRuleMap {
   "capitalized-comments"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever] | [AllowWarnDeny, AlwaysNever, OptionsJsonEnum];
   "class-methods-use-this"?: RuleNoConfig | [AllowWarnDeny, ClassMethodsUseThisConfig];
   complexity?: RuleNoConfig | [AllowWarnDeny, ComplexityConfigEnum];
+  "consistent-this"?: RuleNoConfig | [AllowWarnDeny, string, ...string[]];
   "constructor-super"?: RuleNoConfig;
   curly?: RuleNoConfig | [AllowWarnDeny, CurlyType] | [AllowWarnDeny, CurlyType, CurlyConsistent];
   "default-case"?: RuleNoConfig | [AllowWarnDeny, DefaultCaseConfig];

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -267,6 +267,14 @@ impl RuleRunner for crate::rules::eslint::complexity::Complexity {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::consistent_this::ConsistentThis {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::VariableDeclarator,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+}
+
 impl RuleRunner for crate::rules::eslint::constructor_super::ConstructorSuper {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::Class]));

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -270,6 +270,16 @@ impl RuleRunner for crate::rules::eslint::complexity::Complexity {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::eslint::consistent_this::ConsistentThis {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::Function,
+        AstType::Program,
+        AstType::VariableDeclarator,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::constructor_super::ConstructorSuper {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::Class]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -17,6 +17,7 @@ pub use crate::rules::eslint::block_scoped_var::BlockScopedVar as EslintBlockSco
 pub use crate::rules::eslint::capitalized_comments::CapitalizedComments as EslintCapitalizedComments;
 pub use crate::rules::eslint::class_methods_use_this::ClassMethodsUseThis as EslintClassMethodsUseThis;
 pub use crate::rules::eslint::complexity::Complexity as EslintComplexity;
+pub use crate::rules::eslint::consistent_this::ConsistentThis as EslintConsistentThis;
 pub use crate::rules::eslint::constructor_super::ConstructorSuper as EslintConstructorSuper;
 pub use crate::rules::eslint::curly::Curly as EslintCurly;
 pub use crate::rules::eslint::default_case::DefaultCase as EslintDefaultCase;
@@ -901,6 +902,7 @@ pub enum RuleEnum {
     EslintCapitalizedComments(EslintCapitalizedComments),
     EslintClassMethodsUseThis(EslintClassMethodsUseThis),
     EslintComplexity(EslintComplexity),
+    EslintConsistentThis(EslintConsistentThis),
     EslintConstructorSuper(EslintConstructorSuper),
     EslintCurly(EslintCurly),
     EslintDefaultCase(EslintDefaultCase),
@@ -1751,7 +1753,8 @@ const ESLINT_BLOCK_SCOPED_VAR_ID: usize = ESLINT_ARROW_BODY_STYLE_ID + 1usize;
 const ESLINT_CAPITALIZED_COMMENTS_ID: usize = ESLINT_BLOCK_SCOPED_VAR_ID + 1usize;
 const ESLINT_CLASS_METHODS_USE_THIS_ID: usize = ESLINT_CAPITALIZED_COMMENTS_ID + 1usize;
 const ESLINT_COMPLEXITY_ID: usize = ESLINT_CLASS_METHODS_USE_THIS_ID + 1usize;
-const ESLINT_CONSTRUCTOR_SUPER_ID: usize = ESLINT_COMPLEXITY_ID + 1usize;
+const ESLINT_CONSISTENT_THIS_ID: usize = ESLINT_COMPLEXITY_ID + 1usize;
+const ESLINT_CONSTRUCTOR_SUPER_ID: usize = ESLINT_CONSISTENT_THIS_ID + 1usize;
 const ESLINT_CURLY_ID: usize = ESLINT_CONSTRUCTOR_SUPER_ID + 1usize;
 const ESLINT_DEFAULT_CASE_ID: usize = ESLINT_CURLY_ID + 1usize;
 const ESLINT_DEFAULT_CASE_LAST_ID: usize = ESLINT_DEFAULT_CASE_ID + 1usize;
@@ -2705,6 +2708,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => ESLINT_CAPITALIZED_COMMENTS_ID,
             Self::EslintClassMethodsUseThis(_) => ESLINT_CLASS_METHODS_USE_THIS_ID,
             Self::EslintComplexity(_) => ESLINT_COMPLEXITY_ID,
+            Self::EslintConsistentThis(_) => ESLINT_CONSISTENT_THIS_ID,
             Self::EslintConstructorSuper(_) => ESLINT_CONSTRUCTOR_SUPER_ID,
             Self::EslintCurly(_) => ESLINT_CURLY_ID,
             Self::EslintDefaultCase(_) => ESLINT_DEFAULT_CASE_ID,
@@ -3678,6 +3682,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::NAME,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::NAME,
             Self::EslintComplexity(_) => EslintComplexity::NAME,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::NAME,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::NAME,
             Self::EslintCurly(_) => EslintCurly::NAME,
             Self::EslintDefaultCase(_) => EslintDefaultCase::NAME,
@@ -4639,6 +4644,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::CATEGORY,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::CATEGORY,
             Self::EslintComplexity(_) => EslintComplexity::CATEGORY,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::CATEGORY,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::CATEGORY,
             Self::EslintCurly(_) => EslintCurly::CATEGORY,
             Self::EslintDefaultCase(_) => EslintDefaultCase::CATEGORY,
@@ -5655,6 +5661,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::FIX,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::FIX,
             Self::EslintComplexity(_) => EslintComplexity::FIX,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::FIX,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::FIX,
             Self::EslintCurly(_) => EslintCurly::FIX,
             Self::EslintDefaultCase(_) => EslintDefaultCase::FIX,
@@ -6621,6 +6628,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::documentation(),
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::documentation(),
             Self::EslintComplexity(_) => EslintComplexity::documentation(),
+            Self::EslintConsistentThis(_) => EslintConsistentThis::documentation(),
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::documentation(),
             Self::EslintCurly(_) => EslintCurly::documentation(),
             Self::EslintDefaultCase(_) => EslintDefaultCase::documentation(),
@@ -7906,6 +7914,8 @@ impl RuleEnum {
             }
             Self::EslintComplexity(_) => EslintComplexity::config_schema(generator)
                 .or_else(|| EslintComplexity::schema(generator)),
+            Self::EslintConsistentThis(_) => EslintConsistentThis::config_schema(generator)
+                .or_else(|| EslintConsistentThis::schema(generator)),
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::config_schema(generator)
                 .or_else(|| EslintConstructorSuper::schema(generator)),
             Self::EslintCurly(_) => {
@@ -10261,6 +10271,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => "eslint",
             Self::EslintClassMethodsUseThis(_) => "eslint",
             Self::EslintComplexity(_) => "eslint",
+            Self::EslintConsistentThis(_) => "eslint",
             Self::EslintConstructorSuper(_) => "eslint",
             Self::EslintCurly(_) => "eslint",
             Self::EslintDefaultCase(_) => "eslint",
@@ -11184,6 +11195,9 @@ impl RuleEnum {
             )),
             Self::EslintComplexity(_) => {
                 Ok(Self::EslintComplexity(EslintComplexity::from_configuration(value)?))
+            }
+            Self::EslintConsistentThis(_) => {
+                Ok(Self::EslintConsistentThis(EslintConsistentThis::from_configuration(value)?))
             }
             Self::EslintConstructorSuper(_) => {
                 Ok(Self::EslintConstructorSuper(EslintConstructorSuper::from_configuration(value)?))
@@ -13820,6 +13834,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.to_configuration(),
             Self::EslintClassMethodsUseThis(rule) => rule.to_configuration(),
             Self::EslintComplexity(rule) => rule.to_configuration(),
+            Self::EslintConsistentThis(rule) => rule.to_configuration(),
             Self::EslintConstructorSuper(rule) => rule.to_configuration(),
             Self::EslintCurly(rule) => rule.to_configuration(),
             Self::EslintDefaultCase(rule) => rule.to_configuration(),
@@ -14670,6 +14685,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run(node, ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.run(node, ctx),
             Self::EslintComplexity(rule) => rule.run(node, ctx),
+            Self::EslintConsistentThis(rule) => rule.run(node, ctx),
             Self::EslintConstructorSuper(rule) => rule.run(node, ctx),
             Self::EslintCurly(rule) => rule.run(node, ctx),
             Self::EslintDefaultCase(rule) => rule.run(node, ctx),
@@ -15528,6 +15544,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run_once(ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.run_once(ctx),
             Self::EslintComplexity(rule) => rule.run_once(ctx),
+            Self::EslintConsistentThis(rule) => rule.run_once(ctx),
             Self::EslintConstructorSuper(rule) => rule.run_once(ctx),
             Self::EslintCurly(rule) => rule.run_once(ctx),
             Self::EslintDefaultCase(rule) => rule.run_once(ctx),
@@ -16389,6 +16406,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintComplexity(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintConsistentThis(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintConstructorSuper(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintCurly(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintDefaultCase(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17362,6 +17380,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.should_run(ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.should_run(ctx),
             Self::EslintComplexity(rule) => rule.should_run(ctx),
+            Self::EslintConsistentThis(rule) => rule.should_run(ctx),
             Self::EslintConstructorSuper(rule) => rule.should_run(ctx),
             Self::EslintCurly(rule) => rule.should_run(ctx),
             Self::EslintDefaultCase(rule) => rule.should_run(ctx),
@@ -18213,6 +18232,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::IS_TSGOLINT_RULE,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::IS_TSGOLINT_RULE,
             Self::EslintComplexity(_) => EslintComplexity::IS_TSGOLINT_RULE,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::IS_TSGOLINT_RULE,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::IS_TSGOLINT_RULE,
             Self::EslintCurly(_) => EslintCurly::IS_TSGOLINT_RULE,
             Self::EslintDefaultCase(_) => EslintDefaultCase::IS_TSGOLINT_RULE,
@@ -19434,6 +19454,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::VERSION,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::VERSION,
             Self::EslintComplexity(_) => EslintComplexity::VERSION,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::VERSION,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::VERSION,
             Self::EslintCurly(_) => EslintCurly::VERSION,
             Self::EslintDefaultCase(_) => EslintDefaultCase::VERSION,
@@ -20452,6 +20473,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::HAS_CONFIG,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::HAS_CONFIG,
             Self::EslintComplexity(_) => EslintComplexity::HAS_CONFIG,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::HAS_CONFIG,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::HAS_CONFIG,
             Self::EslintCurly(_) => EslintCurly::HAS_CONFIG,
             Self::EslintDefaultCase(_) => EslintDefaultCase::HAS_CONFIG,
@@ -21507,6 +21529,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::INFO,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::INFO,
             Self::EslintComplexity(_) => EslintComplexity::INFO,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::INFO,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::INFO,
             Self::EslintCurly(_) => EslintCurly::INFO,
             Self::EslintDefaultCase(_) => EslintDefaultCase::INFO,
@@ -22471,6 +22494,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.types_info(),
             Self::EslintClassMethodsUseThis(rule) => rule.types_info(),
             Self::EslintComplexity(rule) => rule.types_info(),
+            Self::EslintConsistentThis(rule) => rule.types_info(),
             Self::EslintConstructorSuper(rule) => rule.types_info(),
             Self::EslintCurly(rule) => rule.types_info(),
             Self::EslintDefaultCase(rule) => rule.types_info(),
@@ -23316,6 +23340,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run_info(),
             Self::EslintClassMethodsUseThis(rule) => rule.run_info(),
             Self::EslintComplexity(rule) => rule.run_info(),
+            Self::EslintConsistentThis(rule) => rule.run_info(),
             Self::EslintConstructorSuper(rule) => rule.run_info(),
             Self::EslintCurly(rule) => rule.run_info(),
             Self::EslintDefaultCase(rule) => rule.run_info(),
@@ -24183,6 +24208,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintCapitalizedComments(EslintCapitalizedComments::default()),
         RuleEnum::EslintClassMethodsUseThis(EslintClassMethodsUseThis::default()),
         RuleEnum::EslintComplexity(EslintComplexity::default()),
+        RuleEnum::EslintConsistentThis(EslintConsistentThis::default()),
         RuleEnum::EslintConstructorSuper(EslintConstructorSuper::default()),
         RuleEnum::EslintCurly(EslintCurly::default()),
         RuleEnum::EslintDefaultCase(EslintDefaultCase::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -17,6 +17,7 @@ pub use crate::rules::eslint::block_scoped_var::BlockScopedVar as EslintBlockSco
 pub use crate::rules::eslint::capitalized_comments::CapitalizedComments as EslintCapitalizedComments;
 pub use crate::rules::eslint::class_methods_use_this::ClassMethodsUseThis as EslintClassMethodsUseThis;
 pub use crate::rules::eslint::complexity::Complexity as EslintComplexity;
+pub use crate::rules::eslint::consistent_this::ConsistentThis as EslintConsistentThis;
 pub use crate::rules::eslint::constructor_super::ConstructorSuper as EslintConstructorSuper;
 pub use crate::rules::eslint::curly::Curly as EslintCurly;
 pub use crate::rules::eslint::default_case::DefaultCase as EslintDefaultCase;
@@ -909,6 +910,7 @@ pub enum RuleEnum {
     EslintCapitalizedComments(EslintCapitalizedComments),
     EslintClassMethodsUseThis(EslintClassMethodsUseThis),
     EslintComplexity(EslintComplexity),
+    EslintConsistentThis(EslintConsistentThis),
     EslintConstructorSuper(EslintConstructorSuper),
     EslintCurly(EslintCurly),
     EslintDefaultCase(EslintDefaultCase),
@@ -1767,7 +1769,8 @@ const ESLINT_BLOCK_SCOPED_VAR_ID: usize = ESLINT_ARROW_BODY_STYLE_ID + 1usize;
 const ESLINT_CAPITALIZED_COMMENTS_ID: usize = ESLINT_BLOCK_SCOPED_VAR_ID + 1usize;
 const ESLINT_CLASS_METHODS_USE_THIS_ID: usize = ESLINT_CAPITALIZED_COMMENTS_ID + 1usize;
 const ESLINT_COMPLEXITY_ID: usize = ESLINT_CLASS_METHODS_USE_THIS_ID + 1usize;
-const ESLINT_CONSTRUCTOR_SUPER_ID: usize = ESLINT_COMPLEXITY_ID + 1usize;
+const ESLINT_CONSISTENT_THIS_ID: usize = ESLINT_COMPLEXITY_ID + 1usize;
+const ESLINT_CONSTRUCTOR_SUPER_ID: usize = ESLINT_CONSISTENT_THIS_ID + 1usize;
 const ESLINT_CURLY_ID: usize = ESLINT_CONSTRUCTOR_SUPER_ID + 1usize;
 const ESLINT_DEFAULT_CASE_ID: usize = ESLINT_CURLY_ID + 1usize;
 const ESLINT_DEFAULT_CASE_LAST_ID: usize = ESLINT_DEFAULT_CASE_ID + 1usize;
@@ -2730,6 +2733,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => ESLINT_CAPITALIZED_COMMENTS_ID,
             Self::EslintClassMethodsUseThis(_) => ESLINT_CLASS_METHODS_USE_THIS_ID,
             Self::EslintComplexity(_) => ESLINT_COMPLEXITY_ID,
+            Self::EslintConsistentThis(_) => ESLINT_CONSISTENT_THIS_ID,
             Self::EslintConstructorSuper(_) => ESLINT_CONSTRUCTOR_SUPER_ID,
             Self::EslintCurly(_) => ESLINT_CURLY_ID,
             Self::EslintDefaultCase(_) => ESLINT_DEFAULT_CASE_ID,
@@ -3711,6 +3715,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::NAME,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::NAME,
             Self::EslintComplexity(_) => EslintComplexity::NAME,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::NAME,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::NAME,
             Self::EslintCurly(_) => EslintCurly::NAME,
             Self::EslintDefaultCase(_) => EslintDefaultCase::NAME,
@@ -4680,6 +4685,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::CATEGORY,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::CATEGORY,
             Self::EslintComplexity(_) => EslintComplexity::CATEGORY,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::CATEGORY,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::CATEGORY,
             Self::EslintCurly(_) => EslintCurly::CATEGORY,
             Self::EslintDefaultCase(_) => EslintDefaultCase::CATEGORY,
@@ -5704,6 +5710,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::FIX,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::FIX,
             Self::EslintComplexity(_) => EslintComplexity::FIX,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::FIX,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::FIX,
             Self::EslintCurly(_) => EslintCurly::FIX,
             Self::EslintDefaultCase(_) => EslintDefaultCase::FIX,
@@ -6678,6 +6685,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::documentation(),
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::documentation(),
             Self::EslintComplexity(_) => EslintComplexity::documentation(),
+            Self::EslintConsistentThis(_) => EslintConsistentThis::documentation(),
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::documentation(),
             Self::EslintCurly(_) => EslintCurly::documentation(),
             Self::EslintDefaultCase(_) => EslintDefaultCase::documentation(),
@@ -7975,6 +7983,8 @@ impl RuleEnum {
             }
             Self::EslintComplexity(_) => EslintComplexity::config_schema(generator)
                 .or_else(|| EslintComplexity::schema(generator)),
+            Self::EslintConsistentThis(_) => EslintConsistentThis::config_schema(generator)
+                .or_else(|| EslintConsistentThis::schema(generator)),
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::config_schema(generator)
                 .or_else(|| EslintConstructorSuper::schema(generator)),
             Self::EslintCurly(_) => {
@@ -10351,6 +10361,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => "eslint",
             Self::EslintClassMethodsUseThis(_) => "eslint",
             Self::EslintComplexity(_) => "eslint",
+            Self::EslintConsistentThis(_) => "eslint",
             Self::EslintConstructorSuper(_) => "eslint",
             Self::EslintCurly(_) => "eslint",
             Self::EslintDefaultCase(_) => "eslint",
@@ -11282,6 +11293,9 @@ impl RuleEnum {
             )),
             Self::EslintComplexity(_) => {
                 Ok(Self::EslintComplexity(EslintComplexity::from_configuration(value)?))
+            }
+            Self::EslintConsistentThis(_) => {
+                Ok(Self::EslintConsistentThis(EslintConsistentThis::from_configuration(value)?))
             }
             Self::EslintConstructorSuper(_) => {
                 Ok(Self::EslintConstructorSuper(EslintConstructorSuper::from_configuration(value)?))
@@ -13944,6 +13958,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.to_configuration(),
             Self::EslintClassMethodsUseThis(rule) => rule.to_configuration(),
             Self::EslintComplexity(rule) => rule.to_configuration(),
+            Self::EslintConsistentThis(rule) => rule.to_configuration(),
             Self::EslintConstructorSuper(rule) => rule.to_configuration(),
             Self::EslintCurly(rule) => rule.to_configuration(),
             Self::EslintDefaultCase(rule) => rule.to_configuration(),
@@ -14802,6 +14817,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run(node, ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.run(node, ctx),
             Self::EslintComplexity(rule) => rule.run(node, ctx),
+            Self::EslintConsistentThis(rule) => rule.run(node, ctx),
             Self::EslintConstructorSuper(rule) => rule.run(node, ctx),
             Self::EslintCurly(rule) => rule.run(node, ctx),
             Self::EslintDefaultCase(rule) => rule.run(node, ctx),
@@ -15668,6 +15684,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run_once(ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.run_once(ctx),
             Self::EslintComplexity(rule) => rule.run_once(ctx),
+            Self::EslintConsistentThis(rule) => rule.run_once(ctx),
             Self::EslintConstructorSuper(rule) => rule.run_once(ctx),
             Self::EslintCurly(rule) => rule.run_once(ctx),
             Self::EslintDefaultCase(rule) => rule.run_once(ctx),
@@ -16537,6 +16554,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintComplexity(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintConsistentThis(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintConstructorSuper(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintCurly(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintDefaultCase(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17518,6 +17536,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.should_run(ctx),
             Self::EslintClassMethodsUseThis(rule) => rule.should_run(ctx),
             Self::EslintComplexity(rule) => rule.should_run(ctx),
+            Self::EslintConsistentThis(rule) => rule.should_run(ctx),
             Self::EslintConstructorSuper(rule) => rule.should_run(ctx),
             Self::EslintCurly(rule) => rule.should_run(ctx),
             Self::EslintDefaultCase(rule) => rule.should_run(ctx),
@@ -18377,6 +18396,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::IS_TSGOLINT_RULE,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::IS_TSGOLINT_RULE,
             Self::EslintComplexity(_) => EslintComplexity::IS_TSGOLINT_RULE,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::IS_TSGOLINT_RULE,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::IS_TSGOLINT_RULE,
             Self::EslintCurly(_) => EslintCurly::IS_TSGOLINT_RULE,
             Self::EslintDefaultCase(_) => EslintDefaultCase::IS_TSGOLINT_RULE,
@@ -19610,6 +19630,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::VERSION,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::VERSION,
             Self::EslintComplexity(_) => EslintComplexity::VERSION,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::VERSION,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::VERSION,
             Self::EslintCurly(_) => EslintCurly::VERSION,
             Self::EslintDefaultCase(_) => EslintDefaultCase::VERSION,
@@ -20636,6 +20657,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::HAS_CONFIG,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::HAS_CONFIG,
             Self::EslintComplexity(_) => EslintComplexity::HAS_CONFIG,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::HAS_CONFIG,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::HAS_CONFIG,
             Self::EslintCurly(_) => EslintCurly::HAS_CONFIG,
             Self::EslintDefaultCase(_) => EslintDefaultCase::HAS_CONFIG,
@@ -21701,6 +21723,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(_) => EslintCapitalizedComments::INFO,
             Self::EslintClassMethodsUseThis(_) => EslintClassMethodsUseThis::INFO,
             Self::EslintComplexity(_) => EslintComplexity::INFO,
+            Self::EslintConsistentThis(_) => EslintConsistentThis::INFO,
             Self::EslintConstructorSuper(_) => EslintConstructorSuper::INFO,
             Self::EslintCurly(_) => EslintCurly::INFO,
             Self::EslintDefaultCase(_) => EslintDefaultCase::INFO,
@@ -22673,6 +22696,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.types_info(),
             Self::EslintClassMethodsUseThis(rule) => rule.types_info(),
             Self::EslintComplexity(rule) => rule.types_info(),
+            Self::EslintConsistentThis(rule) => rule.types_info(),
             Self::EslintConstructorSuper(rule) => rule.types_info(),
             Self::EslintCurly(rule) => rule.types_info(),
             Self::EslintDefaultCase(rule) => rule.types_info(),
@@ -23526,6 +23550,7 @@ impl RuleEnum {
             Self::EslintCapitalizedComments(rule) => rule.run_info(),
             Self::EslintClassMethodsUseThis(rule) => rule.run_info(),
             Self::EslintComplexity(rule) => rule.run_info(),
+            Self::EslintConsistentThis(rule) => rule.run_info(),
             Self::EslintConstructorSuper(rule) => rule.run_info(),
             Self::EslintCurly(rule) => rule.run_info(),
             Self::EslintDefaultCase(rule) => rule.run_info(),
@@ -24401,6 +24426,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintCapitalizedComments(EslintCapitalizedComments::default()),
         RuleEnum::EslintClassMethodsUseThis(EslintClassMethodsUseThis::default()),
         RuleEnum::EslintComplexity(EslintComplexity::default()),
+        RuleEnum::EslintConsistentThis(EslintConsistentThis::default()),
         RuleEnum::EslintConstructorSuper(EslintConstructorSuper::default()),
         RuleEnum::EslintCurly(EslintCurly::default()),
         RuleEnum::EslintDefaultCase(EslintDefaultCase::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -49,6 +49,7 @@ pub(crate) mod eslint {
     pub mod capitalized_comments;
     pub mod class_methods_use_this;
     pub mod complexity;
+    pub mod consistent_this;
     pub mod constructor_super;
     pub mod curly;
     pub mod default_case;

--- a/crates/oxc_linter/src/rules/eslint/consistent_this.rs
+++ b/crates/oxc_linter/src/rules/eslint/consistent_this.rs
@@ -1,0 +1,667 @@
+use oxc_ast::{
+    AstKind,
+    ast::{AssignmentTarget, BindingPattern, Expression, ForStatementInit, ForStatementLeft},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::{AstNode, NodeId};
+use oxc_span::{GetSpan, Span};
+use oxc_str::CompactStr;
+use oxc_syntax::{operator::AssignmentOperator, scope::ScopeId, symbol::SymbolId};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::{Rule, TupleRuleConfig},
+    utils::unique_non_empty_string_spread_schema,
+};
+
+fn alias_not_assigned_to_this(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Designated alias '{name}' is not assigned to 'this'."))
+        .with_label(span)
+}
+
+fn unexpected_alias(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected alias '{name}' for 'this'.")).with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ConsistentThis(Box<ConsistentThisConfig>);
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(try_from = "Vec<CompactStr>")]
+#[schemars(transparent)]
+struct ConsistentThisConfig(
+    #[schemars(schema_with = "unique_non_empty_string_spread_schema")] Box<[CompactStr]>,
+);
+
+impl ConsistentThisConfig {
+    #[inline]
+    fn aliases(&self) -> &[CompactStr] {
+        &self.0
+    }
+}
+
+impl Default for ConsistentThisConfig {
+    fn default() -> Self {
+        Self(vec![CompactStr::new_const("that")].into_boxed_slice())
+    }
+}
+
+impl TryFrom<Vec<CompactStr>> for ConsistentThisConfig {
+    type Error = &'static str;
+
+    fn try_from(aliases: Vec<CompactStr>) -> Result<Self, Self::Error> {
+        if aliases.is_empty() {
+            return Ok(Self::default());
+        }
+
+        for (index, alias) in aliases.iter().enumerate() {
+            if alias.is_empty() {
+                return Err("alias names must not be empty");
+            }
+
+            if aliases[..index].iter().any(|existing| existing == alias) {
+                return Err("alias names must be unique");
+            }
+        }
+
+        Ok(Self(aliases.into_boxed_slice()))
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces consistent naming when capturing the current execution context.
+    ///
+    /// This rule requires variables with configured alias names to be initialized
+    /// or assigned to `this` in the same scope. It also reports initializing or
+    /// assigning `this` to variables whose names are not configured aliases.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// JavaScript code sometimes captures `this` in a variable so callbacks can
+    /// refer to the original execution context. Mixing aliases such as `that`,
+    /// `self`, and `me` makes this pattern harder to read consistently.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule with the default `"that"` alias:
+    /// ```js
+    /// var self = this;
+    /// var that = window;
+    ///
+    /// function outer() {
+    ///   var that;
+    ///   function inner() {
+    ///     that = this;
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the default `"that"` alias:
+    /// ```js
+    /// var that = this;
+    /// var self = window;
+    ///
+    /// function f() {
+    ///   var that;
+    ///   that = this;
+    /// }
+    ///
+    /// var foo = {};
+    /// foo.bar = this;
+    /// ```
+    ConsistentThis,
+    eslint,
+    style,
+    none,
+    config = ConsistentThisConfig,
+    version = "next",
+    short_description = "Enforce consistent naming when capturing the current execution context.",
+);
+
+impl ConsistentThis {
+    #[inline]
+    fn is_alias(&self, name: &str) -> bool {
+        self.0.aliases().iter().any(|alias| alias == name)
+    }
+
+    fn check_assignment(
+        &self,
+        ctx: &LintContext<'_>,
+        span: Span,
+        name: &str,
+        rhs: &Expression<'_>,
+        operator: Option<AssignmentOperator>,
+    ) {
+        let is_this = is_this_expression(rhs);
+
+        if self.is_alias(name) {
+            if !is_this || operator.is_some_and(|operator| operator != AssignmentOperator::Assign) {
+                ctx.diagnostic(alias_not_assigned_to_this(span, name));
+            }
+        } else if is_this {
+            ctx.diagnostic(unexpected_alias(span, name));
+        }
+    }
+
+    fn check_was_assigned(&self, ctx: &LintContext<'_>, scope_id: ScopeId) {
+        let scoping = ctx.scoping();
+
+        for alias in self.0.aliases() {
+            let alias = alias.as_str();
+            let Some(symbol_id) = scoping.get_binding(scope_id, alias.into()) else {
+                continue;
+            };
+
+            if is_named_function_or_class_expression_symbol(ctx, symbol_id) {
+                continue;
+            }
+
+            if scoping
+                .symbol_declarations(symbol_id)
+                .any(|node_id| is_initialized_variable_declarator(ctx, node_id))
+            {
+                continue;
+            }
+
+            if has_same_scope_this_assignment(ctx, symbol_id, scope_id) {
+                continue;
+            }
+
+            for node_id in scoping.symbol_declarations(symbol_id) {
+                if is_unchecked_block_function_declaration(ctx, node_id, scope_id) {
+                    continue;
+                }
+
+                let node = ctx.nodes().get_node(node_id);
+                ctx.diagnostic(alias_not_assigned_to_this(node.kind().span(), alias));
+            }
+        }
+    }
+}
+
+impl Rule for ConsistentThis {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<TupleRuleConfig<ConsistentThisConfig>>(value)
+            .map(TupleRuleConfig::into_inner)
+            .map(Box::new)
+            .map(Self)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::VariableDeclarator(decl) => {
+                let Some(init) = &decl.init else { return };
+                let BindingPattern::BindingIdentifier(id) = &decl.id else {
+                    return;
+                };
+
+                self.check_assignment(ctx, decl.span, id.name.as_str(), init, None);
+            }
+            AstKind::AssignmentExpression(assignment) => {
+                let AssignmentTarget::AssignmentTargetIdentifier(id) = &assignment.left else {
+                    return;
+                };
+
+                self.check_assignment(
+                    ctx,
+                    assignment.span,
+                    id.name.as_str(),
+                    &assignment.right,
+                    Some(assignment.operator),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn run_once(&self, ctx: &LintContext) {
+        for scope_id in ctx.scoping().scope_descendants_from_root() {
+            if is_eslint_checked_scope(ctx, scope_id) {
+                self.check_was_assigned(ctx, scope_id);
+            }
+        }
+    }
+}
+
+fn is_eslint_checked_scope(ctx: &LintContext<'_>, scope_id: ScopeId) -> bool {
+    let scoping = ctx.scoping();
+    let flags = scoping.scope_flags(scope_id);
+
+    if flags.is_top() {
+        return true;
+    }
+
+    if !flags.is_function() || flags.is_arrow() {
+        return false;
+    }
+
+    matches!(ctx.nodes().kind(scoping.get_node_id(scope_id)), AstKind::Function(_))
+}
+
+#[inline]
+fn is_this_expression(expr: &Expression<'_>) -> bool {
+    matches!(expr.without_parentheses(), Expression::ThisExpression(_))
+}
+
+fn is_named_function_or_class_expression_symbol(
+    ctx: &LintContext<'_>,
+    symbol_id: SymbolId,
+) -> bool {
+    ctx.scoping().symbol_declarations(symbol_id).all(|node_id| {
+        let node = ctx.nodes().get_node(node_id);
+        match node.kind() {
+            AstKind::Function(func) => func.is_expression(),
+            AstKind::Class(class) => class.is_expression(),
+            _ => false,
+        }
+    })
+}
+
+fn is_initialized_variable_declarator(ctx: &LintContext<'_>, node_id: NodeId) -> bool {
+    matches!(
+        ctx.nodes().kind(node_id),
+        AstKind::VariableDeclarator(decl) if decl.init.is_some()
+    )
+}
+
+fn is_unchecked_block_function_declaration(
+    ctx: &LintContext<'_>,
+    declaration_id: NodeId,
+    checked_scope_id: ScopeId,
+) -> bool {
+    // ESLint only runs the deferred check for Program, FunctionDeclaration, and
+    // FunctionExpression exits. Annex-B function declarations inside block or
+    // switch scopes may share a var binding in Oxc, but ESLint never checks the
+    // block/switch scope that owns that declaration node.
+    if !matches!(
+        ctx.nodes().kind(declaration_id),
+        AstKind::Function(function) if function.is_declaration()
+    ) {
+        return false;
+    }
+
+    let checked_node_id = ctx.scoping().get_node_id(checked_scope_id);
+    for (ancestor_id, ancestor) in ctx.nodes().ancestors_enumerated(declaration_id) {
+        if ancestor_id == checked_node_id {
+            return false;
+        }
+
+        match ancestor.kind() {
+            AstKind::BlockStatement(_) | AstKind::SwitchStatement(_) => return true,
+            AstKind::Program(_) | AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
+                return false;
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn has_same_scope_this_assignment(
+    ctx: &LintContext<'_>,
+    symbol_id: SymbolId,
+    checked_scope_id: ScopeId,
+) -> bool {
+    ctx.scoping().get_resolved_references(symbol_id).any(|reference| {
+        reference.is_write()
+            && reference_matches_eslint_scope(ctx, reference.scope_id(), checked_scope_id)
+            && reference_write_is_plain_this_assignment(ctx, reference.node_id())
+    })
+}
+
+fn reference_matches_eslint_scope(
+    ctx: &LintContext<'_>,
+    reference_scope_id: ScopeId,
+    checked_scope_id: ScopeId,
+) -> bool {
+    if reference_scope_id == checked_scope_id {
+        return true;
+    }
+
+    let scoping = ctx.scoping();
+    let mut scope_id = reference_scope_id;
+
+    while is_eslint_transparent_scope(ctx, scope_id) {
+        let Some(parent_scope_id) = scoping.scope_parent_id(scope_id) else {
+            return false;
+        };
+
+        if parent_scope_id == checked_scope_id {
+            return true;
+        }
+
+        scope_id = parent_scope_id;
+    }
+
+    false
+}
+
+fn is_eslint_transparent_scope(ctx: &LintContext<'_>, scope_id: ScopeId) -> bool {
+    // Oxc creates scopes for all `for` nodes. ESLint-scope only treats lexical
+    // `for` heads (`let` / `const` / `using`) as separate for this rule, so
+    // non-lexical `for` scopes are transparent for same-scope assignment checks.
+    match ctx.nodes().kind(ctx.scoping().get_node_id(scope_id)) {
+        AstKind::ForStatement(stmt) => {
+            !stmt.init.as_ref().is_some_and(for_statement_init_has_lexical_declaration)
+        }
+        AstKind::ForInStatement(stmt) => !for_statement_left_has_lexical_declaration(&stmt.left),
+        AstKind::ForOfStatement(stmt) => !for_statement_left_has_lexical_declaration(&stmt.left),
+        _ => false,
+    }
+}
+
+fn for_statement_init_has_lexical_declaration(init: &ForStatementInit<'_>) -> bool {
+    matches!(init, ForStatementInit::VariableDeclaration(decl) if decl.kind.is_lexical())
+}
+
+fn for_statement_left_has_lexical_declaration(left: &ForStatementLeft<'_>) -> bool {
+    matches!(left, ForStatementLeft::VariableDeclaration(decl) if decl.kind.is_lexical())
+}
+
+fn reference_write_is_plain_this_assignment(ctx: &LintContext<'_>, node_id: NodeId) -> bool {
+    let mut node = ctx.nodes().get_node(node_id);
+
+    // ESLint uses `reference.writeExpr`. Oxc references do not expose that directly,
+    // so walk from the reference through assignment targets until the containing
+    // assignment expression. This intentionally lets destructuring writes like
+    // `({ self } = this)` satisfy deferred checks.
+    loop {
+        let parent = ctx.nodes().parent_node(node.id());
+
+        match parent.kind() {
+            AstKind::AssignmentExpression(assignment) => {
+                return assignment.operator == AssignmentOperator::Assign
+                    && is_this_expression(&assignment.right);
+            }
+            AstKind::Program(_) | AstKind::Function(_) => return false,
+            _ => node = parent,
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let self_config = Some(serde_json::json!(["self"]));
+    let that_config = Some(serde_json::json!(["that"]));
+    let multi_alias_config = Some(serde_json::json!(["self", "vm"]));
+
+    let pass = vec![
+        ("var foo = 42, that = this", None),
+        ("var foo = 42, self = this", self_config.clone()),
+        ("var self = 42", that_config.clone()),
+        ("var self", that_config.clone()),
+        ("var self; self = this", self_config.clone()),
+        ("var foo, self; self = this", self_config.clone()),
+        ("var foo, self; foo = 42; self = this", self_config.clone()),
+        ("self = 42", that_config.clone()),
+        ("var foo = {}; foo.bar = this", self_config.clone()),
+        ("var self = this; var vm = this;", multi_alias_config),
+        ("var {foo, bar} = this", self_config.clone()),
+        ("({foo, bar} = this)", self_config.clone()),
+        ("var [foo, bar] = this", self_config.clone()),
+        ("[foo, bar] = this", self_config.clone()),
+        ("var self = (this)", self_config.clone()),
+        ("var context = this.foo", self_config.clone()),
+        ("self = this", self_config.clone()),
+        ("self = (this)", self_config.clone()),
+        ("obj.self = this", self_config.clone()),
+        ("this.self = this", self_config.clone()),
+        ("self++", self_config.clone()),
+        ("self = this; var self", self_config.clone()),
+        ("var self; var self = this", self_config.clone()),
+        ("function f(){ var self; self = this }", self_config.clone()),
+        ("var self; if (a) self = this", self_config.clone()),
+        ("(() => { var self; })()", self_config.clone()),
+        ("(() => { let self; })()", self_config.clone()),
+        ("(() => { var self; self = this; })()", self_config.clone()),
+        ("(self) => {}", self_config.clone()),
+        ("(self) => { self = this }", self_config.clone()),
+        ("(self = this) => {}", self_config.clone()),
+        ("({ self }) => {}", self_config.clone()),
+        ("([self]) => {}", self_config.clone()),
+        ("function f(self){ self = this }", self_config.clone()),
+        ("function f(self = this){ self = this }", self_config.clone()),
+        ("function f({ self }){ self = this }", self_config.clone()),
+        ("function f([self]){ self = this }", self_config.clone()),
+        ("function self(){} self = this", self_config.clone()),
+        ("var f = function self(){}", self_config.clone()),
+        ("var f = function self(){ self = this }", self_config.clone()),
+        ("var f = function self(self){ self = this }", self_config.clone()),
+        ("var f = function self(){ var self; self = this }", self_config.clone()),
+        ("class self {} self = this", self_config.clone()),
+        ("var C = class self {}", self_config.clone()),
+        ("var o = { m(){ var self; self = this } }", self_config.clone()),
+        ("class C { m(){ var self; self = this } }", self_config.clone()),
+        ("try{} catch(self){}", self_config.clone()),
+        ("try{} catch(self){ self = this }", self_config.clone()),
+        ("if (a) { let self; }", self_config.clone()),
+        ("for (let self;;) {}", self_config.clone()),
+        ("for (let self of xs) {}", self_config.clone()),
+        ("var self; for (self = this;;) break", self_config.clone()),
+        ("var self; for (;;) self = this", self_config.clone()),
+        ("var self; for (; self = this;) break", self_config.clone()),
+        ("var self; for (;; self = this) break", self_config.clone()),
+        ("var self; for (;; self = this) {}", self_config.clone()),
+        ("var self; for (var i = 0; self = this;) break", self_config.clone()),
+        ("var self; for (var i = 0;; self = this) {}", self_config.clone()),
+        ("var self; for (var i = (self = this);;) {}", self_config.clone()),
+        ("var self; for (;;) for (;;) self = this", self_config.clone()),
+        ("var self; for (key in obj) self = this", self_config.clone()),
+        ("var self; for (var key in obj) self = this", self_config.clone()),
+        ("var self; for (x of xs) self = this", self_config.clone()),
+        ("var self; for (var x of xs) self = this", self_config.clone()),
+        ("var self; while (foo) self = this", self_config.clone()),
+        ("var self; do self = this; while (foo)", self_config.clone()),
+        ("label: { function self() {} }", self_config.clone()),
+        ("if (foo) { function self() {} }", self_config.clone()),
+        ("function f() { if (foo) { function self() {} } }", self_config.clone()),
+        ("switch (foo) { case 1: function self() {} }", self_config.clone()),
+        ("for (;;) { function self() {} }", self_config.clone()),
+        ("(() => { if (foo) { function self() {} } })()", self_config.clone()),
+        ("var { self } = obj", self_config.clone()),
+        ("var { self } = this", self_config.clone()),
+        ("var [self] = arr", self_config.clone()),
+        ("({ self } = this)", self_config.clone()),
+        ("var self; ({ self } = this)", self_config.clone()),
+        ("var self; [self] = this", self_config.clone()),
+        ("var self; ({ self = obj } = this)", self_config.clone()),
+        ("var self; ({ self = this } = this)", self_config.clone()),
+        ("var self; ({ x: self } = this)", self_config.clone()),
+        ("var self; ({ x: self = obj } = this)", self_config.clone()),
+        ("var self; ([, self] = this)", self_config.clone()),
+        ("({ context } = this)", self_config.clone()),
+        ("var self; if (a) { self = this } self = this", self_config.clone()),
+        ("var self; if (a) { self = this } else self = this", self_config.clone()),
+        ("function f(){ return function(){ var self; self = this } }", self_config.clone()),
+        ("class C { field = (() => { var self; })() }", self_config.clone()),
+        ("class C { field = function(){ var self; self = this } }", self_config.clone()),
+        ("class C { static { var self } }", self_config.clone()),
+        ("class C { static { let self; } }", self_config.clone()),
+        ("class C { static { self = this; } }", self_config.clone()),
+        ("class C { field = this }", self_config.clone()),
+        ("class C { field = self = this }", self_config.clone()),
+    ];
+
+    let fail = vec![
+        ("var context = this", None),
+        ("var that = this", self_config.clone()),
+        ("var foo = 42, self = this", that_config.clone()),
+        ("var self = 42", self_config.clone()),
+        ("var self", self_config.clone()),
+        ("var self; self = 42", self_config.clone()),
+        ("context = this", that_config.clone()),
+        ("that = this", self_config.clone()),
+        ("self = this", that_config),
+        ("self += this", self_config.clone()),
+        ("var self; (function() { self = this; }())", self_config.clone()),
+        ("var context = (this)", self_config.clone()),
+        ("var self = this.foo", self_config.clone()),
+        ("var self = this || foo", self_config.clone()),
+        ("var self = () => this", self_config.clone()),
+        ("self = 42", self_config.clone()),
+        ("self = this.foo", self_config.clone()),
+        ("self = this || foo", self_config.clone()),
+        ("self ||= this", self_config.clone()),
+        ("foo += this", self_config.clone()),
+        ("var self = this; self = 42", self_config.clone()),
+        ("var self; self = 42; self = this", self_config.clone()),
+        ("var self; self += this", self_config.clone()),
+        ("var self; var self", self_config.clone()),
+        ("var self; var self = 42", self_config.clone()),
+        ("var self; function f(){ self = this }", self_config.clone()),
+        ("function f(){ var self; function g(){ self = this } }", self_config.clone()),
+        ("var self; if (a) { self = this }", self_config.clone()),
+        ("var self; { self = this }", self_config.clone()),
+        ("var self; class C { static { self = this } }", self_config.clone()),
+        ("(() => { var self = 42; })()", self_config.clone()),
+        ("(() => { var self; self = 42; })()", self_config.clone()),
+        ("(self) => { self = 42 }", self_config.clone()),
+        ("({ self }) => { self = 42 }", self_config.clone()),
+        ("([self]) => { self = 42 }", self_config.clone()),
+        ("function f(self){}", self_config.clone()),
+        ("function f(self = this){}", self_config.clone()),
+        ("function f(self = 42){}", self_config.clone()),
+        ("function f({ self }){}", self_config.clone()),
+        ("function f([self]){}", self_config.clone()),
+        ("function f(self){ self = 42 }", self_config.clone()),
+        ("function f({ self }){ self = 42 }", self_config.clone()),
+        ("function f(self){ var self; }", self_config.clone()),
+        ("function f(self){ var self = 42; }", self_config.clone()),
+        ("function self(){}", self_config.clone()),
+        ("function self(){ self = this }", self_config.clone()),
+        ("var f = function self(){ self = 42 }", self_config.clone()),
+        ("var f = function self(){ var self; }", self_config.clone()),
+        ("var f = function self(self){}", self_config.clone()),
+        ("var f = function self(self){ self = 42 }", self_config.clone()),
+        ("class self {}", self_config.clone()),
+        ("var o = { m(){ var self; } }", self_config.clone()),
+        ("class C { m(){ var self; } }", self_config.clone()),
+        ("try{} catch(self){ self = 42 }", self_config.clone()),
+        ("if (a) { let self = 42; }", self_config.clone()),
+        ("if (a) { var self; }", self_config.clone()),
+        ("for (let self = 0;;) {}", self_config.clone()),
+        ("for (var self;;) {}", self_config.clone()),
+        ("for (var self of xs) {}", self_config.clone()),
+        ("var self; for (;;) { self = this; break }", self_config.clone()),
+        ("var self; for (let i = 0; self = this;) break", self_config.clone()),
+        ("var self; for (let i = 0;; self = this) {}", self_config.clone()),
+        ("var self; for (let i = (self = this);;) {}", self_config.clone()),
+        ("var self; for (let x of xs) self = this", self_config.clone()),
+        ("var self; for (const x in xs) self = this", self_config.clone()),
+        ("var self; for (let key in (self = this, obj)) {}", self_config.clone()),
+        ("var self; for (using x of xs) self = this", self_config.clone()),
+        ("var self; switch(x){ case 1: self = this }", self_config.clone()),
+        ("var self; try { self = this } catch(e){}", self_config.clone()),
+        ("var self; try {} catch { self = this; }", self_config.clone()),
+        ("var self; try {} catch (e) { self = this; }", self_config.clone()),
+        ("var self; with (obj) { self = this }", self_config.clone()),
+        ("function f() { var self; (() => { self = this; })(); }", self_config.clone()),
+        ("if (foo) { function self() {} } var self;", self_config.clone()),
+        ("if (foo) function self() {}", self_config.clone()),
+        ("label: function self() {}", self_config.clone()),
+        ("var self; ({ self } = obj)", self_config.clone()),
+        ("var self; [self] = obj", self_config.clone()),
+        ("var self; ({ self = this } = obj)", self_config.clone()),
+        ("var self; ({ x: self = this } = obj)", self_config.clone()),
+        ("var self; [self = this] = obj", self_config.clone()),
+        ("var self; ([, self] = obj)", self_config.clone()),
+        ("var self; while (foo) { self = this; break }", self_config.clone()),
+        ("var self; do { self = this; break } while (foo)", self_config.clone()),
+        ("var self; if (a) { self = this } else { self = this }", self_config.clone()),
+        ("var self; try { self = this } finally { self = this }", self_config.clone()),
+        ("function f(){ return function(){ var self; } }", self_config.clone()),
+        ("var self; (() => self = this)()", self_config.clone()),
+        ("var self; (() => ({ self } = this))()", self_config.clone()),
+        ("var self; class C { method(){ self = this } }", self_config.clone()),
+        ("function f(){ var self; class C { m(){ self = this } } }", self_config.clone()),
+        ("class C { static { var self = 42; } }", self_config.clone()),
+        ("class C { static { self = 42; } }", self_config.clone()),
+        ("class C { field = self = 42 }", self_config.clone()),
+        ("class C { field = (() => { var self; self = 42; })() }", self_config.clone()),
+        ("class C { field = function(){ var self; } }", self_config.clone()),
+        ("var self; class C { field = self = this }", self_config.clone()),
+        ("var self; class C { field = (self = this); }", self_config.clone()),
+        ("var self; class C { [self = this] = 1; }", self_config.clone()),
+        ("var self; class C extends (self = this) {}", self_config.clone()),
+        (
+            "function f() { var self; class C { field = (() => { self = this; })(); } }",
+            self_config.clone(),
+        ),
+        ("var self; function f(){ var self; }", self_config.clone()),
+    ];
+
+    Tester::new(ConsistentThis::NAME, ConsistentThis::PLUGIN, pass, fail)
+        .change_rule_path_extension("js")
+        .test_and_snapshot();
+
+    let pass = vec![
+        ("var context = this as any", self_config.clone()),
+        ("var context = <any>this", self_config.clone()),
+        ("var self: unknown; self = this", self_config.clone()),
+        ("var self; (self as any) = this", self_config.clone()),
+        ("var self; (self!) = this", self_config.clone()),
+        ("function f(self: unknown){ self = this }", self_config.clone()),
+        ("function f({ self }: { self: unknown }){ self = this }", self_config.clone()),
+        ("(self: unknown) => {}", self_config.clone()),
+    ];
+
+    let fail = vec![
+        ("var self = this as any", self_config.clone()),
+        ("var self = <any>this", self_config.clone()),
+        ("self = this as any", self_config.clone()),
+        ("var self; self = this as any", self_config.clone()),
+        ("function f(self: unknown){}", self_config.clone()),
+        ("function f(self?: unknown){}", self_config.clone()),
+        ("function f(self: unknown){ self = 42 }", self_config.clone()),
+    ];
+
+    Tester::new(ConsistentThis::NAME, ConsistentThis::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .with_snapshot_suffix("ts")
+        .test_and_snapshot();
+
+    let pass = vec![
+        ("import self from 'x'; self = this", self_config.clone()),
+        ("import { x as self } from 'x'; self = this", self_config.clone()),
+        ("import * as self from 'x'; self = this", self_config.clone()),
+        ("if (foo) { function self() {} }", self_config.clone()),
+    ];
+
+    let fail = vec![
+        ("var self; (function() { self = this; }())", self_config.clone()),
+        ("import self from 'x'; self = 42", self_config.clone()),
+        ("import { x as self } from 'x'; self = 42", self_config.clone()),
+        ("import self from 'x'", self_config.clone()),
+        ("import { x as self } from 'x'", self_config.clone()),
+        ("import * as self from 'x'", self_config),
+    ];
+
+    Tester::new(ConsistentThis::NAME, ConsistentThis::PLUGIN, pass, fail)
+        .change_rule_path_extension("mjs")
+        .with_snapshot_suffix("module")
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_config() {
+    assert_eq!(ConsistentThis::default().0.aliases(), [CompactStr::new("that")]);
+
+    let configured = ConsistentThis::from_configuration(serde_json::json!(["self", "vm"]))
+        .expect("valid aliases");
+    assert_eq!(configured.0.aliases(), [CompactStr::new("self"), CompactStr::new("vm")]);
+
+    assert!(ConsistentThis::from_configuration(serde_json::Value::Null).is_ok());
+    assert!(ConsistentThis::from_configuration(serde_json::json!([])).is_ok());
+    assert!(ConsistentThis::from_configuration(serde_json::json!([""])).is_err());
+    assert!(ConsistentThis::from_configuration(serde_json::json!(["self", "self"])).is_err());
+    assert!(ConsistentThis::from_configuration(serde_json::json!([42])).is_err());
+    assert!(ConsistentThis::from_configuration(serde_json::json!({"alias": "self"})).is_err());
+}

--- a/crates/oxc_linter/src/rules/eslint/consistent_this.rs
+++ b/crates/oxc_linter/src/rules/eslint/consistent_this.rs
@@ -1,0 +1,858 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        AssignmentTarget, BindingPattern, Expression, ForStatementInit, ForStatementLeft,
+        match_simple_assignment_target,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::{AstNode, NodeId};
+use oxc_span::{GetSpan, Span};
+use oxc_str::CompactStr;
+use oxc_syntax::{operator::AssignmentOperator, scope::ScopeId, symbol::SymbolId};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::{Rule, TupleRuleConfig},
+    utils::unique_non_empty_string_spread_schema,
+};
+
+fn alias_not_assigned_to_this(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Designated alias '{name}' is not assigned to 'this'."))
+        .with_label(span)
+}
+
+fn unexpected_alias(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected alias '{name}' for 'this'.")).with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ConsistentThis(Box<ConsistentThisConfig>);
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(try_from = "Vec<CompactStr>")]
+#[schemars(transparent)]
+struct ConsistentThisConfig(
+    #[schemars(schema_with = "unique_non_empty_string_spread_schema")] Box<[CompactStr]>,
+);
+
+impl ConsistentThisConfig {
+    #[inline]
+    fn aliases(&self) -> &[CompactStr] {
+        &self.0
+    }
+}
+
+impl Default for ConsistentThisConfig {
+    fn default() -> Self {
+        Self(vec![CompactStr::new_const("that")].into_boxed_slice())
+    }
+}
+
+impl TryFrom<Vec<CompactStr>> for ConsistentThisConfig {
+    type Error = &'static str;
+
+    fn try_from(aliases: Vec<CompactStr>) -> Result<Self, Self::Error> {
+        if aliases.is_empty() {
+            return Ok(Self::default());
+        }
+
+        for (index, alias) in aliases.iter().enumerate() {
+            if alias.is_empty() {
+                return Err("alias names must not be empty");
+            }
+
+            if aliases[..index].iter().any(|existing| existing == alias) {
+                return Err("alias names must be unique");
+            }
+        }
+
+        Ok(Self(aliases.into_boxed_slice()))
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces consistent naming when capturing the current execution context.
+    ///
+    /// This rule requires variables with configured alias names to be initialized
+    /// or assigned to `this` in the same scope. It also reports initializing or
+    /// assigning `this` to variables whose names are not configured aliases.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// JavaScript code sometimes captures `this` in a variable so callbacks can
+    /// refer to the original execution context. Mixing aliases such as `that`,
+    /// `self`, and `me` makes this pattern harder to read consistently.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule with the default `"that"` alias:
+    /// ```js
+    /// var self = this;
+    /// var that = window;
+    ///
+    /// function outer() {
+    ///   var that;
+    ///   function inner() {
+    ///     that = this;
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the default `"that"` alias:
+    /// ```js
+    /// var that = this;
+    /// var self = window;
+    ///
+    /// function f() {
+    ///   var that;
+    ///   that = this;
+    /// }
+    ///
+    /// var foo = {};
+    /// foo.bar = this;
+    /// ```
+    ///
+    /// ### Differences compared to `eslint/consistent-this`
+    ///
+    /// On TypeScript files this rule looks through type-only wrappers — `as`,
+    /// `satisfies`, `<T>` and `!` — on both sides of an assignment, because they
+    /// do not change which value is captured.
+    ///
+    /// ESLint tests `value.type === "ThisExpression"` literally, so it reports
+    /// `var self = this as any`, where the alias really is assigned `this`, and stays
+    /// silent on `var context = this as any`, where `this` is captured under a name
+    /// that is not a configured alias. Its rule is marked `frozen: true` upstream,
+    /// so neither will be fixed there.
+    ///
+    /// ```ts
+    /// /* consistent-this: ["error", "self"] */
+    ///
+    /// var self = this as any;    // allowed here, reported by ESLint
+    /// var context = this!;       // reported here, allowed by ESLint
+    /// ```
+    ///
+    /// JavaScript behaviour is unchanged and reports exactly the same code as ESLint.
+    ConsistentThis,
+    eslint,
+    style,
+    none,
+    config = ConsistentThisConfig,
+    version = "next",
+    short_description = "Enforce consistent naming when capturing the current execution context.",
+);
+
+impl ConsistentThis {
+    #[inline]
+    fn is_alias(&self, name: &str) -> bool {
+        self.0.aliases().iter().any(|alias| alias == name)
+    }
+
+    fn check_assignment(
+        &self,
+        ctx: &LintContext<'_>,
+        span: Span,
+        name: &str,
+        rhs: &Expression<'_>,
+        operator: Option<AssignmentOperator>,
+    ) {
+        let is_this = is_this_expression(rhs);
+
+        if self.is_alias(name) {
+            if !is_this || operator.is_some_and(|operator| operator != AssignmentOperator::Assign) {
+                ctx.diagnostic(alias_not_assigned_to_this(span, name));
+            }
+        } else if is_this {
+            ctx.diagnostic(unexpected_alias(span, name));
+        }
+    }
+
+    fn check_was_assigned(&self, ctx: &LintContext<'_>, scope_id: ScopeId) {
+        let scoping = ctx.scoping();
+
+        for alias in self.0.aliases() {
+            let alias = alias.as_str();
+            let Some(symbol_id) = scoping.get_binding(scope_id, alias.into()) else {
+                continue;
+            };
+
+            if is_named_function_expression_symbol(ctx, symbol_id) {
+                continue;
+            }
+
+            if scoping
+                .symbol_declarations(symbol_id)
+                .any(|node_id| is_initialized_variable_declarator(ctx, node_id))
+            {
+                continue;
+            }
+
+            if has_same_scope_this_assignment(ctx, symbol_id, scope_id) {
+                continue;
+            }
+
+            for node_id in scoping.symbol_declarations(symbol_id) {
+                if is_unchecked_block_function_declaration(ctx, node_id, scope_id) {
+                    continue;
+                }
+
+                let node = ctx.nodes().get_node(node_id);
+                ctx.diagnostic(alias_not_assigned_to_this(node.kind().span(), alias));
+            }
+        }
+    }
+}
+
+impl Rule for ConsistentThis {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<TupleRuleConfig<ConsistentThisConfig>>(value)
+            .map(TupleRuleConfig::into_inner)
+            .map(Box::new)
+            .map(Self)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::VariableDeclarator(decl) => {
+                let Some(init) = &decl.init else { return };
+                let BindingPattern::BindingIdentifier(id) = &decl.id else {
+                    return;
+                };
+
+                self.check_assignment(ctx, decl.span, id.name.as_str(), init, None);
+            }
+            AstKind::AssignmentExpression(assignment) => {
+                let Some(name) = assignment_target_name(&assignment.left) else { return };
+
+                self.check_assignment(
+                    ctx,
+                    assignment.span,
+                    name,
+                    &assignment.right,
+                    Some(assignment.operator),
+                );
+            }
+            AstKind::Program(program) => self.check_was_assigned(ctx, program.scope_id()),
+            AstKind::Function(func) if func.body.is_some() => {
+                self.check_was_assigned(ctx, func.scope_id());
+            }
+            _ => {}
+        }
+    }
+}
+
+#[inline]
+fn is_this_expression(expr: &Expression<'_>) -> bool {
+    matches!(expr.get_inner_expression(), Expression::ThisExpression(_))
+}
+
+fn assignment_target_name<'t>(target: &'t AssignmentTarget<'_>) -> Option<&'t str> {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(id) => Some(id.name.as_str()),
+        target @ match_simple_assignment_target!(AssignmentTarget) => target
+            .to_simple_assignment_target()
+            .get_expression()?
+            .get_identifier_reference()
+            .map(|id| id.name.as_str()),
+        _ => None,
+    }
+}
+
+/// escope keeps a named function expression's own name in a separate scope that
+/// `ensureWasAssigned` never reads; oxc binds it in the function scope, so skip it.
+fn is_named_function_expression_symbol(ctx: &LintContext<'_>, symbol_id: SymbolId) -> bool {
+    ctx.scoping().symbol_declarations(symbol_id).all(|node_id| {
+        let node = ctx.nodes().get_node(node_id);
+        match node.kind() {
+            AstKind::Function(func) => func.is_expression(),
+            _ => false,
+        }
+    })
+}
+
+fn is_initialized_variable_declarator(ctx: &LintContext<'_>, node_id: NodeId) -> bool {
+    matches!(
+        ctx.nodes().kind(node_id),
+        AstKind::VariableDeclarator(decl) if decl.init.is_some()
+    )
+}
+
+/// oxc models Annex-B hoisting, so a block-level `function` has its binding moved into the
+/// enclosing var scope; escope does not, and ESLint never checks the owning block scope.
+fn is_unchecked_block_function_declaration(
+    ctx: &LintContext<'_>,
+    declaration_id: NodeId,
+    checked_scope_id: ScopeId,
+) -> bool {
+    if !matches!(
+        ctx.nodes().kind(declaration_id),
+        AstKind::Function(function) if function.is_declaration()
+    ) {
+        return false;
+    }
+
+    let checked_node_id = ctx.scoping().get_node_id(checked_scope_id);
+    for (ancestor_id, ancestor) in ctx.nodes().ancestors_enumerated(declaration_id) {
+        if ancestor_id == checked_node_id {
+            return false;
+        }
+
+        match ancestor.kind() {
+            AstKind::BlockStatement(_) | AstKind::SwitchStatement(_) => return true,
+            AstKind::Program(_) | AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
+                return false;
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn has_same_scope_this_assignment(
+    ctx: &LintContext<'_>,
+    symbol_id: SymbolId,
+    checked_scope_id: ScopeId,
+) -> bool {
+    ctx.scoping().get_resolved_references(symbol_id).any(|reference| {
+        reference.is_write()
+            && reference_matches_eslint_scope(ctx, reference.scope_id(), checked_scope_id)
+            && reference_write_is_plain_this_assignment(ctx, reference.node_id())
+    })
+}
+
+fn reference_matches_eslint_scope(
+    ctx: &LintContext<'_>,
+    reference_scope_id: ScopeId,
+    checked_scope_id: ScopeId,
+) -> bool {
+    if reference_scope_id == checked_scope_id {
+        return true;
+    }
+
+    let scoping = ctx.scoping();
+    let mut scope_id = reference_scope_id;
+
+    while is_eslint_transparent_scope(ctx, scope_id) {
+        let Some(parent_scope_id) = scoping.scope_parent_id(scope_id) else {
+            return false;
+        };
+
+        if parent_scope_id == checked_scope_id {
+            return true;
+        }
+
+        scope_id = parent_scope_id;
+    }
+
+    false
+}
+
+/// oxc creates a scope for every `for`; escope only for lexical heads (`let`, `const`,
+/// `using`).
+/// Non-lexical `for` scopes are therefore transparent when matching `reference.from`.
+fn is_eslint_transparent_scope(ctx: &LintContext<'_>, scope_id: ScopeId) -> bool {
+    match ctx.nodes().kind(ctx.scoping().get_node_id(scope_id)) {
+        AstKind::ForStatement(stmt) => {
+            !stmt.init.as_ref().is_some_and(for_statement_init_has_lexical_declaration)
+        }
+        AstKind::ForInStatement(stmt) => !for_statement_left_has_lexical_declaration(&stmt.left),
+        AstKind::ForOfStatement(stmt) => !for_statement_left_has_lexical_declaration(&stmt.left),
+        _ => false,
+    }
+}
+
+fn for_statement_init_has_lexical_declaration(init: &ForStatementInit<'_>) -> bool {
+    matches!(init, ForStatementInit::VariableDeclaration(decl) if decl.kind.is_lexical())
+}
+
+fn for_statement_left_has_lexical_declaration(left: &ForStatementLeft<'_>) -> bool {
+    matches!(left, ForStatementLeft::VariableDeclaration(decl) if decl.kind.is_lexical())
+}
+
+fn reference_write_is_plain_this_assignment(ctx: &LintContext<'_>, node_id: NodeId) -> bool {
+    let mut node = ctx.nodes().get_node(node_id);
+
+    loop {
+        let parent = ctx.nodes().parent_node(node.id());
+
+        match parent.kind() {
+            AstKind::AssignmentExpression(assignment) => {
+                return assignment.operator == AssignmentOperator::Assign
+                    && is_this_expression(&assignment.right);
+            }
+            // escope never credits these writes to an enclosing assignment: `writeExpr` is
+            // null for updates, and for `for-in`/`for-of` heads it is the loop RHS, whose
+            // parent is the loop and therefore has no `=` operator.
+            AstKind::UpdateExpression(_)
+            | AstKind::ForInStatement(_)
+            | AstKind::ForOfStatement(_)
+            | AstKind::Program(_)
+            | AstKind::Function(_) => return false,
+            _ => node = parent,
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let self_config = Some(serde_json::json!(["self"]));
+    let that_config = Some(serde_json::json!(["that"]));
+    let multi_alias_config = Some(serde_json::json!(["self", "vm"]));
+
+    let pass = vec![
+        ("var foo = 42, that = this", None),
+        ("var foo = 42, self = this", self_config.clone()),
+        ("var self = 42", that_config.clone()),
+        ("var self", that_config.clone()),
+        ("var self; self = this", self_config.clone()),
+        ("var foo, self; self = this", self_config.clone()),
+        ("var foo, self; foo = 42; self = this", self_config.clone()),
+        ("self = 42", that_config.clone()),
+        ("var foo = {}; foo.bar = this", self_config.clone()),
+        ("var self = this; var vm = this;", multi_alias_config),
+        ("var {foo, bar} = this", self_config.clone()),
+        ("({foo, bar} = this)", self_config.clone()),
+        ("var [foo, bar] = this", self_config.clone()),
+        ("[foo, bar] = this", self_config.clone()),
+        ("var self = (this)", self_config.clone()),
+        ("var context = this.foo", self_config.clone()),
+        ("self = this", self_config.clone()),
+        ("self = (this)", self_config.clone()),
+        ("obj.self = this", self_config.clone()),
+        ("this.self = this", self_config.clone()),
+        ("self++", self_config.clone()),
+        ("self = this; var self", self_config.clone()),
+        ("var self; var self = this", self_config.clone()),
+        ("function f(){ var self; self = this }", self_config.clone()),
+        ("var self; if (a) self = this", self_config.clone()),
+        ("(() => { var self; })()", self_config.clone()),
+        ("(() => { let self; })()", self_config.clone()),
+        ("(() => { var self; self = this; })()", self_config.clone()),
+        ("(self) => {}", self_config.clone()),
+        ("(self) => { self = this }", self_config.clone()),
+        ("(self = this) => {}", self_config.clone()),
+        ("({ self }) => {}", self_config.clone()),
+        ("([self]) => {}", self_config.clone()),
+        ("function f(self){ self = this }", self_config.clone()),
+        ("function f(self = this){ self = this }", self_config.clone()),
+        ("function f({ self }){ self = this }", self_config.clone()),
+        ("function f([self]){ self = this }", self_config.clone()),
+        ("function self(){} self = this", self_config.clone()),
+        ("var f = function self(){}", self_config.clone()),
+        ("var f = function self(){ self = this }", self_config.clone()),
+        ("var f = function self(self){ self = this }", self_config.clone()),
+        ("var f = function self(){ var self; self = this }", self_config.clone()),
+        ("class self {} self = this", self_config.clone()),
+        ("var C = class self {}", self_config.clone()),
+        ("var o = { m(){ var self; self = this } }", self_config.clone()),
+        ("class C { m(){ var self; self = this } }", self_config.clone()),
+        ("try{} catch(self){}", self_config.clone()),
+        ("try{} catch(self){ self = this }", self_config.clone()),
+        ("if (a) { let self; }", self_config.clone()),
+        ("for (let self;;) {}", self_config.clone()),
+        ("for (let self of xs) {}", self_config.clone()),
+        ("var self; for (self = this;;) break", self_config.clone()),
+        ("var self; for (;;) self = this", self_config.clone()),
+        ("var self; for (; self = this;) break", self_config.clone()),
+        ("var self; for (;; self = this) break", self_config.clone()),
+        ("var self; for (;; self = this) {}", self_config.clone()),
+        ("var self; for (var i = 0; self = this;) break", self_config.clone()),
+        ("var self; for (var i = 0;; self = this) {}", self_config.clone()),
+        ("var self; for (var i = (self = this);;) {}", self_config.clone()),
+        ("var self; for (;;) for (;;) self = this", self_config.clone()),
+        ("var self; for (key in obj) self = this", self_config.clone()),
+        ("var self; for (var key in obj) self = this", self_config.clone()),
+        ("var self; for (x of xs) self = this", self_config.clone()),
+        ("var self; for (var x of xs) self = this", self_config.clone()),
+        ("var self; while (foo) self = this", self_config.clone()),
+        ("var self; do self = this; while (foo)", self_config.clone()),
+        ("label: { function self() {} }", self_config.clone()),
+        ("if (foo) { function self() {} }", self_config.clone()),
+        ("function f() { if (foo) { function self() {} } }", self_config.clone()),
+        ("switch (foo) { case 1: function self() {} }", self_config.clone()),
+        ("for (;;) { function self() {} }", self_config.clone()),
+        ("(() => { if (foo) { function self() {} } })()", self_config.clone()),
+        ("var { self } = obj", self_config.clone()),
+        ("var { self } = this", self_config.clone()),
+        ("var [self] = arr", self_config.clone()),
+        ("({ self } = this)", self_config.clone()),
+        ("var self; ({ self } = this)", self_config.clone()),
+        ("var self; [self] = this", self_config.clone()),
+        ("var self; ({ self = obj } = this)", self_config.clone()),
+        ("var self; ({ self = this } = this)", self_config.clone()),
+        ("var self; ({ x: self } = this)", self_config.clone()),
+        ("var self; ({ x: self = obj } = this)", self_config.clone()),
+        ("var self; ([, self] = this)", self_config.clone()),
+        ("({ context } = this)", self_config.clone()),
+        ("var self; if (a) { self = this } self = this", self_config.clone()),
+        ("var self; if (a) { self = this } else self = this", self_config.clone()),
+        ("function f(){ return function(){ var self; self = this } }", self_config.clone()),
+        ("class C { field = (() => { var self; })() }", self_config.clone()),
+        ("class C { field = function(){ var self; self = this } }", self_config.clone()),
+        ("class C { static { var self } }", self_config.clone()),
+        ("class C { static { let self; } }", self_config.clone()),
+        ("class C { static { self = this; } }", self_config.clone()),
+        ("class C { field = this }", self_config.clone()),
+        ("class C { field = self = this }", self_config.clone()),
+        ("switch (a) { default: function self() {} }", self_config.clone()),
+        ("function f() { { function self() {} } }", self_config.clone()),
+        ("try {} catch ({ self }) {}", self_config.clone()),
+        ("try {} catch ({ self }) { self = this }", self_config.clone()),
+        ("var self; a ? (self = this) : (self = this);", self_config.clone()),
+        ("var self; (0, self = this);", self_config.clone()),
+        ("var self; a && (self = this);", self_config.clone()),
+        ("var self = this; var self = this;", self_config.clone()),
+        ("var self = this; var self;", self_config.clone()),
+        ("function self() {} var self = this;", self_config.clone()),
+        ("self = this;", self_config.clone()),
+        ("self.foo = this;", self_config.clone()),
+        ("var self; (self) = this;", self_config.clone()),
+        ("var self; ((self)) = this;", self_config.clone()),
+        ("var o = { self: this };", self_config.clone()),
+        ("var o = { self() { return this } };", self_config.clone()),
+        ("class C { static self = this; }", self_config.clone()),
+        ("class C { #self = this; }", self_config.clone()),
+        ("class C { ['self'] = this; }", self_config.clone()),
+        ("self: for (;;) { break self; }", self_config.clone()),
+        ("var self; ({ ...self } = this);", self_config.clone()),
+        ("var self; [...self] = this;", self_config.clone()),
+        ("var self = this; { var self; }", self_config.clone()),
+        ("if (0) { var self = this; }", self_config.clone()),
+        ("var { self = this } = {};", self_config.clone()),
+        ("var self; (self = this, foo());", self_config.clone()),
+        ("var self = this; self = this;", self_config.clone()),
+        ("let self = this;", self_config.clone()),
+        ("const self = this;", self_config.clone()),
+        ("var self; for (var i in (self = this, {})) {}", self_config.clone()),
+        ("var self; ({ a: { self } } = this);", self_config.clone()),
+        ("var self; [[self]] = this;", self_config.clone()),
+        ("async function f() { var self; self = this; }", self_config.clone()),
+        ("function* g() { var self; self = this; }", self_config.clone()),
+        ("var o = { get self() { return this } };", self_config.clone()),
+        ("globalThis.self = this;", self_config.clone()),
+        ("var self; { var self = this; }", self_config.clone()),
+        ("var self; x = self = this;", self_config.clone()),
+        ("var self; obj[self = this] = 1;", self_config.clone()),
+        ("var self; obj[self = this]++;", self_config.clone()),
+        ("var self; obj[self++] = this; self = this;", self_config.clone()),
+    ];
+
+    let fail = vec![
+        ("var context = this", None),
+        ("var that = this", self_config.clone()),
+        ("var foo = 42, self = this", that_config.clone()),
+        ("var self = 42", self_config.clone()),
+        ("var self", self_config.clone()),
+        ("var self; self = 42", self_config.clone()),
+        ("context = this", that_config.clone()),
+        ("that = this", self_config.clone()),
+        ("self = this", that_config),
+        ("self += this", self_config.clone()),
+        ("var self; (function() { self = this; }())", self_config.clone()),
+        ("var context = (this)", self_config.clone()),
+        ("var self = this.foo", self_config.clone()),
+        ("var self = this || foo", self_config.clone()),
+        ("var self = () => this", self_config.clone()),
+        ("self = 42", self_config.clone()),
+        ("self = this.foo", self_config.clone()),
+        ("self = this || foo", self_config.clone()),
+        ("self ||= this", self_config.clone()),
+        ("foo += this", self_config.clone()),
+        ("var self = this; self = 42", self_config.clone()),
+        ("var self; self = 42; self = this", self_config.clone()),
+        ("var self; self += this", self_config.clone()),
+        ("var self; var self", self_config.clone()),
+        ("var self; var self = 42", self_config.clone()),
+        ("var self; function f(){ self = this }", self_config.clone()),
+        ("function f(){ var self; function g(){ self = this } }", self_config.clone()),
+        ("var self; if (a) { self = this }", self_config.clone()),
+        ("var self; { self = this }", self_config.clone()),
+        ("var self; class C { static { self = this } }", self_config.clone()),
+        ("(() => { var self = 42; })()", self_config.clone()),
+        ("(() => { var self; self = 42; })()", self_config.clone()),
+        ("(self) => { self = 42 }", self_config.clone()),
+        ("({ self }) => { self = 42 }", self_config.clone()),
+        ("([self]) => { self = 42 }", self_config.clone()),
+        ("function f(self){}", self_config.clone()),
+        ("function f(self = this){}", self_config.clone()),
+        ("function f(self = 42){}", self_config.clone()),
+        ("function f({ self }){}", self_config.clone()),
+        ("function f([self]){}", self_config.clone()),
+        ("function f(self){ self = 42 }", self_config.clone()),
+        ("function f({ self }){ self = 42 }", self_config.clone()),
+        ("function f(self){ var self; }", self_config.clone()),
+        ("function f(self){ var self = 42; }", self_config.clone()),
+        ("function self(){}", self_config.clone()),
+        ("function self(){ self = this }", self_config.clone()),
+        ("var f = function self(){ self = 42 }", self_config.clone()),
+        ("var f = function self(){ var self; }", self_config.clone()),
+        ("var f = function self(self){}", self_config.clone()),
+        ("var f = function self(self){ self = 42 }", self_config.clone()),
+        ("class self {}", self_config.clone()),
+        ("var o = { m(){ var self; } }", self_config.clone()),
+        ("class C { m(){ var self; } }", self_config.clone()),
+        ("try{} catch(self){ self = 42 }", self_config.clone()),
+        ("if (a) { let self = 42; }", self_config.clone()),
+        ("if (a) { var self; }", self_config.clone()),
+        ("for (let self = 0;;) {}", self_config.clone()),
+        ("for (var self;;) {}", self_config.clone()),
+        ("for (var self of xs) {}", self_config.clone()),
+        ("var self; for (;;) { self = this; break }", self_config.clone()),
+        ("var self; for (let i = 0; self = this;) break", self_config.clone()),
+        ("var self; for (let i = 0;; self = this) {}", self_config.clone()),
+        ("var self; for (let i = (self = this);;) {}", self_config.clone()),
+        ("var self; for (let x of xs) self = this", self_config.clone()),
+        ("var self; for (const x in xs) self = this", self_config.clone()),
+        ("var self; for (let key in (self = this, obj)) {}", self_config.clone()),
+        ("var self; for (using x of xs) self = this", self_config.clone()),
+        ("var self; switch(x){ case 1: self = this }", self_config.clone()),
+        ("var self; try { self = this } catch(e){}", self_config.clone()),
+        ("var self; try {} catch { self = this; }", self_config.clone()),
+        ("var self; try {} catch (e) { self = this; }", self_config.clone()),
+        ("var self; with (obj) { self = this }", self_config.clone()),
+        ("function f() { var self; (() => { self = this; })(); }", self_config.clone()),
+        ("if (foo) { function self() {} } var self;", self_config.clone()),
+        ("if (foo) function self() {}", self_config.clone()),
+        ("label: function self() {}", self_config.clone()),
+        ("var self; ({ self } = obj)", self_config.clone()),
+        ("var self; [self] = obj", self_config.clone()),
+        ("var self; ({ self = this } = obj)", self_config.clone()),
+        ("var self; ({ x: self = this } = obj)", self_config.clone()),
+        ("var self; [self = this] = obj", self_config.clone()),
+        ("var self; ([, self] = obj)", self_config.clone()),
+        ("var self; while (foo) { self = this; break }", self_config.clone()),
+        ("var self; do { self = this; break } while (foo)", self_config.clone()),
+        ("var self; if (a) { self = this } else { self = this }", self_config.clone()),
+        ("var self; try { self = this } finally { self = this }", self_config.clone()),
+        ("function f(){ return function(){ var self; } }", self_config.clone()),
+        ("var self; (() => self = this)()", self_config.clone()),
+        ("var self; (() => ({ self } = this))()", self_config.clone()),
+        ("var self; class C { method(){ self = this } }", self_config.clone()),
+        ("function f(){ var self; class C { m(){ self = this } } }", self_config.clone()),
+        ("class C { static { var self = 42; } }", self_config.clone()),
+        ("class C { static { self = 42; } }", self_config.clone()),
+        ("class C { field = self = 42 }", self_config.clone()),
+        ("class C { field = (() => { var self; self = 42; })() }", self_config.clone()),
+        ("class C { field = function(){ var self; } }", self_config.clone()),
+        ("var self; class C { field = self = this }", self_config.clone()),
+        ("var self; class C { field = (self = this); }", self_config.clone()),
+        ("var self; class C { [self = this] = 1; }", self_config.clone()),
+        ("var self; class C extends (self = this) {}", self_config.clone()),
+        (
+            "function f() { var self; class C { field = (() => { self = this; })(); } }",
+            self_config.clone(),
+        ),
+        ("var self; function f(){ var self; }", self_config.clone()),
+        ("var self; with (o) { self = this; }", self_config.clone()),
+        ("var self; with (o) { var self; }", self_config.clone()),
+        ("function f() { var self; with (o) { self = this; } }", self_config.clone()),
+        ("label: label2: function self() {}", self_config.clone()),
+        ("function f() { { function self() {} } var self; }", self_config.clone()),
+        ("var self; try { self = this } catch (self) { self = this }", self_config.clone()),
+        ("var self; do { self = this } while (0)", self_config.clone()),
+        ("var self; for (const [self] of xs) {}", self_config.clone()),
+        ("var self; for (let { self } in o) {}", self_config.clone()),
+        ("var self; for (var self of xs) {}", self_config.clone()),
+        ("var self = this; function f() { var self; }", self_config.clone()),
+        ("function f() { var self; { let self = 1; } }", self_config.clone()),
+        ("function f() { let self; { var other; } }", self_config.clone()),
+        ("var self; (() => (() => { self = this })())();", self_config.clone()),
+        ("function f() { var self; return () => { self = this; }; }", self_config.clone()),
+        ("var self; new Function('self = this');", self_config.clone()),
+        ("var self; eval('self = this');", self_config.clone()),
+        ("function self() {} function self() {}", self_config.clone()),
+        ("var self; function self() {}", self_config.clone()),
+        ("var self; import('x');", self_config.clone()),
+        ("var self; self.foo = this;", self_config.clone()),
+        ("var self; this.self = this;", self_config.clone()),
+        ("var self = this?.foo;", self_config.clone()),
+        ("var self = (this, this);", self_config.clone()),
+        ("var self = void this;", self_config.clone()),
+        ("var self = !this;", self_config.clone()),
+        ("var self = this, other = this;", self_config.clone()),
+        ("var self; self ??= this;", self_config.clone()),
+        ("function f() { 'use strict'; var self; }", self_config.clone()),
+        ("var self = this ? a : b;", self_config.clone()),
+        ("class self { static { self = this; } }", self_config.clone()),
+        ("var self; delete self;", self_config.clone()),
+        ("for (var self in this) {}", self_config.clone()),
+        ("var self; queueMicrotask(function () { self = this; });", self_config.clone()),
+        ("var self = globalThis;", self_config.clone()),
+        ("var self; obj[self++] = this;", self_config.clone()),
+        ("var self; obj[--self] = this;", self_config.clone()),
+        ("var self; ({ [self++]: x } = this);", self_config.clone()),
+        ("var self; [obj[self++]] = this;", self_config.clone()),
+        ("var self; self++;", self_config.clone()),
+        ("var self; for (self in obj) {}", self_config.clone()),
+        ("var self; for (self of obj) {}", self_config.clone()),
+        ("var self; for (self of this) {}", self_config.clone()),
+        ("var self; for (self in this) {}", self_config.clone()),
+        ("var self; for ([self] of [this]) {}", self_config.clone()),
+        ("var self; for (obj[self++] of [this]) {}", self_config.clone()),
+        ("var self; obj[self] = this;", self_config.clone()),
+        ("var self; self &&= this;", self_config.clone()),
+        ("var self; self = x = this;", self_config.clone()),
+        ("var self; with (o) self = this;", self_config.clone()),
+    ];
+
+    Tester::new(ConsistentThis::NAME, ConsistentThis::PLUGIN, pass, fail)
+        .change_rule_path_extension("js")
+        .test_and_snapshot();
+
+    let pass = vec![
+        ("var self = this as any", self_config.clone()),
+        ("var self = <any>this", self_config.clone()),
+        ("var self = this satisfies unknown", self_config.clone()),
+        ("var self = this!", self_config.clone()),
+        ("var self = (this as any)!", self_config.clone()),
+        ("var self = this as unknown as any;", self_config.clone()),
+        ("var self = this satisfies unknown satisfies unknown;", self_config.clone()),
+        ("self = this as any", self_config.clone()),
+        ("var self; self = this as any", self_config.clone()),
+        ("var self; (self as any) = this", self_config.clone()),
+        ("var self; (self!) = this", self_config.clone()),
+        ("var self: unknown; self = this", self_config.clone()),
+        ("var context = this.foo as any", self_config.clone()),
+        ("function f(self: unknown){ self = this }", self_config.clone()),
+        ("function f({ self }: { self: unknown }){ self = this }", self_config.clone()),
+        ("(self: unknown) => {}", self_config.clone()),
+        ("class C<self> {}", self_config.clone()),
+        ("type T<self> = self;", self_config.clone()),
+        ("type self = number; var self = this;", self_config.clone()),
+        ("interface self {} var self = this;", self_config.clone()),
+        ("declare global { var self: any; }", self_config.clone()),
+        ("enum E { self }", self_config.clone()),
+        ("class C { self = this; }", self_config.clone()),
+        ("class C { accessor self = this; }", self_config.clone()),
+        ("declare module 'x' { const self: number; }", self_config.clone()),
+        ("namespace N { var self; }", self_config.clone()),
+        ("let self!: any; self = this;", self_config.clone()),
+        ("function f() { using self = this; }", self_config.clone()),
+        ("async function f() { await using self = this; }", self_config.clone()),
+        ("declare function f(self: any): void;", self_config.clone()),
+        ("declare class C { m(self: any): void; }", self_config.clone()),
+        ("declare namespace N { function f(self: any): void; }", self_config.clone()),
+        ("declare const f: (self: any) => void;", self_config.clone()),
+        ("abstract class C { abstract m(self: any): void; }", self_config.clone()),
+        ("class C { m(self: any): void; m(): void {} }", self_config.clone()),
+        ("interface I { m(self: any): void; }", self_config.clone()),
+        ("type F = (self: any) => void;", self_config.clone()),
+    ];
+
+    let fail = vec![
+        // Deliberate divergence: type-only wrappers are transparent, see the rule docs.
+        ("var context = this as any", self_config.clone()),
+        ("var context = <any>this", self_config.clone()),
+        ("var context = this satisfies unknown", self_config.clone()),
+        ("var context = this!", self_config.clone()),
+        ("context = this as any", self_config.clone()),
+        ("(context as any) = this", self_config.clone()),
+        ("var self; (self as any) = 42", self_config.clone()),
+        // Below: verified identical to eslint@9 + @typescript-eslint/parser@8.
+        ("var self = this.foo as any", self_config.clone()),
+        ("var self = foo as any", self_config.clone()),
+        ("function f(self: unknown){}", self_config.clone()),
+        ("function f(self?: unknown){}", self_config.clone()),
+        ("function f(self: unknown){ self = 42 }", self_config.clone()),
+        ("function f(self: any): void {}", self_config.clone()),
+        ("type self = number;", self_config.clone()),
+        ("interface self {}", self_config.clone()),
+        ("enum self { A }", self_config.clone()),
+        ("const enum self { A }", self_config.clone()),
+        ("namespace self { export const x = 1; }", self_config.clone()),
+        ("declare namespace self { const x: number; }", self_config.clone()),
+        ("declare var self: any;", self_config.clone()),
+        ("declare let self: any;", self_config.clone()),
+        ("declare const self: any;", self_config.clone()),
+        ("declare function self(): void;", self_config.clone()),
+        ("declare class self {}", self_config.clone()),
+        ("abstract class self {}", self_config.clone()),
+        ("function f<self>(): void {}", self_config.clone()),
+        ("import type self from 'x';", self_config.clone()),
+        ("import { type x as self } from 'x';", self_config.clone()),
+        ("function self(): void; function self(): void {}", self_config.clone()),
+        ("class C { constructor(private self: any) {} }", self_config.clone()),
+        ("export type self = number;", self_config.clone()),
+        ("function f(this: any, self: number) {}", self_config.clone()),
+        ("class C { m<self>(): void {} }", self_config.clone()),
+        ("let self: any;", self_config.clone()),
+        ("function f(): void { type self = number; }", self_config.clone()),
+        ("function f(): void { interface self {} }", self_config.clone()),
+        ("function f(): void { enum self { A } }", self_config.clone()),
+    ];
+
+    Tester::new(ConsistentThis::NAME, ConsistentThis::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .with_snapshot_suffix("ts")
+        .test_and_snapshot();
+
+    let pass = vec![
+        ("import self from 'x'; self = this", self_config.clone()),
+        ("import { x as self } from 'x'; self = this", self_config.clone()),
+        ("import * as self from 'x'; self = this", self_config.clone()),
+        ("if (foo) { function self() {} }", self_config.clone()),
+        ("export const self = this;", self_config.clone()),
+    ];
+
+    let fail = vec![
+        ("var self; (function() { self = this; }())", self_config.clone()),
+        ("import self from 'x'; self = 42", self_config.clone()),
+        ("import { x as self } from 'x'; self = 42", self_config.clone()),
+        ("import self from 'x'", self_config.clone()),
+        ("import { x as self } from 'x'", self_config.clone()),
+        ("import * as self from 'x'", self_config.clone()),
+        ("export var self;", self_config.clone()),
+        ("export default function self() {}", self_config.clone()),
+        ("export function self() {}", self_config.clone()),
+        ("import 'x'; var self;", self_config.clone()),
+    ];
+
+    Tester::new(ConsistentThis::NAME, ConsistentThis::PLUGIN, pass, fail)
+        .change_rule_path_extension("mjs")
+        .with_snapshot_suffix("module")
+        .test_and_snapshot();
+
+    let pass = vec![
+        ("var self = this as any;", self_config.clone()),
+        ("class C { @dec self = this; }", self_config.clone()),
+        ("var self = this!;", self_config.clone()),
+        ("var self; (self as any)! = this;", self_config.clone()),
+        ("var self; (self satisfies any) = this;", self_config.clone()),
+    ];
+
+    let fail = vec![
+        ("const self = <div />;", self_config.clone()),
+        ("var context = this as any;", self_config.clone()),
+        ("function f<self,>(): void {}", self_config.clone()),
+        ("@dec class self {}", self_config),
+    ];
+
+    Tester::new(ConsistentThis::NAME, ConsistentThis::PLUGIN, pass, fail)
+        .change_rule_path_extension("tsx")
+        .with_snapshot_suffix("tsx")
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_config() {
+    assert_eq!(ConsistentThis::default().0.aliases(), [CompactStr::new("that")]);
+
+    let configured = ConsistentThis::from_configuration(serde_json::json!(["self", "vm"]))
+        .expect("valid aliases");
+    assert_eq!(configured.0.aliases(), [CompactStr::new("self"), CompactStr::new("vm")]);
+
+    assert!(ConsistentThis::from_configuration(serde_json::Value::Null).is_ok());
+    assert!(ConsistentThis::from_configuration(serde_json::json!([])).is_ok());
+    assert!(ConsistentThis::from_configuration(serde_json::json!([""])).is_err());
+    assert!(ConsistentThis::from_configuration(serde_json::json!(["self", "self"])).is_err());
+    assert!(ConsistentThis::from_configuration(serde_json::json!([42])).is_err());
+    assert!(ConsistentThis::from_configuration(serde_json::json!({"alias": "self"})).is_err());
+}

--- a/crates/oxc_linter/src/snapshots/eslint_consistent_this.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_consistent_this.snap
@@ -1,0 +1,663 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var context = this
+   ·     ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'that' for 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var that = this
+   ·     ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'self' for 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ var foo = 42, self = this
+   ·               ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = 42
+   ·     ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self = 42
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self = 42
+   ·           ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ context = this
+   · ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'that' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ that = this
+   · ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'self' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = this
+   · ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self += this
+   · ────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; (function() { self = this; }())
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var context = (this)
+   ·     ────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = this.foo
+   ·     ───────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = this || foo
+   ·     ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = () => this
+   ·     ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = 42
+   · ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = this.foo
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = this || foo
+   · ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self ||= this
+   · ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'foo' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ foo += this
+   · ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:18]
+ 1 │ var self = this; self = 42
+   ·                  ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self = 42; self = this
+   ·           ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self += this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self += this
+   ·           ────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; var self
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ var self; var self
+   ·               ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ var self; var self = 42
+   ·               ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; function f(){ self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ function f(){ var self; function g(){ self = this } }
+   ·                   ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; if (a) { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { static { self = this } }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:14]
+ 1 │ (() => { var self = 42; })()
+   ·              ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ (() => { var self; self = 42; })()
+   ·                    ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:13]
+ 1 │ (self) => { self = 42 }
+   ·             ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:17]
+ 1 │ ({ self }) => { self = 42 }
+   ·                 ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ ([self]) => { self = 42 }
+   ·               ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self){}
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self = this){}
+   ·            ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self = 42){}
+   ·            ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f({ self }){}
+   ·            ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f([self]){}
+   ·            ──────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self){ self = 42 }
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ function f(self){ self = 42 }
+   ·                   ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f({ self }){ self = 42 }
+   ·            ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ function f({ self }){ self = 42 }
+   ·                       ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self){ var self; }
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ function f(self){ var self; }
+   ·                       ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ function f(self){ var self = 42; }
+   ·                       ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ function self(){}
+   · ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ function self(){ self = this }
+   · ──────────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:26]
+ 1 │ var f = function self(){ self = 42 }
+   ·                          ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:30]
+ 1 │ var f = function self(){ var self; }
+   ·                              ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ var f = function self(self){}
+   ·                       ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ var f = function self(self){ self = 42 }
+   ·                       ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:30]
+ 1 │ var f = function self(self){ self = 42 }
+   ·                              ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ class self {}
+   · ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ var o = { m(){ var self; } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ class C { m(){ var self; } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ try{} catch(self){ self = 42 }
+   ·                    ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:14]
+ 1 │ if (a) { let self = 42; }
+   ·              ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:14]
+ 1 │ if (a) { var self; }
+   ·              ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ for (let self = 0;;) {}
+   ·          ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ for (var self;;) {}
+   ·          ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ for (var self of xs) {}
+   ·          ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (;;) { self = this; break }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let i = 0; self = this;) break
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let i = 0;; self = this) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let i = (self = this);;) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let x of xs) self = this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (const x in xs) self = this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let key in (self = this, obj)) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (using x of xs) self = this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; switch(x){ case 1: self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try { self = this } catch(e){}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try {} catch { self = this; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try {} catch (e) { self = this; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; with (obj) { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { var self; (() => { self = this; })(); }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:37]
+ 1 │ if (foo) { function self() {} } var self;
+   ·                                     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ if (foo) function self() {}
+   ·          ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:8]
+ 1 │ label: function self() {}
+   ·        ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ({ self } = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; [self] = obj
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ({ self = this } = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ({ x: self = this } = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; [self = this] = obj
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ([, self] = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; while (foo) { self = this; break }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; do { self = this; break } while (foo)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; if (a) { self = this } else { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try { self = this } finally { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:38]
+ 1 │ function f(){ return function(){ var self; } }
+   ·                                      ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; (() => self = this)()
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; (() => ({ self } = this))()
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { method(){ self = this } }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ function f(){ var self; class C { m(){ self = this } } }
+   ·                   ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:24]
+ 1 │ class C { static { var self = 42; } }
+   ·                        ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ class C { static { self = 42; } }
+   ·                    ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ class C { field = self = 42 }
+   ·                   ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:38]
+ 1 │ class C { field = (() => { var self; self = 42; })() }
+   ·                                      ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:35]
+ 1 │ class C { field = function(){ var self; } }
+   ·                                   ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { field = self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { field = (self = this); }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { [self = this] = 1; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C extends (self = this) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { var self; class C { field = (() => { self = this; })(); } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; function f(){ var self; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:29]
+ 1 │ var self; function f(){ var self; }
+   ·                             ────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/eslint_consistent_this.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_consistent_this.snap
@@ -1,0 +1,1017 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var context = this
+   ·     ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'that' for 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var that = this
+   ·     ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'self' for 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ var foo = 42, self = this
+   ·               ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = 42
+   ·     ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self = 42
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self = 42
+   ·           ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ context = this
+   · ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'that' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ that = this
+   · ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'self' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = this
+   · ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self += this
+   · ────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; (function() { self = this; }())
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var context = (this)
+   ·     ────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = this.foo
+   ·     ───────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = this || foo
+   ·     ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = () => this
+   ·     ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = 42
+   · ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = this.foo
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self = this || foo
+   · ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ self ||= this
+   · ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'foo' for 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ foo += this
+   · ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:18]
+ 1 │ var self = this; self = 42
+   ·                  ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self = 42; self = this
+   ·           ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self += this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self += this
+   ·           ────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; var self
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ var self; var self
+   ·               ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ var self; var self = 42
+   ·               ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; function f(){ self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ function f(){ var self; function g(){ self = this } }
+   ·                   ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; if (a) { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { static { self = this } }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:14]
+ 1 │ (() => { var self = 42; })()
+   ·              ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ (() => { var self; self = 42; })()
+   ·                    ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:13]
+ 1 │ (self) => { self = 42 }
+   ·             ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:17]
+ 1 │ ({ self }) => { self = 42 }
+   ·                 ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:15]
+ 1 │ ([self]) => { self = 42 }
+   ·               ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self){}
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self = this){}
+   ·            ───────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self = 42){}
+   ·            ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f({ self }){}
+   ·            ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f([self]){}
+   ·            ──────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self){ self = 42 }
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ function f(self){ self = 42 }
+   ·                   ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f({ self }){ self = 42 }
+   ·            ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ function f({ self }){ self = 42 }
+   ·                       ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:12]
+ 1 │ function f(self){ var self; }
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ function f(self){ var self; }
+   ·                       ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ function f(self){ var self = 42; }
+   ·                       ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ function self(){}
+   · ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ function self(){ self = this }
+   · ──────────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:26]
+ 1 │ var f = function self(){ self = 42 }
+   ·                          ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:30]
+ 1 │ var f = function self(){ var self; }
+   ·                              ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ var f = function self(self){}
+   ·                       ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:23]
+ 1 │ var f = function self(self){ self = 42 }
+   ·                       ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:30]
+ 1 │ var f = function self(self){ self = 42 }
+   ·                              ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ class self {}
+   · ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ var o = { m(){ var self; } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ class C { m(){ var self; } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ try{} catch(self){ self = 42 }
+   ·                    ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:14]
+ 1 │ if (a) { let self = 42; }
+   ·              ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:14]
+ 1 │ if (a) { var self; }
+   ·              ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ for (let self = 0;;) {}
+   ·          ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ for (var self;;) {}
+   ·          ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ for (var self of xs) {}
+   ·          ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (;;) { self = this; break }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let i = 0; self = this;) break
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let i = 0;; self = this) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let i = (self = this);;) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let x of xs) self = this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (const x in xs) self = this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let key in (self = this, obj)) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (using x of xs) self = this
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; switch(x){ case 1: self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try { self = this } catch(e){}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try {} catch { self = this; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try {} catch (e) { self = this; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; with (obj) { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { var self; (() => { self = this; })(); }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:37]
+ 1 │ if (foo) { function self() {} } var self;
+   ·                                     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ if (foo) function self() {}
+   ·          ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:8]
+ 1 │ label: function self() {}
+   ·        ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ({ self } = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; [self] = obj
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ({ self = this } = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ({ x: self = this } = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; [self = this] = obj
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ([, self] = obj)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; while (foo) { self = this; break }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; do { self = this; break } while (foo)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; if (a) { self = this } else { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try { self = this } finally { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:38]
+ 1 │ function f(){ return function(){ var self; } }
+   ·                                      ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; (() => self = this)()
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; (() => ({ self } = this))()
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { method(){ self = this } }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ function f(){ var self; class C { m(){ self = this } } }
+   ·                   ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:24]
+ 1 │ class C { static { var self = 42; } }
+   ·                        ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ class C { static { self = 42; } }
+   ·                    ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:19]
+ 1 │ class C { field = self = 42 }
+   ·                   ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:38]
+ 1 │ class C { field = (() => { var self; self = 42; })() }
+   ·                                      ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:35]
+ 1 │ class C { field = function(){ var self; } }
+   ·                                   ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { field = self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { field = (self = this); }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C { [self = this] = 1; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; class C extends (self = this) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { var self; class C { field = (() => { self = this; })(); } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; function f(){ var self; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:29]
+ 1 │ var self; function f(){ var self; }
+   ·                             ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; with (o) { self = this; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; with (o) { var self; }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:26]
+ 1 │ var self; with (o) { var self; }
+   ·                          ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { var self; with (o) { self = this; } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:16]
+ 1 │ label: label2: function self() {}
+   ·                ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:43]
+ 1 │ function f() { { function self() {} } var self; }
+   ·                                           ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; try { self = this } catch (self) { self = this }
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; do { self = this } while (0)
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (const [self] of xs) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (let { self } in o) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (var self of xs) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ var self; for (var self of xs) {}
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:37]
+ 1 │ var self = this; function f() { var self; }
+   ·                                     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { var self; { let self = 1; } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:32]
+ 1 │ function f() { var self; { let self = 1; } }
+   ·                                ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { let self; { var other; } }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; (() => (() => { self = this })())();
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function f() { var self; return () => { self = this; }; }
+   ·                    ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; new Function('self = this');
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; eval('self = this');
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ function self() {} function self() {}
+   · ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:20]
+ 1 │ function self() {} function self() {}
+   ·                    ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; function self() {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; function self() {}
+   ·           ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; import('x');
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self.foo = this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; this.self = this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = this?.foo;
+   ·     ────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = (this, this);
+   ·     ───────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = void this;
+   ·     ────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = !this;
+   ·     ────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'other' for 'this'.
+   ╭─[consistent_this.js:1:18]
+ 1 │ var self = this, other = this;
+   ·                  ────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self ??= this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self ??= this;
+   ·           ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:34]
+ 1 │ function f() { 'use strict'; var self; }
+   ·                                  ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = this ? a : b;
+   ·     ───────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:1]
+ 1 │ class self { static { self = this; } }
+   · ──────────────────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; delete self;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:10]
+ 1 │ for (var self in this) {}
+   ·          ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; queueMicrotask(function () { self = this; });
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self = globalThis;
+   ·     ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; obj[self++] = this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; obj[--self] = this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; ({ [self++]: x } = this);
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; [obj[self++]] = this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self++;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (self in obj) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (self of obj) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (self of this) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (self in this) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for ([self] of [this]) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; for (obj[self++] of [this]) {}
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; obj[self] = this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self &&= this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self &&= this;
+   ·           ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; self = x = this;
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:11]
+ 1 │ var self; self = x = this;
+   ·           ───────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'x' for 'this'.
+   ╭─[consistent_this.js:1:18]
+ 1 │ var self; self = x = this;
+   ·                  ────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.js:1:5]
+ 1 │ var self; with (o) self = this;
+   ·     ────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/eslint_consistent_this@module.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_consistent_this@module.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:5]
+ 1 │ var self; (function() { self = this; }())
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:8]
+ 1 │ import self from 'x'; self = 42
+   ·        ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:23]
+ 1 │ import self from 'x'; self = 42
+   ·                       ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:10]
+ 1 │ import { x as self } from 'x'; self = 42
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:32]
+ 1 │ import { x as self } from 'x'; self = 42
+   ·                                ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:8]
+ 1 │ import self from 'x'
+   ·        ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:10]
+ 1 │ import { x as self } from 'x'
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:8]
+ 1 │ import * as self from 'x'
+   ·        ─────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/eslint_consistent_this@module.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_consistent_this@module.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:5]
+ 1 │ var self; (function() { self = this; }())
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:8]
+ 1 │ import self from 'x'; self = 42
+   ·        ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:23]
+ 1 │ import self from 'x'; self = 42
+   ·                       ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:10]
+ 1 │ import { x as self } from 'x'; self = 42
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:32]
+ 1 │ import { x as self } from 'x'; self = 42
+   ·                                ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:8]
+ 1 │ import self from 'x'
+   ·        ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:10]
+ 1 │ import { x as self } from 'x'
+   ·          ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:8]
+ 1 │ import * as self from 'x'
+   ·        ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:12]
+ 1 │ export var self;
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:16]
+ 1 │ export default function self() {}
+   ·                ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:8]
+ 1 │ export function self() {}
+   ·        ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.mjs:1:17]
+ 1 │ import 'x'; var self;
+   ·                 ────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/eslint_consistent_this@ts.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_consistent_this@ts.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var self = this as any
+   ·     ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var self = <any>this
+   ·     ────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ self = this as any
+   · ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var self; self = this as any
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:11]
+ 1 │ var self; self = this as any
+   ·           ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f(self: unknown){}
+   ·            ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f(self?: unknown){}
+   ·            ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f(self: unknown){ self = 42 }
+   ·            ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:28]
+ 1 │ function f(self: unknown){ self = 42 }
+   ·                            ─────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/eslint_consistent_this@ts.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_consistent_this@ts.snap
@@ -1,0 +1,243 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var context = this as any
+   ·     ─────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var context = <any>this
+   ·     ───────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var context = this satisfies unknown
+   ·     ────────────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var context = this!
+   ·     ───────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ context = this as any
+   · ─────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ (context as any) = this
+   · ───────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var self; (self as any) = 42
+   ·     ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:11]
+ 1 │ var self; (self as any) = 42
+   ·           ──────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var self = this.foo as any
+   ·     ──────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ var self = foo as any
+   ·     ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f(self: unknown){}
+   ·            ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f(self?: unknown){}
+   ·            ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f(self: unknown){ self = 42 }
+   ·            ─────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:28]
+ 1 │ function f(self: unknown){ self = 42 }
+   ·                            ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f(self: any): void {}
+   ·            ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ type self = number;
+   · ───────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ interface self {}
+   · ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ enum self { A }
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ const enum self { A }
+   · ─────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ namespace self { export const x = 1; }
+   · ──────────────────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ declare namespace self { const x: number; }
+   · ───────────────────────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:13]
+ 1 │ declare var self: any;
+   ·             ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:13]
+ 1 │ declare let self: any;
+   ·             ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:15]
+ 1 │ declare const self: any;
+   ·               ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ declare function self(): void;
+   · ──────────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ declare class self {}
+   · ─────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ abstract class self {}
+   · ──────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:12]
+ 1 │ function f<self>(): void {}
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:13]
+ 1 │ import type self from 'x';
+   ·             ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:10]
+ 1 │ import { type x as self } from 'x';
+   ·          ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:1]
+ 1 │ function self(): void; function self(): void {}
+   · ──────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:24]
+ 1 │ function self(): void; function self(): void {}
+   ·                        ────────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:23]
+ 1 │ class C { constructor(private self: any) {} }
+   ·                       ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:8]
+ 1 │ export type self = number;
+   ·        ───────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:23]
+ 1 │ function f(this: any, self: number) {}
+   ·                       ────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:13]
+ 1 │ class C { m<self>(): void {} }
+   ·             ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:5]
+ 1 │ let self: any;
+   ·     ─────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:22]
+ 1 │ function f(): void { type self = number; }
+   ·                      ───────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:22]
+ 1 │ function f(): void { interface self {} }
+   ·                      ─────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.ts:1:22]
+ 1 │ function f(): void { enum self { A } }
+   ·                      ───────────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/eslint_consistent_this@tsx.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_consistent_this@tsx.snap
@@ -1,0 +1,27 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.tsx:1:7]
+ 1 │ const self = <div />;
+   ·       ──────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Unexpected alias 'context' for 'this'.
+   ╭─[consistent_this.tsx:1:5]
+ 1 │ var context = this as any;
+   ·     ─────────────────────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.tsx:1:12]
+ 1 │ function f<self,>(): void {}
+   ·            ────
+   ╰────
+
+  ⚠ eslint(consistent-this): Designated alias 'self' is not assigned to 'this'.
+   ╭─[consistent_this.tsx:1:1]
+ 1 │ @dec class self {}
+   · ──────────────────
+   ╰────

--- a/crates/oxc_linter/src/utils/schemars.rs
+++ b/crates/oxc_linter/src/utils/schemars.rs
@@ -1,6 +1,9 @@
 use schemars::{
     r#gen::SchemaGenerator,
-    schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SubschemaValidation},
+    schema::{
+        ArrayValidation, InstanceType, ObjectValidation, Schema, SchemaObject, StringValidation,
+        SubschemaValidation,
+    },
 };
 
 #[cfg(feature = "ruledocs")]
@@ -54,6 +57,28 @@ pub fn object_with_nullable_string_schema(_gen: &mut SchemaGenerator) -> Schema 
         instance_type: Some(InstanceType::Object.into()),
         object: Some(Box::new(ObjectValidation {
             additional_properties: Some(Box::new(value_schema.into())),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+    .into()
+}
+
+/// Generates a JSON schema for ESLint-style "spread" rule options: a variable-length list of unique, non-empty strings.
+/// The items are emitted as `additionalItems` so the rule-config schema generator prepends `AllowWarnDeny` and keeps the list unbounded.
+/// TS type equivalent of the full rule config: `[AllowWarnDeny, string, ...string[]]`
+pub fn unique_non_empty_string_spread_schema(_gen: &mut SchemaGenerator) -> Schema {
+    let item_schema = SchemaObject {
+        instance_type: Some(InstanceType::String.into()),
+        string: Some(Box::new(StringValidation { min_length: Some(1), ..Default::default() })),
+        ..Default::default()
+    };
+
+    SchemaObject {
+        instance_type: Some(InstanceType::Array.into()),
+        array: Some(Box::new(ArrayValidation {
+            additional_items: Some(Box::new(item_schema.into())),
+            unique_items: Some(true),
             ..Default::default()
         })),
         ..Default::default()

--- a/crates/oxc_linter/src/utils/schemars.rs
+++ b/crates/oxc_linter/src/utils/schemars.rs
@@ -1,6 +1,9 @@
 use schemars::{
     r#gen::SchemaGenerator,
-    schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SubschemaValidation},
+    schema::{
+        ArrayValidation, InstanceType, ObjectValidation, Schema, SchemaObject, StringValidation,
+        SubschemaValidation,
+    },
 };
 
 #[cfg(feature = "ruledocs")]
@@ -50,6 +53,28 @@ pub fn object_with_nullable_string_schema(_gen: &mut SchemaGenerator) -> Schema 
         instance_type: Some(InstanceType::Object.into()),
         object: Some(Box::new(ObjectValidation {
             additional_properties: Some(Box::new(value_schema.into())),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+    .into()
+}
+
+/// Generates a JSON schema for ESLint-style "spread" rule options: a variable-length list of unique, non-empty strings.
+/// The items are emitted as `additionalItems` so the rule-config schema generator prepends `AllowWarnDeny` and keeps the list unbounded.
+/// TS type equivalent of the full rule config: `[AllowWarnDeny, string, ...string[]]`
+pub fn unique_non_empty_string_spread_schema(_gen: &mut SchemaGenerator) -> Schema {
+    let item_schema = SchemaObject {
+        instance_type: Some(InstanceType::String.into()),
+        string: Some(Box::new(StringValidation { min_length: Some(1), ..Default::default() })),
+        ..Default::default()
+    };
+
+    SchemaObject {
+        instance_type: Some(InstanceType::Array.into()),
+        array: Some(Box::new(ArrayValidation {
+            additional_items: Some(Box::new(item_schema.into())),
+            unique_items: Some(true),
             ..Default::default()
         })),
         ..Default::default()

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2312,6 +2312,31 @@
             }
           ]
         },
+        "consistent-this": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
+              "additionalItems": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 2,
+              "uniqueItems": true
+            }
+          ]
+        },
         "constructor-super": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2330,6 +2330,31 @@
             }
           ]
         },
+        "consistent-this": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ],
+              "additionalItems": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 2,
+              "uniqueItems": true
+            }
+          ]
+        },
         "constructor-super": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -7,6 +7,7 @@ eslint/block-scoped-var                                    |  31363
 eslint/capitalized-comments                                |      7
 eslint/class-methods-use-this                              |   2676
 eslint/complexity                                          |  17572
+eslint/consistent-this                                     |  64794
 eslint/constructor-super                                   |    300
 eslint/curly                                               |  14797
 eslint/default-case                                        |    284


### PR DESCRIPTION
Implements `eslint/consistent-this`
Defaults to `["that"]` and takes an ESLint-compatible alias list such as `["self"]` or `["self", "vm"]`

ESLint ref: https://eslint.org/docs/latest/rules/consistent-this
Issue: https://github.com/oxc-project/oxc/issues/479

The shape follows the original closely: local checks on initialized `VariableDeclarator`s and identifier `AssignmentExpression`s, plus a deferred per-scope check on `Program` and `Function` nodes — which is exactly ESLint's `Program:exit` / `FunctionDeclaration:exit` / `FunctionExpression:exit` trio, since `AstKind::Function` covers both function forms and skips arrows
Only `run` is implemented, over four node types, with no program-wide or scope-tree walk
No fixer, because ESLint's rule has none either

Three spots where oxc's scope model differs from `eslint-scope` needed bridging — each is commented and pinned by tests: oxc creates a scope for every `for` (escope only for lexical heads), it hoists Annex-B block function declarations into the enclosing var scope, and it binds a named function expression's own name inside the function scope

### Checked against ESLint, case by case

Rather than eyeballing it, I ran every case through `eslint@9` — and `@typescript-eslint/parser@8` for the TypeScript suites — and diffed positions and messages: 196 cases from the main suite plus a 276-case probe matrix covering every `SymbolFlags` binding kind, scope shape, TS declaration form and sloppy-mode construct
Nothing came back unexplained

Two classes of difference remain, both deliberate

**Spans for parameter aliases.** ESLint reports `def.node`, which for a parameter is the whole function; this rule points at the parameter
Same diagnostics, same messages, tighter span

```js
/* consistent-this: ["error", "self"] */
function f(self) {}
// eslint 1:1   oxlint 1:12
```

**TypeScript wrappers.** In `.ts`/`.tsx` the rule looks through `as`, `satisfies`, `<T>` and `!` on both sides of an assignment, since none of them change what gets captured
ESLint compares `value.type === "ThisExpression"` literally, so it flags `var self = this as any` — where the alias really does hold `this` — and misses `var context = this!`, where `this` lands under a name that is not a configured alias
Upstream marks the rule `frozen: true` and typescript-eslint has no override for it, so neither will be fixed there
JavaScript behaviour is untouched and reports the same code as ESLint

### AI Disclosure

Claude Opus 5:
- Code review
- ESLint compatibility analysis
- Discussion of edge cases
- Writing and validating tests
