### PR TITLE
chore(linter): add react/no-deprecated to unsupported rules

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -82,6 +82,7 @@
     "react/jsx-one-expression-per-line": "Stylistic rule from eslint-plugin-react. Should use Oxfmt for stylistic rules, or use JS Plugins to enable this rule.",
     "react/jsx-sort-props": "Stylistic rule from eslint-plugin-react. Should use Oxfmt for stylistic rules, or use JS Plugins to enable this rule.",
     "react/no-adjacent-inline-elements": "Stylistic rule from eslint-plugin-react. Should use Oxfmt for stylistic rules, or use JS Plugins to enable this rule.",
+    "react/no-deprecated": "No need to implement, already implemented by `typescript/no-deprecated` via tsgolint.",
 
     "react/config": "React Compiler rules will not be implemented in oxlint for now, as they require integration with the react compiler itself. These rules can be used via JS Plugins if desired.",
     "react/error-boundaries": "React Compiler rules will not be implemented in oxlint for now, as they require integration with the react compiler itself. These rules can be used via JS Plugins if desired.",


### PR DESCRIPTION
Follow up to https://github.com/oxc-project/oxc/pull/22233

This adds the unsupported rule as we concluded this is better served as done by the more general typescript rule