### PR TITLE
fix(oxfmt): Send expandedStates variants as shared refs

### DIFF
--- a/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-deeply-nested-call-arguments.vue
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-deeply-nested-call-arguments.vue
@@ -1,0 +1,27 @@
+<script lang="ts" setup>
+// Deeply nested call expressions whose arguments are themselves nested call expressions
+// produced a `BestFitting` IR with each variant duplicating the inner content.
+// Cloning the converted JSON across variants blew up the Prettier Doc size exponentially
+// (~48 MB at 3 levels), and effectively hung.
+//
+// `oxc_formatter::Interned` sub-trees are now emitted once into a `_oxfmtRefs`
+// array and referenced via `_oxfmtRef` placeholders, preserving sharing across the JSON boundary.
+// https://github.com/oxc-project/oxc/issues/22350
+const schema = computed(() =>
+  yup.object({
+    a: yup.object({
+      b: yup.object({
+        c: yup.object().when(() =>
+          yup.object({
+            d: yup.object().when(() =>
+              yup.object({
+                e: yup.object({ f: yup.object({ g: yup.string() }) }),
+              }),
+            ),
+          }),
+        ),
+      }),
+    }),
+  }),
+);
+</script>

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -1,6 +1,6 @@
 ## js-in-vue
 
-### Option 1: 421/423 (99.53%)
+### Option 1: 422/424 (99.53%)
 
 ```json
 {"printWidth":80}
@@ -11,7 +11,7 @@
 | [externals/prettier/vue/multiparser/lang-tsx.vue](diffs/js-in-vue/externals__prettier__vue__multiparser__lang-tsx.vue.md) | `lang=tsx` is not supported |
 | [externals/vue-vben-admin/effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/externals__vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file |
 
-### Option 2: 421/423 (99.53%)
+### Option 2: 422/424 (99.53%)
 
 ```json
 {"printWidth":100,"vueIndentScriptAndStyle":true,"singleQuote":true}

--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
@@ -19,20 +19,65 @@ export const textToDoc: Parser<Doc>["parse"] = async (embeddedSourceText, textTo
   // Detect context from Prettier's internal flags
   const parentContext = detectParentContext(parentParser!, textToDocOptions);
 
-  const doc = await jsTextToDoc(
+  const docJSON = await jsTextToDoc(
     embeddedSourceExt,
     embeddedSourceText,
     _oxfmtPluginOptionsJson as string,
     parentContext,
   );
 
-  if (doc === null) {
+  if (docJSON === null) {
     throw new Error("`oxfmt::textToDoc()` failed. Use `OXC_LOG` env var to see Rust-side logs.");
   }
 
-  // SAFETY: Rust side returns Prettier's `Doc` JSON
-  return JSON.parse(doc) as Doc;
+  // SAFETY: Rust side returns Prettier's `Doc` JSON wrapped with `{ doc, refs }` for sharing.
+  const { doc, refs } = JSON.parse(docJSON) as { doc: unknown; refs: unknown[] };
+
+  // Fast path for no refs (common when formatting small AST fragments).
+  if (refs.length === 0) return doc as Doc;
+
+  // Sparse array sized to ref count; index = ref id.
+  // Faster than `Map` for dense numeric keys and avoids hashing overhead.
+  const cache: unknown[] = Array.from({ length: refs.length });
+  return resolveRefs(doc, refs, cache) as Doc;
 };
+
+/**
+ * Rust emits `Interned` sub-trees once into `refs` and references them via `{ _REF: <id> }` placeholders,
+ * preventing exponential JSON blowup when the same sub-tree is duplicated variants.
+ *
+ * Restore shared object references so Prettier sees the original (memory-shared) structure.
+ * Identity does not affect output because Prettier identifies groups by their `id` field,
+ * not by JS object identity.
+ *
+ * The `_REF` key (uppercase, prefixed) is chosen to never collide with valid Prettier Doc node keys,
+ * so the `typeof obj._REF === "number"` check uniquely identifies placeholders.
+ *
+ * Refs are resolved on-demand with memoization.
+ * A ref `i` may reference any other ref `j` (including `j < i`) because Rust caches `Interned` by pointer
+ * and an earlier-encountered `Interned` (smaller id) can also appear inside a later one's content.
+ * Topological / reverse-order resolution would observe `undefined` holes, so we recurse lazily.
+ */
+function resolveRefs(node: unknown, rawRefs: unknown[], cache: unknown[]): unknown {
+  if (node === null || typeof node !== "object") return node;
+  if (Array.isArray(node)) return node.map((n) => resolveRefs(n, rawRefs, cache));
+
+  const obj = node as Record<string, unknown>;
+  if (typeof obj._REF === "number") {
+    const id = obj._REF;
+    // Doc values are never `undefined`,
+    // so `undefined` in `cache[id]` means "not yet cached" rather than "cached undefined".
+    const cached = cache[id];
+    if (cached !== undefined) return cached;
+    const resolved = resolveRefs(rawRefs[id], rawRefs, cache);
+    cache[id] = resolved;
+    return resolved;
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const k in obj) out[k] = resolveRefs(obj[k], rawRefs, cache);
+  return out;
+}
 
 /**
  * Detects Vue fragment mode from Prettier's internal flags.

--- a/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
@@ -18,25 +18,44 @@ use oxc_formatter::{
 /// This is used for js-in-xxx formatting (both full and fragment)
 /// where the IR must be returned to Prettier as an unresolved Doc (rather than a printed string)
 /// so that Prettier can handle line-wrapping in the parent context.
+///
+/// # Ref-based sharing
+///
+/// `oxc_formatter` IR uses [`FormatElement::Interned`] to share sub-trees by pointer.
+/// Naively cloning the converted JSON for each reference duplicates content,
+/// which explodes exponentially when nested inside [`FormatElement::BestFitting`] variants
+/// (each variant emits its own copy of the inner Interned content in the Prettier Doc's `expandedStates`).
+///
+/// To preserve sharing across the JSON boundary, every Interned slice is emitted once
+/// into a `refs` array and referenced via `{ "_REF": <index> }` placeholders.
+/// The uppercase, prefixed key avoids any chance of collision with valid Prettier
+/// Doc node keys (`type`, `contents`, `id`, etc.).
+/// The JS-side plugin resolves these back into shared object references before
+/// handing to Prettier as `Doc`, matching the original (memory-shared) structure exactly.
+/// Output is unchanged because Prettier identifies groups by `id`, not by JS object identity.
 pub fn format_elements_to_prettier_doc(
     elements: &[FormatElement],
     sorted_tailwind_classes: &[String],
 ) -> Result<Value, String> {
     let mut state = ConvertState::new(sorted_tailwind_classes);
     let children = convert_elements(elements, &mut state)?;
-    Ok(normalize_array(children))
+    let doc = normalize_array(children);
+    Ok(json!({ "doc": doc, "refs": Value::Array(state.refs) }))
 }
 
 type InternedCacheKey = (usize, usize);
 
 struct ConvertState<'a> {
     sorted_tailwind_classes: &'a [String],
-    interned_cache: FxHashMap<InternedCacheKey, Vec<Value>>,
+    /// Maps `Interned` slice pointer to its ref id in `refs`.
+    interned_to_ref: FxHashMap<InternedCacheKey, usize>,
+    /// Converted content per ref id (index = id).
+    refs: Vec<Value>,
 }
 
 impl<'a> ConvertState<'a> {
     fn new(sorted_tailwind_classes: &'a [String]) -> Self {
-        Self { sorted_tailwind_classes, interned_cache: FxHashMap::default() }
+        Self { sorted_tailwind_classes, interned_to_ref: FxHashMap::default(), refs: Vec::new() }
     }
 }
 
@@ -269,13 +288,20 @@ fn convert_elements(
                     printer.pending_space = false;
                 }
                 let key = interned_cache_key(interned);
-                if let Some(cached) = state.interned_cache.get(&key) {
-                    current_children_mut(&mut stack)?.extend(cached.iter().cloned());
+                let id = if let Some(&id) = state.interned_to_ref.get(&key) {
+                    id
                 } else {
+                    // Reserve the slot index now:
+                    // the recursive `convert_elements` call below may push more refs,
+                    // so `state.refs.len()` would no longer equal this Interned's slot when we go to fill it.
+                    let id = state.refs.len();
+                    state.refs.push(Value::Null);
+                    state.interned_to_ref.insert(key, id);
                     let converted = convert_elements(interned, state)?;
-                    state.interned_cache.insert(key, converted.clone());
-                    current_children_mut(&mut stack)?.extend(converted);
-                }
+                    state.refs[id] = normalize_array(converted);
+                    id
+                };
+                current_children_mut(&mut stack)?.push(json!({ "_REF": id }));
                 printer.last_was_hardline = false;
             }
             FormatElement::BestFitting(best_fitting) => {
@@ -508,21 +534,37 @@ fn convert_best_fitting(
         return Ok(json!({"type": "group", "contents": ""}));
     }
 
-    let first_contents = normalize_array(convert_elements(variants[0], state)?);
-
     if variants.len() == 1 {
+        let first_contents = normalize_array(convert_elements(variants[0], state)?);
         return Ok(json!({"type": "group", "contents": first_contents}));
     }
 
-    let expanded_states: Vec<Value> = variants
-        .iter()
-        .map(|v| convert_elements(v, state).map(normalize_array))
-        .collect::<Result<_, _>>()?;
+    // `variants[0]` is rendered twice in Prettier's Doc.
+    // - once as `contents` (the flat-mode candidate)
+    // - and once as `expandedStates[0]` (the first break-mode candidate)
+    // Convert it once and stash the result in `refs`,
+    // then reference it from both positions via `{ _REF: id }` placeholders.
+    // The JS-side resolver restores both to the same memory-shared object
+    // (identity unaffected — Prettier identifies groups by `id`).
+    //
+    // Reserve the slot before recursing so any nested Interned refs pushed during conversion
+    // get later ids; `state.refs[id]` is filled in after.
+    let first_id = state.refs.len();
+    state.refs.push(Value::Null);
+    let first_content = normalize_array(convert_elements(variants[0], state)?);
+    state.refs[first_id] = first_content;
+    let first_ref = json!({ "_REF": first_id });
+
+    let mut expanded_states: Vec<Value> = Vec::with_capacity(variants.len());
+    expanded_states.push(first_ref.clone());
+    for v in &variants[1..] {
+        expanded_states.push(normalize_array(convert_elements(v, state)?));
+    }
 
     Ok(json!({
         "type": "group",
-        "contents": first_contents,
-        "expandedStates": Value::Array(expanded_states)
+        "contents": first_ref,
+        "expandedStates": Value::Array(expanded_states),
     }))
 }
 


### PR DESCRIPTION
Fixes #22350

Currently, the js-in-vue process involves formatting the code on the Rust side using `oxc_formatter`, converting it into an IR, transforming that into a Prettier `Doc`, serializing it into JSON, and then sending it to the JS side, where it is finally passed to Prettier.

Some types of `Docs` include multiple variations that are selected based on the `printWidth`, and all of these variations were being included as part of the JSON payload.

As a result, deep nesting caused the payload size to grow exponentially, leading to hangs.

This PR resolves the issue by sending these variations separately as shared references.