### PR TITLE
fix(linter): report type-only unused parameters in no-unused-vars

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
@@ -107,16 +107,24 @@ where
 }
 
 /// Parameter 'x' is declared but never used.
-pub fn param<R>(symbol: &Symbol<'_, '_>, pat: &IgnorePattern<R>) -> OxcDiagnostic
+pub fn param<R>(
+    symbol: &Symbol<'_, '_>,
+    pat: &IgnorePattern<R>,
+    only_used_as_type: bool,
+) -> OxcDiagnostic
 where
     R: fmt::Display,
 {
     let name = symbol.name();
     let suffix = pat.diagnostic_help("parameters");
 
-    OxcDiagnostic::warn(format!("Parameter '{name}' is declared but never used.{suffix}"))
-        .with_label(symbol.span().label(format!("'{name}' is declared here")))
-        .with_help("Consider removing this parameter.")
+    OxcDiagnostic::warn(if only_used_as_type {
+        format!("Parameter '{name}' is declared but only used as a type.{suffix}")
+    } else {
+        format!("Parameter '{name}' is declared but never used.{suffix}")
+    })
+    .with_label(symbol.span().label(format!("'{name}' is declared here")))
+    .with_help("Consider removing this parameter.")
 }
 
 /// Identifier 'x' imported but never used.

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -310,7 +310,12 @@ impl NoUnusedVars {
                 Self::report_with_fix_mode(
                     self.fix.variables,
                     ctx,
-                    diagnostic::param(symbol, &self.args_ignore_pattern),
+                    diagnostic::param(
+                        symbol,
+                        &self.args_ignore_pattern,
+                        symbol.is_used_in_return_type_predicate()
+                            || symbol.has_reference_used_as_type_query(),
+                    ),
                     |fixer| self.rename_unused_function_parameter(fixer, symbol, param),
                 );
             }
@@ -318,7 +323,7 @@ impl NoUnusedVars {
                 if NoUnusedVars::is_allowed_binding_rest_element(symbol) {
                     return;
                 }
-                ctx.diagnostic(diagnostic::param(symbol, &self.vars_ignore_pattern));
+                ctx.diagnostic(diagnostic::param(symbol, &self.vars_ignore_pattern, false));
             }
             AstKind::BindingRestElement(_) => {
                 if NoUnusedVars::is_allowed_binding_rest_element(symbol) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1562,6 +1562,11 @@ fn test_type_references() {
         "interface LinkedList<T> { next: LinkedList<T> | undefined }",
         "function foo(): typeof foo { }",
         "function foo(): typeof foo { return foo }",
+        // https://github.com/oxc-project/oxc/issues/22367
+        "export function foo(a: unknown): a is string { return true }",
+        "export const foo = (a: unknown): a is string => true",
+        "function assertString(a: unknown): asserts a is string {} assertString('')",
+        "function assertDefined(a: unknown): asserts a {} assertDefined('')",
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -354,6 +354,46 @@ impl<'a> Symbol<'_, 'a> {
         false
     }
 
+    /// Checks if this formal parameter is used in a TypeScript return type predicate.
+    pub fn is_used_in_return_type_predicate(&self) -> bool {
+        if !matches!(self.declaration().kind(), AstKind::FormalParameter(_)) {
+            return false;
+        }
+
+        for parent in self.iter_parents().map(AstNode::kind) {
+            match parent {
+                AstKind::Function(func) => {
+                    return self
+                        .return_type_predicate_references_symbol(func.return_type.as_deref());
+                }
+                AstKind::ArrowFunctionExpression(expr) => {
+                    return self
+                        .return_type_predicate_references_symbol(expr.return_type.as_deref());
+                }
+                AstKind::Program(_) => return false,
+                _ => {}
+            }
+        }
+
+        false
+    }
+
+    fn return_type_predicate_references_symbol(
+        &self,
+        return_type: Option<&TSTypeAnnotation<'a>>,
+    ) -> bool {
+        let Some(TSTypeAnnotation { type_annotation: TSType::TSTypePredicate(predicate), .. }) =
+            return_type
+        else {
+            return false;
+        };
+
+        matches!(
+            &predicate.parameter_name,
+            TSTypePredicateName::Identifier(identifier) if identifier.name == self.name()
+        )
+    }
+
     /// Checks if a read reference is only ever used to modify itself.
     ///
     /// ## Algorithm

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-type-references.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-type-references.snap
@@ -109,3 +109,35 @@ source: crates/oxc_linter/src/tester.rs
    ·           ╰── 'foo' is declared here
    ╰────
   help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but only used as a type. Unused parameters should start with a '_'.
+   ╭─[no_unused_vars.ts:1:21]
+ 1 │ export function foo(a: unknown): a is string { return true }
+   ·                     ┬
+   ·                     ╰── 'a' is declared here
+   ╰────
+  help: Consider removing this parameter.
+
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but only used as a type. Unused parameters should start with a '_'.
+   ╭─[no_unused_vars.ts:1:21]
+ 1 │ export const foo = (a: unknown): a is string => true
+   ·                     ┬
+   ·                     ╰── 'a' is declared here
+   ╰────
+  help: Consider removing this parameter.
+
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but only used as a type. Unused parameters should start with a '_'.
+   ╭─[no_unused_vars.ts:1:23]
+ 1 │ function assertString(a: unknown): asserts a is string {} assertString('')
+   ·                       ┬
+   ·                       ╰── 'a' is declared here
+   ╰────
+  help: Consider removing this parameter.
+
+  ⚠ eslint(no-unused-vars): Parameter 'a' is declared but only used as a type. Unused parameters should start with a '_'.
+   ╭─[no_unused_vars.ts:1:24]
+ 1 │ function assertDefined(a: unknown): asserts a {} assertDefined('')
+   ·                        ┬
+   ·                        ╰── 'a' is declared here
+   ╰────
+  help: Consider removing this parameter.


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/22367

I noticed that `@typescript-eslint/no-unused-vars` reports these cases slightly differently and figured we might as well improve our output too.

<img width="1190" height="181" alt="image" src="https://github.com/user-attachments/assets/01836192-e291-46f7-b910-5770b3955b93" />
