### PR TITLE
fix(formatter/sort_imports): Handle ignore comment as boundary

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -129,16 +129,14 @@ impl<'a> SourceLine<'a> {
             }
         }
 
-        // The chunk passed to `transform` only contains `ImportDeclaration`s,
-        // their surrounding comments, and line breaks.
-        // So a non-comment-only line must contain an `ImportDeclaration` with a source.
-        let source = source.expect("`ImportDeclaration` must have a source");
-
-        // TODO: Check line has trailing ignore comment?
         SourceLine::Import(
             range,
             ImportLineMetadata {
-                source,
+                // The chunk only contains non-suppressed `ImportDeclaration`s,
+                // their surrounding comments, and line breaks,
+                // (= suppressed imports are filtered out by the caller)
+                // so a non-comment-only line is guaranteed to be an import with a source.
+                source: source.expect("`ImportDeclaration` must have a source"),
                 is_side_effect,
                 is_type_import,
                 has_default_specifier,

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -63,9 +63,12 @@ impl<'a> Format<'a> for FormatStatementsWithImports<'a, '_> {
         let mut stmts_iter =
             self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_)));
         while let Some(mut stmt) = stmts_iter.next() {
-            // If import sort is enabled, and current statement is an `ImportDeclaration`,
-            // collect consecutive `ImportDeclaration`s starting with `stmt`, sort them, and output them
-            if import_sort_enabled && matches!(stmt.as_ref(), Statement::ImportDeclaration(_)) {
+            // Suppressed imports are emitted verbatim and act as partition boundaries,
+            // so they are excluded from the sortable run.
+            if import_sort_enabled
+                && matches!(stmt.as_ref(), Statement::ImportDeclaration(_))
+                && !is_import_suppressed(stmt, join.fmt())
+            {
                 let next_stmt = format_import_decls_with_sort(stmt, &mut stmts_iter, &mut join);
                 match next_stmt {
                     Some(next_stmt) => stmt = next_stmt,
@@ -134,29 +137,39 @@ fn format_import_decls_with_sort<'a, 'iter>(
     // Output first `ImportDeclaration`
     join.entry_no_separator(stmt);
 
-    // Output all following `ImportDeclaration`s.
     // The first import was already written above, so start the count at 1.
+    // A suppressed `ImportDeclaration` ends the run:
+    // its verbatim IR has no `JsLabels::ImportDeclaration` label, so the sort transform can't see it as an import.
     let mut count = 1;
     let mut next_stmt = None;
     for stmt in stmts_iter {
         if let Statement::ImportDeclaration(decl) = stmt.as_ref() {
+            if is_import_suppressed(stmt, join.fmt()) {
+                next_stmt = Some(stmt);
+                break;
+            }
             join.entry(decl.span, stmt);
             count += 1;
         } else {
-            // Some other statement
             next_stmt = Some(stmt);
             break;
         }
     }
 
-    // Sort the run of `ImportDeclaration`s.
     // A single-import run is already in order, so skip the transform.
     if count >= 2 {
         sort_imports_chunk(join.fmt_mut(), chunk_start);
     }
 
-    // Return the next statement (which isn't an `ImportDeclaration`)
     next_stmt
+}
+
+/// An `ImportDeclaration` is suppressed if it has a leading or trailing suppression comment,
+/// which causes it to be emitted verbatim and act as a partition boundary, excluding it from the sortable run.
+fn is_import_suppressed(stmt: &AstNode<'_, Statement<'_>>, f: &Formatter<'_, '_>) -> bool {
+    let span = stmt.span();
+    let comments = f.comments();
+    comments.is_suppressed(span.start) || comments.has_trailing_suppression_comment(span.end)
 }
 
 impl<'a> Format<'a> for AstNode<'a, Vec<'a, Directive<'a>>> {

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
@@ -1334,6 +1334,96 @@ import c from "c";
 // ---
 
 #[test]
+fn should_preserve_imports_with_ignore_directive() {
+    // An import marked with a leading `// oxfmt-ignore` keeps its original
+    // text (extra spaces are not normalized) and its original position.
+    // Surrounding imports are sorted independently on each side of the ignored line.
+    assert_format(
+        r#"
+import b from "b";
+// oxfmt-ignore
+import   a from "a";
+"#,
+        r#"{ "sortImports": {} }"#,
+        r#"
+import b from "b";
+// oxfmt-ignore
+import   a from "a";
+"#,
+    );
+
+    // Imports before and after a leading ignore directive are sorted in
+    // separate chunks and do not cross the ignored line.
+    assert_format(
+        r#"
+import d from "d";
+import c from "c";
+// oxfmt-ignore
+import   b from "b";
+import a from "a";
+"#,
+        r#"{ "sortImports": {} }"#,
+        r#"
+import c from "c";
+import d from "d";
+// oxfmt-ignore
+import   b from "b";
+import a from "a";
+"#,
+    );
+
+    // A leading ignore directive at the top of a run leaves the first import
+    // verbatim and sorts the rest.
+    assert_format(
+        r#"
+// oxfmt-ignore
+import   c from "c";
+import b from "b";
+import a from "a";
+"#,
+        r#"{ "sortImports": {} }"#,
+        r#"
+// oxfmt-ignore
+import   c from "c";
+import a from "a";
+import b from "b";
+"#,
+    );
+
+    // A trailing `// oxfmt-ignore` works the same way as a leading one.
+    assert_format(
+        r#"
+import b from "b";
+import   a from "a"; // oxfmt-ignore
+"#,
+        r#"{ "sortImports": {} }"#,
+        r#"
+import b from "b";
+import   a from "a"; // oxfmt-ignore
+"#,
+    );
+
+    // Trailing ignore in the middle of a run also forms a boundary.
+    assert_format(
+        r#"
+import d from "d";
+import   c from "c"; // oxfmt-ignore
+import b from "b";
+import a from "a";
+"#,
+        r#"{ "sortImports": {} }"#,
+        r#"
+import d from "d";
+import   c from "c"; // oxfmt-ignore
+import a from "a";
+import b from "b";
+"#,
+    );
+}
+
+// ---
+
+#[test]
 fn issue_17788() {
     // Should not panic
     assert_format(


### PR DESCRIPTION
Fixes #22354
