### PR TITLE
fix(formatter/sort_imports): treat submodule imports as internal patterns

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
@@ -219,7 +219,6 @@ fn to_path_kind(source: &str, options: &SortImportsOptions) -> ImportPathKind {
         return ImportPathKind::Internal;
     }
 
-    // Subpath imports (e.g., `#foo`) are also considered external
     ImportPathKind::External
 }
 

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
@@ -27,7 +27,7 @@ pub struct SortImportsOptions {
     /// NOTE: Cannot be used together with `partition_by_newline: true`.
     pub newlines_between: bool,
     /// Prefixes for internal imports.
-    /// Defaults to `["~/", "@/"]`.
+    /// Defaults to `["~/", "@/", "#"]`.
     pub internal_pattern: Vec<String>,
     /// Groups configuration for organizing imports.
     /// Each inner `Vec` represents a group, and multiple entries in the same `Vec` are treated as one.
@@ -134,9 +134,9 @@ pub struct CustomGroupDefinition {
     pub modifiers: Vec<ImportModifier>,
 }
 
-/// Returns default prefixes for identifying internal imports: `["~/", "@/"]`.
+/// Returns default prefixes for identifying internal imports: `["~/", "@/", "#"]`.
 pub fn default_internal_patterns() -> Vec<String> {
-    ["~/", "@/"].iter().map(|s| (*s).to_string()).collect()
+    ["~/", "@/", "#"].iter().map(|s| (*s).to_string()).collect()
 }
 
 /// Returns default groups configuration for organizing imports.

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/groups.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/groups.rs
@@ -648,4 +648,22 @@ import { c } from "c";
 import "node:os";
 "#,
     );
+    // Submodule imports (#foo) are treated as internal by default
+    assert_format(
+        r##"
+import foo from "#utils";
+import bar from "react";
+import baz from "~/local";
+import qux from "node:fs";
+"##,
+        r#"{ "sortImports": {} }"#,
+        r##"
+import qux from "node:fs";
+
+import bar from "react";
+
+import foo from "#utils";
+import baz from "~/local";
+"##,
+    );
 }


### PR DESCRIPTION
see https://github.com/azat-io/eslint-plugin-perfectionist/pull/732