### PR TITLE
fix(linter/consistent-function-scoping): allow imported bindings

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -280,6 +280,9 @@ impl Rule for ConsistentFunctionScoping {
         for reference_id in function_body_var_references {
             let reference = ctx.scoping().get_reference(reference_id);
             let Some(symbol_id) = reference.symbol_id() else { continue };
+            if ctx.scoping().symbol_flags(symbol_id).is_import() {
+                continue;
+            }
             let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
             if parent_scope_ids.contains(&scope_id) && symbol_id != function_declaration_symbol_id {
                 return;
@@ -1012,6 +1015,17 @@ fn test() {
         ),
         (
             "jest.mock('@kbn/i18n-react', () => { return { I18nProvider: function MockI18nProvider() { }, }; });",
+            None,
+        ),
+        (
+            "import { notifications } from 'some-module';
+            export const Outer = () => {
+                const usesImport = () => {
+                    notifications.show({ message: 'x' });
+                };
+
+                return usesImport;
+            };",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/unicorn_consistent_function_scoping.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_consistent_function_scoping.snap
@@ -504,3 +504,16 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                                      ────────────────
    ╰────
   help: Move `MockI18nProvider` to the outer scope to avoid recreating it on every call.
+
+  ⚠ unicorn(consistent-function-scoping): Function `usesImport` does not capture any variables from its parent scope
+   ╭─[consistent_function_scoping.tsx:3:23]
+ 1 │ import { notifications } from 'some-module';
+ 2 │             export const Outer = () => {
+   ·                          ──┬──
+   ·                            ╰── Outer scope where this function is defined
+ 3 │                 const usesImport = () => {
+   ·                       ─────┬────
+   ·                            ╰── This function does not use any variables from the parent arrow function
+ 4 │                     notifications.show({ message: 'x' });
+   ╰────
+  help: Move `usesImport` to the outer scope to avoid recreating it on every call.


### PR DESCRIPTION
Fixes #22381