### PR TITLE
feat(linter/jsdoc): implement `require-throws-description` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -641,6 +641,7 @@ export interface DummyRuleMap {
   "jsdoc/require-returns"?: DummyRule;
   "jsdoc/require-returns-description"?: DummyRule;
   "jsdoc/require-returns-type"?: DummyRule;
+  "jsdoc/require-throws-description"?: DummyRule;
   "jsdoc/require-throws-type"?: DummyRule;
   "jsdoc/require-yields"?: DummyRule;
   "jsdoc/require-yields-type"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4332,6 +4332,11 @@ impl RuleRunner for crate::rules::jsdoc::require_returns_type::RequireReturnsTyp
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::jsdoc::require_throws_description::RequireThrowsDescription {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::jsdoc::require_throws_type::RequireThrowsType {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -298,6 +298,7 @@ pub use crate::rules::jsdoc::require_property_type::RequirePropertyType as Jsdoc
 pub use crate::rules::jsdoc::require_returns::RequireReturns as JsdocRequireReturns;
 pub use crate::rules::jsdoc::require_returns_description::RequireReturnsDescription as JsdocRequireReturnsDescription;
 pub use crate::rules::jsdoc::require_returns_type::RequireReturnsType as JsdocRequireReturnsType;
+pub use crate::rules::jsdoc::require_throws_description::RequireThrowsDescription as JsdocRequireThrowsDescription;
 pub use crate::rules::jsdoc::require_throws_type::RequireThrowsType as JsdocRequireThrowsType;
 pub use crate::rules::jsdoc::require_yields::RequireYields as JsdocRequireYields;
 pub use crate::rules::jsdoc::require_yields_type::RequireYieldsType as JsdocRequireYieldsType;
@@ -1493,6 +1494,7 @@ pub enum RuleEnum {
     JsdocRequireReturns(JsdocRequireReturns),
     JsdocRequireReturnsDescription(JsdocRequireReturnsDescription),
     JsdocRequireReturnsType(JsdocRequireReturnsType),
+    JsdocRequireThrowsDescription(JsdocRequireThrowsDescription),
     JsdocRequireThrowsType(JsdocRequireThrowsType),
     JsdocRequireYields(JsdocRequireYields),
     JsdocRequireYieldsType(JsdocRequireYieldsType),
@@ -2380,7 +2382,8 @@ const JSDOC_REQUIRE_PROPERTY_TYPE_ID: usize = JSDOC_REQUIRE_PROPERTY_NAME_ID + 1
 const JSDOC_REQUIRE_RETURNS_ID: usize = JSDOC_REQUIRE_PROPERTY_TYPE_ID + 1usize;
 const JSDOC_REQUIRE_RETURNS_DESCRIPTION_ID: usize = JSDOC_REQUIRE_RETURNS_ID + 1usize;
 const JSDOC_REQUIRE_RETURNS_TYPE_ID: usize = JSDOC_REQUIRE_RETURNS_DESCRIPTION_ID + 1usize;
-const JSDOC_REQUIRE_THROWS_TYPE_ID: usize = JSDOC_REQUIRE_RETURNS_TYPE_ID + 1usize;
+const JSDOC_REQUIRE_THROWS_DESCRIPTION_ID: usize = JSDOC_REQUIRE_RETURNS_TYPE_ID + 1usize;
+const JSDOC_REQUIRE_THROWS_TYPE_ID: usize = JSDOC_REQUIRE_THROWS_DESCRIPTION_ID + 1usize;
 const JSDOC_REQUIRE_YIELDS_ID: usize = JSDOC_REQUIRE_THROWS_TYPE_ID + 1usize;
 const JSDOC_REQUIRE_YIELDS_TYPE_ID: usize = JSDOC_REQUIRE_YIELDS_ID + 1usize;
 const PROMISE_ALWAYS_RETURN_ID: usize = JSDOC_REQUIRE_YIELDS_TYPE_ID + 1usize;
@@ -3303,6 +3306,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(_) => JSDOC_REQUIRE_RETURNS_ID,
             Self::JsdocRequireReturnsDescription(_) => JSDOC_REQUIRE_RETURNS_DESCRIPTION_ID,
             Self::JsdocRequireReturnsType(_) => JSDOC_REQUIRE_RETURNS_TYPE_ID,
+            Self::JsdocRequireThrowsDescription(_) => JSDOC_REQUIRE_THROWS_DESCRIPTION_ID,
             Self::JsdocRequireThrowsType(_) => JSDOC_REQUIRE_THROWS_TYPE_ID,
             Self::JsdocRequireYields(_) => JSDOC_REQUIRE_YIELDS_ID,
             Self::JsdocRequireYieldsType(_) => JSDOC_REQUIRE_YIELDS_TYPE_ID,
@@ -4215,6 +4219,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(_) => JsdocRequireReturns::NAME,
             Self::JsdocRequireReturnsDescription(_) => JsdocRequireReturnsDescription::NAME,
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::NAME,
+            Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::NAME,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::NAME,
             Self::JsdocRequireYields(_) => JsdocRequireYields::NAME,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::NAME,
@@ -5167,6 +5172,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(_) => JsdocRequireReturns::CATEGORY,
             Self::JsdocRequireReturnsDescription(_) => JsdocRequireReturnsDescription::CATEGORY,
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::CATEGORY,
+            Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::CATEGORY,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::CATEGORY,
             Self::JsdocRequireYields(_) => JsdocRequireYields::CATEGORY,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::CATEGORY,
@@ -6088,6 +6094,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(_) => JsdocRequireReturns::FIX,
             Self::JsdocRequireReturnsDescription(_) => JsdocRequireReturnsDescription::FIX,
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::FIX,
+            Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::FIX,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::FIX,
             Self::JsdocRequireYields(_) => JsdocRequireYields::FIX,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::FIX,
@@ -7203,6 +7210,9 @@ impl RuleEnum {
                 JsdocRequireReturnsDescription::documentation()
             }
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::documentation(),
+            Self::JsdocRequireThrowsDescription(_) => {
+                JsdocRequireThrowsDescription::documentation()
+            }
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::documentation(),
             Self::JsdocRequireYields(_) => JsdocRequireYields::documentation(),
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::documentation(),
@@ -9316,6 +9326,10 @@ impl RuleEnum {
             }
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::config_schema(generator)
                 .or_else(|| JsdocRequireReturnsType::schema(generator)),
+            Self::JsdocRequireThrowsDescription(_) => {
+                JsdocRequireThrowsDescription::config_schema(generator)
+                    .or_else(|| JsdocRequireThrowsDescription::schema(generator))
+            }
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::config_schema(generator)
                 .or_else(|| JsdocRequireThrowsType::schema(generator)),
             Self::JsdocRequireYields(_) => JsdocRequireYields::config_schema(generator)
@@ -10327,6 +10341,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(_) => "jsdoc",
             Self::JsdocRequireReturnsDescription(_) => "jsdoc",
             Self::JsdocRequireReturnsType(_) => "jsdoc",
+            Self::JsdocRequireThrowsDescription(_) => "jsdoc",
             Self::JsdocRequireThrowsType(_) => "jsdoc",
             Self::JsdocRequireYields(_) => "jsdoc",
             Self::JsdocRequireYieldsType(_) => "jsdoc",
@@ -12634,6 +12649,9 @@ impl RuleEnum {
             Self::JsdocRequireReturnsType(_) => Ok(Self::JsdocRequireReturnsType(
                 JsdocRequireReturnsType::from_configuration(value)?,
             )),
+            Self::JsdocRequireThrowsDescription(_) => Ok(Self::JsdocRequireThrowsDescription(
+                JsdocRequireThrowsDescription::from_configuration(value)?,
+            )),
             Self::JsdocRequireThrowsType(_) => {
                 Ok(Self::JsdocRequireThrowsType(JsdocRequireThrowsType::from_configuration(value)?))
             }
@@ -13694,6 +13712,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(rule) => rule.to_configuration(),
             Self::JsdocRequireReturnsDescription(rule) => rule.to_configuration(),
             Self::JsdocRequireReturnsType(rule) => rule.to_configuration(),
+            Self::JsdocRequireThrowsDescription(rule) => rule.to_configuration(),
             Self::JsdocRequireThrowsType(rule) => rule.to_configuration(),
             Self::JsdocRequireYields(rule) => rule.to_configuration(),
             Self::JsdocRequireYieldsType(rule) => rule.to_configuration(),
@@ -14502,6 +14521,7 @@ impl RuleEnum {
                 Self::JsdocRequireReturns(rule) => rule.run(node, ctx),
                 Self::JsdocRequireReturnsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireReturnsType(rule) => rule.run(node, ctx),
+                Self::JsdocRequireThrowsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run(node, ctx),
@@ -15303,6 +15323,7 @@ impl RuleEnum {
                 Self::JsdocRequireReturns(rule) => rule.run(node, ctx),
                 Self::JsdocRequireReturnsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireReturnsType(rule) => rule.run(node, ctx),
+                Self::JsdocRequireThrowsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run(node, ctx),
@@ -16111,6 +16132,7 @@ impl RuleEnum {
                 Self::JsdocRequireReturns(rule) => rule.run_once(ctx),
                 Self::JsdocRequireReturnsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireReturnsType(rule) => rule.run_once(ctx),
+                Self::JsdocRequireThrowsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYields(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_once(ctx),
@@ -16912,6 +16934,7 @@ impl RuleEnum {
                 Self::JsdocRequireReturns(rule) => rule.run_once(ctx),
                 Self::JsdocRequireReturnsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireReturnsType(rule) => rule.run_once(ctx),
+                Self::JsdocRequireThrowsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYields(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_once(ctx),
@@ -17943,6 +17966,7 @@ impl RuleEnum {
                 Self::JsdocRequireReturns(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireReturnsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireReturnsType(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::JsdocRequireThrowsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18992,6 +19016,7 @@ impl RuleEnum {
                 Self::JsdocRequireReturns(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireReturnsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireReturnsType(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::JsdocRequireThrowsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19819,6 +19844,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(rule) => rule.should_run(ctx),
             Self::JsdocRequireReturnsDescription(rule) => rule.should_run(ctx),
             Self::JsdocRequireReturnsType(rule) => rule.should_run(ctx),
+            Self::JsdocRequireThrowsDescription(rule) => rule.should_run(ctx),
             Self::JsdocRequireThrowsType(rule) => rule.should_run(ctx),
             Self::JsdocRequireYields(rule) => rule.should_run(ctx),
             Self::JsdocRequireYieldsType(rule) => rule.should_run(ctx),
@@ -20927,6 +20953,9 @@ impl RuleEnum {
                 JsdocRequireReturnsDescription::IS_TSGOLINT_RULE
             }
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::IS_TSGOLINT_RULE,
+            Self::JsdocRequireThrowsDescription(_) => {
+                JsdocRequireThrowsDescription::IS_TSGOLINT_RULE
+            }
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::IS_TSGOLINT_RULE,
             Self::JsdocRequireYields(_) => JsdocRequireYields::IS_TSGOLINT_RULE,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::IS_TSGOLINT_RULE,
@@ -21915,6 +21944,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(_) => JsdocRequireReturns::VERSION,
             Self::JsdocRequireReturnsDescription(_) => JsdocRequireReturnsDescription::VERSION,
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::VERSION,
+            Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::VERSION,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::VERSION,
             Self::JsdocRequireYields(_) => JsdocRequireYields::VERSION,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::VERSION,
@@ -22910,6 +22940,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(_) => JsdocRequireReturns::HAS_CONFIG,
             Self::JsdocRequireReturnsDescription(_) => JsdocRequireReturnsDescription::HAS_CONFIG,
             Self::JsdocRequireReturnsType(_) => JsdocRequireReturnsType::HAS_CONFIG,
+            Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::HAS_CONFIG,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::HAS_CONFIG,
             Self::JsdocRequireYields(_) => JsdocRequireYields::HAS_CONFIG,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::HAS_CONFIG,
@@ -23732,6 +23763,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(rule) => rule.types_info(),
             Self::JsdocRequireReturnsDescription(rule) => rule.types_info(),
             Self::JsdocRequireReturnsType(rule) => rule.types_info(),
+            Self::JsdocRequireThrowsDescription(rule) => rule.types_info(),
             Self::JsdocRequireThrowsType(rule) => rule.types_info(),
             Self::JsdocRequireYields(rule) => rule.types_info(),
             Self::JsdocRequireYieldsType(rule) => rule.types_info(),
@@ -24530,6 +24562,7 @@ impl RuleEnum {
             Self::JsdocRequireReturns(rule) => rule.run_info(),
             Self::JsdocRequireReturnsDescription(rule) => rule.run_info(),
             Self::JsdocRequireReturnsType(rule) => rule.run_info(),
+            Self::JsdocRequireThrowsDescription(rule) => rule.run_info(),
             Self::JsdocRequireThrowsType(rule) => rule.run_info(),
             Self::JsdocRequireYields(rule) => rule.run_info(),
             Self::JsdocRequireYieldsType(rule) => rule.run_info(),
@@ -25454,6 +25487,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JsdocRequireReturns(JsdocRequireReturns::default()),
         RuleEnum::JsdocRequireReturnsDescription(JsdocRequireReturnsDescription::default()),
         RuleEnum::JsdocRequireReturnsType(JsdocRequireReturnsType::default()),
+        RuleEnum::JsdocRequireThrowsDescription(JsdocRequireThrowsDescription::default()),
         RuleEnum::JsdocRequireThrowsType(JsdocRequireThrowsType::default()),
         RuleEnum::JsdocRequireYields(JsdocRequireYields::default()),
         RuleEnum::JsdocRequireYieldsType(JsdocRequireYieldsType::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -711,6 +711,7 @@ pub(crate) mod jsdoc {
     pub mod require_returns;
     pub mod require_returns_description;
     pub mod require_returns_type;
+    pub mod require_throws_description;
     pub mod require_throws_type;
     pub mod require_yields;
     pub mod require_yields_type;

--- a/crates/oxc_linter/src/rules/jsdoc/require_throws_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_throws_description.rs
@@ -1,0 +1,135 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{should_ignore_as_internal, should_ignore_as_private},
+};
+
+fn require_throws_description_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Missing JSDoc `@throws` description.")
+        .with_help("Add description comment to `@throws` tag.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RequireThrowsDescription;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires a description for `@throws` tags.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `@throws` tag should explain the condition or reason an error may be thrown.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// /**
+    ///  * @throws {Error}
+    ///  */
+    /// function quux () {
+    ///   throw new Error('error');
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// /**
+    ///  * @throws {Error} Has a description
+    ///  */
+    /// function quux () {
+    ///   throw new Error('error');
+    /// }
+    /// ```
+    RequireThrowsDescription,
+    jsdoc,
+    style,
+    version = "next",
+);
+
+impl Rule for RequireThrowsDescription {
+    fn run_once(&self, ctx: &LintContext) {
+        let settings = &ctx.settings().jsdoc;
+
+        for jsdoc in ctx
+            .jsdoc()
+            .iter_all()
+            .filter(|jsdoc| !should_ignore_as_internal(jsdoc, settings))
+            .filter(|jsdoc| !should_ignore_as_private(jsdoc, settings))
+        {
+            for tag in jsdoc.tags() {
+                let tag_name = tag.kind;
+
+                if !matches!(tag_name.parsed(), "throws" | "exception") {
+                    continue;
+                }
+
+                let (_, comment_part) = tag.type_comment();
+
+                if comment_part.parsed().is_empty() {
+                    ctx.diagnostic(require_throws_description_diagnostic(tag_name.span));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "
+                    /**
+                     * @throws {SomeType} Has a description
+                     */
+                  ",
+        "
+                    /**
+                     * @throws Has a description
+                     */
+                  ",
+        "
+                    /**
+                     * @exception {SomeType} Has a description
+                     */
+                  ",
+        "
+                    /**
+                     * @exception Has a description
+                     */
+                  ",
+    ];
+
+    let fail = vec![
+        "
+                    /**
+                     * @throws
+                     */
+                  ",
+        "
+                    /**
+                     * @exception
+                     */
+                  ",
+        "
+                    /**
+                     * @throws {SomeType}
+                     */
+                  ",
+        "
+                    /**
+                     * @exception {SomeType}
+                     */
+                  ",
+    ];
+
+    Tester::new(RequireThrowsDescription::NAME, RequireThrowsDescription::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_throws_description.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_throws_description.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ jsdoc(require-throws-description): Missing JSDoc `@throws` description.
+   ╭─[require_throws_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @throws
+   ·                        ───────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@throws` tag.
+
+  ⚠ jsdoc(require-throws-description): Missing JSDoc `@throws` description.
+   ╭─[require_throws_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @exception
+   ·                        ──────────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@throws` tag.
+
+  ⚠ jsdoc(require-throws-description): Missing JSDoc `@throws` description.
+   ╭─[require_throws_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @throws {SomeType}
+   ·                        ───────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@throws` tag.
+
+  ⚠ jsdoc(require-throws-description): Missing JSDoc `@throws` description.
+   ╭─[require_throws_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @exception {SomeType}
+   ·                        ──────────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@throws` tag.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -634,6 +634,9 @@
         "jsdoc/require-returns-type": {
           "$ref": "#/definitions/DummyRule"
         },
+        "jsdoc/require-throws-description": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "jsdoc/require-throws-type": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -638,6 +638,9 @@ expression: json
         "jsdoc/require-returns-type": {
           "$ref": "#/definitions/DummyRule"
         },
+        "jsdoc/require-throws-description": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "jsdoc/require-throws-type": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
this PR implements `jsdoc/require-throws-description` rule. Unlike `require-returns-description` and `require-property-description`, this rule is not listed in the recommended section, so i picked `style` category for it

[rule doc](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-throws-description.md)
[rule source](https://github.com/gajus/eslint-plugin-jsdoc/blob/f631620cc1b5bc948f2dfec4228913d19bb2ec0d/src/index.js#L221)

issue #1170