### PR TITLE
refactor(napi/parser): raw transfer store source text at end of buffer

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -29,16 +29,20 @@ const NodeProto = Object.create(Object.prototype, {
   },
 });
 
-export function deserializeProgramOnly(buffer, sourceText, sourceStartPosInput, sourceByteLen) {
-  sourceStartPos = sourceStartPosInput;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeProgram);
+export function deserializeProgramOnly(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(buffer, sourceText, sourceStartPos, sourceByteLen, deserializeProgram);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
     firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;

--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -338,20 +338,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
             if footer.is_fixed_size {
                 // Attempt to grow the chunk in place to accommodate the allocation.
                 //
-                // `fixed_size` feature is only enabled in Oxlint.
-                // * In Oxlint itself, `grow_fixed_size_chunk` will attempt to grow the chunk in place.
-                // * In Oxlint's `RuleTester`, `Arena`s have `is_fixed_size: true`, but `start_ptr` is aligned on 4 GiB,
-                //   so `grow_fixed_size_chunk` will always fail to grow the chunk, and will return `None`.
-                // * In `napi/parser` with raw transfer enabled, `Arena`s also have `is_fixed_size: true`.
-                //   `start_ptr` is *not* aligned on 4 GiB, so calling `grow_fixed_size_chunk` would be UB.
-                //   (on Windows it would attempt to call `VirtualAlloc` with a pointer which was part of an allocation
-                //   made by JS runtime, not `VirtualAlloc`).
-                //   But `napi/parser` does not enable `fixed_size` Cargo feature, so this whole block is skipped,
-                //   and this function returns `None`.
-                //
-                // This is all rather fragile. It will be improved in future, by moving Oxlint `RuleTester`
-                // and `napi/parser` over to creating backing allocations for `Arena`s via `Arena::new_fixed_size`,
-                // so then all usage will follow the same path.
+                // `is_fixed_size` can only be `true` in 3 circumstances:
+                // * Oxlint: `grow_fixed_size_chunk` will attempt to grow the chunk in place.
+                // * NAPI parser raw transfer: `start_ptr` is aligned on 4 GiB, so `grow_fixed_size_chunk`
+                //   considers the container already grown to maximum size, will always fail to grow the chunk,
+                //   and returns `None`.
+                // * Oxlint's `RuleTester`: Same as NAPI parser raw transfer.
                 #[cfg(all(
                     feature = "fixed_size",
                     target_pointer_width = "64",

--- a/crates/oxc_allocator/src/arena/fixed_size/windows.rs
+++ b/crates/oxc_allocator/src/arena/fixed_size/windows.rs
@@ -367,17 +367,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         // 1. The request is too large to fit, even with the whole Container fully committed.
         // 2. The Container is already fully committed (`chunk_start_addr == container_start_addr`).
         // 3. The arena was created via `Arena::from_raw_parts` from an externally-managed buffer
-        //    (e.g. Oxlint's raw transfer parser used in `RuleTester`), which creates Arena with `start_ptr`
-        //    at start of Container. Same logic as the fully-committed case. We must not `VirtualAlloc(MEM_COMMIT)`
-        //    on these - the backing memory wasn't reserved via `VirtualAlloc`.
-        //
-        // Note: `napi/parser` creates an `Arena` with `Arena::from_raw_parts`, so with `is_fixed_size: true`.
-        // But it *doesn't* have `start_ptr` aligned on `CONTAINER_ALIGN`. In extreme cases, this could allow this check
-        // to pass when it shouldn't, and attempt to commit memory which wasn't reserved via `VirtualAlloc`.
-        // However, `napi/parser` doesn't enable `fixed_size` Cargo feature, so this code is not compiled,
-        // and therefore there's no way for this failure to arise.
-        // TODO: This is fragile. Fix it by aligning `start_ptr` to `CONTAINER_ALIGN` in `napi/parser`
-        // (write source text into end of buffer, not start).
+        //    (e.g. NAPI parser with raw transfer enabled), which creates Arena with `start_ptr` at start of Container.
+        //    Same logic as the fully-committed case. We must not `VirtualAlloc(MEM_COMMIT)` on these -
+        //    the backing memory wasn't reserved via `VirtualAlloc`.
         if new_ptr.addr().wrapping_sub(container_start_addr) > isize::MAX as usize {
             return None;
         }

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0;
 
 const { fromCharCode } = String,
@@ -14,24 +14,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -4520,15 +4531,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0,
   parent = null;
 
@@ -15,24 +15,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -5033,15 +5044,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0;
 
 const { fromCharCode } = String,
@@ -14,24 +14,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -5061,15 +5072,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0,
   parent = null;
 
@@ -15,24 +15,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -5573,15 +5584,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0;
 
 const { fromCharCode } = String,
@@ -14,24 +14,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -4796,15 +4807,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0,
   parent = null;
 
@@ -15,24 +15,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -5339,15 +5350,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0;
 
 const { fromCharCode } = String,
@@ -14,24 +14,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -5365,15 +5376,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -6,7 +6,7 @@ let uint8,
   float64,
   sourceText,
   sourceTextLatin,
-  sourceEndPos = 0,
+  sourceStartPos = 0,
   firstNonAsciiPos = 0,
   parent = null;
 
@@ -15,24 +15,35 @@ const { fromCharCode } = String,
   stringDecodeArrays = Array(65).fill(null);
 for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
-export function deserialize(buffer, sourceText, sourceByteLen) {
-  sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {
+  return deserializeWith(
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    deserializeRawTransferData,
+  );
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   int32 = buffer.int32;
   float64 = buffer.float64;
   sourceText = sourceTextInput;
+  sourceStartPos = sourceStartPosInput;
+  // Find first non-ASCII byte in source region.
+  // `sourceText.substr()` can be used for strings which are within source text and ending before
+  // this position, since byte offsets equal char offsets in the all-ASCII prefix.
+  // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
   if (sourceText.length === sourceByteLen) {
-    firstNonAsciiPos = sourceByteLen;
+    firstNonAsciiPos = sourceStartPos + sourceByteLen;
     sourceTextLatin = sourceText;
   } else {
-    let i = 0;
-    for (; i < sourceByteLen && uint8[i] < 128; i++);
+    let i = sourceStartPos,
+      sourceEndPos = sourceStartPos + sourceByteLen;
+    for (; i < sourceEndPos && uint8[i] < 128; i++);
     firstNonAsciiPos = i;
-    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
+    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   let data = deserialize(int32[536870890]);
   resetBuffer();
@@ -5907,15 +5918,18 @@ function deserializeStr(pos) {
     len = int32[pos32 + 2];
   if (len === 0) return "";
   pos = int32[pos32];
-  let end = pos + len;
-  if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
+  let end = pos + len,
+    isInSourceRegion = pos >= sourceStartPos;
+  if (isInSourceRegion && end <= firstNonAsciiPos)
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   // Use `utf8Slice` for strings longer than 64 bytes
   if (len > 64) return utf8Slice.call(uint8, pos, end);
-  if (pos < sourceEndPos) {
+  // If string is in source region, use slice of `sourceTextLatin` if all ASCII
+  if (isInSourceRegion) {
     // Check if all bytes are ASCII, use `utf8Slice` if not
     for (let i = pos; i < end; i++) if (uint8[i] >= 128) return utf8Slice.call(uint8, pos, end);
     // String is all ASCII, so slice from `sourceTextLatin`
-    return sourceTextLatin.substr(pos, len);
+    return sourceTextLatin.substr(pos - sourceStartPos, len);
   }
   // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.
   // Copy bytes into temp array.

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -12638,7 +12638,10 @@ function constructStr(pos, ast) {
   if (len === 0) return "";
 
   pos = int32[pos32];
-  if (ast.sourceIsAscii && pos < ast.sourceByteLen) return ast.sourceText.substr(pos, len);
+  if (ast.sourceIsAscii) {
+    const { sourceStartPos } = ast;
+    if (pos >= sourceStartPos) return ast.sourceText.substr(pos - sourceStartPos, len);
+  }
 
   // Longer strings use `TextDecoder`
   // TODO: Find best switch-over point

--- a/napi/parser/src-js/raw-transfer/common.js
+++ b/napi/parser/src-js/raw-transfer/common.js
@@ -1,5 +1,11 @@
 import os from "node:os";
-import { BLOCK_SIZE, BLOCK_ALIGN, BUFFER_SIZE, IS_TS_FLAG_POS } from "../generated/constants.js";
+import {
+  BLOCK_SIZE,
+  BLOCK_ALIGN,
+  BUFFER_SIZE,
+  ACTIVE_SIZE,
+  IS_TS_FLAG_POS,
+} from "../generated/constants.js";
 import {
   getBufferOffset,
   parseRaw as parseRawBinding,
@@ -33,9 +39,9 @@ if (!rawTransferSupported()) {
  * @returns {Object} - The return value of `convert`
  */
 export function parseSyncRawImpl(filename, sourceText, options, convert) {
-  const { buffer, sourceByteLen } = prepareRaw(sourceText);
-  parseRawSyncBinding(filename, buffer.block, sourceByteLen, options);
-  return convert(buffer, sourceText, sourceByteLen, options);
+  const { buffer, sourceStartPos, sourceByteLen } = prepareRaw(sourceText);
+  parseRawSyncBinding(filename, buffer.block, sourceStartPos, sourceByteLen, options);
+  return convert(buffer, sourceText, sourceStartPos, sourceByteLen, options);
 }
 
 // User should not schedule more async tasks than there are available CPUs, as it hurts performance,
@@ -113,9 +119,9 @@ export async function parseAsyncRawImpl(filename, sourceText, options, convert) 
   }
 
   // Parse
-  const { buffer, sourceByteLen } = prepareRaw(sourceText);
-  await parseRawBinding(filename, buffer.block, sourceByteLen, options);
-  const data = convert(buffer, sourceText, sourceByteLen, options);
+  const { buffer, sourceStartPos, sourceByteLen } = prepareRaw(sourceText);
+  await parseRawBinding(filename, buffer.block, sourceStartPos, sourceByteLen, options);
+  const data = convert(buffer, sourceText, sourceStartPos, sourceByteLen, options);
 
   // Free the CPU core
   if (queue.length > 0) {
@@ -174,8 +180,9 @@ const textEncoder = new TextEncoder();
  * Get a buffer (from cache if possible), and copy source text into it.
  *
  * @param {string} sourceText - Source text of file
- * @returns {Object} - Object of form `{ buffer, sourceByteLen }`.
+ * @returns {Object} - Object of form `{ buffer, sourceStartPos, sourceByteLen }`.
  *   - `buffer`: `Uint8Array` containing the AST in raw form.
+ *   - `sourceStartPos`: Position of first byte of source text in buffer
  *   - `sourceByteLen`: Length of source text in UTF-8 bytes
  *     (which may not be equal to `sourceText.length` if source contains non-ASCII characters).
  */
@@ -200,14 +207,25 @@ export function prepareRaw(sourceText) {
   // Reuse existing buffer, or create a new one
   const buffer = buffers.length > 0 ? buffers.pop() : createBuffer();
 
-  // Write source into start of buffer.
-  // `TextEncoder` cannot write into a `Uint8Array` larger than 1 GiB,
-  // so create a view into buffer of this size to write into.
-  const sourceBuffer = new Uint8Array(buffer.buffer, buffer.byteOffset, ONE_GIB);
+  // Write source into end of buffer.
+  // Maximum size of a string encoded in UTF-8 is 3 x the length of the string in UTF-16 characters
+  // (a source which consists entirely of 3-byte UTF-8 characters).
+  // We can't predict how many bytes will be needed exactly in advance of encoding, so we reserve
+  // the maximum theoretically possible number of bytes required.
+  // `TextEncoder` cannot write into a `Uint8Array` larger than 1 GiB, so size is capped at 1 GiB.
+  const maxSourceByteLen = sourceText.length * 3;
+  if (maxSourceByteLen > ONE_GIB) throw new Error("Source text is too long");
+  const sourceStartPos = ACTIVE_SIZE - maxSourceByteLen;
+
+  const sourceBuffer = new Uint8Array(
+    buffer.buffer,
+    buffer.byteOffset + sourceStartPos,
+    maxSourceByteLen,
+  );
   const { read, written: sourceByteLen } = textEncoder.encodeInto(sourceText, sourceBuffer);
   if (read !== sourceText.length) throw new Error("Failed to write source text into buffer");
 
-  return { buffer, sourceByteLen };
+  return { buffer, sourceStartPos, sourceByteLen };
 }
 
 /**

--- a/napi/parser/src-js/raw-transfer/eager.js
+++ b/napi/parser/src-js/raw-transfer/eager.js
@@ -58,11 +58,12 @@ const deserializerNames = [
  *
  * @param {Uint8Array} buffer - Buffer containing AST in raw form
  * @param {string} sourceText - Source for the file
+ * @param {number} sourceStartPos - Position of first byte of source text in buffer
  * @param {number} sourceByteLen - Length of source text in UTF-8 bytes
  * @param {Object} options - Parsing options
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
  */
-function deserialize(buffer, sourceText, sourceByteLen, options) {
+function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen, options) {
   const isJs = isJsAst(buffer),
     range = !!options.range,
     parent = !!options.experimentalParent;
@@ -76,7 +77,7 @@ function deserialize(buffer, sourceText, sourceByteLen, options) {
     ).deserialize;
   }
 
-  const data = deserializeThis(buffer, sourceText, sourceByteLen);
+  const data = deserializeThis(buffer, sourceText, sourceStartPos, sourceByteLen);
 
   // Add a line comment for hashbang if JS.
   // Do not add comment if TS, to match `@typescript-eslint/parser`.

--- a/napi/parser/src-js/raw-transfer/lazy.js
+++ b/napi/parser/src-js/raw-transfer/lazy.js
@@ -83,15 +83,24 @@ const bufferRecycleRegistry =
  *
  * @param {Uint8Array} buffer - Buffer containing AST in raw form
  * @param {string} sourceText - Source for the file
+ * @param {number} sourceStartPos - Position of first byte of source text in buffer
  * @param {number} sourceByteLen - Length of source text in UTF-8 bytes
  * @param {Object} _options - Parsing options
  * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`,
  *   and `dispose` and `visit` methods
  */
-function construct(buffer, sourceText, sourceByteLen, _options) {
+function construct(buffer, sourceText, sourceStartPos, sourceByteLen, _options) {
   // Create AST object
   const sourceIsAscii = sourceText.length === sourceByteLen;
-  const ast = { buffer, sourceText, sourceByteLen, sourceIsAscii, nodes: new Map(), token: TOKEN };
+  const ast = {
+    buffer,
+    sourceText,
+    sourceStartPos,
+    sourceByteLen,
+    sourceIsAscii,
+    nodes: new Map(),
+    token: TOKEN,
+  };
 
   // Register `ast` with the recycle registry so buffer is returned to cache
   // when `ast` is garbage collected

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -40,8 +40,6 @@ use crate::{
 //    So avoiding the 32nd bit being set enables using `>>` bitshift operator,
 //    which is cheaper than `>>>`, and does not risk offsets being interpreted as negative.
 
-const ARENA_ALIGN: usize = Allocator::RAW_MIN_ALIGN;
-
 /// Layout describing the JS-owned buffer (`BLOCK_SIZE` bytes, aligned on `BLOCK_ALIGN`).
 const BLOCK_LAYOUT: Layout = match Layout::from_size_align(BLOCK_SIZE, BLOCK_ALIGN) {
     Ok(layout) => layout,
@@ -66,8 +64,8 @@ pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
 
 /// Parse AST into provided `Uint8Array` buffer, synchronously.
 ///
-/// Source text must be written into the start of the buffer, and its length (in UTF-8 bytes)
-/// provided as `source_len`.
+/// Source text must be written into the buffer, starting at offset `source_start`,
+/// and its length (in UTF-8 bytes) provided as `source_len`.
 ///
 /// This function will parse the source, and write the AST into the buffer, starting at the end.
 ///
@@ -78,9 +76,9 @@ pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
 /// # SAFETY
 ///
 /// Caller must ensure:
-/// * Source text is written into start of the buffer.
+/// * Source text is written into buffer starting at offset `source_start`.
 /// * Source text's UTF-8 byte length is `source_len`.
-/// * The 1st `source_len` bytes of the buffer comprises a valid UTF-8 string.
+/// * The bytes comprising the source text form a valid UTF-8 string.
 ///
 /// If source text is originally a JS string on JS side, and converted to a buffer with
 /// `Buffer.from(str)` or `new TextEncoder().encode(str)`, this guarantees it's valid UTF-8.
@@ -93,6 +91,7 @@ pub fn get_buffer_offset(buffer: Uint8Array) -> u32 {
 pub unsafe fn parse_raw_sync(
     filename: String,
     mut buffer: Uint8Array,
+    source_start: u32,
     source_len: u32,
     options: Option<ParserOptions>,
 ) {
@@ -101,15 +100,15 @@ pub unsafe fn parse_raw_sync(
     let buffer = unsafe { buffer.as_mut() };
 
     // SAFETY: `parse_raw_impl` has same safety requirements as this function
-    unsafe { parse_raw_impl(&filename, buffer, source_len, options) };
+    unsafe { parse_raw_impl(&filename, buffer, source_start, source_len, options) };
 }
 
 /// Parse AST into provided `Uint8Array` buffer, asynchronously.
 ///
 /// Note: This function can be slower than `parseRawSync` due to the overhead of spawning a thread.
 ///
-/// Source text must be written into the start of the buffer, and its length (in UTF-8 bytes)
-/// provided as `source_len`.
+/// Source text must be written into the buffer, starting at offset `source_start`,
+/// and its length (in UTF-8 bytes) provided as `source_len`.
 ///
 /// This function will parse the source, and write the AST into the buffer, starting at the end.
 ///
@@ -120,9 +119,9 @@ pub unsafe fn parse_raw_sync(
 /// # SAFETY
 ///
 /// Caller must ensure:
-/// * Source text is written into start of the buffer.
+/// * Source text is written into buffer starting at offset `source_start`.
 /// * Source text's UTF-8 byte length is `source_len`.
-/// * The 1st `source_len` bytes of the buffer comprises a valid UTF-8 string.
+/// * The bytes comprising the source text form a valid UTF-8 string.
 /// * Contents of buffer must not be mutated by caller until the `AsyncTask` returned by this
 ///   function resolves.
 ///
@@ -136,15 +135,17 @@ pub unsafe fn parse_raw_sync(
 pub fn parse_raw(
     filename: String,
     buffer: Uint8Array,
+    source_start: u32,
     source_len: u32,
     options: Option<ParserOptions>,
 ) -> AsyncTask<ResolveTask> {
-    AsyncTask::new(ResolveTask { filename, buffer, source_len, options })
+    AsyncTask::new(ResolveTask { filename, buffer, source_start, source_len, options })
 }
 
 pub struct ResolveTask {
     filename: String,
     buffer: Uint8Array,
+    source_start: u32,
     source_len: u32,
     options: Option<ParserOptions>,
 }
@@ -160,7 +161,15 @@ impl Task for ResolveTask {
         // Therefore, this is a valid exclusive `&mut [u8]`.
         let buffer = unsafe { self.buffer.as_mut() };
         // SAFETY: Caller of `parse_async` guarantees to uphold invariants of `parse_raw_impl`
-        unsafe { parse_raw_impl(&self.filename, buffer, self.source_len, self.options.take()) };
+        unsafe {
+            parse_raw_impl(
+                &self.filename,
+                buffer,
+                self.source_start,
+                self.source_len,
+                self.options.take(),
+            );
+        }
         Ok(())
     }
 
@@ -174,9 +183,9 @@ impl Task for ResolveTask {
 /// # SAFETY
 ///
 /// Caller must ensure:
-/// * Source text is written into start of the buffer.
+/// * Source text is written into buffer starting at offset `source_start`.
 /// * Source text's UTF-8 byte length is `source_len`.
-/// * The 1st `source_len` bytes of the buffer comprises a valid UTF-8 string.
+/// * The bytes comprising the source text form a valid UTF-8 string.
 ///
 /// If source text is originally a JS string on JS side, and converted to a buffer with
 /// `Buffer.from(str)` or `new TextEncoder().encode(str)`, this guarantees it's valid UTF-8.
@@ -184,6 +193,7 @@ impl Task for ResolveTask {
 unsafe fn parse_raw_impl(
     filename: &str,
     buffer: &mut [u8],
+    source_start: u32,
     source_len: u32,
     options: Option<ParserOptions>,
 ) {
@@ -192,56 +202,34 @@ unsafe fn parse_raw_impl(
     let buffer_ptr = NonNull::from_mut(buffer).cast::<u8>();
     assert!(buffer_ptr.addr().get().is_multiple_of(BLOCK_ALIGN));
 
-    // Get offsets and size of data region to be managed by arena allocator.
-    //
-    // After the source text, the allocator's chunk fills the rest of the buffer from `data_ptr` to the end.
-    // After the allocatable region (size `ACTIVE_SIZE`) sits:
-    // * `RawTransferMetadata`
-    // * A reserved slot for `FixedSizeAllocatorMetadata` (unused in `napi/parser`)
-    // * `ChunkFooter`
-    // The end of `ChunkFooter` is the end of the buffer.
-    //
-    // We set the cursor to before `RawTransferMetadata` so allocations don't overwrite the metadata regions.
-    //
-    // Round up `data_offset` to next multiple of `ARENA_ALIGN`, as required by `Allocator`.
-    // Check that there's enough space for `RawTransferMetadata`, `FixedSizeAllocatorMetadata`, and `ChunkFooter`.
-    let source_len = source_len as usize;
-    let data_offset = source_len.next_multiple_of(ARENA_ALIGN);
-    assert!(data_offset <= ACTIVE_SIZE, "Source text is too long");
-
-    // Calculate size of allocator chunk (including metadata and `ChunkFooter`)
-    let data_size = BLOCK_SIZE - data_offset;
+    const _: () = {
+        assert!(BLOCK_SIZE.is_multiple_of(Allocator::RAW_MIN_ALIGN));
+        assert!(BLOCK_SIZE >= Allocator::RAW_MIN_SIZE);
+        assert!(BLOCK_ALIGN.is_multiple_of(Allocator::RAW_MIN_ALIGN));
+    };
 
     // Create `Allocator`.
+    //
     // Wrap in `ManuallyDrop` so the allocation doesn't get freed at end of function, or if panic.
-    // The buffer is owned by JS, so Rust must not free it - hence `ManuallyDrop`. The
-    // `backing_alloc_ptr` and `layout` we pass to `from_raw_parts` are never used (the `Allocator`
-    // is never dropped), but the safety contract requires the chunk region to lie within them,
-    // so we describe the buffer itself.
-    // SAFETY: `data_offset` is less than `buffer.len()`, so `.add(data_offset)` cannot wrap
-    // or be out of bounds.
-    let data_ptr = unsafe { buffer_ptr.add(data_offset) };
-    debug_assert!(data_ptr.addr().get().is_multiple_of(ARENA_ALIGN));
-    debug_assert!(data_size.is_multiple_of(ARENA_ALIGN));
-
-    // SAFETY: `data_ptr` and `data_size` outline a section of the memory in `buffer`.
-    // `data_ptr` and `data_size` are multiples of `ARENA_ALIGN`.
-    // `data_size` is greater than `Allocator::RAW_MIN_SIZE`.
-    // The chunk region (`data_ptr..data_ptr + data_size`) lies entirely within the buffer.
-    // `buffer_ptr` was derived from a `&mut [u8]` slice, so has permission for writes.
-    // `data_ptr` was derived from `buffer_ptr`, so inherits that permission.
+    // The buffer is owned by JS, so Rust must not free it - hence `ManuallyDrop`.
+    // The `backing_alloc_ptr` and `layout` we pass to `from_raw_parts` aren't used (the `Allocator` is never dropped),
+    // but the safety contract requires the chunk region to lie within them, so we describe the buffer itself.
+    //
+    // SAFETY: `buffer_ptr` and `BLOCK_SIZE` outline the entirety of `buffer`.
+    // `buffer_ptr` and `BLOCK_SIZE` are multiples of `ARENA_ALIGN`.
+    // `BLOCK_SIZE` is `>= Allocator::RAW_MIN_SIZE`.
+    // `buffer_ptr` is derived from a `&mut [u8]` slice, so has permission for writes.
     let allocator =
-        unsafe { Allocator::from_raw_parts(data_ptr, data_size, buffer_ptr, BLOCK_LAYOUT) };
+        unsafe { Allocator::from_raw_parts(buffer_ptr, BLOCK_SIZE, buffer_ptr, BLOCK_LAYOUT) };
     let allocator = ManuallyDrop::new(allocator);
 
-    const _: () = assert!(ACTIVE_SIZE.is_multiple_of(CURSOR_MIN_ALIGN));
-
-    // Set cursor to before `RawTransferMetadata` so allocations don't overwrite the metadata regions.
-    // `RawTransferMetadata` starts at offset `ACTIVE_SIZE` within the buffer.
-    // SAFETY: `ACTIVE_SIZE` is within the chunk (after `data_ptr`, before the `ChunkFooter`).
-    // `ACTIVE_SIZE` is aligned on `Arena::MIN_ALIGN`.
+    // Set cursor to before start of source text. AST will be written into the buffer before the source text.
+    // Round down the pointer, so it's aligned on `CURSOR_MIN_ALIGN`.
+    // SAFETY: Caller guarantees that source text starts at `source_start` bytes from start of buffer.
     unsafe {
-        let cursor_ptr = buffer_ptr.add(ACTIVE_SIZE);
+        let cursor_pos = source_start as usize & !(CURSOR_MIN_ALIGN - 1);
+        debug_assert!(cursor_pos <= ACTIVE_SIZE);
+        let cursor_ptr = buffer_ptr.add(cursor_pos);
         allocator.set_cursor_ptr(cursor_ptr);
     }
 
@@ -254,10 +242,13 @@ unsafe fn parse_raw_impl(
     let is_ts = get_ast_type(source_type, &options) == AstType::TypeScript;
 
     let (data_offset, tokens_offset, tokens_len) = {
-        // SAFETY: We checked above that `source_len` does not exceed length of buffer
-        let source_text = unsafe { buffer.get_unchecked(..source_len) };
         // SAFETY: Caller guarantees source occupies this region of the buffer and is valid UTF-8
-        let source_text = unsafe { str::from_utf8_unchecked(source_text) };
+        let source_text = unsafe {
+            let source_end = source_start as usize + source_len as usize;
+            debug_assert!(source_end <= ACTIVE_SIZE);
+            let source_bytes = buffer.get_unchecked(source_start as usize..source_end);
+            str::from_utf8_unchecked(source_bytes)
+        };
 
         let ret = parse_impl(&allocator, source_type, source_text, &options);
         let mut program = ret.program;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -149,7 +149,7 @@ fn generate_deserializers(
         /* END_IF */
 
         let uint8, int32, float64, sourceText, sourceTextLatin,
-            sourceStartPos = 0, sourceEndPos = 0, firstNonAsciiPos = 0;
+            sourceStartPos = 0, firstNonAsciiPos = 0;
 
         let parent = null;
 
@@ -178,25 +178,24 @@ fn generate_deserializers(
         /* END_IF */
 
         /* IF !LINTER */
-        export function deserialize(buffer, sourceText, sourceByteLen) {{
-            sourceEndPos = sourceByteLen;
-            return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
+        export function deserialize(buffer, sourceText, sourceStartPos, sourceByteLen) {{
+            return deserializeWith(buffer, sourceText, sourceStartPos, sourceByteLen, deserializeRawTransferData);
         }}
         /* END_IF */
 
         /* IF LINTER */
-        export function deserializeProgramOnly(buffer, sourceText, sourceStartPosInput, sourceByteLen) {{
-            sourceStartPos = sourceStartPosInput;
-            return deserializeWith(buffer, sourceText, sourceByteLen, deserializeProgram);
+        export function deserializeProgramOnly(buffer, sourceText, sourceStartPos, sourceByteLen) {{
+            return deserializeWith(buffer, sourceText, sourceStartPos, sourceByteLen, deserializeProgram);
         }}
         /* END_IF */
 
-        function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {{
+        function deserializeWith(buffer, sourceTextInput, sourceStartPosInput, sourceByteLen, deserialize) {{
             uint8 = buffer;
             int32 = buffer.int32;
             float64 = buffer.float64;
 
             sourceText = sourceTextInput;
+            sourceStartPos = sourceStartPosInput;
 
             const sourceIsAscii = sourceText.length === sourceByteLen;
 
@@ -204,29 +203,16 @@ fn generate_deserializers(
             // `sourceText.substr()` can be used for strings which are within source text and ending before
             // this position, since byte offsets equal char offsets in the all-ASCII prefix.
             // Also decode source text as Latin-1 (or reuse `sourceText` if it's all ASCII).
-            if (LINTER) {{
-                if (sourceIsAscii === true) {{
-                    firstNonAsciiPos = sourceStartPos + sourceByteLen;
-                    sourceTextLatin = sourceText;
-                }} else {{
-                    let i = sourceStartPos;
-                    const sourceEndPos = sourceStartPos + sourceByteLen;
-                    for (; i < sourceEndPos && uint8[i] < 128; i++);
-                    firstNonAsciiPos = i;
-
-                    sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
-                }}
+            if (sourceIsAscii === true) {{
+                firstNonAsciiPos = sourceStartPos + sourceByteLen;
+                sourceTextLatin = sourceText;
             }} else {{
-                if (sourceIsAscii === true) {{
-                    firstNonAsciiPos = sourceByteLen;
-                    sourceTextLatin = sourceText;
-                }} else {{
-                    let i = 0;
-                    for (; i < sourceByteLen && uint8[i] < 128; i++);
-                    firstNonAsciiPos = i;
+                let i = sourceStartPos;
+                const sourceEndPos = sourceStartPos + sourceByteLen;
+                for (; i < sourceEndPos && uint8[i] < 128; i++);
+                firstNonAsciiPos = i;
 
-                    sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
-                }}
+                sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
             }}
 
             const data = deserialize(int32[{data_pointer_pos_32}]);
@@ -965,8 +951,7 @@ fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &
     ");
 }
 
-// In parser, source text is always at the start of the buffer, and all other strings are after it.
-// In linter, source text is towards the end of the buffer, and all other strings are before it.
+// Source text is towards the end of the buffer, and all other strings are before it
 static STR_DESERIALIZER_BODY: &str = "
     const pos32 = pos >> 2,
         len = int32[pos32 + 2];
@@ -977,11 +962,6 @@ static STR_DESERIALIZER_BODY: &str = "
 
     const end = pos + len;
 
-    /* IF !LINTER */
-    if (end <= firstNonAsciiPos) return sourceTextLatin.substr(pos, len);
-    /* END_IF */
-
-    /* IF LINTER */
     // Note: Tried reducing this check to a single branch by making the comparison the equivalent of this Rust:
     // `end.wrapping_sub(sourceStartPos) <= firstNonAsciiOffset`.
     //
@@ -1002,16 +982,11 @@ static STR_DESERIALIZER_BODY: &str = "
     if (isInSourceRegion && end <= firstNonAsciiPos) {
         return sourceTextLatin.substr(pos - sourceStartPos, len);
     }
-    /* END_IF */
 
     // Use `utf8Slice` for strings longer than 64 bytes
     if (len > STRING_DECODE_CROSSOVER) return utf8Slice.call(uint8, pos, end);
 
     // If string is in source region, use slice of `sourceTextLatin` if all ASCII
-    /* IF !LINTER */
-    const isInSourceRegion = pos < sourceEndPos;
-    /* END_IF */
-
     if (isInSourceRegion) {
         // Check if all bytes are ASCII, use `utf8Slice` if not
         for (let i = pos; i < end; i++) {
@@ -1019,7 +994,7 @@ static STR_DESERIALIZER_BODY: &str = "
         }
 
         // String is all ASCII, so slice from `sourceTextLatin`
-        return sourceTextLatin.substr(LINTER ? pos - sourceStartPos : pos, len);
+        return sourceTextLatin.substr(pos - sourceStartPos, len);
     }
 
     // String is not in source region - use `fromCharCode.apply` with a temp array of correct length.

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -953,6 +953,7 @@ fn generate_primitive(primitive_def: &PrimitiveDef, state: &mut State, schema: &
     ");
 }
 
+// TODO: Alter this in line with the more efficient version in eager deserializer
 static STR_DESERIALIZER_BODY: &str = "
     const pos32 = pos >> 2,
         { buffer } = ast,
@@ -961,7 +962,10 @@ static STR_DESERIALIZER_BODY: &str = "
     if (len === 0) return '';
 
     pos = int32[pos32];
-    if (ast.sourceIsAscii && pos < ast.sourceByteLen) return ast.sourceText.substr(pos, len);
+    if (ast.sourceIsAscii) {
+        const { sourceStartPos } = ast;
+        if (pos >= sourceStartPos) return ast.sourceText.substr(pos - sourceStartPos, len);
+    }
 
     // Longer strings use `TextDecoder`
     // TODO: Find best switch-over point


### PR DESCRIPTION
Oxlint's raw transfer implementation stores the source text at end of the buffer. Prior to this PR `napi/parser` stored source text at the start of the buffer.

Bring `napi/parser` into line with Oxlint, by also storing source text at end of the buffer.

Making all versions of raw transfer that we use align with each other removes complication (all versions now have the same implementation of `deserializeStr`) and also removes some fragile code where it'd be easy to accidentally trigger UB (see the updated comments in `arena/fixed_size/windows.rs` and `arena/alloc_impl.rs`).

Unfortunately, storing source at end of buffer is slightly less efficient than storing it at the start. We'll switch all implementations to storing source at start of buffer when we move to storing all strings (source text and all other strings) together in a single contiguous block. But in meantime, this slight inefficiency is outweighed by the gain in safety.