### PR TITLE
perf(linter): optimize `oxc/bad-array-method-on-arguments`

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3960,7 +3960,8 @@ impl RuleRunner for crate::rules::oxc::approx_constant::ApproxConstant {
 }
 
 impl RuleRunner for crate::rules::oxc::bad_array_method_on_arguments::BadArrayMethodOnArguments {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::IdentifierReference]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_array_method_on_arguments.rs
@@ -63,9 +63,13 @@ declare_oxc_lint!(
 
 impl Rule for BadArrayMethodOnArguments {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !node.kind().is_specific_id_reference("arguments") {
+        let AstKind::IdentifierReference(ident) = node.kind() else {
+            return;
+        };
+        if ident.name != "arguments" {
             return;
         }
+
         let parent = ctx.nodes().parent_node(node.id());
         let Some(member_expr) = parent.kind().as_member_expression_kind() else {
             return;


### PR DESCRIPTION
AI assisted.

Running on `vscode` (just this rule):

- Baseline: 301.698ms, 17.5% of total, 9,749,545 calls
- After: 46.185ms, 3.1% of total, 1,417,222 calls

The main optimization is using a simple `node.kind()` check that our linter codegen recognizes, rather than `is_specific_id_reference` which isn't analyzed.