### PR TITLE
fix(linter): skip per-node dispatch for run_once-only rules in large files

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -178,7 +178,7 @@ fn execute_rules<'a, const TIMINGS: bool>(
                 for ty in ast_types {
                     rules_by_ast_type[ty as usize].push((rule_index, rule, ctx));
                 }
-            } else {
+            } else if !with_runtime_optimization || run_info.is_run_implemented() {
                 rules_any_ast_type.push((rule_index, rule, ctx));
             }
 


### PR DESCRIPTION
Fix #22396. Below is Claude's explanation of the fix. I haven't tested this deeply or fully understood the code yet, so it may be fully wrong, but on first look it does appear to solve the call count problem at the very least.

--- 

## Summary

The large-files branch (>200k AST nodes) in `execute_rules` was adding every rule without bucketable AST types to `rules_any_ast_type`, then calling `rule.run` per node on the entire bucket — including `run_once`-only rules whose `run` is the default empty impl.

With `--debug timings`, each of those per-node calls increments `Calls` and adds `time()` overhead, inflating the "boring rules floor" (unicode-bom, no-dupe-class-members, no-this-before-super, no-redeclare, no-unused-private-class-members, jsx-filename-extension, etc.) by N nodes per large file.

This is what makes those rules cluster near a fixed ~11ms / similar call count in `--debug timings` output even on codebases where they have almost no real work to do: a handful of large generated/bundled files dominate the count.

The fix: gate the else branch on `is_run_implemented()` so `run_once`-only rules don't get dispatched through `run` per node.

### Reproduction

Before:
```
$ oxlint --debug timings -A all -W unicode-bom big.js  # 60k-line file, 240k AST nodes
...
eslint/unicode-bom       2.857    100.0%  240002  native
```

After:
```
$ oxlint --debug timings -A all -W unicode-bom big.js
...
eslint/unicode-bom       0.048    100.0%       1  native
```

### Impact

- **`--debug timings` output**: significant correction. The rule timings table now reflects real cost.
- **Production (non-`--debug`)**: small win on files >200k nodes from skipping per-node dispatch into empty `run`; unmeasurable on typical files.

## Test plan

- [x] `cargo test -p oxc_linter --lib` (1119 tests pass)
- [x] Verified large-file fix empirically (240,002 → 1 call for unicode-bom on a 240k-node file)
- [x] Verified small-file path unchanged (multi-file test still reports correct per-file call counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)