### PR TITLE
fix(codegen): keep `Object.defineProperty` property name as plain string in minify

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1502,9 +1502,51 @@ impl GenExpr for CallExpression<'_> {
             if let Some(type_parameters) = &self.type_arguments {
                 type_parameters.print(p, ctx);
             }
-            p.print_arguments(self.span, &self.arguments, ctx);
+            if !try_print_cjs_define_property_call(p, self, ctx) {
+                p.print_arguments(self.span, &self.arguments, ctx);
+            }
         });
     }
+}
+
+/// Print `Object.defineProperty(_, "name", ...)` / `Reflect.defineProperty(...)` with the
+/// property-name argument as a plain string literal so `cjs-module-lexer` (used by Node for
+/// CJS/ESM interop) can detect the export. Returns `true` if printed.
+/// See <https://github.com/oxc-project/oxc/issues/22342>.
+///
+/// Minify-only: outside minify, `print_string_literal` already uses `self.quote` (never
+/// backtick), and this path skips the argument comments that `print_arguments` preserves.
+fn try_print_cjs_define_property_call(
+    p: &mut Codegen<'_>,
+    call: &CallExpression<'_>,
+    ctx: Context,
+) -> bool {
+    if !p.options.minify {
+        return false;
+    }
+    let Some(Argument::StringLiteral(name)) = call.arguments.get(1) else {
+        return false;
+    };
+    if !call.callee.is_specific_member_access("Object", "defineProperty")
+        && !call.callee.is_specific_member_access("Reflect", "defineProperty")
+    {
+        return false;
+    }
+    p.print_ascii_byte(b'(');
+    for (i, arg) in call.arguments.iter().enumerate() {
+        if i != 0 {
+            p.print_comma();
+            p.print_soft_space();
+        }
+        if i == 1 {
+            p.print_string_literal(name, false);
+        } else {
+            arg.print(p, ctx);
+        }
+    }
+    p.add_source_mapping_end(call.span);
+    p.print_ascii_byte(b')');
+    true
 }
 
 impl Gen for Argument<'_> {

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -639,6 +639,16 @@ fn string() {
         r#";`eval("'\\vstr\\ving\\v'") === "\\vstr\\ving\\v"`;"#,
     );
     test_minify(r#"foo("\n")"#, "foo(`\n`);");
+
+    // https://github.com/oxc-project/oxc/issues/22342
+    test_minify(
+        r#"Object.defineProperty(exports, "getInclusionReasons", { enumerable: true });"#,
+        r#"Object.defineProperty(exports,"getInclusionReasons",{enumerable:true});"#,
+    );
+    test_minify(
+        r#"Reflect.defineProperty(exports, "getInclusionReasons", { enumerable: true });"#,
+        r#"Reflect.defineProperty(exports,"getInclusionReasons",{enumerable:true});"#,
+    );
 }
 
 #[test]

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -7,7 +7,7 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 287.63 kB  | 89.26 kB   | 90.07 kB   | 30.91 kB   | 31.95 kB   |          2 | jquery.js  
 
-342.15 kB  | 116.98 kB  | 118.14 kB  | 43.17 kB   | 44.37 kB   |          2 | vue.js     
+342.15 kB  | 116.98 kB  | 118.14 kB  | 43.18 kB   | 44.37 kB   |          2 | vue.js     
 
 544.10 kB  | 71.04 kB   | 72.48 kB   | 25.77 kB   | 26.20 kB   |          2 | lodash.js  
 
@@ -15,13 +15,13 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 1.01 MB    | 439.37 kB  | 458.89 kB  | 122.05 kB  | 126.71 kB  |          2 | bundle.min.js 
 
-1.25 MB    | 642.65 kB  | 646.76 kB  | 159.39 kB  | 163.73 kB  |          2 | three.js   
+1.25 MB    | 642.65 kB  | 646.76 kB  | 159.41 kB  | 163.73 kB  |          2 | three.js   
 
-2.14 MB    | 711.10 kB  | 724.14 kB  | 160.42 kB  | 181.07 kB  |          2 | victory.js 
+2.14 MB    | 711.10 kB  | 724.14 kB  | 160.43 kB  | 181.07 kB  |          2 | victory.js 
 
 3.20 MB    | 1.00 MB    | 1.01 MB    | 322.61 kB  | 331.56 kB  |          2 | echarts.js 
 
-6.69 MB    | 2.22 MB    | 2.31 MB    | 458.43 kB  | 488.28 kB  |          4 | antd.js    
+6.69 MB    | 2.22 MB    | 2.31 MB    | 458.44 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 853.29 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 853.30 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
Fix `cjs-module-lexer` failing to detect `Object.defineProperty(exports, "name", ...)` named exports after oxc minify.

`calculate_quote_maybe_backtick` favored backtick when all three quote costs tied at zero, so a plain ASCII property name like `"getInclusionReasons"` was emitted as a backtick template. [`cjs-module-lexer`](https://github.com/nodejs/cjs-module-lexer) (used by Node for CJS/ESM interop) only matches plain string literals there, so the affected exports silently dropped out of its export set — downstream ESM consumers then failed with `Named export 'X' not found`.

In `CallExpression::gen_expr`, detect `Object.defineProperty` / `Reflect.defineProperty` and print the 2nd argument via `print_string_literal(name, false)` (the existing `allow_backtick: false` path). Other arguments — and nested strings inside the descriptor — still benefit from backtick optimization. Minify-only: outside minify, `print_string_literal` uses `self.quote` (never backtick), and `print_arguments` is needed there to preserve argument comments.

### Before / after

```js
// input
Object.defineProperty(exports, "getInclusionReasons", { ... });
```

```js
// before
Object.defineProperty(exports,`getInclusionReasons`,{...});

// after
Object.defineProperty(exports,"getInclusionReasons",{...});
```

Closes #22342

AI assisted.