### PR TITLE
fix(codegen): keep `exports[STR] = …` key as plain string in minify

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1978,13 +1978,48 @@ impl GenExpr for AssignmentExpression<'_> {
             && matches!(self.left, AssignmentTarget::ObjectAssignmentTarget(_));
         p.wrap(wrap || precedence >= self.precedence(), |p| {
             p.add_source_mapping(self.span);
-            self.left.print(p, ctx);
+            if !try_print_cjs_exports_computed_target(p, &self.left, ctx) {
+                self.left.print(p, ctx);
+            }
             p.print_soft_space();
             p.print_str(self.operator.as_str());
             p.print_soft_space();
             self.right.print_expr(p, Precedence::Comma, ctx);
         });
     }
+}
+
+/// Print `exports[STR] = …` / `module.exports[STR] = …`'s LHS with the computed key as a
+/// plain string literal so `cjs-module-lexer` (used by Node for CJS/ESM interop) can detect
+/// the export. Returns `true` if printed. Same minify-only rationale as
+/// [`try_print_cjs_define_property_call`]. See <https://github.com/oxc-project/oxc/issues/22342>.
+fn try_print_cjs_exports_computed_target(
+    p: &mut Codegen<'_>,
+    target: &AssignmentTarget<'_>,
+    ctx: Context,
+) -> bool {
+    if !p.options.minify {
+        return false;
+    }
+    let AssignmentTarget::ComputedMemberExpression(member) = target else {
+        return false;
+    };
+    let Expression::StringLiteral(key) = &member.expression else {
+        return false;
+    };
+    if !member.object.is_specific_id("exports")
+        && !member.object.is_specific_member_access("module", "exports")
+    {
+        return false;
+    }
+    member.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
+    if member.optional {
+        p.print_str("?.");
+    }
+    p.print_ascii_byte(b'[');
+    p.print_string_literal(key, false);
+    p.print_ascii_byte(b']');
+    true
 }
 
 impl Gen for AssignmentTarget<'_> {

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -649,6 +649,11 @@ fn string() {
         r#"Reflect.defineProperty(exports, "getInclusionReasons", { enumerable: true });"#,
         r#"Reflect.defineProperty(exports,"getInclusionReasons",{enumerable:true});"#,
     );
+    test_minify(
+        r#"exports["has-dash"] = a; module.exports["__esModule"] = true;"#,
+        r#"exports["has-dash"]=a;module.exports["__esModule"]=true;"#,
+    );
+    test_minify(r#"obj["not-exports"] = a;"#, "obj[`not-exports`]=a;");
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #22400. Closes the second `cjs-module-lexer` gap.

After #22400, `Object.defineProperty(exports, "name", ...)` is fine, but `exports["name"] = …` / `module.exports["name"] = …` were still being emitted with backtick keys in minify. The lexer recognises this form too — it just couldn't see them past the template literal.

Valid-identifier keys (`exports["foo"]`) are already collapsed to dot access by the minifier earlier in the pipeline, so only non-identifier keys (`exports["has-dash"]`, `module.exports["__esModule"]`, …) survive to the codegen stage and were affected.

In `AssignmentExpression::gen_expr`, detect when the LHS is a computed member expression on `exports` / `module.exports` whose key is a `StringLiteral`, and print the key via `print_string_literal(key, false)`. Other computed access (`otherObj["x"]`) is unaffected.

### Where each cjs-module-lexer named-export form lands

| Pattern | Status |
|---|---|
| `exports.name = …` | identifier — never affected |
| `module.exports.name = …` | identifier — never affected |
| `module.exports = { "name": … }` | object property keys already use `allow_backtick: false` |
| `Object.defineProperty(exports, "name", …)` | fixed in #22400 |
| `exports["name"] = …` / `module.exports["name"] = …` | **fixed here** |

### Before / after

```js
// input
exports["has-dash"] = a;
module.exports["__esModule"] = true;
otherObj["not-exports"] = d;
```

```js
// before
exports[`has-dash`]=a,module.exports[`__esModule`]=!0,otherObj[`not-exports`]=d;

// after
exports["has-dash"]=a,module.exports.__esModule=!0,otherObj[`not-exports`]=d;
```

(`module.exports.__esModule` collapses to dot via a separate minifier pass; `otherObj["x"]` correctly stays backtick.)

Refs #22342

AI assisted.