### PR TITLE
refactor(semantic): add `move_binding_by_symbol_id`

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -173,8 +173,11 @@ impl<'a> Binder<'a> for Function<'a> {
                 if let Some(var_scope_id) = var_scope_id
                     && !builder.scoping.scope_has_binding(var_scope_id, ident.name)
                 {
-                    builder.scoping.move_binding(block_scope_id, var_scope_id, ident.name);
-                    builder.scoping.set_symbol_scope_id(symbol_id, var_scope_id);
+                    builder.scoping.move_binding_by_symbol_id(
+                        block_scope_id,
+                        var_scope_id,
+                        symbol_id,
+                    );
                     builder
                         .hoisting_variables
                         .entry(block_scope_id)

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -886,6 +886,29 @@ impl Scoping {
         });
     }
 
+    /// Move a binding from one scope to another by its [`SymbolId`].
+    ///
+    /// Looks up the symbol's name internally, moves the entry from `from`'s binding map to `to`'s
+    /// (a no-op if no binding for the symbol exists in `from`), and always updates the symbol's
+    /// recorded scope id to `to`.
+    ///
+    /// Prefer this over the [`move_binding`] + [`set_symbol_scope_id`] pair when a `SymbolId` is
+    /// available, and use it when the name isn't otherwise accessible with the arena lifetime
+    /// (e.g. when iterating `from`'s binding map).
+    ///
+    /// [`move_binding`]: Scoping::move_binding
+    /// [`set_symbol_scope_id`]: Scoping::set_symbol_scope_id
+    pub fn move_binding_by_symbol_id(&mut self, from: ScopeId, to: ScopeId, symbol_id: SymbolId) {
+        debug_assert_ne!(from, to);
+        self.cell.with_dependent_mut(|_allocator, cell| {
+            let name = cell.symbol_names[symbol_id.index()];
+            if let Some((name, sid)) = cell.bindings[from].remove_entry(&name) {
+                cell.bindings[to].insert(name, sid);
+            }
+        });
+        self.set_symbol_scope_id(symbol_id, to);
+    }
+
     /// Rename a binding to a new name.
     ///
     /// The following must be true for successful operation:

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -876,8 +876,11 @@ impl<'a> ArrowFunctionConverter<'a> {
     ) {
         let original_scope_id = ctx.scoping().symbol_scope_id(binding.symbol_id);
         if target_scope_id != original_scope_id {
-            ctx.scoping_mut().set_symbol_scope_id(binding.symbol_id, target_scope_id);
-            ctx.scoping_mut().move_binding(original_scope_id, target_scope_id, binding.name);
+            ctx.scoping_mut().move_binding_by_symbol_id(
+                original_scope_id,
+                target_scope_id,
+                binding.symbol_id,
+            );
         }
     }
 

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -920,12 +920,12 @@ impl<'a, 'ctx> BindingMover<'a, 'ctx> {
 impl<'a> Visit<'a> for BindingMover<'a, '_> {
     /// Visits a binding identifier and moves it to the target scope.
     fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
-        let symbols = self.ctx.scoping();
         let symbol_id = ident.symbol_id();
-        let current_scope_id = symbols.symbol_scope_id(symbol_id);
-        let scopes = self.ctx.scoping_mut();
-        scopes.move_binding(current_scope_id, self.target_scope_id, ident.name);
-        let symbols = self.ctx.scoping_mut();
-        symbols.set_symbol_scope_id(symbol_id, self.target_scope_id);
+        let current_scope_id = self.ctx.scoping().symbol_scope_id(symbol_id);
+        self.ctx.scoping_mut().move_binding_by_symbol_id(
+            current_scope_id,
+            self.target_scope_id,
+            symbol_id,
+        );
     }
 }

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -645,8 +645,11 @@ impl<'a> ObjectRestSpread<'a> {
                 );
                 // Move the bindings from the for init scope to scope of the loop body.
                 for ident in bound_names {
-                    ctx.scoping_mut().set_symbol_scope_id(ident.symbol_id(), new_scope_id);
-                    ctx.scoping_mut().move_binding(scope_id, new_scope_id, ident.name);
+                    ctx.scoping_mut().move_binding_by_symbol_id(
+                        scope_id,
+                        new_scope_id,
+                        ident.symbol_id(),
+                    );
                 }
             }
         }

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -89,7 +89,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
             variable_declarator.id.get_binding_identifier().unwrap();
 
         let for_of_init_symbol_id = variable_declarator_binding_ident.symbol_id();
-        let for_of_init_name = variable_declarator_binding_ident.name;
 
         let temp_id = ctx.generate_uid_based_on_node(
             variable_declarator.id.get_binding_identifier().unwrap(),
@@ -123,8 +122,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                 ScopeFlags::empty(),
             ),
         };
-        ctx.scoping_mut().set_symbol_scope_id(for_of_init_symbol_id, scope_id);
-        ctx.scoping_mut().move_binding(for_of_stmt_scope_id, scope_id, for_of_init_name);
+        ctx.scoping_mut().move_binding_by_symbol_id(
+            for_of_stmt_scope_id,
+            scope_id,
+            for_of_init_symbol_id,
+        );
 
         if let Statement::BlockStatement(body) = &mut for_of_stmt.body {
             // `for (const _x of y) { x(); }` -> `for (const _x of y) { using x = _x; x(); }`
@@ -169,8 +171,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                 ScopeFlags::ClassStaticBlock,
             );
 
-            ctx.scoping_mut().set_symbol_scope_id(using_ctx.symbol_id, static_block_new_scope_id);
-            ctx.scoping_mut().move_binding(scope_id, static_block_new_scope_id, using_ctx.name);
+            ctx.scoping_mut().move_binding_by_symbol_id(
+                scope_id,
+                static_block_new_scope_id,
+                using_ctx.symbol_id,
+            );
             *ctx.scoping_mut().scope_flags_mut(scope_id) = ScopeFlags::StrictMode;
 
             block.set_scope_id(static_block_new_scope_id);
@@ -287,8 +292,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
 
             let current_hoist_scope_id = ctx.current_hoist_scope_id();
             node.block.set_scope_id(block_stmt_scope_id);
-            ctx.scoping_mut().set_symbol_scope_id(using_ctx.symbol_id, current_hoist_scope_id);
-            ctx.scoping_mut().move_binding(scope_id, current_hoist_scope_id, using_ctx.name);
+            ctx.scoping_mut().move_binding_by_symbol_id(
+                scope_id,
+                current_hoist_scope_id,
+                using_ctx.symbol_id,
+            );
 
             ctx.scoping_mut().change_scope_parent_id(scope_id, Some(block_stmt_scope_id));
         }


### PR DESCRIPTION
## Summary

Adds `Scoping::move_binding_by_symbol_id(from, to, symbol_id)` that bundles `move_binding` + `set_symbol_scope_id`, looking up the symbol's name internally.

Every existing call to `move_binding` is paired with `set_symbol_scope_id` to keep `symbol_scope_ids` consistent with the binding map. Folding them into one call also lets callers move a binding without holding an arena-lifetime `Ident` across the `&mut Scoping` access — useful when the only name source is `Scoping`'s own binding map (the next step in the ERM scope-binding fix in #22320).

The 6 existing pair sites are migrated:

- `oxc_semantic/src/binder.rs` (var-hoist Annex B)
- `oxc_transformer/src/common/arrow_function_converter.rs` (`adjust_binding_scope`)
- `oxc_transformer/src/es2017/async_to_generator.rs` (`BindingMover`)
- `oxc_transformer/src/es2018/object_rest_spread.rs` (for-init bindings)
- `oxc_transformer/src/es2026/explicit_resource_management.rs` x3 (for-of init, static block, try statement)

## Notes

- The helper updates `symbol_scope_ids` unconditionally — matching the pre-existing pair behavior, which always set the scope id even when `move_binding` was a silent no-op.
- The internal `remove_entry(&name)` lookup uses `Ident`'s precomputed hash via `IdentBuildHasher::write_u64`, skipping the byte-by-byte hash path that `name.as_str()` would take.
- No new tests: each migrated call site is exercised by transformer Babel/conformance and `semantic_*` coverage; snapshots are unchanged.