### PR TITLE
perf(codegen): inline identifier-name accessors

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -772,6 +772,7 @@ impl<'a> Codegen<'a> {
         }
     }
 
+    #[inline]
     fn get_identifier_reference_name(&self, reference: &IdentifierReference<'a>) -> &'a str {
         if let Some(scoping) = &self.scoping
             && let Some(reference_id) = reference.reference_id.get()
@@ -783,6 +784,7 @@ impl<'a> Codegen<'a> {
         reference.name.as_str()
     }
 
+    #[inline]
     fn get_binding_identifier_name(&self, ident: &BindingIdentifier<'a>) -> &'a str {
         if let Some(scoping) = &self.scoping
             && let Some(symbol_id) = ident.symbol_id.get()


### PR DESCRIPTION
## Summary

`Codegen::get_identifier_reference_name` and `Codegen::get_binding_identifier_name` are called once per identifier emission (every `IdentifierReference`, `BindingIdentifier`, import/export spec, etc.) but were not marked `#[inline]`. The bodies are short and in the common case (no scoping i.e. no mangling) compile to a couple of loads, so the function-call overhead is a noticeable share of codegen self-time on identifier-heavy inputs.

## Measurements

Wall-time on codegen-only loop (parse once, codegen N times), `--profile release-with-debug`, median of 3 runs:

| file | before | after | delta |
|---|---|---|---|
| antd.js (6.7M) | 14.49 ms/iter | 13.25 ms/iter | **-8.6%** |
| checker.ts (2.8M) | 4.35 ms/iter | 4.12 ms/iter | **-5.3%** |
| binder.ts (189K) | 155 µs/iter | 150 µs/iter | -3.2% |
| pdf.mjs (554K) | 961 µs/iter | 935 µs/iter | -2.7% |
| cal.com.tsx (1.0M) | 1.46 ms/iter | 1.48 ms/iter | noise |

xctrace Time Profiler self-time on `Codegen::get_identifier_reference_name` (antd.js): 0.50% → 0.33%; samples redistribute into `GenExpr::print_expr` (the inlining call site) as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)