### PR TITLE
perf(semantic): add opt-out flag to skip reference resolution

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -114,6 +114,14 @@ pub struct SemanticBuilder<'a> {
     /// See: [`crate::checker::check`]
     check_syntax_error: bool,
 
+    /// Should identifier references be resolved to their symbols?
+    ///
+    /// When `false`, the scope tree and symbol table are still built, but
+    /// `Reference::symbol_id` will be unset for every reference, no resolved-
+    /// reference list is populated on any symbol, and root unresolved references
+    /// are not collected.
+    resolve_references: bool,
+
     #[cfg(feature = "cfg")]
     pub(crate) cfg: Option<ControlFlowGraphBuilder<'a>>,
     #[cfg(not(feature = "cfg"))]
@@ -168,6 +176,7 @@ impl<'a> SemanticBuilder<'a> {
             excess_capacity: 0.0,
             enum_eval: false,
             check_syntax_error: false,
+            resolve_references: true,
             #[cfg(feature = "cfg")]
             cfg: None,
             #[cfg(not(feature = "cfg"))]
@@ -188,6 +197,22 @@ impl<'a> SemanticBuilder<'a> {
     #[must_use]
     pub fn with_check_syntax_error(mut self, yes: bool) -> Self {
         self.check_syntax_error = yes;
+        self
+    }
+
+    /// Enable or disable resolving identifier references to their symbols.
+    ///
+    /// When disabled, the scope tree and symbol table are still built, but every
+    /// [`Reference`] keeps `symbol_id` unset and no resolved-reference list is
+    /// recorded on any symbol. Useful for consumers that only need lexical scope
+    /// and binding information (e.g. formatters or codegen).
+    ///
+    /// By default, this is `true`.
+    ///
+    /// [`Reference`]: oxc_syntax::reference::Reference
+    #[must_use]
+    pub fn with_resolve_references(mut self, yes: bool) -> Self {
+        self.resolve_references = yes;
         self
     }
 
@@ -539,6 +564,9 @@ impl<'a> SemanticBuilder<'a> {
     /// Walk-up is faster because it only does hashmap lookups (no drain+insert),
     /// and reference creation is a simple Vec push instead of a hashmap insert.
     fn resolve_all_references(&mut self) {
+        if !self.resolve_references {
+            return;
+        }
         let refs = self.unresolved_references.take();
         for (name, reference_id) in refs {
             if !self.walk_up_resolve_reference(name, reference_id) {
@@ -622,6 +650,9 @@ impl<'a> SemanticBuilder<'a> {
     /// list for later resolution by `resolve_all_references` (which handles
     /// forward references to declarations not yet visited).
     fn resolve_references_for_current_scope(&mut self) {
+        if !self.resolve_references {
+            return;
+        }
         let checkpoint = self.unresolved_references_checkpoint;
         let refs = self.unresolved_references.slice_from(checkpoint).to_vec();
         if refs.is_empty() {


### PR DESCRIPTION
Add `SemanticBuilder::with_resolve_references(bool)` so consumers that only need the scope tree and symbol table can skip the reference-resolution pass.

When disabled:
- `Reference::symbol_id` stays unset on every reference
- No resolved-reference list is populated on any symbol
- Root unresolved references are not collected

Default is `true`, so existing callers are unaffected. Intended for downstream consumers that don't depend on the resolved reference graph (e.g. formatter, codegen-only paths).

Measured on `typescript.js` (7.83 MB, Microsoft/TypeScript bundle), M3-class machine, in-process semantic build timing:

| Feature set | Default | `with_resolve_references(false)` | Speedup |
|---|---|---|---|
| no features | 1.034 s | 707 ms | 1.46× (-31.6%) |
| `cfg,linter` (oxlint config) | 1.173 s | 849 ms | 1.38× (-27.6%) |

This matches the phase-split measurement showing `resolve_all_references` was ~6.1 ms out of ~16 ms inside the with-stats build path.

Verified with `cargo coverage -- semantic` — all four `semantic_*.snap` snapshots match committed values exactly (`semantic_test262` 47095/47095, `semantic_babel` 2236/2236, `semantic_typescript` 4773/4773, `semantic_misc` 66/66, all with identical pass counts). Also: `cargo test -p oxc_semantic --features cfg,linter` (98 tests), `cargo test -p oxc_linter --lib` (1119 tests), `cargo test -p oxc_transformer --lib` (31 tests) — all pass.

AI assisted.
