### PR TITLE
perf(semantic): `#[inline]` `Scoping::get_binding`

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -793,6 +793,7 @@ impl Scoping {
     /// binding that might be declared in a parent scope, use [`find_binding`].
     ///
     /// [`find_binding`]: Scoping::find_binding
+    #[inline]
     pub fn get_binding(&self, scope_id: ScopeId, name: Ident<'_>) -> Option<SymbolId> {
         self.cell.borrow_dependent().bindings[scope_id].get(&name).copied()
     }


### PR DESCRIPTION
`walk_up_resolve_reference` — the hot scope-chain walk in reference resolution — is `#[inline(always)]`, but it calls `Scoping::get_binding` which wasn't `#[inline]`. With `oxc_semantic` and `oxc_syntax` in separate crates and `borrow_dependent` from `self_cell`, the inliner wouldn't reach through the boundary without the hint, even under LTO.

Adding `#[inline]` lets the caller inline through `borrow_dependent` + the indexed `FxHashMap` lookup as a single specialized path.

Measured on `typescript.js` (7.83 MB, Microsoft/TypeScript bundle), M3-class machine, in-process semantic build:

| Feature set | Baseline | With `#[inline]` | Speedup |
|---|---|---|---|
| no features | 1.034 s ± 0.014 | 1.010 s ± 0.008 | 1.02× (clean signal) |
| `cfg,linter` (oxlint config) | 1.159 s ± 0.018 | 1.148 s ± 0.010 | 1.01× ± 0.02 (within noise) |

Sub-2% in the lightweight config; noise-level under `cfg,linter` because per-node bookkeeping (`AstTypesBitset::set`, CFG block tracking) dominates there. Shipping anyway since the change is a single-attribute hint with no API or behavior change — costs nothing if the inliner ignores it.

Verified by `cargo test -p oxc_semantic --features cfg,linter` (98 tests), `cargo test -p oxc_linter --lib` (1119 tests).

AI assisted.
