### PR TITLE
perf(parser): split TriviaBuilder::handle_token hot/cold paths

### DIFF
--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -105,19 +105,27 @@ impl<'a> TriviaBuilder<'a> {
         self.saw_newline_for_comment = true;
     }
 
+    #[inline]
     pub fn handle_token(&mut self, token: Token) {
-        let len = self.comments.len();
         self.previous_kind = token.kind();
-        if self.processed < len {
-            // All unprocessed preceding comments are leading comments attached to this token start.
-            for comment in &mut self.comments[self.processed..] {
-                comment.position = CommentPosition::Leading;
-                comment.attached_to = token.start();
-            }
-            self.processed = len;
-        }
         self.saw_newline = false;
         self.saw_newline_for_comment = false;
+        // Cold path: any unprocessed comments since the last token become leading comments
+        // of this one. For files with no comments (or once all comments are consumed)
+        // `processed == comments.len()`, so this branch is skipped.
+        let len = self.comments.len();
+        if self.processed < len {
+            self.attach_pending_leading_comments(token.start(), len);
+        }
+    }
+
+    #[cold]
+    fn attach_pending_leading_comments(&mut self, attached_to: u32, len: usize) {
+        for comment in &mut self.comments[self.processed..] {
+            comment.position = CommentPosition::Leading;
+            comment.attached_to = attached_to;
+        }
+        self.processed = len;
     }
 
     /// Determines if the current line comment should be treated as a trailing comment.


### PR DESCRIPTION
## Summary

`TriviaBuilder::handle_token` is called by `Lexer::finish_token` per token. The original body mixed two paths:

- **Hot path** — three field writes (`previous_kind`, `saw_newline`, `saw_newline_for_comment`).
- **Cold path** — a for-loop that retroactively marks any pending comments as leading comments of the current token. Only fires when there are unprocessed comments before a token, which is rare on a per-token basis.

LLVM wasn't inlining the function — it appeared as a separate symbol at 1.46% parse self-time in xctrace Time Profiler. Splitting the for-loop into a `#[cold]` helper and marking the wrapper `#[inline]` lets the hot path fuse into `finish_token`'s body and keeps the cold attachment loop out of the inlined code.

No behavior change: the same fields are written and the same comments attached in the same order. test262 conformance unchanged: 47086/47086 positive, 4588/4588 negative.

## Measurements

Wall-time on parse-only loop (parse N times, reusing allocator), `--profile release-with-debug`, median of 3 runs:

| file | before | after | delta |
|---|---|---|---|
| cal.com.tsx (1.0M) | 3.97 ms/iter | 3.80 ms/iter | **-4.3%** |
| checker.ts (2.8M) | 7.69 ms/iter | 7.56 ms/iter | -1.7% |
| antd.js (6.7M) | 15.46 ms/iter | 15.23 ms/iter | -1.5% |
| pdf.mjs (554K) | 2.27 ms/iter | 2.27 ms/iter | noise |
| binder.ts (189K) | 418 µs/iter | 420 µs/iter | noise |

Modest but consistent across the larger inputs. Best on TSX (JSX brings more tokens per byte of source, so more `handle_token` calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)