### PR TITLE
perf(parser): split TriviaBuilder::handle_newline hot/cold paths

### DIFF
--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -91,18 +91,27 @@ impl<'a> TriviaBuilder<'a> {
 
     // For block comments only. This function is not called after line comments because the lexer skips
     // newline after line comments.
+    #[inline]
     pub fn handle_newline(&mut self) {
-        // The last unprocessed comment is on a newline.
+        // Cold path: the previous block comment ended just before this newline,
+        // so mark it as followed by a newline and (when appropriate) promote it
+        // to a trailing comment of the prior token. For files with no comments,
+        // `processed == comments.len() == 0`, so we skip the body.
         let len = self.comments.len();
         if self.processed < len {
-            let comment = &mut self.comments[len - 1];
-            comment.set_followed_by_newline(true);
-            if !self.saw_newline && !Self::should_stay_leading(comment) {
-                self.processed = self.comments.len();
-            }
+            self.mark_last_comment_followed_by_newline(len);
         }
         self.saw_newline = true;
         self.saw_newline_for_comment = true;
+    }
+
+    #[cold]
+    fn mark_last_comment_followed_by_newline(&mut self, len: usize) {
+        let comment = &mut self.comments[len - 1];
+        comment.set_followed_by_newline(true);
+        if !self.saw_newline && !Self::should_stay_leading(comment) {
+            self.processed = self.comments.len();
+        }
     }
 
     pub fn handle_token(&mut self, token: Token) {


### PR DESCRIPTION
## Summary

Follow-up to #22415 applying the same hot/cold pattern to `TriviaBuilder::handle_newline`.

`handle_newline` is called from `line_break_handler` whenever the lexer consumes a newline byte. The original body mixed two paths:

- **Hot path** — two field writes (\`saw_newline = true\`, \`saw_newline_for_comment = true\`) plus the empty-comments check.
- **Cold path** — when the previous block comment ended just before the newline, mark it as followed-by-newline and (sometimes) promote it to trailing.

LLVM wasn't inlining the function — it appeared as part of the 1.25% \`line_break_handler\` self-time. Splitting the cold branch into `#[cold] fn mark_last_comment_followed_by_newline` and marking the wrapper `#[inline]` lets the hot path (two writes + a length check) fuse into the caller.

No behavior change: same writes in same order, same comment marking. test262: 47086/47086 positive, 4588/4588 negative.

This is independent of #22415; both can land in either order. Together they cover the two trivia per-token/per-newline state-update functions called from the lexer's hot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)