### PR TITLE
fix(transformer/object-rest-spread): correct scope id when moving bindings

### DIFF
--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -635,16 +635,24 @@ impl<'a> ObjectRestSpread<'a> {
                     unreachable!();
                 };
                 let bound_symbol_ids = declarator.id.get_symbol_ids();
+                let old_scope_id =
+                    if decl.kind.is_var() { ctx.current_hoist_scope_id() } else { scope_id };
+
                 Self::replace_rest_element(
                     declarator.kind,
                     &mut declarator.id,
                     &mut block.body,
-                    if decl.kind.is_var() { ctx.current_hoist_scope_id() } else { scope_id },
+                    old_scope_id,
                     ctx,
                 );
+
                 // Move the bindings from the for init scope to scope of the loop body.
                 for symbol_id in bound_symbol_ids {
-                    ctx.scoping_mut().move_binding_by_symbol_id(scope_id, new_scope_id, symbol_id);
+                    ctx.scoping_mut().move_binding_by_symbol_id(
+                        old_scope_id,
+                        new_scope_id,
+                        symbol_id,
+                    );
                 }
             }
         }

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: ccaac100
 
 semantic_test262 Summary:
 AST Parsed     : 47115/47115 (100.00%)
-Positive Passed: 45522/47115 (96.62%)
+Positive Passed: 45525/47115 (96.63%)
 semantic Error: tasks/coverage/test262/test/language/arguments-object/cls-decl-async-private-gen-meth-args-trailing-comma-multiple.js
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
@@ -12930,30 +12930,6 @@ semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/asy
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(6): Some(ScopeId(5))
-
-semantic Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-rest-getter.js
-Bindings mismatch:
-after transform: ScopeId(0): ["_extends", "_objectDestructuringEmpty", "_ref", "count", "iterCount", "x"]
-rebuilt        : ScopeId(0): ["_extends", "_objectDestructuringEmpty", "_ref", "count", "iterCount"]
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["x"]
-
-semantic Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-rest-skip-non-enumerable.js
-Bindings mismatch:
-after transform: ScopeId(0): ["_extends", "_objectDestructuringEmpty", "_ref", "iterCount", "o", "rest"]
-rebuilt        : ScopeId(0): ["_extends", "_objectDestructuringEmpty", "_ref", "iterCount", "o"]
-Bindings mismatch:
-after transform: ScopeId(2): []
-rebuilt        : ScopeId(2): ["rest"]
-
-semantic Error: tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-rest-val-obj.js
-Bindings mismatch:
-after transform: ScopeId(0): ["_excluded", "_objectWithoutProperties", "_ref", "a", "b", "iterCount", "rest"]
-rebuilt        : ScopeId(0): ["_excluded", "_objectWithoutProperties", "_ref", "iterCount"]
-Bindings mismatch:
-after transform: ScopeId(2): []
-rebuilt        : ScopeId(2): ["a", "b", "rest"]
 
 semantic Error: tasks/coverage/test262/test/language/statements/for-of/head-await-using-bound-names-fordecl-tdz.js
 Symbol reference IDs mismatch for "x":


### PR DESCRIPTION
Previously, given:
```
for (var { x, ...rest } of iterable) {}
```

The destructuring pattern appears in the `for` head, but `var` bindings are not owned by that scope - `x` and `rest` are hoisted into the current hoist scope.

After transform:

```
for (var _ref of iterable) {
  var x = _ref.x;
  var rest = _objectWithoutProperties(_ref, _excluded);
}
```

The bindings moved into the loop scope, but since we were passing the `for` loop's scope, `move_binding_by_symbol_id` was a no-op as the var decls were not defined in the `for` loop's scope.

This PR get's the declared scope of the symbol and uses it rather than assuming that the var is scoped to the function

