### PR TITLE
test(linter/plugins): fix conformance init script

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -40,7 +40,7 @@ cd submodules
 clone_repo eslint
 
 # Install dependencies
-pnpm install --ignore-workspace
+pnpm install --ignore-workspace --config.strict-dep-builds=false
 
 # Return to `submodules` directory
 cd ..
@@ -86,7 +86,7 @@ clone_repo stylistic
 
 # Install dependencies.
 # No `--ignore-workspace` because `eslint-stylistic` has its own `pnpm-workspace.yaml`.
-pnpm install
+pnpm install --config.strict-dep-builds=false
 
 # Patch `package.json` files to add Node.js subpath imports.
 # ESLint Stylistic uses TypeScript `paths` in `tsconfig.base.json` (e.g. `#test`),
@@ -144,7 +144,7 @@ cd ..
 clone_repo sonarjs
 
 # Install dependencies
-pnpm install --ignore-workspace
+pnpm install --ignore-workspace --config.strict-dep-builds=false
 
 # Build
 # (ignore errors, it's just typecheck fail)
@@ -190,7 +190,7 @@ cd ..
 clone_repo e18e
 
 # Install dependencies
-pnpm install --ignore-workspace
+pnpm install --ignore-workspace --config.strict-dep-builds=false
 
 # Return to `submodules` directory
 cd ..
@@ -203,7 +203,7 @@ cd ..
 clone_repo testing_library
 
 # Install dependencies
-pnpm install --ignore-workspace
+pnpm install --ignore-workspace --config.strict-dep-builds=false
 
 # Return to `submodules` directory
 cd ..


### PR DESCRIPTION
Fix the init script which initializes submodules for Oxlint JS plugins conformance tests.

The script was broken by upgrade to PNPM 11 (#22224), which made installing packages which have install scripts a hard error.

Fix by telling PNPM not to run packages' install scripts, but not to raise an error about it either.

