### PR TITLE
refactor(napi/parser, linter/plugins): improve safety of raw transfer interface

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -154,11 +154,18 @@ unsafe fn parse_raw_impl(
         unsafe { Allocator::from_raw_parts(buffer_ptr, BLOCK_SIZE, buffer_ptr, BLOCK_LAYOUT) };
     let allocator = ManuallyDrop::new(allocator);
 
+    // Check source text is in bounds of active data region of buffer.
+    // Caller guarantees it is, but as this is critical to avoid reading/writing out of bounds,
+    // we add this defensive runtime check.
+    let source_start = source_start as usize;
+    let source_end = source_start + (source_len as usize);
+    assert!(source_end <= ACTIVE_SIZE);
+
     // Set cursor to before start of source text. AST will be written into the buffer before the source text.
     // Round down the pointer, so it's aligned on `CURSOR_MIN_ALIGN`.
     // SAFETY: Caller guarantees that source text starts at `source_start` bytes from start of buffer.
     unsafe {
-        let cursor_pos = source_start as usize & !(CURSOR_MIN_ALIGN - 1);
+        let cursor_pos = source_start & !(CURSOR_MIN_ALIGN - 1);
         debug_assert!(cursor_pos <= ACTIVE_SIZE);
         let cursor_ptr = buffer_ptr.add(cursor_pos);
         allocator.set_cursor_ptr(cursor_ptr);
@@ -173,12 +180,17 @@ unsafe fn parse_raw_impl(
     // Parse source.
     // Enclose parsing logic in a scope to make 100% sure no references to within `Allocator` exist after this.
     let (program_offset, has_bom, tokens_offset, tokens_len) = {
-        // SAFETY: Caller guarantees source occupies this region of the buffer and is valid UTF-8
-        let source_text = unsafe {
-            let source_end = source_start as usize + source_len as usize;
-            debug_assert!(source_end <= ACTIVE_SIZE);
-            let source_bytes = buffer.get_unchecked(source_start as usize..source_end);
-            str::from_utf8_unchecked(source_bytes)
+        // Get source text from buffer.
+        // Use zero-cost unchecked conversion to `&str` in release builds, full UTF-8 validation in debug builds.
+        let source_text = if cfg!(debug_assertions) {
+            let source_bytes = &buffer[source_start..source_end];
+            str::from_utf8(source_bytes).expect("Source text is not valid UTF-8")
+        } else {
+            // SAFETY: Caller guarantees source occupies this region of the buffer and is valid UTF-8
+            unsafe {
+                let source_bytes = buffer.get_unchecked(source_start..source_end);
+                str::from_utf8_unchecked(source_bytes)
+            }
         };
 
         // Parse with same options as linter.

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -223,11 +223,18 @@ unsafe fn parse_raw_impl(
         unsafe { Allocator::from_raw_parts(buffer_ptr, BLOCK_SIZE, buffer_ptr, BLOCK_LAYOUT) };
     let allocator = ManuallyDrop::new(allocator);
 
+    // Check source text is in bounds of active data region of buffer.
+    // Caller guarantees it is, but as this is critical to avoid reading/writing out of bounds,
+    // we add this defensive runtime check.
+    let source_start = source_start as usize;
+    let source_end = source_start + (source_len as usize);
+    assert!(source_end <= ACTIVE_SIZE);
+
     // Set cursor to before start of source text. AST will be written into the buffer before the source text.
     // Round down the pointer, so it's aligned on `CURSOR_MIN_ALIGN`.
     // SAFETY: Caller guarantees that source text starts at `source_start` bytes from start of buffer.
     unsafe {
-        let cursor_pos = source_start as usize & !(CURSOR_MIN_ALIGN - 1);
+        let cursor_pos = source_start & !(CURSOR_MIN_ALIGN - 1);
         debug_assert!(cursor_pos <= ACTIVE_SIZE);
         let cursor_ptr = buffer_ptr.add(cursor_pos);
         allocator.set_cursor_ptr(cursor_ptr);
@@ -242,14 +249,20 @@ unsafe fn parse_raw_impl(
     let is_ts = get_ast_type(source_type, &options) == AstType::TypeScript;
 
     let (data_offset, tokens_offset, tokens_len) = {
-        // SAFETY: Caller guarantees source occupies this region of the buffer and is valid UTF-8
-        let source_text = unsafe {
-            let source_end = source_start as usize + source_len as usize;
-            debug_assert!(source_end <= ACTIVE_SIZE);
-            let source_bytes = buffer.get_unchecked(source_start as usize..source_end);
-            str::from_utf8_unchecked(source_bytes)
+        // Get source text from buffer.
+        // Use zero-cost unchecked conversion to `&str` in release builds, full UTF-8 validation in debug builds.
+        let source_text = if cfg!(debug_assertions) {
+            let source_bytes = &buffer[source_start..source_end];
+            str::from_utf8(source_bytes).expect("Source text is not valid UTF-8")
+        } else {
+            // SAFETY: Caller guarantees source occupies this region of the buffer and is valid UTF-8
+            unsafe {
+                let source_bytes = buffer.get_unchecked(source_start..source_end);
+                str::from_utf8_unchecked(source_bytes)
+            }
         };
 
+        // Parse
         let ret = parse_impl(&allocator, source_type, source_text, &options);
         let mut program = ret.program;
         let mut comments = mem::replace(&mut program.comments, ArenaVec::new_in(&allocator));


### PR DESCRIPTION
Add a check that the input passed to raw transfer parser implementations is valid - both in `napi/parser` and in the raw transfer implementation used in Oxlint's `RuleTester`.

Check that `source_start` and `source_len` which are passed from JS side are within bounds of the active region of the `Arena`. This check is not strictly necessary - it's part of the safety contract, and is enforced on JS side - but it's critical as the setup of the `Arena` on Rust side depends on the accuracy of these values. If they were wrong, it could lead to reading/writing out of bounds. The check is cheap, so it seems worthwhile - safety trumps the tiny perf impact here.

The 3rd invariant of these functions is that the bytes in the buffer between `source_start` and `source_start + source_len` represent a valid UTF-8 string. Here a full runtime check isn't appropriate, as it would involve scanning and validating the whole source text string (expensive). But _do_ enable the full check in debug builds (used by raw transfer parser tests, and Oxlint conformance tests).