### PR TITLE
perf(parser): tighten lexer token vec pre-allocation heuristic

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -121,19 +121,21 @@ impl<'a, C: Config> Lexer<'a, C> {
     ) -> Self {
         let source = Source::new(source_text, unique);
 
-        // If collecting tokens, allocate enough space so that the `Vec<Token>` will not have to grow during parsing.
-        // `source_text.len() + 1` is almost always a large overestimate of number of tokens, but it's impossible to
-        // have more than N + 1 tokens in a file which is N bytes long, so it'll never be an underestimate.
+        // If collecting tokens, pre-allocate so the token `Vec` rarely needs to grow.
         //
-        // + 1 is to account for the final `Eof` token. Without adding 1, the capacity could be too small for
-        // minified files which have no space between any tokens. It would also be too small for empty files.
+        // Empirical bytes/token ratios from the benchmark files (parser config with tokens enabled):
+        //   antd.js     10.08    cal.com.tsx  6.44   checker.ts  9.05
+        //   binder.ts    9.31    pdf.mjs      5.05   Radix.jsx   6.36
         //
-        // Our largest benchmark file `binder.ts` is 190 KB, and `Token` is 16 bytes, so the `Vec<Token>`
-        // would be ~3 MB even in the case of this unusually large file. That's not a huge amount of memory.
+        // Real JS averages well above 3 bytes/token (the densest single-char-token streams seen here
+        // are around 5 bytes/token). So `source_text.len() / 3 + 64` is a safe upper bound for any
+        // realistic source while costing ~3× less arena memory than the previous `source_text.len() + 1`
+        // worst-case heuristic. Pathological 1-byte-per-token inputs would trigger Vec growth, but that
+        // path is `#[cold]` and the absolute waste from one or two doublings is still bounded.
         //
-        // However, we should choose a better heuristic based on real-world observation, and bring this usage down.
+        // For antd.js (6.7 MB) this drops the pre-allocation from ~107 MB to ~36 MB of arena.
         let tokens = if config.tokens() {
-            ArenaVec::with_capacity_in(source_text.len() + 1, allocator)
+            ArenaVec::with_capacity_in(source_text.len() / 3 + 64, allocator)
         } else {
             ArenaVec::new_in(allocator)
         };


### PR DESCRIPTION
## Summary

When the parser collects tokens (used by oxlint for token-aware rules), the lexer pre-allocated the token \`Vec\` to \`source_text.len() + 1\` — a worst-case bound assuming every byte of source produces a token. The pre-existing comment in the file acknowledged this was overly conservative.

I measured the actual ratio across the benchmark files (parser with tokens enabled):

| file | bytes/token |
|---|---|
| antd.js | 10.08 |
| cal.com.tsx | 6.44 |
| checker.ts | 9.05 |
| pdf.mjs | **5.05** (densest) |
| binder.ts | 9.31 |
| Radix.jsx | 6.36 |

Even the densest realistic input is well above 3 bytes/token, so \`source_text.len() / 3 + 64\` is a safe upper bound for any realistic source while costing ~3× less arena memory. Pathological one-byte-per-token streams would trigger the \`Vec\`'s cold growth path, but the absolute waste from one or two doublings is bounded.

## Arena bytes used by the tokens vec at parse-end

Measured via \`Allocator::used_bytes()\` before/after the parse with \`RuntimeParserConfig::new(true)\`:

| file | before | after | saving |
|---|---|---|---|
| antd.js (6.7M) | 130.1 MB | 62.1 MB | **−68 MB (52%)** |
| checker.ts (2.9M) | 57.0 MB | 27.3 MB | **−30 MB (52%)** |
| cal.com.tsx (1.0M) | 24.0 MB | 13.3 MB | −10.7 MB (45%) |
| pdf.mjs (554K) | 13.0 MB | 7.2 MB | −5.8 MB (45%) |
| binder.ts (193K) | 3.8 MB | 1.9 MB | −1.9 MB (50%) |
| Radix.jsx (2.5K) | 61 KB | 36 KB | −25 KB (41%) |

## Behavior

Unchanged. \`cargo test -p oxc_parser\` 65/65 pass. test262 conformance 47086/47086 positive, 4588/4588 negative.

The default parser config (\`NoTokensLexerConfig\`) does not collect tokens, so this change is invisible to most callers — including all the standard \`just minsize\`/\`just allocs\` snapshots which use the no-tokens path. It matters primarily for callers that set \`RuntimeParserConfig::new(true)\` or use \`TokensLexerConfig\` — i.e. the linter's token-collecting code path, where peak memory on large files (\`oxlint\` lint runs over large dist bundles) drops by ~50%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)