### PR TITLE
fix(formatter/sort_imports): Treat subpath imports as internal

### DIFF
--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -615,7 +615,7 @@ export interface SortImportsConfig {
    *
    * This is useful for distinguishing your own modules from external dependencies.
    *
-   * - Default: `["~/", "@/"]`
+   * - Default: `["~/", "@/", "#"]`
    */
   internalPattern?: string[];
   /**

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -477,7 +477,7 @@ pub struct SortImportsConfig {
     ///
     /// This is useful for distinguishing your own modules from external dependencies.
     ///
-    /// - Default: `["~/", "@/"]`
+    /// - Default: `["~/", "@/", "#"]`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub internal_pattern: Option<Vec<String>>,
     /// Specifies a list of predefined import groups for sorting.

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
@@ -219,7 +219,6 @@ fn to_path_kind(source: &str, options: &SortImportsOptions) -> ImportPathKind {
         return ImportPathKind::Internal;
     }
 
-    // Subpath imports (e.g., `#foo`) are also considered external
     ImportPathKind::External
 }
 

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
@@ -134,9 +134,9 @@ pub struct CustomGroupDefinition {
     pub modifiers: Vec<ImportModifier>,
 }
 
-/// Returns default prefixes for identifying internal imports: `["~/", "@/"]`.
+/// Returns default prefixes for identifying internal imports: `["~/", "@/", "#"]`.
 pub fn default_internal_patterns() -> Vec<String> {
-    ["~/", "@/"].iter().map(|s| (*s).to_string()).collect()
+    ["~/", "@/", "#"].iter().map(|s| (*s).to_string()).collect()
 }
 
 /// Returns default groups configuration for organizing imports.

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
@@ -1078,6 +1078,29 @@ import { z } from "z";
 // ---
 
 #[test]
+fn should_treat_subpath_imports_as_internal_by_default() {
+    assert_format(
+        r##"
+import foo from "#utils";
+import bar from "react";
+import baz from "~/local";
+import qux from "node:fs";
+"##,
+        r#"{ "sortImports": {} }"#,
+        r##"
+import qux from "node:fs";
+
+import bar from "react";
+
+import foo from "#utils";
+import baz from "~/local";
+"##,
+    );
+}
+
+// ---
+
+#[test]
 fn should_support_internal_pattern_option() {
     assert_format(
         r##"

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -645,12 +645,12 @@
           "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`"
         },
         "internalPattern": {
-          "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
+          "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\", \"#\"]`",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`"
+          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\", \"#\"]`"
         },
         "newlinesBetween": {
           "description": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -649,12 +649,12 @@ expression: json
           "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`"
         },
         "internalPattern": {
-          "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
+          "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\", \"#\"]`",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`"
+          "markdownDescription": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\", \"#\"]`"
         },
         "newlinesBetween": {
           "description": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -789,7 +789,7 @@ Specifies a prefix for identifying internal imports.
 
 This is useful for distinguishing your own modules from external dependencies.
 
-- Default: `["~/", "@/"]`
+- Default: `["~/", "@/", "#"]`
 
 
 ###### overrides[n].options.sortImports.newlinesBetween
@@ -1320,7 +1320,7 @@ Specifies a prefix for identifying internal imports.
 
 This is useful for distinguishing your own modules from external dependencies.
 
-- Default: `["~/", "@/"]`
+- Default: `["~/", "@/", "#"]`
 
 
 ### sortImports.newlinesBetween


### PR DESCRIPTION
Closes #22371, follows https://github.com/azat-io/eslint-plugin-perfectionist/pull/732

---

As a baseline, while the result effectively follows the behavior of a perfectionist, there is no fundamental reason why it must be done that way.

Node.js subpaths are more flexible and aren't necessarily "internal", you can also alias external modules.

However, I do think it's consistent in the sense that it treats them the same way as other conventions like `@`.