### PR TITLE
refactor(oxlint,oxfmt): Use `shared/importJsConfig` for js config

### DIFF
--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -7,7 +7,7 @@ import {
   formatEmbeddedDoc,
   sortTailwindClasses,
 } from "./cli/worker-proxy";
-import { loadJsConfig, loadVitePlusConfig } from "./cli/js_config/index";
+import { loadJsConfig, loadVitePlusConfig } from "./cli/js_config";
 
 // napi-JS `oxfmt` CLI entry point
 // See also `run_cli()` function in `./src/main_napi.rs`

--- a/apps/oxfmt/src-js/cli/js_config.ts
+++ b/apps/oxfmt/src-js/cli/js_config.ts
@@ -1,29 +1,6 @@
-import { pathToFileURL } from "node:url";
-import { getUnsupportedTypeScriptModuleLoadHintForError } from "@oxapps/shared";
+import { importJsConfig } from "@oxapps/shared";
 
 const isObject = (v: unknown) => typeof v === "object" && v !== null && !Array.isArray(v);
-
-/**
- * Load a JavaScript/TypeScript config file and import it.
- *
- * Uses native Node.js `import()` to evaluate the config file.
- * The config file should have a default export containing the oxfmt configuration object.
- */
-async function importJsConfig(path: string): Promise<unknown> {
-  // Bypass Node.js module cache to allow reloading changed config files (used for LSP)
-  const fileUrl = pathToFileURL(path);
-  fileUrl.searchParams.set("cache", Date.now().toString());
-
-  const { default: config } = await import(fileUrl.href).catch((err) => {
-    const hint = getUnsupportedTypeScriptModuleLoadHintForError(err, path);
-    if (hint && err instanceof Error) err.message = hint;
-    throw err;
-  });
-
-  if (config === undefined) throw new Error("Configuration file has no default export.");
-
-  return config;
-}
 
 /**
  * Load and validate a standard oxfmt JS/TS config file.
@@ -33,7 +10,7 @@ async function importJsConfig(path: string): Promise<unknown> {
  * @returns Config object
  */
 export async function loadJsConfig(path: string): Promise<object> {
-  const config = await importJsConfig(path);
+  const config = await importJsConfig(path, Date.now());
 
   if (!isObject(config)) {
     throw new Error("Configuration file must have a default export that is an object.");
@@ -50,7 +27,7 @@ const VITE_OXFMT_CONFIG_FIELD = "fmt";
  * @returns Config object from `.fmt` field, or `null` to signal "skip"
  */
 export async function loadVitePlusConfig(path: string): Promise<object | null> {
-  const config = await importJsConfig(path);
+  const config = await importJsConfig(path, Date.now());
 
   // NOTE: Vite configs may export a function via `defineConfig(() => ({ ... }))`,
   // but we don't know the arguments to call the function.

--- a/apps/oxlint/src-js/js_config.ts
+++ b/apps/oxlint/src-js/js_config.ts
@@ -1,6 +1,6 @@
+import { importJsConfig } from "@oxapps/shared";
 import { getErrorMessage } from "./utils/utils.ts";
 import { DateNow, JSONStringify } from "./utils/globals.ts";
-import { getUnsupportedTypeScriptModuleLoadHintForError } from "@oxapps/shared";
 
 interface JsConfigResult {
   path: string;
@@ -81,27 +81,11 @@ function validateConfigExtends(root: object): void {
 }
 
 /**
- * Import a JS/TS config file and return its default export.
- */
-async function importConfig(path: string, cacheKey: number): Promise<unknown> {
-  // Bypass Node.js module cache to allow reloading changed config files (used for LSP)
-  const fileUrl = new URL(`file://${path}?cache=${cacheKey}`);
-  const module = await import(fileUrl.href);
-  const config = module.default;
-
-  if (config === undefined) {
-    throw new Error(`Configuration file has no default export.`);
-  }
-
-  return config;
-}
-
-/**
  * Resolve a single config path to a `JsConfigResult`.
  * Standard mode: default export must be a plain object.
  */
 async function resolveJsConfig(path: string, cacheKey: number): Promise<JsConfigResult> {
-  const config = await importConfig(path, cacheKey);
+  const config = await importJsConfig(path, cacheKey);
 
   if (!isObject(config)) {
     throw new Error(`Configuration file must have a default export that is an object.`);
@@ -117,7 +101,7 @@ const VITE_OXLINT_CONFIG_FIELD = "lint";
  * Extracts the `.lint` field. Returns `null` config when missing (signals "skip").
  */
 async function resolveVitePlusConfig(path: string, cacheKey: number): Promise<JsConfigResult> {
-  const config = await importConfig(path, cacheKey);
+  const config = await importJsConfig(path, cacheKey);
 
   // NOTE: Vite configs may export a function via `defineConfig(() => ({ ... }))`,
   // but we don't know the arguments to call the function.
@@ -160,14 +144,9 @@ async function loadConfigs(
       if (result.status === "fulfilled") {
         successes.push(result.value);
       } else {
-        const path = paths[i];
-        const unsupportedNodeHint = getUnsupportedTypeScriptModuleLoadHintForError(
-          result.reason,
-          path,
-        );
         errors.push({
-          path,
-          error: unsupportedNodeHint ?? getErrorMessage(result.reason),
+          path: paths[i],
+          error: getErrorMessage(result.reason),
         });
       }
     }

--- a/apps/shared/src-js/index.ts
+++ b/apps/shared/src-js/index.ts
@@ -1,1 +1,1 @@
-export { getUnsupportedTypeScriptModuleLoadHintForError } from "./node_version.ts";
+export { importJsConfig } from "./js_config.ts";

--- a/apps/shared/src-js/js_config.ts
+++ b/apps/shared/src-js/js_config.ts
@@ -1,0 +1,35 @@
+import { pathToFileURL } from "node:url";
+import { getUnsupportedTypeScriptModuleLoadHintForError } from "./node_version.ts";
+
+/**
+ * Import a JS/TS config file and return its `default` export.
+ *
+ * - Bypasses Node.js module cache (uses `?cache=<key>`) so changed files reload (used for LSP).
+ * - On `ERR_UNKNOWN_FILE_EXTENSION` for TS specifiers, overwrites `err.message` with a
+ *   Node.js upgrade hint that already includes the original message.
+ *
+ * @param path - Absolute path to the JS/TS config file
+ * @param cacheKey - Cache-busting key.
+ *   Callers decide whether to use a fresh value per call or share one across a batch.
+ * @throws When the file has no `default` export,
+ *   or import fails (with rewritten message for unsupported TS module load).
+ */
+export async function importJsConfig(path: string, cacheKey: number): Promise<unknown> {
+  const fileUrl = pathToFileURL(path);
+  fileUrl.searchParams.set("cache", cacheKey.toString());
+
+  let module;
+  try {
+    module = await import(fileUrl.href);
+  } catch (err) {
+    const hint = getUnsupportedTypeScriptModuleLoadHintForError(err, path);
+    if (hint && err instanceof Error) err.message = hint;
+    throw err;
+  }
+
+  if (module.default === undefined) {
+    throw new Error("Configuration file has no default export.");
+  }
+
+  return module.default;
+}


### PR DESCRIPTION
Consolidate the following parts:

- Using native `import()`s
- Specifying `cacheKey`
- Extracting default exports
- Returning hints for TS incompatibility errors