### PR TITLE
feat(oxlint): Support `vite-plus/resolveConfig` for vite.config.ts

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -65,6 +65,7 @@
     "tsdown": "catalog:",
     "tsx": "^4.21.0",
     "type-fest": "^5.2.0",
+    "vite-plus": "catalog:",
     "vitest": "catalog:",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-languageserver-textdocument": "^1.0.12"

--- a/apps/oxlint/src-js/js_config.ts
+++ b/apps/oxlint/src-js/js_config.ts
@@ -1,4 +1,4 @@
-import { importJsConfig } from "@oxapps/shared";
+import { importJsConfig, loadViteConfigField } from "@oxapps/shared";
 import { getErrorMessage } from "./utils/utils.ts";
 import { DateNow, JSONStringify } from "./utils/globals.ts";
 
@@ -94,34 +94,14 @@ async function resolveJsConfig(path: string, cacheKey: number): Promise<JsConfig
   return { path, config };
 }
 
-const VITE_OXLINT_CONFIG_FIELD = "lint";
-
 /**
  * Resolve a single Vite+ config path to a `JsConfigResult`.
- * Extracts the `.lint` field. Returns `null` config when missing (signals "skip").
+ * Extracts the `.lint` field via `vite-plus`. Returns `null` config when missing (signals "skip").
  */
-async function resolveVitePlusConfig(path: string, cacheKey: number): Promise<JsConfigResult> {
-  const config = await importJsConfig(path, cacheKey);
-
-  // NOTE: Vite configs may export a function via `defineConfig(() => ({ ... }))`,
-  // but we don't know the arguments to call the function.
-  // Treat non-object exports as "no config" and skip.
-  if (!isObject(config)) {
-    return { path, config: null };
-  }
-
-  const lintConfig = (config as Record<string, unknown>)[VITE_OXLINT_CONFIG_FIELD];
-  // NOTE: return `null` if `.lint` is missing which signals "skip" this
-  if (lintConfig === undefined) {
-    return { path, config: null };
-  }
-
-  if (!isObject(lintConfig)) {
-    throw new Error(
-      `The \`${VITE_OXLINT_CONFIG_FIELD}\` field in the default export must be an object.`,
-    );
-  }
-  validateConfigExtends(lintConfig as object);
+async function resolveVitePlusConfig(path: string): Promise<JsConfigResult> {
+  const lintConfig = await loadViteConfigField(path, "lint");
+  if (lintConfig === null) return { path, config: null };
+  validateConfigExtends(lintConfig);
   return { path, config: lintConfig };
 }
 
@@ -130,11 +110,10 @@ async function resolveVitePlusConfig(path: string, cacheKey: number): Promise<Js
  */
 async function loadConfigs(
   paths: string[],
-  resolver: (path: string, cacheKey: number) => Promise<JsConfigResult>,
+  resolver: (path: string) => Promise<JsConfigResult>,
 ): Promise<string> {
   try {
-    const cacheKey = DateNow();
-    const results = await Promise.allSettled(paths.map((path) => resolver(path, cacheKey)));
+    const results = await Promise.allSettled(paths.map(resolver));
 
     const successes: JsConfigResult[] = [];
     const errors: { path: string; error: string }[] = [];
@@ -168,7 +147,12 @@ export type ConfigLoader = (paths: string[]) => Promise<string>;
 /**
  * Load standard oxlint JS/TS config files in parallel.
  */
-export const loadJsConfigs: ConfigLoader = (paths) => loadConfigs(paths, resolveJsConfig);
+export const loadJsConfigs: ConfigLoader = (paths) => {
+  // Share one cache-busting key across the batch so that `?cache=<key>` is identical
+  // for every path resolved in this call (consistent reload semantics for LSP).
+  const cacheKey = DateNow();
+  return loadConfigs(paths, (path) => resolveJsConfig(path, cacheKey));
+};
 
 /**
  * Load Vite+ config files in parallel, extracting the `.lint` field from each.

--- a/apps/oxlint/test/fixtures/vite_plus_fn_export/vite.config.ts
+++ b/apps/oxlint/test/fixtures/vite_plus_fn_export/vite.config.ts
@@ -1,4 +1,4 @@
-const defineConfig = (config: unknown) => config;
+import { defineConfig } from "vite-plus";
 
 export default defineConfig(() => ({
   plugins: [],

--- a/apps/oxlint/test/fixtures/vite_plus_no_lint_field/vite.config.ts
+++ b/apps/oxlint/test/fixtures/vite_plus_no_lint_field/vite.config.ts
@@ -1,3 +1,6 @@
-export default {
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  fmt: {},
   plugins: [],
-};
+});

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -103,6 +103,8 @@ export default defineConfig([
         // External native bindings
         "./oxlint.*.node",
         "@oxlint/*",
+        // Optional peer dependency; must be installed by the user
+        "vite-plus",
       ],
     },
     minify: minifyConfig,

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -46,10 +46,14 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "oxlint-tsgolint": ">=0.22.1"
+    "oxlint-tsgolint": ">=0.22.1",
+    "vite-plus": "*"
   },
   "peerDependenciesMeta": {
     "oxlint-tsgolint": {
+      "optional": true
+    },
+    "vite-plus": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       type-fest:
         specifier: ^5.2.0
         version: 5.6.0
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.21(@arethetypeswrong/core@0.18.2)(@types/node@24.1.0)(esbuild@0.28.0)(happy-dom@20.0.11)(publint@0.3.21)(terser@5.44.1)(tsx@4.22.0)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.6(@types/node@24.1.0)(@vitest/browser-playwright@4.1.6)(happy-dom@20.0.11)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.0))
@@ -364,6 +367,9 @@ importers:
       oxlint-tsgolint:
         specifier: '>=0.22.1'
         version: 0.23.0
+      vite-plus:
+        specifier: '*'
+        version: 0.1.21(@arethetypeswrong/core@0.18.2)(@types/node@25.0.2)(esbuild@0.28.0)(happy-dom@20.0.11)(publint@0.3.21)(terser@5.44.1)(tsx@4.22.0)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.0))
 
   npm/oxlint-plugin-eslint: {}
 


### PR DESCRIPTION
Fixes #21417 and #21057

Now Oxlint can use the common functions defined in `shared` as well.