### PR TITLE
fix(codegen): preserve string quotes in require() calls during minification

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1502,7 +1502,8 @@ impl GenExpr for CallExpression<'_> {
             if let Some(type_parameters) = &self.type_arguments {
                 type_parameters.print(p, ctx);
             }
-            if !try_print_cjs_define_property_call(p, self, ctx) {
+            if !try_print_cjs_define_property_call(p, self, ctx) && !try_print_require_call(p, self)
+            {
                 p.print_arguments(self.span, &self.arguments, ctx);
             }
         });
@@ -1544,6 +1545,25 @@ fn try_print_cjs_define_property_call(
             arg.print(p, ctx);
         }
     }
+    p.add_source_mapping_end(call.span);
+    p.print_ascii_byte(b')');
+    true
+}
+
+/// Print `require("...")` with a plain string literal so `cjs-module-lexer` (used by Node for
+/// CJS/ESM interop) can detect reexport sources. Returns `true` if printed.
+///
+/// Minify-only: outside minify, `print_string_literal` already uses `self.quote` (never
+/// backtick), and this path skips the argument comments that `print_arguments` preserves.
+fn try_print_require_call(p: &mut Codegen<'_>, call: &CallExpression<'_>) -> bool {
+    if !p.options.minify {
+        return false;
+    }
+    let Some(str_lit) = call.common_js_require() else {
+        return false;
+    };
+    p.print_ascii_byte(b'(');
+    p.print_string_literal(str_lit, false);
     p.add_source_mapping_end(call.span);
     p.print_ascii_byte(b')');
     true

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -667,7 +667,7 @@ fn string() {
     // Dynamic require is not affected
     test_minify("require(foo);", "require(foo);");
     // Single-quoted require
-    test_minify(r#"require('./foo');"#, r#"require("./foo");"#);
+    test_minify(r"require('./foo');", r#"require("./foo");"#);
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -664,6 +664,10 @@ fn string() {
     test_minify(r#"require("./foo");"#, r#"require("./foo");"#);
     // Non-require calls should still use backtick optimization
     test_minify(r#"foo("./bar")"#, "foo(`./bar`);");
+    // Dynamic require is not affected
+    test_minify("require(foo);", "require(foo);");
+    // Single-quoted require
+    test_minify(r#"require('./foo');"#, r#"require("./foo");"#);
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -654,6 +654,16 @@ fn string() {
         r#"exports["has-dash"]=a;module.exports["__esModule"]=true;"#,
     );
     test_minify(r#"obj["not-exports"] = a;"#, "obj[`not-exports`]=a;");
+
+    // require() should preserve string quotes for cjs-module-lexer compatibility
+    test_minify(
+        r#"__exportStar(require("./decorators"), exports);"#,
+        r#"__exportStar(require("./decorators"),exports);"#,
+    );
+    test_minify(r#"var a = require("./foo");"#, r#"var a=require("./foo");"#);
+    test_minify(r#"require("./foo");"#, r#"require("./foo");"#);
+    // Non-require calls should still use backtick optimization
+    test_minify(r#"foo("./bar")"#, "foo(`./bar`);");
 }
 
 #[test]

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -21,7 +21,7 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 3.20 MB    | 1.00 MB    | 1.01 MB    | 322.61 kB  | 331.56 kB  |          2 | echarts.js 
 
-6.69 MB    | 2.22 MB    | 2.31 MB    | 458.44 kB  | 488.28 kB  |          4 | antd.js    
+6.69 MB    | 2.22 MB    | 2.31 MB    | 458.45 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 853.30 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 853.31 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
Closes #22463

## Summary

- Add `try_print_require_call` to force plain string literals (no backticks) for `require("...")` calls during minification
- Prevents `cjs-module-lexer` from failing to detect CJS reexport sources

### Problem

When minifying, `StringLiteral::gen` passes `allow_backtick: true`, which can convert:
```js
__exportStar(require("./decorators"), exports);
```
into:
```js
__exportStar(require(`./decorators`),exports);
```

Node.js uses `cjs-module-lexer` for CJS/ESM interop. This lexer uses a fast heuristic parser that does **not** recognize template literals as `require()` arguments, causing named reexports to silently disappear from the module's export list.

### Fix

Add `try_print_require_call` (following the existing `try_print_cjs_define_property_call` pattern) that detects `require("...")` calls via the existing `CallExpression::common_js_require()` helper and prints the string argument with `allow_backtick: false`.

## Test plan

- [x] `require("./decorators")` stays quoted when minified
- [x] `require('./foo')` normalizes to double quotes (not backticks)
- [x] `require(foo)` (dynamic) is unaffected
- [x] Non-require calls like `foo("./bar")` still get backtick optimization
- [x] `cargo test -p oxc_codegen` passes
- [x] Follows existing CJS special-case pattern in codegen

🤖 Generated with [Claude Code](https://claude.com/claude-code)