### PR TITLE
perf(linter): Improve performance of `eslint/no-loop-func` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
@@ -663,6 +663,8 @@ fn test() {
                   };
                 }
                   ",
+        // Function in the for-update slot is not in the loop body.
+        "for (var i = 0; i < l; i++, (function () { i; })()) { }",
     ];
 
     let fail = vec![
@@ -901,6 +903,31 @@ fn test() {
                 })();
             }
             ",
+        // Multiple sibling functions in one loop body — all must be reported.
+        "for (var i = 0; i < 5; i++) {
+            (function () { return i; });
+            (function () { return i + 1; });
+            (() => i);
+        }",
+        // Function nested inside switch/if/try inside a loop body — descendant walk
+        // must reach it.
+        "for (var i = 0; i < 5; i++) {
+            if (cond) {
+                try {
+                    arr.push(function () { return i; });
+                } catch (e) {}
+            } else {
+                switch (k) {
+                    case 1:
+                        arr.push(() => i);
+                }
+            }
+        }",
+        // do-while body comes before the test in source; multiple statements in body.
+        "var i = 0; do {
+            arr.push(function () { return i; });
+            arr.push(() => i);
+        } while (i++ < 5);",
     ];
 
     Tester::new(NoLoopFunc::NAME, NoLoopFunc::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
@@ -1,11 +1,21 @@
-use oxc_ast::AstKind;
+use rustc_hash::FxHashSet;
+
+use oxc_ast::{AstKind, AstType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNode, SymbolId};
+use oxc_semantic::{AstNode, NodeId, SymbolId};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::symbol::SymbolFlags;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::ContextHost, context::LintContext, rule::Rule};
+
+const LOOP_NODE_TYPES: &AstTypesBitset = &AstTypesBitset::from_types(&[
+    AstType::ForStatement,
+    AstType::ForInStatement,
+    AstType::ForOfStatement,
+    AstType::WhileStatement,
+    AstType::DoWhileStatement,
+]);
 
 fn no_loop_func_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Function declared in a loop contains unsafe references to variable(s)")
@@ -56,6 +66,12 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoLoopFunc {
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        // The rule only fires for functions inside loops, so skip files
+        // that contain no loop statements at all.
+        ctx.semantic().nodes().contains_any(LOOP_NODE_TYPES)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // Check for function expressions, arrow functions, and function declarations
         let (func_span, is_async_or_generator) = match node.kind() {
@@ -150,11 +166,16 @@ impl NoLoopFunc {
         let nodes = ctx.nodes();
         let scoping = ctx.scoping();
 
-        // Check all nodes to find nested functions within this function
-        for node in ctx.nodes() {
+        // Walk only the function's descendants. `NodeId`s are assigned in DFS pre-order
+        // by the semantic builder, so all descendants live in `(func_id, ...]` until the
+        // span exits the function.
+        let total = nodes.len();
+        let start = func_node.id().index() + 1;
+        for idx in start..total {
+            let node = nodes.get_node(NodeId::new(idx));
             let node_span = node.span();
-            if node_span == func_span || !func_span.contains_inclusive(node_span) {
-                continue;
+            if !func_span.contains_inclusive(node_span) {
+                break;
             }
 
             let (is_async_or_generator, func_id, is_function) = match node.kind() {
@@ -247,8 +268,31 @@ impl NoLoopFunc {
         let nodes = ctx.nodes();
         let func_span = func_node.span();
 
-        // Iterate through all symbols and check their references
-        for symbol_id in scoping.symbol_ids() {
+        // Walk only the function's descendants (DFS pre-order; see
+        // `contains_nested_functions` for the rationale) and collect the unique
+        // resolved symbols actually referenced from inside the function.
+        // This avoids iterating every symbol in the file for every function in a loop.
+        let total = nodes.len();
+        let start = func_node.id().index() + 1;
+        let mut seen_symbols = FxHashSet::default();
+        for idx in start..total {
+            let node = nodes.get_node(NodeId::new(idx));
+            if !func_span.contains_inclusive(node.span()) {
+                break;
+            }
+            let AstKind::IdentifierReference(ident) = node.kind() else {
+                continue;
+            };
+            let Some(reference_id) = ident.reference_id.get() else {
+                continue;
+            };
+            let Some(symbol_id) = scoping.get_reference(reference_id).symbol_id() else {
+                continue;
+            };
+            if !seen_symbols.insert(symbol_id) {
+                continue;
+            }
+
             let flags = scoping.symbol_flags(symbol_id);
 
             // Skip type-only symbols (TypeScript types, interfaces, etc.)
@@ -256,29 +300,10 @@ impl NoLoopFunc {
                 continue;
             }
 
-            // Get the declaration node for the symbol
-            let symbol_decl_node_id = scoping.symbol_declaration(symbol_id);
-            let symbol_decl_node = nodes.get_node(symbol_decl_node_id);
-            let symbol_decl_span = symbol_decl_node.span();
-
             // Skip if the symbol is declared inside the function (local variable)
+            let symbol_decl_node_id = scoping.symbol_declaration(symbol_id);
+            let symbol_decl_span = nodes.get_node(symbol_decl_node_id).span();
             if func_span.contains_inclusive(symbol_decl_span) {
-                continue;
-            }
-
-            // Check if any reference to this symbol is from inside the function
-            let mut is_referenced_in_function = false;
-            for reference in scoping.get_resolved_references(symbol_id) {
-                let ref_node = nodes.get_node(reference.node_id());
-                let ref_span = ref_node.span();
-                // A reference is only inside the function if its span is contained within the function's span
-                if func_span.contains_inclusive(ref_span) {
-                    is_referenced_in_function = true;
-                    break;
-                }
-            }
-
-            if !is_referenced_in_function {
                 continue;
             }
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_loop_func.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_loop_func.snap
@@ -379,3 +379,66 @@ source: crates/oxc_linter/src/tester.rs
  10 │                 }
     ╰────
   help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:2:14]
+ 1 │ for (var i = 0; i < 5; i++) {
+ 2 │             (function () { return i; });
+   ·              ─────────────────────────
+ 3 │             (function () { return i + 1; });
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:3:14]
+ 2 │             (function () { return i; });
+ 3 │             (function () { return i + 1; });
+   ·              ─────────────────────────────
+ 4 │             (() => i);
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:4:14]
+ 3 │             (function () { return i + 1; });
+ 4 │             (() => i);
+   ·              ───────
+ 5 │         }
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:4:30]
+ 3 │                 try {
+ 4 │                     arr.push(function () { return i; });
+   ·                              ─────────────────────────
+ 5 │                 } catch (e) {}
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+    ╭─[no_loop_func.tsx:9:34]
+  8 │                     case 1:
+  9 │                         arr.push(() => i);
+    ·                                  ───────
+ 10 │                 }
+    ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:2:22]
+ 1 │ var i = 0; do {
+ 2 │             arr.push(function () { return i; });
+   ·                      ─────────────────────────
+ 3 │             arr.push(() => i);
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:3:22]
+ 2 │             arr.push(function () { return i; });
+ 3 │             arr.push(() => i);
+   ·                      ───────
+ 4 │         } while (i++ < 5);
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.


### PR DESCRIPTION
Generated with Claude Code, reviewed and tested by me.

This optimizes the rule by reducing the number of files on which the rule gets run by refactoring it to be able to use codegen'd node types to skip the many files that have functions but no loops, and by walking only function descendants.

Benchmark result:

| Variant | with loops (1000 files) | no loops (1000 files) | total |
| --- | --- | --- | --- |
| Original (pre-PR) | 41.0 ms | 27.0 ms | 68.0 ms |
| Optimized | **24.3 ms** | **11.0 ms** | **35.3 ms** |
| Speedup vs original | ~1.69x | ~2.45x | ~1.93x |

Fix #22471, I assume we may be able to get the time down further from this with further optimization.

Also add a few additional test cases (these pass on main as well so the behavior is unchanged by this refactor).