### PR TITLE
fix(linter/jest/vitest): jest/no-standalone-expect ignores additionalTestBlockFunctions option for jest/vitest hooks

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -157,6 +157,34 @@ fn test() {
                 };",
             None,
         ),
+        (
+            r"describe('additionalTestBlockFunctions reproduction', () => {
+                beforeEach(() => {
+                    expect(true).toBe(true);
+                });
+
+                describe('nested describe', () => {
+                    afterEach(() => {
+                        expect(true).toBe(true);
+                    });
+                });
+
+                it('should always pass', () => {
+                    expect(true).toBe(true);
+                });
+            });",
+            Some(
+                serde_json::json!([{ "additionalTestBlockFunctions": ["beforeEach", "afterEach"] }]),
+            ),
+        ),
+        (
+            r"customTest('a custom block', () => { expect(1).toBe(1); });",
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["customTest"] }])),
+        ),
+        (
+            r"setup.beforeEach(() => { expect(1).toBe(1); });",
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["setup.beforeEach"] }])),
+        ),
     ];
 
     let fail = vec![
@@ -248,6 +276,20 @@ fn test() {
                 beforeEach(() => pleaseExpect.hasAssertions());
             ",
             None,
+        ),
+        // Without `additionalTestBlockFunctions`, hook callbacks are still flagged.
+        (
+            r"describe('a test', () => {
+                beforeEach(() => { expect(1).toBe(1); });
+            });",
+            None,
+        ),
+        // The allowlist is precise: `beforeEach` is allowed, but `beforeAll` is not.
+        (
+            r"describe('a test', () => {
+                beforeAll(() => { expect(1).toBe(1); });
+            });",
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["beforeEach"] }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_standalone_expect.rs
@@ -195,15 +195,16 @@ fn is_var_declarator_or_test_block<'a>(
     match node.kind() {
         AstKind::VariableDeclarator(_) => return true,
         AstKind::CallExpression(call_expr) => {
+            let node_name = get_node_name(&call_expr.callee);
+
+            if additional_test_block_functions.contains(&node_name) {
+                return true;
+            }
+
             if let Some(jest_node) = id_nodes_mapping.get(&node.id())
                 && let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, jest_node, ctx)
             {
                 return matches!(jest_fn_call.kind, JestFnKind::General(JestGeneralFnKind::Test));
-            }
-
-            let node_name = get_node_name(&call_expr.callee);
-            if additional_test_block_functions.contains(&node_name) {
-                return true;
             }
 
             let parent = ctx.nodes().parent_node(node.id());

--- a/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_standalone_expect.rs
@@ -210,6 +210,34 @@ fn test() {
                 };",
             None,
         ),
+        (
+            r"describe('additionalTestBlockFunctions reproduction', () => {
+                beforeEach(() => {
+                    expect(true).toBe(true);
+                });
+
+                describe('nested describe', () => {
+                    afterEach(() => {
+                        expect(true).toBe(true);
+                    });
+                });
+
+                it('should always pass', () => {
+                    expect(true).toBe(true);
+                });
+            });",
+            Some(
+                serde_json::json!([{ "additionalTestBlockFunctions": ["beforeEach", "afterEach"] }]),
+            ),
+        ),
+        (
+            r"customTest('a custom block', () => { expect(1).toBe(1); });",
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["customTest"] }])),
+        ),
+        (
+            r"setup.beforeEach(() => { expect(1).toBe(1); });",
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["setup.beforeEach"] }])),
+        ),
     ];
 
     let fail = vec![
@@ -338,6 +366,20 @@ fn test() {
                    expect(a + b).toBe(expected);
                  });",
             Some(serde_json::json!([{ "additionalTestBlockFunctions": ["test"] }])),
+        ),
+        // Without `additionalTestBlockFunctions`, hook callbacks are still flagged.
+        (
+            r"describe('a test', () => {
+                beforeEach(() => { expect(1).toBe(1); });
+            });",
+            None,
+        ),
+        // The allowlist is precise: `beforeEach` is allowed, but `beforeAll` is not.
+        (
+            r"describe('a test', () => {
+                beforeAll(() => { expect(1).toBe(1); });
+            });",
+            Some(serde_json::json!([{ "additionalTestBlockFunctions": ["beforeEach"] }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/jest_no_standalone_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_standalone_expect.snap
@@ -148,3 +148,21 @@ source: crates/oxc_linter/src/tester.rs
  4 │             
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ jest(no-standalone-expect): `expect` must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:2:36]
+ 1 │ describe('a test', () => {
+ 2 │                 beforeEach(() => { expect(1).toBe(1); });
+   ·                                    ──────
+ 3 │             });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ jest(no-standalone-expect): `expect` must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:2:35]
+ 1 │ describe('a test', () => {
+ 2 │                 beforeAll(() => { expect(1).toBe(1); });
+   ·                                   ──────
+ 3 │             });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?

--- a/crates/oxc_linter/src/snapshots/vitest_no_standalone_expect.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_no_standalone_expect.snap
@@ -203,3 +203,21 @@ source: crates/oxc_linter/src/tester.rs
  8 │                  });
    ╰────
   help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ vitest(no-standalone-expect): `expect` must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:2:36]
+ 1 │ describe('a test', () => {
+ 2 │                 beforeEach(() => { expect(1).toBe(1); });
+   ·                                    ──────
+ 3 │             });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?
+
+  ⚠ vitest(no-standalone-expect): `expect` must be inside of a test block.
+   ╭─[no_standalone_expect.tsx:2:35]
+ 1 │ describe('a test', () => {
+ 2 │                 beforeAll(() => { expect(1).toBe(1); });
+   ·                                   ──────
+ 3 │             });
+   ╰────
+  help: Did you forget to wrap `expect` in a `test` or `it` block?


### PR DESCRIPTION
## AI usage disclosure

I used Claude Code to review the fix I applied and to add additional tests, besides the one that was c/p-ed from the reported GH issue.
I also used it to generate this PR description

## Summary

Fixes #22390. The `jest/no-standalone-expect` rule was silently ignoring the `additionalTestBlockFunctions` option whenever a configured name was also a built-in Jest function (`beforeEach`, `afterEach`, `beforeAll`, `afterAll`).

In `is_var_declarator_or_test_block`, the built-in `parse_general_jest_fn_call` check ran first. For a hook like `beforeEach`, it returned `Some(_)` with kind `Hook` (not `Test`), causing an early `return false` before the user's `additionalTestBlockFunctions` allowlist was ever consulted.

Swapping the order so the user-configured allowlist is checked first lets explicit config override built-in classification — matching `eslint-plugin-jest`'s behavior.