### PR TITLE
fix(formatter): normalize destructuring keys in DCR

### DIFF
--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -207,6 +207,8 @@ impl StatsCollector {
         if matches!(
             parent_kind,
             AstKind::ObjectProperty(_)
+                | AstKind::BindingProperty(_)
+                | AstKind::AssignmentTargetPropertyProperty(_)
                 | AstKind::MethodDefinition(_)
                 | AstKind::PropertyDefinition(_)
                 | AstKind::ImportAttribute(_)
@@ -334,6 +336,8 @@ mod tests {
             ("for ((let.a) of foo);", "for ((let).a of foo);"),
             ("for ((let[a]) of foo);", "for ((let)[a] of foo);"),
             ("for ((let.a) in foo);", "for (let.a in foo);"),
+            (r#"const { index, "0": code } = match;"#, r"const { index, 0: code } = match;"),
+            (r#"({ "0": code } = match);"#, r"({ 0: code } = match);"),
             ("<div>{' '}</div>", "<div> </div>"),
             ("type T = | A;", "type T = A;"),
             ("type T = & A;", "type T = A;"),


### PR DESCRIPTION
Fixes a false positive in formatter detect-code-removal checks when formatting object destructuring keys.

The detector already normalizes object-like property keys because formatter output can change quoted keys into equivalent unquoted or numeric keys. This extends that normalization to destructuring binding and assignment pattern properties, covering cases like:

```js
const { index, "0": code } = match;
```

which formats to:

```js
const { index, 0: code } = match;
```

without removing code.

failing monitor oxc: https://github.com/oxc-project/monitor-oxc/actions/runs/25915602942/job/76171605899