### PR TITLE
feat(linter): implement react no-object-type-as-default-prop

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -941,6 +941,7 @@ export interface DummyRuleMap {
   "react/no-is-mounted"?: DummyRule;
   "react/no-multi-comp"?: DummyRule;
   "react/no-namespace"?: DummyRule;
+  "react/no-object-type-as-default-prop"?: DummyRule;
   "react/no-react-children"?: DummyRule;
   "react/no-redundant-should-component-update"?: DummyRule;
   "react/no-render-return-value"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2694,6 +2694,12 @@ impl RuleRunner for crate::rules::react::no_namespace::NoNamespace {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::no_object_type_as_default_prop::NoObjectTypeAsDefaultProp {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentPattern]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::no_react_children::NoReactChildren {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -447,6 +447,7 @@ pub use crate::rules::react::no_find_dom_node::NoFindDomNode as ReactNoFindDomNo
 pub use crate::rules::react::no_is_mounted::NoIsMounted as ReactNoIsMounted;
 pub use crate::rules::react::no_multi_comp::NoMultiComp as ReactNoMultiComp;
 pub use crate::rules::react::no_namespace::NoNamespace as ReactNoNamespace;
+pub use crate::rules::react::no_object_type_as_default_prop::NoObjectTypeAsDefaultProp as ReactNoObjectTypeAsDefaultProp;
 pub use crate::rules::react::no_react_children::NoReactChildren as ReactNoReactChildren;
 pub use crate::rules::react::no_redundant_should_component_update::NoRedundantShouldComponentUpdate as ReactNoRedundantShouldComponentUpdate;
 pub use crate::rules::react::no_render_return_value::NoRenderReturnValue as ReactNoRenderReturnValue;
@@ -1239,6 +1240,7 @@ pub enum RuleEnum {
     ReactNoIsMounted(ReactNoIsMounted),
     ReactNoMultiComp(ReactNoMultiComp),
     ReactNoNamespace(ReactNoNamespace),
+    ReactNoObjectTypeAsDefaultProp(ReactNoObjectTypeAsDefaultProp),
     ReactNoReactChildren(ReactNoReactChildren),
     ReactNoRedundantShouldComponentUpdate(ReactNoRedundantShouldComponentUpdate),
     ReactNoRenderReturnValue(ReactNoRenderReturnValue),
@@ -2090,7 +2092,8 @@ const REACT_NO_FIND_DOM_NODE_ID: usize = REACT_NO_DIRECT_MUTATION_STATE_ID + 1us
 const REACT_NO_IS_MOUNTED_ID: usize = REACT_NO_FIND_DOM_NODE_ID + 1usize;
 const REACT_NO_MULTI_COMP_ID: usize = REACT_NO_IS_MOUNTED_ID + 1usize;
 const REACT_NO_NAMESPACE_ID: usize = REACT_NO_MULTI_COMP_ID + 1usize;
-const REACT_NO_REACT_CHILDREN_ID: usize = REACT_NO_NAMESPACE_ID + 1usize;
+const REACT_NO_OBJECT_TYPE_AS_DEFAULT_PROP_ID: usize = REACT_NO_NAMESPACE_ID + 1usize;
+const REACT_NO_REACT_CHILDREN_ID: usize = REACT_NO_OBJECT_TYPE_AS_DEFAULT_PROP_ID + 1usize;
 const REACT_NO_REDUNDANT_SHOULD_COMPONENT_UPDATE_ID: usize = REACT_NO_REACT_CHILDREN_ID + 1usize;
 const REACT_NO_RENDER_RETURN_VALUE_ID: usize =
     REACT_NO_REDUNDANT_SHOULD_COMPONENT_UPDATE_ID + 1usize;
@@ -3017,6 +3020,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => REACT_NO_IS_MOUNTED_ID,
             Self::ReactNoMultiComp(_) => REACT_NO_MULTI_COMP_ID,
             Self::ReactNoNamespace(_) => REACT_NO_NAMESPACE_ID,
+            Self::ReactNoObjectTypeAsDefaultProp(_) => REACT_NO_OBJECT_TYPE_AS_DEFAULT_PROP_ID,
             Self::ReactNoReactChildren(_) => REACT_NO_REACT_CHILDREN_ID,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 REACT_NO_REDUNDANT_SHOULD_COMPONENT_UPDATE_ID
@@ -3938,6 +3942,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::NAME,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::NAME,
             Self::ReactNoNamespace(_) => ReactNoNamespace::NAME,
+            Self::ReactNoObjectTypeAsDefaultProp(_) => ReactNoObjectTypeAsDefaultProp::NAME,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::NAME,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::NAME
@@ -4875,6 +4880,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::CATEGORY,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::CATEGORY,
             Self::ReactNoNamespace(_) => ReactNoNamespace::CATEGORY,
+            Self::ReactNoObjectTypeAsDefaultProp(_) => ReactNoObjectTypeAsDefaultProp::CATEGORY,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::CATEGORY,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::CATEGORY
@@ -5817,6 +5823,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::FIX,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::FIX,
             Self::ReactNoNamespace(_) => ReactNoNamespace::FIX,
+            Self::ReactNoObjectTypeAsDefaultProp(_) => ReactNoObjectTypeAsDefaultProp::FIX,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::FIX,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::FIX
@@ -6833,6 +6840,9 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::documentation(),
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::documentation(),
             Self::ReactNoNamespace(_) => ReactNoNamespace::documentation(),
+            Self::ReactNoObjectTypeAsDefaultProp(_) => {
+                ReactNoObjectTypeAsDefaultProp::documentation()
+            }
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::documentation(),
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::documentation()
@@ -8590,6 +8600,10 @@ impl RuleEnum {
                 .or_else(|| ReactNoMultiComp::schema(generator)),
             Self::ReactNoNamespace(_) => ReactNoNamespace::config_schema(generator)
                 .or_else(|| ReactNoNamespace::schema(generator)),
+            Self::ReactNoObjectTypeAsDefaultProp(_) => {
+                ReactNoObjectTypeAsDefaultProp::config_schema(generator)
+                    .or_else(|| ReactNoObjectTypeAsDefaultProp::schema(generator))
+            }
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::config_schema(generator)
                 .or_else(|| ReactNoReactChildren::schema(generator)),
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
@@ -10112,6 +10126,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => "react",
             Self::ReactNoMultiComp(_) => "react",
             Self::ReactNoNamespace(_) => "react",
+            Self::ReactNoObjectTypeAsDefaultProp(_) => "react",
             Self::ReactNoReactChildren(_) => "react",
             Self::ReactNoRedundantShouldComponentUpdate(_) => "react",
             Self::ReactNoRenderReturnValue(_) => "react",
@@ -11850,6 +11865,9 @@ impl RuleEnum {
             Self::ReactNoNamespace(_) => {
                 Ok(Self::ReactNoNamespace(ReactNoNamespace::from_configuration(value)?))
             }
+            Self::ReactNoObjectTypeAsDefaultProp(_) => Ok(Self::ReactNoObjectTypeAsDefaultProp(
+                ReactNoObjectTypeAsDefaultProp::from_configuration(value)?,
+            )),
             Self::ReactNoReactChildren(_) => {
                 Ok(Self::ReactNoReactChildren(ReactNoReactChildren::from_configuration(value)?))
             }
@@ -13491,6 +13509,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(rule) => rule.to_configuration(),
             Self::ReactNoMultiComp(rule) => rule.to_configuration(),
             Self::ReactNoNamespace(rule) => rule.to_configuration(),
+            Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.to_configuration(),
             Self::ReactNoReactChildren(rule) => rule.to_configuration(),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.to_configuration(),
             Self::ReactNoRenderReturnValue(rule) => rule.to_configuration(),
@@ -14302,6 +14321,7 @@ impl RuleEnum {
                 Self::ReactNoIsMounted(rule) => rule.run(node, ctx),
                 Self::ReactNoMultiComp(rule) => rule.run(node, ctx),
                 Self::ReactNoNamespace(rule) => rule.run(node, ctx),
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.run(node, ctx),
                 Self::ReactNoReactChildren(rule) => rule.run(node, ctx),
                 Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run(node, ctx),
                 Self::ReactNoRenderReturnValue(rule) => rule.run(node, ctx),
@@ -15106,6 +15126,7 @@ impl RuleEnum {
                 Self::ReactNoIsMounted(rule) => rule.run(node, ctx),
                 Self::ReactNoMultiComp(rule) => rule.run(node, ctx),
                 Self::ReactNoNamespace(rule) => rule.run(node, ctx),
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.run(node, ctx),
                 Self::ReactNoReactChildren(rule) => rule.run(node, ctx),
                 Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run(node, ctx),
                 Self::ReactNoRenderReturnValue(rule) => rule.run(node, ctx),
@@ -15917,6 +15938,7 @@ impl RuleEnum {
                 Self::ReactNoIsMounted(rule) => rule.run_once(ctx),
                 Self::ReactNoMultiComp(rule) => rule.run_once(ctx),
                 Self::ReactNoNamespace(rule) => rule.run_once(ctx),
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.run_once(ctx),
                 Self::ReactNoReactChildren(rule) => rule.run_once(ctx),
                 Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run_once(ctx),
                 Self::ReactNoRenderReturnValue(rule) => rule.run_once(ctx),
@@ -16721,6 +16743,7 @@ impl RuleEnum {
                 Self::ReactNoIsMounted(rule) => rule.run_once(ctx),
                 Self::ReactNoMultiComp(rule) => rule.run_once(ctx),
                 Self::ReactNoNamespace(rule) => rule.run_once(ctx),
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.run_once(ctx),
                 Self::ReactNoReactChildren(rule) => rule.run_once(ctx),
                 Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run_once(ctx),
                 Self::ReactNoRenderReturnValue(rule) => rule.run_once(ctx),
@@ -17659,6 +17682,7 @@ impl RuleEnum {
                 Self::ReactNoIsMounted(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoMultiComp(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoNamespace(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoReactChildren(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoRedundantShouldComponentUpdate(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
@@ -18713,6 +18737,7 @@ impl RuleEnum {
                 Self::ReactNoIsMounted(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoMultiComp(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoNamespace(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoReactChildren(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ReactNoRedundantShouldComponentUpdate(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
@@ -19641,6 +19666,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(rule) => rule.should_run(ctx),
             Self::ReactNoMultiComp(rule) => rule.should_run(ctx),
             Self::ReactNoNamespace(rule) => rule.should_run(ctx),
+            Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.should_run(ctx),
             Self::ReactNoReactChildren(rule) => rule.should_run(ctx),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.should_run(ctx),
             Self::ReactNoRenderReturnValue(rule) => rule.should_run(ctx),
@@ -20614,6 +20640,9 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::IS_TSGOLINT_RULE,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::IS_TSGOLINT_RULE,
             Self::ReactNoNamespace(_) => ReactNoNamespace::IS_TSGOLINT_RULE,
+            Self::ReactNoObjectTypeAsDefaultProp(_) => {
+                ReactNoObjectTypeAsDefaultProp::IS_TSGOLINT_RULE
+            }
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::IS_TSGOLINT_RULE,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::IS_TSGOLINT_RULE
@@ -21693,6 +21722,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::VERSION,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::VERSION,
             Self::ReactNoNamespace(_) => ReactNoNamespace::VERSION,
+            Self::ReactNoObjectTypeAsDefaultProp(_) => ReactNoObjectTypeAsDefaultProp::VERSION,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::VERSION,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::VERSION
@@ -22677,6 +22707,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(_) => ReactNoIsMounted::HAS_CONFIG,
             Self::ReactNoMultiComp(_) => ReactNoMultiComp::HAS_CONFIG,
             Self::ReactNoNamespace(_) => ReactNoNamespace::HAS_CONFIG,
+            Self::ReactNoObjectTypeAsDefaultProp(_) => ReactNoObjectTypeAsDefaultProp::HAS_CONFIG,
             Self::ReactNoReactChildren(_) => ReactNoReactChildren::HAS_CONFIG,
             Self::ReactNoRedundantShouldComponentUpdate(_) => {
                 ReactNoRedundantShouldComponentUpdate::HAS_CONFIG
@@ -23570,6 +23601,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(rule) => rule.types_info(),
             Self::ReactNoMultiComp(rule) => rule.types_info(),
             Self::ReactNoNamespace(rule) => rule.types_info(),
+            Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.types_info(),
             Self::ReactNoReactChildren(rule) => rule.types_info(),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.types_info(),
             Self::ReactNoRenderReturnValue(rule) => rule.types_info(),
@@ -24371,6 +24403,7 @@ impl RuleEnum {
             Self::ReactNoIsMounted(rule) => rule.run_info(),
             Self::ReactNoMultiComp(rule) => rule.run_info(),
             Self::ReactNoNamespace(rule) => rule.run_info(),
+            Self::ReactNoObjectTypeAsDefaultProp(rule) => rule.run_info(),
             Self::ReactNoReactChildren(rule) => rule.run_info(),
             Self::ReactNoRedundantShouldComponentUpdate(rule) => rule.run_info(),
             Self::ReactNoRenderReturnValue(rule) => rule.run_info(),
@@ -25262,6 +25295,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactNoIsMounted(ReactNoIsMounted::default()),
         RuleEnum::ReactNoMultiComp(ReactNoMultiComp::default()),
         RuleEnum::ReactNoNamespace(ReactNoNamespace::default()),
+        RuleEnum::ReactNoObjectTypeAsDefaultProp(ReactNoObjectTypeAsDefaultProp::default()),
         RuleEnum::ReactNoReactChildren(ReactNoReactChildren::default()),
         RuleEnum::ReactNoRedundantShouldComponentUpdate(
             ReactNoRedundantShouldComponentUpdate::default(),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -439,6 +439,7 @@ pub(crate) mod react {
     pub mod no_is_mounted;
     pub mod no_multi_comp;
     pub mod no_namespace;
+    pub mod no_object_type_as_default_prop;
     pub mod no_react_children;
     pub mod no_redundant_should_component_update;
     pub mod no_render_return_value;

--- a/crates/oxc_linter/src/rules/react/no_object_type_as_default_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_object_type_as_default_prop.rs
@@ -249,6 +249,9 @@ fn test() {
         "function Foo({ pattern = /abc/ }) { return <div /> }",
         // JSX element default.
         "function Foo({ icon = <span /> }) { return <div /> }",
+        // JSX fragment default. (eslint-plugin-react v7.37 does not flag this; we do
+        // since fragments create a new reference each render just like JSX elements.)
+        "function Foo({ icon = <></> }) { return <div /> }",
         // Arrow component.
         "const Foo = ({ items = [] }) => <div />;",
         // Function expression component.

--- a/crates/oxc_linter/src/rules/react/no_object_type_as_default_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_object_type_as_default_prop.rs
@@ -1,0 +1,274 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    ast_util::outermost_paren_parent,
+    context::{ContextHost, LintContext},
+    rule::Rule,
+    utils::{is_hoc_call, is_react_component_name},
+};
+
+fn no_object_type_as_default_prop_diagnostic(kind: ForbiddenKind, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Do not use {} as default prop value. Use a stable reference instead.",
+        kind.label()
+    ))
+    .with_help(
+        "Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoObjectTypeAsDefaultProp;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using object, array, function, class, regex, JSX, or `new`-constructed
+    /// values as default values for destructured React component props.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Default values of destructured parameters are evaluated on every render. When the
+    /// default is an object literal, array literal, function expression, class expression,
+    /// regular expression, `new` expression, or JSX element, a new reference is created on
+    /// every render. Passing that fresh reference to child components or hook dependency
+    /// arrays defeats memoization and causes unnecessary re-renders.
+    ///
+    /// Note: you do not need to enable this rule when using React Compiler, since React
+    /// Compiler memoizes default values automatically.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// function Foo({ items = [] }) {
+    ///   return <List items={items} />;
+    /// }
+    ///
+    /// const Bar = ({ config = {} }) => <div data-config={config} />;
+    ///
+    /// function Baz({ onClick = () => {} }) {
+    ///   return <button onClick={onClick} />;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// const DEFAULT_ITEMS = [];
+    /// function Foo({ items = DEFAULT_ITEMS }) {
+    ///   return <List items={items} />;
+    /// }
+    ///
+    /// const Bar = ({ name = "world" }) => <div>{name}</div>;
+    ///
+    /// function Baz({ onClick }) {
+    ///   return <button onClick={onClick} />;
+    /// }
+    /// ```
+    NoObjectTypeAsDefaultProp,
+    react,
+    perf,
+    version = "next",
+);
+
+impl Rule for NoObjectTypeAsDefaultProp {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::AssignmentPattern(assign_pat) = node.kind() else { return };
+
+        let right = assign_pat.right.get_inner_expression();
+        let Some(kind) = forbidden_default_kind(right) else { return };
+
+        if !is_in_component_first_param(node, ctx) {
+            return;
+        }
+
+        ctx.diagnostic(no_object_type_as_default_prop_diagnostic(kind, right.span()));
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ForbiddenKind {
+    Object,
+    Array,
+    Function,
+    Class,
+    New,
+    Regex,
+    Jsx,
+}
+
+impl ForbiddenKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Object => "an object literal",
+            Self::Array => "an array literal",
+            Self::Function => "a function expression",
+            Self::Class => "a class expression",
+            Self::New => "a `new` expression",
+            Self::Regex => "a regular expression literal",
+            Self::Jsx => "a JSX element",
+        }
+    }
+}
+
+fn forbidden_default_kind(expr: &Expression) -> Option<ForbiddenKind> {
+    match expr {
+        Expression::ObjectExpression(_) => Some(ForbiddenKind::Object),
+        Expression::ArrayExpression(_) => Some(ForbiddenKind::Array),
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => {
+            Some(ForbiddenKind::Function)
+        }
+        Expression::ClassExpression(_) => Some(ForbiddenKind::Class),
+        Expression::NewExpression(_) => Some(ForbiddenKind::New),
+        Expression::RegExpLiteral(_) => Some(ForbiddenKind::Regex),
+        Expression::JSXElement(_) | Expression::JSXFragment(_) => Some(ForbiddenKind::Jsx),
+        _ => None,
+    }
+}
+
+/// Returns true when `node` is an `AssignmentPattern` nested inside the destructuring
+/// pattern of the first parameter of a function component.
+fn is_in_component_first_param<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    for ancestor in ctx.nodes().ancestors(node.id()).skip(1) {
+        match ancestor.kind() {
+            AstKind::BindingProperty(_)
+            | AstKind::ObjectPattern(_)
+            | AstKind::ArrayPattern(_)
+            | AstKind::AssignmentPattern(_)
+            | AstKind::BindingRestElement(_) => {}
+            AstKind::FormalParameter(_) => return is_first_param_of_component(ancestor, ctx),
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn is_first_param_of_component<'a>(formal_param_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let AstKind::FormalParameter(this_param) = formal_param_node.kind() else { return false };
+
+    let params_node = ctx.nodes().parent_node(formal_param_node.id());
+    let AstKind::FormalParameters(params) = params_node.kind() else { return false };
+
+    if !params.items.first().is_some_and(|first| std::ptr::eq(first, this_param)) {
+        return false;
+    }
+
+    let func_node = ctx.nodes().parent_node(params_node.id());
+    is_function_component(func_node, ctx)
+}
+
+fn is_function_component<'a>(func_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    match func_node.kind() {
+        AstKind::Function(func) => {
+            if let Some(id) = &func.id
+                && is_react_component_name(&id.name)
+            {
+                return true;
+            }
+            is_in_component_context(func_node, ctx)
+        }
+        AstKind::ArrowFunctionExpression(_) => is_in_component_context(func_node, ctx),
+        _ => false,
+    }
+}
+
+fn is_in_component_context<'a>(func_node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let Some(parent) = outermost_paren_parent(func_node, ctx.semantic()) else { return false };
+
+    match parent.kind() {
+        AstKind::VariableDeclarator(decl) => {
+            decl.id.get_identifier_name().is_some_and(|name| is_react_component_name(&name))
+        }
+        AstKind::CallExpression(call) => {
+            call.callee_name().is_some_and(|name| is_hoc_call(name, ctx))
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Primitive defaults are stable.
+        "function Foo({ name = 'hello' }) { return <div>{name}</div>; }",
+        "function Foo({ count = 0 }) { return <div>{count}</div>; }",
+        "function Foo({ enabled = true }) { return <div /> }",
+        "function Foo({ data = null }) { return <div /> }",
+        "function Foo({ data = undefined }) { return <div /> }",
+        // Identifier references (stable when declared outside the component).
+        "const EMPTY = []; function Foo({ items = EMPTY }) { return <div /> }",
+        // Member access is fine (presumed stable).
+        "function Foo({ items = obj.value }) { return <div /> }",
+        // No destructuring default.
+        "function Foo(props) { return <div>{props.children}</div>; }",
+        "function Foo({ items }) { return <div /> }",
+        // Top-level (non-component) destructuring – should not trigger.
+        "const { items = [] } = obj;",
+        "function notAComponent({ items = [] }) { return items; }",
+        "function lower_case({ items = [] }) { return items; }",
+        // Inner destructure in a variable declaration within a component.
+        "function Foo(props) { const { items = [] } = props; return <div /> }",
+        // Not the first parameter.
+        "function Foo(first, { items = [] }) { return <div /> }",
+        // forwardRef – primitive default is fine.
+        "const Foo = forwardRef(({ name = 'a' }, ref) => <div ref={ref}>{name}</div>);",
+        // memo with primitive default.
+        "const Foo = memo(({ name = 'a' }) => <div>{name}</div>);",
+        // Non-React function (lowercase name) destructuring with object default.
+        "const foo = ({ items = [] }) => items;",
+        // Template literal without expressions.
+        "function Foo({ greeting = `hello` }) { return <div>{greeting}</div>; }",
+    ];
+
+    let fail = vec![
+        // Plain object literal default.
+        "function Foo({ items = {} }) { return <div /> }",
+        // Plain array literal default.
+        "function Foo({ items = [] }) { return <div /> }",
+        // Arrow function default.
+        "function Foo({ onClick = () => {} }) { return <div /> }",
+        // Function expression default.
+        "function Foo({ onClick = function () {} }) { return <div /> }",
+        // Class expression default.
+        "function Foo({ Klass = class {} }) { return <div /> }",
+        // `new` expression default.
+        "function Foo({ items = new Set() }) { return <div /> }",
+        "function Foo({ items = new Map() }) { return <div /> }",
+        // Regex literal default.
+        "function Foo({ pattern = /abc/ }) { return <div /> }",
+        // JSX element default.
+        "function Foo({ icon = <span /> }) { return <div /> }",
+        // Arrow component.
+        "const Foo = ({ items = [] }) => <div />;",
+        // Function expression component.
+        "const Foo = function Foo({ items = [] }) { return <div />; };",
+        // Default parameter inside React.forwardRef.
+        "const Foo = React.forwardRef(({ items = [] }, ref) => <div ref={ref} />);",
+        // Default parameter inside memo.
+        "const Foo = memo(({ items = [] }) => <div />);",
+        // Nested destructuring with object default.
+        "function Foo({ data: { items = [] } }) { return <div /> }",
+        // Whole sub-pattern default.
+        "function Foo({ data = {}, ...rest }) { return <div /> }",
+        // Array destructuring inside object destructuring with default.
+        "function Foo({ data: [first = []] }) { return <div /> }",
+        // Multiple violations in one component.
+        "function Foo({ a = [], b = {} }) { return <div /> }",
+        // Parenthesized object default.
+        "function Foo({ items = ({}) }) { return <div /> }",
+    ];
+
+    Tester::new(NoObjectTypeAsDefaultProp::NAME, NoObjectTypeAsDefaultProp::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_no_object_type_as_default_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_object_type_as_default_prop.snap
@@ -65,6 +65,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
 
+  ⚠ react(no-object-type-as-default-prop): Do not use a JSX element as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:23]
+ 1 │ function Foo({ icon = <></> }) { return <div /> }
+   ·                       ─────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
   ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
    ╭─[no_object_type_as_default_prop.tsx:1:24]
  1 │ const Foo = ({ items = [] }) => <div />;

--- a/crates/oxc_linter/src/snapshots/react_no_object_type_as_default_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_object_type_as_default_prop.snap
@@ -1,0 +1,136 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an object literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:24]
+ 1 │ function Foo({ items = {} }) { return <div /> }
+   ·                        ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:24]
+ 1 │ function Foo({ items = [] }) { return <div /> }
+   ·                        ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use a function expression as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:26]
+ 1 │ function Foo({ onClick = () => {} }) { return <div /> }
+   ·                          ────────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use a function expression as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:26]
+ 1 │ function Foo({ onClick = function () {} }) { return <div /> }
+   ·                          ──────────────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use a class expression as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:24]
+ 1 │ function Foo({ Klass = class {} }) { return <div /> }
+   ·                        ────────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use a `new` expression as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:24]
+ 1 │ function Foo({ items = new Set() }) { return <div /> }
+   ·                        ─────────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use a `new` expression as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:24]
+ 1 │ function Foo({ items = new Map() }) { return <div /> }
+   ·                        ─────────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use a regular expression literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:26]
+ 1 │ function Foo({ pattern = /abc/ }) { return <div /> }
+   ·                          ─────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use a JSX element as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:23]
+ 1 │ function Foo({ icon = <span /> }) { return <div /> }
+   ·                       ────────
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:24]
+ 1 │ const Foo = ({ items = [] }) => <div />;
+   ·                        ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:36]
+ 1 │ const Foo = function Foo({ items = [] }) { return <div />; };
+   ·                                    ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:41]
+ 1 │ const Foo = React.forwardRef(({ items = [] }, ref) => <div ref={ref} />);
+   ·                                         ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:29]
+ 1 │ const Foo = memo(({ items = [] }) => <div />);
+   ·                             ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:32]
+ 1 │ function Foo({ data: { items = [] } }) { return <div /> }
+   ·                                ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an object literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:23]
+ 1 │ function Foo({ data = {}, ...rest }) { return <div /> }
+   ·                       ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:31]
+ 1 │ function Foo({ data: [first = []] }) { return <div /> }
+   ·                               ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:20]
+ 1 │ function Foo({ a = [], b = {} }) { return <div /> }
+   ·                    ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an object literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:28]
+ 1 │ function Foo({ a = [], b = {} }) { return <div /> }
+   ·                            ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
+
+  ⚠ react(no-object-type-as-default-prop): Do not use an object literal as default prop value. Use a stable reference instead.
+   ╭─[no_object_type_as_default_prop.tsx:1:25]
+ 1 │ function Foo({ items = ({}) }) { return <div /> }
+   ·                         ──
+   ╰────
+  help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1534,6 +1534,9 @@
         "react/no-namespace": {
           "$ref": "#/definitions/DummyRule"
         },
+        "react/no-object-type-as-default-prop": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "react/no-react-children": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1538,6 +1538,9 @@ expression: json
         "react/no-namespace": {
           "$ref": "#/definitions/DummyRule"
         },
+        "react/no-object-type-as-default-prop": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "react/no-react-children": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
> [!NOTE]
>
> **AI disclosure**: Claude Opus 4.7 authored all code changes. I reviewed all of them.

This PR implements [react/no-object-type-as-default-prop](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-object-type-as-default-prop.md). That was the only missing piece when I migrated from ESLint 😀

Related: #1022 

## Difference from `eslint-plugin-react`

As a result of pursuing the best possible implementation, it diverges from `eslint-plugin-react`'s in the following ways.

If we should strictly match the `eslint-plugin-react` behavior, I'm happy to revise the implementation.

### 1. Flags JSX Fragment as object type

```jsx
// Flagged by ours, not by eslint-plugin-react
function Foo({ icon = <></> }) { return <div /> }
```

### 2. Flags wrapped components

```jsx
// Flagged by ours, not by eslint-plugi-react
const Foo = React.forwardRef(({ items = [] }, ref) => <div ref={ref} />);
```