### PR TITLE
feat(linter/no-underscore-dangle): add `allowInUsingDeclarations` option

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         BindingIdentifier, Expression, FunctionType, PrivateFieldExpression, PropertyKey,
-        StaticMemberExpression,
+        StaticMemberExpression, VariableDeclarationKind,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -42,6 +42,8 @@ pub struct NoUnderscoreDangleConfig {
     allow_in_object_destructuring: bool,
     /// Whether to allow dangling underscores in function parameter names.
     allow_function_params: bool,
+    /// Whether to allow dangling underscores in `using` and `await using` declarations.
+    allow_after_using: bool,
     /// Whether to enforce dangling underscores in class field names.
     enforce_in_class_fields: bool,
     /// Whether to enforce dangling underscores in method names.
@@ -69,6 +71,7 @@ impl Default for NoUnderscoreDangleConfig {
             allow_in_array_destructuring: true,
             allow_in_object_destructuring: true,
             allow_function_params: true,
+            allow_after_using: false,
             enforce_in_class_fields: false,
             enforce_in_method_names: false,
         }
@@ -139,6 +142,7 @@ enum BindingContext {
     ArrayDestructure,
     ObjectDestructure,
     FunctionParam,
+    Using,
     Plain,
     NotInteresting,
 }
@@ -191,6 +195,7 @@ impl NoUnderscoreDangle {
             BindingContext::ArrayDestructure => self.allow_in_array_destructuring,
             BindingContext::ObjectDestructure => self.allow_in_object_destructuring,
             BindingContext::FunctionParam => self.allow_function_params,
+            BindingContext::Using => self.allow_after_using,
             BindingContext::Plain => false,
             BindingContext::NotInteresting => return,
         };
@@ -224,8 +229,15 @@ fn binding_context(ctx: &LintContext, id: NodeId) -> BindingContext {
                     BindingContext::FunctionParam
                 };
             }
-            AstKind::VariableDeclarator(_) => {
-                return destructure_context.unwrap_or(BindingContext::Plain);
+            AstKind::VariableDeclarator(declarator) => {
+                return if matches!(
+                    declarator.kind,
+                    VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing
+                ) {
+                    BindingContext::Using
+                } else {
+                    destructure_context.unwrap_or(BindingContext::Plain)
+                };
             }
             _ => return BindingContext::NotInteresting,
         }
@@ -388,6 +400,14 @@ fn test() {
         ("import('foo.json', { _with: { _type } })", None),         // { "ecmaVersion": 2025 }
         ("const o = { _foo: 'bar' }", Some(serde_json::json!([{ "enforceInMethodNames": true }]))), // { "ecmaVersion": 6 },
         (
+            "using _guard = enterCriticalSection();",
+            Some(serde_json::json!([{ "allowAfterUsing": true }])),
+        ),
+        (
+            "async function foo() { await using _guard = enterCriticalSection(); }",
+            Some(serde_json::json!([{ "allowAfterUsing": true }])),
+        ),
+        (
             "function foo([_bar]) {}",
             Some(serde_json::json!([{ "allowInArrayDestructuring": false }])),
         ), // { "ecmaVersion": 6 },
@@ -515,6 +535,11 @@ fn test() {
         ("class foo { #field_; }", Some(serde_json::json!([{ "enforceInClassFields": true }]))), // { "ecmaVersion": 2022 },
         ("var __filename = 1;", None),
         ("class Foo { #_x; foo() { this.#_x; } }", None),
+        ("using _guard = enterCriticalSection();", None),
+        (
+            "using guard_ = enterCriticalSection();",
+            Some(serde_json::json!([{ "allowAfterUsing": false }])),
+        ),
     ];
 
     Tester::new(NoUnderscoreDangle::NAME, NoUnderscoreDangle::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -230,10 +230,7 @@ fn binding_context(ctx: &LintContext, id: NodeId) -> BindingContext {
                 };
             }
             AstKind::VariableDeclarator(declarator) => {
-                return if matches!(
-                    declarator.kind,
-                    VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing
-                ) {
+                return if declarator.kind.is_using() {
                     BindingContext::Using
                 } else {
                     destructure_context.unwrap_or(BindingContext::Plain)

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -43,7 +43,7 @@ pub struct NoUnderscoreDangleConfig {
     /// Whether to allow dangling underscores in function parameter names.
     allow_function_params: bool,
     /// Whether to allow dangling underscores in `using` and `await using` declarations.
-    allow_after_using: bool,
+    allow_in_using_declarations: bool,
     /// Whether to enforce dangling underscores in class field names.
     enforce_in_class_fields: bool,
     /// Whether to enforce dangling underscores in method names.
@@ -71,7 +71,7 @@ impl Default for NoUnderscoreDangleConfig {
             allow_in_array_destructuring: true,
             allow_in_object_destructuring: true,
             allow_function_params: true,
-            allow_after_using: false,
+            allow_in_using_declarations: false,
             enforce_in_class_fields: false,
             enforce_in_method_names: false,
         }
@@ -195,7 +195,7 @@ impl NoUnderscoreDangle {
             BindingContext::ArrayDestructure => self.allow_in_array_destructuring,
             BindingContext::ObjectDestructure => self.allow_in_object_destructuring,
             BindingContext::FunctionParam => self.allow_function_params,
-            BindingContext::Using => self.allow_after_using,
+            BindingContext::Using => self.allow_in_using_declarations,
             BindingContext::Plain => false,
             BindingContext::NotInteresting => return,
         };
@@ -398,11 +398,11 @@ fn test() {
         ("const o = { _foo: 'bar' }", Some(serde_json::json!([{ "enforceInMethodNames": true }]))), // { "ecmaVersion": 6 },
         (
             "using _guard = enterCriticalSection();",
-            Some(serde_json::json!([{ "allowAfterUsing": true }])),
+            Some(serde_json::json!([{ "allowInUsingDeclarations": true }])),
         ),
         (
             "async function foo() { await using _guard = enterCriticalSection(); }",
-            Some(serde_json::json!([{ "allowAfterUsing": true }])),
+            Some(serde_json::json!([{ "allowInUsingDeclarations": true }])),
         ),
         (
             "function foo([_bar]) {}",
@@ -535,7 +535,7 @@ fn test() {
         ("using _guard = enterCriticalSection();", None),
         (
             "using guard_ = enterCriticalSection();",
-            Some(serde_json::json!([{ "allowAfterUsing": false }])),
+            Some(serde_json::json!([{ "allowInUsingDeclarations": false }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         BindingIdentifier, Expression, FunctionType, PrivateFieldExpression, PropertyKey,
-        StaticMemberExpression, VariableDeclarationKind,
+        StaticMemberExpression,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;

--- a/crates/oxc_linter/src/snapshots/eslint_no_underscore_dangle.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_underscore_dangle.snap
@@ -337,3 +337,17 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ───
    ╰────
   help: Remove the dangling '_' or add `_x` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`_guard`'.
+   ╭─[no_underscore_dangle.tsx:1:7]
+ 1 │ using _guard = enterCriticalSection();
+   ·       ──────
+   ╰────
+  help: Remove the dangling '_' or add `_guard` to the 'allow' configuration.
+
+  ⚠ eslint(no-underscore-dangle): Unexpected dangling '_' in '`guard_`'.
+   ╭─[no_underscore_dangle.tsx:1:7]
+ 1 │ using guard_ = enterCriticalSection();
+   ·       ──────
+   ╰────
+  help: Remove the dangling '_' or add `guard_` to the 'allow' configuration.


### PR DESCRIPTION
## Summary

- add an `allowAfterUsing` option to `eslint/no-underscore-dangle`
- treat `using` and `await using` declarators as their own binding context
- add pass/fail coverage and update the rule snapshot

Fixes #22322.

## Test Plan

- `cargo fmt --package oxc_linter`
- `cargo lintgen`
- `cargo test -p oxc_linter no_underscore_dangle::test -- --nocapture`

## AI usage disclosure

This PR was prepared with assistance from Hermes Agent. I reviewed the diff and test results before submission.
