### PR TITLE
test(linter): Add a few more test cases on `eslint/no-loop-func`.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loop_func.rs
@@ -638,6 +638,8 @@ fn test() {
                   };
                 }
                   ",
+        // Function in the for-update slot is not in the loop body.
+        "for (var i = 0; i < l; i++, (function () { i; })()) { }",
     ];
 
     let fail = vec![
@@ -876,6 +878,31 @@ fn test() {
                 })();
             }
             ",
+        // Multiple sibling functions in one loop body — all must be reported.
+        "for (var i = 0; i < 5; i++) {
+            (function () { return i; });
+            (function () { return i + 1; });
+            (() => i);
+        }",
+        // Function nested inside switch/if/try inside a loop body — descendant walk
+        // must reach it.
+        "for (var i = 0; i < 5; i++) {
+            if (cond) {
+                try {
+                    arr.push(function () { return i; });
+                } catch (e) {}
+            } else {
+                switch (k) {
+                    case 1:
+                        arr.push(() => i);
+                }
+            }
+        }",
+        // do-while body comes before the test in source; multiple statements in body.
+        "var i = 0; do {
+            arr.push(function () { return i; });
+            arr.push(() => i);
+        } while (i++ < 5);",
     ];
 
     Tester::new(NoLoopFunc::NAME, NoLoopFunc::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_loop_func.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_loop_func.snap
@@ -379,3 +379,66 @@ source: crates/oxc_linter/src/tester.rs
  10 │                 }
     ╰────
   help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:2:14]
+ 1 │ for (var i = 0; i < 5; i++) {
+ 2 │             (function () { return i; });
+   ·              ─────────────────────────
+ 3 │             (function () { return i + 1; });
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:3:14]
+ 2 │             (function () { return i; });
+ 3 │             (function () { return i + 1; });
+   ·              ─────────────────────────────
+ 4 │             (() => i);
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:4:14]
+ 3 │             (function () { return i + 1; });
+ 4 │             (() => i);
+   ·              ───────
+ 5 │         }
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:4:30]
+ 3 │                 try {
+ 4 │                     arr.push(function () { return i; });
+   ·                              ─────────────────────────
+ 5 │                 } catch (e) {}
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+    ╭─[no_loop_func.tsx:9:34]
+  8 │                     case 1:
+  9 │                         arr.push(() => i);
+    ·                                  ───────
+ 10 │                 }
+    ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:2:22]
+ 1 │ var i = 0; do {
+ 2 │             arr.push(function () { return i; });
+   ·                      ─────────────────────────
+ 3 │             arr.push(() => i);
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.
+
+  ⚠ eslint(no-loop-func): Function declared in a loop contains unsafe references to variable(s)
+   ╭─[no_loop_func.tsx:3:22]
+ 2 │             arr.push(function () { return i; });
+ 3 │             arr.push(() => i);
+   ·                      ───────
+ 4 │         } while (i++ < 5);
+   ╰────
+  help: Variables declared with 'var' are function-scoped, not block-scoped. Consider using 'let' or 'const' for block-scoped variables, or move the function outside the loop.


### PR DESCRIPTION
From the optimization PR I closed earlier, I've confirmed in the ESLint playground that each of these pass/fail accordingly.