### PR TITLE
perf(oxlint): align walker thread count with rayon pool

### DIFF
--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -109,6 +109,8 @@ impl Walk {
         let has_vcs_boundary = all_paths_have_vcs_boundary(paths, cwd);
         let inner = configure_walk_builder(&mut inner, has_vcs_boundary)
             .follow_links(true)
+            // Use the same thread count as rayon (controlled by `--threads`)
+            .threads(rayon::current_num_threads())
             .build_parallel();
         Self { inner, extensions: Extensions::default() }
     }


### PR DESCRIPTION
## Summary

- The file walker (`ignore::WalkParallel`) was using its own default thread count (`available_parallelism()`), independent of rayon's pool size. When users pass `--threads=N` to lower rayon's count, the walker still silently spun up a full background pool, adding kernel pressure during the walk phase.
- This brings oxlint in line with oxfmt, which already does the same: `apps/oxfmt/src/cli/walk.rs:416`.

## Measurement

On a 72k-file repo (rolldown) on M3 Max, 8 runs per config:

| Config | Wall | User | Sys |
|---|---|---|---|
| `--threads=14` (default) before | 3.31 s | 2.50 s | 32.0 s |
| `--threads=14` after | 3.21 s | 2.50 s | 29.4 s |
| `--threads=6` before | 1.36 s | 1.88 s | 5.88 s |
| `--threads=6` after | **1.28 s** | 1.84 s | **3.91 s** |

The win is largest when `--threads` is set below `available_parallelism()`: 33% sys-time reduction at `--threads=6`. At default threads it's a small consistency improvement (no behavior change since both pools were already at the same count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)