### PR TITLE
perf(oxlint, oxfmt): enable mimalloc v3

### DIFF
--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -70,12 +70,13 @@ napi-build = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_arch = "riscv64", target_family = "wasm")))'.dependencies]
-mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
+mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "v3"] }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64"), not(target_arch = "riscv64")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = [
   "skip_collect_on_exit",
   "local_dynamic_tls",
+  "v3",
 ] }
 
 [target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
@@ -83,6 +84,7 @@ mimalloc-safe = { workspace = true, optional = true, features = [
   "skip_collect_on_exit",
   "local_dynamic_tls",
   "no_opt_arch",
+  "v3",
 ] }
 
 [features]

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -60,12 +60,13 @@ tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feat
 tower-lsp-server = { workspace = true, features = ["proposed"] }
 
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_arch = "riscv64", target_family = "wasm")))'.dependencies]
-mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
+mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit", "v3"] }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64"), not(target_arch = "riscv64")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = [
   "skip_collect_on_exit",
   "local_dynamic_tls",
+  "v3",
 ] }
 
 [target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
@@ -73,6 +74,7 @@ mimalloc-safe = { workspace = true, optional = true, features = [
   "skip_collect_on_exit",
   "local_dynamic_tls",
   "no_opt_arch",
+  "v3",
 ] }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary

- Enable the `v3` feature on `mimalloc-safe` for all supported targets in both `apps/oxlint/Cargo.toml` and `apps/oxfmt/Cargo.toml`.
- v3 is the upstream-recommended release line (`v3.3.1`, 2026-04-20). It simplifies the lock-free design of previous versions and improves cross-thread memory sharing.
- rolldown's `rolldown_binding` already ships v3 (`crates/rolldown_binding/Cargo.toml:79`).

## Measurement (rolldown repo, 72k files, M3 Max)

For oxlint/oxfmt's short-lived CLI workloads, v2 and v3 perform within measurement noise. v3 is adopted to stay on the maintained branch and benefit from ongoing fixes (Windows finalization, THP alignment, TLS slot leak fixes, etc.), not for a specific perf win on this workload.

| Tool | v2 | v3 |
|---|---|---|
| oxlint (10 runs) | 3.33 s | 3.14 s |
| oxfmt (5 runs) | 3.60 s | 3.64 s |

Both ranges fully overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

No measurable difference, but it's good to use the latest technology.