### PR TITLE
fix(transformer/typescript): keep enum IIFE when a non-inlinable value reference remains

### DIFF
--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -432,12 +432,21 @@ impl<'a> TypeScriptEnum {
     }
 
     /// Check if an enum declaration can be safely removed (post-inlining).
-    /// Const enums are always removed when `optimize_const_enums` is set.
-    /// Regular enums are removed only if all references were inlined away by `enter_expression`.
+    ///
+    /// The decl is removable when no value references (`Read`/`Write`) remain —
+    /// `enter_expression` inlines member accesses and deletes those references. Type
+    /// references (e.g. from `as E` / `: E`) are kept here and stripped later by
+    /// `annotations.rs`, so they don't block removal.
+    ///
+    /// If a non-inlinable value reference remains (e.g. `export default E`, `E.toString()`),
+    /// we emit the IIFE form so the binding still exists at runtime — matching tsc under
+    /// `--isolatedModules`. Babel drops the declaration in this case, leaving dangling
+    /// references; oxc diverges intentionally to preserve runtime correctness.
     fn can_remove_enum(&self, decl: &TSEnumDeclaration<'a>, ctx: &TraverseCtx<'a>) -> bool {
-        self.may_remove_enum(decl, ctx)
-            && (decl.r#const
-                || ctx.scoping().get_resolved_reference_ids(decl.id.symbol_id()).is_empty())
+        if !self.may_remove_enum(decl, ctx) {
+            return false;
+        }
+        ctx.scoping().get_resolved_references(decl.id.symbol_id()).all(|r| !r.is_value())
     }
 
     /// Check if all members of an enum declaration have known constant values.

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/optimize-const-enums/local/output.mjs
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/optimize-const-enums/local/output.mjs
@@ -1,0 +1,9 @@
+var A = /* @__PURE__ */ function(A) {
+  A[A["x"] = 0] = "x";
+  A[A["y"] = 1] = "y";
+  return A;
+}(A || {});
+0;
+1;
+A.z;
+A;

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/optimize-const-enums/merged/output.mjs
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/optimize-const-enums/merged/output.mjs
@@ -1,0 +1,14 @@
+var A = /* @__PURE__ */ function(A) {
+  A[A["x"] = 0] = "x";
+  A[A["y"] = 1] = "y";
+  return A;
+}(A || {});
+A = /* @__PURE__ */ function(A) {
+  A[A["z"] = 0] = "z";
+  return A;
+}(A || {});
+0;
+1;
+0;
+A.w;
+A;

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -2303,26 +2303,35 @@ x Output mismatch
 x Output mismatch
 
 * optimize-const-enums/local/input.ts
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : <None>
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["A"]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "x", "y"]
+rebuilt        : ScopeId(1): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * optimize-const-enums/merged/input.ts
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : <None>
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["A"]
+Bindings mismatch:
+after transform: ScopeId(1): ["A", "x", "y"]
+rebuilt        : ScopeId(1): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["A", "z"]
+rebuilt        : ScopeId(2): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch for "A":
+after transform: SymbolId(0): [Span { start: 11, end: 12 }, Span { start: 36, end: 37 }]
+rebuilt        : SymbolId(0): []
 
 * optimize-const-enums/merged-exported/input.ts
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 4079bcda
 
-Passed: 236/384
+Passed: 237/386
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -63,7 +63,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (23/58)
+# babel-plugin-transform-typescript (24/60)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]
@@ -117,6 +117,28 @@ rebuilt        : ["Infinity"]
 Unresolved reference IDs mismatch for "Infinity":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(18)]
 rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12)]
+
+* const-enum-mixed-refs/input.ts
+Bindings mismatch:
+after transform: ScopeId(1): ["Phase", "one", "two"]
+rebuilt        : ScopeId(1): ["Phase"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Phase":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+* const-enum-value-ref-kept/input.ts
+Bindings mismatch:
+after transform: ScopeId(1): ["Phase", "one", "two"]
+rebuilt        : ScopeId(1): ["Phase"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Phase":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * elimination-declare/input.ts
 Bindings mismatch:
@@ -525,20 +547,6 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "B":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-
-* optimize-enums/type-cast/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["Direction", "Down", "Up"]
-rebuilt        : ScopeId(1): ["Direction"]
-Scope flags mismatch:
-after transform: ScopeId(1): ScopeFlags(0x0)
-rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol flags mismatch for "Direction":
-after transform: SymbolId(0): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Direction":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(1), ReferenceId(7), ReferenceId(3), ReferenceId(14)]
-rebuilt        : SymbolId(0): [ReferenceId(5)]
 
 * optimize-enums/typeof-kept/input.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-mixed-refs/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-mixed-refs/input.ts
@@ -1,0 +1,10 @@
+// Member accesses are inlined; the bare value reference forces the IIFE
+// to be kept so the runtime binding still exists.
+const enum Phase {
+  one = "one",
+  two = "two",
+}
+
+const a = Phase.one;
+const b = Phase.two;
+const c = Phase;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-mixed-refs/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-mixed-refs/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-typescript", { "optimizeConstEnums": true }]]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-mixed-refs/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-mixed-refs/output.js
@@ -1,0 +1,8 @@
+var Phase = /* @__PURE__ */ function(Phase) {
+  Phase["one"] = "one";
+  Phase["two"] = "two";
+  return Phase;
+}(Phase || {});
+const a = "one";
+const b = "two";
+const c = Phase;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-value-ref-kept/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-value-ref-kept/input.ts
@@ -1,0 +1,9 @@
+// `export default <enum>` is a bare value reference that can't be inlined.
+// The IIFE form must be emitted so the binding still exists at runtime,
+// otherwise the export resolves to `undefined`/ReferenceError.
+const enum Phase {
+  one = "one",
+  two = "two",
+}
+
+export default Phase;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-value-ref-kept/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-value-ref-kept/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-typescript", { "optimizeConstEnums": true }]]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-value-ref-kept/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-value-ref-kept/output.js
@@ -1,0 +1,6 @@
+var Phase = /* @__PURE__ */ function(Phase) {
+  Phase["one"] = "one";
+  Phase["two"] = "two";
+  return Phase;
+}(Phase || {});
+export default Phase;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/optimize-enums/type-cast/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/optimize-enums/type-cast/output.js
@@ -1,8 +1,3 @@
-var Direction = /* @__PURE__ */ function(Direction) {
-  Direction[Direction["Up"] = 0] = "Up";
-  Direction[Direction["Down"] = 1] = "Down";
-  return Direction;
-}(Direction || {});
 0;
 1;
 0;


### PR DESCRIPTION
Refs vitejs/vite#22452 (comment).

The optimize pass dropped the enum declaration whenever the members were all evaluable — regardless of whether some non-inlinable value reference still named the enum at runtime. The result referenced a binding that no longer existed:

```ts
const enum Phase { one = 'one' }
export default Phase;
// -> export default Phase;  // ReferenceError at runtime

enum Direction { Up }
Direction.Up.toString();
// -> Direction.Up.toString();  // ReferenceError at runtime
```

## Fix

Decide based on the remaining resolved references: drop only when none of them is a value reference (`Read`/`Write`). Type references (`as E`, `: E`) are kept here and stripped later by `annotations.rs`, so they don't block removal. `typeof E` in JS expression position is `Read` and correctly keeps the IIFE; `typeof E` in TS type position is `ValueAsType` (not in `Value`) and doesn't.

Unifies the rule for regular and const enums — the previous asymmetry (const always dropped, regular dropped only when no refs at all) had no principled basis.

## Compatibility

Diverges from Babel on two `optimize-const-enums/*` fixtures where the input has a bare value reference to the enum that we can't inline. Three engines disagree on what to do:

| Engine | Inline `E.X` member accesses | Preserve `E` binding (IIFE) | Result for `E.unknown` / bare `E` |
|---|---|---|---|
| Babel `transform-typescript` (optimize-const-enums) | yes | **no** | runtime ReferenceError / TypeError |
| tsc `--isolatedModules` | no | yes | `undefined` / resolves |
| oxc after this PR | yes | yes | `undefined` / resolves |

We now hybridize: inline what's inlinable (Babel) **and** keep the binding (tsc). Local overrides under `tasks/transform_conformance/overrides/` record the new expected output for the two affected Babel fixtures.

### `optimize-const-enums/local`

Input:

```ts
const enum A {
  x, y
}

A.x;
A["y"];
A.z;
A;
```

Babel (and oxc before this PR):

```js
0;
1;
A.z;
A;
```

`A.z` is `TypeError: cannot read properties of undefined`; `A;` is `ReferenceError`.

tsc (`--isolatedModules`):

```js
var A;
(function (A) {
    A[A["x"] = 0] = "x";
    A[A["y"] = 1] = "y";
})(A || (A = {}));
A.x;
A["y"];
A.z;
A;
```

Keeps the IIFE binding, no member-access inlining. `A.z` evaluates to `undefined`; `A;` is a no-op.

oxc after this PR (`overrides/.../optimize-const-enums/local/output.mjs`):

```js
var A = /* @__PURE__ */ function(A) {
  A[A["x"] = 0] = "x";
  A[A["y"] = 1] = "y";
  return A;
}(A || {});
0;
1;
A.z;
A;
```

Hybrid: inlines `A.x` / `A["y"]` like Babel, **and** keeps the IIFE binding like tsc — so `A.z` evaluates to `undefined` (not crash) and `A;` resolves.

### `optimize-const-enums/merged`

Input:

```ts
const enum A {
  x, y
}

const enum A {
  z
}

A.x;
A["y"];
A.z;
A.w;
A;
```

Babel (and oxc before this PR):

```js
0;
1;
0;
A.w;
A;
```

`A.w` is `TypeError: cannot read properties of undefined`; `A;` is `ReferenceError`.

tsc (`--isolatedModules`):

```js
var A;
(function (A) {
    A[A["x"] = 0] = "x";
    A[A["y"] = 1] = "y";
})(A || (A = {}));
(function (A) {
    A[A["z"] = 0] = "z";
})(A || (A = {}));
A.x;
A["y"];
A.z;
A.w;
A;
```

Both IIFEs emitted, no inlining. `A.w` is `undefined`; `A;` resolves.

oxc after this PR (`overrides/.../optimize-const-enums/merged/output.mjs`):

```js
var A = /* @__PURE__ */ function(A) {
  A[A["x"] = 0] = "x";
  A[A["y"] = 1] = "y";
  return A;
}(A || {});
A = /* @__PURE__ */ function(A) {
  A[A["z"] = 0] = "z";
  return A;
}(A || {});
0;
1;
0;
A.w;
A;
```

Hybrid: both enum bodies lower (the second reuses the first's binding via `A = (function(A) { … })(A || {})` — assignment, not `var`) **and** members are inlined like Babel. `A.w` evaluates to `undefined`; `A;` resolves.

## Verification

New fixtures cover the bug shapes:
- `babel-plugin-transform-typescript/const-enum-value-ref-kept/` — `export default Phase`
- `babel-plugin-transform-typescript/const-enum-mixed-refs/` — member access + bare ref combined

Existing `optimize-enums/type-cast` updated to drop the IIFE for the all-type-refs case (the regular-enum side of the unified rule).
