### PR TITLE
fix(transformer/async-to-generator): move only parameter bindings

### DIFF
--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -918,6 +918,30 @@ impl<'a, 'ctx> BindingMover<'a, 'ctx> {
 }
 
 impl<'a> Visit<'a> for BindingMover<'a, '_> {
+    fn visit_formal_parameter(&mut self, param: &FormalParameter<'a>) {
+        // Only move the parameter binding itself; initializer expressions can contain their own
+        // function/class scopes whose bindings must stay where semantic analysis placed them.
+        self.visit_binding_pattern(&param.pattern);
+    }
+
+    fn visit_formal_parameter_rest(&mut self, param: &FormalParameterRest<'a>) {
+        // Rest parameters have no initializer, so the binding rest element is the only binding
+        // position that needs to be moved.
+        self.visit_binding_rest_element(&param.rest);
+    }
+
+    fn visit_assignment_pattern(&mut self, pattern: &AssignmentPattern<'a>) {
+        // Default values are expressions, not parameter bindings. Visiting only the left-hand side
+        // avoids moving bindings declared inside the initializer expression.
+        self.visit_binding_pattern(&pattern.left);
+    }
+
+    fn visit_binding_property(&mut self, property: &BindingProperty<'a>) {
+        // Computed keys are expressions and can contain their own scopes. Only the property value
+        // is a binding position.
+        self.visit_binding_pattern(&property.value);
+    }
+
     /// Visits a binding identifier and moves it to the target scope.
     fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
         let symbol_id = ident.symbol_id();

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -618,24 +618,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -646,38 +637,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-throws.js
 Scope parent mismatch:
@@ -690,24 +663,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -718,38 +682,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-ary-empty-init.js
 Scope parent mismatch:
@@ -772,24 +718,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -800,38 +737,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-throws.js
 Scope parent mismatch:
@@ -844,24 +763,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -872,38 +782,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-init-iter-close.js
 Scope flags mismatch:
@@ -995,15 +887,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(10): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(4): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(6): Some(ScopeId(4))
@@ -1013,9 +899,6 @@ rebuilt        : ScopeId(7): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(10)
-rebuilt        : SymbolId(10): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -1035,18 +918,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(8): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(4): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -1056,23 +933,14 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(8): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(4): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -1082,9 +950,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-hole.js
 Scope flags mismatch:
@@ -1651,15 +1516,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(10): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(4): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(6): Some(ScopeId(4))
@@ -1669,9 +1528,6 @@ rebuilt        : ScopeId(7): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(10)
-rebuilt        : SymbolId(10): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -1691,18 +1547,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(8): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(4): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -1712,23 +1562,14 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(8): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(4): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -1738,9 +1579,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-skipped.js
 Scope flags mismatch:
@@ -1935,15 +1773,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(9): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(3): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(3))
@@ -1953,9 +1785,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(9)
-rebuilt        : SymbolId(9): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -1975,18 +1804,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(7): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(3): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -1996,23 +1819,14 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(8): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(7): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(3): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -2022,9 +1836,6 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(8): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-hole.js
 Scope flags mismatch:
@@ -2591,15 +2402,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(9): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(3): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(3))
@@ -2609,9 +2414,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(9)
-rebuilt        : SymbolId(9): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -2631,18 +2433,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(7): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(3): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -2652,23 +2448,14 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(8): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(7): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(3): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -2678,9 +2465,6 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(8): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-skipped.js
 Scope flags mismatch:
@@ -6519,24 +6303,15 @@ after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(7): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(1): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(1))
 rebuilt        : ScopeId(4): Some(ScopeId(1))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(7)
-rebuilt        : SymbolId(6): ScopeId(3)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -6547,38 +6322,20 @@ after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(5): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(1): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(5)
-rebuilt        : SymbolId(5): ScopeId(3)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(5): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(1): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(5)
-rebuilt        : SymbolId(5): ScopeId(3)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-throws.js
 Scope parent mismatch:
@@ -6591,24 +6348,15 @@ after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(7): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(1): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(1))
 rebuilt        : ScopeId(4): Some(ScopeId(1))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(7)
-rebuilt        : SymbolId(6): ScopeId(3)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -6619,38 +6367,20 @@ after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(5): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(1): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(5)
-rebuilt        : SymbolId(5): ScopeId(3)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(5): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(1): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(2): Some(ScopeId(1))
 rebuilt        : ScopeId(2): Some(ScopeId(1))
-Bindings mismatch:
-after transform: ScopeId(3): []
-rebuilt        : ScopeId(3): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(1))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(5)
-rebuilt        : SymbolId(5): ScopeId(3)
 
 semantic Error: tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-meth-eval-var-scope-syntax-err.js
 Scope flags mismatch:
@@ -6930,24 +6660,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -6958,38 +6679,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-throws.js
 Scope parent mismatch:
@@ -7002,24 +6705,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -7030,38 +6724,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-ary-empty-init.js
 Scope parent mismatch:
@@ -7084,24 +6760,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -7112,38 +6779,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-throws.js
 Scope parent mismatch:
@@ -7156,24 +6805,15 @@ after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(8): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(2))
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(8)
-rebuilt        : SymbolId(6): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-cover.js
 Scope parent mismatch:
@@ -7184,38 +6824,20 @@ after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(6): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(2): ["fn", "xFn"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(6): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(2): ["gen", "xGen"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(3): Some(ScopeId(2))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(4): ["x"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(2))
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(6)
-rebuilt        : SymbolId(5): ScopeId(4)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-init-iter-close.js
 Scope flags mismatch:
@@ -7307,15 +6929,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(10): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(4): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(6): Some(ScopeId(4))
@@ -7325,9 +6941,6 @@ rebuilt        : ScopeId(7): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(10)
-rebuilt        : SymbolId(10): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -7347,18 +6960,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(8): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(4): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -7368,23 +6975,14 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(8): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(4): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -7394,9 +6992,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-hole.js
 Scope flags mismatch:
@@ -7963,15 +7558,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(10): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(4): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(6): Some(ScopeId(4))
@@ -7981,9 +7570,6 @@ rebuilt        : ScopeId(7): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(10)
-rebuilt        : SymbolId(10): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -8003,18 +7589,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(8): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(4): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -8024,23 +7604,14 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(8): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(4): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(4))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(6): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -8050,9 +7621,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(4))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(8)
-rebuilt        : SymbolId(9): ScopeId(6)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-skipped.js
 Scope flags mismatch:
@@ -8247,15 +7815,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(9): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(3): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(3))
@@ -8265,9 +7827,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(9)
-rebuilt        : SymbolId(8): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -8287,18 +7846,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(7): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(3): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -8308,23 +7861,14 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(7): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(7): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(3): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -8334,9 +7878,6 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(7): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-hole.js
 Scope flags mismatch:
@@ -8903,15 +8444,9 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
-Bindings mismatch:
-after transform: ScopeId(9): ["X", "cls", "xCls", "xCls2"]
-rebuilt        : ScopeId(3): ["cls", "xCls", "xCls2"]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["X"]
 Scope parent mismatch:
 after transform: ScopeId(4): Some(ScopeId(2))
 rebuilt        : ScopeId(5): Some(ScopeId(3))
@@ -8921,9 +8456,6 @@ rebuilt        : ScopeId(6): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Symbol scope ID mismatch for "X":
-after transform: SymbolId(5): ScopeId(9)
-rebuilt        : SymbolId(8): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-cover.js
 Scope flags mismatch:
@@ -8943,18 +8475,12 @@ after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
-Bindings mismatch:
-after transform: ScopeId(7): ["fn", "x", "xFn"]
-rebuilt        : ScopeId(3): ["fn", "xFn"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -8964,23 +8490,14 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(7): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
-Bindings mismatch:
-after transform: ScopeId(7): ["gen", "x", "xGen"]
-rebuilt        : ScopeId(3): ["gen", "xGen"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
-Bindings mismatch:
-after transform: ScopeId(4): []
-rebuilt        : ScopeId(5): ["x"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -8990,9 +8507,6 @@ rebuilt        : ScopeId(5): Some(ScopeId(3))
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol scope ID mismatch for "x":
-after transform: SymbolId(4): ScopeId(7)
-rebuilt        : SymbolId(7): ScopeId(5)
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-skipped.js
 Scope flags mismatch:

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 4079bcda
 
-Passed: 234/381
+Passed: 234/382
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -11,7 +11,6 @@ Passed: 234/381
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-async-generator-functions
 * babel-plugin-transform-object-rest-spread
-* babel-plugin-transform-async-to-generator
 * babel-plugin-transform-exponentiation-operator
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
@@ -61,6 +60,13 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(8), R
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9), ReferenceId(12)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
+
+
+# babel-plugin-transform-async-to-generator (27/28)
+* class/computed-key-binding/input.js
+Scope parent mismatch:
+after transform: ScopeId(3): Some(ScopeId(2))
+rebuilt        : ScopeId(3): Some(ScopeId(2))
 
 
 # babel-plugin-transform-typescript (22/56)

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/computed-key-binding/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/computed-key-binding/input.js
@@ -1,0 +1,3 @@
+class C {
+  async method({ [function y() {}]: x }) {}
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/computed-key-binding/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/computed-key-binding/output.js
@@ -1,0 +1,7 @@
+class C {
+  method({
+    [function y() {}]: x
+  }) {
+    return babelHelpers.asyncToGenerator(function* () {})();
+  }
+}


### PR DESCRIPTION
Previously, given:

```js
class C {
  async method(x = function y() {}) {}
}
```

The async-to-generator transform generates:

```js
class C {
  method(x = function y() {}) {
    return babelHelpers.asyncToGenerator(function* () {})();
  }
}
```

The method parameter stays on the outer wrapper method, while only the original body moves into the inner generator function.

Before this change, `BindingMover` walked the full parameter AST while moving those parameter bindings. That meant it also visited default initializer expressions, so bindings created inside the initializer, like `y` above, could be moved out of their own function/class scope and into the wrapper method scope.

After transform, rebuilt semantics would disagree with the transformed scope tree because the parameter binding was correct, but nested initializer bindings had the wrong owning scope.

This PR makes `BindingMover` only visit the binding positions for formal parameters, rest parameters, and the left side of assignment patterns. It skips initializer expressions so nested function/class bindings stay in the scopes created for those expressions.