### PR TITLE
docs(linter): exclude directly provide autoFocus to dialog pattern

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -64,11 +64,8 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     /// ```jsx
     /// <div />
-    /// <dialog autoFocus />
     /// <dialog><input autoFocus /></dialog>
-    /// <div role="dialog" autoFocus />
     /// <div role="dialog"><input autoFocus /></div>
-    /// <div popover autoFocus />
     /// <div popover><input autoFocus /></div>
     /// ```
     NoAutofocus,


### PR DESCRIPTION
I forgot to exclude `<dialog autoFocus />` from correct pattern docs, so I removed them.
ref: https://github.com/oxc-project/oxc/pull/22289