### PR TITLE
refactor(formatter/sort_imports): Wrap every `Comment` with label

### DIFF
--- a/crates/oxc_formatter/src/formatter/jsdoc/serialize.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/serialize.rs
@@ -9,7 +9,7 @@ use crate::external_formatter::ExternalCallbacks;
 use crate::formatter::Formatter;
 use crate::formatter::prelude::*;
 use crate::options::{JsdocOptions, QuoteStyle};
-use crate::{FormatOptions, JsLabels, write};
+use crate::{FormatOptions, write};
 
 use super::{
     imports::process_import_tags, line_buffer::LineBuffer,
@@ -35,15 +35,6 @@ impl<'a> Format<'a> for FormattedJsdoc<'a> {
                 write!(f, [token("/**"), " ", text(content), " ", token("*/")]);
             }
             FormattedJsdoc::MultiLine(content_str) => {
-                // Wrap with `JsLabels::AlignableBlockComment` so the sort-imports IR transform
-                // suppresses the internal `hard_line_break()`s and treats the whole block as one line.
-                // Mirrors the unformatted alignable-block path in `trivia.rs`.
-                let sort_imports_enabled = f.options().sort_imports.is_some();
-                if sort_imports_enabled {
-                    f.write_element(FormatElement::Tag(Tag::StartLabelled(LabelId::of(
-                        JsLabels::AlignableBlockComment,
-                    ))));
-                }
                 write!(f, [token("/**")]);
                 for line in content_str.split('\n') {
                     if line.is_empty() {
@@ -53,9 +44,6 @@ impl<'a> Format<'a> for FormattedJsdoc<'a> {
                     }
                 }
                 write!(f, [hard_line_break(), " ", token("*/")]);
-                if sort_imports_enabled {
-                    f.write_element(FormatElement::Tag(Tag::EndLabelled));
-                }
             }
         }
     }

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -418,8 +418,16 @@ impl<'a> Format<'a> for FormatDanglingComments<'a> {
 
 impl<'a> Format<'a> for Comment {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        // Wrap every emitted comment with `JsLabels::Comment` when `sort_imports` is enabled.
+        // So the IR transform can identify comments structurally (without textual prefix checks)
+        // and suppress any internal line breaks (e.g. multi-line block / JSDoc).
+        let wrap = f.options().sort_imports.is_some();
+        if wrap {
+            f.write_element(FormatElement::Tag(Tag::StartLabelled(LabelId::of(JsLabels::Comment))));
+        }
+
         // JSDoc formatting: if enabled, try to format JSDoc comments
-        if self.is_jsdoc()
+        let formatted_jsdoc = if self.is_jsdoc()
             && !self.is_legal()
             && let Some(jsdoc_options) = &f.options().jsdoc
         {
@@ -447,53 +455,45 @@ impl<'a> Format<'a> for Comment {
                     .sum::<usize>()
             };
             let available_width = line_width.saturating_sub(indent_chars);
-            if let Some(formatted) =
-                super::jsdoc::format_jsdoc_comment(self, jsdoc_options, source, available_width, f)
-            {
-                write!(f, [formatted]);
-                return;
+            super::jsdoc::format_jsdoc_comment(self, jsdoc_options, source, available_width, f)
+        } else {
+            None
+        };
+
+        if let Some(formatted) = formatted_jsdoc {
+            write!(f, [formatted]);
+        } else {
+            let content = f.source_text().text_for(&self.span);
+            if self.is_multiline_block() {
+                let mut lines = LineTerminatorSplitter::new(content);
+                if is_alignable_comment(content) {
+                    // `unwrap` is safe because `content` contains at least one line.
+                    let first_line = lines.next().unwrap();
+                    write!(f, [text(first_line.trim_end())]);
+
+                    // Indent the remaining lines by one space so that all `*` are aligned.
+                    for line in lines {
+                        write!(f, [hard_line_break(), " ", text(line.trim())]);
+                    }
+                } else {
+                    // Normalize line endings `\r\n` to `\n`
+                    let mut string = StringBuilder::with_capacity_in(content.len(), f.allocator());
+                    // `unwrap` is safe because `content` contains at least one line.
+                    string.push_str(lines.next().unwrap().trim_end());
+
+                    for str in lines {
+                        string.push('\n');
+                        string.push_str(str);
+                    }
+                    write!(f, [text(string.into_str())]);
+                }
+            } else {
+                write!(f, [text(content.trim_end())]);
             }
         }
 
-        let content = f.source_text().text_for(&self.span);
-        if self.is_multiline_block() {
-            let mut lines = LineTerminatorSplitter::new(content);
-            if is_alignable_comment(content) {
-                // Using `write_element` directly instead of `labelled()`
-                // to avoid allocating a `Vec` for `lines` iter
-                let sort_imports_enabled = f.options().sort_imports.is_some();
-                if sort_imports_enabled {
-                    f.write_element(FormatElement::Tag(Tag::StartLabelled(LabelId::of(
-                        JsLabels::AlignableBlockComment,
-                    ))));
-                }
-
-                // `unwrap` is safe because `content` contains at least one line.
-                let first_line = lines.next().unwrap();
-                write!(f, [text(first_line.trim_end())]);
-
-                // Indent the remaining lines by one space so that all `*` are aligned.
-                for line in lines {
-                    write!(f, [hard_line_break(), " ", text(line.trim())]);
-                }
-
-                if sort_imports_enabled {
-                    f.write_element(FormatElement::Tag(Tag::EndLabelled));
-                }
-            } else {
-                // Normalize line endings `\r\n` to `\n`
-                let mut string = StringBuilder::with_capacity_in(content.len(), f.allocator());
-                // `unwrap` is safe because `content` contains at least one line.
-                string.push_str(lines.next().unwrap().trim_end());
-
-                for str in lines {
-                    string.push('\n');
-                    string.push_str(str);
-                }
-                write!(f, [text(string.into_str())]);
-            }
-        } else {
-            write!(f, [text(content.trim_end())]);
+        if wrap {
+            f.write_element(FormatElement::Tag(Tag::EndLabelled));
         }
     }
 }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -102,7 +102,7 @@ fn transform<'a>(
     //   a,
     // } from "foo";
     // ```
-    let mut in_alignable_block_comment = false;
+    let mut inside_comment = false;
     let mut inside_multiline_import = false;
     // Trailing comments emitted via `line_suffix(...)` live inside `StartLineSuffix..End`,
     // and any `Line(_)` inside is for output positioning, not a real line boundary.
@@ -112,8 +112,8 @@ fn transform<'a>(
         if let FormatElement::Tag(tag) = el {
             match tag {
                 Tag::StartLabelled(id) => {
-                    if *id == LabelId::of(JsLabels::AlignableBlockComment) {
-                        in_alignable_block_comment = true;
+                    if *id == LabelId::of(JsLabels::Comment) {
+                        inside_comment = true;
                     } else if *id == LabelId::of(JsLabels::ImportDeclaration) {
                         inside_multiline_import = true;
                     }
@@ -123,8 +123,8 @@ fn transform<'a>(
                 Tag::EndLabelled => {
                     // `EndLabelled` doesn't carry the label ID.
                     // Neither label is expected to nest, so this naive reset is sufficient.
-                    if in_alignable_block_comment {
-                        in_alignable_block_comment = false;
+                    if inside_comment {
+                        inside_comment = false;
                     } else if inside_multiline_import {
                         inside_multiline_import = false;
                     }
@@ -137,7 +137,7 @@ fn transform<'a>(
             && matches!(mode, LineMode::Empty | LineMode::Hard)
         {
             // Don't flush mid-block, the line break is internal to the label.
-            if in_alignable_block_comment || inside_multiline_import || inside_line_suffix {
+            if inside_comment || inside_multiline_import || inside_line_suffix {
                 continue;
             }
 
@@ -162,7 +162,7 @@ fn transform<'a>(
     // so the in-loop flush above won't catch the last line.
     if current_line_start < prev_elements.len() {
         debug_assert!(
-            !in_alignable_block_comment && !inside_multiline_import && !inside_line_suffix,
+            !inside_comment && !inside_multiline_import && !inside_line_suffix,
             "Unbalanced labelled tags at end of chunk"
         );
         lines.push(SourceLine::from_element_range(

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -118,9 +118,10 @@ pub(crate) enum JsLabels {
     /// For `ir_transform/sort_imports`
     ImportDeclaration,
     /// For `ir_transform/sort_imports`
-    /// Marks `alignable_comment` (Block comment where each line starts with `*`)
-    /// to distinguish from other text content like template literals that may contain `/*`.
-    AlignableBlockComment,
+    /// Wraps a single emitted comment so the transform can identify it without
+    /// inspecting element shape (which varies by comment kind / `jsdoc` formatting).
+    /// Also suppresses internal line breaks for multi-line block comments.
+    Comment,
 }
 
 impl Label for JsLabels {
@@ -132,7 +133,7 @@ impl Label for JsLabels {
         match self {
             Self::MemberChain => "MemberChain",
             Self::ImportDeclaration => "ImportDeclaration",
-            Self::AlignableBlockComment => "AlignableBlockComment",
+            Self::Comment => "Comment",
         }
     }
 }


### PR DESCRIPTION
Standardize how the `sort_imports` IR transform identifies comments.

Previously it mixed two strategies:

- a label (`JsLabels::AlignableBlockComment`) for multi-line block comments only
- and a textual prefix check (`text.starts_with("//") || "/*")`) for everything else

The textual path was fragile against IR shapes that don't fit the assumption, formatted JSDoc emitting a `Token`/`Text` mix is the most visible case (see #22486).

This PR unifies both paths under a single label: every emitted comment is wrapped in `JsLabels::Comment`, and classification becomes a pure structural check.