### PR TITLE
fix(parser): break extends clause loop on fatal error

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -171,6 +171,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         loop {
             let span = self.start_span();
             let mut extend = self.parse_lhs_expression_or_higher();
+            if self.fatal_error.is_some() {
+                break;
+            }
             let type_argument;
             if let Expression::TSInstantiationExpression(expr) = extend {
                 let expr = expr.unbox();

--- a/tasks/coverage/misc/fail/oxc-22515.js
+++ b/tasks/coverage/misc/fail/oxc-22515.js
@@ -1,0 +1,1 @@
+class extends,{

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 66/66 (100.00%)
 Positive Passed: 66/66 (100.00%)
-Negative Passed: 136/136 (100.00%)
+Negative Passed: 137/137 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -3482,6 +3482,12 @@ Negative Passed: 136/136 (100.00%)
  1 │ class {}
  2 │ export class {}
    ·        ─────
+   ╰────
+
+  × Unexpected token
+   ╭─[misc/fail/oxc-22515.js:1:14]
+ 1 │ class extends,{
+   ·              ─
    ╰────
 
   × Optional declaration is not allowed here


### PR DESCRIPTION
## Summary

`parse_extends_clause` kept iterating after `parse_lhs_expression_or_higher` set a fatal error, producing a `TSInterfaceHeritage` with an inverted span (`start > end`). `parse_class` then passed that span to `classes_can_only_extend_single_class`, which panicked in `miette` when converting the span to a label (`debug_assert!(self.start <= self.end)` in `Span::size`). Release builds silently produced garbage diagnostics.

Repro from the issue:

```js
class extends,{
```

Closes #22515

🤖 Generated with [Claude Code](https://claude.com/claude-code)