### PR TITLE
fix(parser): avoid duplicate export in top-level await reparse

### DIFF
--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -813,6 +813,9 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         let original_tokens =
             if self.lexer.config.tokens() { Some(self.lexer.take_tokens()) } else { None };
 
+        // Module record already built in the first parse; skip re-recording (#22158).
+        self.module_record_builder.set_suppressed(true);
+
         let checkpoints = std::mem::take(&mut self.state.potential_await_reparse);
         for (stmt_index, checkpoint) in checkpoints {
             // Rewind to the checkpoint
@@ -828,6 +831,8 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
                 statements[stmt_index] = stmt;
             }
         }
+
+        self.module_record_builder.set_suppressed(false);
 
         if let Some(original_tokens) = original_tokens {
             self.lexer.set_tokens(original_tokens);

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -13,6 +13,10 @@ pub struct ModuleRecordBuilder<'a> {
     module_record: ModuleRecord<'a>,
     export_entries: Vec<'a, ExportEntry<'a>>,
     exported_bindings_duplicated: Vec<'a, NameSpan<'a>>,
+    /// When set, `visit_*` calls are ignored. Used while reparsing top-level
+    /// `await` statements in unambiguous mode: the first pass already recorded
+    /// the module record, and reparsing only patches AST nodes.
+    suppressed: bool,
 }
 
 impl<'a> ModuleRecordBuilder<'a> {
@@ -23,7 +27,12 @@ impl<'a> ModuleRecordBuilder<'a> {
             module_record: ModuleRecord::new(allocator),
             export_entries: Vec::new_in(allocator),
             exported_bindings_duplicated: Vec::new_in(allocator),
+            suppressed: false,
         }
+    }
+
+    pub(crate) fn set_suppressed(&mut self, suppressed: bool) {
+        self.suppressed = suppressed;
     }
 
     pub fn build(mut self) -> (ModuleRecord<'a>, std::vec::Vec<OxcDiagnostic>) {
@@ -189,17 +198,26 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     pub fn visit_import_expression(&mut self, e: &ImportExpression<'a>) {
+        if self.suppressed {
+            return;
+        }
         self.module_record
             .dynamic_imports
             .push(DynamicImport { span: e.span, module_request: e.source.span() });
     }
 
     pub fn visit_import_meta(&mut self, span: Span) {
+        if self.suppressed {
+            return;
+        }
         self.module_record.has_module_syntax = true;
         self.module_record.import_metas.push(span);
     }
 
     pub fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        if self.suppressed {
+            return;
+        }
         let module_request = NameSpan::new(decl.source.value, decl.source.span);
 
         if let Some(specifiers) = &decl.specifiers {
@@ -246,6 +264,9 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     pub fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
+        if self.suppressed {
+            return;
+        }
         let module_request = NameSpan::new(decl.source.value, decl.source.span);
         let export_entry = ExportEntry {
             statement_span: decl.span,
@@ -282,6 +303,9 @@ impl<'a> ModuleRecordBuilder<'a> {
         decl: &ExportDefaultDeclaration<'a>,
         default_keyword_span: Span,
     ) {
+        if self.suppressed {
+            return;
+        }
         let local_name = match &decl.declaration {
             ExportDefaultDeclarationKind::Identifier(ident) => {
                 ExportLocalName::Default(NameSpan::new(ident.name.into(), ident.span))
@@ -315,6 +339,9 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     pub fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+        if self.suppressed {
+            return;
+        }
         let module_request =
             decl.source.as_ref().map(|source| NameSpan::new(source.value, source.span));
 

--- a/tasks/coverage/misc/pass/unambiguous-await-export-init.js
+++ b/tasks/coverage/misc/pass/unambiguous-await-export-init.js
@@ -1,0 +1,2 @@
+// In unambiguous mode with ESM syntax, `await` in an exported initializer must not report a duplicate export
+export var x = await + 1;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)
 Negative Passed: 137/137 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 52/66 (78.79%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 53/67 (79.10%)
 semantic Error: tasks/coverage/misc/pass/conditional-arrow-alternate-return-type.ts
 Unresolved references mismatch:
 after transform: ["Pick", "Record"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)


### PR DESCRIPTION
Fixes #22158.

In unambiguous mode, `export var x = await + 1;` reports a false `Duplicated export 'x'` diagnostic. The parser sees top-level `await`, queues a reparse, then re-walks the export statement and registers `x` a second time on the module record.

`ModuleRecordBuilder` now has a `suppressed` flag that returns early from every `visit_*` method, and `reparse_potential_top_level_awaits` sets the flag around its loop so pass 2 updates the AST without re-recording entries the first parse already captured.

AI assisted.
