### PR TITLE
fix(parser): avoid duplicate exports during TLA reparse

### DIFF
--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -813,6 +813,13 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         let original_tokens =
             if self.lexer.config.tokens() { Some(self.lexer.take_tokens()) } else { None };
 
+        // Reparsing only patches AST nodes. Discard module record side effects
+        // so imports/exports collected during the first parse are not duplicated.
+        let module_record_builder = std::mem::replace(
+            &mut self.module_record_builder,
+            ModuleRecordBuilder::new(self.ast.allocator, self.source_type),
+        );
+
         let checkpoints = std::mem::take(&mut self.state.potential_await_reparse);
         for (stmt_index, checkpoint) in checkpoints {
             // Rewind to the checkpoint
@@ -828,6 +835,8 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
                 statements[stmt_index] = stmt;
             }
         }
+
+        self.module_record_builder = module_record_builder;
 
         if let Some(original_tokens) = original_tokens {
             self.lexer.set_tokens(original_tokens);

--- a/tasks/coverage/misc/pass/oxc-22158.js
+++ b/tasks/coverage/misc/pass/oxc-22158.js
@@ -1,0 +1,1 @@
+export var x = await + 1;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)
 Negative Passed: 137/137 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 52/66 (78.79%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 53/67 (79.10%)
 semantic Error: tasks/coverage/misc/pass/conditional-arrow-alternate-return-type.ts
 Unresolved references mismatch:
 after transform: ["Pick", "Record"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 66/66 (100.00%)
-Positive Passed: 66/66 (100.00%)
+AST Parsed     : 67/67 (100.00%)
+Positive Passed: 67/67 (100.00%)


### PR DESCRIPTION
- Avoid recording module import/export side effects during the unambiguous top-level await reparse pass.
- Add a misc parser coverage fixture for the `.js` auto-detect false duplicate export case.

fixes #22158
closes #22520
