### PR TITLE
chore(build): package third-party licenses for oxlint and oxfmt

### DIFF
--- a/.github/scripts/check-npm-packages.js
+++ b/.github/scripts/check-npm-packages.js
@@ -47,6 +47,11 @@ function checkPackageFiles(packageDir, packageJson) {
   return allFilesExist;
 }
 
+function syncThirdPartyLicense(packageDir) {
+  const scriptPath = path.join(__dirname, "sync-third-party-license.mjs");
+  execFileSync(process.execPath, [scriptPath, packageDir], { stdio: "inherit" });
+}
+
 function dryRunPublish(packageDir) {
   try {
     const flags = "--provenance --access public --no-git-checks";
@@ -99,6 +104,8 @@ function checkPackage(packageDir, skipExistenceCheck = false) {
     console.log("");
     return true;
   }
+
+  syncThirdPartyLicense(packageDir);
 
   // Check if package exists on npm (unless skipped)
   if (!skipExistenceCheck) {

--- a/.github/scripts/publish-if-needed.sh
+++ b/.github/scripts/publish-if-needed.sh
@@ -25,4 +25,5 @@ else
 fi
 rm -f "$npm_stderr"
 
+node .github/scripts/sync-third-party-license.mjs "${pkg_dir}"
 pnpm publish "${pkg_dir}/" "$@"

--- a/.github/scripts/sync-third-party-license.mjs
+++ b/.github/scripts/sync-third-party-license.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(scriptDir, "../..");
+const sourcePath = join(rootDir, "THIRD-PARTY-LICENSE");
+const separator = "-".repeat(80);
+
+const packageSections = {
+  oxlint: [
+    "* TypeScript",
+    "ESLint",
+    "typescript-eslint",
+    "eslint-plugin-import",
+    "eslint-plugin-jest",
+    "eslint-plugin-promise",
+    "jsparagus",
+    "acorn",
+    "sindresorhus/globals",
+    "index_vec",
+    "Ajv",
+    "@typescript-eslint/scope-manager",
+  ],
+  oxfmt: [
+    "* TypeScript",
+    "jsparagus",
+    "Biome",
+    "acorn",
+    "prettier",
+    "prettier-plugin-tailwindcss",
+    "prettier-plugin-svelte",
+  ],
+};
+
+const args = process.argv.slice(2);
+const clean = args[0] === "--clean";
+const packageArgs = clean ? args.slice(1) : args;
+const packageDirs = packageArgs.length === 0 ? ["npm/oxlint", "npm/oxfmt"] : packageArgs;
+
+for (const packageDirArg of packageDirs) {
+  const packageDir = resolve(process.cwd(), packageDirArg);
+  const packageJsonPath = join(packageDir, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    throw new Error(`package.json not found in ${packageDir}`);
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  if (!packageJson.files?.includes("THIRD-PARTY-LICENSE")) continue;
+
+  const targetPath = join(packageDir, "THIRD-PARTY-LICENSE");
+  if (clean) {
+    rmSync(targetPath, { force: true });
+  } else {
+    writeFileSync(targetPath, buildThirdPartyLicense(packageJson.name));
+  }
+}
+
+function buildThirdPartyLicense(packageName) {
+  const sections = packageSections[packageName];
+  if (!sections) {
+    throw new Error(`No THIRD-PARTY-LICENSE sections configured for ${packageName}`);
+  }
+
+  const sourceSections = parseSourceSections();
+  const missingSections = sections.filter((sectionName) => !sourceSections.has(sectionName));
+  if (missingSections.length > 0) {
+    throw new Error(
+      `Missing THIRD-PARTY-LICENSE sections for ${packageName}: ${missingSections.join(", ")}`,
+    );
+  }
+
+  return `${sections.map((sectionName) => sourceSections.get(sectionName).trim()).join(`\n\n${separator}\n\n`)}\n`;
+}
+
+function parseSourceSections() {
+  const source = readFileSync(sourcePath, "utf8");
+  const sections = new Map();
+
+  for (const section of source.split(`\n${separator}\n`)) {
+    const heading = section
+      .trimStart()
+      .split(/\r?\n/)
+      .find((line) => line.trim().length > 0);
+
+    if (heading) sections.set(heading.trim(), section);
+  }
+
+  return sections;
+}

--- a/THIRD-PARTY-LICENSE
+++ b/THIRD-PARTY-LICENSE
@@ -497,3 +497,106 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
+--------------------------------------------------------------------------------
+
+Ajv
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+@typescript-eslint/scope-manager
+
+MIT License
+
+Copyright (c) 2019 typescript-eslint and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+prettier-plugin-tailwindcss
+
+MIT License
+
+Copyright (c) Tailwind Labs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+prettier-plugin-svelte
+
+MIT License
+
+Copyright (c) 2019 [Contributors](https://github.com/sveltejs/prettier-plugin-svelte/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -29,6 +29,7 @@
     "configuration_schema.json",
     "dist",
     "README.md",
+    "THIRD-PARTY-LICENSE",
     "bin/oxfmt"
   ],
   "type": "module",
@@ -40,6 +41,10 @@
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
+  },
+  "scripts": {
+    "prepack": "node ../../.github/scripts/sync-third-party-license.mjs .",
+    "postpack": "node ../../.github/scripts/sync-third-party-license.mjs --clean ."
   },
   "dependencies": {
     "tinypool": "2.1.0"

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -29,6 +29,7 @@
     "configuration_schema.json",
     "dist",
     "README.md",
+    "THIRD-PARTY-LICENSE",
     "bin/oxlint"
   ],
   "type": "module",
@@ -44,6 +45,10 @@
       "default": "./dist/plugins-dev.js"
     },
     "./package.json": "./package.json"
+  },
+  "scripts": {
+    "prepack": "node ../../.github/scripts/sync-third-party-license.mjs .",
+    "postpack": "node ../../.github/scripts/sync-third-party-license.mjs --clean ."
   },
   "peerDependencies": {
     "oxlint-tsgolint": ">=0.22.1"


### PR DESCRIPTION
This PR adds scripts to package third party licenses for oxlint and oxfmt. It will use the main file and split up by usage during the publishing process.

Context: [Socials](https://bsky.app/profile/dominikg.dev/post/3mlnt7nfyes2b) & https://github.com/oxc-project/oxc/issues/684#issuecomment-4529461165