### PR TITLE
feat(linter/vue): implement valid-next-tick rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1314,6 +1314,7 @@ export interface DummyRuleMap {
   "vue/valid-define-emits"?: DummyRule;
   "vue/valid-define-options"?: DummyRule;
   "vue/valid-define-props"?: DummyRule;
+  "vue/valid-next-tick"?: DummyRule;
   yoda?: DummyRule;
   [k: string]: DummyRule;
 }

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5080,3 +5080,11 @@ impl RuleRunner for crate::rules::vue::valid_define_props::ValidDefineProps {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
+
+impl RuleRunner for crate::rules::vue::valid_next_tick::ValidNextTick {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::IdentifierReference,
+        AstType::StaticMemberExpression,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -813,6 +813,7 @@ pub use crate::rules::vue::return_in_computed_property::ReturnInComputedProperty
 pub use crate::rules::vue::valid_define_emits::ValidDefineEmits as VueValidDefineEmits;
 pub use crate::rules::vue::valid_define_options::ValidDefineOptions as VueValidDefineOptions;
 pub use crate::rules::vue::valid_define_props::ValidDefineProps as VueValidDefineProps;
+pub use crate::rules::vue::valid_next_tick::ValidNextTick as VueValidNextTick;
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
@@ -1636,6 +1637,7 @@ pub enum RuleEnum {
     VueValidDefineEmits(VueValidDefineEmits),
     VueValidDefineOptions(VueValidDefineOptions),
     VueValidDefineProps(VueValidDefineProps),
+    VueValidNextTick(VueValidNextTick),
 }
 const IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID: usize = 0usize;
 const IMPORT_DEFAULT_ID: usize = IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID + 1usize;
@@ -2543,6 +2545,7 @@ const VUE_RETURN_IN_COMPUTED_PROPERTY_ID: usize = VUE_REQUIRE_TYPED_REF_ID + 1us
 const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_COMPUTED_PROPERTY_ID + 1usize;
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
+const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
 impl RuleEnum {
     pub fn id(&self) -> usize {
         match self {
@@ -3477,6 +3480,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VUE_VALID_DEFINE_EMITS_ID,
             Self::VueValidDefineOptions(_) => VUE_VALID_DEFINE_OPTIONS_ID,
             Self::VueValidDefineProps(_) => VUE_VALID_DEFINE_PROPS_ID,
+            Self::VueValidNextTick(_) => VUE_VALID_NEXT_TICK_ID,
         }
     }
     pub fn name(&self) -> &'static str {
@@ -4396,6 +4400,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::NAME,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::NAME,
             Self::VueValidDefineProps(_) => VueValidDefineProps::NAME,
+            Self::VueValidNextTick(_) => VueValidNextTick::NAME,
         }
     }
     pub fn category(&self) -> RuleCategory {
@@ -5373,6 +5378,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::CATEGORY,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::CATEGORY,
             Self::VueValidDefineProps(_) => VueValidDefineProps::CATEGORY,
+            Self::VueValidNextTick(_) => VueValidNextTick::CATEGORY,
         }
     }
     #[doc = r" This [`Rule`]'s auto-fix capabilities."]
@@ -6293,6 +6299,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::FIX,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::FIX,
             Self::VueValidDefineProps(_) => VueValidDefineProps::FIX,
+            Self::VueValidNextTick(_) => VueValidNextTick::FIX,
         }
     }
     #[cfg(feature = "ruledocs")]
@@ -7461,6 +7468,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::documentation(),
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::documentation(),
             Self::VueValidDefineProps(_) => VueValidDefineProps::documentation(),
+            Self::VueValidNextTick(_) => VueValidNextTick::documentation(),
         }
     }
     #[cfg(feature = "ruledocs")]
@@ -9780,6 +9788,8 @@ impl RuleEnum {
                 .or_else(|| VueValidDefineOptions::schema(generator)),
             Self::VueValidDefineProps(_) => VueValidDefineProps::config_schema(generator)
                 .or_else(|| VueValidDefineProps::schema(generator)),
+            Self::VueValidNextTick(_) => VueValidNextTick::config_schema(generator)
+                .or_else(|| VueValidNextTick::schema(generator)),
         }
     }
     pub fn plugin_name(&self) -> &'static str {
@@ -10589,6 +10599,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => "vue",
             Self::VueValidDefineOptions(_) => "vue",
             Self::VueValidDefineProps(_) => "vue",
+            Self::VueValidNextTick(_) => "vue",
         }
     }
     pub fn from_configuration(
@@ -13191,6 +13202,9 @@ impl RuleEnum {
             Self::VueValidDefineProps(_) => {
                 Ok(Self::VueValidDefineProps(VueValidDefineProps::from_configuration(value)?))
             }
+            Self::VueValidNextTick(_) => {
+                Ok(Self::VueValidNextTick(VueValidNextTick::from_configuration(value)?))
+            }
         }
     }
     pub fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
@@ -14004,6 +14018,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(rule) => rule.to_configuration(),
             Self::VueValidDefineOptions(rule) => rule.to_configuration(),
             Self::VueValidDefineProps(rule) => rule.to_configuration(),
+            Self::VueValidNextTick(rule) => rule.to_configuration(),
         }
     }
     pub(crate) fn run<'a, const TIMINGS: bool>(
@@ -14823,6 +14838,7 @@ impl RuleEnum {
                 Self::VueValidDefineEmits(rule) => rule.run(node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run(node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run(node, ctx),
+                Self::VueValidNextTick(rule) => rule.run(node, ctx),
             });
         } else {
             match self {
@@ -15635,6 +15651,7 @@ impl RuleEnum {
                 Self::VueValidDefineEmits(rule) => rule.run(node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run(node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run(node, ctx),
+                Self::VueValidNextTick(rule) => rule.run(node, ctx),
             }
         }
     }
@@ -16454,6 +16471,7 @@ impl RuleEnum {
                 Self::VueValidDefineEmits(rule) => rule.run_once(ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_once(ctx),
                 Self::VueValidDefineProps(rule) => rule.run_once(ctx),
+                Self::VueValidNextTick(rule) => rule.run_once(ctx),
             });
         } else {
             match self {
@@ -17266,6 +17284,7 @@ impl RuleEnum {
                 Self::VueValidDefineEmits(rule) => rule.run_once(ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_once(ctx),
                 Self::VueValidDefineProps(rule) => rule.run_once(ctx),
+                Self::VueValidNextTick(rule) => rule.run_once(ctx),
             }
         }
     }
@@ -18338,6 +18357,7 @@ impl RuleEnum {
                 Self::VueValidDefineEmits(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueValidNextTick(rule) => rule.run_on_jest_node(jest_node, ctx),
             });
         } else {
             match self {
@@ -19402,6 +19422,7 @@ impl RuleEnum {
                 Self::VueValidDefineEmits(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineOptions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueValidNextTick(rule) => rule.run_on_jest_node(jest_node, ctx),
             }
         }
     }
@@ -20212,6 +20233,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(rule) => rule.should_run(ctx),
             Self::VueValidDefineOptions(rule) => rule.should_run(ctx),
             Self::VueValidDefineProps(rule) => rule.should_run(ctx),
+            Self::VueValidNextTick(rule) => rule.should_run(ctx),
         }
     }
     pub fn is_tsgolint_rule(&self) -> bool {
@@ -21379,6 +21401,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::IS_TSGOLINT_RULE,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::IS_TSGOLINT_RULE,
             Self::VueValidDefineProps(_) => VueValidDefineProps::IS_TSGOLINT_RULE,
+            Self::VueValidNextTick(_) => VueValidNextTick::IS_TSGOLINT_RULE,
         }
     }
     #[doc = r" The version of oxlint in which this rule was first available."]
@@ -22358,6 +22381,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::VERSION,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::VERSION,
             Self::VueValidDefineProps(_) => VueValidDefineProps::VERSION,
+            Self::VueValidNextTick(_) => VueValidNextTick::VERSION,
         }
     }
     #[doc = r" Whether this rule declares a configuration type."]
@@ -23372,6 +23396,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::HAS_CONFIG,
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::HAS_CONFIG,
             Self::VueValidDefineProps(_) => VueValidDefineProps::HAS_CONFIG,
+            Self::VueValidNextTick(_) => VueValidNextTick::HAS_CONFIG,
         }
     }
     pub fn types_info(&self) -> Option<&'static AstTypesBitset> {
@@ -24181,6 +24206,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(rule) => rule.types_info(),
             Self::VueValidDefineOptions(rule) => rule.types_info(),
             Self::VueValidDefineProps(rule) => rule.types_info(),
+            Self::VueValidNextTick(rule) => rule.types_info(),
         }
     }
     pub fn run_info(&self) -> RuleRunFunctionsImplemented {
@@ -24990,6 +25016,7 @@ impl RuleEnum {
             Self::VueValidDefineEmits(rule) => rule.run_info(),
             Self::VueValidDefineOptions(rule) => rule.run_info(),
             Self::VueValidDefineProps(rule) => rule.run_info(),
+            Self::VueValidNextTick(rule) => rule.run_info(),
         }
     }
 }
@@ -25931,5 +25958,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueValidDefineEmits(VueValidDefineEmits::default()),
         RuleEnum::VueValidDefineOptions(VueValidDefineOptions::default()),
         RuleEnum::VueValidDefineProps(VueValidDefineProps::default()),
+        RuleEnum::VueValidNextTick(VueValidNextTick::default()),
     ]
 });

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -853,6 +853,7 @@ pub(crate) mod vue {
     pub mod valid_define_emits;
     pub mod valid_define_options;
     pub mod valid_define_props;
+    pub mod valid_next_tick;
 }
 
 pub(crate) mod shared;

--- a/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
@@ -81,10 +81,6 @@ declare_oxc_lint!(
 );
 
 impl Rule for ValidNextTick {
-    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_extension().is_some_and(|ext| ext == "vue")
-    }
-
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let (next_tick_node, report_span) = match node.kind() {
             AstKind::StaticMemberExpression(m) => {
@@ -142,6 +138,10 @@ impl Rule for ValidNextTick {
                 });
             }
         }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
     }
 }
 

--- a/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
@@ -378,8 +378,9 @@ fn is_legacy_vue_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>
 
 #[test]
 fn test() {
-    use crate::tester::Tester;
     use std::path::PathBuf;
+
+    use crate::tester::Tester;
 
     let pass = vec![
         ("", None, None, Some(PathBuf::from("test.vue"))),

--- a/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
@@ -1,0 +1,714 @@
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression, IdentifierReference},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode, ast_util::get_declaration_from_reference_id, context::LintContext,
+    module_record::ImportImportName, rule::Rule,
+};
+
+fn should_be_function_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`nextTick` is a function.").with_label(span)
+}
+
+fn missing_callback_or_await_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Await the Promise returned by `nextTick` or pass a callback function.")
+        .with_label(span)
+}
+
+fn too_many_parameters_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`nextTick` expects zero or one parameters.").with_label(span)
+}
+
+fn either_await_or_callback_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Either await the Promise or pass a callback function to `nextTick`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ValidNextTick;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce valid `nextTick` function calls.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `nextTick` is a function that takes either a callback or returns a Promise.
+    /// Misuse (accessing it as a value, passing extra arguments, both awaiting and
+    /// passing a callback) is almost always a bug.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// import { nextTick } from 'vue'
+    /// export default {
+    ///   async mounted() {
+    ///     nextTick()                     // missing await or callback
+    ///     this.$nextTick                 // not invoked
+    ///     this.$nextTick(a, b)           // too many args
+    ///     await this.$nextTick(callback) // both await and callback
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// import { nextTick } from 'vue'
+    /// export default {
+    ///   async mounted() {
+    ///     await nextTick()
+    ///     this.$nextTick(callback)
+    ///     this.$nextTick().then(callback)
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ValidNextTick,
+    vue,
+    correctness,
+    fix,
+    version = "next",
+);
+
+impl Rule for ValidNextTick {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let (next_tick_node, report_span) = match node.kind() {
+            AstKind::StaticMemberExpression(m) => {
+                let prop_name = m.property.name.as_str();
+                let object = m.object.get_inner_expression();
+                let matches = match prop_name {
+                    "$nextTick" => match object {
+                        Expression::ThisExpression(_) => true,
+                        Expression::Identifier(id) => is_this_alias(id, ctx),
+                        _ => false,
+                    },
+                    "nextTick" => {
+                        matches!(object, Expression::Identifier(id) if id.name == "Vue")
+                    }
+                    _ => false,
+                };
+                if !matches {
+                    return;
+                }
+                (node, m.property.span)
+            }
+            AstKind::IdentifierReference(ident) => {
+                if !is_vue_next_tick_import(ident, ctx) {
+                    return;
+                }
+                (node, ident.span)
+            }
+            _ => return,
+        };
+
+        if !is_in_vue_component_instance_method(next_tick_node, ctx)
+            && !is_in_legacy_vue_instance_method(next_tick_node, ctx)
+        {
+            return;
+        }
+
+        // Skip `ConditionalExpression`: `bar ? nt : undefined`.
+        let mut parent = ctx.nodes().parent_node(next_tick_node.id());
+        if matches!(parent.kind(), AstKind::ConditionalExpression(_)) {
+            parent = ctx.nodes().parent_node(parent.id());
+        }
+
+        match parent.kind() {
+            AstKind::CallExpression(call) if call.callee.span() == next_tick_node.kind().span() => {
+                check_call(parent, call, report_span, ctx);
+            }
+            // OK: `foo.then(nt)` (passed as value) / `let foo = nt` / `foo = nt`
+            AstKind::CallExpression(_)
+            | AstKind::VariableDeclarator(_)
+            | AstKind::AssignmentExpression(_) => {}
+            _ => {
+                let end = next_tick_node.kind().span().end;
+                ctx.diagnostic_with_fix(should_be_function_diagnostic(report_span), |fixer| {
+                    fixer.insert_text_after_range(Span::new(end, end), "()")
+                });
+            }
+        }
+    }
+}
+
+fn check_call<'a>(
+    call_node: &AstNode<'a>,
+    call: &CallExpression<'a>,
+    report_span: Span,
+    ctx: &LintContext<'a>,
+) {
+    let args_len = call.arguments.len();
+    let awaited = is_awaited_promise(call_node, ctx);
+
+    if args_len == 0 {
+        if !awaited {
+            ctx.diagnostic(missing_callback_or_await_diagnostic(report_span));
+        }
+        return;
+    }
+    if args_len > 1 {
+        ctx.diagnostic(too_many_parameters_diagnostic(report_span));
+        return;
+    }
+    if awaited {
+        ctx.diagnostic(either_await_or_callback_diagnostic(report_span));
+    }
+}
+
+fn is_awaited_promise(call_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let parent = ctx.nodes().parent_node(call_node.id());
+    match parent.kind() {
+        AstKind::AwaitExpression(_)
+        | AstKind::ReturnStatement(_)
+        | AstKind::VariableDeclarator(_)
+        | AstKind::AssignmentExpression(_) => true,
+        // `() => nextTick()` (expression body arrow). The call's direct parent is
+        // an `ExpressionStatement` whose grandparent is the arrow's `FunctionBody`.
+        AstKind::ExpressionStatement(_) => {
+            let gp = ctx.nodes().parent_node(parent.id());
+            if !matches!(gp.kind(), AstKind::FunctionBody(_)) {
+                return false;
+            }
+            let ggp = ctx.nodes().parent_node(gp.id());
+            matches!(ggp.kind(), AstKind::ArrowFunctionExpression(arrow) if arrow.expression)
+        }
+        // `nextTick().then(...)`
+        AstKind::StaticMemberExpression(m) => m.property.name == "then",
+        // `Promise.all([nextTick()])`
+        AstKind::ArrayExpression(_) => {
+            let grandparent = ctx.nodes().parent_node(parent.id());
+            if let AstKind::CallExpression(c) = grandparent.kind()
+                && let Some(member) = c.callee.get_member_expr()
+                && let Expression::Identifier(obj) = member.object().get_inner_expression()
+                && obj.name == "Promise"
+            {
+                return true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn is_this_alias(ident: &IdentifierReference, ctx: &LintContext<'_>) -> bool {
+    get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
+        .and_then(|node| match node.kind() {
+            AstKind::VariableDeclarator(var) => var.init.as_ref(),
+            _ => None,
+        })
+        .is_some_and(|init| matches!(init.get_inner_expression(), Expression::ThisExpression(_)))
+}
+
+fn is_vue_next_tick_import(ident: &IdentifierReference, ctx: &LintContext<'_>) -> bool {
+    let scoping = ctx.scoping();
+    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
+        return false;
+    };
+    for entry in &ctx.module_record().import_entries {
+        if entry.module_request.name() != "vue" {
+            continue;
+        }
+        let ImportImportName::Name(name_span) = &entry.import_name else { continue };
+        if name_span.name() != "nextTick" {
+            continue;
+        }
+        if scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_in_vue_component_instance_method(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let Some(function_node) = ctx
+        .nodes()
+        .ancestors(node.id())
+        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
+    else {
+        return false;
+    };
+
+    let property_node = ctx.nodes().parent_node(function_node.id());
+    let AstKind::ObjectProperty(_) = property_node.kind() else {
+        return false;
+    };
+
+    let object_node = ctx.nodes().parent_node(property_node.id());
+    if is_vue_component_options_object(object_node, ctx) {
+        return true;
+    }
+
+    let container_property_node = ctx.nodes().parent_node(object_node.id());
+    if !matches!(container_property_node.kind(), AstKind::ObjectProperty(_)) {
+        return false;
+    }
+
+    let Some(container_name) = container_property_node
+        .kind()
+        .as_object_property()
+        .and_then(|prop| if prop.computed { None } else { prop.key.static_name() })
+    else {
+        return false;
+    };
+
+    matches!(container_name.as_ref(), "computed" | "methods" | "watch")
+        && is_vue_component_options_object(
+            ctx.nodes().parent_node(container_property_node.id()),
+            ctx,
+        )
+}
+
+fn is_vue_component_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let AstKind::ObjectExpression(object_expr) = object_node.kind() else {
+        return false;
+    };
+
+    ctx.nodes().ancestors(object_node.id()).any(|ancestor| match ancestor.kind() {
+        AstKind::ExportDefaultDeclaration(export_default_decl) => {
+            export_default_decl.declaration.span() == object_expr.span
+        }
+        AstKind::CallExpression(call_expr) => {
+            call_expr
+                .arguments
+                .iter()
+                .any(|arg| arg.as_expression().is_some_and(|expr| expr.span() == object_expr.span))
+                && is_vue_component_options_call(call_expr)
+        }
+        _ => false,
+    })
+}
+
+fn is_vue_component_options_call(call_expr: &CallExpression<'_>) -> bool {
+    if call_expr
+        .callee
+        .get_identifier_reference()
+        .is_some_and(|ident| matches!(ident.name.as_str(), "createApp" | "defineComponent"))
+    {
+        return true;
+    }
+
+    call_expr.callee.get_member_expr().is_some_and(|member_expr| {
+        member_expr.static_property_name().is_some_and(|name| name == "component")
+    })
+}
+
+// Detect Vue 2 forms: `new Vue({...})` and `Vue.extend({...})`.
+fn is_in_legacy_vue_instance_method(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let Some(function_node) = ctx
+        .nodes()
+        .ancestors(node.id())
+        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
+    else {
+        return false;
+    };
+
+    let property_node = ctx.nodes().parent_node(function_node.id());
+    if !matches!(property_node.kind(), AstKind::ObjectProperty(_)) {
+        return false;
+    }
+
+    let object_node = ctx.nodes().parent_node(property_node.id());
+    if is_legacy_vue_options_object(object_node, ctx) {
+        return true;
+    }
+
+    let container_property_node = ctx.nodes().parent_node(object_node.id());
+    if !matches!(container_property_node.kind(), AstKind::ObjectProperty(_)) {
+        return false;
+    }
+    let Some(container_name) = container_property_node
+        .kind()
+        .as_object_property()
+        .and_then(|prop| if prop.computed { None } else { prop.key.static_name() })
+    else {
+        return false;
+    };
+
+    matches!(container_name.as_ref(), "computed" | "methods" | "watch")
+        && is_legacy_vue_options_object(ctx.nodes().parent_node(container_property_node.id()), ctx)
+}
+
+fn is_legacy_vue_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let AstKind::ObjectExpression(object_expr) = object_node.kind() else {
+        return false;
+    };
+    ctx.nodes().ancestors(object_node.id()).any(|ancestor| match ancestor.kind() {
+        // `new Vue({...})`
+        AstKind::NewExpression(new_expr) => {
+            new_expr
+                .arguments
+                .iter()
+                .any(|arg| arg.as_expression().is_some_and(|e| e.span() == object_expr.span))
+                && new_expr
+                    .callee
+                    .get_identifier_reference()
+                    .is_some_and(|ident| ident.name == "Vue")
+        }
+        // `Vue.extend({...})`
+        AstKind::CallExpression(call_expr) => {
+            call_expr
+                .arguments
+                .iter()
+                .any(|arg| arg.as_expression().is_some_and(|e| e.span() == object_expr.span))
+                && call_expr.callee.get_member_expr().is_some_and(|member| {
+                    member.static_property_name().is_some_and(|name| name == "extend")
+                        && matches!(
+                            member.object().get_inner_expression(),
+                            Expression::Identifier(id) if id.name == "Vue"
+                        )
+                })
+        }
+        _ => false,
+    })
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let pass = vec![
+        ("", None, None, Some(PathBuf::from("test.vue"))),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    async mounted() {
+                      await nt();
+                      await Vue.nextTick();
+                      await this.$nextTick();
+
+                      nt().then(callback);
+                      Vue.nextTick().then(callback);
+                      this.$nextTick().then(callback);
+
+                      nt(callback);
+                      Vue.nextTick(callback);
+                      this.$nextTick(callback);
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      foo.then(nt);
+                      foo.then(Vue.nextTick);
+                      foo.then(this.$nextTick);
+
+                      foo.then(nt, catchHandler);
+                      foo.then(Vue.nextTick, catchHandler);
+                      foo.then(this.$nextTick, catchHandler);
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      let foo = nt;
+                      foo = Vue.nextTick;
+                      foo = this.$nextTick;
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      Promise.all([nt(), someOtherPromise]);
+                      Promise.all([Vue.nextTick(), someOtherPromise]);
+                      Promise.all([this.$nextTick(), someOtherPromise]);
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    created() {
+                      let queue = nt();
+                      queue = queue.then(nt);
+                      return nt();
+                    },
+                    mounted() {
+                      const queue = Vue.nextTick();
+                      return Vue.nextTick();
+                    },
+                    updated() {
+                      const queue = this.$nextTick();
+                      return this.$nextTick();
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>;
+                  export default {
+                    methods: {
+                      fn1 () {
+                        return this.$nextTick()
+                      },
+                      fn2 () {
+                        return this.$nextTick()
+                          .then(() => this.$nextTick())
+                      },
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      let foo = bar ? nt : undefined;
+                      foo = bar ? Vue.nextTick : undefined;
+                      foo = bar ? this.$nextTick : undefined;
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Vue 2 legacy: detected via the rule, but properly used = pass
+        (
+            "<script>
+                  new Vue({
+                    async mounted() {
+                      await this.$nextTick();
+                      this.$nextTick(callback);
+                    }
+                  })</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  Vue.extend({
+                    async mounted() {
+                      await this.$nextTick();
+                      this.$nextTick(callback);
+                    }
+                  })</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    async mounted() {
+                      nt();
+                      Vue.nextTick();
+                      this.$nextTick();
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      nt;
+                      Vue.nextTick;
+                      this.$nextTick;
+
+                      nt.then(callback);
+                      Vue.nextTick.then(callback);
+                      this.$nextTick.then(callback);
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    async mounted() {
+                      await nt;
+                      await Vue.nextTick;
+                      return this.$nextTick;
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      Promise.all([nt, someOtherPromise]);
+                      Promise.all([Vue.nextTick, someOtherPromise]);
+                      Promise.all([this.$nextTick, someOtherPromise]);
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      nt(callback, anotherCallback);
+                      Vue.nextTick(callback, anotherCallback);
+                      this.$nextTick(callback, anotherCallback);
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    async mounted() {
+                      nt(callback).then(anotherCallback);
+                      Vue.nextTick(callback).then(anotherCallback);
+                      this.$nextTick(callback).then(anotherCallback);
+
+                      await nt(callback);
+                      await Vue.nextTick(callback);
+                      await this.$nextTick(callback);
+                    }
+                  }</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Vue 2 legacy: misused inside `new Vue({...})` / `Vue.extend({...})`
+        (
+            "<script>
+                  new Vue({
+                    mounted() {
+                      this.$nextTick;
+                    }
+                  })</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  Vue.extend({
+                    mounted() {
+                      this.$nextTick;
+                    }
+                  })</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      nt;
+                      Vue.nextTick;
+                      this.$nextTick;
+
+                      nt.then(callback);
+                      Vue.nextTick.then(callback);
+                      this.$nextTick.then(callback);
+                    }
+                  }</script>",
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      nt();
+                      Vue.nextTick();
+                      this.$nextTick();
+
+                      nt().then(callback);
+                      Vue.nextTick().then(callback);
+                      this.$nextTick().then(callback);
+                    }
+                  }</script>",
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    async mounted() {
+                      await nt;
+                      await Vue.nextTick;
+                      return this.$nextTick;
+                    }
+                  }</script>",
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    async mounted() {
+                      await nt();
+                      await Vue.nextTick();
+                      return this.$nextTick();
+                    }
+                  }</script>",
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      Promise.all([nt, someOtherPromise]);
+                      Promise.all([Vue.nextTick, someOtherPromise]);
+                      Promise.all([this.$nextTick, someOtherPromise]);
+                    }
+                  }</script>",
+            "<script>import { nextTick as nt } from 'vue';
+                  export default {
+                    mounted() {
+                      Promise.all([nt(), someOtherPromise]);
+                      Promise.all([Vue.nextTick(), someOtherPromise]);
+                      Promise.all([this.$nextTick(), someOtherPromise]);
+                    }
+                  }</script>",
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(ValidNextTick::NAME, ValidNextTick::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
+++ b/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
@@ -1,0 +1,225 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(valid-next-tick): Await the Promise returned by `nextTick` or pass a callback function.
+   ╭─[valid_next_tick.tsx:4:23]
+ 3 │                     async mounted() {
+ 4 │                       nt();
+   ·                       ──
+ 5 │                       Vue.nextTick();
+   ╰────
+
+  ⚠ vue(valid-next-tick): Await the Promise returned by `nextTick` or pass a callback function.
+   ╭─[valid_next_tick.tsx:5:27]
+ 4 │                       nt();
+ 5 │                       Vue.nextTick();
+   ·                           ────────
+ 6 │                       this.$nextTick();
+   ╰────
+
+  ⚠ vue(valid-next-tick): Await the Promise returned by `nextTick` or pass a callback function.
+   ╭─[valid_next_tick.tsx:6:28]
+ 5 │                       Vue.nextTick();
+ 6 │                       this.$nextTick();
+   ·                            ─────────
+ 7 │                     }
+   ╰────
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:4:23]
+ 3 │                     mounted() {
+ 4 │                       nt;
+   ·                       ──
+ 5 │                       Vue.nextTick;
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:5:27]
+ 4 │                       nt;
+ 5 │                       Vue.nextTick;
+   ·                           ────────
+ 6 │                       this.$nextTick;
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:6:28]
+ 5 │                       Vue.nextTick;
+ 6 │                       this.$nextTick;
+   ·                            ─────────
+ 7 │ 
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:8:23]
+ 7 │ 
+ 8 │                       nt.then(callback);
+   ·                       ──
+ 9 │                       Vue.nextTick.then(callback);
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+    ╭─[valid_next_tick.tsx:9:27]
+  8 │                       nt.then(callback);
+  9 │                       Vue.nextTick.then(callback);
+    ·                           ────────
+ 10 │                       this.$nextTick.then(callback);
+    ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+    ╭─[valid_next_tick.tsx:10:28]
+  9 │                       Vue.nextTick.then(callback);
+ 10 │                       this.$nextTick.then(callback);
+    ·                            ─────────
+ 11 │                     }
+    ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:4:29]
+ 3 │                     async mounted() {
+ 4 │                       await nt;
+   ·                             ──
+ 5 │                       await Vue.nextTick;
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:5:33]
+ 4 │                       await nt;
+ 5 │                       await Vue.nextTick;
+   ·                                 ────────
+ 6 │                       return this.$nextTick;
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:6:35]
+ 5 │                       await Vue.nextTick;
+ 6 │                       return this.$nextTick;
+   ·                                   ─────────
+ 7 │                     }
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:4:36]
+ 3 │                     mounted() {
+ 4 │                       Promise.all([nt, someOtherPromise]);
+   ·                                    ──
+ 5 │                       Promise.all([Vue.nextTick, someOtherPromise]);
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:5:40]
+ 4 │                       Promise.all([nt, someOtherPromise]);
+ 5 │                       Promise.all([Vue.nextTick, someOtherPromise]);
+   ·                                        ────────
+ 6 │                       Promise.all([this.$nextTick, someOtherPromise]);
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:6:41]
+ 5 │                       Promise.all([Vue.nextTick, someOtherPromise]);
+ 6 │                       Promise.all([this.$nextTick, someOtherPromise]);
+   ·                                         ─────────
+ 7 │                     }
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` expects zero or one parameters.
+   ╭─[valid_next_tick.tsx:4:23]
+ 3 │                     mounted() {
+ 4 │                       nt(callback, anotherCallback);
+   ·                       ──
+ 5 │                       Vue.nextTick(callback, anotherCallback);
+   ╰────
+
+  ⚠ vue(valid-next-tick): `nextTick` expects zero or one parameters.
+   ╭─[valid_next_tick.tsx:5:27]
+ 4 │                       nt(callback, anotherCallback);
+ 5 │                       Vue.nextTick(callback, anotherCallback);
+   ·                           ────────
+ 6 │                       this.$nextTick(callback, anotherCallback);
+   ╰────
+
+  ⚠ vue(valid-next-tick): `nextTick` expects zero or one parameters.
+   ╭─[valid_next_tick.tsx:6:28]
+ 5 │                       Vue.nextTick(callback, anotherCallback);
+ 6 │                       this.$nextTick(callback, anotherCallback);
+   ·                            ─────────
+ 7 │                     }
+   ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+   ╭─[valid_next_tick.tsx:4:23]
+ 3 │                     async mounted() {
+ 4 │                       nt(callback).then(anotherCallback);
+   ·                       ──
+ 5 │                       Vue.nextTick(callback).then(anotherCallback);
+   ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+   ╭─[valid_next_tick.tsx:5:27]
+ 4 │                       nt(callback).then(anotherCallback);
+ 5 │                       Vue.nextTick(callback).then(anotherCallback);
+   ·                           ────────
+ 6 │                       this.$nextTick(callback).then(anotherCallback);
+   ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+   ╭─[valid_next_tick.tsx:6:28]
+ 5 │                       Vue.nextTick(callback).then(anotherCallback);
+ 6 │                       this.$nextTick(callback).then(anotherCallback);
+   ·                            ─────────
+ 7 │ 
+   ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+   ╭─[valid_next_tick.tsx:8:29]
+ 7 │ 
+ 8 │                       await nt(callback);
+   ·                             ──
+ 9 │                       await Vue.nextTick(callback);
+   ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+    ╭─[valid_next_tick.tsx:9:33]
+  8 │                       await nt(callback);
+  9 │                       await Vue.nextTick(callback);
+    ·                                 ────────
+ 10 │                       await this.$nextTick(callback);
+    ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+    ╭─[valid_next_tick.tsx:10:34]
+  9 │                       await Vue.nextTick(callback);
+ 10 │                       await this.$nextTick(callback);
+    ·                                  ─────────
+ 11 │                     }
+    ╰────
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:4:28]
+ 3 │                     mounted() {
+ 4 │                       this.$nextTick;
+   ·                            ─────────
+ 5 │                     }
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:4:28]
+ 3 │                     mounted() {
+ 4 │                       this.$nextTick;
+   ·                            ─────────
+ 5 │                     }
+   ╰────
+  help: Insert `()`

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2653,6 +2653,9 @@
         "vue/valid-define-props": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/valid-next-tick": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "yoda": {
           "$ref": "#/definitions/DummyRule"
         }

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2657,6 +2657,9 @@ expression: json
         "vue/valid-define-props": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/valid-next-tick": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "yoda": {
           "$ref": "#/definitions/DummyRule"
         }


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/valid-next-tick.html

Vue 2 forms (`new Vue({...})` and `Vue.extend({...})`) are also detected via a local helper in this rule. The shared `utils::is_vue_component_options_object` does not cover them yet — can submit a follow-up PR to consolidate.

AI disclosure: implemented with Claude Code, reviewed manually.