### PR TITLE
feat(linter): add debug option to print files to be linted

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -293,11 +293,16 @@ pub struct OutputOptions {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DebugOption {
+    /// Print the list of files that will be linted
+    Files,
+
     /// Enable per-rule timing information
     Timings,
 }
 
 impl DebugOption {
+    const FILES_NAME: &str = "files";
+    const FILES_HELP: &str = "Print the list of files that will be linted, then exit";
     const TIMINGS_NAME: &str = "timings";
     const TIMINGS_HELP: &str = "Enable per-rule timing information";
 }
@@ -307,6 +312,7 @@ impl FromStr for DebugOption {
 
     fn from_str(option: &str) -> Result<Self, Self::Err> {
         match option {
+            Self::FILES_NAME => Ok(Self::Files),
             Self::TIMINGS_NAME => Ok(Self::Timings),
             _ => Err(format!("'{option}' is not a known debug option")),
         }
@@ -325,6 +331,11 @@ impl DebugOptions {
             Style::Text,
         ),
         ("  * `", Style::Text),
+        (DebugOption::FILES_NAME, Style::Text),
+        ("` - ", Style::Text),
+        (DebugOption::FILES_HELP, Style::Text),
+        (".\n", Style::Text),
+        ("  * `", Style::Text),
         (DebugOption::TIMINGS_NAME, Style::Text),
         ("` - ", Style::Text),
         (DebugOption::TIMINGS_HELP, Style::Text),
@@ -340,12 +351,19 @@ impl FromStr for DebugOptions {
     type Err = String;
 
     fn from_str(options: &str) -> Result<Self, Self::Err> {
-        options
+        let options = options
             .split(',')
             .filter(|option| !option.is_empty())
             .map(DebugOption::from_str)
-            .collect::<Result<Vec<_>, _>>()
-            .map(|options| Self { options })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if options.contains(&DebugOption::Files)
+            && options.iter().any(|option| *option != DebugOption::Files)
+        {
+            return Err("debug option 'files' cannot be combined with other debug options".into());
+        }
+
+        Ok(Self { options })
     }
 }
 
@@ -704,6 +722,21 @@ mod lint_options {
         let options = get_lint_options("--debug timings src");
         assert!(options.output_options.debug.contains(DebugOption::Timings));
         assert_eq!(options.paths, vec![PathBuf::from("src")]);
+
+        let options = get_lint_options("--debug files src");
+        assert!(options.output_options.debug.contains(DebugOption::Files));
+        assert_eq!(options.paths, vec![PathBuf::from("src")]);
+    }
+
+    #[test]
+    fn debug_files_is_exclusive() {
+        let args = "--debug files,timings"
+            .split(' ')
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>();
+        let result = lint_command().run_inner(args.as_slice());
+        assert!(result.is_err_and(|err| err.unwrap_stderr()
+            == "couldn't parse `files,timings`: debug option 'files' cannot be combined with other debug options"));
     }
 
     #[test]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -71,6 +71,7 @@ impl CliRunner {
     /// # Panics
     pub fn run(self, stdout: &mut dyn Write) -> CliRunResult {
         let format_str = self.options.output_options.format;
+        let debug_files = self.options.output_options.debug.contains(DebugOption::Files);
         let debug_timings = self.options.output_options.debug.contains(DebugOption::Timings);
         let output_formatter = OutputFormatter::new(format_str);
 
@@ -161,6 +162,14 @@ impl CliRunner {
             // If explicit paths were provided, but all have been
             // filtered, return early.
             if provided_path_count > 0 {
+                if debug_files {
+                    return crate::mode::run_debug_files(
+                        std::iter::empty::<&Path>(),
+                        &self.cwd,
+                        stdout,
+                    );
+                }
+
                 return Self::handle_no_files_found(
                     stdout,
                     &output_formatter,
@@ -327,6 +336,19 @@ impl CliRunner {
         let ignore_matcher =
             { LintIgnoreMatcher::new(&base_ignore_patterns, &self.cwd, nested_ignore_patterns) };
 
+        let files_to_lint = paths
+            .into_iter()
+            .filter(|path| !ignore_matcher.should_ignore(Path::new(path)))
+            .collect::<Vec<Arc<OsStr>>>();
+
+        if debug_files {
+            return crate::mode::run_debug_files(
+                files_to_lint.iter().map(|path| Path::new(path.as_ref())),
+                &self.cwd,
+                stdout,
+            );
+        }
+
         // If no external rules, discard `ExternalLinter`
         let mut external_linter = self.external_linter;
         if external_plugin_store.is_empty() {
@@ -408,11 +430,6 @@ impl CliRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         }
-
-        let files_to_lint = paths
-            .into_iter()
-            .filter(|path| !ignore_matcher.should_ignore(Path::new(path)))
-            .collect::<Vec<Arc<OsStr>>>();
 
         let linter = Linter::new(LintOptions::default(), config_store, external_linter)
             .with_fix(fix_options.fix_kind())
@@ -1005,6 +1022,11 @@ mod test {
             "no-debugger",
             "fixtures/cli/linter/debugger.js",
         ]);
+    }
+
+    #[test]
+    fn debug_files() {
+        Tester::new().test_and_snapshot(&["--debug", "files", "fixtures/cli/linter"]);
     }
 
     #[test]

--- a/apps/oxlint/src/mode/debug_files.rs
+++ b/apps/oxlint/src/mode/debug_files.rs
@@ -1,0 +1,31 @@
+use std::{io::Write, path::Path};
+
+use cow_utils::CowUtils;
+
+use crate::{cli::CliRunResult, lint::print_and_flush_stdout};
+
+pub fn run_debug_files(
+    files_to_lint: impl IntoIterator<Item = impl AsRef<Path>>,
+    cwd: &Path,
+    stdout: &mut dyn Write,
+) -> CliRunResult {
+    let mut files = files_to_lint.into_iter().collect::<Vec<_>>();
+    files.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+
+    let mut output = String::new();
+    for file in files {
+        push_cwd_relative_path(&mut output, file.as_ref(), cwd);
+        output.push('\n');
+    }
+
+    if !output.is_empty() {
+        print_and_flush_stdout(stdout, &output);
+    }
+
+    CliRunResult::LintSucceeded
+}
+
+fn push_cwd_relative_path(output: &mut String, path: &Path, cwd: &Path) {
+    let path = path.strip_prefix(cwd).unwrap_or(path);
+    output.push_str(&path.to_string_lossy().cow_replace('\\', "/"));
+}

--- a/apps/oxlint/src/mode/mod.rs
+++ b/apps/oxlint/src/mode/mod.rs
@@ -1,7 +1,9 @@
+mod debug_files;
 mod init;
 mod print_config;
 mod rules;
 
+pub use debug_files::run_debug_files;
 pub use init::run_init;
 pub use print_config::run_print_config;
 pub use rules::run_rules;

--- a/apps/oxlint/src/snapshots/_--debug files fixtures__cli__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--debug files fixtures__cli__linter@oxlint.snap
@@ -1,0 +1,13 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --debug files fixtures/cli/linter
+working directory: 
+----------
+fixtures/cli/linter/debugger.js
+fixtures/cli/linter/js_as_jsx.js
+fixtures/cli/linter/nan.js
+----------
+CLI result: LintSucceeded
+----------

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -123,6 +123,7 @@ Arguments:
   Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
 - **`    --debug`**=_`OPTIONS`_ &mdash; 
   Enable debug output options. Options are comma-separated. Possible values:
+ * `files` - Print the list of files that will be linted, then exit.
  * `timings` - Enable per-rule timing information.
 
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -77,6 +77,7 @@ Output
                               `stylish`, `unix`
         --debug=OPTIONS       Enable debug output options. Options are comma-separated. Possible
                               values:
+                               * `files` - Print the list of files that will be linted, then exit.
                                * `timings` - Enable per-rule timing information.
 
 Miscellaneous


### PR DESCRIPTION
- supersedes https://github.com/oxc-project/oxc/pull/17233
- part of https://github.com/oxc-project/oxc/issues/19833

Adds a `--debug files` option to print all files that will be linted, for debugging purposes.