### PR TITLE
fix(minifier): preserve IIFE structure in DCE-only mode

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1887,18 +1887,16 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// Take the IIFE body out for inlining, propagating the outer `pure`
-    /// annotation onto a call/new body. Propagation runs in both DCE and
-    /// full-minify modes; only the bail-out (via
-    /// [`Self::iife_inline_would_lose_pure`]) is gated to DCE mode, where
-    /// preserving the IIFE wrapper matters for downstream tools.
+    /// Take the IIFE body out for inlining and propagate `pure` onto a
+    /// call/new body. Bails in DCE-only mode — see the
+    /// `preserve_iife_in_dce_mode` test.
     /// Returns `None` to signal the caller should leave the IIFE intact.
     fn try_take_iife_body(
         body: &mut Expression<'a>,
         is_pure: bool,
         ctx: &TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
-        if Self::iife_inline_would_lose_pure(is_pure, body, ctx) {
+        if ctx.state.dce {
             return None;
         }
         let mut taken = body.take_in(ctx.ast);
@@ -1910,23 +1908,6 @@ impl<'a> PeepholeOptimizations {
             }
         }
         Some(taken)
-    }
-
-    /// Whether inlining the IIFE body would weaken the outer pure assertion.
-    /// Fires only in DCE-only mode (rolldown's per-module preprocess): the
-    /// outer call has no arguments, so its `pure` flag covers the entire
-    /// body. Inlining any side-effectful body surfaces sub-effects at the
-    /// outer call site, where rolldown's side-effect detector treats them
-    /// as real side effects regardless of the inlined node's `pure` flag.
-    fn iife_inline_would_lose_pure(
-        is_pure: bool,
-        body: &Expression<'a>,
-        ctx: &TraverseCtx<'a>,
-    ) -> bool {
-        if !is_pure || !ctx.state.dce {
-            return false;
-        }
-        body.may_have_side_effects(ctx)
     }
 }
 

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -548,32 +548,41 @@ fn remove_pure_function_calls() {
 }
 
 #[test]
-fn preserve_pure_iife_in_used_position_for_downstream_treeshake() {
+fn preserve_iife_in_dce_mode() {
     // https://github.com/oxc-project/oxc/issues/17480
+    // https://github.com/rolldown/rolldown/issues/9437
     //
-    // In DCE-only mode the IIFE inliner refuses to inline a
-    // `@__PURE__`-annotated IIFE when the body can't carry a `pure` flag,
-    // so the outer call's annotation stays visible to rolldown's
-    // side-effect detector.
+    // IIFE body extraction is a peephole / strength-reduction rewrite, not
+    // DCE. In DCE-only mode (rolldown's per-module preprocess) the IIFE
+    // structure is preserved entirely — matching Rollup, esbuild
+    // `--tree-shaking=true`, Terser (no compress), and SWC (no minify).
+    //
+    // The only DCE-relevant IIFE rewrites that still run: dropping
+    // pure-annotated IIFEs whose result is unused (handled separately via
+    // `is_expression_result_unused` → `void 0`), and replacing fully-empty
+    // IIFEs with `void 0`.
 
+    // Pure-annotated IIFEs preserved across all body shapes.
     test_same("export const exec = /* @__PURE__ */ (() => _M.exec)();");
     test_same("export const x = /* @__PURE__ */ (() => foo()?.bar())();");
     test_same("export const x = /* @__PURE__ */ (() => foo`tpl`)();");
     test_same("export const x = /* @__PURE__ */ (() => (a(), b()))();");
     test_same("export const x = /* @__PURE__ */ (() => c ? a() : b())();");
-    // Bare-identifier conditional — unknown global reads count as side
-    // effects in DCE mode, so the IIFE wrapper stays.
     test_same("export const x = /* @__PURE__ */ (() => a ? b : c)();");
-
     test_same("export const x = /* @__PURE__ */ (() => foo())();");
     test_same("export const x = /* @__PURE__ */ (() => new Foo())();");
-    // Effectful arg inside the body call — the original IIFE could be dropped
-    // wholesale; the inlined form would expose `bar()` as a surviving side
-    // effect of the outer call.
     test_same("export const x = /* @__PURE__ */ (() => foo(bar()))();");
     test_same("export const x = /* @__PURE__ */ (() => new Foo(bar()))();");
+    test_same("export const x = /* @__PURE__ */ (() => 42)();");
+    test_same("export const x = /* @__PURE__ */ (() => [1, 2, 3])();");
+    test_same("export const x = /* @__PURE__ */ (() => ({ a: 1 }))();");
 
-    test("export const x = /* @__PURE__ */ (() => 42)();", "export const x = 42;");
+    // Non-pure IIFEs are also preserved — inlining is not DCE.
+    test_same("export const x = (() => foo())();");
+    test_same("export const x = (() => [1, 2, 3])();");
+    test_same("export const x = (() => 42)();");
+    test_same("export const x = (() => { foo(); })();");
+    test_same("export const x = (() => { return foo(); })();");
 }
 
 #[test]

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -196,12 +196,14 @@ fn this_expr() {
 
     test(
         r"
-        // This code should be the same as above
+        // The IIFE wrapper is preserved under DCE-only mode — inlining IIFE
+        // bodies is a peephole rewrite, not DCE. See oxc_minifier PR #22547.
         (() => { ok( this, this.foo, this.foo.bar, this.foo.baz, this.bar,) })();
     ",
         "
-        // This code should be the same as above
-        ok(1, 2, 3, 2 .baz, 1 .bar);",
+        // The IIFE wrapper is preserved under DCE-only mode — inlining IIFE
+        // bodies is a peephole rewrite, not DCE. See oxc_minifier PR #22547.
+        (() => { ok(1, 2, 3, 2 .baz, 1 .bar); })();",
         &config,
     );
 


### PR DESCRIPTION
Fixes upstream rolldown/rolldown#9437. Supersedes the `iife_inline_would_lose_pure` gate from #22349.

## Bug

In DCE-only mode (rolldown's per-module preprocess via `Compressor::dead_code_elimination_with_scoping`), `substitute_iife_call` inlines `const x = /* @__PURE__ */ (() => [1, 2, 3])()` down to `const x = [1, 2, 3]`, dropping the `@__PURE__` annotation downstream tree-shakers rely on.

The previous `iife_inline_would_lose_pure` gate only bailed for side-effecting bodies, so array / object / primitive bodies still got inlined.

## Cross-tool comparison

Empirical, same input `export const x = /* @__PURE__ */ (() => [1, 2, 3])();`:

| Tool / Mode                              | Result                 |
| ---------------------------------------- | ---------------------- |
| Rollup 4.60 `treeshake: true`            | preserved              |
| esbuild 0.27 `--tree-shaking=true`       | preserved              |
| SWC 1.15 default (no minify)             | preserved              |
| Terser 5.46 no `-c` (no compress)        | preserved              |
| Terser 5.46 `-c` (compress / minify)     | inlined to `[1, 2, 3]` |
| **oxc DCE-only — before this PR**        | inlined to `[1, 2, 3]` |
| **oxc DCE-only — after this PR**         | preserved              |
| oxc full-minify (unchanged by this PR)   | inlined to `[1, 2, 3]` |

DCE-only is "tree-shake without minify" — the analogous reference is the "non-minify" rows. oxc DCE-only was the only mode inlining there.

## Fix

`try_take_iife_body` bails on `ctx.state.dce` directly. The `iife_inline_would_lose_pure` helper is removed.

Full-minify is untouched — `state.dce` is only set to `true` for `dead_code_elimination[_with_scoping]` entry points (exactly two writers in `compressor.rs`).

DCE-only IIFE rewrites that **still fire** (real DCE):

- Dropping pure-annotated IIFEs whose result is unused — `is_expression_result_unused` → `void 0`
- Replacing fully-empty IIFEs with `void 0`
- Dropping unused-var pure IIFEs via #22349's widened `is_expression_result_unused` (the original #17480 fix)

Covered by `preserve_iife_in_dce_mode` (renamed + extended from `preserve_pure_iife_in_used_position_for_downstream_treeshake`). 501 / 501 `cargo test -p oxc_minifier` pass, idempotent under `--twice`, `minsize` / `allocs` snapshots unchanged.
