### PR TITLE
refactor(codegen): consolidate cjs-module-lexer helpers into one module

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -10,53 +10,7 @@ use oxc_syntax::{
     precedence::{GetPrecedence, Precedence},
 };
 
-use crate::{Codegen, Context, Operator, r#gen::GenExpr};
-
-/// Force plain string quotes for `"default"` and `"__esModule"` when they
-/// appear as an operand of an equality comparison during minification. This
-/// keeps `cjs-module-lexer` (used by Node for CJS/ESM interop) able to
-/// recognise the re-export pattern emitted by Babel / TypeScript / Rollup:
-///
-/// ```js
-/// Object.keys(mod).forEach(function (key) {
-///   if (key === "default" || key === "__esModule") return;
-///   ...
-/// });
-/// ```
-///
-/// Without this, `print_string_literal`'s tie-breaker in
-/// `calculate_quote_maybe_backtick` prefers backtick on equal cost, and the
-/// lexer's heuristic parser does not match `key === \`default\``.
-///
-/// Companion to `try_print_require_call` and `try_print_cjs_define_property_call`
-/// in `gen.rs`, which preserve plain quotes at the other two syntactic positions
-/// `cjs-module-lexer` recognises.
-///
-/// Returns `true` if printed.
-#[inline]
-fn try_print_cjs_lexer_equality_string(
-    operator: BinaryishOperator,
-    operand: &Expression,
-    p: &mut Codegen,
-) -> bool {
-    if !p.options.minify {
-        return false;
-    }
-    let BinaryishOperator::Binary(op) = operator else {
-        return false;
-    };
-    if !op.is_equality() {
-        return false;
-    }
-    let Expression::StringLiteral(str_lit) = operand else {
-        return false;
-    };
-    if !matches!(str_lit.value.as_str(), "default" | "__esModule") {
-        return false;
-    }
-    p.print_string_literal(str_lit, false);
-    true
-}
+use crate::{Codegen, Context, Operator, cjs_module_lexer, r#gen::GenExpr};
 
 #[derive(Clone, Copy)]
 pub enum Binaryish<'a> {
@@ -170,7 +124,7 @@ impl<'a> BinaryExpressionVisitor<'a> {
             };
 
             let Some(left_binary) = left_binary else {
-                if !try_print_cjs_lexer_equality_string(v.operator, left, p) {
+                if !cjs_module_lexer::try_print_equality_string(p, v.operator, left) {
                     left.gen_expr(p, v.left_precedence, v.ctx);
                 }
                 v.visit_right_and_finish(p);
@@ -272,7 +226,7 @@ impl<'a> BinaryExpressionVisitor<'a> {
         self.operator.r#gen(p);
         p.print_soft_space();
         let right = self.e.right();
-        if !try_print_cjs_lexer_equality_string(self.operator, right, p) {
+        if !cjs_module_lexer::try_print_equality_string(p, self.operator, right) {
             right.gen_expr(p, self.right_precedence, self.ctx);
         }
         if self.wrap {

--- a/crates/oxc_codegen/src/cjs_module_lexer.rs
+++ b/crates/oxc_codegen/src/cjs_module_lexer.rs
@@ -1,0 +1,166 @@
+//! Workarounds for [cjs-module-lexer].
+//!
+//! `cjs-module-lexer` is the heuristic parser Node uses (under
+//! `--experimental-require-module` and on `require()` of an ESM graph) to
+//! discover the named exports of a CommonJS module without executing it. It
+//! does **not** run a real JS parser — it pattern-matches a fixed set of
+//! syntactic shapes that bundlers (Babel, TypeScript, Rollup) emit when
+//! lowering ESM to CJS. If our minifier rewrites any of those shapes in a way
+//! the heuristic doesn't recognise, Node silently drops the affected exports
+//! and downstream `import { x } from "cjs-pkg"` fails at runtime.
+//!
+//! In practice every breakage we've hit comes from the same root cause:
+//! `print_string_literal`'s `allow_backtick: true` tie-breaker in
+//! `calculate_quote_maybe_backtick` prefers backtick on equal cost, turning
+//! `"default"` into `` `default` ``. The lexer's pattern matcher accepts only
+//! plain string literals at the positions below, so we hand-print those
+//! positions with `allow_backtick: false`.
+//!
+//! The four positions we currently preserve, all `minify`-only:
+//!
+//! | Helper                            | Pattern                                                |
+//! | --------------------------------- | ------------------------------------------------------ |
+//! | [`try_print_require_call`]         | `require("…")`                                         |
+//! | [`try_print_define_property_call`] | `Object.defineProperty(_, "name", …)` / `Reflect.…`     |
+//! | [`try_print_exports_computed_target`] | `exports[STR] = …` / `module.exports[STR] = …`      |
+//! | [`try_print_equality_string`]      | `key === "default"` / `key === "__esModule"` (and `==`/`!=`/`!==`) |
+//!
+//! Each helper returns `true` if it printed the construct, so the caller can
+//! fall back to the default print path when the helper declines.
+//!
+//! Outside `minify`, `print_string_literal` already uses `self.quote` (never
+//! backtick), so these helpers no-op — see <https://github.com/oxc-project/oxc/issues/22342>.
+//!
+//! [cjs-module-lexer]: https://github.com/nodejs/cjs-module-lexer
+
+use oxc_ast::ast::{Argument, AssignmentTarget, CallExpression, Expression};
+use oxc_syntax::precedence::Precedence;
+
+use crate::{
+    Codegen, Context,
+    binary_expr_visitor::BinaryishOperator,
+    r#gen::{Gen, GenExpr},
+};
+
+/// Print `require("...")` with a plain string literal so `cjs-module-lexer`
+/// can detect re-export sources.
+///
+/// Skips the argument comments that `print_arguments` would preserve.
+pub fn try_print_require_call(p: &mut Codegen<'_>, call: &CallExpression<'_>) -> bool {
+    if !p.options.minify {
+        return false;
+    }
+    let Some(str_lit) = call.common_js_require() else {
+        return false;
+    };
+    p.print_ascii_byte(b'(');
+    p.print_string_literal(str_lit, false);
+    p.add_source_mapping_end(call.span);
+    p.print_ascii_byte(b')');
+    true
+}
+
+/// Print `Object.defineProperty(_, "name", ...)` / `Reflect.defineProperty(...)`
+/// with the property-name argument as a plain string literal so
+/// `cjs-module-lexer` can detect the export.
+///
+/// Skips the argument comments that `print_arguments` would preserve.
+pub fn try_print_define_property_call(
+    p: &mut Codegen<'_>,
+    call: &CallExpression<'_>,
+    ctx: Context,
+) -> bool {
+    if !p.options.minify {
+        return false;
+    }
+    let Some(Argument::StringLiteral(name)) = call.arguments.get(1) else {
+        return false;
+    };
+    if !call.callee.is_specific_member_access("Object", "defineProperty")
+        && !call.callee.is_specific_member_access("Reflect", "defineProperty")
+    {
+        return false;
+    }
+    p.print_ascii_byte(b'(');
+    for (i, arg) in call.arguments.iter().enumerate() {
+        if i != 0 {
+            p.print_comma();
+            p.print_soft_space();
+        }
+        if i == 1 {
+            p.print_string_literal(name, false);
+        } else {
+            arg.print(p, ctx);
+        }
+    }
+    p.add_source_mapping_end(call.span);
+    p.print_ascii_byte(b')');
+    true
+}
+
+/// Print `exports[STR] = …` / `module.exports[STR] = …`'s LHS with the
+/// computed key as a plain string literal so `cjs-module-lexer` can detect
+/// the export.
+pub fn try_print_exports_computed_target(
+    p: &mut Codegen<'_>,
+    target: &AssignmentTarget<'_>,
+    ctx: Context,
+) -> bool {
+    if !p.options.minify {
+        return false;
+    }
+    let AssignmentTarget::ComputedMemberExpression(member) = target else {
+        return false;
+    };
+    let Expression::StringLiteral(key) = &member.expression else {
+        return false;
+    };
+    if !member.object.is_specific_id("exports")
+        && !member.object.is_specific_member_access("module", "exports")
+    {
+        return false;
+    }
+    member.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
+    if member.optional {
+        p.print_str("?.");
+    }
+    p.print_ascii_byte(b'[');
+    p.print_string_literal(key, false);
+    p.print_ascii_byte(b']');
+    true
+}
+
+/// Print `"default"` / `"__esModule"` as a plain string literal when they
+/// appear as an operand of an equality comparison, so `cjs-module-lexer` can
+/// recognise the re-export filter emitted by Babel / TypeScript / Rollup:
+///
+/// ```js
+/// Object.keys(mod).forEach(function (key) {
+///   if (key === "default" || key === "__esModule") return;
+///   ...
+/// });
+/// ```
+#[inline]
+pub fn try_print_equality_string(
+    p: &mut Codegen,
+    operator: BinaryishOperator,
+    operand: &Expression,
+) -> bool {
+    if !p.options.minify {
+        return false;
+    }
+    let BinaryishOperator::Binary(op) = operator else {
+        return false;
+    };
+    if !op.is_equality() {
+        return false;
+    }
+    let Expression::StringLiteral(str_lit) = operand else {
+        return false;
+    };
+    if !matches!(str_lit.value.as_str(), "default" | "__esModule") {
+        return false;
+    }
+    p.print_string_literal(str_lit, false);
+    true
+}

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -12,6 +12,7 @@ use oxc_syntax::{
 use crate::{
     Codegen, Context, Operator, Quote,
     binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
+    cjs_module_lexer,
 };
 
 const PURE_COMMENT: &str = "/* @__PURE__ */ ";
@@ -1502,77 +1503,13 @@ impl GenExpr for CallExpression<'_> {
             if let Some(type_parameters) = &self.type_arguments {
                 type_parameters.print(p, ctx);
             }
-            if !try_print_cjs_define_property_call(p, self, ctx) && !try_print_require_call(p, self)
+            if !cjs_module_lexer::try_print_define_property_call(p, self, ctx)
+                && !cjs_module_lexer::try_print_require_call(p, self)
             {
                 p.print_arguments(self.span, &self.arguments, ctx);
             }
         });
     }
-}
-
-/// Print `Object.defineProperty(_, "name", ...)` / `Reflect.defineProperty(...)` with the
-/// property-name argument as a plain string literal so `cjs-module-lexer` (used by Node for
-/// CJS/ESM interop) can detect the export. Returns `true` if printed.
-/// See <https://github.com/oxc-project/oxc/issues/22342>.
-///
-/// Minify-only: outside minify, `print_string_literal` already uses `self.quote` (never
-/// backtick), and this path skips the argument comments that `print_arguments` preserves.
-///
-/// Companion to `try_print_require_call` (below) and
-/// `try_print_cjs_lexer_equality_string` in `binary_expr_visitor.rs`.
-fn try_print_cjs_define_property_call(
-    p: &mut Codegen<'_>,
-    call: &CallExpression<'_>,
-    ctx: Context,
-) -> bool {
-    if !p.options.minify {
-        return false;
-    }
-    let Some(Argument::StringLiteral(name)) = call.arguments.get(1) else {
-        return false;
-    };
-    if !call.callee.is_specific_member_access("Object", "defineProperty")
-        && !call.callee.is_specific_member_access("Reflect", "defineProperty")
-    {
-        return false;
-    }
-    p.print_ascii_byte(b'(');
-    for (i, arg) in call.arguments.iter().enumerate() {
-        if i != 0 {
-            p.print_comma();
-            p.print_soft_space();
-        }
-        if i == 1 {
-            p.print_string_literal(name, false);
-        } else {
-            arg.print(p, ctx);
-        }
-    }
-    p.add_source_mapping_end(call.span);
-    p.print_ascii_byte(b')');
-    true
-}
-
-/// Print `require("...")` with a plain string literal so `cjs-module-lexer` (used by Node for
-/// CJS/ESM interop) can detect reexport sources. Returns `true` if printed.
-///
-/// Minify-only: outside minify, `print_string_literal` already uses `self.quote` (never
-/// backtick), and this path skips the argument comments that `print_arguments` preserves.
-///
-/// Companion to `try_print_cjs_define_property_call` (above) and
-/// `try_print_cjs_lexer_equality_string` in `binary_expr_visitor.rs`.
-fn try_print_require_call(p: &mut Codegen<'_>, call: &CallExpression<'_>) -> bool {
-    if !p.options.minify {
-        return false;
-    }
-    let Some(str_lit) = call.common_js_require() else {
-        return false;
-    };
-    p.print_ascii_byte(b'(');
-    p.print_string_literal(str_lit, false);
-    p.add_source_mapping_end(call.span);
-    p.print_ascii_byte(b')');
-    true
 }
 
 impl Gen for Argument<'_> {
@@ -2004,7 +1941,7 @@ impl GenExpr for AssignmentExpression<'_> {
             && matches!(self.left, AssignmentTarget::ObjectAssignmentTarget(_));
         p.wrap(wrap || precedence >= self.precedence(), |p| {
             p.add_source_mapping(self.span);
-            if !try_print_cjs_exports_computed_target(p, &self.left, ctx) {
+            if !cjs_module_lexer::try_print_exports_computed_target(p, &self.left, ctx) {
                 self.left.print(p, ctx);
             }
             p.print_soft_space();
@@ -2013,39 +1950,6 @@ impl GenExpr for AssignmentExpression<'_> {
             self.right.print_expr(p, Precedence::Comma, ctx);
         });
     }
-}
-
-/// Print `exports[STR] = …` / `module.exports[STR] = …`'s LHS with the computed key as a
-/// plain string literal so `cjs-module-lexer` (used by Node for CJS/ESM interop) can detect
-/// the export. Returns `true` if printed. Same minify-only rationale as
-/// [`try_print_cjs_define_property_call`]. See <https://github.com/oxc-project/oxc/issues/22342>.
-fn try_print_cjs_exports_computed_target(
-    p: &mut Codegen<'_>,
-    target: &AssignmentTarget<'_>,
-    ctx: Context,
-) -> bool {
-    if !p.options.minify {
-        return false;
-    }
-    let AssignmentTarget::ComputedMemberExpression(member) = target else {
-        return false;
-    };
-    let Expression::StringLiteral(key) = &member.expression else {
-        return false;
-    };
-    if !member.object.is_specific_id("exports")
-        && !member.object.is_specific_member_access("module", "exports")
-    {
-        return false;
-    }
-    member.object.print_expr(p, Precedence::Postfix, ctx.intersection(Context::FORBID_CALL));
-    if member.optional {
-        p.print_str("?.");
-    }
-    p.print_ascii_byte(b'[');
-    p.print_string_literal(key, false);
-    p.print_ascii_byte(b']');
-    true
 }
 
 impl Gen for AssignmentTarget<'_> {

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -22,6 +22,7 @@ use oxc_syntax::{
 use rustc_hash::FxHashMap;
 
 mod binary_expr_visitor;
+mod cjs_module_lexer;
 mod comment;
 mod context;
 mod r#gen;


### PR DESCRIPTION
## Summary

- Move all four `try_print_cjs_*` helpers — `require("…")`, `Object.defineProperty(_, "name", …)`, `exports[STR] = …`, and `key === "default"` / `key === "__esModule"` — into a new `cjs_module_lexer` module.
- Add a module-level doc explaining the shared root cause (`calculate_quote_maybe_backtick`'s backtick tie-breaker that the lexer's heuristic parser doesn't accept) and listing all four positions in one table, so the next workaround has an obvious home.
- Names drop the redundant `cjs_` prefix; call sites use `cjs_module_lexer::try_print_…`. No behavior change.

Stacked on top of #22551.

AI disclosure: drafted with Claude Code, reviewed manually.
