### PR TITLE
refactor(linter/vue): consolidate Vue component detection into shared utils

### DIFF
--- a/crates/oxc_linter/src/rules/vue/no_deprecated_data_object_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_data_object_declaration.rs
@@ -250,6 +250,21 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            "
+                    <script>
+                    Vue.mixin({
+                      data: {
+                        foo: 'bar'
+                      }
+                    })
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     Tester::new(

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_data_object_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_data_object_declaration.rs
@@ -3,7 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_vue_component_options_object};
 
 fn no_deprecated_data_object_declaration_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Object declaration on `data` property is deprecated.")
@@ -72,22 +72,12 @@ impl Rule for NoDeprecatedDataObjectDeclaration {
             return;
         }
 
-        let mut ancestors = ctx.nodes().ancestors(node.id());
-        let Some(parent) = ancestors.next() else { return };
+        let parent = ctx.nodes().parent_node(node.id());
         if !matches!(parent.kind(), AstKind::ObjectExpression(_)) {
             return;
         }
 
-        let Some(grand) = ancestors.next() else { return };
-        let in_vue = match grand.kind() {
-            AstKind::ExportDefaultDeclaration(_) => true,
-            AstKind::CallExpression(call) => call
-                .callee
-                .get_identifier_reference()
-                .is_some_and(|id| id.name == "defineComponent"),
-            _ => false,
-        };
-        if !in_vue {
+        if !is_vue_component_options_object(parent, ctx) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_data_object_declaration.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_data_object_declaration.rs
@@ -250,7 +250,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             "
                     <script>

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_events_api.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_events_api.rs
@@ -338,6 +338,31 @@ fn test() {
             None,
             Some(PathBuf::from("test.js")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            r"
+            Vue.mixin({
+              mounted() {
+                this.$on('start', foo)
+              }
+            })
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ),
+        (
+            r"
+            new Vue({
+              mounted() {
+                this.$on('start', foo)
+              }
+            })
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ),
     ];
 
     Tester::new(NoDeprecatedEventsApi::NAME, NoDeprecatedEventsApi::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_events_api.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_events_api.rs
@@ -338,7 +338,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.js")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             r"
             Vue.mixin({

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_events_api.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_events_api.rs
@@ -1,13 +1,14 @@
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression, IdentifierReference, MemberExpression},
+    ast::{Expression, IdentifierReference, MemberExpression},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 
 use crate::{
     AstNode, ast_util::get_declaration_from_reference_id, context::LintContext, rule::Rule,
+    utils::is_in_vue_component_instance_method,
 };
 
 const DEPRECATED_EVENTS_API_METHODS: [&str; 3] = ["$on", "$off", "$once"];
@@ -122,79 +123,6 @@ fn is_this(ident: &IdentifierReference, ctx: &LintContext<'_>) -> bool {
             _ => None,
         })
         .is_some_and(|init| matches!(init, Expression::ThisExpression(_)))
-}
-
-fn is_in_vue_component_instance_method(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let Some(function_node) = ctx
-        .nodes()
-        .ancestors(node.id())
-        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
-    else {
-        return false;
-    };
-
-    let property_node = ctx.nodes().parent_node(function_node.id());
-    let AstKind::ObjectProperty(_) = property_node.kind() else {
-        return false;
-    };
-
-    let object_node = ctx.nodes().parent_node(property_node.id());
-    if is_vue_component_options_object(object_node, ctx) {
-        return true;
-    }
-
-    let container_property_node = ctx.nodes().parent_node(object_node.id());
-    if !matches!(container_property_node.kind(), AstKind::ObjectProperty(_)) {
-        return false;
-    }
-
-    let Some(container_name) = container_property_node
-        .kind()
-        .as_object_property()
-        .and_then(|prop| if prop.computed { None } else { prop.key.static_name() })
-    else {
-        return false;
-    };
-
-    matches!(container_name.as_ref(), "computed" | "methods" | "watch")
-        && is_vue_component_options_object(
-            ctx.nodes().parent_node(container_property_node.id()),
-            ctx,
-        )
-}
-
-fn is_vue_component_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let AstKind::ObjectExpression(object_expr) = object_node.kind() else {
-        return false;
-    };
-
-    ctx.nodes().ancestors(object_node.id()).any(|ancestor| match ancestor.kind() {
-        AstKind::ExportDefaultDeclaration(export_default_decl) => {
-            export_default_decl.declaration.span() == object_expr.span
-        }
-        AstKind::CallExpression(call_expr) => {
-            call_expr
-                .arguments
-                .iter()
-                .any(|arg| arg.as_expression().is_some_and(|expr| expr.span() == object_expr.span))
-                && is_vue_component_options_call(call_expr)
-        }
-        _ => false,
-    })
-}
-
-fn is_vue_component_options_call(call_expr: &CallExpression<'_>) -> bool {
-    if call_expr
-        .callee
-        .get_identifier_reference()
-        .is_some_and(|ident| matches!(ident.name.as_str(), "createApp" | "defineComponent"))
-    {
-        return true;
-    }
-
-    call_expr.callee.get_member_expr().is_some_and(|member_expr| {
-        member_expr.static_property_name().is_some_and(|name| name == "component")
-    })
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_model_definition.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_model_definition.rs
@@ -353,6 +353,22 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            "
+                <script>
+                new Vue({
+                  model: {
+                    prop: 'checked',
+                    event: 'change'
+                  }
+                })
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     Tester::new(NoDeprecatedModelDefinition::NAME, NoDeprecatedModelDefinition::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_model_definition.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_model_definition.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression, MemberExpression, ObjectExpression, ObjectPropertyKind},
+    ast::{Expression, ObjectExpression, ObjectPropertyKind},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -14,6 +14,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
+    utils::is_vue_component_options_object,
 };
 
 fn deprecated_model_diagnostic(span: Span) -> OxcDiagnostic {
@@ -109,14 +110,12 @@ impl Rule for NoDeprecatedModelDefinition {
             return;
         };
 
-        let mut ancestors = ctx.nodes().ancestors(node.id());
-        let Some(parent) = ancestors.next() else { return };
+        let parent = ctx.nodes().parent_node(node.id());
         if !matches!(parent.kind(), AstKind::ObjectExpression(_)) {
             return;
         }
 
-        let Some(grand) = ancestors.next() else { return };
-        if !is_vue_component_root(grand.kind()) {
+        if !is_vue_component_options_object(parent, ctx) {
             return;
         }
 
@@ -138,41 +137,6 @@ impl Rule for NoDeprecatedModelDefinition {
             ctx.diagnostic(vue3_compat_diagnostic(prop.span));
         }
     }
-}
-
-fn is_vue_component_root(grand_kind: AstKind<'_>) -> bool {
-    match grand_kind {
-        AstKind::ExportDefaultDeclaration(_) => true,
-        AstKind::CallExpression(call) => is_vue_component_definition_call(call),
-        AstKind::NewExpression(new_expr) => {
-            new_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == "Vue")
-        }
-        _ => false,
-    }
-}
-
-fn is_vue_component_definition_call(call: &CallExpression<'_>) -> bool {
-    let callee = call.callee.get_inner_expression();
-
-    if let Expression::Identifier(ident) = callee {
-        return matches!(
-            ident.name.as_str(),
-            "defineComponent" | "component" | "createApp" | "defineNuxtComponent"
-        );
-    }
-
-    let Some(MemberExpression::StaticMemberExpression(static_member)) =
-        callee.as_member_expression()
-    else {
-        return false;
-    };
-    let prop_name = static_member.property.name.as_str();
-    if let Expression::Identifier(obj_ident) = static_member.object.get_inner_expression()
-        && obj_ident.name == "Vue"
-    {
-        return matches!(prop_name, "component" | "mixin" | "extend");
-    }
-    matches!(prop_name, "component" | "mixin")
 }
 
 fn find_string_property_value(obj: &ObjectExpression<'_>, key: &str) -> Option<String> {

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_model_definition.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_model_definition.rs
@@ -353,7 +353,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             "
                 <script>

--- a/crates/oxc_linter/src/rules/vue/no_shared_component_data.rs
+++ b/crates/oxc_linter/src/rules/vue/no_shared_component_data.rs
@@ -345,6 +345,19 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            "
+                <script>
+                Vue.mixin({
+                  data: { foo: 'bar' }
+                })
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     Tester::new(NoSharedComponentData::NAME, NoSharedComponentData::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/no_shared_component_data.rs
+++ b/crates/oxc_linter/src/rules/vue/no_shared_component_data.rs
@@ -345,7 +345,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             "
                 <script>

--- a/crates/oxc_linter/src/rules/vue/no_shared_component_data.rs
+++ b/crates/oxc_linter/src/rules/vue/no_shared_component_data.rs
@@ -1,12 +1,12 @@
-use oxc_ast::{
-    AstKind,
-    ast::{CallExpression, Expression, MemberExpression},
-};
+use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode, context::LintContext, rule::Rule,
+    utils::is_vue_component_options_object_excluding_instance,
+};
 
 fn no_shared_component_data_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`data` property in component must be a function.").with_label(span)
@@ -76,63 +76,17 @@ impl Rule for NoSharedComponentData {
             return;
         }
 
-        let mut ancestors = ctx.nodes().ancestors(node.id());
-        let Some(parent) = ancestors.next() else { return };
+        let parent = ctx.nodes().parent_node(node.id());
         if !matches!(parent.kind(), AstKind::ObjectExpression(_)) {
             return;
         }
 
-        let Some(grand) = ancestors.next() else { return };
-        let in_vue_component = match grand.kind() {
-            AstKind::ExportDefaultDeclaration(_) => {
-                ctx.file_extension().is_some_and(|ext| ext == "vue")
-            }
-            AstKind::CallExpression(call) => {
-                is_last_object_argument(parent, call) && is_vue_component_definition_call(call)
-            }
-            _ => false,
-        };
-        if !in_vue_component {
+        if !is_vue_component_options_object_excluding_instance(parent, ctx) {
             return;
         }
 
         ctx.diagnostic(no_shared_component_data_diagnostic(prop.span));
     }
-}
-
-fn is_last_object_argument(node: &AstNode<'_>, call: &CallExpression<'_>) -> bool {
-    let AstKind::ObjectExpression(object) = node.kind() else { return false };
-
-    call.arguments.last().and_then(|argument| argument.as_expression()).is_some_and(|argument| {
-        match argument.get_inner_expression() {
-            Expression::ObjectExpression(argument_object) => argument_object.span == object.span,
-            _ => false,
-        }
-    })
-}
-
-fn is_vue_component_definition_call(call: &CallExpression<'_>) -> bool {
-    let callee = call.callee.get_inner_expression();
-
-    if let Expression::Identifier(ident) = callee {
-        return matches!(
-            ident.name.as_str(),
-            "defineComponent" | "component" | "createApp" | "defineNuxtComponent"
-        );
-    }
-
-    let Some(MemberExpression::StaticMemberExpression(static_member)) =
-        callee.as_member_expression()
-    else {
-        return false;
-    };
-    let prop_name = static_member.property.name.as_str();
-    if let Expression::Identifier(obj_ident) = static_member.object.get_inner_expression()
-        && obj_ident.name == "Vue"
-    {
-        return matches!(prop_name, "component" | "mixin" | "extend");
-    }
-    matches!(prop_name, "component" | "mixin")
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
+++ b/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
@@ -1,8 +1,7 @@
 use oxc_ast::{
     AstKind,
     ast::{
-        AssignmentTarget, CallExpression, ChainElement, Expression, IdentifierReference,
-        StaticMemberExpression,
+        AssignmentTarget, ChainElement, Expression, IdentifierReference, StaticMemberExpression,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -12,6 +11,7 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode, ast_util::get_declaration_from_reference_id, context::LintContext, rule::Rule,
+    utils::is_vue_component_options_object,
 };
 
 fn require_slots_as_functions_diagnostic(span: Span) -> OxcDiagnostic {
@@ -166,40 +166,6 @@ fn verify(node: &AstNode<'_>, report_span: Span, ctx: &LintContext<'_>) {
 
 fn is_under_vue_component_options_object(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
     ctx.nodes().ancestors(node.id()).any(|ancestor| is_vue_component_options_object(ancestor, ctx))
-}
-
-fn is_vue_component_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let AstKind::ObjectExpression(object_expr) = object_node.kind() else {
-        return false;
-    };
-
-    ctx.nodes().ancestors(object_node.id()).any(|ancestor| match ancestor.kind() {
-        AstKind::ExportDefaultDeclaration(export_default_decl) => {
-            export_default_decl.declaration.span() == object_expr.span
-        }
-        AstKind::CallExpression(call_expr) => {
-            call_expr
-                .arguments
-                .iter()
-                .any(|arg| arg.as_expression().is_some_and(|expr| expr.span() == object_expr.span))
-                && is_vue_component_options_call(call_expr)
-        }
-        _ => false,
-    })
-}
-
-fn is_vue_component_options_call(call_expr: &CallExpression<'_>) -> bool {
-    if call_expr
-        .callee
-        .get_identifier_reference()
-        .is_some_and(|ident| matches!(ident.name.as_str(), "createApp" | "defineComponent"))
-    {
-        return true;
-    }
-
-    call_expr.callee.get_member_expr().is_some_and(|member_expr| {
-        member_expr.static_property_name().is_some_and(|name| name == "component")
-    })
 }
 
 fn follow_references(symbol_id: SymbolId, report_span: Span, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
+++ b/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
@@ -291,7 +291,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             "
                   <script>

--- a/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
+++ b/crates/oxc_linter/src/rules/vue/require_slots_as_functions.rs
@@ -291,6 +291,22 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            "
+                  <script>
+                  Vue.mixin({
+                    render (h) {
+                      var children = this.$slots.default
+                      return h('div', [...children])
+                    }
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     Tester::new(RequireSlotsAsFunctions::NAME, RequireSlotsAsFunctions::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression, MemberExpression},
+    ast::{CallExpression, Expression},
 };
 use oxc_cfg::{
     EdgeType, ErrorEdgeKind, InstructionKind, ReturnInstructionKind,
@@ -20,6 +20,7 @@ use crate::{
     context::{ContextHost, LintContext},
     module_record::ImportImportName,
     rule::{DefaultRuleConfig, Rule},
+    utils::is_vue_component_options_object,
 };
 
 fn return_in_computed_property_diagnostic(span: Span) -> OxcDiagnostic {
@@ -191,7 +192,7 @@ fn is_vue_computed_getter(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
 }
 
 fn is_under_vue_root(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    ctx.nodes().ancestors(node.id()).any(|a| is_vue_component_root(a.kind()))
+    ctx.nodes().ancestors(node.id()).any(|a| is_vue_component_options_object(a, ctx))
 }
 
 fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
@@ -220,41 +221,6 @@ fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> boo
         }
         scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
     })
-}
-
-fn is_vue_component_root(kind: AstKind<'_>) -> bool {
-    match kind {
-        AstKind::ExportDefaultDeclaration(_) => true,
-        AstKind::CallExpression(call) => is_vue_component_definition_call(call),
-        AstKind::NewExpression(new_expr) => {
-            new_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == "Vue")
-        }
-        _ => false,
-    }
-}
-
-fn is_vue_component_definition_call(call: &CallExpression<'_>) -> bool {
-    let callee = call.callee.get_inner_expression();
-
-    if let Expression::Identifier(ident) = callee {
-        return matches!(
-            ident.name.as_str(),
-            "defineComponent" | "component" | "createApp" | "defineNuxtComponent"
-        );
-    }
-
-    let Some(MemberExpression::StaticMemberExpression(static_member)) =
-        callee.as_member_expression()
-    else {
-        return false;
-    };
-    let prop_name = static_member.property.name.as_str();
-    if let Expression::Identifier(obj_ident) = static_member.object.get_inner_expression()
-        && obj_ident.name == "Vue"
-    {
-        return matches!(prop_name, "component" | "mixin" | "extend");
-    }
-    matches!(prop_name, "component" | "mixin")
 }
 
 fn definitely_returns_in_all_codepaths(

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -672,7 +672,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             "
                 <script>

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -672,6 +672,22 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            "
+                <script>
+                new Vue({
+                  computed: {
+                    foo() {
+                    }
+                  }
+                })
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     Tester::new(ReturnInComputedProperty::NAME, ReturnInComputedProperty::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
@@ -541,7 +541,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             "
                 <script>

--- a/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
@@ -541,6 +541,22 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            "
+                <script>
+                Vue.mixin({
+                  emits: {
+                    foo () {
+                    }
+                  }
+                })
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     Tester::new(ReturnInEmitsValidator::NAME, ReturnInEmitsValidator::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_emits_validator.rs
@@ -1,16 +1,17 @@
 use oxc_ast::{
     AstKind,
-    ast::{
-        ArrowFunctionExpression, CallExpression, Expression, Function, ReturnStatement, Statement,
-    },
+    ast::{ArrowFunctionExpression, Expression, Function, ReturnStatement, Statement},
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
+use crate::{
+    AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule,
+    utils::is_vue_component_options_object,
+};
 
 fn expected_boolean_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -140,33 +141,6 @@ fn get_emit_validator_name(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<
     }
 
     None
-}
-
-fn is_vue_component_options_object(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let AstKind::ObjectExpression(obj) = node.kind() else { return false };
-    ctx.nodes().ancestors(node.id()).any(|ancestor| match ancestor.kind() {
-        AstKind::ExportDefaultDeclaration(decl) => decl.declaration.span() == obj.span,
-        AstKind::CallExpression(call) => {
-            call.arguments
-                .iter()
-                .any(|arg| arg.as_expression().is_some_and(|e| e.span() == obj.span))
-                && is_vue_component_factory_call(call)
-        }
-        _ => false,
-    })
-}
-
-fn is_vue_component_factory_call(call: &CallExpression<'_>) -> bool {
-    if call
-        .callee
-        .get_identifier_reference()
-        .is_some_and(|ident| matches!(ident.name.as_str(), "createApp" | "defineComponent"))
-    {
-        return true;
-    }
-    call.callee.get_member_expr().is_some_and(|member_expr| {
-        member_expr.static_property_name().is_some_and(|name| name == "component")
-    })
 }
 
 /// Walks the body of an emits validator and reports whether at least one

--- a/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
@@ -491,6 +491,29 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // Forms covered after consolidating component detection into utils.
+        (
+            "<script>
+                  Vue.mixin({
+                    mounted() {
+                      this.$nextTick;
+                    }
+                  })</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  defineNuxtComponent({
+                    mounted() {
+                      this.$nextTick;
+                    }
+                  })</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
@@ -8,7 +8,7 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode, ast_util::get_declaration_from_reference_id, context::LintContext,
-    module_record::ImportImportName, rule::Rule,
+    module_record::ImportImportName, rule::Rule, utils::is_in_vue_component_instance_method,
 };
 
 fn should_be_function_diagnostic(span: Span) -> OxcDiagnostic {
@@ -111,9 +111,7 @@ impl Rule for ValidNextTick {
             _ => return,
         };
 
-        if !is_in_vue_component_instance_method(next_tick_node, ctx)
-            && !is_in_legacy_vue_instance_method(next_tick_node, ctx)
-        {
+        if !is_in_vue_component_instance_method(next_tick_node, ctx) {
             return;
         }
 
@@ -231,149 +229,6 @@ fn is_vue_next_tick_import(ident: &IdentifierReference, ctx: &LintContext<'_>) -
         }
     }
     false
-}
-
-fn is_in_vue_component_instance_method(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let Some(function_node) = ctx
-        .nodes()
-        .ancestors(node.id())
-        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
-    else {
-        return false;
-    };
-
-    let property_node = ctx.nodes().parent_node(function_node.id());
-    let AstKind::ObjectProperty(_) = property_node.kind() else {
-        return false;
-    };
-
-    let object_node = ctx.nodes().parent_node(property_node.id());
-    if is_vue_component_options_object(object_node, ctx) {
-        return true;
-    }
-
-    let container_property_node = ctx.nodes().parent_node(object_node.id());
-    if !matches!(container_property_node.kind(), AstKind::ObjectProperty(_)) {
-        return false;
-    }
-
-    let Some(container_name) = container_property_node
-        .kind()
-        .as_object_property()
-        .and_then(|prop| if prop.computed { None } else { prop.key.static_name() })
-    else {
-        return false;
-    };
-
-    matches!(container_name.as_ref(), "computed" | "methods" | "watch")
-        && is_vue_component_options_object(
-            ctx.nodes().parent_node(container_property_node.id()),
-            ctx,
-        )
-}
-
-fn is_vue_component_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let AstKind::ObjectExpression(object_expr) = object_node.kind() else {
-        return false;
-    };
-
-    ctx.nodes().ancestors(object_node.id()).any(|ancestor| match ancestor.kind() {
-        AstKind::ExportDefaultDeclaration(export_default_decl) => {
-            export_default_decl.declaration.span() == object_expr.span
-        }
-        AstKind::CallExpression(call_expr) => {
-            call_expr
-                .arguments
-                .iter()
-                .any(|arg| arg.as_expression().is_some_and(|expr| expr.span() == object_expr.span))
-                && is_vue_component_options_call(call_expr)
-        }
-        _ => false,
-    })
-}
-
-fn is_vue_component_options_call(call_expr: &CallExpression<'_>) -> bool {
-    if call_expr
-        .callee
-        .get_identifier_reference()
-        .is_some_and(|ident| matches!(ident.name.as_str(), "createApp" | "defineComponent"))
-    {
-        return true;
-    }
-
-    call_expr.callee.get_member_expr().is_some_and(|member_expr| {
-        member_expr.static_property_name().is_some_and(|name| name == "component")
-    })
-}
-
-// Detect Vue 2 forms: `new Vue({...})` and `Vue.extend({...})`.
-fn is_in_legacy_vue_instance_method(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let Some(function_node) = ctx
-        .nodes()
-        .ancestors(node.id())
-        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
-    else {
-        return false;
-    };
-
-    let property_node = ctx.nodes().parent_node(function_node.id());
-    if !matches!(property_node.kind(), AstKind::ObjectProperty(_)) {
-        return false;
-    }
-
-    let object_node = ctx.nodes().parent_node(property_node.id());
-    if is_legacy_vue_options_object(object_node, ctx) {
-        return true;
-    }
-
-    let container_property_node = ctx.nodes().parent_node(object_node.id());
-    if !matches!(container_property_node.kind(), AstKind::ObjectProperty(_)) {
-        return false;
-    }
-    let Some(container_name) = container_property_node
-        .kind()
-        .as_object_property()
-        .and_then(|prop| if prop.computed { None } else { prop.key.static_name() })
-    else {
-        return false;
-    };
-
-    matches!(container_name.as_ref(), "computed" | "methods" | "watch")
-        && is_legacy_vue_options_object(ctx.nodes().parent_node(container_property_node.id()), ctx)
-}
-
-fn is_legacy_vue_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let AstKind::ObjectExpression(object_expr) = object_node.kind() else {
-        return false;
-    };
-    ctx.nodes().ancestors(object_node.id()).any(|ancestor| match ancestor.kind() {
-        // `new Vue({...})`
-        AstKind::NewExpression(new_expr) => {
-            new_expr
-                .arguments
-                .iter()
-                .any(|arg| arg.as_expression().is_some_and(|e| e.span() == object_expr.span))
-                && new_expr
-                    .callee
-                    .get_identifier_reference()
-                    .is_some_and(|ident| ident.name == "Vue")
-        }
-        // `Vue.extend({...})`
-        AstKind::CallExpression(call_expr) => {
-            call_expr
-                .arguments
-                .iter()
-                .any(|arg| arg.as_expression().is_some_and(|e| e.span() == object_expr.span))
-                && call_expr.callee.get_member_expr().is_some_and(|member| {
-                    member.static_property_name().is_some_and(|name| name == "extend")
-                        && matches!(
-                            member.object().get_inner_expression(),
-                            Expression::Identifier(id) if id.name == "Vue"
-                        )
-                })
-        }
-        _ => false,
-    })
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_next_tick.rs
@@ -491,7 +491,6 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Forms covered after consolidating component detection into utils.
         (
             "<script>
                   Vue.mixin({

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_data_object_declaration.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_data_object_declaration.snap
@@ -31,3 +31,13 @@ source: crates/oxc_linter/src/tester.rs
  7 │                         })
    ╰────
   help: Use a function declaration instead.
+
+  ⚠ vue(no-deprecated-data-object-declaration): Object declaration on `data` property is deprecated.
+   ╭─[no_deprecated_data_object_declaration.tsx:4:23]
+ 3 │                         Vue.mixin({
+ 4 │ ╭─▶                       data: {
+ 5 │ │                           foo: 'bar'
+ 6 │ ╰─▶                       }
+ 7 │                         })
+   ╰────
+  help: Use a function declaration instead.

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_events_api.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_events_api.snap
@@ -91,3 +91,21 @@ source: crates/oxc_linter/src/tester.rs
  7 │               }
    ╰────
   help: Using external library instead, for example mitt.
+
+  ⚠ vue(no-deprecated-events-api): The Events api `$on`, `$off`, `$once` is deprecated.
+   ╭─[no_deprecated_events_api.tsx:4:22]
+ 3 │               mounted() {
+ 4 │                 this.$on('start', foo)
+   ·                      ───
+ 5 │               }
+   ╰────
+  help: Using external library instead, for example mitt.
+
+  ⚠ vue(no-deprecated-events-api): The Events api `$on`, `$off`, `$once` is deprecated.
+   ╭─[no_deprecated_events_api.tsx:4:22]
+ 3 │               mounted() {
+ 4 │                 this.$on('start', foo)
+   ·                      ───
+ 5 │               }
+   ╰────
+  help: Using external library instead, for example mitt.

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_model_definition.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_model_definition.snap
@@ -87,3 +87,13 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                   }
  8 │                     })
    ╰────
+
+  ⚠ vue(no-deprecated-model-definition): `model` definition is deprecated.
+   ╭─[no_deprecated_model_definition.tsx:4:19]
+ 3 │                     new Vue({
+ 4 │ ╭─▶                   model: {
+ 5 │ │                       prop: 'checked',
+ 6 │ │                       event: 'change'
+ 7 │ ╰─▶                   }
+ 8 │                     })
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_shared_component_data.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_shared_component_data.snap
@@ -61,3 +61,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ────────────────────
  5 │                 })
    ╰────
+
+  ⚠ vue(no-shared-component-data): `data` property in component must be a function.
+   ╭─[no_shared_component_data.tsx:4:19]
+ 3 │                 Vue.mixin({
+ 4 │                   data: { foo: 'bar' }
+   ·                   ────────────────────
+ 5 │                 })
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_require_slots_as_functions.snap
+++ b/crates/oxc_linter/src/snapshots/vue_require_slots_as_functions.snap
@@ -41,3 +41,11 @@ source: crates/oxc_linter/src/tester.rs
     ·                                                 ───
  10 │                       var bar = (this?.$slots)?.foo?.() // OK
     ╰────
+
+  ⚠ vue(require-slots-as-functions): Property in `$slots` should be used as function.
+   ╭─[require_slots_as_functions.tsx:5:50]
+ 4 │                     render (h) {
+ 5 │                       var children = this.$slots.default
+   ·                                                  ───────
+ 6 │                       return h('div', [...children])
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
+++ b/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
@@ -153,3 +153,12 @@ source: crates/oxc_linter/src/tester.rs
  7 │                       }
    ╰────
   help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:5:24]
+ 4 │                       computed: {
+ 5 │ ╭─▶                     foo() {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────
+  help: All code paths inside a computed getter must return a value.

--- a/crates/oxc_linter/src/snapshots/vue_return_in_emits_validator.snap
+++ b/crates/oxc_linter/src/snapshots/vue_return_in_emits_validator.snap
@@ -104,3 +104,11 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                   }
  6 │                     })
    ╰────
+
+  ⚠ vue(return-in-emits-validator): Expected to return a boolean value in "foo" emits validator.
+   ╭─[return_in_emits_validator.tsx:5:25]
+ 4 │                       emits: {
+ 5 │ ╭─▶                     foo () {
+ 6 │ ╰─▶                     }
+ 7 │                       }
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
+++ b/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
@@ -223,3 +223,21 @@ source: crates/oxc_linter/src/tester.rs
  5 │                     }
    ╰────
   help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:4:28]
+ 3 │                     mounted() {
+ 4 │                       this.$nextTick;
+   ·                            ─────────
+ 5 │                     }
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:4:28]
+ 3 │                     mounted() {
+ 4 │                       this.$nextTick;
+   ·                            ─────────
+ 5 │                     }
+   ╰────
+  help: Insert `()`

--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -5,8 +5,9 @@ use oxc_ast::{
         ObjectPropertyKind,
     },
 };
+use oxc_span::GetSpan;
 
-use crate::{ContextSubHost, LintContext};
+use crate::{AstNode, ContextSubHost, LintContext, frameworks::FrameworkOptions};
 
 /// Check if any of the other contexts has a default export with the `name` property.
 ///
@@ -114,4 +115,163 @@ fn is_non_local_reference(identifier: &IdentifierReference, ctx: &LintContext<'_
     // variables outside the current `<script>` block are valid.
     // This is the same for unresolved variables.
     true
+}
+
+/// Check if the given node is inside a Vue component instance method.
+///
+/// Vue component instance methods are `function` properties directly on a
+/// component options object (e.g. `mounted() {}`) or under `methods` /
+/// `computed` / `watch`.
+pub fn is_in_vue_component_instance_method(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    let Some(function_node) = ctx
+        .nodes()
+        .ancestors(node.id())
+        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
+    else {
+        return false;
+    };
+
+    let property_node = ctx.nodes().parent_node(function_node.id());
+    let AstKind::ObjectProperty(_) = property_node.kind() else {
+        return false;
+    };
+
+    let object_node = ctx.nodes().parent_node(property_node.id());
+    if is_vue_component_options_object(object_node, ctx) {
+        return true;
+    }
+
+    let container_property_node = ctx.nodes().parent_node(object_node.id());
+    if !matches!(container_property_node.kind(), AstKind::ObjectProperty(_)) {
+        return false;
+    }
+
+    let Some(container_name) = container_property_node
+        .kind()
+        .as_object_property()
+        .and_then(|prop| if prop.computed { None } else { prop.key.static_name() })
+    else {
+        return false;
+    };
+
+    matches!(container_name.as_ref(), "computed" | "methods" | "watch")
+        && is_vue_component_options_object(
+            ctx.nodes().parent_node(container_property_node.id()),
+            ctx,
+        )
+}
+
+/// What kind of Vue component options object an `ObjectExpression` is.
+///
+/// Mirrors upstream `getVueObjectType` return values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VueComponentObjectKind {
+    /// `export default {...}` in a `.vue` file (outside `<script setup>`).
+    Export,
+    /// `createApp / defineComponent / Vue.component / app.mixin / ...` argument.
+    Definition,
+    /// `new Vue({...})` — a runtime instance, not a reusable component.
+    Instance,
+}
+
+/// Classify the given `ObjectExpression` node as a Vue component options
+/// object. Returns `None` if the node is not a Vue options object.
+///
+/// Recognized forms (see [`VueComponentObjectKind`] for the corresponding kind):
+/// - `export default {...}` (`.vue` files only, skipped inside `<script setup>`)
+/// - `createApp({...})` / `defineComponent({...})` / `defineNuxtComponent({...})`
+/// - `Vue.component(name, {...})` / `Vue.mixin({...})` / `Vue.extend({...})` (Vue 2)
+/// - `app.component(name, {...})` / `app.mixin({...})` (Vue 3 app instance)
+/// - `component('x', {...})` (destructured)
+/// - `new Vue({...})`
+pub fn vue_component_options_kind(
+    object_node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+) -> Option<VueComponentObjectKind> {
+    let AstKind::ObjectExpression(object_expr) = object_node.kind() else {
+        return None;
+    };
+
+    ctx.nodes().ancestors(object_node.id()).find_map(|ancestor| match ancestor.kind() {
+        AstKind::ExportDefaultDeclaration(export_default_decl) => {
+            if ctx.file_extension().is_none_or(|ext| ext != "vue") {
+                return None;
+            }
+            if ctx.frameworks_options() == FrameworkOptions::VueSetup {
+                return None;
+            }
+            (export_default_decl.declaration.span() == object_expr.span)
+                .then_some(VueComponentObjectKind::Export)
+        }
+        AstKind::CallExpression(call_expr) => (is_last_argument_span(call_expr, object_expr.span)
+            && is_vue_component_options_call(call_expr))
+        .then_some(VueComponentObjectKind::Definition),
+        AstKind::NewExpression(new_expr) => (new_expr
+            .arguments
+            .first()
+            .and_then(|arg| arg.as_expression())
+            .is_some_and(|expr| expr.span() == object_expr.span)
+            && new_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == "Vue"))
+        .then_some(VueComponentObjectKind::Instance),
+        _ => None,
+    })
+}
+
+/// Whether the given `ObjectExpression` is *any* Vue options object — the
+/// counterpart of upstream `executeOnVue` / `defineVueVisitor`.
+///
+/// See [`vue_component_options_kind`] for the recognized forms.
+pub fn is_vue_component_options_object(object_node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    vue_component_options_kind(object_node, ctx).is_some()
+}
+
+/// Whether the given `ObjectExpression` is a Vue *component* options object,
+/// **excluding** `new Vue({...})` instances — the counterpart of upstream
+/// `executeOnVueComponent`.
+pub fn is_vue_component_options_object_excluding_instance(
+    object_node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+) -> bool {
+    matches!(
+        vue_component_options_kind(object_node, ctx),
+        Some(VueComponentObjectKind::Export | VueComponentObjectKind::Definition)
+    )
+}
+
+fn is_last_argument_span(call_expr: &CallExpression<'_>, span: oxc_span::Span) -> bool {
+    call_expr
+        .arguments
+        .last()
+        .and_then(|arg| arg.as_expression())
+        .is_some_and(|expr| expr.span() == span)
+}
+
+/// Check if the call expression is a Vue component / instance definition call.
+///
+/// Recognized forms:
+/// - `createApp(...)` / `defineComponent(...)` / `defineNuxtComponent(...)` / `component(...)`
+/// - `Vue.component(...)` / `Vue.mixin(...)` / `Vue.extend(...)` (Vue 2)
+/// - `app.component(...)` / `app.mixin(...)` (Vue 3 app instance)
+pub fn is_vue_component_options_call(call_expr: &CallExpression<'_>) -> bool {
+    if let Some(ident) = call_expr.callee.get_identifier_reference() {
+        return matches!(
+            ident.name.as_str(),
+            "createApp" | "defineComponent" | "defineNuxtComponent" | "component"
+        );
+    }
+
+    let Some(member_expr) = call_expr.callee.get_member_expr() else {
+        return false;
+    };
+    let Some(prop_name) = member_expr.static_property_name() else {
+        return false;
+    };
+
+    if let Expression::Identifier(obj) = member_expr.object().get_inner_expression()
+        && obj.name == "Vue"
+    {
+        return matches!(prop_name, "component" | "mixin" | "extend");
+    }
+
+    matches!(prop_name, "component" | "mixin")
 }


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

follow-up to #22531.

- 71e96f91e8: extract Vue component detection (`getVueObjectType` / `executeOnVue` equivalents) into shared `utils/vue.rs`. 8 Vue rules migrated.
- e99ee4818f: cover newly-detected component forms (`Vue.mixin`, `defineNuxtComponent`, `new Vue`, etc.) with test cases.

Other Vue rules with extra checks or different visitor shapes are left as-is.

AI disclosure: implemented with Claude Code, reviewed manually.