### PR TITLE
perf(semantic): recycle scoping rebuild storage

### DIFF
--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -54,6 +54,16 @@ impl<'a> Compressor<'a> {
         scoping: Scoping,
         options: CompressOptions,
     ) -> u8 {
+        self.dead_code_elimination_with_scoping_returning_scoping(program, scoping, options).0
+    }
+
+    /// Returns total number of iterations ran and the stale scoping storage after DCE.
+    pub fn dead_code_elimination_with_scoping_returning_scoping(
+        self,
+        program: &mut Program<'a>,
+        scoping: Scoping,
+        options: CompressOptions,
+    ) -> (u8, Scoping) {
         let max_iterations = options.max_iterations;
         let state = MinifierState::new(program.source_type, options, /* dce */ true, &scoping);
         let mut ctx = ReusableTraverseCtx::new(state, scoping, self.allocator);
@@ -63,7 +73,8 @@ impl<'a> Compressor<'a> {
             remove_unnecessary_use_strict: false,
         };
         Normalize::new(normalize_options).build(program, &mut ctx);
-        Self::run_in_loop(max_iterations, program, &mut ctx)
+        let iterations = Self::run_in_loop(max_iterations, program, &mut ctx);
+        (iterations, ctx.into_scoping())
     }
 
     /// Fixed-point iteration loop for peephole optimizations.

--- a/crates/oxc_minifier/src/traverse_context/reusable.rs
+++ b/crates/oxc_minifier/src/traverse_context/reusable.rs
@@ -28,6 +28,11 @@ impl<'a, State> ReusableTraverseCtx<'a, State> {
     pub fn state(&self) -> &State {
         &self.0.state
     }
+
+    /// Consume [`ReusableTraverseCtx`] and return [`Scoping`].
+    pub fn into_scoping(self) -> Scoping {
+        self.0.scoping.into_scoping()
+    }
 }
 
 // Internal methods

--- a/crates/oxc_minifier/src/traverse_context/scoping.rs
+++ b/crates/oxc_minifier/src/traverse_context/scoping.rs
@@ -368,6 +368,11 @@ impl TraverseScoping<'_> {
         }
     }
 
+    /// Consume [`TraverseScoping`] and return [`Scoping`].
+    pub(super) fn into_scoping(self) -> Scoping {
+        self.scoping
+    }
+
     /// Set current scope ID
     #[inline]
     pub(crate) fn set_current_scope_id(&mut self, scope_id: ScopeId) {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -134,6 +134,16 @@ pub struct SemanticBuilderReturn<'a> {
     pub errors: Vec<OxcDiagnostic>,
 }
 
+/// Data returned by [`SemanticBuilder::build_scoping`].
+pub struct SemanticScopingBuilderReturn {
+    /// Built scoping model.
+    pub scoping: Scoping,
+    /// Diagnostics collected during semantic analysis.
+    pub errors: Vec<OxcDiagnostic>,
+    /// Statistics for the rebuilt AST and scoping data.
+    pub stats: Stats,
+}
+
 impl Default for SemanticBuilder<'_> {
     fn default() -> Self {
         Self::new()
@@ -231,6 +241,17 @@ impl<'a> SemanticBuilder<'a> {
     #[must_use]
     pub fn with_stats(mut self, stats: Stats) -> Self {
         self.stats = Some(stats);
+        self
+    }
+
+    /// Reuse a stale [`Scoping`] allocation for a fresh semantic rebuild.
+    ///
+    /// All old semantic facts are cleared. Only backing allocation capacity is kept.
+    #[must_use]
+    pub fn with_recycled_scoping(mut self, mut scoping: Scoping) -> Self {
+        scoping.clear_reusing_allocations();
+        self.current_scope_id = scoping.root_scope_id();
+        self.scoping = scoping;
         self
     }
 
@@ -334,6 +355,32 @@ impl<'a> SemanticBuilder<'a> {
             cfg: (),
         };
         SemanticBuilderReturn { semantic, errors: self.errors.into_inner() }
+    }
+
+    /// Build semantic data and return only the resulting [`Scoping`].
+    ///
+    /// This is intended for transform/rebuild pipelines that do not need to retain
+    /// [`Semantic`] after the rebuild. It keeps the normal full-build hot path unchanged while
+    /// still allowing callers to recycle stale [`Scoping`] storage with
+    /// [`SemanticBuilder::with_recycled_scoping`].
+    ///
+    /// # Panics
+    /// Panics if syntax checking or CFG construction is enabled.
+    pub fn build_scoping(self, program: &'a Program<'a>) -> SemanticScopingBuilderReturn {
+        assert!(
+            !self.check_syntax_error,
+            "SemanticBuilder::build_scoping requires syntax checks disabled"
+        );
+        #[cfg(feature = "cfg")]
+        assert!(self.cfg.is_none(), "SemanticBuilder::build_scoping cannot build CFG");
+
+        let ret = self.build(program);
+        let stats = ret.semantic.stats();
+        SemanticScopingBuilderReturn {
+            scoping: ret.semantic.into_scoping(),
+            errors: ret.errors,
+            stats,
+        }
     }
 
     /// Push a Syntax Error

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -45,7 +45,7 @@ mod unresolved_stack;
 
 #[cfg(feature = "linter")]
 pub use ast_types_bitset::AstTypesBitset;
-pub use builder::{SemanticBuilder, SemanticBuilderReturn};
+pub use builder::{SemanticBuilder, SemanticBuilderReturn, SemanticScopingBuilderReturn};
 pub use is_global_reference::IsGlobalReference;
 #[cfg(feature = "jsdoc")]
 pub use jsdoc::JSDocFinder;
@@ -349,6 +349,174 @@ mod tests {
 
         let second = SemanticBuilder::new().with_check_syntax_error(true).build(&parse.program);
         assert!(second.errors.is_empty());
+    }
+
+    fn build_full_scoping(source: &str, source_type: SourceType) -> (Scoping, Stats) {
+        let allocator = Allocator::default();
+        let parse = oxc_parser::Parser::new(&allocator, source, source_type).parse();
+        assert!(parse.errors.is_empty(), "Parse error: {}", parse.errors[0]);
+
+        let semantic = SemanticBuilder::new().with_enum_eval(true).build(&parse.program);
+        assert!(semantic.errors.is_empty(), "Semantic error: {}", semantic.errors[0]);
+
+        let stats = semantic.semantic.stats();
+        (semantic.semantic.into_scoping(), stats)
+    }
+
+    fn build_scoping(
+        source: &str,
+        source_type: SourceType,
+        recycled_scoping: Option<Scoping>,
+    ) -> (Scoping, Stats) {
+        let allocator = Allocator::default();
+        let parse = oxc_parser::Parser::new(&allocator, source, source_type).parse();
+        assert!(parse.errors.is_empty(), "Parse error: {}", parse.errors[0]);
+
+        let mut builder = SemanticBuilder::new().with_enum_eval(true);
+        if let Some(scoping) = recycled_scoping {
+            builder = builder.with_recycled_scoping(scoping);
+        }
+        let semantic = builder.build_scoping(&parse.program);
+        assert!(semantic.errors.is_empty(), "Semantic error: {}", semantic.errors[0]);
+
+        (semantic.scoping, semantic.stats)
+    }
+
+    fn scoping_snapshot(scoping: &Scoping, stats: Stats) -> Vec<String> {
+        let mut rows = vec![format!("stats:{stats:?}")];
+
+        for scope_id in scoping.scope_descendants_from_root() {
+            let mut bindings = scoping
+                .get_bindings(scope_id)
+                .iter()
+                .map(|(name, symbol_id)| format!("{}:{}", name.as_str(), usize::from(*symbol_id)))
+                .collect::<Vec<_>>();
+            bindings.sort_unstable();
+            rows.push(format!(
+                "scope:{} parent:{:?} node:{} flags:{:?} bindings:{bindings:?}",
+                usize::from(scope_id),
+                scoping.scope_parent_id(scope_id).map(usize::from),
+                usize::from(scoping.get_node_id(scope_id)),
+                scoping.scope_flags(scope_id),
+            ));
+        }
+
+        for symbol_id in scoping.symbol_ids() {
+            let redeclarations = scoping
+                .symbol_redeclarations(symbol_id)
+                .iter()
+                .map(|redeclaration| {
+                    format!(
+                        "{:?}@{:?}:{}",
+                        redeclaration.flags,
+                        redeclaration.span,
+                        usize::from(redeclaration.declaration)
+                    )
+                })
+                .collect::<Vec<_>>();
+            let references = scoping
+                .get_resolved_reference_ids(symbol_id)
+                .iter()
+                .map(|reference_id| usize::from(*reference_id))
+                .collect::<Vec<_>>();
+            let enum_value = scoping
+                .get_enum_member_value(symbol_id)
+                .map(|value| format!("{value:?}"))
+                .unwrap_or_default();
+            rows.push(format!(
+                "symbol:{} name:{} scope:{} decl:{} span:{:?} flags:{:?} refs:{references:?} redecl:{redeclarations:?} enum:{enum_value}",
+                usize::from(symbol_id),
+                scoping.symbol_name(symbol_id),
+                usize::from(scoping.symbol_scope_id(symbol_id)),
+                usize::from(scoping.symbol_declaration(symbol_id)),
+                scoping.symbol_span(symbol_id),
+                scoping.symbol_flags(symbol_id),
+            ));
+        }
+
+        for (reference_id, reference) in scoping.references.iter_enumerated() {
+            let symbol = reference
+                .symbol_id()
+                .map(|symbol_id| {
+                    format!("{}:{}", scoping.symbol_name(symbol_id), usize::from(symbol_id))
+                })
+                .unwrap_or_default();
+            rows.push(format!(
+                "reference:{} node:{} scope:{} symbol:{symbol} flags:{:?}",
+                usize::from(reference_id),
+                usize::from(reference.node_id()),
+                usize::from(reference.scope_id()),
+                reference.flags(),
+            ));
+        }
+
+        let mut unresolved = scoping
+            .root_unresolved_references()
+            .iter()
+            .map(|(name, references)| {
+                let references = references.iter().map(|id| usize::from(*id)).collect::<Vec<_>>();
+                format!("{}:{references:?}", name.as_str())
+            })
+            .collect::<Vec<_>>();
+        unresolved.sort_unstable();
+        rows.push(format!("unresolved:{unresolved:?}"));
+
+        let mut pure = scoping
+            .no_side_effects()
+            .iter()
+            .map(|symbol_id| {
+                format!("{}:{}", scoping.symbol_name(*symbol_id), usize::from(*symbol_id))
+            })
+            .collect::<Vec<_>>();
+        pure.sort_unstable();
+        rows.push(format!("pure:{pure:?}"));
+
+        rows
+    }
+
+    #[test]
+    fn build_scoping_matches_full_build() {
+        let source = r"
+            /* @__NO_SIDE_EFFECTS__ */ function pureFn() {}
+            (function named(named) { var named; return named; })();
+            var hoisted;
+            if (true) { function annex() {} }
+            enum E { A = 1, B = A + 2 }
+            namespace N {
+                export const x = E.B;
+                export import Alias = N;
+            }
+            declare const ambient: string;
+            class C {
+                #x = 1;
+                method() { return this.#x; }
+                check(value) { return #x in value; }
+            }
+            try { throw 1; } catch (caught) { var caught; }
+            rootMissing(pureFn, ambient);
+        ";
+        let source_type = SourceType::ts().with_module(true);
+
+        let (full_scoping, full_stats) = build_full_scoping(source, source_type);
+        let full_snapshot = scoping_snapshot(&full_scoping, full_stats);
+
+        let (scoping, scoping_stats) = build_scoping(source, source_type, None);
+        assert_eq!(scoping_snapshot(&scoping, scoping_stats), full_snapshot);
+
+        let recycled_source = "const stale = 1; stale; missingStale;";
+        let (recycled_scoping, _) = build_scoping(recycled_source, source_type, Some(scoping));
+        let (recycled_scoping, recycled_stats) =
+            build_scoping(source, source_type, Some(recycled_scoping));
+        assert_eq!(scoping_snapshot(&recycled_scoping, recycled_stats), full_snapshot);
+    }
+
+    #[test]
+    #[should_panic(expected = "SemanticBuilder::build_scoping requires syntax checks disabled")]
+    fn build_scoping_rejects_syntax_checks() {
+        let allocator = Allocator::default();
+        let source = "let x = 1;";
+        let parse = oxc_parser::Parser::new(&allocator, source, SourceType::default()).parse();
+        SemanticBuilder::new().with_check_syntax_error(true).build_scoping(&parse.program);
     }
 
     #[test]

--- a/crates/oxc_semantic/src/multi_index_vec.rs
+++ b/crates/oxc_semantic/src/multi_index_vec.rs
@@ -134,6 +134,24 @@ macro_rules! multi_index_vec {
                 self.len == 0
             }
 
+            /// Clear all elements while keeping the current allocation.
+            #[allow(dead_code)]
+            $vis fn clear(&mut self) {
+                let len = self.len as usize;
+                $(
+                    if ::core::mem::needs_drop::<$fty>() {
+                        for i in 0..len {
+                            // SAFETY: `i < len <= cap`, so the pointer is within the allocation.
+                            // Each initialized element is dropped exactly once.
+                            unsafe {
+                                ::core::ptr::drop_in_place(self.$fname.as_ptr().add(i));
+                            }
+                        }
+                    }
+                )*
+                self.len = 0;
+            }
+
             /// Reserve capacity for at least `additional` more elements.
             $vis fn reserve(&mut self, additional: usize) {
                 let required = (self.len as usize).checked_add(additional).expect("capacity overflow");
@@ -417,5 +435,24 @@ mod tests {
 
         assert_eq!(table.values(id), "a1");
         assert_eq!(clone.values(id), "a2");
+    }
+
+    #[test]
+    fn clear_keeps_capacity_and_allows_reuse() {
+        let mut table = StringTable::new();
+        table.reserve(2);
+        let id = table.push(String::from("a"));
+        table.push(String::from("b"));
+        assert_eq!(table.len(), 2);
+        assert_eq!(table.cap, 4);
+        assert_eq!(table.values(id), "a");
+
+        table.clear();
+        assert!(table.is_empty());
+        assert_eq!(table.cap, 4);
+
+        let id = table.push(String::from("c"));
+        assert_eq!(table.len(), 1);
+        assert_eq!(table.values(id), "c");
     }
 }

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -250,7 +250,10 @@ mod scoping_cell {
         }
 
         /// Consume [`ScopingCell`] and return the [`Allocator`] it contains.
-        #[expect(dead_code)]
+        ///
+        /// This is used by [`Scoping::reset`] to pull the arena out before
+        /// resetting it and rebuilding the inner state on top of the now-empty
+        /// arena.
         #[inline(always)]
         pub fn into_owner(self) -> Allocator {
             self.0.into_owner()
@@ -612,6 +615,36 @@ impl Scoping {
         self.scope_table.reserve(additional_scopes);
         self.cell.with_dependent_mut(|_allocator, cell| {
             cell.bindings.reserve(additional_scopes);
+        });
+    }
+
+    /// Clear all semantic facts while preserving reusable allocations.
+    ///
+    /// This is used by transform pipelines that need to rebuild fresh scoping for a mutated AST,
+    /// but can reuse the backing storage from a stale [`Scoping`].
+    pub fn clear_reusing_allocations(&mut self) {
+        self.symbol_table.clear();
+        self.references.clear();
+        self.no_side_effects.clear();
+        self.enum_data.clear();
+        self.scope_table.clear();
+
+        let empty_cell = ScopingCell::new(Allocator::default(), |allocator| ScopingInner {
+            symbol_names: ArenaVec::new_in(allocator),
+            resolved_references: ArenaVec::new_in(allocator),
+            symbol_redeclarations: FxHashMap::default(),
+            bindings: IndexVec::new(),
+            root_unresolved_references: UnresolvedReferences::new_in(allocator),
+        });
+        let old_cell = mem::replace(&mut self.cell, empty_cell);
+        let mut allocator = old_cell.into_owner();
+        allocator.reset();
+        self.cell = ScopingCell::new(allocator, |allocator| ScopingInner {
+            symbol_names: ArenaVec::new_in(allocator),
+            resolved_references: ArenaVec::new_in(allocator),
+            symbol_redeclarations: FxHashMap::default(),
+            bindings: IndexVec::new(),
+            root_unresolved_references: UnresolvedReferences::new_in(allocator),
         });
     }
 

--- a/crates/oxc_semantic/src/ts_enum/data.rs
+++ b/crates/oxc_semantic/src/ts_enum/data.rs
@@ -30,4 +30,9 @@ impl EnumData {
     pub(crate) fn add_body_scope(&mut self, symbol_id: SymbolId, scope_id: ScopeId) {
         self.body_scopes.entry(symbol_id).or_default().push(scope_id);
     }
+
+    pub(crate) fn clear(&mut self) {
+        self.member_values.clear();
+        self.body_scopes.clear();
+    }
 }

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -39,5 +39,97 @@ fn bench_semantic(criterion: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(semantic, bench_semantic);
+/// Mirrors rolldown's repeated scoping rebuilds after transform passes invalidate prior `Scoping`.
+/// Compares the previous full semantic rebuild against rebuilding with recycled `Scoping` storage.
+fn bench_semantic_rebuild(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("semantic_rebuild");
+    for file in TestFiles::minimal().files() {
+        let source_text = &file.source_text;
+        let source_type = file.source_type;
+
+        let mut allocator = Allocator::default();
+
+        // Compute `Stats` once on a throwaway build so subsequent rebuilds can pass them in via
+        // `with_stats`, matching rolldown's preprocessing pipeline.
+        let stats = {
+            allocator.reset();
+            let program = Parser::new(&allocator, source_text, source_type).parse().program;
+            SemanticBuilder::new().with_enum_eval(true).build(&program).semantic.stats()
+        };
+
+        // One-shot: print used-bytes for one recycled 4-rebuild sequence so the storage-portion
+        // signal is visible alongside criterion's wall-time.
+        {
+            allocator.reset();
+            let program = Parser::new(&allocator, source_text, source_type).parse().program;
+            let mut stats = stats;
+            let mut recycled_scoping = None;
+            for _ in 0..4 {
+                let mut builder = SemanticBuilder::new().with_enum_eval(true).with_stats(stats);
+                if let Some(scoping) = recycled_scoping.take() {
+                    builder = builder.with_recycled_scoping(scoping);
+                }
+                let ret = black_box(builder.build_scoping(&program));
+                stats = ret.stats;
+                recycled_scoping = Some(ret.scoping);
+            }
+            eprintln!(
+                "semantic_rebuild[{}]: allocator used_bytes after 4x recycled scoping rebuild = {}",
+                file.file_name,
+                allocator.used_bytes()
+            );
+        }
+
+        group.bench_function(BenchmarkId::new("full", &file.file_name), |b| {
+            b.iter_with_setup_wrapper(|runner| {
+                allocator.reset();
+                let program = Parser::new(&allocator, source_text, source_type).parse().program;
+                let program = black_box(program);
+
+                runner.run(|| {
+                    let mut last_errors = Vec::new();
+                    let mut stats = stats;
+                    for _ in 0..4 {
+                        let ret = SemanticBuilder::new()
+                            .with_enum_eval(true)
+                            .with_stats(stats)
+                            .build(&program);
+                        stats = ret.semantic.stats();
+                        last_errors = black_box(ret).errors;
+                    }
+                    last_errors
+                });
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("build_scoping_recycled", &file.file_name), |b| {
+            b.iter_with_setup_wrapper(|runner| {
+                allocator.reset();
+                let program = Parser::new(&allocator, source_text, source_type).parse().program;
+                let program = black_box(program);
+
+                runner.run(|| {
+                    let mut last_errors = Vec::new();
+                    let mut stats = stats;
+                    let mut recycled_scoping = None;
+                    for _ in 0..4 {
+                        let mut builder =
+                            SemanticBuilder::new().with_enum_eval(true).with_stats(stats);
+                        if let Some(scoping) = recycled_scoping.take() {
+                            builder = builder.with_recycled_scoping(scoping);
+                        }
+                        let ret = black_box(builder.build_scoping(&program));
+                        stats = ret.stats;
+                        last_errors = ret.errors;
+                        recycled_scoping = Some(ret.scoping);
+                    }
+                    last_errors
+                });
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(semantic, bench_semantic, bench_semantic_rebuild);
 criterion_main!(semantic);


### PR DESCRIPTION
## Summary
- Adds a conservative `build_scoping` API that returns `Scoping` for rebuild pipelines while keeping the normal semantic full-build path unchanged.
- Adds `with_recycled_scoping` so callers can clear stale scoping facts and reuse backing allocations across rebuilds.
- Related Rolldown integration and benchmark PR: rolldown/rolldown#9458, which patches Cargo to this branch until the APIs are released.
- Verified with `cargo test -p oxc_semantic --features cfg`, `cargo check -p oxc_minifier`, and `cargo check -p oxc_benchmark --bench semantic --features compiler`; local pre-commit clippy still reports an unrelated `oxc_allocator/src/arena/mod.rs` `redundant_pub_crate` lint under the installed toolchain.

AI assistance: this PR was prepared with Codex; the contributor remains responsible for reviewing and validating the changes.
