### PR TITLE
fix(parser): apply PURE comment through member-access chains

### DIFF
--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -450,7 +450,8 @@ fn pure_comment() {
     test("/*#__PURE__*/ (foo(), bar());", "/*#__PURE__*/ foo(), bar();\n"); // INVALID, there is a comma expression in the parentheses
 
     test_same("/* @__PURE__ */ a.b().c.d();\n");
-    test("/* @__PURE__ */ a().b;", "/* @__PURE__ */ a().b;\n"); // INVALID, it does not end with a call
+    // PURE applies to the innermost call; codegen wraps to keep the annotation on the call.
+    test("/* @__PURE__ */ a().b;", "(/* @__PURE__ */ a()).b;\n");
     test_same("(/* @__PURE__ */ a()).b;\n");
 
     // More

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1448,14 +1448,25 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Expression::ConditionalExpression(conditional_expr) => {
                 Self::set_pure_on_call_or_new_expr(&mut conditional_expr.test)
             }
-            Expression::ChainExpression(chain_expr) => {
-                if let ChainElement::CallExpression(call_expr) = &mut chain_expr.expression {
+            // Recurse through member-access chains: `/* #__PURE__ */ foo().a.b.c`
+            // applies PURE to the underlying call/new (Rollup/esbuild semantics).
+            expr @ match_member_expression!(Expression) => {
+                Self::set_pure_on_call_or_new_expr(expr.to_member_expression_mut().object_mut())
+            }
+            Expression::ChainExpression(chain_expr) => match &mut chain_expr.expression {
+                ChainElement::CallExpression(call_expr) => {
                     call_expr.pure = true;
                     true
-                } else {
-                    false
                 }
-            }
+                element @ match_member_expression!(ChainElement) => {
+                    Self::set_pure_on_call_or_new_expr(
+                        element.to_member_expression_mut().object_mut(),
+                    )
+                }
+                ChainElement::TSNonNullExpression(non_null_expr) => {
+                    Self::set_pure_on_call_or_new_expr(&mut non_null_expr.expression)
+                }
+            },
             _ => false,
         }
     }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -640,6 +640,26 @@ function bar() {}";
     }
 
     #[test]
+    fn pure_comment_applied_on_member_chain() {
+        // Rollup/esbuild treat PURE as applying to the innermost call/new even when
+        // member access wraps it; member-access side effects are a separate concern.
+        let cases = [
+            "/*#__PURE__*/ test().a.b.c;",
+            "/*#__PURE__*/ new Foo().a;",
+            "/*#__PURE__*/ test()[0].b;",
+            "class C { #bar; m() { /*#__PURE__*/ this.foo().#bar; } }",
+            // Chain expressions with member root
+            "/*#__PURE__*/ foo()?.a.b;",
+            "/*#__PURE__*/ foo?.().a.b;",
+            "/*#__PURE__*/ foo?.()[0];",
+        ];
+        for source_text in cases {
+            let comments = get_comments(source_text);
+            assert_eq!(comments[0].content, CommentContent::Pure, "{source_text}");
+        }
+    }
+
+    #[test]
     fn pure_comment_not_applied_marks_correct_comment() {
         // The first pure comment is invalid (before `foo`), the second is valid (before `bar()`).
         // `mark_pure_comment_not_applied` must retag the first comment, not the second.


### PR DESCRIPTION
`/* #__PURE__ */ test().a.b.c` was marked as `PureNotApplied` because `set_pure_on_call_or_new_expr` only checked the top-level AST node. For member-access chains rooted at a call/new, the top-level node is a `MemberExpression`, which fell through to the `_ => false` arm.

Rollup and esbuild apply PURE to the innermost call/new in this shape (member-access side effects are handled separately by `propertyReadSideEffects` in Rollup). Aligning here fixes false-positive warnings in downstream consumers that forward `PureNotApplied` to users (e.g. rolldown/rolldown#9381).

Recurse through `StaticMemberExpression`, `ComputedMemberExpression`, `PrivateFieldExpression`, and the matching `ChainElement` variants (plus `TSNonNullExpression` in chains) to reach the underlying call.

Fixes #22394

AI disclosure: implemented with Claude Code, reviewed manually.
