### PR TITLE
fix(linter): treat `TSGlobalDeclaration` as ambient in `has_ambient_typescript_ancestor`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -236,6 +236,12 @@ fn test() {
             None,
             Some(PathBuf::from("test.d.ts")),
         ),
+        (
+            "global { namespace foo {} }",
+            Some(serde_json::json!([{ "allowDeclarations": true, "allowDefinitionFiles": false }])),
+            None,
+            Some(PathBuf::from("test.d.ts")),
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/utils/typescript.rs
+++ b/crates/oxc_linter/src/utils/typescript.rs
@@ -118,7 +118,9 @@ pub enum NameSpecifier {
 pub fn has_ambient_typescript_ancestor(node_id: NodeId, nodes: &AstNodes) -> bool {
     nodes.ancestors(node_id).any(|ancestor| match ancestor.kind() {
         AstKind::TSModuleDeclaration(module) => module.declare,
-        AstKind::TSGlobalDeclaration(global) => global.declare,
+        // `TSGlobalDeclaration`s are only valid inside ambient declarations, hence
+        // we do not need to check `declare` as it only tracks an explicit `declare global`.
+        AstKind::TSGlobalDeclaration(_) => true,
         _ => false,
     })
 }


### PR DESCRIPTION
Follow-up to #22572 to handle ambient `global {}` declarations without requiring an explicit `declare global`.