### PR TITLE
perf(linter/no-extra-non-null-assertion): reduce node matches

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1654,12 +1654,8 @@ impl RuleRunner for crate::rules::typescript::no_explicit_any::NoExplicitAny {
 }
 
 impl RuleRunner for crate::rules::typescript::no_extra_non_null_assertion::NoExtraNonNullAssertion {
-    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
-        AstType::CallExpression,
-        AstType::ComputedMemberExpression,
-        AstType::StaticMemberExpression,
-        AstType::TSNonNullExpression,
-    ]));
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSNonNullExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -1,10 +1,14 @@
-use oxc_ast::{AstKind, ast::Expression};
+use oxc_ast::{
+    AstKind,
+    ast::{ChainElement, Expression, match_member_expression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
     AstNode,
+    ast_util::outermost_paren_parent,
     context::{ContextHost, LintContext},
     rule::Rule,
 };
@@ -76,41 +80,51 @@ declare_oxc_lint!(
 
 impl Rule for NoExtraNonNullAssertion {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let expr = match node.kind() {
-            AstKind::TSNonNullExpression(expr) => {
-                if let Expression::TSNonNullExpression(expr) = expr.expression.without_parentheses()
-                {
-                    Some(expr)
-                } else {
-                    None
-                }
-            }
-            AstKind::StaticMemberExpression(expr) if expr.optional => {
-                if let Expression::TSNonNullExpression(expr) = expr.object.without_parentheses() {
-                    Some(expr)
-                } else {
-                    None
-                }
-            }
-            AstKind::ComputedMemberExpression(expr) if expr.optional => {
-                if let Expression::TSNonNullExpression(expr) = expr.object.without_parentheses() {
-                    Some(expr)
-                } else {
-                    None
-                }
-            }
-            AstKind::CallExpression(expr) if expr.optional => {
-                if let Expression::TSNonNullExpression(expr) = expr.callee.without_parentheses() {
-                    Some(expr)
-                } else {
-                    None
-                }
-            }
-            _ => return,
+        let AstKind::TSNonNullExpression(non_null_expr) = node.kind() else {
+            return;
         };
 
-        if let Some(expr) = expr {
-            let span = Span::sized(expr.span.end - 1, 1);
+        let Some(parent) = outermost_paren_parent(node, ctx.semantic()) else {
+            return;
+        };
+
+        let is_extra_non_null_assertion = match parent.kind() {
+            AstKind::TSNonNullExpression(_) => true,
+            _ if let Some(member_expr) = parent.kind().as_member_expression_kind() => {
+                member_expr.optional()
+                    && matches!(
+                        member_expr.object().without_parentheses(),
+                        Expression::TSNonNullExpression(expr) if expr.span == non_null_expr.span
+                    )
+            }
+            AstKind::CallExpression(expr) if expr.optional => {
+                matches!(
+                    expr.callee.without_parentheses(),
+                    Expression::TSNonNullExpression(expr) if expr.span == non_null_expr.span
+                )
+            }
+            AstKind::ChainExpression(expr) => match &expr.expression {
+                chain_element @ match_member_expression!(ChainElement) => {
+                    let member_expr = chain_element.to_member_expression();
+                    member_expr.optional()
+                        && matches!(
+                            member_expr.object().without_parentheses(),
+                            Expression::TSNonNullExpression(expr) if expr.span == non_null_expr.span
+                        )
+                }
+                ChainElement::CallExpression(expr) if expr.optional => {
+                    matches!(
+                        expr.callee.without_parentheses(),
+                        Expression::TSNonNullExpression(expr) if expr.span == non_null_expr.span
+                    )
+                }
+                _ => false,
+            },
+            _ => false,
+        };
+
+        if is_extra_non_null_assertion {
+            let span = Span::sized(non_null_expr.span.end - 1, 1);
             ctx.diagnostic_with_fix(no_extra_non_null_assertion_diagnostic(span), |fixer| {
                 fixer.delete_range(span)
             });


### PR DESCRIPTION
**Summary**

- Restrict `typescript/no-extra-non-null-assertion` to run only on `TSNonNullExpression` nodes.
- Move optional member/call handling to parent/chain context checks from the non-null assertion node.
- Regenerate the linter rule runner so this rule is registered only for `AstType::TSNonNullExpression`.

**Performance**

Profiled release `oxlint` with only this rule enabled:

```bash
oxlint -f default --disable-nested-config \
  --disable-unicorn-plugin --disable-oxc-plugin \
  -A all -W no-extra-non-null-assertion \
  --debug=timings --threads=1 .
```

Full repo profile over 5 runs. The repo contains intentionally invalid fixture files, so both before and after reported `Found 0 warnings and 534 errors`, but timing output was still emitted and file counts matched.

| Build | Files | Rule calls | Avg rule time |
| --- | ---: | ---: | ---: |
| main | 3914 | 31,289 | 0.670 ms |
| this PR | 3914 | 332 | 0.019 ms |

This is about a 99% reduction in rule calls for this rule on the repo profile.
