### PR TITLE
fix(minifier): drop empty-body IIFE wrapper when called with arguments

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1798,7 +1798,12 @@ impl<'a> PeepholeOptimizations {
     pub fn substitute_iife_call(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::CallExpression(call_expr) = e else { return };
 
-        if !call_expr.arguments.is_empty() || !call_expr.callee.is_function() {
+        if !call_expr.callee.is_function() {
+            return;
+        }
+
+        if !call_expr.arguments.is_empty() {
+            Self::substitute_empty_body_iife_call_with_args(e, ctx);
             return;
         }
 
@@ -1885,6 +1890,53 @@ impl<'a> PeepholeOptimizations {
                 _ => {}
             }
         }
+    }
+
+    /// `(() => {})(a, b)` → `(a, b, void 0)` — drop the wrapper when the body
+    /// is empty and every param is a bare identifier; spread args become
+    /// `[...a]` to keep the iterator-protocol invocation.
+    fn substitute_empty_body_iife_call_with_args(
+        e: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let Expression::CallExpression(call_expr) = e else { return };
+
+        // Looser than the spec's `IsSimpleParameterList` (which forbids rest):
+        // a rest binding to an identifier is safe here — the empty body never
+        // observes the collected array.
+        let params_simple = |p: &FormalParameters<'a>| {
+            p.items
+                .iter()
+                .all(|item| item.pattern.is_binding_identifier() && item.initializer.is_none())
+                && p.rest.as_ref().is_none_or(|r| r.rest.argument.is_binding_identifier())
+        };
+
+        let is_drop_candidate = match &call_expr.callee {
+            Expression::FunctionExpression(f) => {
+                !f.r#async
+                    && !f.generator
+                    && f.body.as_ref().is_some_and(|b| b.is_empty())
+                    && params_simple(&f.params)
+            }
+            Expression::ArrowFunctionExpression(f) => {
+                !f.r#async && f.body.is_empty() && params_simple(&f.params)
+            }
+            _ => false,
+        };
+
+        if !is_drop_candidate {
+            return;
+        }
+
+        let span = call_expr.span;
+        let mut exprs = Self::fold_arguments_into_needed_expressions(&mut call_expr.arguments, ctx);
+        *e = if exprs.is_empty() {
+            ctx.ast.void_0(span)
+        } else {
+            exprs.push(ctx.ast.void_0(span));
+            ctx.ast.expression_sequence(span, exprs)
+        };
+        ctx.state.changed = true;
     }
 
     /// Take the IIFE body out for inlining and propagate `pure` onto a

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -438,6 +438,32 @@ fn test_fold_iife() {
         "function foo(x) { if (x) { return (/* @__PURE__ */ (() => 42)(), foo) } return x }",
         "function foo(x) { return x && foo }",
     );
+
+    // Empty-body IIFE called with arguments: drop the wrapper, args still
+    // evaluate for side effects.
+    test("(() => {})(a);", "a;");
+    test("((x, y) => {})(a, b);", "a, b;");
+    test("((x) => {})(a, b);", "a, b;");
+    test("(function(x) {})(a);", "a;");
+    test("var u = (() => {})(a)", "var u = (a, void 0)");
+    // Rest binding to an identifier is safe (collected array unobserved).
+    test("((x, ...r) => {})(a, b)", "a, b;");
+    // Spread arg kept as `[...a]` to preserve iterator-protocol invocation.
+    test("(() => {})(...a)", "[...a];");
+    // All-pure args → `void 0` directly (no single-element sequence).
+    test("(() => {})(1, 2);", "");
+
+    // Negative cases — wrapper must NOT drop.
+    test_same("(([x]) => {})(a)");
+    test_same("(({z}) => {})(a)");
+    test_same("((x = side()) => {})(a)");
+    test_same("((...{x}) => {})(a)");
+    test_same("(async () => {})(a)");
+    test_same("(function*() {})(a)");
+    test_same("(() => { foo() })(a)");
+    // Directive-only body: in module source the redundant `'use strict'` is
+    // stripped upstream, then the empty-body path drops the wrapper.
+    test("(function() { 'use strict' })(a)", "a;");
 }
 
 #[test]


### PR DESCRIPTION
## Why

`substitute_iife_call` bailed out as soon as the call had any arguments, so `(() => {})(a)` stayed in the output while esbuild emits `a;`. The existing logic (#22349, closing #17480) only handled the zero-args case.

Surfaced by rolldown ↔ esbuild compatibility tests for `dce/dce_of_iife` (rolldown/rolldown#8688):

```js
// input
(() => {})(keepThisButRemoveTheIIFE);

// before (oxc DCE)
(() => {})(keepThisButRemoveTheIIFE);

// after (matches esbuild)
keepThisButRemoveTheIIFE;
```

## Fix

Extend `substitute_iife_call` to drop the wrapper when the body is empty, the callee is neither `async` nor a generator, and every named parameter is a bare `BindingIdentifier` with no default. The arguments become a sequence ending in `void 0` (preserving the call's `undefined` result); `remove_unused_expression` strips the tail at statement position. Argument conversion reuses `fold_arguments_into_needed_expressions`, which also drops pure args for free.

Two related cases handled in the same path:

- Rest parameter binding to a simple identifier (`((...r) => {})(a)` → `a;`). Deliberately looser than the spec `IsSimpleParameterList` (which forbids any rest): the empty body never observes the collected array.
- Spread argument (`(() => {})(...a)` → `[...a];`) — converted to a single-spread array literal that preserves the iterator-protocol invocation. Matches esbuild's `--minify` output.

Rejected (no behaviour change): destructured params, parameter defaults, `async` / generator callees, destructured rest bindings — each can have observable effects that the empty body would otherwise elide.

New positive + negative cases in `test_fold_iife` (`tests/peephole/remove_unused_expression.rs`); full minifier suite (501/0) and `minsize` snapshots unchanged.