### PR TITLE
perf(minifier): drop per-call buffers in try_fold_concat

### DIFF
--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -206,7 +206,7 @@ impl<'a> PeepholeOptimizations {
         span: Span,
         args: &mut Arguments<'a>,
         callee: &mut Expression<'a>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         // let concat chaining reduction handle it first
         if let Ancestor::StaticMemberExpressionObject(parent_member) = ctx.parent()
@@ -286,62 +286,69 @@ impl<'a> PeepholeOptimizations {
                     return None;
                 }
 
-                let mut quasi_strs: Vec<Cow<'a, str>> =
-                    vec![Cow::Borrowed(base_str.value.as_str())];
-                let mut expressions = ctx.ast.vec_with_capacity(expression_count);
-                let mut pushed_quasi = true;
+                // `AstBuilder` is `Copy`; take a local copy so the arena
+                // builder stays available alongside `&mut ctx.state` (the
+                // borrow checker would otherwise reject the simultaneous use).
+                let ast = ctx.ast;
+                // Reuse a scratch `String` held on `MinifierState` across calls
+                // to accumulate the cooked text of the in-progress quasi. On
+                // flush we copy the text into the arena and clear the scratch.
+                //
+                // INVARIANT: every flush must end with `scratch.clear()` so
+                // the next string-arg `push_str` starts a fresh quasi. Two
+                // expressions in a row rely on this — the second one's flush
+                // sees an empty `scratch`, producing the required empty
+                // separator quasi without a state-machine flag.
+                let scratch = &mut ctx.state.concat_scratch;
+                scratch.clear();
+                scratch.push_str(base_str.value.as_str());
+
+                let mut expressions = ast.vec_with_capacity(expression_count);
+                let mut quasis = ast.vec_with_capacity(expression_count + 1);
+
                 for argument in args.drain(..) {
                     if let Argument::StringLiteral(str_lit) = argument {
-                        if pushed_quasi {
-                            let last_quasi = quasi_strs
-                                .last_mut()
-                                .expect("last element should exist because pushed_quasi is true");
-                            last_quasi.to_mut().push_str(&str_lit.value);
-                        } else {
-                            quasi_strs.push(Cow::Borrowed(str_lit.value.as_str()));
-                        }
-                        pushed_quasi = true;
+                        // Append onto the in-progress quasi.
+                        scratch.push_str(&str_lit.value);
                     } else {
-                        if !pushed_quasi {
-                            // need a pair
-                            quasi_strs.push(Cow::Borrowed(""));
-                        }
+                        // Flush the current quasi (possibly empty) before
+                        // pushing the next expression.
+                        let cooked = ast.str(scratch);
+                        let raw_cow = Self::escape_string_for_template_literal(scratch);
+                        let raw = ast.str(&raw_cow);
+                        quasis.push(ast.template_element(
+                            SPAN,
+                            TemplateElementValue { raw, cooked: Some(cooked) },
+                            false,
+                            false, // raw is already escaped
+                        ));
+                        scratch.clear(); // maintains INVARIANT above
                         // checked that all the arguments are expression above
                         expressions.push(argument.into_expression());
-                        pushed_quasi = false;
                     }
-                }
-                if !pushed_quasi {
-                    quasi_strs.push(Cow::Borrowed(""));
                 }
 
                 if expressions.is_empty() {
-                    debug_assert_eq!(quasi_strs.len(), 1);
-                    return Some(ctx.ast.expression_string_literal(
-                        span,
-                        ctx.ast.str_from_cow(&quasi_strs.pop().unwrap()),
-                        None,
-                    ));
+                    debug_assert_eq!(quasis.len(), 0);
+                    let s = ast.str(scratch);
+                    return Some(ast.expression_string_literal(span, s, None));
                 }
 
-                let mut quasis = ctx.ast.vec_from_iter(quasi_strs.into_iter().map(|s| {
-                    let cooked = ctx.ast.str_from_cow(&s);
-                    ctx.ast.template_element(
-                        SPAN,
-                        TemplateElementValue {
-                            raw: ctx.ast.str(&Self::escape_string_for_template_literal(&s)),
-                            cooked: Some(cooked),
-                        },
-                        false,
-                        false, // raw is already escaped by escape_string_for_template_literal
-                    )
-                }));
-                if let Some(last_quasi) = quasis.last_mut() {
-                    last_quasi.tail = true;
-                }
+                // Flush the trailing quasi. If the last arg was an expression
+                // `scratch` is empty, giving the required trailing empty
+                // quasi; otherwise it holds the accumulated tail text.
+                let cooked = ast.str(scratch);
+                let raw_cow = Self::escape_string_for_template_literal(scratch);
+                let raw = ast.str(&raw_cow);
+                quasis.push(ast.template_element(
+                    SPAN,
+                    TemplateElementValue { raw, cooked: Some(cooked) },
+                    true, // tail
+                    false,
+                ));
 
                 debug_assert_eq!(quasis.len(), expressions.len() + 1);
-                Some(ctx.ast.expression_template_literal(span, quasis, expressions))
+                Some(ast.expression_template_literal(span, quasis, expressions))
             }
             _ => None,
         }

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -31,6 +31,10 @@ pub struct MinifierState<'a> {
     pub proto_write_symbols: FxHashSet<SymbolId>,
 
     pub changed: bool,
+
+    /// Scratch buffer reused by `try_fold_concat` to build template literal
+    /// quasis without allocating a fresh `String` per call.
+    pub concat_scratch: String,
 }
 
 impl MinifierState<'_> {
@@ -49,6 +53,7 @@ impl MinifierState<'_> {
             class_symbols_stack: ClassSymbolsStack::new(),
             proto_write_symbols: FxHashSet::default(),
             changed: false,
+            concat_scratch: String::new(),
         }
     }
 }

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -8,7 +8,7 @@ RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 |
 
 pdf.mjs                    | 567.30 kB      ||           3926 |            393 ||          47465 |           7740
 
-antd.js                    | 6.69 MB        ||           4652 |           1622 ||         333609 |          69349
+antd.js                    | 6.69 MB        ||           3084 |             53 ||         336992 |          69349
 
 binder.ts                  | 193.08 kB      ||             41 |              1 ||           7076 |            824
 


### PR DESCRIPTION
## Summary

When the minifier folds `.concat()` calls into template literals via `try_fold_concat` in `peephole/replace_known_methods.rs`, the original implementation built two short-lived intermediate buffers per call:

- `quasi_strs: Vec<Cow<'a, str>>` — fresh `std::Vec` allocation per call.
- A `String` inside each `Cow::Owned` — created when `Cow::to_mut()` cloned a `Borrowed` into an `Owned`, then grown via doubling as more arg strings were pushed in.

For files with many `.concat()` calls — common in bundled ES5 libraries where template literals weren't available — both structures were freshly allocated thousands of times per minify, with the `String` growing via doubling each time.

This PR replaces those per-call buffers with a single reusable scratch `String` held on `MinifierState`, and constructs `TemplateElement` AST nodes directly into the arena `Vec` as args are drained. The intermediate `Vec<Cow<'a, str>>` is gone entirely. After the first few folds the scratch's capacity stabilizes and subsequent folds are amortized zero std-heap allocs.

The state machine simplifies in the process: the `pushed_quasi: bool` flag is gone. Its invariant ("scratch holds an in-progress quasi") is naturally maintained because every expression flush clears the scratch, so a back-to-back expression's flush produces the required empty separator quasi without a branch.

## Allocation impact

`cargo allocs`, `allocs_minifier.snap` (baseline = parent commit, after resolve-refs and var-hoist landed):

| File | Size | Sys allocs before | Sys allocs after | Sys reallocs before | Sys reallocs after |
|---|---|---|---|---|---|
| `antd.js` | 6.69 MB ES5 | **4,652** | **3,084** (`−1,568`, `−33.7%`) | **1,622** | **53** (`−1,569`) |
| Other tracked files | various | unchanged | unchanged | unchanged | unchanged |

Only `antd.js` shows a change because it's the only tracked file that exercises `.concat()` folding heavily. ES5 bundled code uses `.concat()` instead of template literals; antd.js has thousands of these.

The headline `Sys reallocs` improvement (`1,622` → `53`) comes from eliminating the per-call `String` doubling. The headline `Sys allocs` improvement (`4,652` → `3,084`) comes from eliminating the per-call `Vec<Cow<'a, str>>` allocation.

## Commits

This PR contains two commits, kept separate for review history:

1. **`perf(minifier): pre-size buffers in try_fold_concat to eliminate growth reallocs`** — the original tactical fix that pre-sized the doomed-to-be-removed intermediate buffers. Dropped sys reallocs first but didn't touch sys allocs.
2. **`perf(minifier): drop per-call buffers in try_fold_concat`** — the root-cause refactor described above. Removes the intermediate buffers entirely. Cuts both columns.

Once the second commit lands, the pre-sizing in the first becomes dead-code (the buffers it pre-sized no longer exist). They're kept as separate commits so the diff against `main` is reviewable — feel free to squash on merge.

## How I found this

After #22580, profiling on `antd.js` minifier showed it had unusually high sys reallocs vs other tracked files. I wrote a backtrace-capturing `System` allocator wrapper and ran it on the minify path. The top realloc sites all converged on `try_fold_concat` — the overwhelming majority of captured reallocs came from this one function. After landing the pre-size fix, code review pushed for a root-cause fix that also addressed the `Sys allocs` column, which this refactor delivers.

## Timing

The minifier bench suite (originally) didn't include antd.js or other `.concat()`-heavy fixtures, so bench numbers locally were flat (no regression, no obvious improvement). With kitchen-sink in the bench input set (#22609), CodSpeed shows: **minifier mean −1.5%, min −3.7%** on kitchen-sink.

## Verification

- `cargo test -p oxc_minifier` — pass.
- `cargo minsize` — no size regressions (`minsize.snap` byte-identical).
- `cargo allocs` — only `antd.js` row changed in `allocs_minifier.snap`.
- `cargo fmt -p oxc_minifier` clean.

AI disclosure: drafted with Claude Code, reviewed manually.