### PR TITLE
fix(tasks): reset allocators in mangler keep_names benchmark

### DIFF
--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -82,10 +82,12 @@ fn bench_mangler(criterion: &mut Criterion) {
         let id = BenchmarkId::from_parameter(format!("{}_keep_names", &first_file.file_name));
         let source_type = SourceType::from_path(&first_file.file_name).unwrap();
         let source_text = first_file.source_text.as_str();
-        let allocator = Allocator::default();
-        let temp_allocator = Allocator::default();
+        let mut allocator = Allocator::default();
+        let mut temp_allocator = Allocator::default();
         group.bench_function(id, |b| {
             b.iter_with_setup_wrapper(|runner| {
+                allocator.reset();
+                temp_allocator.reset();
                 let program = Parser::new(&allocator, source_text, source_type).parse().program;
                 let mut semantic = SemanticBuilder::new().build(&program).semantic;
                 runner.run(|| {


### PR DESCRIPTION
## Summary

- `bench_mangler`'s `keep_names` variant was missing the `allocator.reset()` / `temp_allocator.reset()` calls that every other write-into-arena bench has. Without resets, the arenas grew across criterion's warmup + measurement iterations and hit libc allocation paths — explicitly called out as non-deterministic in `tasks/benchmark/src/lib.rs`.
- This was the source of recurring ~3% noise on `mangler[RadixUIAdoptionSection.jsx_keep_names]` in CodSpeed, appearing as false-positive regressions on unrelated PRs.
- Fix mirrors the working sibling pattern at the regular `bench_mangler` immediately above.

AI disclosure: drafted with Claude Code, reviewed manually.