### PR TITLE
perf(linter/no-async-endpoint-handlers): populate node types

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4102,7 +4102,8 @@ impl RuleRunner for crate::rules::oxc::no_async_await::NoAsyncAwait {
 }
 
 impl RuleRunner for crate::rules::oxc::no_async_endpoint_handlers::NoAsyncEndpointHandlers {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -197,8 +197,8 @@ impl Rule for NoAsyncEndpointHandlers {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let kind = node.kind();
-        let Some((endpoint, args)) = utils::as_endpoint_registration(&kind) else {
+        let AstKind::CallExpression(call) = node.kind() else { return };
+        let Some((endpoint, args)) = utils::as_endpoint_registration(call) else {
             return;
         };
         for arg in

--- a/crates/oxc_linter/src/utils/express.rs
+++ b/crates/oxc_linter/src/utils/express.rs
@@ -1,10 +1,7 @@
-use oxc_ast::{
-    AstKind,
-    ast::{Argument, Expression, FormalParameter},
-};
+use oxc_ast::ast::{Argument, CallExpression, Expression, FormalParameter};
 use oxc_str::Str;
 
-/// Check if the given node is registering an endpoint handler or middleware to
+/// Check if the given call is registering an endpoint handler or middleware to
 /// a route or Express application object. If it is, it
 /// returns:
 /// - the endpoint path being handled, if found and statically analyzable
@@ -18,9 +15,8 @@ use oxc_str::Str;
 ///
 /// ```
 pub fn as_endpoint_registration<'a, 'n>(
-    node: &'n AstKind<'a>,
+    call: &'n CallExpression<'a>,
 ) -> Option<(Option<Str<'a>>, &'n [Argument<'a>])> {
-    let call = node.as_call_expression()?;
     let callee = call.callee.as_member_expression()?;
     let method_name = callee.static_property_name()?;
     if ROUTER_HANDLER_METHOD_NAMES.binary_search(&method_name).is_err() {


### PR DESCRIPTION
Refactor `oxc/no-async-endpoint-handlers` so its `run` method starts with a `let AstKind::CallExpression(..) = node.kind() else { return };` guard.

The rule only needs to inspect endpoint registration calls, so `linter_codegen` can generate a narrow `NODE_TYPES` entry with `CallExpression` instead of running the rule on every AST node. The Express helper now accepts a `CallExpression` directly, which keeps the call-site type-narrowed after the guard.
