### PR TITLE
perf(linter/no-negated-condition): populate node types

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -852,7 +852,8 @@ impl RuleRunner for crate::rules::eslint::no_multi_str::NoMultiStr {
 }
 
 impl RuleRunner for crate::rules::eslint::no_negated_condition::NoNegatedCondition {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression, AstType::IfStatement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -3142,7 +3143,8 @@ impl RuleRunner for crate::rules::unicorn::no_magic_array_flat_depth::NoMagicArr
 }
 
 impl RuleRunner for crate::rules::unicorn::no_negated_condition::NoNegatedCondition {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ConditionalExpression, AstType::IfStatement]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
@@ -1,10 +1,13 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
     AstNode,
     context::LintContext,
     rule::Rule,
-    rules::shared::no_negated_condition::{DOCUMENTATION, run},
+    rules::shared::no_negated_condition::{
+        DOCUMENTATION, run_on_conditional_expression, run_on_if_statement,
+    },
 };
 
 #[derive(Debug, Default, Clone)]
@@ -21,7 +24,15 @@ declare_oxc_lint!(
 
 impl Rule for NoNegatedCondition {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        run(node, ctx);
+        match node.kind() {
+            AstKind::IfStatement(if_stmt) => {
+                run_on_if_statement(if_stmt, ctx);
+            }
+            AstKind::ConditionalExpression(conditional_expr) => {
+                run_on_conditional_expression(conditional_expr, ctx);
+            }
+            _ => {}
+        }
     }
 }
 

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -1,12 +1,9 @@
-use oxc_ast::{
-    AstKind,
-    ast::{Expression, Statement},
-};
+use oxc_ast::ast::{ConditionalExpression, Expression, IfStatement, Statement};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::{AstNode, context::LintContext};
+use crate::context::LintContext;
 
 fn no_negated_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected negated condition.")
@@ -47,29 +44,28 @@ a ? doSomethingB() : doSomethingC()
 ```
 ";
 
-pub fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
-    match node.kind() {
-        AstKind::IfStatement(if_stmt) => {
-            let Some(if_stmt_alternate) = &if_stmt.alternate else {
-                return;
-            };
+pub fn run_on_if_statement(if_stmt: &IfStatement<'_>, ctx: &LintContext) {
+    let Some(if_stmt_alternate) = &if_stmt.alternate else {
+        return;
+    };
 
-            if matches!(if_stmt_alternate, Statement::IfStatement(_)) {
-                return;
-            }
+    if matches!(if_stmt_alternate, Statement::IfStatement(_)) {
+        return;
+    }
 
-            let test = if_stmt.test.without_parentheses();
-            if is_negated_expression(test) {
-                ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
-            }
-        }
-        AstKind::ConditionalExpression(conditional_expr) => {
-            let test = conditional_expr.test.without_parentheses();
-            if is_negated_expression(test) {
-                ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
-            }
-        }
-        _ => {}
+    let test = if_stmt.test.without_parentheses();
+    if is_negated_expression(test) {
+        ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
+    }
+}
+
+pub fn run_on_conditional_expression(
+    conditional_expr: &ConditionalExpression<'_>,
+    ctx: &LintContext,
+) {
+    let test = conditional_expr.test.without_parentheses();
+    if is_negated_expression(test) {
+        ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -1,10 +1,13 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
     AstNode,
     context::LintContext,
     rule::Rule,
-    rules::shared::no_negated_condition::{DOCUMENTATION, run},
+    rules::shared::no_negated_condition::{
+        DOCUMENTATION, run_on_conditional_expression, run_on_if_statement,
+    },
 };
 
 #[derive(Debug, Default, Clone)]
@@ -21,7 +24,15 @@ declare_oxc_lint!(
 
 impl Rule for NoNegatedCondition {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        run(node, ctx);
+        match node.kind() {
+            AstKind::IfStatement(if_stmt) => {
+                run_on_if_statement(if_stmt, ctx);
+            }
+            AstKind::ConditionalExpression(conditional_expr) => {
+                run_on_conditional_expression(conditional_expr, ctx);
+            }
+            _ => {}
+        }
     }
 }
 


### PR DESCRIPTION
Refactor the ESLint and Unicorn `no-negated-condition` rule wrappers so they dispatch from a top-level `match node.kind()`.

The shared implementation now exposes the two concrete checks directly, which lets `linter_codegen` infer the rule node set instead of falling back to every AST node. The generated runner now lists `ConditionalExpression` and `IfStatement` for both aliases.
