### PR TITLE
fix(oxlint/lsp): "ignore this" actions merge with existing directive

### DIFF
--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -407,6 +407,13 @@ pub fn offset_to_position(rope: &Rope, offset: u32, source_text: &str) -> Positi
     Position::new(line, column)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DisableDirective {
+    NextLine,
+    Line,
+    Section,
+}
+
 /// Add "ignore this line" and "ignore this rule" fixes to the existing fixes.
 /// These fixes will be added to the end of the existing fixes.
 /// If the existing fixes already contain an "remove unused disable directive" fix,
@@ -446,6 +453,20 @@ fn disable_for_this_line(
     source_text: &str,
 ) -> FixedContent {
     let bytes = source_text.as_bytes();
+    let message = format!("Disable {rule_name} for this line");
+
+    // Reuse an inline disable-line comment on the same line when present.
+    if let Some(existing_comment_end) = get_inline_disable_line_comment_end(error_offset, bytes) {
+        let position = offset_to_position(rope, existing_comment_end, source_text);
+        return FixedContent {
+            message,
+            code: format!(" {rule_name}"),
+            range: Range::new(position, position),
+            kind: FixKind::SafeFix,
+            lsp_kind: FixedContentKind::IgnoreLintRuleLine,
+        };
+    }
+
     // Find the line break before the error
     let mut line_break_offset = error_offset;
     for byte in bytes[section_offset as usize..error_offset as usize].iter().rev() {
@@ -463,6 +484,21 @@ fn disable_for_this_line(
     let (content_prefix, insert_offset) =
         get_section_insert_position(section_offset, line_break_offset, bytes);
 
+    // Reuse an existing disable-next-line comment when present by appending the rule.
+    if let Some(existing_comment_end) =
+        get_existing_disable_comment_end(insert_offset, DisableDirective::NextLine, bytes)
+    {
+        let position = offset_to_position(rope, existing_comment_end, source_text);
+        return FixedContent {
+            message,
+            code: format!(" {rule_name}"),
+            range: Range::new(position, position),
+            kind: FixKind::SafeFix,
+            lsp_kind: FixedContentKind::IgnoreLintRuleLine,
+        };
+    }
+
+    // Preserve leading indentation from the target line for newly inserted comments.
     let whitespace_range = {
         let start = insert_offset as usize;
         let end = error_offset as usize;
@@ -477,7 +513,7 @@ fn disable_for_this_line(
 
     let position = offset_to_position(rope, insert_offset, source_text);
     FixedContent {
-        message: format!("Disable {rule_name} for this line"),
+        message,
         code: format!(
             "{content_prefix}{whitespace_string}// oxlint-disable-next-line {rule_name}\n"
         ),
@@ -493,16 +529,31 @@ fn disable_for_this_section(
     rope: &Rope,
     source_text: &str,
 ) -> FixedContent {
-    let comment = format!("// oxlint-disable {rule_name}\n");
+    let bytes = source_text.as_bytes();
+    let message = format!("Disable {rule_name} for this whole file");
 
     let (content_prefix, insert_offset) =
-        get_section_insert_position(section_offset, section_offset, source_text.as_bytes());
+        get_section_insert_position(section_offset, section_offset, bytes);
 
-    let content = format!("{content_prefix}{comment}");
+    // Reuse an existing section disable comment when present by appending the rule.
+    if let Some(existing_comment_end) =
+        get_existing_disable_comment_end(insert_offset, DisableDirective::Section, bytes)
+    {
+        let position = offset_to_position(rope, existing_comment_end, source_text);
+        return FixedContent {
+            message,
+            code: format!(" {rule_name}"),
+            range: Range::new(position, position),
+            kind: FixKind::SafeFix,
+            lsp_kind: FixedContentKind::IgnoreLintRuleSection,
+        };
+    }
+
+    let content = format!("{content_prefix}// oxlint-disable {rule_name}\n");
     let position = offset_to_position(rope, insert_offset, source_text);
 
     FixedContent {
-        message: format!("Disable {rule_name} for this whole file"),
+        message,
         code: content,
         range: Range::new(position, position),
         kind: FixKind::SafeFix,
@@ -563,7 +614,190 @@ fn get_section_insert_position(
     }
 }
 
+#[expect(clippy::cast_possible_truncation)]
+fn get_existing_disable_comment_end(
+    insert_offset: u32,
+    directive: DisableDirective,
+    bytes: &[u8],
+) -> Option<u32> {
+    let insert_offset = insert_offset as usize;
+
+    if insert_offset > bytes.len() {
+        return None;
+    }
+
+    // First check the insertion line itself (e.g. section offsets that already point at a comment).
+    if let Some(line_end) = get_disable_comment_end_at_line_start(insert_offset, directive, bytes) {
+        return Some(line_end as u32);
+    }
+
+    if insert_offset == 0 {
+        return None;
+    }
+
+    // We only merge when insertion happens at the start of a line.
+    if !matches!(bytes[insert_offset - 1], b'\n' | b'\r') {
+        return None;
+    }
+
+    // Then check the line immediately above the insertion point.
+    let mut line_end = insert_offset;
+    while line_end > 0 && matches!(bytes[line_end - 1], b'\n' | b'\r') {
+        line_end -= 1;
+    }
+
+    if line_end == 0 {
+        return None;
+    }
+
+    let mut line_start = line_end;
+    while line_start > 0 && !matches!(bytes[line_start - 1], b'\n' | b'\r') {
+        line_start -= 1;
+    }
+
+    get_disable_comment_end_at_line_start(line_start, directive, bytes)
+        .map(|line_end| line_end as u32)
+}
+
+fn get_disable_comment_end_at_line_start(
+    line_start: usize,
+    directive: DisableDirective,
+    bytes: &[u8],
+) -> Option<usize> {
+    if line_start > bytes.len() {
+        return None;
+    }
+
+    if line_start > 0 && !matches!(bytes[line_start - 1], b'\n' | b'\r') {
+        return None;
+    }
+
+    get_disable_comment_end_at_comment_start(line_start, directive, bytes)
+}
+
+fn get_disable_comment_end_at_comment_start(
+    comment_start: usize,
+    directive: DisableDirective,
+    bytes: &[u8],
+) -> Option<usize> {
+    if comment_start > bytes.len() {
+        return None;
+    }
+
+    let mut line_end = comment_start;
+    while line_end < bytes.len() && !matches!(bytes[line_end], b'\n' | b'\r') {
+        line_end += 1;
+    }
+
+    // Parse a single-line comment in place and ensure it starts with the expected directive.
+    let line = &bytes[comment_start..line_end];
+    let mut idx = 0;
+
+    while idx < line.len() && matches!(line[idx], b' ' | b'\t') {
+        idx += 1;
+    }
+
+    if !line[idx..].starts_with(b"//") {
+        return None;
+    }
+    idx += 2;
+
+    while idx < line.len() && matches!(line[idx], b' ' | b'\t') {
+        idx += 1;
+    }
+
+    let matched_directive_len = match directive {
+        DisableDirective::NextLine => {
+            if line[idx..].starts_with(b"oxlint-disable-next-line") {
+                Some(b"oxlint-disable-next-line".len())
+            } else if line[idx..].starts_with(b"eslint-disable-next-line") {
+                Some(b"eslint-disable-next-line".len())
+            } else {
+                None
+            }
+        }
+        DisableDirective::Line => {
+            if line[idx..].starts_with(b"oxlint-disable-line") {
+                Some(b"oxlint-disable-line".len())
+            } else if line[idx..].starts_with(b"eslint-disable-line") {
+                Some(b"eslint-disable-line".len())
+            } else {
+                None
+            }
+        }
+        DisableDirective::Section => {
+            if line[idx..].starts_with(b"oxlint-disable") {
+                Some(b"oxlint-disable".len())
+            } else if line[idx..].starts_with(b"eslint-disable") {
+                Some(b"eslint-disable".len())
+            } else {
+                None
+            }
+        }
+    }?;
+    idx += matched_directive_len;
+
+    // Avoid matching prefixes like "oxlint-disable-next-line-foo".
+    if idx < line.len() && !matches!(line[idx], b' ' | b'\t') {
+        return None;
+    }
+
+    // Match the same description forms as `DisableDirectivesBuilder::get_rule_names`:
+    // - `--` anywhere
+    // - a single `-` surrounded by whitespace
+    let merge_end = find_description_start_offset(&line[idx..])
+        .map_or(line_end, |pos| comment_start + idx + pos);
+
+    Some(merge_end)
+}
+
+fn find_description_start_offset(text: &[u8]) -> Option<usize> {
+    let mut previous = None;
+
+    for (index, &ch) in text.iter().enumerate() {
+        if ch != b'-' {
+            previous = Some(ch);
+            continue;
+        }
+
+        let next = text.get(index + 1).copied();
+        let is_description_start = next.is_some_and(|c| {
+            c == b'-'
+                || (previous.is_some_and(|p: u8| p.is_ascii_whitespace())
+                    && c.is_ascii_whitespace())
+        });
+
+        if is_description_start {
+            return Some(index);
+        }
+
+        previous = Some(ch);
+    }
+
+    None
+}
+
+#[expect(clippy::cast_possible_truncation)]
+fn get_inline_disable_line_comment_end(error_offset: u32, bytes: &[u8]) -> Option<u32> {
+    let error_offset = error_offset as usize;
+    if error_offset > bytes.len() {
+        return None;
+    }
+
+    let mut line_end = error_offset;
+    while line_end < bytes.len() && !matches!(bytes[line_end], b'\n' | b'\r') {
+        line_end += 1;
+    }
+
+    let comment_start = bytes[error_offset..line_end].windows(2).position(|w| w == b"//")?;
+    let comment_offset = error_offset + comment_start;
+
+    get_disable_comment_end_at_comment_start(comment_offset, DisableDirective::Line, bytes)
+        .map(|offset| offset as u32)
+}
+
 #[cfg(test)]
+#[expect(clippy::cast_possible_truncation)]
 mod test {
     use oxc_data_structures::rope::Rope;
     use oxc_diagnostics::OxcCode;
@@ -682,6 +916,61 @@ mod test {
         assert_eq!(fix.code, "\n// oxlint-disable no-unused-vars\n");
         assert_eq!(fix.range.start.line, 0);
         assert_eq!(fix.range.start.character, 6);
+    }
+
+    #[test]
+    fn disable_for_section_vue_script_block_after_template() {
+        let source =
+            "<template>\n  <div />\n</template>\n<script>\nconsole.log('hello');\n</script>";
+        let rope = Rope::from_str(source);
+        let section_offset = source.find("<script>").unwrap() as u32 + "<script>".len() as u32;
+        let fix = super::disable_for_this_section("no-console", section_offset, &rope, source);
+
+        assert_eq!(fix.code, "// oxlint-disable no-console\n");
+        assert_eq!(fix.range.start.line, 4);
+        assert_eq!(fix.range.start.character, 0);
+    }
+
+    #[test]
+    fn disable_for_section_vue_script_block_after_template_crlf() {
+        let source = "<template>\r\n  <div />\r\n</template>\r\n<script>\r\nconsole.log('hello');\r\n</script>";
+        let rope = Rope::from_str(source);
+        let section_offset = source.find("<script>").unwrap() as u32 + "<script>".len() as u32;
+        let fix = super::disable_for_this_section("no-console", section_offset, &rope, source);
+
+        assert_eq!(fix.code, "// oxlint-disable no-console\n");
+        assert_eq!(fix.range.start.line, 4);
+        assert_eq!(fix.range.start.character, 0);
+    }
+
+    #[test]
+    fn disable_for_section_vue_script_setup_mid_line() {
+        let source = "<template><div /></template>\n<script setup>const x = 1;\n</script>";
+        let rope = Rope::from_str(source);
+        let section_offset = source.find("const x").unwrap() as u32;
+        let fix = super::disable_for_this_section("no-unused-vars", section_offset, &rope, source);
+
+        assert_eq!(fix.code, "\n// oxlint-disable no-unused-vars\n");
+        assert_eq!(fix.range.start.line, 1);
+        assert_eq!(fix.range.start.character, "<script setup>".len() as u32);
+    }
+
+    #[test]
+    fn disable_for_section_vue_script_block_merges_existing_ignore_line() {
+        let existing = "// oxlint-disable no-alert";
+        let source = format!(
+            "<template>\n</template>\n<script>\n{existing}\nconsole.log('hello');\n</script>"
+        );
+        let rope = Rope::from_str(&source);
+        let section_offset = source.find(existing).unwrap() as u32;
+
+        let fix = super::disable_for_this_section("no-console", section_offset, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 3);
+        assert_eq!(fix.range.start.character, existing.len() as u32);
+        assert_eq!(fix.range.end.line, 3);
+        assert_eq!(fix.range.end.character, existing.len() as u32);
     }
 
     #[test]
@@ -899,6 +1188,185 @@ mod test {
         assert_eq!(fix.code, "// oxlint-disable-next-line no-console\n");
         assert_eq!(fix.range.start.line, 1);
         assert_eq!(fix.range.start.character, 0);
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_with_existing_ignore_comment_above() {
+        let existing = "// oxlint-disable-next-line no-alert";
+        let source = format!("{existing}\nconsole.log('hello');");
+        let rope = Rope::from_str(&source);
+        let error_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, existing.len() as u32);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, existing.len() as u32);
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_with_inline_disable_line_comment() {
+        let existing = "// oxlint-disable-line no-alert";
+        let source = format!("console.log('hello'); {existing}");
+        let rope = Rope::from_str(&source);
+        let error_offset = source.find("console").unwrap() as u32;
+        let insert_offset = source.find(existing).unwrap() as u32 + existing.len() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, insert_offset);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, insert_offset);
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_inline_disable_line_before_description() {
+        let existing = "// oxlint-disable-line no-alert -- reason";
+        let source = format!("console.log('hello'); {existing}");
+        let rope = Rope::from_str(&source);
+        let error_offset = source.find("console").unwrap() as u32;
+        let insert_offset = source.find("--").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, insert_offset);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, insert_offset);
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_before_description_suffix() {
+        let existing = "// oxlint-disable-next-line no-alert -- description";
+        let source = format!("{existing}\nconsole.log('hello');");
+        let rope = Rope::from_str(&source);
+        let error_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, existing.find("--").unwrap() as u32);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, existing.find("--").unwrap() as u32);
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_before_single_dash_description_suffix() {
+        let existing = "// oxlint-disable-next-line no-alert\t-\treason";
+        let source = format!("{existing}\nconsole.log('hello');");
+        let rope = Rope::from_str(&source);
+        let error_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, existing.find("-\t").unwrap() as u32);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, existing.find("-\t").unwrap() as u32);
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_before_double_dash_without_leading_space() {
+        let existing = "// oxlint-disable-next-line no-alert-- reason";
+        let source = format!("{existing}\nconsole.log('hello');");
+        let rope = Rope::from_str(&source);
+        let error_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, existing.find("--").unwrap() as u32);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, existing.find("--").unwrap() as u32);
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_with_eslint_disable_comment_above() {
+        let existing = "// eslint-disable-next-line no-alert";
+        let source = format!("{existing}\nconsole.log('hello');");
+        let rope = Rope::from_str(&source);
+        let error_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, existing.len() as u32);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, existing.len() as u32);
+    }
+
+    #[test]
+    fn disable_for_this_section_merges_with_existing_ignore_comment_above() {
+        let existing = "// oxlint-disable no-alert";
+        let source = format!("{existing}\nconsole.log('hello');");
+        let rope = Rope::from_str(&source);
+        let section_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_section("no-console", section_offset, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, existing.len() as u32);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, existing.len() as u32);
+    }
+
+    #[test]
+    fn disable_for_this_section_merges_with_eslint_disable_comment_above() {
+        let existing = "// eslint-disable no-alert";
+        let source = format!("{existing}\nconsole.log('hello');");
+        let rope = Rope::from_str(&source);
+        let section_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_section("no-console", section_offset, &rope, &source);
+
+        assert_eq!(fix.code, " no-console");
+        assert_eq!(fix.range.start.line, 0);
+        assert_eq!(fix.range.start.character, existing.len() as u32);
+        assert_eq!(fix.range.end.line, 0);
+        assert_eq!(fix.range.end.character, existing.len() as u32);
+    }
+
+    #[test]
+    fn disable_for_this_line_does_not_merge_with_non_disable_comment_above() {
+        let source = "// this is not a disable comment\nconsole.log('hello');";
+        let rope = Rope::from_str(source);
+        let error_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, source);
+
+        assert_eq!(fix.code, "// oxlint-disable-next-line no-console\n");
+    }
+
+    #[test]
+    fn disable_for_this_line_does_not_merge_with_lookalike_comment_above() {
+        let source = "// oxlint-disable-next-line-foo no-alert\nconsole.log('hello');";
+        let rope = Rope::from_str(source);
+        let error_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_line("no-console", error_offset, 0, &rope, source);
+
+        assert_eq!(fix.code, "// oxlint-disable-next-line no-console\n");
+    }
+
+    #[test]
+    fn disable_for_this_section_does_not_merge_with_non_disable_comment_above() {
+        let source = "// tslint:disable no-alert\nconsole.log('hello');";
+        let rope = Rope::from_str(source);
+        let section_offset = source.find("console").unwrap() as u32;
+
+        let fix = super::disable_for_this_section("no-console", section_offset, &rope, source);
+
+        assert_eq!(fix.code, "\n// oxlint-disable no-console\n");
     }
 
     fn assert_position(source: &str, offset: u32, expected: (u32, u32)) {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
@@ -81,15 +81,15 @@ Is Preferred: Some(false)
 TextEdit: TextEdit {
     range: Range {
         start: Position {
-            line: 9,
-            character: 0,
+            line: 8,
+            character: 52,
         },
         end: Position {
-            line: 9,
-            character: 0,
+            line: 8,
+            character: 52,
         },
     },
-    new_text: "// oxlint-disable-next-line no-console\n",
+    new_text: " no-console",
 }
 
 


### PR DESCRIPTION
> ## Pull request overview
> This PR updates oxlint’s LSP “ignore this” code actions so that when a relevant disable directive already exists (oxlint or ESLint form), the action appends the new rule to the existing directive instead of inserting a new comment.

Now it will check for `oxlint-disable-line` first and searched `oxlint-disable-next-line` if no comment after the diagnostic is found.

closes https://github.com/oxc-project/oxc/issues/16060

Generated by GPT-5.3-Codex 🤖 
Reviewed & manually tested by me.
