### PR TITLE
feat(linter/vue): implement require-render-return rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1311,6 +1311,7 @@ export interface DummyRuleMap {
   "vue/no-watch-after-await"?: DummyRule;
   "vue/prefer-import-from-vue"?: DummyRule;
   "vue/require-default-export"?: DummyRule;
+  "vue/require-render-return"?: DummyRule;
   "vue/require-slots-as-functions"?: DummyRule;
   "vue/require-typed-ref"?: DummyRule;
   "vue/return-in-computed-property"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5083,6 +5083,12 @@ impl RuleRunner for crate::rules::vue::require_default_export::RequireDefaultExp
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vue::require_render_return::RequireRenderReturn {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::require_slots_as_functions::RequireSlotsAsFunctions {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -810,6 +810,7 @@ pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnt
 pub use crate::rules::vue::no_watch_after_await::NoWatchAfterAwait as VueNoWatchAfterAwait;
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
 pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRequireDefaultExport;
+pub use crate::rules::vue::require_render_return::RequireRenderReturn as VueRequireRenderReturn;
 pub use crate::rules::vue::require_slots_as_functions::RequireSlotsAsFunctions as VueRequireSlotsAsFunctions;
 pub use crate::rules::vue::require_typed_ref::RequireTypedRef as VueRequireTypedRef;
 pub use crate::rules::vue::return_in_computed_property::ReturnInComputedProperty as VueReturnInComputedProperty;
@@ -1638,6 +1639,7 @@ pub enum RuleEnum {
     VueNoWatchAfterAwait(VueNoWatchAfterAwait),
     VuePreferImportFromVue(VuePreferImportFromVue),
     VueRequireDefaultExport(VueRequireDefaultExport),
+    VueRequireRenderReturn(VueRequireRenderReturn),
     VueRequireSlotsAsFunctions(VueRequireSlotsAsFunctions),
     VueRequireTypedRef(VueRequireTypedRef),
     VueReturnInComputedProperty(VueReturnInComputedProperty),
@@ -2551,7 +2553,8 @@ const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize = VUE_NO_SHARED_COMPONENT_DATA
 const VUE_NO_WATCH_AFTER_AWAIT_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
 const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
 const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
-const VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
+const VUE_REQUIRE_RENDER_RETURN_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
+const VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID: usize = VUE_REQUIRE_RENDER_RETURN_ID + 1usize;
 const VUE_REQUIRE_TYPED_REF_ID: usize = VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID + 1usize;
 const VUE_RETURN_IN_COMPUTED_PROPERTY_ID: usize = VUE_REQUIRE_TYPED_REF_ID + 1usize;
 const VUE_RETURN_IN_EMITS_VALIDATOR_ID: usize = VUE_RETURN_IN_COMPUTED_PROPERTY_ID + 1usize;
@@ -3490,6 +3493,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VUE_NO_WATCH_AFTER_AWAIT_ID,
             Self::VuePreferImportFromVue(_) => VUE_PREFER_IMPORT_FROM_VUE_ID,
             Self::VueRequireDefaultExport(_) => VUE_REQUIRE_DEFAULT_EXPORT_ID,
+            Self::VueRequireRenderReturn(_) => VUE_REQUIRE_RENDER_RETURN_ID,
             Self::VueRequireSlotsAsFunctions(_) => VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID,
             Self::VueRequireTypedRef(_) => VUE_REQUIRE_TYPED_REF_ID,
             Self::VueReturnInComputedProperty(_) => VUE_RETURN_IN_COMPUTED_PROPERTY_ID,
@@ -4414,6 +4418,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::NAME,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::NAME,
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::NAME,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::NAME,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::NAME,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::NAME,
@@ -5396,6 +5401,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::CATEGORY,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::CATEGORY,
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::CATEGORY,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::CATEGORY,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::CATEGORY,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::CATEGORY,
@@ -6321,6 +6327,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::FIX,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::FIX,
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::FIX,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::FIX,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::FIX,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::FIX,
@@ -7496,6 +7503,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::documentation(),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::documentation(),
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::documentation(),
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::documentation(),
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::documentation(),
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::documentation(),
@@ -9815,6 +9823,8 @@ impl RuleEnum {
                 .or_else(|| VuePreferImportFromVue::schema(generator)),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::config_schema(generator)
                 .or_else(|| VueRequireDefaultExport::schema(generator)),
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::config_schema(generator)
+                .or_else(|| VueRequireRenderReturn::schema(generator)),
             Self::VueRequireSlotsAsFunctions(_) => {
                 VueRequireSlotsAsFunctions::config_schema(generator)
                     .or_else(|| VueRequireSlotsAsFunctions::schema(generator))
@@ -10643,6 +10653,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => "vue",
             Self::VuePreferImportFromVue(_) => "vue",
             Self::VueRequireDefaultExport(_) => "vue",
+            Self::VueRequireRenderReturn(_) => "vue",
             Self::VueRequireSlotsAsFunctions(_) => "vue",
             Self::VueRequireTypedRef(_) => "vue",
             Self::VueReturnInComputedProperty(_) => "vue",
@@ -13244,6 +13255,9 @@ impl RuleEnum {
             Self::VueRequireDefaultExport(_) => Ok(Self::VueRequireDefaultExport(
                 VueRequireDefaultExport::from_configuration(value)?,
             )),
+            Self::VueRequireRenderReturn(_) => {
+                Ok(Self::VueRequireRenderReturn(VueRequireRenderReturn::from_configuration(value)?))
+            }
             Self::VueRequireSlotsAsFunctions(_) => Ok(Self::VueRequireSlotsAsFunctions(
                 VueRequireSlotsAsFunctions::from_configuration(value)?,
             )),
@@ -14078,6 +14092,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(rule) => rule.to_configuration(),
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
             Self::VueRequireDefaultExport(rule) => rule.to_configuration(),
+            Self::VueRequireRenderReturn(rule) => rule.to_configuration(),
             Self::VueRequireSlotsAsFunctions(rule) => rule.to_configuration(),
             Self::VueRequireTypedRef(rule) => rule.to_configuration(),
             Self::VueReturnInComputedProperty(rule) => rule.to_configuration(),
@@ -14902,6 +14917,7 @@ impl RuleEnum {
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
+                Self::VueRequireRenderReturn(rule) => rule.run(node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run(node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run(node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run(node, ctx),
@@ -15719,6 +15735,7 @@ impl RuleEnum {
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
+                Self::VueRequireRenderReturn(rule) => rule.run(node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run(node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run(node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run(node, ctx),
@@ -16543,6 +16560,7 @@ impl RuleEnum {
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
+                Self::VueRequireRenderReturn(rule) => rule.run_once(ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_once(ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_once(ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_once(ctx),
@@ -17360,6 +17378,7 @@ impl RuleEnum {
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
+                Self::VueRequireRenderReturn(rule) => rule.run_once(ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_once(ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_once(ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_once(ctx),
@@ -18439,6 +18458,7 @@ impl RuleEnum {
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueRequireRenderReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19510,6 +19530,7 @@ impl RuleEnum {
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueRequireRenderReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireSlotsAsFunctions(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireTypedRef(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueReturnInComputedProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20325,6 +20346,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(rule) => rule.should_run(ctx),
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
             Self::VueRequireDefaultExport(rule) => rule.should_run(ctx),
+            Self::VueRequireRenderReturn(rule) => rule.should_run(ctx),
             Self::VueRequireSlotsAsFunctions(rule) => rule.should_run(ctx),
             Self::VueRequireTypedRef(rule) => rule.should_run(ctx),
             Self::VueReturnInComputedProperty(rule) => rule.should_run(ctx),
@@ -21499,6 +21521,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::IS_TSGOLINT_RULE,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::IS_TSGOLINT_RULE,
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::IS_TSGOLINT_RULE,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::IS_TSGOLINT_RULE,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::IS_TSGOLINT_RULE,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::IS_TSGOLINT_RULE,
@@ -22483,6 +22506,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::VERSION,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::VERSION,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::VERSION,
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::VERSION,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::VERSION,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::VERSION,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::VERSION,
@@ -23502,6 +23526,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::HAS_CONFIG,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::HAS_CONFIG,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::HAS_CONFIG,
+            Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::HAS_CONFIG,
             Self::VueRequireSlotsAsFunctions(_) => VueRequireSlotsAsFunctions::HAS_CONFIG,
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::HAS_CONFIG,
             Self::VueReturnInComputedProperty(_) => VueReturnInComputedProperty::HAS_CONFIG,
@@ -24316,6 +24341,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(rule) => rule.types_info(),
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
             Self::VueRequireDefaultExport(rule) => rule.types_info(),
+            Self::VueRequireRenderReturn(rule) => rule.types_info(),
             Self::VueRequireSlotsAsFunctions(rule) => rule.types_info(),
             Self::VueRequireTypedRef(rule) => rule.types_info(),
             Self::VueReturnInComputedProperty(rule) => rule.types_info(),
@@ -25130,6 +25156,7 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(rule) => rule.run_info(),
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
             Self::VueRequireDefaultExport(rule) => rule.run_info(),
+            Self::VueRequireRenderReturn(rule) => rule.run_info(),
             Self::VueRequireSlotsAsFunctions(rule) => rule.run_info(),
             Self::VueRequireTypedRef(rule) => rule.run_info(),
             Self::VueReturnInComputedProperty(rule) => rule.run_info(),
@@ -26076,6 +26103,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoWatchAfterAwait(VueNoWatchAfterAwait::default()),
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),
         RuleEnum::VueRequireDefaultExport(VueRequireDefaultExport::default()),
+        RuleEnum::VueRequireRenderReturn(VueRequireRenderReturn::default()),
         RuleEnum::VueRequireSlotsAsFunctions(VueRequireSlotsAsFunctions::default()),
         RuleEnum::VueRequireTypedRef(VueRequireTypedRef::default()),
         RuleEnum::VueReturnInComputedProperty(VueReturnInComputedProperty::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -850,6 +850,7 @@ pub(crate) mod vue {
     pub mod no_watch_after_await;
     pub mod prefer_import_from_vue;
     pub mod require_default_export;
+    pub mod require_render_return;
     pub mod require_slots_as_functions;
     pub mod require_typed_ref;
     pub mod return_in_computed_property;

--- a/crates/oxc_linter/src/rules/vue/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/vue/require_render_return.rs
@@ -1,0 +1,337 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{definitely_returns_in_all_codepaths, is_vue_component_options_object},
+};
+
+fn require_render_return_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Expected to return a value in render function.")
+        .with_help("All code paths inside a render function must return a value.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RequireRenderReturn;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce that a `render` function always returns a value.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A Vue component's `render` function must produce a VNode tree. If a
+    /// code path falls through without returning, Vue receives `undefined`
+    /// and silently renders nothing.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   render() {
+    ///     if (foo) {
+    ///       return h('div')
+    ///     }
+    ///     // falls through without returning
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   render() {
+    ///     return h('div')
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    RequireRenderReturn,
+    vue,
+    correctness,
+    version = "next",
+);
+
+impl Rule for RequireRenderReturn {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::Function(_) => {}
+            AstKind::ArrowFunctionExpression(arrow) => {
+                // Expression-body arrow (`render: () => x`) implicitly returns.
+                if arrow.expression {
+                    return;
+                }
+            }
+            _ => return,
+        }
+
+        let Some(render_prop_key_span) = render_property_key_span(node, ctx) else {
+            return;
+        };
+
+        if !definitely_returns_in_all_codepaths(node, ctx, true) {
+            ctx.diagnostic(require_render_return_diagnostic(render_prop_key_span));
+        }
+    }
+}
+
+/// Return the `render` key span if `node` is the function value of a `render:`
+/// property on a Vue component options object.
+fn render_property_key_span(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Span> {
+    let nodes = ctx.nodes();
+    let parent = nodes.parent_node(node.id());
+    let AstKind::ObjectProperty(prop) = parent.kind() else {
+        return None;
+    };
+    if !prop.key.is_specific_static_name("render") {
+        return None;
+    }
+
+    let opts_node = nodes.parent_node(parent.id());
+    if !matches!(opts_node.kind(), AstKind::ObjectExpression(_)) {
+        return None;
+    }
+    if !is_vue_component_options_object(opts_node, ctx) {
+        return None;
+    }
+
+    Some(prop.key.span())
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "Vue.component('test', {
+                    ...foo,
+                    render() {
+                      return {}
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test', {
+                    foo() {
+                      return {}
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test', {
+                    foo: {}
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test', {
+                    render: foo
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test', {
+                    render() {
+                      return <div></div>
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "<script>
+                  export default {
+                    render() {
+                      return {}
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  export default {
+                    render() {
+                      const foo = function () {}
+                      return foo
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  export default {
+                    render() {
+                      if (a) {
+                        if (b) {
+
+                        }
+                        if (c) {
+                          return true
+                        } else {
+                          return foo
+                        }
+                      } else {
+                        return foo
+                      }
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  export default {
+                    render: () => null
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  export default {
+                    render() {
+                      if (a) {
+                        return `<div>a</div>`
+                      } else {
+                        return `<span>a</span>`
+                      }
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  export default {
+                    render(h) {
+                      const options = []
+                      this.matches.forEach(function (match) {
+                        options.push(match)
+                      })
+                      return h('div', options)
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "<script>
+                  export default {
+                    render() {
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+                  export default {
+                    render: function () {
+                      if (foo) {
+                        return h('div', 'hello')
+                      }
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "Vue.component('test', {
+                    render: function () {
+                      if (a) {
+                        return
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "app.component('test', {
+                    render: function () {
+                      if (a) {
+                        return
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test2', {
+                    render: function () {
+                      if (a) {
+                        return h('div', 'hello')
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test2', {
+                    render: function () {
+                      if (a) {
+
+                      } else {
+                        return h('div', 'hello')
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+    ];
+
+    Tester::new(RequireRenderReturn::NAME, RequireRenderReturn::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -2,13 +2,6 @@ use oxc_ast::{
     AstKind,
     ast::{CallExpression, Expression},
 };
-use oxc_cfg::{
-    EdgeType, ErrorEdgeKind, InstructionKind, ReturnInstructionKind,
-    graph::{
-        Direction,
-        visit::{Control, DfsEvent, set_depth_first_search},
-    },
-};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -20,7 +13,7 @@ use crate::{
     context::{ContextHost, LintContext},
     module_record::ImportImportName,
     rule::{DefaultRuleConfig, Rule},
-    utils::is_vue_component_options_object,
+    utils::{definitely_returns_in_all_codepaths, is_vue_component_options_object},
 };
 
 fn return_in_computed_property_diagnostic(span: Span) -> OxcDiagnostic {
@@ -221,75 +214,6 @@ fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> boo
         }
         scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
     })
-}
-
-fn definitely_returns_in_all_codepaths(
-    node: &AstNode<'_>,
-    ctx: &LintContext<'_>,
-    treat_undefined_as_unspecified: bool,
-) -> bool {
-    let cfg = ctx.cfg();
-    let graph = cfg.graph();
-
-    let output =
-        set_depth_first_search(graph, Some(ctx.nodes().cfg_id(node.id())), |event| match event {
-            DfsEvent::TreeEdge(a, b) => {
-                if graph.edges_connecting(a, b).any(|e| {
-                    matches!(
-                        e.weight(),
-                        EdgeType::Normal
-                            | EdgeType::Jump
-                            | EdgeType::Error(ErrorEdgeKind::Explicit)
-                    )
-                }) {
-                    Control::Continue
-                } else {
-                    Control::Prune
-                }
-            }
-            DfsEvent::Discover(basic_block_id, _) => {
-                let return_instruction =
-                    cfg.basic_block(basic_block_id).instructions().iter().find(|it| {
-                        match it.kind {
-                            InstructionKind::Return(_) | InstructionKind::Throw => true,
-                            InstructionKind::ImplicitReturn
-                            | InstructionKind::Break(_)
-                            | InstructionKind::Continue(_)
-                            | InstructionKind::Iteration(_)
-                            | InstructionKind::Unreachable
-                            | InstructionKind::Condition
-                            | InstructionKind::Statement => false,
-                        }
-                    });
-
-                let does_return = return_instruction.is_some_and(|ret| {
-                    !matches!(
-                        ret.kind,
-                        InstructionKind::Return(ReturnInstructionKind::ImplicitUndefined)
-                            if treat_undefined_as_unspecified
-                    )
-                });
-
-                if graph.edges_directed(basic_block_id, Direction::Outgoing).any(|e| {
-                    matches!(
-                        e.weight(),
-                        EdgeType::Jump
-                            | EdgeType::Normal
-                            | EdgeType::Backedge
-                            | EdgeType::Error(ErrorEdgeKind::Explicit)
-                    )
-                }) {
-                    Control::Continue
-                } else if does_return {
-                    Control::Prune
-                } else {
-                    Control::Break(())
-                }
-            }
-            _ => Control::Continue,
-        });
-
-    output.break_value().is_none()
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/vue_require_render_return.snap
+++ b/crates/oxc_linter/src/snapshots/vue_require_render_return.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(require-render-return): Expected to return a value in render function.
+   ╭─[require_render_return.tsx:3:21]
+ 2 │                   export default {
+ 3 │                     render() {
+   ·                     ──────
+ 4 │                     }
+   ╰────
+  help: All code paths inside a render function must return a value.
+
+  ⚠ vue(require-render-return): Expected to return a value in render function.
+   ╭─[require_render_return.tsx:3:21]
+ 2 │                   export default {
+ 3 │                     render: function () {
+   ·                     ──────
+ 4 │                       if (foo) {
+   ╰────
+  help: All code paths inside a render function must return a value.
+
+  ⚠ vue(require-render-return): Expected to return a value in render function.
+   ╭─[require_render_return.tsx:2:21]
+ 1 │ Vue.component('test', {
+ 2 │                     render: function () {
+   ·                     ──────
+ 3 │                       if (a) {
+   ╰────
+  help: All code paths inside a render function must return a value.
+
+  ⚠ vue(require-render-return): Expected to return a value in render function.
+   ╭─[require_render_return.tsx:2:21]
+ 1 │ app.component('test', {
+ 2 │                     render: function () {
+   ·                     ──────
+ 3 │                       if (a) {
+   ╰────
+  help: All code paths inside a render function must return a value.
+
+  ⚠ vue(require-render-return): Expected to return a value in render function.
+   ╭─[require_render_return.tsx:2:21]
+ 1 │ Vue.component('test2', {
+ 2 │                     render: function () {
+   ·                     ──────
+ 3 │                       if (a) {
+   ╰────
+  help: All code paths inside a render function must return a value.
+
+  ⚠ vue(require-render-return): Expected to return a value in render function.
+   ╭─[require_render_return.tsx:2:21]
+ 1 │ Vue.component('test2', {
+ 2 │                     render: function () {
+   ·                     ──────
+ 3 │                       if (a) {
+   ╰────
+  help: All code paths inside a render function must return a value.

--- a/crates/oxc_linter/src/utils/control_flow.rs
+++ b/crates/oxc_linter/src/utils/control_flow.rs
@@ -1,0 +1,87 @@
+use oxc_cfg::{
+    EdgeType, ErrorEdgeKind, InstructionKind, ReturnInstructionKind,
+    graph::{
+        Direction,
+        visit::{Control, DfsEvent, set_depth_first_search},
+    },
+};
+
+use crate::{AstNode, context::LintContext};
+
+/// Whether every code path inside the given function definitely reaches a
+/// `return` (or `throw`) before falling off the end.
+///
+/// When `treat_undefined_as_unspecified` is `true`, a bare `return;`
+/// (which implicitly returns `undefined`) is treated as a missing return.
+///
+/// `node` should be a `Function` or `ArrowFunctionExpression` (block-body).
+/// Concise-body arrows (`() => expr`) always return, so callers can short-
+/// circuit before invoking this.
+pub fn definitely_returns_in_all_codepaths(
+    node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+    treat_undefined_as_unspecified: bool,
+) -> bool {
+    let cfg = ctx.cfg();
+    let graph = cfg.graph();
+
+    let output =
+        set_depth_first_search(graph, Some(ctx.nodes().cfg_id(node.id())), |event| match event {
+            DfsEvent::TreeEdge(a, b) => {
+                if graph.edges_connecting(a, b).any(|e| {
+                    matches!(
+                        e.weight(),
+                        EdgeType::Normal
+                            | EdgeType::Jump
+                            | EdgeType::Error(ErrorEdgeKind::Explicit)
+                    )
+                }) {
+                    Control::Continue
+                } else {
+                    Control::Prune
+                }
+            }
+            DfsEvent::Discover(basic_block_id, _) => {
+                let return_instruction =
+                    cfg.basic_block(basic_block_id).instructions().iter().find(|it| {
+                        match it.kind {
+                            InstructionKind::Return(_) | InstructionKind::Throw => true,
+                            InstructionKind::ImplicitReturn
+                            | InstructionKind::Break(_)
+                            | InstructionKind::Continue(_)
+                            | InstructionKind::Iteration(_)
+                            | InstructionKind::Unreachable
+                            | InstructionKind::Condition
+                            | InstructionKind::Statement => false,
+                        }
+                    });
+
+                let does_return = return_instruction.is_some_and(|ret| {
+                    !matches!(
+                        ret.kind,
+                        InstructionKind::Return(ReturnInstructionKind::ImplicitUndefined)
+                            if treat_undefined_as_unspecified
+                    )
+                });
+
+                if graph.edges_directed(basic_block_id, Direction::Outgoing).any(|e| {
+                    matches!(
+                        e.weight(),
+                        EdgeType::Jump
+                            | EdgeType::Normal
+                            | EdgeType::Backedge
+                            | EdgeType::Error(ErrorEdgeKind::Explicit)
+                    )
+                }) {
+                    Control::Continue
+                } else if does_return {
+                    Control::Prune
+                } else {
+                    Control::Break(())
+                }
+            }
+            _ => Control::Continue,
+        });
+
+    output.break_value().is_none()
+}

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -16,6 +16,7 @@ use oxc_syntax::identifier::{is_identifier_part, is_identifier_start};
 
 mod comment;
 mod config;
+mod control_flow;
 mod express;
 mod jest;
 mod jsdoc;
@@ -32,9 +33,9 @@ mod vitest;
 mod vue;
 
 pub use self::{
-    comment::*, config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*, react::*,
-    react_perf::*, regex::*, this_expression::*, typescript::*, unicorn::*, url::*, vitest::*,
-    vue::*,
+    comment::*, config::*, control_flow::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*,
+    react::*, react_perf::*, regex::*, this_expression::*, typescript::*, unicorn::*, url::*,
+    vitest::*, vue::*,
 };
 
 /// List of Eslint rules that have TypeScript equivalents.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2644,6 +2644,9 @@
         "vue/require-default-export": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/require-render-return": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/require-slots-as-functions": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2648,6 +2648,9 @@ expression: json
         "vue/require-default-export": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/require-render-return": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/require-slots-as-functions": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/require-render-return.html

- 9ed6e4b290: implement `require-render-return`.
- 12d3b43250: extract `definitely_returns_in_all_codepaths` into shared `utils/control_flow.rs`, and migrate `return-in-computed-property` to use it.

AI disclosure: implemented with Claude Code, reviewed manually.