### PR TITLE
fix(track-memory-allocations): reserve transform scoping capacity

### DIFF
--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             20 |              1 ||           4400 |             64
+checker.ts                 | 2.92 MB        ||             20 |              0 ||           4400 |             64
 
-App.tsx                    | 415.34 kB      ||             26 |              3 ||            719 |             77
+App.tsx                    | 415.34 kB      ||             25 |              2 ||            719 |             77
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             22 |              3 ||            259 |             24
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              2 ||            259 |             24
 
 pdf.mjs                    | 567.30 kB      ||             15 |              0 ||              2 |              0
 
 antd.js                    | 6.69 MB        ||             15 |              0 ||              2 |              0
 
-binder.ts                  | 193.08 kB      ||             18 |              1 ||            379 |              6
+binder.ts                  | 193.08 kB      ||             17 |              0 ||            379 |              6
 

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -154,6 +154,7 @@ pub fn run() -> Result<(), io::Error> {
 
         // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
         let scoping = SemanticBuilder::new()
+            .with_excess_capacity(2.0)
             .with_enum_eval(true)
             .build(&parsed.program)
             .semantic
@@ -197,12 +198,8 @@ pub fn run() -> Result<(), io::Error> {
             width,
         ));
 
-        let (scoping, semantic_stats) = record_stats_in(&allocator, || {
-            SemanticBuilder::new()
-                .with_enum_eval(true)
-                .build(&parsed.program)
-                .semantic
-                .into_scoping()
+        let ((), semantic_stats) = record_stats_in(&allocator, || {
+            let _ = SemanticBuilder::new().with_enum_eval(true).build(&parsed.program);
         });
 
         semantic_out.push_str(&format_table_row(
@@ -212,6 +209,15 @@ pub fn run() -> Result<(), io::Error> {
             fixture_width,
             width,
         ));
+
+        // Match the production compiler path for transforms: transformers add scopes, symbols, and
+        // references, so semantic analysis reserves excess capacity up front.
+        let scoping = SemanticBuilder::new()
+            .with_excess_capacity(2.0)
+            .with_enum_eval(true)
+            .build(&parsed.program)
+            .semantic
+            .into_scoping();
 
         // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
         let transform_options = TransformOptions::from_target("esnext").unwrap();


### PR DESCRIPTION
## Issue

The `Allocations` CI job can fail on PRs that do not touch the transformer because `cargo allocs` can rewrite `allocs_transformer.snap` differently across platforms. In the observed failure, Linux x64 reported one extra transformer system allocation for `App.tsx`, while macOS/arm64 still reported the old count.

## Why

The allocation tracker was passing transformer a `Scoping` built differently from the production compiler path. Production builds semantic data with `SemanticBuilder::with_excess_capacity(2.0)` before running transforms, because transforms may add scopes, symbols, and references. The allocation tracker did not reserve that extra semantic capacity.

That made the transformer snapshot accidentally include growth of semantic scoping storage. In this case, JSX automatic runtime import generation creates a new root-scope binding. The traced Linux-only allocation happened under `JsxImpl::get_create_element -> AutomaticModuleBindings::import_jsx -> TraverseScoping::add_binding -> Scoping::create_symbol`, when pushing the generated symbol forced the semantic `Scoping` arena to allocate another chunk.

Linux got a different allocation count because this is a capacity-boundary effect, not different transformer behavior. The `Scoping` arena layout depends on target layout and alignment. On Linux x64, the generated binding crossed the arena chunk boundary and allocated a new 16-byte-aligned chunk, so the measured transformer count became 27. On macOS/arm64, the same push still fit in the existing semantic arena capacity, so the measured count stayed 26.

So the root cause is that transformer allocation tracking was measuring platform-sensitive semantic storage growth. Any unrelated PR could expose the same stale snapshot whenever CI regenerated allocations on a platform that lands on the other side of that capacity boundary.

## Fix

Keep `allocs_semantic.snap` measuring regular semantic analysis, but build a separate production-like semantic `Scoping` for transformer measurement using `with_excess_capacity(2.0)`. This matches the compiler and transformer benchmarks, and removes the semantic arena capacity cliff from the transformer allocation snapshot.

The transformer allocation snapshot is regenerated after the measurement fix.

## Validation

Verified `cargo allocs` leaves the branch clean on macOS/arm64 and in Linux amd64 Docker.

AI usage: I used AI assistance to investigate, implement, and validate this change.