### PR TITLE
fix(linter): respect args none for unused rest parameters

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -113,6 +113,11 @@ fn is_ambient_namespace_without_explicit_exports(namespace: &TSModuleDeclaration
     true
 }
 
+pub(super) enum FunctionParameterKind<'a> {
+    Normal(&'a FormalParameter<'a>),
+    Rest,
+}
+
 impl NoUnusedVars {
     #[expect(clippy::unused_self)]
     pub(super) fn is_allowed_ts_namespace<'a>(
@@ -207,7 +212,7 @@ impl NoUnusedVars {
         semantic: &Semantic<'a>,
         module_record: &ModuleRecord,
         symbol: &Symbol<'_, 'a>,
-        param: &FormalParameter<'a>,
+        argument: &FunctionParameterKind<'a>,
     ) -> bool {
         // early short-circuit when no argument checking should be performed
         if self.args.is_none() {
@@ -216,15 +221,23 @@ impl NoUnusedVars {
 
         // find FormalParameters. Should be the next parent of param, but this
         // is safer.
-        let Some((params, params_id)) = symbol.iter_parents().find_map(|p| {
+        let Some(params) = symbol.iter_parents().find_map(|p| {
             let params = p.kind().as_formal_parameters()?;
-            Some((params, p.id()))
+            Some(params)
         }) else {
             debug_assert!(false, "FormalParameter should always have a parent FormalParameters");
             return false;
         };
 
-        if Self::is_allowed_param_because_of_method(semantic, param, params_id) {
+        if let FunctionParameterKind::Normal(param) = argument
+            && Self::is_allowed_param_because_of_method(semantic, param, params.node_id())
+        {
+            return true;
+        }
+
+        if matches!(argument, FunctionParameterKind::Rest)
+            && Self::is_allowed_binding_rest_element(symbol)
+        {
             return true;
         }
 
@@ -236,6 +249,11 @@ impl NoUnusedVars {
         }
 
         debug_assert_eq!(self.args, ArgsOption::AfterUsed);
+
+        let FunctionParameterKind::Normal(param) = argument else {
+            // Rest parameters are always last, so `after-used` checks them.
+            return false;
+        };
 
         // from eslint rule documentation:
         // after-used - unused positional arguments that occur before the last

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -11,6 +11,7 @@ mod usage;
 
 use std::ops::Deref;
 
+use allowed::FunctionParameterKind;
 use ignored::IgnoreReason;
 use options::{IgnorePattern, NoUnusedVarsFixMode, NoUnusedVarsOptions};
 use oxc_ast::{AstKind, ast::CatchParameter};
@@ -304,7 +305,12 @@ impl NoUnusedVars {
                 });
             }
             AstKind::FormalParameter(param) => {
-                if self.is_allowed_argument(ctx.semantic(), ctx.module_record(), symbol, param) {
+                if self.is_allowed_argument(
+                    ctx.semantic(),
+                    ctx.module_record(),
+                    symbol,
+                    &FunctionParameterKind::Normal(param),
+                ) {
                     return;
                 }
                 Self::report_with_fix_mode(
@@ -320,7 +326,12 @@ impl NoUnusedVars {
                 );
             }
             AstKind::FormalParameterRest(_) => {
-                if NoUnusedVars::is_allowed_binding_rest_element(symbol) {
+                if self.is_allowed_argument(
+                    ctx.semantic(),
+                    ctx.module_record(),
+                    symbol,
+                    &FunctionParameterKind::Rest,
+                ) {
                     return;
                 }
                 ctx.diagnostic(diagnostic::param(

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1139,6 +1139,12 @@ fn test_arguments() {
         ("foo.bar((a, b) => (a.foo[b.bar].baz++, a))", None),
         // Multiple parameters used in sequence
         ("foo.bar((a, b, c) => (b[c.x]++, a[b.y]++, a))", None),
+        ("function foo(...args) { return 1 } foo()", Some(json!([{ "args": "none" }]))),
+        ("function foo(...args: unknown[]) { return 1 } foo()", Some(json!([{ "args": "none" }]))),
+        (
+            "function foo(a, ...args: unknown[]) { return a } foo()",
+            Some(json!([{ "args": "none" }])),
+        ),
     ];
     let fail = vec![
         ("function foo(a) {} foo()", None),
@@ -1147,6 +1153,8 @@ fn test_arguments() {
         ("function foo(...args: typeof args) {} foo()", None),
         ("function foo(...args: unknown[]): args is string[] { return true } foo()", None),
         ("function foo(...unused) {} foo()", Some(json!([{ "argsIgnorePattern": "^ignored" }]))),
+        ("function foo(...args) { return 1 } foo()", Some(json!([{ "args": "after-used" }]))),
+        ("function foo(...args: unknown[]) { return 1 } foo()", Some(json!([{ "args": "all" }]))),
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-arguments.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-arguments.snap
@@ -49,3 +49,19 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ╰── 'unused' is declared here
    ╰────
   help: Consider removing this parameter.
+
+  ⚠ eslint(no-unused-vars): Parameter 'args' is declared but never used.
+   ╭─[no_unused_vars.tsx:1:17]
+ 1 │ function foo(...args) { return 1 } foo()
+   ·                 ──┬─
+   ·                   ╰── 'args' is declared here
+   ╰────
+  help: Consider removing this parameter.
+
+  ⚠ eslint(no-unused-vars): Parameter 'args' is declared but never used.
+   ╭─[no_unused_vars.tsx:1:17]
+ 1 │ function foo(...args: unknown[]) { return 1 } foo()
+   ·                 ──┬─
+   ·                   ╰── 'args' is declared here
+   ╰────
+  help: Consider removing this parameter.


### PR DESCRIPTION
fixes #22625