### PR TITLE
fix(transformer/legacy-decorator): return runtime binding for design:type

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -39,14 +39,16 @@
 ///
 /// ### Compared to TypeScript
 ///
-/// We are lacking a kind of type inference ability that TypeScript has, so we are not able to determine
-/// the exactly type of the type reference. See [`LegacyDecoratorMetadata::serialize_type_reference_node`] does.
+/// We do not have TypeScript's type-checker, so we cannot statically classify a
+/// cross-file reference (`String` / `Number` / `Object`) the way tsc does.
+/// Instead we emit the `typeof X === "undefined" ? Object : X` guard used by
+/// SWC and Babel — matching the established ecosystem default.
 ///
 /// For example:
 ///
 /// Input:
 /// ```ts
-/// type Foo = string;
+/// import { Foo } from "./mod";
 /// class Cls {
 ///   @dec
 ///   p: Foo = ""
@@ -55,39 +57,27 @@
 ///
 /// TypeScript Output:
 /// ```js
-/// class Cls {
-///   constructor() {
-///     this.p = "";
-///   }
-/// }
 /// __decorate([
 ///   dec,
-///   __metadata("design:type", String) // Infer the type of `Foo` is `String`
+///   __metadata("design:type", typeof (_a = typeof Foo !== "undefined" && Foo) === "function" ? _a : Object)
 /// ], Cls.prototype, "p", void 0);
 /// ```
 ///
 /// OXC Output:
 /// ```js
-/// var _ref;
-/// class Cls {
-///     p = "";
-/// }
 /// babelHelpers.decorate([
 ///   dec,
-///   babelHelpers.decorateMetadata("design:type", typeof (_ref = typeof Foo === "undefined" && Foo) === "function" ? _ref : Object)
-/// ],
-/// Cls.prototype, "p", void 0);
+///   babelHelpers.decorateMetadata("design:type", typeof Foo === "undefined" ? Object : Foo)
+/// ], Cls.prototype, "p", void 0);
 /// ```
 ///
-/// ### Compared to SWC
-///
-/// SWC also has the above limitation, considering that SWC has been adopted in [NestJS](https://docs.nestjs.com/recipes/swc#jest--swc),
-/// so the limitation may not be a problem. In addition, SWC provides additional support for inferring enum members, which we currently
-/// do not have. We haven't dived into how NestJS uses it, so we don't know if it matters, thus we may leave it until we receive feedback.
+/// The OXC form returns the actual binding (including enum objects) when
+/// defined — see [#14740](https://github.com/oxc-project/oxc/issues/14740) for
+/// the design rationale.
 ///
 /// ## References
 /// * TypeScript's [emitDecoratorMetadata](https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata)
-use oxc_allocator::{Box as ArenaBox, TakeIn};
+use oxc_allocator::Box as ArenaBox;
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
 use oxc_semantic::{Reference, ReferenceFlags, SymbolId};
@@ -96,10 +86,7 @@ use oxc_traverse::{MaybeBoundIdentifier, Traverse};
 use rustc_hash::FxHashMap;
 
 use crate::{
-    Helper,
-    common::{helper_loader::helper_call_expr, var_declarations::VarDeclarationsStore},
-    context::TraverseCtx,
-    state::TransformState,
+    Helper, common::helper_loader::helper_call_expr, context::TraverseCtx, state::TransformState,
     utils::ast_builder::create_property_access,
 };
 
@@ -476,110 +463,120 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         }
     }
 
-    /// `A.B` -> `typeof (_a$b = typeof A !== "undefined" && A.B) == "function" ? _a$b : Object`
+    /// Serializes a type reference for `design:type` / `design:paramtypes` / `design:returntype`.
     ///
-    /// NOTE: This function only ports `unknown` part from [TypeScript](https://github.com/microsoft/TypeScript/blob/d85767abfd83880cea17cea70f9913e9c4496dcc/src/compiler/transformers/typeSerializer.ts#L499-L506)
+    /// Matches the emit shape used by SWC and Babel:
+    ///
+    /// - `X` → `typeof X === "undefined" ? Object : X`
+    /// - `A.B` → `typeof A === "undefined" || typeof A.B === "undefined" ? Object : A.B`
+    /// - `A.B.C` → `typeof A === "undefined" || typeof A.B === "undefined" || typeof A.B.C === "undefined" ? Object : A.B.C`
+    ///
+    /// Local enums are pre-classified through [`Self::enum_types`] and emit `String` /
+    /// `Number` / `Object` directly (matching SWC and tsc).
+    /// Type-only references and `this`-typed entity names emit `Object` without a
+    /// runtime check (matching tsc).
+    ///
+    /// See [issue #14740](https://github.com/oxc-project/oxc/issues/14740): the guard
+    /// short-circuits to `Object` when the binding is missing, but evaluates to the
+    /// actual runtime binding when present — including enum objects, so consumers like
+    /// `type-graphql` and `typeorm` can introspect them via `Object.values()`.
     fn serialize_type_reference_node(
-        &mut self,
+        &self,
         name: &TSTypeName<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        // Check if this is an enum type reference - if so, return the primitive type directly
-        if let TSTypeName::IdentifierReference(ident) = name {
-            let symbol_id = ctx.scoping().get_reference(ident.reference_id()).symbol_id();
-            if let Some(symbol_id) = symbol_id
-                && let Some(enum_type) = self.enum_types.get(&symbol_id)
-            {
-                return match enum_type {
-                    EnumType::String => Self::global_string(ctx),
-                    EnumType::Number => Self::global_number(ctx),
-                    EnumType::Object => Self::global_object(ctx),
-                };
-            }
-        }
-
-        let Some(serialized_type) = self.serialize_entity_name_as_expression_fallback(name, ctx)
-        else {
-            // Reach here means the referent is a type symbol, so use `Object` as fallback.
+        let Some((root_ident, properties)) = Self::decompose_entity_name(name) else {
+            // `this`-typed entity name — no runtime binding to check.
             return Self::global_object(ctx);
         };
-        let binding = VarDeclarationsStore::create_uid_var_based_on_node(&serialized_type, ctx);
-        let target = binding.create_write_target(ctx);
-        let assignment = ctx.ast.expression_assignment(
-            SPAN,
-            AssignmentOperator::Assign,
-            target,
-            serialized_type,
-        );
-        let type_of = ctx.ast.expression_unary(SPAN, UnaryOperator::Typeof, assignment);
-        let right = ctx.ast.expression_string_literal(SPAN, "function", None);
-        let operator = BinaryOperator::StrictEquality;
-        let test = ctx.ast.expression_binary(SPAN, type_of, operator, right);
-        let consequent = binding.create_read_expression(ctx);
-        let alternate = Self::global_object(ctx);
-        ctx.ast.expression_conditional(SPAN, test, consequent, alternate)
+
+        let symbol_id = ctx.scoping().get_reference(root_ident.reference_id()).symbol_id();
+
+        // Local enum fast path: classify by member shape and emit the primitive globally.
+        if properties.is_empty()
+            && let Some(symbol_id) = symbol_id
+            && let Some(enum_type) = self.enum_types.get(&symbol_id)
+        {
+            return match enum_type {
+                EnumType::String => Self::global_string(ctx),
+                EnumType::Number => Self::global_number(ctx),
+                EnumType::Object => Self::global_object(ctx),
+            };
+        }
+
+        // Type-only references have no runtime binding either.
+        if Self::is_type_symbol(symbol_id, ctx) {
+            return Self::global_object(ctx);
+        }
+
+        Self::build_undefined_guard(root_ident, &properties, ctx)
     }
 
-    /// Serializes an entity name which may not exist at runtime, but whose access shouldn't throw
-    #[expect(clippy::self_only_used_in_recursion)]
-    fn serialize_entity_name_as_expression_fallback(
-        &mut self,
-        name: &TSTypeName<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> Option<Expression<'a>> {
-        match name {
-            // `A` -> `typeof A !== "undefined" && A`
-            TSTypeName::IdentifierReference(ident) => {
-                let binding = MaybeBoundIdentifier::from_identifier_reference(ident, ctx);
-                if Self::is_type_symbol(binding.symbol_id, ctx) {
-                    return None;
+    /// Walk a [`TSTypeName`] from leaf to root, returning the root identifier and the
+    /// ordered list of property names (root → leaf). Returns `None` if the entity name
+    /// is rooted at a `this`-type, which has no static identifier to guard.
+    fn decompose_entity_name<'b>(
+        name: &'b TSTypeName<'a>,
+    ) -> Option<(&'b IdentifierReference<'a>, Vec<&'b str>)> {
+        let mut properties: Vec<&str> = vec![];
+        let mut current = name;
+        loop {
+            match current {
+                TSTypeName::IdentifierReference(ident) => {
+                    properties.reverse();
+                    return Some((ident, properties));
                 }
-                let flags = Self::get_reference_flags(&binding, ctx);
-                let ident1 = binding.create_expression(flags, ctx);
-                let ident2 = binding.create_expression(flags, ctx);
-                Some(Self::create_checked_value(ident1, ident2, ctx))
-            }
-            TSTypeName::QualifiedName(qualified) => {
-                if let TSTypeName::IdentifierReference(ident) = &qualified.left {
-                    // `A.B` -> `typeof A !== "undefined" && A.B`
-                    let binding = MaybeBoundIdentifier::from_identifier_reference(ident, ctx);
-                    if Self::is_type_symbol(binding.symbol_id, ctx) {
-                        return None;
-                    }
-                    let flags = Self::get_reference_flags(&binding, ctx);
-                    let ident1 = binding.create_expression(flags, ctx);
-                    let ident2 = binding.create_expression(flags, ctx);
-                    let member = create_property_access(SPAN, ident1, &qualified.right.name, ctx);
-                    Some(Self::create_checked_value(ident2, member, ctx))
-                } else {
-                    // `A.B.C` -> `typeof A !== "undefined" && (_a = A.B) !== void 0 && _a.C`
-                    let mut left =
-                        self.serialize_entity_name_as_expression_fallback(&qualified.left, ctx)?;
-                    let binding = VarDeclarationsStore::create_uid_var_based_on_node(&left, ctx);
-                    let Expression::LogicalExpression(logical) = &mut left else { unreachable!() };
-                    let right = logical.right.take_in(ctx.ast);
-                    // `(_a = A.B)`
-                    let right = ctx.ast.expression_assignment(
-                        SPAN,
-                        AssignmentOperator::Assign,
-                        binding.create_write_target(ctx),
-                        right,
-                    );
-                    // `(_a = A.B) !== void 0`
-                    logical.right = ctx.ast.expression_binary(
-                        SPAN,
-                        right,
-                        BinaryOperator::StrictInequality,
-                        ctx.ast.void_0(SPAN),
-                    );
-
-                    let object = binding.create_read_expression(ctx);
-                    let member = create_property_access(SPAN, object, &qualified.right.name, ctx);
-                    Some(ctx.ast.expression_logical(SPAN, left, LogicalOperator::And, member))
+                TSTypeName::QualifiedName(q) => {
+                    properties.push(q.right.name.as_str());
+                    current = &q.left;
                 }
+                TSTypeName::ThisExpression(_) => return None,
             }
-            TSTypeName::ThisExpression(_) => None,
         }
+    }
+
+    /// Build the SWC-style undefined-fallback guard for the given root + property path.
+    ///
+    /// OR-chains `typeof <prefix> === "undefined"` for every prefix from root to leaf.
+    /// Left-to-right short-circuit keeps the chain safe even when an intermediate is
+    /// undefined — the later `typeof <prefix>.foo` is never evaluated.
+    fn build_undefined_guard(
+        root: &IdentifierReference<'a>,
+        properties: &[&str],
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let binding = MaybeBoundIdentifier::from_identifier_reference(root, ctx);
+        let ref_flags = Self::get_reference_flags(&binding, ctx);
+
+        let root_expr = binding.create_expression(ref_flags, ctx);
+        let mut test = Self::typeof_undefined(root_expr, ctx);
+        for i in 1..=properties.len() {
+            let prefix = Self::build_path(&binding, ref_flags, &properties[..i], ctx);
+            let next = Self::typeof_undefined(prefix, ctx);
+            test = ctx.ast.expression_logical(SPAN, test, LogicalOperator::Or, next);
+        }
+
+        let alternate = Self::build_path(&binding, ref_flags, properties, ctx);
+        ctx.ast.expression_conditional(SPAN, test, Self::global_object(ctx), alternate)
+    }
+
+    fn build_path(
+        binding: &MaybeBoundIdentifier<'a>,
+        ref_flags: ReferenceFlags,
+        properties: &[&str],
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        let mut expr = binding.create_expression(ref_flags, ctx);
+        for prop in properties {
+            expr = create_property_access(SPAN, expr, prop, ctx);
+        }
+        expr
+    }
+
+    fn typeof_undefined(expr: Expression<'a>, ctx: &TraverseCtx<'a>) -> Expression<'a> {
+        let typeof_expr = ctx.ast.expression_unary(SPAN, UnaryOperator::Typeof, expr);
+        let undefined_str = ctx.ast.expression_string_literal(SPAN, "undefined", None);
+        ctx.ast.expression_binary(SPAN, typeof_expr, BinaryOperator::StrictEquality, undefined_str)
     }
 
     fn serialize_literal_of_literal_type_node(
@@ -744,27 +741,6 @@ impl<'a> LegacyDecoratorMetadata<'a> {
     #[inline]
     fn global_promise(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         Self::create_global_identifier("Promise", ctx)
-    }
-
-    /// Produces an expression that results in `right` if `left` is not undefined at runtime:
-    ///
-    /// ```rust,ignore
-    /// typeof left !== "undefined" && right
-    /// ```
-    ///
-    /// We use `typeof L !== "undefined"` (rather than `L !== undefined`) since `L` may not be declared.
-    /// It's acceptable for this expression to result in `false` at runtime, as the result is intended to be
-    /// further checked by any containing expression.
-    fn create_checked_value(
-        left: Expression<'a>,
-        right: Expression<'a>,
-        ctx: &TraverseCtx<'a>,
-    ) -> Expression<'a> {
-        let operator = BinaryOperator::StrictInequality;
-        let undefined = ctx.ast.expression_string_literal(SPAN, "undefined", None);
-        let typeof_left = ctx.ast.expression_unary(SPAN, UnaryOperator::Typeof, left);
-        let left_check = ctx.ast.expression_binary(SPAN, typeof_left, operator, undefined);
-        ctx.ast.expression_logical(SPAN, left_check, LogicalOperator::And, right)
     }
 
     // `_metadata(key, value)

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -144,55 +144,55 @@ after transform: ScopeId(0): ["BrowserWorkingCopyBackupTracker", "CancellationTo
 rebuilt        : ScopeId(0): ["BrowserWorkingCopyBackupTracker", "DisposableStore", "EditorService", "IEditorGroupsService", "IEditorService", "IFilesConfigurationService", "ILifecycleService", "ILogService", "IWorkingCopyBackupService", "IWorkingCopyEditorService", "IWorkingCopyService", "InMemoryTestWorkingCopyBackupService", "LifecyclePhase", "Schemas", "TestServiceAccessor", "TestWorkingCopy", "URI", "UntitledTextEditorInput", "VSBuffer", "_asyncToGenerator", "_decorate", "_decorateMetadata", "_decorateParam", "_defineProperty", "assert", "bufferToReadable", "createEditorPart", "ensureNoDisposablesAreLeakedInTestSuite", "isWindows", "registerTestResourceEditor", "timeout", "toResource", "toTypedWorkingCopyId", "toUntypedWorkingCopyId", "workbenchInstantiationService", "workbenchTeardown"]
 Symbol reference IDs mismatch for "URI":
 after transform: SymbolId(1): [ReferenceId(109), ReferenceId(117), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
-rebuilt        : SymbolId(1): [ReferenceId(212), ReferenceId(214), ReferenceId(216), ReferenceId(218)]
+rebuilt        : SymbolId(1): [ReferenceId(196), ReferenceId(198), ReferenceId(200), ReferenceId(202)]
 Symbol reference IDs mismatch for "IEditorService":
-after transform: SymbolId(2): [ReferenceId(23), ReferenceId(24), ReferenceId(67), ReferenceId(184), ReferenceId(370), ReferenceId(371)]
-rebuilt        : SymbolId(2): [ReferenceId(38), ReferenceId(73), ReferenceId(74), ReferenceId(111), ReferenceId(239)]
+after transform: SymbolId(2): [ReferenceId(23), ReferenceId(24), ReferenceId(67), ReferenceId(184), ReferenceId(358), ReferenceId(359)]
+rebuilt        : SymbolId(2): [ReferenceId(38), ReferenceId(60), ReferenceId(62), ReferenceId(95), ReferenceId(223)]
 Symbol reference IDs mismatch for "IEditorGroupsService":
-after transform: SymbolId(4): [ReferenceId(25), ReferenceId(26), ReferenceId(57), ReferenceId(176), ReferenceId(375), ReferenceId(376)]
-rebuilt        : SymbolId(3): [ReferenceId(40), ReferenceId(78), ReferenceId(79), ReferenceId(102), ReferenceId(232)]
+after transform: SymbolId(4): [ReferenceId(25), ReferenceId(26), ReferenceId(57), ReferenceId(176), ReferenceId(361), ReferenceId(362)]
+rebuilt        : SymbolId(3): [ReferenceId(40), ReferenceId(63), ReferenceId(65), ReferenceId(86), ReferenceId(216)]
 Symbol reference IDs mismatch for "EditorService":
 after transform: SymbolId(5): [ReferenceId(61), ReferenceId(64), ReferenceId(178), ReferenceId(181)]
-rebuilt        : SymbolId(4): [ReferenceId(108), ReferenceId(236)]
+rebuilt        : SymbolId(4): [ReferenceId(92), ReferenceId(220)]
 Symbol reference IDs mismatch for "IWorkingCopyBackupService":
 after transform: SymbolId(7): [ReferenceId(11), ReferenceId(12), ReferenceId(51), ReferenceId(170), ReferenceId(340), ReferenceId(341)]
-rebuilt        : SymbolId(5): [ReferenceId(26), ReferenceId(43), ReferenceId(44), ReferenceId(96), ReferenceId(226)]
+rebuilt        : SymbolId(5): [ReferenceId(26), ReferenceId(42), ReferenceId(44), ReferenceId(80), ReferenceId(210)]
 Symbol reference IDs mismatch for "IFilesConfigurationService":
-after transform: SymbolId(10): [ReferenceId(13), ReferenceId(14), ReferenceId(345), ReferenceId(346)]
-rebuilt        : SymbolId(8): [ReferenceId(28), ReferenceId(48), ReferenceId(49)]
+after transform: SymbolId(10): [ReferenceId(13), ReferenceId(14), ReferenceId(343), ReferenceId(344)]
+rebuilt        : SymbolId(8): [ReferenceId(28), ReferenceId(45), ReferenceId(47)]
 Symbol reference IDs mismatch for "IWorkingCopyService":
-after transform: SymbolId(11): [ReferenceId(15), ReferenceId(16), ReferenceId(350), ReferenceId(351)]
-rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(53), ReferenceId(54)]
+after transform: SymbolId(11): [ReferenceId(15), ReferenceId(16), ReferenceId(346), ReferenceId(347)]
+rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(48), ReferenceId(50)]
 Symbol reference IDs mismatch for "ILogService":
-after transform: SymbolId(13): [ReferenceId(19), ReferenceId(20), ReferenceId(360), ReferenceId(361)]
-rebuilt        : SymbolId(10): [ReferenceId(34), ReferenceId(63), ReferenceId(64)]
+after transform: SymbolId(13): [ReferenceId(19), ReferenceId(20), ReferenceId(352), ReferenceId(353)]
+rebuilt        : SymbolId(10): [ReferenceId(34), ReferenceId(54), ReferenceId(56)]
 Symbol reference IDs mismatch for "ILifecycleService":
-after transform: SymbolId(14): [ReferenceId(17), ReferenceId(18), ReferenceId(355), ReferenceId(356)]
-rebuilt        : SymbolId(11): [ReferenceId(32), ReferenceId(58), ReferenceId(59)]
+after transform: SymbolId(14): [ReferenceId(17), ReferenceId(18), ReferenceId(349), ReferenceId(350)]
+rebuilt        : SymbolId(11): [ReferenceId(32), ReferenceId(51), ReferenceId(53)]
 Symbol reference IDs mismatch for "UntitledTextEditorInput":
 after transform: SymbolId(17): [ReferenceId(38), ReferenceId(87)]
-rebuilt        : SymbolId(13): [ReferenceId(83)]
+rebuilt        : SymbolId(13): [ReferenceId(67)]
 Symbol reference IDs mismatch for "InMemoryTestWorkingCopyBackupService":
 after transform: SymbolId(19): [ReferenceId(43), ReferenceId(46), ReferenceId(165)]
-rebuilt        : SymbolId(15): [ReferenceId(91), ReferenceId(221)]
+rebuilt        : SymbolId(15): [ReferenceId(75), ReferenceId(205)]
 Symbol reference IDs mismatch for "TestServiceAccessor":
 after transform: SymbolId(21): [ReferenceId(40), ReferenceId(155), ReferenceId(1), ReferenceId(71), ReferenceId(188)]
-rebuilt        : SymbolId(17): [ReferenceId(115), ReferenceId(243)]
+rebuilt        : SymbolId(17): [ReferenceId(99), ReferenceId(227)]
 Symbol reference IDs mismatch for "IWorkingCopyEditorService":
-after transform: SymbolId(32): [ReferenceId(21), ReferenceId(22), ReferenceId(365), ReferenceId(366)]
-rebuilt        : SymbolId(26): [ReferenceId(36), ReferenceId(68), ReferenceId(69)]
+after transform: SymbolId(32): [ReferenceId(21), ReferenceId(22), ReferenceId(355), ReferenceId(356)]
+rebuilt        : SymbolId(26): [ReferenceId(36), ReferenceId(57), ReferenceId(59)]
 Symbol span mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(39): Span { start: 3208, end: 3236 }
-rebuilt        : SymbolId(46): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "TestWorkingCopyBackupTracker":
-after transform: SymbolId(39): [ReferenceId(42), ReferenceId(154), ReferenceId(74), ReferenceId(215), ReferenceId(392), ReferenceId(394)]
-rebuilt        : SymbolId(46): [ReferenceId(23), ReferenceId(82), ReferenceId(118), ReferenceId(270)]
+after transform: SymbolId(39): [ReferenceId(42), ReferenceId(154), ReferenceId(74), ReferenceId(215), ReferenceId(376), ReferenceId(378)]
+rebuilt        : SymbolId(38): [ReferenceId(23), ReferenceId(66), ReferenceId(102), ReferenceId(254)]
 Symbol span mismatch for "TestWorkingCopyBackupTracker":
-after transform: SymbolId(144): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(47): Span { start: 3208, end: 3236 }
+after transform: SymbolId(136): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(39): Span { start: 3208, end: 3236 }
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(36), ReferenceId(39), ReferenceId(82), ReferenceId(114), ReferenceId(153), ReferenceId(282)]
-rebuilt        : [ReferenceId(343)]
+rebuilt        : [ReferenceId(327)]
 
 semantic Error: tasks/coverage/misc/pass/oxc-4449.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -5381,12 +5381,12 @@ rebuilt        : SymbolId(1): []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImport.ts
 Symbol reference IDs mismatch for "Observable":
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(12), ReferenceId(13)]
+rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImportOnDeclare.ts
 Symbol reference IDs mismatch for "Observable":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoStrictNull.ts
 Unresolved reference IDs mismatch for "String":
@@ -5395,8 +5395,8 @@ rebuilt        : [ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataPromise.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["A", "_asyncToGenerator", "_decorate", "_decorateMetadata", "_ref", "_ref2", "decorator"]
-rebuilt        : ScopeId(0): ["A", "_asyncToGenerator", "_decorate", "_decorateMetadata", "_ref", "_ref2"]
+after transform: ScopeId(0): ["A", "_asyncToGenerator", "_decorate", "_decorateMetadata", "decorator"]
+rebuilt        : ScopeId(0): ["A", "_asyncToGenerator", "_decorate", "_decorateMetadata"]
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
@@ -5407,23 +5407,23 @@ Reference symbol mismatch for "decorator":
 after transform: SymbolId(0) "decorator"
 rebuilt        : <None>
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(30): ReferenceFlags(Read | Type)
-rebuilt        : ReferenceId(28): ReferenceFlags(Read)
+after transform: ReferenceId(28): ReferenceFlags(Read | Type)
+rebuilt        : ReferenceId(27): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
-after transform: ReferenceId(31): ReferenceFlags(Read | Type)
+after transform: ReferenceId(29): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(29): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
 after transform: ReferenceId(25): ReferenceFlags(Read | Type)
-rebuilt        : ReferenceId(34): ReferenceFlags(Read)
+rebuilt        : ReferenceId(31): ReferenceFlags(Read)
 Reference flags mismatch for "Promise":
 after transform: ReferenceId(26): ReferenceFlags(Read | Type)
-rebuilt        : ReferenceId(35): ReferenceFlags(Read)
+rebuilt        : ReferenceId(33): ReferenceFlags(Read)
 Unresolved references mismatch:
 after transform: ["Function", "MethodDecorator", "Object", "Promise", "require"]
 rebuilt        : ["Function", "Object", "Promise", "decorator", "require"]
 Unresolved reference IDs mismatch for "Promise":
-after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(17), ReferenceId(25), ReferenceId(26), ReferenceId(30), ReferenceId(31)]
-rebuilt        : [ReferenceId(12), ReferenceId(20), ReferenceId(28), ReferenceId(29), ReferenceId(34), ReferenceId(35)]
+after transform: [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(17), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(29)]
+rebuilt        : [ReferenceId(12), ReferenceId(20), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
 Symbol reference IDs mismatch for "Foo":
@@ -5433,7 +5433,7 @@ rebuilt        : SymbolId(0): []
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
 Symbol reference IDs mismatch for "Yoha":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(8), ReferenceId(9)]
+rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
 Bindings mismatch:
@@ -11030,7 +11030,7 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromAlias.ts
 Symbol reference IDs mismatch for "SomeClass":
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6)]
+rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(6)]
 Unresolved references mismatch:
 after transform: ["Object", "PropertyDecorator"]
 rebuilt        : ["Object"]
@@ -11044,13 +11044,13 @@ after transform: ScopeId(4): ScopeFlags(0x0)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(3): [ReferenceId(2)]
-rebuilt        : SymbolId(7): []
+rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(5): SymbolFlags(RegularEnum)
-rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
+rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(5): [ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(42), ReferenceId(47), ReferenceId(48)]
-rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(39), ReferenceId(40)]
+after transform: SymbolId(5): [ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(42), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
+rebuilt        : SymbolId(8): [ReferenceId(30), ReferenceId(38), ReferenceId(39), ReferenceId(41)]
 Unresolved references mismatch:
 after transform: ["Boolean", "Number", "Object", "String", "require"]
 rebuilt        : ["Boolean", "Number", "Object", "require"]
@@ -11058,8 +11058,8 @@ Unresolved reference IDs mismatch for "Boolean":
 after transform: [ReferenceId(22), ReferenceId(23), ReferenceId(28)]
 rebuilt        : [ReferenceId(14)]
 Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(0), ReferenceId(18), ReferenceId(29), ReferenceId(51), ReferenceId(55), ReferenceId(63)]
-rebuilt        : [ReferenceId(9), ReferenceId(19), ReferenceId(42), ReferenceId(47), ReferenceId(57)]
+after transform: [ReferenceId(0), ReferenceId(18), ReferenceId(29), ReferenceId(50), ReferenceId(54), ReferenceId(62)]
+rebuilt        : [ReferenceId(9), ReferenceId(19), ReferenceId(40), ReferenceId(46), ReferenceId(56)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnionWithNull.ts
 Symbol reference IDs mismatch for "A":
@@ -11078,7 +11078,7 @@ rebuilt        : [ReferenceId(18), ReferenceId(28), ReferenceId(49), ReferenceId
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/metadataReferencedWithinFilteredUnion.ts
 Symbol reference IDs mismatch for "Class1":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(0): [ReferenceId(12), ReferenceId(13)]
+rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(13)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/missingCloseParenStatements.ts
 Expected `)` but found `{`

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 3d34928e
 
-Passed: 237/386
+Passed: 237/392
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -663,7 +663,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (9/96)
+# legacy-decorators (9/102)
 * oxc/accessor/input.ts
 x Output mismatch
 
@@ -746,24 +746,41 @@ rebuilt        : SymbolId(1): ScopeId(0)
 * oxc/metadata/abstract-class/input.ts
 Symbol reference IDs mismatch for "Dependency":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(7)]
+rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(7)]
 Symbol span mismatch for "AbstractClass":
 after transform: SymbolId(2): Span { start: 69, end: 82 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "AbstractClass":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 69, end: 82 }
+after transform: SymbolId(4): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(3): Span { start: 69, end: 82 }
+
+* oxc/metadata/ambient-declared-class/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["Ambient", "Source", "dec"]
+rebuilt        : ScopeId(0): ["Source"]
+Reference symbol mismatch for "dec":
+after transform: SymbolId(1) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "Ambient":
+after transform: SymbolId(0) "Ambient"
+rebuilt        : <None>
+Reference symbol mismatch for "Ambient":
+after transform: SymbolId(0) "Ambient"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Object", "babelHelpers"]
+rebuilt        : ["Ambient", "Object", "babelHelpers", "dec"]
 
 * oxc/metadata/bound-type-reference/input.ts
 Symbol reference IDs mismatch for "BoundTypeReference":
 after transform: SymbolId(0): [ReferenceId(3), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(7), ReferenceId(9)]
 Symbol span mismatch for "Example":
 after transform: SymbolId(1): Span { start: 87, end: 94 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol span mismatch for "Example":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 87, end: 94 }
+after transform: SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(2): Span { start: 87, end: 94 }
 
 * oxc/metadata/class-and-method-decorators/input.ts
 Symbol span mismatch for "Problem":
@@ -772,6 +789,32 @@ rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol span mismatch for "Problem":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 90, end: 97 }
+
+* oxc/metadata/class-expression-via-const/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["C", "Source", "dec"]
+rebuilt        : ScopeId(0): ["C", "Source"]
+Symbol reference IDs mismatch for "C":
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5)]
+Reference symbol mismatch for "dec":
+after transform: SymbolId(1) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "C":
+after transform: <None>
+rebuilt        : SymbolId(0) "C"
+Reference flags mismatch for "C":
+after transform: ReferenceId(2): ReferenceFlags(Read | Type)
+rebuilt        : ReferenceId(3): ReferenceFlags(Read)
+Reference symbol mismatch for "C":
+after transform: <None>
+rebuilt        : SymbolId(0) "C"
+Reference flags mismatch for "C":
+after transform: ReferenceId(3): ReferenceFlags(Read | Type)
+rebuilt        : ReferenceId(5): ReferenceFlags(Read)
+Unresolved references mismatch:
+after transform: ["C", "Object", "babelHelpers"]
+rebuilt        : ["Object", "babelHelpers", "dec"]
 
 * oxc/metadata/constructor-overload/input.ts
 Bindings mismatch:
@@ -789,6 +832,20 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["ClassDecorator", "String", "babelHelpers"]
 rebuilt        : ["String", "babelHelpers", "dec"]
+
+* oxc/metadata/cross-file-imported-enum/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["Source", "StringEnum", "dec"]
+rebuilt        : ScopeId(0): ["Source", "StringEnum"]
+Symbol reference IDs mismatch for "StringEnum":
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5)]
+Reference symbol mismatch for "dec":
+after transform: SymbolId(1) "dec"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Object", "babelHelpers"]
+rebuilt        : ["Object", "babelHelpers", "dec"]
 
 * oxc/metadata/enum-types/input.ts
 Bindings mismatch:
@@ -888,6 +945,34 @@ Symbol reference IDs mismatch for "ComputedEnum":
 after transform: SymbolId(25): [ReferenceId(19), ReferenceId(72)]
 rebuilt        : SymbolId(15): [ReferenceId(52)]
 
+* oxc/metadata/erased-import-no-type-keyword/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["Source", "T", "dec"]
+rebuilt        : ScopeId(0): ["Source", "T"]
+Symbol reference IDs mismatch for "T":
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5)]
+Reference symbol mismatch for "dec":
+after transform: SymbolId(1) "dec"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Object", "babelHelpers"]
+rebuilt        : ["Object", "babelHelpers", "dec"]
+
+* oxc/metadata/forward-ref-class/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["LaterClass", "Source", "dec"]
+rebuilt        : ScopeId(0): ["LaterClass", "Source"]
+Symbol reference IDs mismatch for "LaterClass":
+after transform: SymbolId(5): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(1): [ReferenceId(3), ReferenceId(5)]
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Object", "PropertyDescriptor", "babelHelpers"]
+rebuilt        : ["Object", "babelHelpers", "dec"]
+
 * oxc/metadata/getter-setter-method/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Getter", "Setter", "UntypedGetter", "UntypedSetter", "dec"]
@@ -916,23 +1001,37 @@ rebuilt        : ["Function", "Number", "Object", "String", "babelHelpers", "dec
 
 * oxc/metadata/imports/input.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Cls", "Foo", "Zoo", "_ref", "dec"]
-rebuilt        : ScopeId(0): ["Cls", "Foo", "_ref"]
+after transform: ScopeId(0): ["Bar", "Cls", "Foo", "Zoo", "dec"]
+rebuilt        : ScopeId(0): ["Cls", "Foo"]
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(12), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(11), ReferenceId(12)]
+rebuilt        : SymbolId(0): [ReferenceId(10), ReferenceId(12)]
 Symbol span mismatch for "Cls":
 after transform: SymbolId(7): Span { start: 145, end: 148 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol span mismatch for "Cls":
-after transform: SymbolId(13): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 145, end: 148 }
+after transform: SymbolId(12): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(2): Span { start: 145, end: 148 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(3) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "PropertyDescriptor", "babelHelpers", "console"]
 rebuilt        : ["Object", "babelHelpers", "console", "dec"]
+
+* oxc/metadata/namespace-imported-enum/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["NS", "Source", "dec"]
+rebuilt        : ScopeId(0): ["NS", "Source"]
+Symbol reference IDs mismatch for "NS":
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(6)]
+Reference symbol mismatch for "dec":
+after transform: SymbolId(1) "dec"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Object", "babelHelpers"]
+rebuilt        : ["Object", "babelHelpers", "dec"]
 
 * oxc/metadata/params/input.ts
 Bindings mismatch:
@@ -1024,17 +1123,17 @@ rebuilt        : [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6)
 
 * oxc/metadata/static-anonymous-class-expression/input.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["A", "Foo", "_ref", "dec"]
-rebuilt        : ScopeId(0): ["A", "Foo", "_ref"]
+after transform: ScopeId(0): ["A", "Foo", "dec"]
+rebuilt        : ScopeId(0): ["A", "Foo"]
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
-rebuilt        : SymbolId(1): [ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(8)]
 Symbol span mismatch for "Foo":
 after transform: SymbolId(2): Span { start: 72, end: 75 }
-rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol span mismatch for "Foo":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 72, end: 75 }
+after transform: SymbolId(4): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(2): Span { start: 72, end: 75 }
 Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
@@ -1066,19 +1165,19 @@ rebuilt        : SymbolId(1): Span { start: 6, end: 13 }
 * oxc/metadata/unbound-type-reference/input.ts
 Symbol span mismatch for "Example":
 after transform: SymbolId(0): Span { start: 6, end: 13 }
-rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol span mismatch for "Example":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(2): Span { start: 6, end: 13 }
+after transform: SymbolId(2): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 6, end: 13 }
 Reference flags mismatch for "UnboundTypeReference":
 after transform: ReferenceId(2): ReferenceFlags(Read | Type)
-rebuilt        : ReferenceId(6): ReferenceFlags(Read)
+rebuilt        : ReferenceId(5): ReferenceFlags(Read)
 Reference flags mismatch for "UnboundTypeReference":
 after transform: ReferenceId(3): ReferenceFlags(Read | Type)
 rebuilt        : ReferenceId(7): ReferenceFlags(Read)
 Unresolved reference IDs mismatch for "UnboundTypeReference":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(6), ReferenceId(7)]
+rebuilt        : [ReferenceId(5), ReferenceId(7)]
 
 * oxc/metadata/without-decorator/input.ts
 Symbol span mismatch for "C":

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/output.ts
@@ -1,12 +1,11 @@
 import { dce, Dependency } from "mod";
 
-var _ref;
 let AbstractClass = class AbstractClass {
   dependency;
   constructor(dependency) {
     this.dependency = dependency;
   }
 };
-AbstractClass = babelHelpers.decorate([dce(), babelHelpers.decorateMetadata("design:paramtypes", [typeof (_ref = typeof Dependency !== "undefined" && Dependency) === "function" ? _ref : Object])], AbstractClass);
+AbstractClass = babelHelpers.decorate([dce(), babelHelpers.decorateMetadata("design:paramtypes", [typeof Dependency === "undefined" ? Object : Dependency])], AbstractClass);
 
 export { AbstractClass };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/ambient-declared-class/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/ambient-declared-class/input.ts
@@ -1,0 +1,11 @@
+// Ambient `declare class X {}`: the guard falls back to `Object` when the
+// runtime binding is missing, avoiding a `ReferenceError` for stale ambient
+// declarations and returning the actual class when the runtime provides it.
+
+declare class Ambient {}
+
+declare function dec(target: any, key: string): void;
+
+class Source {
+  @dec value!: Ambient;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/ambient-declared-class/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/ambient-declared-class/output.js
@@ -1,0 +1,4 @@
+class Source {
+  value;
+}
+babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:type", typeof Ambient === "undefined" ? Object : Ambient)], Source.prototype, "value", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/bound-type-reference/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/bound-type-reference/output.js
@@ -1,24 +1,18 @@
 import { BoundTypeReference } from "./output";
 
-var _ref;
-
 console.log(BoundTypeReference);
 
 let Example = class Example {
-	constructor(count) {}
-	prop = 1;
+  constructor(count) {}
+  prop = 1;
 };
 
 Example = babelHelpers.decorate(
-	[
-		babelHelpers.decorateParam(0, dce),
-		babelHelpers.decorateMetadata("design:paramtypes", [
-			typeof (_ref =
-				typeof BoundTypeReference !== "undefined" && BoundTypeReference) ===
-			"function"
-				? _ref
-				: Object,
-		]),
-	],
-	Example,
+  [
+    babelHelpers.decorateParam(0, dce),
+    babelHelpers.decorateMetadata("design:paramtypes", [
+      typeof BoundTypeReference === "undefined" ? Object : BoundTypeReference,
+    ]),
+  ],
+  Example,
 );

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-expression-via-const/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-expression-via-const/input.ts
@@ -1,0 +1,12 @@
+// `const C = class {}` (Variable symbol, not Class declaration). The guard
+// returns `C` at runtime — same code path as named class declarations.
+
+const C = class {
+  value = 1;
+};
+
+declare function dec(target: any, key: string): void;
+
+class Source {
+  @dec x!: C;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-expression-via-const/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-expression-via-const/output.js
@@ -1,0 +1,7 @@
+const C = class {
+  value = 1;
+};
+class Source {
+  x;
+}
+babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:type", typeof C === "undefined" ? Object : C)], Source.prototype, "x", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/cross-file-imported-enum/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/cross-file-imported-enum/input.ts
@@ -1,0 +1,11 @@
+// Cross-file imported enum: the guard returns the actual enum object at runtime,
+// so consumers (type-graphql, typeorm, NestJS Swagger, AutoMapper, class-validator)
+// can introspect members via `Object.values()`. See oxc-project/oxc#14740.
+
+import { StringEnum } from './enums';
+
+declare function dec(target: any, key: string): void;
+
+class Source {
+  @dec value!: StringEnum;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/cross-file-imported-enum/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/cross-file-imported-enum/output.js
@@ -1,0 +1,5 @@
+import { StringEnum } from "./enums";
+class Source {
+  value;
+}
+babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:type", typeof StringEnum === "undefined" ? Object : StringEnum)], Source.prototype, "value", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/erased-import-no-type-keyword/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/erased-import-no-type-keyword/input.ts
@@ -1,0 +1,11 @@
+// Type-only export imported without the `type` keyword: `T` is `undefined` at
+// runtime after erasure. The guard falls back to `Object` rather than
+// `undefined`, matching SWC and babel.
+
+import { T } from './m';
+
+declare function dec(target: any, key: string): void;
+
+class Source {
+  @dec x!: T;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/erased-import-no-type-keyword/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/erased-import-no-type-keyword/output.js
@@ -1,0 +1,5 @@
+import { T } from "./m";
+class Source {
+  x;
+}
+babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:type", typeof T === "undefined" ? Object : T)], Source.prototype, "x", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/forward-ref-class/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/forward-ref-class/input.ts
@@ -1,0 +1,13 @@
+// `LaterClass` resolves to a same-file class declared after the decorated class.
+// The guard `typeof X === "undefined" ? Object : X` throws `ReferenceError` at
+// decoration time (TDZ), matching SWC and babel.
+
+declare function dec(target: any, key: string, descriptor: PropertyDescriptor): void;
+
+class Source {
+  @dec laterRef!: LaterClass;
+}
+
+class LaterClass {
+  tag = 'later';
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/forward-ref-class/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/forward-ref-class/output.js
@@ -1,0 +1,7 @@
+class Source {
+  laterRef;
+}
+babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:type", typeof LaterClass === "undefined" ? Object : LaterClass)], Source.prototype, "laterRef", void 0);
+class LaterClass {
+  tag = "later";
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/imports/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/imports/output.ts
@@ -1,23 +1,19 @@
 import { Foo } from "mod";
-var _ref;
 
 let Cls = class Cls {
-	constructor(param, param2, param3, param4) {
-		console.log(param, param2, param3, param4);
-	}
+  constructor(param, param2, param3, param4) {
+    console.log(param, param2, param3, param4);
+  }
 };
-
 Cls = babelHelpers.decorate(
-	[
-		babelHelpers.decorateParam(0, dec),
-		babelHelpers.decorateMetadata("design:paramtypes", [
-			typeof (_ref = typeof Foo !== "undefined" && Foo) === "function"
-				? _ref
-				: Object,
-			Object,
-			Object,
-			Object,
-		]),
-	],
-	Cls,
+  [
+    babelHelpers.decorateParam(0, dec),
+    babelHelpers.decorateMetadata("design:paramtypes", [
+      typeof Foo === "undefined" ? Object : Foo,
+      Object,
+      Object,
+      Object,
+    ]),
+  ],
+  Cls,
 );

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/namespace-imported-enum/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/namespace-imported-enum/input.ts
@@ -1,0 +1,11 @@
+// Namespace-imported enum (qualified `NS.E`): the guard chains
+// `typeof NS === "undefined" || typeof NS.E === "undefined"`, short-circuiting
+// safely if the namespace itself is missing — matching SWC.
+
+import * as NS from './enums';
+
+declare function dec(target: any, key: string): void;
+
+class Source {
+  @dec value!: NS.StringEnum;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/namespace-imported-enum/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/namespace-imported-enum/output.js
@@ -1,0 +1,5 @@
+import * as NS from "./enums";
+class Source {
+  value;
+}
+babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:type", typeof NS === "undefined" || typeof NS.StringEnum === "undefined" ? Object : NS.StringEnum)], Source.prototype, "value", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/static-anonymous-class-expression/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/static-anonymous-class-expression/output.js
@@ -1,9 +1,8 @@
-var _ref;
 class A {}
 let Foo = class Foo {
   static Error1 = class extends Error {};
   static Error2 = class extends Error {};
   constructor(a) {}
 };
-Foo = babelHelpers.decorate([dec(), babelHelpers.decorateMetadata("design:paramtypes", [typeof (_ref = typeof A !== "undefined" && A) === "function" ? _ref : Object])], Foo);
+Foo = babelHelpers.decorate([dec(), babelHelpers.decorateMetadata("design:paramtypes", [typeof A === "undefined" ? Object : A])], Foo);
 export { Foo };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/unbound-type-reference/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/unbound-type-reference/output.js
@@ -1,18 +1,13 @@
-var _ref;
 let Example = class Example {
-	constructor(count) {}
+  constructor(count) {}
 };
 
 Example = babelHelpers.decorate(
-	[
-		babelHelpers.decorateParam(0, dce),
-		babelHelpers.decorateMetadata("design:paramtypes", [
-			typeof (_ref =
-				typeof UnboundTypeReference !== "undefined" && UnboundTypeReference) ===
-			"function"
-				? _ref
-				: Object,
-		]),
-	],
-	Example,
+  [
+    babelHelpers.decorateParam(0, dce),
+    babelHelpers.decorateMetadata("design:paramtypes", [
+      typeof UnboundTypeReference === "undefined" ? Object : UnboundTypeReference,
+    ]),
+  ],
+  Example,
 );


### PR DESCRIPTION
Closes #22227.
Closes #22228.

## Summary

- Switch `design:type` / `design:paramtypes` / `design:returntype` emit from `typeof X === "function" ? X : Object` to `typeof X === "undefined" ? Object : X`, matching SWC and Babel. Cross-file imported enums and namespace-imported enums (`NS.E`) now return the actual enum object instead of silently degrading to `Object` — consumers like type-graphql, typeorm, NestJS Swagger, AutoMapper, and class-validator can introspect via `Object.values()`.
- Cases where the runtime binding is genuinely missing still fall back to `Object` (stale ambient declarations, erased type imports, unresolved references), so existing behavior is preserved everywhere else.
- See #14740 for the design rationale: matching SWC/Babel rather than tsc's primitive-type emit (which requires cross-file type information OXC doesn't have).
- Conformance: 5 existing fixtures updated for the new emit shape, 6 new fixtures cover the bug paths and predicate boundaries; no `Output mismatch` regressions.

## Example

Input:
```ts
import { StringEnum } from './enums';

class Source {
  @dec value!: StringEnum;
}
```

Before:
```js
// design:type === Object — StringEnum is an enum object, typeof !== "function"
babelHelpers.decorateMetadata("design:type",
  typeof (_ref = typeof StringEnum !== "undefined" && StringEnum) === "function"
    ? _ref : Object)
```

After:
```js
// design:type === StringEnum (the enum object — introspectable via Object.values)
babelHelpers.decorateMetadata("design:type",
  typeof StringEnum === "undefined" ? Object : StringEnum)
```

## Note on the SWC enum-metadata debate

[swc-project/swc#11033](https://github.com/swc-project/swc/issues/11033) argues SWC's emit is wrong for cross-file enums — the runtime returns the enum object (an `{...}`) rather than `Number` / `String` / `Object` as tsc would. This PR adopts the same emit shape SWC and Babel use, so it has the same property: cross-file enum metadata is the enum binding itself, not a primitive constructor.

OXC chose this side of the debate deliberately in #14740 — returning the enum object is what type-graphql, typeorm, NestJS Swagger, AutoMapper, and class-validator depend on to introspect enum members. Matching tsc's primitive emit would require cross-file type information OXC doesn't have, and would unblock no real consumer. If TypeScript publishes a position on what non-type-checker transformers should emit, this can be revisited.

AI disclosure: drafted with Claude Code, reviewed manually.
