### PR TITLE
perf(semantic): use direct byte access for numeric leading-zero check

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -386,12 +386,8 @@ pub fn check_number_literal(lit: &NumericLiteral, ctx: &SemanticBuilder<'_>) {
     // * It is a Syntax Error if the source text matched by this production is strict mode code.
     fn leading_zero(s: Option<Str>) -> bool {
         if let Some(s) = s {
-            let mut chars = s.bytes();
-            if let Some(first) = chars.next()
-                && let Some(second) = chars.next()
-            {
-                return first == b'0' && second.is_ascii_digit();
-            }
+            let bytes = s.as_bytes();
+            return bytes.len() >= 2 && bytes[0] == b'0' && bytes[1].is_ascii_digit();
         }
         false
     }


### PR DESCRIPTION
this change avoids loading `bytes[1]` unless `bytes[0]` is `0`.

Since the common case is that the code is valid (no leading zero), we can skip loading the second byte unless it's actually required.

before:
```
leading_zero_v1:
        test    rdi, rdi
        sete    al
        cmp     rsi, 2
        setb    cl
        or      cl, al
        je      .LBB0_3
        xor     eax, eax
        ret
.LBB0_3:
        movzx   eax, byte ptr [rdi + 1]
        cmp     byte ptr [rdi], 48
        sete    cl
        add     al, -48
        cmp     al, 10
        setb    al
        and     al, cl
        ret
```

after:
```
leading_zero_v2:
        test    rdi, rdi
        setne   al
        cmp     rsi, 2
        setae   cl
        and     cl, al
        cmp     cl, 1
        jne     .LBB1_1
        cmp     byte ptr [rdi], 48
        jne     .LBB1_1
        movzx   eax, byte ptr [rdi + 1]
        add     al, -48
        cmp     al, 10
        setb    al
        ret
.LBB1_1:
        xor     eax, eax
        ret
```