### PR TITLE
fix(linter/no-focused-tests): mark fixer as a suggestion

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -10,7 +10,14 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct NoFocusedTests;
 
-declare_oxc_lint!(NoFocusedTests, jest, correctness, fix, docs = DOCUMENTATION, version = "0.0.8",);
+declare_oxc_lint!(
+    NoFocusedTests,
+    jest,
+    correctness,
+    suggestion,
+    docs = DOCUMENTATION,
+    version = "0.0.8",
+);
 
 impl Rule for NoFocusedTests {
     fn run_on_jest_node<'a, 'c>(
@@ -24,6 +31,7 @@ impl Rule for NoFocusedTests {
 
 #[test]
 fn test() {
+    use crate::fixer::FixKind;
     use crate::tester::Tester;
 
     let pass = vec![
@@ -66,9 +74,14 @@ fn test() {
     ];
 
     let fix = vec![
-        ("describe.only('foo', () => {})", "describe('foo', () => {})", None),
-        ("describe['only']('foo', () => {})", "describe('foo', () => {})", None),
-        ("fdescribe('foo', () => {})", "describe('foo', () => {})", None),
+        ("describe.only('foo', () => {})", "describe('foo', () => {})", None, FixKind::Suggestion),
+        (
+            "describe['only']('foo', () => {})",
+            "describe('foo', () => {})",
+            None,
+            FixKind::Suggestion,
+        ),
+        ("fdescribe('foo', () => {})", "describe('foo', () => {})", None, FixKind::Suggestion),
     ];
 
     Tester::new(NoFocusedTests::NAME, NoFocusedTests::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_focused_tests.rs
@@ -61,7 +61,7 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
     }
 
     if name.starts_with('f') {
-        ctx.diagnostic_with_fix(
+        ctx.diagnostic_with_suggestion(
             no_focused_tests_diagnostic(Span::sized(
                 call_expr.span.start,
                 u32::try_from(name.len()).unwrap_or(1),
@@ -74,7 +74,7 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
 
     let only_node = members.iter().find(|member| member.is_name_equal("only"));
     if let Some(only_node) = only_node {
-        ctx.diagnostic_with_fix(no_focused_tests_diagnostic(only_node.span), |fixer| {
+        ctx.diagnostic_with_suggestion(no_focused_tests_diagnostic(only_node.span), |fixer| {
             let mut span = only_node.span.expand_left(1);
             if !matches!(only_node.element, MemberExpressionElement::IdentName(_)) {
                 span = span.expand_right(1);

--- a/crates/oxc_linter/src/rules/vitest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_focused_tests.rs
@@ -14,7 +14,7 @@ declare_oxc_lint!(
     NoFocusedTests,
     vitest,
     correctness,
-    fix,
+    suggestion,
     docs = DOCUMENTATION,
     version = "0.0.8",
 );
@@ -31,6 +31,7 @@ impl Rule for NoFocusedTests {
 
 #[test]
 fn test() {
+    use crate::fixer::FixKind;
     use crate::tester::Tester;
 
     let mut pass = vec![
@@ -73,8 +74,13 @@ fn test() {
     ];
 
     let mut fix = vec![
-        ("describe.only('foo', () => {})", "describe('foo', () => {})", None),
-        ("describe['only']('foo', () => {})", "describe('foo', () => {})", None),
+        ("describe.only('foo', () => {})", "describe('foo', () => {})", None, FixKind::Suggestion),
+        (
+            "describe['only']('foo', () => {})",
+            "describe('foo', () => {})",
+            None,
+            FixKind::Suggestion,
+        ),
     ];
 
     let pass_vitest = vec![
@@ -100,12 +106,37 @@ fn test() {
     ];
 
     let fix_vitest = vec![
-        (r#"it.only("test", () => {});"#, r#"it("test", () => {});"#, None),
-        (r#"describe.only("test", () => {});"#, r#"describe("test", () => {});"#, None),
-        (r#"test.only("test", () => {});"#, r#"test("test", () => {});"#, None),
-        (r#"it.only.each([])("test", () => {});"#, r#"it.each([])("test", () => {});"#, None),
-        (r#"test.only.each``("test", () => {});"#, r#"test.each``("test", () => {});"#, None),
-        (r#"it.only.each``("test", () => {});"#, r#"it.each``("test", () => {});"#, None),
+        (r#"it.only("test", () => {});"#, r#"it("test", () => {});"#, None, FixKind::Suggestion),
+        (
+            r#"describe.only("test", () => {});"#,
+            r#"describe("test", () => {});"#,
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r#"test.only("test", () => {});"#,
+            r#"test("test", () => {});"#,
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r#"it.only.each([])("test", () => {});"#,
+            r#"it.each([])("test", () => {});"#,
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r#"test.only.each``("test", () => {});"#,
+            r#"test.each``("test", () => {});"#,
+            None,
+            FixKind::Suggestion,
+        ),
+        (
+            r#"it.only.each``("test", () => {});"#,
+            r#"it.each``("test", () => {});"#,
+            None,
+            FixKind::Suggestion,
+        ),
     ];
 
     pass.extend(pass_vitest);


### PR DESCRIPTION
- Change shared Jest/Vitest `no-focused-tests` diagnostics from safe fixes to suggestions.
- Mark both `jest/no-focused-tests` and `vitest/no-focused-tests` metadata as suggestion-capable.
- Assert the focused-test rewrite cases use `FixKind::Suggestion` in rule tests.

Fixes #22644
