### PR TITLE
fix(semantic): propagate unresolved auto-increment enum value instead of defaulting to 0

### DIFF
--- a/crates/oxc_semantic/src/ts_enum/eval.rs
+++ b/crates/oxc_semantic/src/ts_enum/eval.rs
@@ -44,7 +44,10 @@ pub fn evaluate_enum_members(decl: &TSEnumDeclaration<'_>, scoping: &mut Scoping
         scoping.add_enum_body_scope(id, scope_id);
     }
 
-    let mut prev_value: Option<ConstantValue> = None;
+    // Sentinel: the first member with no initializer evaluates to `-1.0 + 1.0 = 0.0`.
+    // Once a member fails to resolve, `prev_value` becomes `None` and stays there, so
+    // subsequent auto-increment members correctly propagate "unknown" instead of restarting at 0.
+    let mut prev_value: Option<ConstantValue> = Some(ConstantValue::Number(-1.0));
 
     for member in &decl.body.members {
         let value = if let Some(init) = &member.initializer {
@@ -52,9 +55,8 @@ pub fn evaluate_enum_members(decl: &TSEnumDeclaration<'_>, scoping: &mut Scoping
             evaluate_expression(init, &ctx)
         } else {
             match &prev_value {
-                None => Some(ConstantValue::Number(0.0)),
                 Some(ConstantValue::Number(n)) => Some(ConstantValue::Number(n + 1.0)),
-                Some(ConstantValue::String(_)) => None,
+                None | Some(ConstantValue::String(_)) => None,
             }
         };
 

--- a/crates/oxc_semantic/tests/integration/enum_values.rs
+++ b/crates/oxc_semantic/tests/integration/enum_values.rs
@@ -118,6 +118,19 @@ fn auto_increment_after_string_fails() {
 }
 
 #[test]
+fn auto_increment_after_unresolvable_fails() {
+    // Auto-increment must propagate the "unknown" state of the previous member,
+    // not silently restart at 0.
+    let source = "enum A { X = foo(), Y }";
+    debug_assert_eq!(get_enum_member_value(source, "X"), None);
+    debug_assert_eq!(get_enum_member_value(source, "Y"), None);
+
+    let source = "enum A { X = foo(), Y, Z }";
+    debug_assert_eq!(get_enum_member_value(source, "Y"), None);
+    debug_assert_eq!(get_enum_member_value(source, "Z"), None);
+}
+
+#[test]
 fn parenthesized_expression() {
     let source = "enum A { X = (1 + 2) }";
     debug_assert_eq!(get_enum_member_value(source, "X"), Some(ConstantValue::Number(3.0)));


### PR DESCRIPTION
## Summary

- When a TypeScript enum member with no initializer follows one whose initializer could not be evaluated to a constant, the auto-increment value previously fell back to `0`. It now propagates "unresolved" (`None`) like the existing `Some(String) => None` arm, matching tsc 6.0.3 (which errors on this construct and emits `void 0`, never `0`).
- The bug surfaced via rolldown's cross-module enum inliner (rolldown/rolldown#9494). Rolldown reads `Scoping::get_enum_member_value` to populate its `enum_member_value_map`; once the wrong `0` landed in the map, every call-site reference to the affected member was inlined to `0`. After this fix the map omits the entry and rolldown leaves the reference alone — matching tsc's call-site behavior.
- Adopts the existing `prev = Some(Number(-1.0))` sentinel pattern from `oxc_isolated_declarations/src/enum.rs` and `oxc_transformer/src/typescript/enum.rs`, so the first-member-defaults-to-0 case still resolves naturally and the auto-increment branch shrinks to two arms.

## Example

Input:

```ts
import { External } from './external'; // External.X = 0, External.Y = 1
enum Local { A = External.X, B = External.Y, C }
```

`Scoping::get_enum_member_value` before:

- A → None, B → None, C → Some(Number(0.0))  (wrong)

After:

- A → None, B → None, C → None

Covered by new test `crates/oxc_semantic/tests/integration/enum_values.rs::auto_increment_after_unresolvable_fails`; existing `auto_increment` (first member defaults to 0) and `auto_increment_after_string_fails` continue to pass.

AI disclosure: drafted with Claude Code, reviewed manually.
