### PR TITLE
perf(parser): fast path identifier parsing and inline operator helpers

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -119,8 +119,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     #[inline]
     pub(crate) fn parse_identifier_kind(&mut self, kind: Kind) -> (Span, Ident<'a>) {
-        let span = self.cur_token().span();
-        let name = self.cur_string();
+        let token = self.cur_token();
+        let span = token.span();
+        // Fast path: most identifiers are not escaped, so we can slice directly
+        // from source text without going through `get_string`'s kind matching.
+        let name = if token.escaped() { self.cur_string() } else { self.token_source(&token) };
         self.advance(kind);
         (span, Ident::from(name))
     }

--- a/crates/oxc_parser/src/js/operator.rs
+++ b/crates/oxc_parser/src/js/operator.rs
@@ -7,6 +7,7 @@ use oxc_syntax::{
 
 use crate::lexer::Kind;
 
+#[inline]
 pub fn kind_to_precedence(kind: Kind) -> Option<Precedence> {
     match kind {
         Kind::Question2 => Some(Precedence::NullishCoalescing),
@@ -28,6 +29,7 @@ pub fn kind_to_precedence(kind: Kind) -> Option<Precedence> {
     }
 }
 
+#[inline]
 pub fn map_binary_operator(kind: Kind) -> BinaryOperator {
     match kind {
         Kind::Eq2 => BinaryOperator::Equality,
@@ -56,6 +58,7 @@ pub fn map_binary_operator(kind: Kind) -> BinaryOperator {
     }
 }
 
+#[inline]
 pub fn map_unary_operator(kind: Kind) -> UnaryOperator {
     match kind {
         Kind::Minus => UnaryOperator::UnaryNegation,
@@ -69,6 +72,7 @@ pub fn map_unary_operator(kind: Kind) -> UnaryOperator {
     }
 }
 
+#[inline]
 pub fn map_logical_operator(kind: Kind) -> LogicalOperator {
     match kind {
         Kind::Pipe2 => LogicalOperator::Or,
@@ -78,6 +82,7 @@ pub fn map_logical_operator(kind: Kind) -> LogicalOperator {
     }
 }
 
+#[inline]
 pub fn map_update_operator(kind: Kind) -> UpdateOperator {
     match kind {
         Kind::Plus2 => UpdateOperator::Increment,
@@ -86,6 +91,7 @@ pub fn map_update_operator(kind: Kind) -> UpdateOperator {
     }
 }
 
+#[inline]
 pub fn map_assignment_operator(kind: Kind) -> AssignmentOperator {
     match kind {
         Kind::Eq => AssignmentOperator::Assign,


### PR DESCRIPTION
## Summary

Two small but compounding hot-path wins in the parser:

- **`parse_identifier_kind` fast path** — for unescaped identifiers (the common case), slice directly from source text via `token_source` instead of going through `lexer.get_string()`, which dispatches on `Kind`. This is the same approach as Cam's earlier branch (`03-31-perf_parser_fast_path_in_parse_identifier_kind...`) that never landed.
- **`#[inline]` on operator helpers** — `kind_to_precedence`, `map_binary_operator`, `map_logical_operator`, `map_unary_operator`, `map_update_operator`, `map_assignment_operator`. They're called from the Pratt loop in `parse_binary_expression_rest` but lived in a sibling module where rustc wouldn't auto-inline them.

## Benchmarks

Criterion medians (baseline → patched, lower is better):

| File | Baseline | Patched | Δ |
| --- | --- | --- | --- |
| `parser/binder.ts` | 433.60 µs | 425.28 µs | **~1.9%** |
| `parser/kitchen-sink.tsx` | 3.5702 ms | 3.5368 ms | ~0.9% |
| `parser/cal.com.tsx` | 3.9827 ms | 3.9519 ms | ~0.8% |
| `estree_tokens/checker.ts` | 9.6080 ms | 9.5566 ms | ~0.5% |
| `estree/checker.ts` | 13.395 ms | 13.373 ms | ~0.2% |

Identifier-dense TypeScript benefits the most, as expected — `binder.ts` is mostly identifiers.

## Notes

- No allocation regression (`cargo allocs` snapshot unchanged).
- `cargo coverage -- parser` still 100% on test262 (47115/47115 positive, 4588/4588 negative).
- `cargo test -p oxc_parser`, `cargo clippy`, `just fmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)