### PR TITLE
perf(parser): inline hot identifier and member-access functions

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -56,11 +56,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// `PrimaryExpression`: Identifier Reference
+    #[inline]
     pub(crate) fn parse_identifier_expression(&mut self) -> Expression<'a> {
         let ident = self.parse_identifier_reference();
         Expression::Identifier(self.alloc(ident))
     }
 
+    #[inline]
     pub(crate) fn parse_identifier_reference(&mut self) -> IdentifierReference<'a> {
         // allow `await` and `yield`, let semantic analysis report error
         let kind = self.cur_kind();
@@ -103,6 +105,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.label_identifier(span, name)
     }
 
+    #[inline]
     pub(crate) fn parse_identifier_name(&mut self) -> IdentifierName<'a> {
         if !self.cur_kind().is_identifier_name() {
             return self.unexpected();
@@ -125,6 +128,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         (span, Ident::from(name))
     }
 
+    #[inline]
     pub(crate) fn check_identifier(&mut self, kind: Kind, ctx: Context) {
         self.check_identifier_with_span(kind, ctx, self.cur_token().span());
     }
@@ -715,6 +719,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// Section 13.3 Left-Hand-Side Expression
+    #[inline]
     pub(crate) fn parse_lhs_expression_or_higher(&mut self) -> Expression<'a> {
         let span = self.start_span();
         let mut in_optional_chain = false;
@@ -896,6 +901,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.3 `MemberExpression`
     /// static member `a.b`
+    #[inline]
     fn parse_static_member_expression(
         &mut self,
         lhs_span: u32,


### PR DESCRIPTION
## Summary

Adds `#[inline]` to functions on the very hot identifier / member-access path so they can be folded into their callers (mostly `parse_primary_expression` and `parse_member_expression_rest`):

- `parse_identifier_expression`
- `parse_identifier_reference`
- `parse_identifier_name`
- `check_identifier`
- `parse_lhs_expression_or_higher`
- `parse_static_member_expression`

Cross-module `#[inline]` is required because most callers live in sibling modules (`statement.rs`, `class.rs`, etc.) where rustc won't auto-inline across the module boundary.

These hints were originally proposed in Cam McHenry's `03-31-perf_parser_inline_*` branches (4e9e262275, b91b85a201, d1a1ff8f92) which never landed; this PR rebases them on current main.

## Notes

- `cargo test -p oxc_parser` — pass (67 tests)
- `cargo coverage -- parser` — 100% (47115/47115 positive, 4588/4588 negative)
- `cargo allocs` snapshot unchanged
- This is independent of #22650 (the parse_identifier_kind fast path) but composes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)