### PR TITLE
perf(semantic): reorder ident reference strict mode check

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -275,7 +275,7 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
 
     //  Static Semantics: AssignmentTargetType
     //  1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or "arguments", return invalid.
-    if ctx.strict_mode() && matches!(ident.name.as_str(), "arguments" | "eval") {
+    if matches!(ident.name.as_str(), "arguments" | "eval") && ctx.strict_mode() {
         for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
             match node_kind {
                 // Only check for actual assignment contexts, not member expression access


### PR DESCRIPTION
check_identifier_reference runs for every identifier reference during semantic, but this strict-mode early error only applies to two identifier names: arguments and eval.

Given the following two reasonable assumptions: most code is strict mode, and most identifiers are not `arguments` or `eval`, checking the identifier name first makes the common path cheaper. We avoid querying the current scope’s strict-mode flags for almost every identifier reference, and only perform that lookup when the identifier could actually trigger this diagnostic.

This is behavior-preserving because both sides of the condition are side-effect free; it only changes which cheap guard runs first.