### PR TITLE
perf(semantic): reorder numeric literal strict mode checks

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -397,16 +397,14 @@ pub fn check_number_literal(lit: &NumericLiteral, ctx: &SemanticBuilder<'_>) {
         false
     }
 
-    if ctx.strict_mode() {
-        match lit.base {
-            NumberBase::Octal if leading_zero(lit.raw) => {
-                ctx.error(diagnostics::legacy_octal(lit.span));
-            }
-            NumberBase::Decimal | NumberBase::Float if leading_zero(lit.raw) => {
-                ctx.error(diagnostics::leading_zero_decimal(lit.span));
-            }
-            _ => {}
+    match lit.base {
+        NumberBase::Octal if leading_zero(lit.raw) && ctx.strict_mode() => {
+            ctx.error(diagnostics::legacy_octal(lit.span));
         }
+        NumberBase::Decimal | NumberBase::Float if leading_zero(lit.raw) && ctx.strict_mode() => {
+            ctx.error(diagnostics::leading_zero_decimal(lit.span));
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
`check_number_literal` runs for every numeric literal, but these strict-mode diagnostics only apply to numeric literals whose raw source starts with a legacy- style leading zero.

Given that most code we check is strict mode, `ctx.strict_mode()` is not a very selective guard here. Checking the raw literal shape first lets ordinary numeric literals fall through after a small byte check, and only queries the current scope’s strict-mode flags when the literal could actually produce one of these diagnostics.
