### PR TITLE
perf(semantic): use direct grandparent lookup for TS type parameters

### DIFF
--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -15,12 +15,10 @@ pub fn check_ts_type_parameter<'a>(param: &TSTypeParameter<'a>, ctx: &SemanticBu
     if param.r#in || param.out {
         let is_allowed_node = matches!(
             // skip parent TSTypeParameterDeclaration
-            ctx.nodes.ancestor_kinds(ctx.current_node_id).nth(1),
-            Some(
-                AstKind::TSInterfaceDeclaration(_)
-                    | AstKind::Class(_)
-                    | AstKind::TSTypeAliasDeclaration(_)
-            )
+            ctx.nodes.parent_kind(ctx.nodes.parent_id(ctx.current_node_id)),
+            AstKind::TSInterfaceDeclaration(_)
+                | AstKind::Class(_)
+                | AstKind::TSTypeAliasDeclaration(_)
         );
         if !is_allowed_node {
             if param.r#in {


### PR DESCRIPTION
`check_ts_type_parameter` validates `in` / `out` variance modifiers by checking the node that owns the surrounding `TSTypeParameterDeclaration`.

The parent of a `TSTypeParameter` is always the `TSTypeParameterDeclaration`, so this replaces `ancestor_kinds(...).nth(1)` with direct `parent_id` / `parent_kind` access. That avoids constructing and advancing the ancestor iterator when the grandparent node is the only value needed.

note: no performance improvement is expected here as we do not test this path in the benchmarks