### PR TITLE
perf(semantic): skip unresolved checks for re-exports

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -28,7 +28,9 @@ pub fn check_unresolved_exports(program: &Program<'_>, ctx: &SemanticBuilder<'_>
 
     let mut available_names: Option<Vec<&str>> = None;
     for stmt in &program.body {
-        if let Statement::ExportNamedDeclaration(decl) = stmt {
+        if let Statement::ExportNamedDeclaration(decl) = stmt
+            && decl.source.is_none()
+        {
             for specifier in &decl.specifiers {
                 if let ModuleExportName::IdentifierReference(ident) = &specifier.local
                     && ident.is_global_reference(&ctx.scoping)


### PR DESCRIPTION
`check_unresolved_exports` scans named exports in JavaScript modules and verifies that local export specifiers resolve to local bindings.

Sourced re-exports, such as `export { value as name } from "pkg"`, do not need this local binding check. This adds a `decl.source.is_none()` guard so `check_unresolved_exports` skips the specifier/reference loop for sourced re-exports entirely.
