### PR TITLE
perf(semantic): avoid duplicate ident clone for bindings

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -444,11 +444,14 @@ impl<'a> SemanticBuilder<'a> {
             return symbol_id;
         }
 
-        let symbol_id =
-            self.scoping.create_symbol(span, name, includes, scope_id, self.current_node_id);
-
-        self.scoping.add_binding(scope_id, name, symbol_id);
-        symbol_id
+        self.scoping.create_symbol_with_binding(
+            span,
+            name,
+            includes,
+            scope_id,
+            scope_id,
+            self.current_node_id,
+        )
     }
 
     /// Declare a new symbol on the current scope.
@@ -522,15 +525,14 @@ impl<'a> SemanticBuilder<'a> {
         scope_id: ScopeId,
         includes: SymbolFlags,
     ) -> SymbolId {
-        let symbol_id = self.scoping.create_symbol(
+        self.scoping.create_symbol_with_binding(
             span,
             name,
             includes,
             self.current_scope_id,
+            scope_id,
             self.current_node_id,
-        );
-        self.scoping.insert_binding(scope_id, name, symbol_id);
-        symbol_id
+        )
     }
 
     /// Resolve all collected references by walking up the scope chain from each

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -446,6 +446,26 @@ impl Scoping {
         self.symbol_table.push(span, flags, scope_id, node_id)
     }
 
+    /// Create a new symbol, append symbol metadata to the symbol table, and bind it to a scope.
+    pub(crate) fn create_symbol_with_binding(
+        &mut self,
+        span: Span,
+        name: Ident<'_>,
+        flags: SymbolFlags,
+        symbol_scope_id: ScopeId,
+        binding_scope_id: ScopeId,
+        node_id: NodeId,
+    ) -> SymbolId {
+        let symbol_id = self.symbol_table.push(span, flags, symbol_scope_id, node_id);
+        self.cell.with_dependent_mut(|allocator, cell| {
+            let name = name.clone_in(allocator);
+            cell.symbol_names.push(name);
+            cell.resolved_references.push(ArenaVec::new_in(allocator));
+            cell.bindings[binding_scope_id].insert(name, symbol_id);
+        });
+        symbol_id
+    }
+
     /// Record a redeclaration for an existing symbol.
     pub fn add_symbol_redeclaration(
         &mut self,
@@ -840,19 +860,6 @@ impl Scoping {
     #[inline]
     pub fn iter_bindings_in(&self, scope_id: ScopeId) -> impl Iterator<Item = SymbolId> + '_ {
         self.cell.borrow_dependent().bindings[scope_id].values().copied()
-    }
-
-    #[inline]
-    pub(crate) fn insert_binding(
-        &mut self,
-        scope_id: ScopeId,
-        name: Ident<'_>,
-        symbol_id: SymbolId,
-    ) {
-        self.cell.with_dependent_mut(|allocator, cell| {
-            let name = name.clone_in(allocator);
-            cell.bindings[scope_id].insert(name, symbol_id);
-        });
     }
 
     /// Create a scope.


### PR DESCRIPTION
Avoid cloning identifier names twice when creating a semantic symbol and adding its scope binding.

`Ident` is `Copy`, so `create_symbol_with_binding` now clones the name into the semantic arena once, then stores that same arena-backed ident in both the symbol name table and the bindings map. This also lets the catch-parameter shadow binding path use the same helper.

| Fixture                    | Before (num allocs) | After (num allocs) | num alloc Delta | Before (num reallocs) | After (num reallocs) | num realloc Delta |
| -------------------------- | -------------------:| ------------------:| ---------------:| ----------------------:| ---------------------:| -----------------:|
| TypeScript `checker.ts` | 53020 | 37851 | -15169 (-28.61%) | 22022 | 22022 | 0 (0.00%) |
| Excalidraw `App.tsx` | 6824 | 4936 | -1888 (-27.67%) | 2229 | 2229 | 0 (0.00%) |
| `RadixUIAdoptionSection.jsx` | 36 | 25 | -11 (-30.56%) | 14 | 14 | 0 (0.00%) |
| `pdf.mjs` | 16507 | 11977 | -4530 (-27.44%) | 5101 | 5101 | 0 (0.00%) |
| Ant Design `antd.js` | 143881 | 100200 | -43681 (-30.36%) | 30529 | 30529 | 0 (0.00%) |
| TypeScript `binder.ts` | 3642 | 2557 | -1085 (-29.79%) | 1447 | 1447 | 0 (0.00%) |
| `kitchen-sink.tsx` | 25635 | 18651 | -6984 (-27.24%) | 6363 | 6363 | 0 (0.00%) |
