### PR TITLE
perf(semantic): early-exit `check_object_expression` for objects with <2 properties

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -1293,6 +1293,15 @@ pub fn check_object_expression(obj_expr: &ObjectExpression, ctx: &SemanticBuilde
     // ObjectLiteral : { PropertyDefinitionList }
     // It is a Syntax Error if PropertyNameList of PropertyDefinitionList contains any duplicate entries for "__proto__"
     // and at least two of those entries were obtained from productions of the form PropertyDefinition : PropertyName : AssignmentExpression
+
+    // A duplicate requires ≥2 entries. JSX/TSX call sites emit huge numbers
+    // of single-property object literals (`<Foo prop={x}>` → `{prop: x}`), so
+    // the early-exit skips the loop setup and `prop_name()` call for those
+    // very common cases.
+    if obj_expr.properties.len() < 2 {
+        return;
+    }
+
     let mut prev_proto: Option<Span> = None;
     for prop in &obj_expr.properties {
         if let ObjectPropertyKind::ObjectProperty(obj_prop) = prop {


### PR DESCRIPTION
## Summary

A duplicate `__proto__` entry needs at least two property definitions — empty and single-property objects can't violate the rule. JSX/TSX call sites compile to enormous numbers of single-property object literals (`<Foo prop={x}>` → `{prop: x}`), so bailing before the loop setup and `prop_name()` call skips per-call overhead for the vast majority of `ObjectExpression` nodes seen during semantic checking.

## Context

The original version of this PR also reordered `check_identifier`, `check_identifier_reference`, and `check_binding_identifier` to defer expensive scope/symbol-flag loads behind a cheap name-match. While I was working on it, @camc314 shipped equivalent changes as three separate PRs (#22652, #22653, #22656). After rebasing onto `main`, only the `check_object_expression` early-exit remains as new work; the rest of the checker hot path is already covered.

This single change shows no measurable delta in `cargo bench --bench semantic` against current `main` (all five files within criterion's noise threshold) — JSX/TSX-heavy benches have already been driven down by the related PRs, and the property loop on a 1-property object is a fast path already. Pushing for completeness; happy to close if the maintainers would prefer to skip a change with no benchmark signal.

Verified by `cargo test -p oxc_semantic --features cfg` (72 tests) and `cargo clippy -p oxc_semantic --all-features`.

AI assisted.
