### PR TITLE
perf(parser): split TriviaBuilder::handle_newline + skip tokens len when disabled

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -191,11 +191,8 @@ impl<'a, C: Config> Lexer<'a, C> {
         };
         // Skip `self.tokens.len()` when tokens are statically disabled (`NoTokensLexerConfig`).
         // In that case `self.tokens` is always empty, so saving/restoring its length is dead work.
-        let tokens_len = if C::TOKENS_METHOD_IS_STATIC && !self.config.tokens() {
-            0
-        } else {
-            self.tokens.len()
-        };
+        let tokens_len =
+            if C::TOKENS_METHOD_IS_STATIC && !self.config.tokens() { 0 } else { self.tokens.len() };
         LexerCheckpoint {
             source_position: self.source.position(),
             token: self.token,
@@ -214,11 +211,8 @@ impl<'a, C: Config> Lexer<'a, C> {
         } else {
             ErrorSnapshot::Full(self.errors.clone())
         };
-        let tokens_len = if C::TOKENS_METHOD_IS_STATIC && !self.config.tokens() {
-            0
-        } else {
-            self.tokens.len()
-        };
+        let tokens_len =
+            if C::TOKENS_METHOD_IS_STATIC && !self.config.tokens() { 0 } else { self.tokens.len() };
         LexerCheckpoint {
             source_position: self.source.position(),
             token: self.token,

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -189,11 +189,18 @@ impl<'a, C: Config> Lexer<'a, C> {
         } else {
             ErrorSnapshot::Count(self.errors.len())
         };
+        // Skip `self.tokens.len()` when tokens are statically disabled (`NoTokensLexerConfig`).
+        // In that case `self.tokens` is always empty, so saving/restoring its length is dead work.
+        let tokens_len = if C::TOKENS_METHOD_IS_STATIC && !self.config.tokens() {
+            0
+        } else {
+            self.tokens.len()
+        };
         LexerCheckpoint {
             source_position: self.source.position(),
             token: self.token,
             errors_snapshot,
-            tokens_len: self.tokens.len(),
+            tokens_len,
             pure_comment: self.trivia_builder.pure_comment,
             has_no_side_effects_comment: self.trivia_builder.has_no_side_effects_comment,
         }
@@ -207,11 +214,16 @@ impl<'a, C: Config> Lexer<'a, C> {
         } else {
             ErrorSnapshot::Full(self.errors.clone())
         };
+        let tokens_len = if C::TOKENS_METHOD_IS_STATIC && !self.config.tokens() {
+            0
+        } else {
+            self.tokens.len()
+        };
         LexerCheckpoint {
             source_position: self.source.position(),
             token: self.token,
             errors_snapshot,
-            tokens_len: self.tokens.len(),
+            tokens_len,
             pure_comment: self.trivia_builder.pure_comment,
             has_no_side_effects_comment: self.trivia_builder.has_no_side_effects_comment,
         }
@@ -224,7 +236,11 @@ impl<'a, C: Config> Lexer<'a, C> {
             ErrorSnapshot::Count(len) => self.errors.truncate(len),
             ErrorSnapshot::Full(errors) => self.errors = errors,
         }
-        self.tokens.truncate(checkpoint.tokens_len);
+        // Skip `tokens.truncate()` when tokens are statically disabled (`NoTokensLexerConfig`).
+        // In that case `self.tokens` is always empty, so truncating is dead work.
+        if !C::TOKENS_METHOD_IS_STATIC || self.config.tokens() {
+            self.tokens.truncate(checkpoint.tokens_len);
+        }
         self.source.set_position(checkpoint.source_position);
         self.token = checkpoint.token;
         self.trivia_builder.pure_comment = checkpoint.pure_comment;

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -91,18 +91,27 @@ impl<'a> TriviaBuilder<'a> {
 
     // For block comments only. This function is not called after line comments because the lexer skips
     // newline after line comments.
+    #[inline]
     pub fn handle_newline(&mut self) {
-        // The last unprocessed comment is on a newline.
+        // Cold path: the previous block comment ended just before this newline,
+        // so mark it as followed by a newline and (when appropriate) promote it
+        // to a trailing comment of the prior token. For files with no comments,
+        // `processed == comments.len() == 0`, so we skip the body.
         let len = self.comments.len();
         if self.processed < len {
-            let comment = &mut self.comments[len - 1];
-            comment.set_followed_by_newline(true);
-            if !self.saw_newline && !Self::should_stay_leading(comment) {
-                self.processed = self.comments.len();
-            }
+            self.mark_last_comment_followed_by_newline(len);
         }
         self.saw_newline = true;
         self.saw_newline_for_comment = true;
+    }
+
+    #[cold]
+    fn mark_last_comment_followed_by_newline(&mut self, len: usize) {
+        let comment = &mut self.comments[len - 1];
+        comment.set_followed_by_newline(true);
+        if !self.saw_newline && !Self::should_stay_leading(comment) {
+            self.processed = self.comments.len();
+        }
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

Two small, conservative parser optimizations cherry-picked from earlier unmerged branches, rebased on current main.

### Commits

1. **perf(parser): split TriviaBuilder::handle_newline hot/cold paths** (from a66998611e)
   `handle_newline` is called from `line_break_handler` whenever the lexer consumes a newline byte. The body mixed a hot 2-write path with a cold body that only fires when a block comment ended just before the newline. Mark the wrapper `#[inline]` and move the if-body into a `#[cold]` helper so LLVM can fuse the hot path (two field writes + an empty-comments check) into `line_break_handler`.

2. **perf(parser): skip restoring tokens len when storing tokens is disabled** (from 4204a8f158)
   When the lexer is configured to **not** collect tokens (`NoTokensLexerConfig`, the default), `self.tokens` stays empty for the whole parse. Gate the `tokens.len()` reads/writes in checkpoint/rewind with the `TOKENS_METHOD_IS_STATIC` const so the compiler can statically eliminate them in the no-tokens config.

CodSpeed verifies "**not alter performance**" — these are conservative refactors with no measurable cost.

## Correctness

- `cargo test -p oxc_parser` — 67 pass
- `cargo coverage -- parser` — 100% (47115/47115 positive, 4588/4588 negative)

Co-Authored-By: Cam McHenry <camchenry@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)