### PR TITLE
ci(tasks/conformance): Run jsdoc conformance on CI

### DIFF
--- a/tasks/prettier_conformance/src/main.rs
+++ b/tasks/prettier_conformance/src/main.rs
@@ -6,21 +6,15 @@ use oxc_prettier_conformance::{
     options::{TestLanguage, TestRunnerOptions},
 };
 
-/// This CLI runs in 3 modes:
-/// - `cargo run`: Run all Prettier conformance tests
-/// - `cargo run -- --jsdoc`: Run JSDoc plugin conformance tests
+/// - `cargo run`: Run all Prettier conformance tests (JS + TS + JSDoc)
 /// - `cargo run -- --filter <filter>`: Debug a specific test
 fn main() {
     let mut args = Arguments::from_env();
-    let jsdoc = args.contains("--jsdoc");
     let debug = args.contains("--debug");
     let filter: Option<String> = args.opt_value_from_str("--filter").unwrap();
 
-    if jsdoc {
-        JsdocTestRunner::new(filter, debug).run();
-    } else {
-        let options = TestRunnerOptions { language: TestLanguage::Js, debug, filter };
-        TestRunner::new(options.clone()).run();
-        TestRunner::new(TestRunnerOptions { language: TestLanguage::Ts, ..options }).run();
-    }
+    let options = TestRunnerOptions { language: TestLanguage::Js, debug, filter: filter.clone() };
+    TestRunner::new(options.clone()).run();
+    TestRunner::new(TestRunnerOptions { language: TestLanguage::Ts, ..options }).run();
+    JsdocTestRunner::new(filter, debug).run();
 }


### PR DESCRIPTION
I've just noticed that was missing.

Considering that I'll be adding JSON later, with the current setup, running everything in one go would be fine.