### PR TITLE
refactor(linter/vue): extract find_property helper to utils

### DIFF
--- a/crates/oxc_linter/src/rules/vue/max_props.rs
+++ b/crates/oxc_linter/src/rules/vue/max_props.rs
@@ -2,10 +2,10 @@ use oxc_allocator::Vec;
 use oxc_ast::{
     AstKind,
     ast::{
-        ExportDefaultDeclarationKind, Expression, ObjectPropertyKind, TSSignature, TSType,
-        TSTypeName, TSTypeReference,
+        ExportDefaultDeclarationKind, Expression, TSSignature, TSType, TSTypeName, TSTypeReference,
     },
 };
+
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -21,6 +21,7 @@ use crate::{
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{DefaultRuleConfig, Rule},
+    utils::find_property,
 };
 
 fn max_props_diagnostic(span: Span, cur: usize, limit: usize) -> OxcDiagnostic {
@@ -163,18 +164,11 @@ impl MaxProps {
             return;
         };
 
-        let Some(props_obj_expr) = obj_expr.properties.iter().find_map(|item| {
-            if let ObjectPropertyKind::ObjectProperty(obj_prop) = item
-                && let Some(key) = obj_prop.key.static_name()
-                && key == "props"
-                && let Expression::ObjectExpression(props_expr) =
-                    obj_prop.value.get_inner_expression()
-            {
-                Some(props_expr)
-            } else {
-                None
-            }
-        }) else {
+        let Some(props_prop) = find_property(obj_expr, "props") else {
+            return;
+        };
+        let Expression::ObjectExpression(props_obj_expr) = props_prop.value.get_inner_expression()
+        else {
             return;
         };
 

--- a/crates/oxc_linter/src/rules/vue/no_arrow_functions_in_watch.rs
+++ b/crates/oxc_linter/src/rules/vue/no_arrow_functions_in_watch.rs
@@ -9,7 +9,9 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
+use crate::{
+    AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule, utils::find_property,
+};
 
 fn no_arrow_functions_in_watch_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("You should not use an arrow function to define a watcher.")
@@ -131,16 +133,8 @@ fn check_define_component_function<'a>(call_expr: &'a CallExpression<'a>, ctx: &
 fn get_watch_object_expression<'a>(
     obj_expr: &'a ObjectExpression<'a>,
 ) -> Option<&'a ObjectExpression<'a>> {
-    let watch_obj = obj_expr.properties.iter().find_map(|item| {
-        if let ObjectPropertyKind::ObjectProperty(prop) = item
-            && prop.key.static_name().is_some_and(|key| key == "watch")
-        {
-            Some(&prop.value)
-        } else {
-            None
-        }
-    })?;
-    let Expression::ObjectExpression(watch_obj) = watch_obj.get_inner_expression() else {
+    let watch_prop = find_property(obj_expr, "watch")?;
+    let Expression::ObjectExpression(watch_obj) = watch_prop.value.get_inner_expression() else {
         return None;
     };
     Some(watch_obj)

--- a/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         AwaitExpression, CallExpression, ExportDefaultDeclarationKind, Expression, Function,
-        ObjectExpression, ObjectPropertyKind,
+        ObjectExpression,
     },
 };
 use oxc_ast_visit::{Visit, walk};
@@ -13,7 +13,9 @@ use oxc_span::Span;
 use rustc_hash::FxHashMap;
 
 use crate::module_record::{ImportEntry, ImportImportName};
-use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
+use crate::{
+    AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule, utils::find_property,
+};
 
 fn no_lifecycle_after_await_diagnostic(span: Span, hook_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -116,12 +118,7 @@ impl Rule for NoLifecycleAfterAwait {
 }
 
 fn check_setup_in_object<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
-    let Some(setup_prop) = obj_expr.properties.iter().find_map(|prop| {
-        let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else {
-            return None;
-        };
-        obj_prop.key.static_name().is_some_and(|name| name == "setup").then_some(obj_prop)
-    }) else {
+    let Some(setup_prop) = find_property(obj_expr, "setup") else {
         return;
     };
 

--- a/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
+++ b/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
@@ -19,6 +19,7 @@ use crate::{
     fixer::{RuleFix, RuleFixer},
     frameworks::FrameworkOptions,
     rule::Rule,
+    utils::find_property,
 };
 
 fn no_required_prop_with_default_diagnostic(span: Span, prop_name: &str) -> OxcDiagnostic {
@@ -367,18 +368,7 @@ fn handle_type_argument(ctx: &LintContext, ts_type: &TSType, key_hash: &FxHashSe
 }
 
 fn handle_object_expression(ctx: &LintContext, obj: &ObjectExpression) {
-    let Some(prop) = obj.properties.iter().find(|item| {
-        if let ObjectPropertyKind::ObjectProperty(obj_prop) = item
-            && let Some(key) = obj_prop.key.static_name()
-        {
-            key == "props"
-        } else {
-            false
-        }
-    }) else {
-        return;
-    };
-    let ObjectPropertyKind::ObjectProperty(prop_obj) = prop else {
+    let Some(prop_obj) = find_property(obj, "props") else {
         return;
     };
     let Expression::ObjectExpression(prop_obj_expr) = prop_obj.value.get_inner_expression() else {

--- a/crates/oxc_linter/src/rules/vue/no_this_in_before_route_enter.rs
+++ b/crates/oxc_linter/src/rules/vue/no_this_in_before_route_enter.rs
@@ -1,13 +1,18 @@
 use oxc_ast::{
     AstKind,
-    ast::{ExportDefaultDeclarationKind, Expression, ObjectPropertyKind},
+    ast::{ExportDefaultDeclarationKind, Expression},
 };
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{AstNode, context::LintContext, rule::Rule, utils::ThisExpressionFinder};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{ThisExpressionFinder, find_property},
+};
 
 fn no_this_in_before_route_enter_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`beforeRouteEnter` does NOT have access to `this` component instance.")
@@ -68,18 +73,7 @@ impl Rule for NoThisInBeforeRouteEnter {
             return;
         };
 
-        let before_route_enter_prop = obj_expr.properties.iter().find_map(|prop| {
-            if let ObjectPropertyKind::ObjectProperty(obj_prop) = prop
-                && let Some(key_name) = obj_prop.key.static_name()
-                && key_name == "beforeRouteEnter"
-            {
-                Some(obj_prop)
-            } else {
-                None
-            }
-        });
-
-        if let Some(before_route_enter_prop) = before_route_enter_prop {
+        if let Some(before_route_enter_prop) = find_property(obj_expr, "beforeRouteEnter") {
             let function_body = match &before_route_enter_prop.value {
                 Expression::FunctionExpression(func_expr) => func_expr.body.as_ref(),
                 _ => return,

--- a/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_watch_after_await.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         ArrowFunctionExpression, AwaitExpression, ChainElement, ExportDefaultDeclarationKind,
-        Expression, ExpressionStatement, Function, ObjectExpression, ObjectPropertyKind,
+        Expression, ExpressionStatement, Function, ObjectExpression,
     },
 };
 use oxc_ast_visit::{Visit, walk};
@@ -14,7 +14,9 @@ use oxc_semantic::{ScopeFlags, Scoping, SymbolId};
 use oxc_span::Span;
 
 use crate::module_record::{ImportEntry, ImportImportName};
-use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
+use crate::{
+    AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule, utils::find_property,
+};
 
 fn no_watch_after_await_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("`{name}` is forbidden after an `await` expression."))
@@ -103,12 +105,7 @@ impl Rule for NoWatchAfterAwait {
 }
 
 fn check_setup_in_object<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
-    let Some(setup_prop) = obj_expr.properties.iter().find_map(|prop| {
-        let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else {
-            return None;
-        };
-        obj_prop.key.static_name().is_some_and(|name| name == "setup").then_some(obj_prop)
-    }) else {
+    let Some(setup_prop) = find_property(obj_expr, "setup") else {
         return;
     };
 

--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         CallExpression, ExportDefaultDeclarationKind, Expression, IdentifierReference,
-        ObjectPropertyKind,
+        ObjectExpression, ObjectProperty, ObjectPropertyKind,
     },
 };
 use oxc_span::GetSpan;
@@ -274,4 +274,16 @@ pub fn is_vue_component_options_call(call_expr: &CallExpression<'_>) -> bool {
     }
 
     matches!(prop_name, "component" | "mixin")
+}
+
+/// Finds the first `ObjectProperty` whose static key matches `name` in the given object.
+/// `SpreadElement` entries are skipped.
+pub fn find_property<'a, 'b>(
+    obj: &'b ObjectExpression<'a>,
+    name: &str,
+) -> Option<&'b ObjectProperty<'a>> {
+    obj.properties.iter().find_map(|prop| {
+        let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else { return None };
+        obj_prop.key.is_specific_static_name(name).then_some(obj_prop.as_ref())
+    })
 }


### PR DESCRIPTION
Extract the `obj.properties.iter().find_map(...)` pattern duplicated across 6 Vue rules into `utils::find_property` (matches `eslint-plugin-vue`'s `findProperty()`). Pure refactor.
