### PR TITLE
feat(linter/vue): implement no-computed-properties-in-data rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1294,6 +1294,7 @@ export interface DummyRuleMap {
   "vue/define-props-destructuring"?: DummyRule;
   "vue/max-props"?: DummyRule;
   "vue/no-arrow-functions-in-watch"?: DummyRule;
+  "vue/no-computed-properties-in-data"?: DummyRule;
   "vue/no-deprecated-data-object-declaration"?: DummyRule;
   "vue/no-deprecated-delete-set"?: DummyRule;
   "vue/no-deprecated-destroyed-lifecycle"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4970,6 +4970,12 @@ impl RuleRunner for crate::rules::vue::no_arrow_functions_in_watch::NoArrowFunct
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::no_computed_properties_in_data::NoComputedPropertiesInData {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner
     for crate::rules::vue::no_deprecated_data_object_declaration::NoDeprecatedDataObjectDeclaration
 {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -793,6 +793,7 @@ pub use crate::rules::vue::define_props_declaration::DefinePropsDeclaration as V
 pub use crate::rules::vue::define_props_destructuring::DefinePropsDestructuring as VueDefinePropsDestructuring;
 pub use crate::rules::vue::max_props::MaxProps as VueMaxProps;
 pub use crate::rules::vue::no_arrow_functions_in_watch::NoArrowFunctionsInWatch as VueNoArrowFunctionsInWatch;
+pub use crate::rules::vue::no_computed_properties_in_data::NoComputedPropertiesInData as VueNoComputedPropertiesInData;
 pub use crate::rules::vue::no_deprecated_data_object_declaration::NoDeprecatedDataObjectDeclaration as VueNoDeprecatedDataObjectDeclaration;
 pub use crate::rules::vue::no_deprecated_delete_set::NoDeprecatedDeleteSet as VueNoDeprecatedDeleteSet;
 pub use crate::rules::vue::no_deprecated_destroyed_lifecycle::NoDeprecatedDestroyedLifecycle as VueNoDeprecatedDestroyedLifecycle;
@@ -1622,6 +1623,7 @@ pub enum RuleEnum {
     VueDefinePropsDestructuring(VueDefinePropsDestructuring),
     VueMaxProps(VueMaxProps),
     VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch),
+    VueNoComputedPropertiesInData(VueNoComputedPropertiesInData),
     VueNoDeprecatedDataObjectDeclaration(VueNoDeprecatedDataObjectDeclaration),
     VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet),
     VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle),
@@ -2532,8 +2534,9 @@ const VUE_DEFINE_PROPS_DECLARATION_ID: usize = VUE_DEFINE_EMITS_DECLARATION_ID +
 const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID + 1usize;
 const VUE_MAX_PROPS_ID: usize = VUE_DEFINE_PROPS_DESTRUCTURING_ID + 1usize;
 const VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID: usize = VUE_MAX_PROPS_ID + 1usize;
+const VUE_NO_COMPUTED_PROPERTIES_IN_DATA_ID: usize = VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID + 1usize;
 const VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID: usize =
-    VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID + 1usize;
+    VUE_NO_COMPUTED_PROPERTIES_IN_DATA_ID + 1usize;
 const VUE_NO_DEPRECATED_DELETE_SET_ID: usize =
     VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID + 1usize;
 const VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID: usize = VUE_NO_DEPRECATED_DELETE_SET_ID + 1usize;
@@ -3474,6 +3477,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VUE_DEFINE_PROPS_DESTRUCTURING_ID,
             Self::VueMaxProps(_) => VUE_MAX_PROPS_ID,
             Self::VueNoArrowFunctionsInWatch(_) => VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID,
+            Self::VueNoComputedPropertiesInData(_) => VUE_NO_COMPUTED_PROPERTIES_IN_DATA_ID,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID
             }
@@ -4399,6 +4403,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::NAME,
             Self::VueMaxProps(_) => VueMaxProps::NAME,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::NAME,
+            Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::NAME,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::NAME
             }
@@ -5380,6 +5385,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::CATEGORY,
             Self::VueMaxProps(_) => VueMaxProps::CATEGORY,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::CATEGORY,
+            Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::CATEGORY,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::CATEGORY
             }
@@ -6308,6 +6314,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::FIX,
             Self::VueMaxProps(_) => VueMaxProps::FIX,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::FIX,
+            Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::FIX,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::FIX
             }
@@ -7476,6 +7483,9 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::documentation(),
             Self::VueMaxProps(_) => VueMaxProps::documentation(),
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::documentation(),
+            Self::VueNoComputedPropertiesInData(_) => {
+                VueNoComputedPropertiesInData::documentation()
+            }
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::documentation()
             }
@@ -9773,6 +9783,10 @@ impl RuleEnum {
                 VueNoArrowFunctionsInWatch::config_schema(generator)
                     .or_else(|| VueNoArrowFunctionsInWatch::schema(generator))
             }
+            Self::VueNoComputedPropertiesInData(_) => {
+                VueNoComputedPropertiesInData::config_schema(generator)
+                    .or_else(|| VueNoComputedPropertiesInData::schema(generator))
+            }
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::config_schema(generator)
                     .or_else(|| VueNoDeprecatedDataObjectDeclaration::schema(generator))
@@ -10636,6 +10650,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => "vue",
             Self::VueMaxProps(_) => "vue",
             Self::VueNoArrowFunctionsInWatch(_) => "vue",
+            Self::VueNoComputedPropertiesInData(_) => "vue",
             Self::VueNoDeprecatedDataObjectDeclaration(_) => "vue",
             Self::VueNoDeprecatedDeleteSet(_) => "vue",
             Self::VueNoDeprecatedDestroyedLifecycle(_) => "vue",
@@ -13198,6 +13213,9 @@ impl RuleEnum {
             Self::VueNoArrowFunctionsInWatch(_) => Ok(Self::VueNoArrowFunctionsInWatch(
                 VueNoArrowFunctionsInWatch::from_configuration(value)?,
             )),
+            Self::VueNoComputedPropertiesInData(_) => Ok(Self::VueNoComputedPropertiesInData(
+                VueNoComputedPropertiesInData::from_configuration(value)?,
+            )),
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 Ok(Self::VueNoDeprecatedDataObjectDeclaration(
                     VueNoDeprecatedDataObjectDeclaration::from_configuration(value)?,
@@ -14075,6 +14093,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(rule) => rule.to_configuration(),
             Self::VueMaxProps(rule) => rule.to_configuration(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.to_configuration(),
+            Self::VueNoComputedPropertiesInData(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.to_configuration(),
@@ -14900,6 +14919,7 @@ impl RuleEnum {
                 Self::VueDefinePropsDestructuring(rule) => rule.run(node, ctx),
                 Self::VueMaxProps(rule) => rule.run(node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run(node, ctx),
+                Self::VueNoComputedPropertiesInData(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
@@ -15718,6 +15738,7 @@ impl RuleEnum {
                 Self::VueDefinePropsDestructuring(rule) => rule.run(node, ctx),
                 Self::VueMaxProps(rule) => rule.run(node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run(node, ctx),
+                Self::VueNoComputedPropertiesInData(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
@@ -16543,6 +16564,7 @@ impl RuleEnum {
                 Self::VueDefinePropsDestructuring(rule) => rule.run_once(ctx),
                 Self::VueMaxProps(rule) => rule.run_once(ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_once(ctx),
+                Self::VueNoComputedPropertiesInData(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
@@ -17361,6 +17383,7 @@ impl RuleEnum {
                 Self::VueDefinePropsDestructuring(rule) => rule.run_once(ctx),
                 Self::VueMaxProps(rule) => rule.run_once(ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_once(ctx),
+                Self::VueNoComputedPropertiesInData(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
@@ -18433,6 +18456,7 @@ impl RuleEnum {
                 Self::VueDefinePropsDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueMaxProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoComputedPropertiesInData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -19505,6 +19529,7 @@ impl RuleEnum {
                 Self::VueDefinePropsDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueMaxProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoComputedPropertiesInData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -20329,6 +20354,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(rule) => rule.should_run(ctx),
             Self::VueMaxProps(rule) => rule.should_run(ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.should_run(ctx),
+            Self::VueNoComputedPropertiesInData(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.should_run(ctx),
@@ -21494,6 +21520,9 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::IS_TSGOLINT_RULE,
             Self::VueMaxProps(_) => VueMaxProps::IS_TSGOLINT_RULE,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::IS_TSGOLINT_RULE,
+            Self::VueNoComputedPropertiesInData(_) => {
+                VueNoComputedPropertiesInData::IS_TSGOLINT_RULE
+            }
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::IS_TSGOLINT_RULE
             }
@@ -22485,6 +22514,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::VERSION,
             Self::VueMaxProps(_) => VueMaxProps::VERSION,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::VERSION,
+            Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::VERSION,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::VERSION
             }
@@ -23503,6 +23533,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::HAS_CONFIG,
             Self::VueMaxProps(_) => VueMaxProps::HAS_CONFIG,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::HAS_CONFIG,
+            Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::HAS_CONFIG,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::HAS_CONFIG
             }
@@ -24324,6 +24355,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(rule) => rule.types_info(),
             Self::VueMaxProps(rule) => rule.types_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.types_info(),
+            Self::VueNoComputedPropertiesInData(rule) => rule.types_info(),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.types_info(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.types_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.types_info(),
@@ -25139,6 +25171,7 @@ impl RuleEnum {
             Self::VueDefinePropsDestructuring(rule) => rule.run_info(),
             Self::VueMaxProps(rule) => rule.run_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_info(),
+            Self::VueNoComputedPropertiesInData(rule) => rule.run_info(),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_info(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_info(),
@@ -26084,6 +26117,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueDefinePropsDestructuring(VueDefinePropsDestructuring::default()),
         RuleEnum::VueMaxProps(VueMaxProps::default()),
         RuleEnum::VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch::default()),
+        RuleEnum::VueNoComputedPropertiesInData(VueNoComputedPropertiesInData::default()),
         RuleEnum::VueNoDeprecatedDataObjectDeclaration(
             VueNoDeprecatedDataObjectDeclaration::default(),
         ),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -833,6 +833,7 @@ pub(crate) mod vue {
     pub mod define_props_destructuring;
     pub mod max_props;
     pub mod no_arrow_functions_in_watch;
+    pub mod no_computed_properties_in_data;
     pub mod no_deprecated_data_object_declaration;
     pub mod no_deprecated_delete_set;
     pub mod no_deprecated_destroyed_lifecycle;

--- a/crates/oxc_linter/src/rules/vue/no_computed_properties_in_data.rs
+++ b/crates/oxc_linter/src/rules/vue/no_computed_properties_in_data.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use rustc_hash::FxHashSet;
+
 use oxc_ast::{
     AstKind,
     ast::{Expression, ObjectExpression, ObjectPropertyKind},
@@ -7,7 +9,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use rustc_hash::FxHashSet;
 
 use crate::{
     AstNode,
@@ -73,10 +74,6 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoComputedPropertiesInData {
-    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_extension().is_some_and(|ext| ext == "vue")
-    }
-
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::StaticMemberExpression(member) = node.kind() else { return };
         if !is_this_object(&member.object, ctx) {
@@ -90,6 +87,10 @@ impl Rule for NoComputedPropertiesInData {
         }
 
         ctx.diagnostic(no_computed_properties_in_data_diagnostic(member.span()));
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
     }
 }
 

--- a/crates/oxc_linter/src/rules/vue/no_computed_properties_in_data.rs
+++ b/crates/oxc_linter/src/rules/vue/no_computed_properties_in_data.rs
@@ -1,0 +1,259 @@
+use std::borrow::Cow;
+
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, ObjectExpression, ObjectPropertyKind},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use rustc_hash::FxHashSet;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{is_this_object, is_vue_component_options_object},
+};
+
+fn no_computed_properties_in_data_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "The computed property cannot be used in `data()` because it is before initialization.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoComputedPropertiesInData;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow accessing computed properties inside `data()`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `data()` runs **before** computed properties are initialized, so
+    /// `this.<computedName>` evaluates to `undefined` and leaves silently
+    /// broken state in the component instance.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   data() {
+    ///     const foo = this.foo // `foo` is a computed property
+    ///     return {}
+    ///   },
+    ///   computed: {
+    ///     foo() {}
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   data() {
+    ///     const foo = this.foo // `foo` is a prop, not a computed
+    ///     return {}
+    ///   },
+    ///   props: ['foo']
+    /// }
+    /// </script>
+    /// ```
+    NoComputedPropertiesInData,
+    vue,
+    correctness,
+    version = "next",
+);
+
+impl Rule for NoComputedPropertiesInData {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::StaticMemberExpression(member) = node.kind() else { return };
+        if !is_this_object(&member.object, ctx) {
+            return;
+        }
+
+        let Some(options) = enclosing_data_options(node, ctx) else { return };
+
+        if !collect_computed_names(options).contains(member.property.name.as_str()) {
+            return;
+        }
+
+        ctx.diagnostic(no_computed_properties_in_data_diagnostic(member.span()));
+    }
+}
+
+/// Return the Vue component options object when `node` sits inside the body of a
+/// `data` function (`data() {}` / `data: function() {}` / `data: () => {}`)
+/// that is itself declared on a Vue component options object.
+fn enclosing_data_options<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let nodes = ctx.nodes();
+
+    let function_node = nodes.ancestors(node.id()).find(|ancestor| {
+        matches!(ancestor.kind(), AstKind::Function(_) | AstKind::ArrowFunctionExpression(_))
+    })?;
+
+    let prop_node = nodes.parent_node(function_node.id());
+    let AstKind::ObjectProperty(prop) = prop_node.kind() else { return None };
+    if !prop.key.is_specific_static_name("data") {
+        return None;
+    }
+
+    let options_node = nodes.parent_node(prop_node.id());
+    let AstKind::ObjectExpression(options) = options_node.kind() else { return None };
+    if !is_vue_component_options_object(options_node, ctx) {
+        return None;
+    }
+    Some(options)
+}
+
+fn collect_computed_names<'a>(options: &ObjectExpression<'a>) -> FxHashSet<&'a str> {
+    let Some(computed_obj) = options.properties.iter().find_map(|p| match p {
+        ObjectPropertyKind::ObjectProperty(prop)
+            if prop.key.is_specific_static_name("computed") =>
+        {
+            match prop.value.get_inner_expression() {
+                Expression::ObjectExpression(obj) => Some(obj),
+                _ => None,
+            }
+        }
+        _ => None,
+    }) else {
+        return FxHashSet::default();
+    };
+
+    computed_obj
+        .properties
+        .iter()
+        .filter_map(|entry| match entry {
+            ObjectPropertyKind::ObjectProperty(prop) if !prop.computed => Some(prop),
+            _ => None,
+        })
+        .filter_map(|prop| match prop.key.static_name()? {
+            Cow::Borrowed(name) => Some(name),
+            // Computed keys backed by literals (e.g. `0: foo`) produce an owned
+            // string; they are not valid identifiers to reference via `this`, so skip.
+            Cow::Owned(_) => None,
+        })
+        .collect()
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "<script>
+            export default {
+              data() {
+                const foo = this.foo
+                return {}
+              }
+            }
+            </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+            export default {
+              data() {
+                const foo = this.foo()
+                return {}
+              },
+              methods: {
+                foo() {}
+              }
+            }
+            </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+            export default {
+              props: ['foo'],
+              data() {
+                const foo = this.foo
+                return {}
+              },
+            }
+            </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+            export default {
+              data: {
+                foo: this.foo
+              },
+              computed: {
+                foo () {}
+              }
+            }
+            </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "<script>
+            export default {
+              data() {
+                const foo = this.foo
+                return  {}
+              },
+              computed: {
+                foo () {}
+              }
+            }
+            </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "<script>
+            export default {
+              data() {
+                const vm = this
+                const foo = vm.foo
+                return  {}
+              },
+              computed: {
+                foo () {}
+              }
+            }
+            </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(NoComputedPropertiesInData::NAME, NoComputedPropertiesInData::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vue_no_computed_properties_in_data.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_computed_properties_in_data.snap
@@ -1,0 +1,19 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(no-computed-properties-in-data): The computed property cannot be used in `data()` because it is before initialization.
+   ╭─[no_computed_properties_in_data.tsx:4:29]
+ 3 │               data() {
+ 4 │                 const foo = this.foo
+   ·                             ────────
+ 5 │                 return  {}
+   ╰────
+
+  ⚠ vue(no-computed-properties-in-data): The computed property cannot be used in `data()` because it is before initialization.
+   ╭─[no_computed_properties_in_data.tsx:5:29]
+ 4 │                 const vm = this
+ 5 │                 const foo = vm.foo
+   ·                             ──────
+ 6 │                 return  {}
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2593,6 +2593,9 @@
         "vue/no-arrow-functions-in-watch": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-computed-properties-in-data": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-deprecated-data-object-declaration": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2597,6 +2597,9 @@ expression: json
         "vue/no-arrow-functions-in-watch": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-computed-properties-in-data": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-deprecated-data-object-declaration": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/no-computed-properties-in-data.html

AI disclosure: implemented with Claude Code, reviewed manually.