### PR TITLE
feat(linter/vue): implement no-expose-after-await rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1302,6 +1302,7 @@ export interface DummyRuleMap {
   "vue/no-deprecated-props-default-this"?: DummyRule;
   "vue/no-deprecated-vue-config-keycodes"?: DummyRule;
   "vue/no-export-in-script-setup"?: DummyRule;
+  "vue/no-expose-after-await"?: DummyRule;
   "vue/no-import-compiler-macros"?: DummyRule;
   "vue/no-lifecycle-after-await"?: DummyRule;
   "vue/no-multiple-slot-args"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5025,6 +5025,15 @@ impl RuleRunner for crate::rules::vue::no_export_in_script_setup::NoExportInScri
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vue::no_expose_after_await::NoExposeAfterAwait {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::ExportDefaultDeclaration,
+        AstType::Program,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::no_import_compiler_macros::NoImportCompilerMacros {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -801,6 +801,7 @@ pub use crate::rules::vue::no_deprecated_model_definition::NoDeprecatedModelDefi
 pub use crate::rules::vue::no_deprecated_props_default_this::NoDeprecatedPropsDefaultThis as VueNoDeprecatedPropsDefaultThis;
 pub use crate::rules::vue::no_deprecated_vue_config_keycodes::NoDeprecatedVueConfigKeycodes as VueNoDeprecatedVueConfigKeycodes;
 pub use crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup as VueNoExportInScriptSetup;
+pub use crate::rules::vue::no_expose_after_await::NoExposeAfterAwait as VueNoExposeAfterAwait;
 pub use crate::rules::vue::no_import_compiler_macros::NoImportCompilerMacros as VueNoImportCompilerMacros;
 pub use crate::rules::vue::no_lifecycle_after_await::NoLifecycleAfterAwait as VueNoLifecycleAfterAwait;
 pub use crate::rules::vue::no_multiple_slot_args::NoMultipleSlotArgs as VueNoMultipleSlotArgs;
@@ -1630,6 +1631,7 @@ pub enum RuleEnum {
     VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis),
     VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes),
     VueNoExportInScriptSetup(VueNoExportInScriptSetup),
+    VueNoExposeAfterAwait(VueNoExposeAfterAwait),
     VueNoImportCompilerMacros(VueNoImportCompilerMacros),
     VueNoLifecycleAfterAwait(VueNoLifecycleAfterAwait),
     VueNoMultipleSlotArgs(VueNoMultipleSlotArgs),
@@ -2544,7 +2546,8 @@ const VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID: usize =
 const VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID: usize =
     VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID + 1usize;
 const VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID: usize = VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID + 1usize;
-const VUE_NO_IMPORT_COMPILER_MACROS_ID: usize = VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID + 1usize;
+const VUE_NO_EXPOSE_AFTER_AWAIT_ID: usize = VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID + 1usize;
+const VUE_NO_IMPORT_COMPILER_MACROS_ID: usize = VUE_NO_EXPOSE_AFTER_AWAIT_ID + 1usize;
 const VUE_NO_LIFECYCLE_AFTER_AWAIT_ID: usize = VUE_NO_IMPORT_COMPILER_MACROS_ID + 1usize;
 const VUE_NO_MULTIPLE_SLOT_ARGS_ID: usize = VUE_NO_LIFECYCLE_AFTER_AWAIT_ID + 1usize;
 const VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID: usize = VUE_NO_MULTIPLE_SLOT_ARGS_ID + 1usize;
@@ -3484,6 +3487,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(_) => VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID,
             Self::VueNoExportInScriptSetup(_) => VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID,
+            Self::VueNoExposeAfterAwait(_) => VUE_NO_EXPOSE_AFTER_AWAIT_ID,
             Self::VueNoImportCompilerMacros(_) => VUE_NO_IMPORT_COMPILER_MACROS_ID,
             Self::VueNoLifecycleAfterAwait(_) => VUE_NO_LIFECYCLE_AFTER_AWAIT_ID,
             Self::VueNoMultipleSlotArgs(_) => VUE_NO_MULTIPLE_SLOT_ARGS_ID,
@@ -4409,6 +4413,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::NAME,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::NAME,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::NAME,
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::NAME,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::NAME,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::NAME,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::NAME,
@@ -5392,6 +5397,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::CATEGORY,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::CATEGORY,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::CATEGORY,
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::CATEGORY,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::CATEGORY,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::CATEGORY,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::CATEGORY,
@@ -6318,6 +6324,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::FIX,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::FIX,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::FIX,
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::FIX,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::FIX,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::FIX,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::FIX,
@@ -7494,6 +7501,7 @@ impl RuleEnum {
                 VueNoDeprecatedVueConfigKeycodes::documentation()
             }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::documentation(),
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::documentation(),
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::documentation(),
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::documentation(),
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::documentation(),
@@ -9799,6 +9807,8 @@ impl RuleEnum {
             }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::config_schema(generator)
                 .or_else(|| VueNoExportInScriptSetup::schema(generator)),
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::config_schema(generator)
+                .or_else(|| VueNoExposeAfterAwait::schema(generator)),
             Self::VueNoImportCompilerMacros(_) => {
                 VueNoImportCompilerMacros::config_schema(generator)
                     .or_else(|| VueNoImportCompilerMacros::schema(generator))
@@ -10644,6 +10654,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(_) => "vue",
             Self::VueNoDeprecatedVueConfigKeycodes(_) => "vue",
             Self::VueNoExportInScriptSetup(_) => "vue",
+            Self::VueNoExposeAfterAwait(_) => "vue",
             Self::VueNoImportCompilerMacros(_) => "vue",
             Self::VueNoLifecycleAfterAwait(_) => "vue",
             Self::VueNoMultipleSlotArgs(_) => "vue",
@@ -13228,6 +13239,9 @@ impl RuleEnum {
             Self::VueNoExportInScriptSetup(_) => Ok(Self::VueNoExportInScriptSetup(
                 VueNoExportInScriptSetup::from_configuration(value)?,
             )),
+            Self::VueNoExposeAfterAwait(_) => {
+                Ok(Self::VueNoExposeAfterAwait(VueNoExposeAfterAwait::from_configuration(value)?))
+            }
             Self::VueNoImportCompilerMacros(_) => Ok(Self::VueNoImportCompilerMacros(
                 VueNoImportCompilerMacros::from_configuration(value)?,
             )),
@@ -14083,6 +14097,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.to_configuration(),
             Self::VueNoExportInScriptSetup(rule) => rule.to_configuration(),
+            Self::VueNoExposeAfterAwait(rule) => rule.to_configuration(),
             Self::VueNoImportCompilerMacros(rule) => rule.to_configuration(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.to_configuration(),
             Self::VueNoMultipleSlotArgs(rule) => rule.to_configuration(),
@@ -14908,6 +14923,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
+                Self::VueNoExposeAfterAwait(rule) => rule.run(node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
                 Self::VueNoLifecycleAfterAwait(rule) => rule.run(node, ctx),
                 Self::VueNoMultipleSlotArgs(rule) => rule.run(node, ctx),
@@ -15726,6 +15742,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
+                Self::VueNoExposeAfterAwait(rule) => rule.run(node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
                 Self::VueNoLifecycleAfterAwait(rule) => rule.run(node, ctx),
                 Self::VueNoMultipleSlotArgs(rule) => rule.run(node, ctx),
@@ -16551,6 +16568,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
+                Self::VueNoExposeAfterAwait(rule) => rule.run_once(ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
                 Self::VueNoLifecycleAfterAwait(rule) => rule.run_once(ctx),
                 Self::VueNoMultipleSlotArgs(rule) => rule.run_once(ctx),
@@ -17369,6 +17387,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
+                Self::VueNoExposeAfterAwait(rule) => rule.run_once(ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
                 Self::VueNoLifecycleAfterAwait(rule) => rule.run_once(ctx),
                 Self::VueNoMultipleSlotArgs(rule) => rule.run_once(ctx),
@@ -18449,6 +18468,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VueNoExportInScriptSetup(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoExposeAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoLifecycleAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoMultipleSlotArgs(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19521,6 +19541,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VueNoExportInScriptSetup(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoExposeAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoLifecycleAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoMultipleSlotArgs(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20337,6 +20358,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.should_run(ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.should_run(ctx),
+            Self::VueNoExposeAfterAwait(rule) => rule.should_run(ctx),
             Self::VueNoImportCompilerMacros(rule) => rule.should_run(ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.should_run(ctx),
             Self::VueNoMultipleSlotArgs(rule) => rule.should_run(ctx),
@@ -21512,6 +21534,7 @@ impl RuleEnum {
                 VueNoDeprecatedVueConfigKeycodes::IS_TSGOLINT_RULE
             }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::IS_TSGOLINT_RULE,
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::IS_TSGOLINT_RULE,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::IS_TSGOLINT_RULE,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::IS_TSGOLINT_RULE,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::IS_TSGOLINT_RULE,
@@ -22497,6 +22520,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::VERSION,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::VERSION,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::VERSION,
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::VERSION,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::VERSION,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::VERSION,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::VERSION,
@@ -23517,6 +23541,7 @@ impl RuleEnum {
                 VueNoDeprecatedVueConfigKeycodes::HAS_CONFIG
             }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::HAS_CONFIG,
+            Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::HAS_CONFIG,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::HAS_CONFIG,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::HAS_CONFIG,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::HAS_CONFIG,
@@ -24332,6 +24357,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.types_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.types_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.types_info(),
+            Self::VueNoExposeAfterAwait(rule) => rule.types_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.types_info(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.types_info(),
             Self::VueNoMultipleSlotArgs(rule) => rule.types_info(),
@@ -25147,6 +25173,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.run_info(),
+            Self::VueNoExposeAfterAwait(rule) => rule.run_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.run_info(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run_info(),
             Self::VueNoMultipleSlotArgs(rule) => rule.run_info(),
@@ -26094,6 +26121,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis::default()),
         RuleEnum::VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes::default()),
         RuleEnum::VueNoExportInScriptSetup(VueNoExportInScriptSetup::default()),
+        RuleEnum::VueNoExposeAfterAwait(VueNoExposeAfterAwait::default()),
         RuleEnum::VueNoImportCompilerMacros(VueNoImportCompilerMacros::default()),
         RuleEnum::VueNoLifecycleAfterAwait(VueNoLifecycleAfterAwait::default()),
         RuleEnum::VueNoMultipleSlotArgs(VueNoMultipleSlotArgs::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -841,6 +841,7 @@ pub(crate) mod vue {
     pub mod no_deprecated_props_default_this;
     pub mod no_deprecated_vue_config_keycodes;
     pub mod no_export_in_script_setup;
+    pub mod no_expose_after_await;
     pub mod no_import_compiler_macros;
     pub mod no_lifecycle_after_await;
     pub mod no_multiple_slot_args;

--- a/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
@@ -1,0 +1,458 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrowFunctionExpression, AwaitExpression, BindingPattern, CallExpression, ChainElement,
+        ExportDefaultDeclarationKind, Expression, ExpressionStatement, Function, ObjectExpression,
+        ObjectPropertyKind, Program, Statement,
+    },
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::{ScopeFlags, Scoping, SymbolId};
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
+
+fn no_expose_after_await_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`{name}` is forbidden after an `await` expression."))
+        .with_help(
+            "`expose` should be called synchronously in `setup()` \
+            (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoExposeAfterAwait;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow asynchronously registered `expose`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `defineExpose` and `context.expose()` registered after an `await`
+    /// expression in `<script setup>` or `setup()` may not work as expected
+    /// because they are registered after the component instance has finished
+    /// setting up.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script setup>
+    /// await doSomething()
+    /// defineExpose({ /* ... */ }) // error
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script setup>
+    /// defineExpose({ /* ... */ }) // ok
+    /// await doSomething()
+    /// </script>
+    /// ```
+    NoExposeAfterAwait,
+    vue,
+    correctness,
+    version = "next",
+);
+
+impl Rule for NoExposeAfterAwait {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            // e.g. `export default { setup() {} }`
+            AstKind::ExportDefaultDeclaration(export_decl) => {
+                if let ExportDefaultDeclarationKind::ObjectExpression(obj_expr) =
+                    &export_decl.declaration
+                {
+                    check_setup_in_object(obj_expr, ctx);
+                }
+            }
+            // e.g. `defineComponent({ setup() {} })`
+            AstKind::CallExpression(call_expr) => {
+                if let Some(ident) = call_expr.callee.get_identifier_reference()
+                    && ident.name == "defineComponent"
+                    && let Some(first_arg) = call_expr.arguments.first()
+                    && let Some(Expression::ObjectExpression(obj_expr)) = first_arg.as_expression()
+                {
+                    check_setup_in_object(obj_expr, ctx);
+                }
+            }
+            // <script setup>
+            AstKind::Program(program) if ctx.frameworks_options() == FrameworkOptions::VueSetup => {
+                check_script_setup(program, ctx);
+            }
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+}
+
+fn check_setup_in_object<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+    let Some(setup_prop) = obj_expr.properties.iter().find_map(|prop| {
+        let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else {
+            return None;
+        };
+        obj_prop.key.static_name().is_some_and(|name| name == "setup").then_some(obj_prop)
+    }) else {
+        return;
+    };
+
+    let (params, body) = match &setup_prop.value {
+        Expression::FunctionExpression(func) => (&func.params, func.body.as_ref()),
+        Expression::ArrowFunctionExpression(arrow) => (&arrow.params, Some(&arrow.body)),
+        _ => return,
+    };
+    let Some(body) = body else {
+        return;
+    };
+
+    let Some(second_param) = params.items.get(1) else {
+        return;
+    };
+
+    let binding = match &second_param.pattern {
+        // `setup(_, {expose})` — destructured `expose`
+        BindingPattern::ObjectPattern(obj_pat) => obj_pat.properties.iter().find_map(|prop| {
+            let key_name = prop.key.static_name()?;
+            if key_name != "expose" {
+                return None;
+            }
+            let binding_id = prop.value.get_binding_identifier()?;
+            binding_id.symbol_id.get().map(ExposeBinding::Expose)
+        }),
+        // `setup(_, ctx)` — whole context bound to a name
+        BindingPattern::BindingIdentifier(binding_id) => {
+            binding_id.symbol_id.get().map(ExposeBinding::Ctx)
+        }
+        _ => None,
+    };
+
+    let Some(binding) = binding else {
+        return;
+    };
+
+    let scoping = ctx.scoping();
+    let mut visitor = ExposeAfterAwaitVisitor::new(scoping, binding);
+    visitor.visit_function_body(body);
+
+    visitor.errors.iter().for_each(|(span, name)| {
+        ctx.diagnostic(no_expose_after_await_diagnostic(*span, name));
+    });
+}
+
+fn check_script_setup<'a>(program: &Program<'a>, ctx: &LintContext<'a>) {
+    let mut after_await = false;
+    for stmt in &program.body {
+        if after_await
+            && let Statement::ExpressionStatement(expr_stmt) = stmt
+            && let Some(call_expr) = extract_call_expression(&expr_stmt.expression)
+            && let Some(ident) = call_expr.callee.get_inner_expression().get_identifier_reference()
+            && ident.name == "defineExpose"
+        {
+            ctx.diagnostic(no_expose_after_await_diagnostic(call_expr.span, "defineExpose"));
+        }
+
+        if !after_await {
+            let mut detector = AwaitDetector::default();
+            detector.visit_statement(stmt);
+            if detector.found {
+                after_await = true;
+            }
+        }
+    }
+}
+
+fn extract_call_expression<'a, 'b>(expr: &'b Expression<'a>) -> Option<&'b CallExpression<'a>> {
+    match expr.get_inner_expression() {
+        Expression::CallExpression(c) => Some(c),
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::CallExpression(c) => Some(c),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+struct AwaitDetector {
+    found: bool,
+}
+
+impl<'a> Visit<'a> for AwaitDetector {
+    fn visit_await_expression(&mut self, _: &AwaitExpression) {
+        self.found = true;
+    }
+
+    fn visit_function(&mut self, _: &Function<'a>, _: ScopeFlags) {}
+
+    fn visit_arrow_function_expression(&mut self, _: &ArrowFunctionExpression<'a>) {}
+}
+
+enum ExposeBinding {
+    /// `setup(_, {expose})` — detect bare `expose(...)` calls
+    Expose(SymbolId),
+    /// `setup(_, ctx)` — detect `ctx.expose(...)` member calls
+    Ctx(SymbolId),
+}
+
+struct ExposeAfterAwaitVisitor<'a> {
+    found: bool,
+    errors: Vec<(Span, String)>,
+    scoping: &'a Scoping,
+    binding: ExposeBinding,
+}
+
+impl<'a> ExposeAfterAwaitVisitor<'a> {
+    fn new(scoping: &'a Scoping, binding: ExposeBinding) -> Self {
+        Self { found: false, errors: Vec::new(), scoping, binding }
+    }
+
+    fn matches_target(&self, call_expr: &CallExpression<'a>) -> bool {
+        let callee = call_expr.callee.get_inner_expression();
+
+        match self.binding {
+            ExposeBinding::Expose(expose_id) => {
+                let Some(ident) = callee.get_identifier_reference() else {
+                    return false;
+                };
+                let reference = self.scoping.get_reference(ident.reference_id());
+                reference.symbol_id() == Some(expose_id)
+            }
+            ExposeBinding::Ctx(ctx_id) => {
+                let Expression::StaticMemberExpression(member) = callee else {
+                    return false;
+                };
+                if member.property.name != "expose" {
+                    return false;
+                }
+                let Some(obj_ident) =
+                    member.object.get_inner_expression().get_identifier_reference()
+                else {
+                    return false;
+                };
+                let reference = self.scoping.get_reference(obj_ident.reference_id());
+                reference.symbol_id() == Some(ctx_id)
+            }
+        }
+    }
+}
+
+impl<'a> Visit<'a> for ExposeAfterAwaitVisitor<'a> {
+    fn visit_await_expression(&mut self, _expr: &AwaitExpression) {
+        self.found = true;
+    }
+
+    // Only `ExpressionStatement` direct children are reported. Stop handles such
+    // as `var a = expose()`, `c = expose()`, `d(expose())`, `{ foo: expose() }`,
+    // `[expose()]` are wrapped in another expression and are intentionally ignored.
+    fn visit_expression_statement(&mut self, stmt: &ExpressionStatement<'a>) {
+        if !self.found {
+            walk::walk_expression_statement(self, stmt);
+            return;
+        }
+
+        if let Some(call_expr) = extract_call_expression(&stmt.expression)
+            && self.matches_target(call_expr)
+        {
+            self.errors.push((call_expr.span, "expose".to_string()));
+        }
+
+        walk::walk_expression_statement(self, stmt);
+    }
+
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+
+    fn visit_arrow_function_expression(&mut self, _func: &ArrowFunctionExpression<'a>) {}
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, {expose}) {
+                      expose({ /* ... */ }) // ok
+                      await doSomething()
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, ctx) {
+                      ctx.expose({ /* ... */ }) // ok
+                      await doSomething()
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, {expose}) {
+                      expose({ /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, ctx) {
+                      ctx.expose({ /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async _setup(_, {expose}) {
+                      expose({ /* ... */ })
+                      await doSomething()
+                      expose({ /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async _setup(_, ctx) {
+                      ctx.expose({ /* ... */ })
+                      await doSomething()
+                      ctx.expose({ /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  defineExpose({ /* ... */ })
+                  await doSomething()
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  await doSomething()
+                  {
+                    defineExpose({ /* ... */ })
+                  }
+                  function defineExpose() {}
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  import { onMounted } from 'vue';
+                  await doSomething()
+                  onMounted(() => {})
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, {expose}) {
+                      await doSomething()
+                      expose({ /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, ctx) {
+                      await doSomething()
+                      ctx.expose({ /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  await doSomething()
+                  defineExpose({ /* ... */ })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(NoExposeAfterAwait::NAME, NoExposeAfterAwait::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_expose_after_await.rs
@@ -2,8 +2,8 @@ use oxc_ast::{
     AstKind,
     ast::{
         ArrowFunctionExpression, AwaitExpression, BindingPattern, CallExpression, ChainElement,
-        ExportDefaultDeclarationKind, Expression, ExpressionStatement, Function, ObjectExpression,
-        ObjectPropertyKind, Program, Statement,
+        ExportDefaultDeclarationKind, Expression, Function, ObjectExpression, ObjectPropertyKind,
+        Program, Statement,
     },
 };
 use oxc_ast_visit::{Visit, walk};
@@ -250,22 +250,17 @@ impl<'a> Visit<'a> for ExposeAfterAwaitVisitor<'a> {
         self.found = true;
     }
 
-    // Only `ExpressionStatement` direct children are reported. Stop handles such
-    // as `var a = expose()`, `c = expose()`, `d(expose())`, `{ foo: expose() }`,
-    // `[expose()]` are wrapped in another expression and are intentionally ignored.
-    fn visit_expression_statement(&mut self, stmt: &ExpressionStatement<'a>) {
+    fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         if !self.found {
-            walk::walk_expression_statement(self, stmt);
+            walk::walk_call_expression(self, call_expr);
             return;
         }
 
-        if let Some(call_expr) = extract_call_expression(&stmt.expression)
-            && self.matches_target(call_expr)
-        {
+        if self.matches_target(call_expr) {
             self.errors.push((call_expr.span, "expose".to_string()));
         }
 
-        walk::walk_expression_statement(self, stmt);
+        walk::walk_call_expression(self, call_expr);
     }
 
     fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
@@ -407,6 +402,22 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, ctx) {
+                      await doSomething()
+                      const expose = ctx.expose
+                      expose({ /* ... */ })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     let fail = vec![
@@ -445,6 +456,38 @@ fn test() {
                   <script setup>
                   await doSomething()
                   defineExpose({ /* ... */ })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, {expose}) {
+                      await doSomething()
+                      const a = expose({ /* ... */ })
+                      b(expose())
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  export default {
+                    async setup(_, ctx) {
+                      await doSomething()
+                      const a = ctx.expose({ /* ... */ })
+                      b(ctx.expose())
+                    }
+                  }
                   </script>
                   ",
             None,

--- a/crates/oxc_linter/src/snapshots/vue_no_expose_after_await.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_expose_after_await.snap
@@ -28,3 +28,39 @@ source: crates/oxc_linter/src/tester.rs
  5 │                   </script>
    ╰────
   help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.
+
+  ⚠ vue(no-expose-after-await): `expose` is forbidden after an `await` expression.
+   ╭─[no_expose_after_await.tsx:6:33]
+ 5 │                       await doSomething()
+ 6 │                       const a = expose({ /* ... */ })
+   ·                                 ─────────────────────
+ 7 │                       b(expose())
+   ╰────
+  help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.
+
+  ⚠ vue(no-expose-after-await): `expose` is forbidden after an `await` expression.
+   ╭─[no_expose_after_await.tsx:7:25]
+ 6 │                       const a = expose({ /* ... */ })
+ 7 │                       b(expose())
+   ·                         ────────
+ 8 │                     }
+   ╰────
+  help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.
+
+  ⚠ vue(no-expose-after-await): `expose` is forbidden after an `await` expression.
+   ╭─[no_expose_after_await.tsx:6:33]
+ 5 │                       await doSomething()
+ 6 │                       const a = ctx.expose({ /* ... */ })
+   ·                                 ─────────────────────────
+ 7 │                       b(ctx.expose())
+   ╰────
+  help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.
+
+  ⚠ vue(no-expose-after-await): `expose` is forbidden after an `await` expression.
+   ╭─[no_expose_after_await.tsx:7:25]
+ 6 │                       const a = ctx.expose({ /* ... */ })
+ 7 │                       b(ctx.expose())
+   ·                         ────────────
+ 8 │                     }
+   ╰────
+  help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.

--- a/crates/oxc_linter/src/snapshots/vue_no_expose_after_await.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_expose_after_await.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(no-expose-after-await): `expose` is forbidden after an `await` expression.
+   ╭─[no_expose_after_await.tsx:6:23]
+ 5 │                       await doSomething()
+ 6 │                       expose({ /* ... */ })
+   ·                       ─────────────────────
+ 7 │                     }
+   ╰────
+  help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.
+
+  ⚠ vue(no-expose-after-await): `expose` is forbidden after an `await` expression.
+   ╭─[no_expose_after_await.tsx:6:23]
+ 5 │                       await doSomething()
+ 6 │                       ctx.expose({ /* ... */ })
+   ·                       ─────────────────────────
+ 7 │                     }
+   ╰────
+  help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.
+
+  ⚠ vue(no-expose-after-await): `defineExpose` is forbidden after an `await` expression.
+   ╭─[no_expose_after_await.tsx:4:19]
+ 3 │                   await doSomething()
+ 4 │                   defineExpose({ /* ... */ })
+   ·                   ───────────────────────────
+ 5 │                   </script>
+   ╰────
+  help: `expose` should be called synchronously in `setup()` (or `defineExpose()` in `<script setup>`). Move the call before the first `await`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2617,6 +2617,9 @@
         "vue/no-export-in-script-setup": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-expose-after-await": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-import-compiler-macros": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2621,6 +2621,9 @@ expression: json
         "vue/no-export-in-script-setup": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-expose-after-await": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-import-compiler-macros": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/no-expose-after-await.html

AI disclosure: implemented with Claude Code, reviewed manually.