### PR TITLE
feat(linter/typescript): implement `method-signature-style` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -993,6 +993,7 @@ export interface DummyRuleMap {
   "typescript/explicit-function-return-type"?: DummyRule;
   "typescript/explicit-member-accessibility"?: DummyRule;
   "typescript/explicit-module-boundary-types"?: DummyRule;
+  "typescript/method-signature-style"?: DummyRule;
   "typescript/no-array-delete"?: DummyRule;
   "typescript/no-base-to-string"?: DummyRule;
   "typescript/no-confusing-non-null-assertion"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1592,6 +1592,14 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::typescript::method_signature_style::MethodSignatureStyle {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::TSMethodSignature,
+        AstType::TSPropertySignature,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::typescript::no_array_delete::NoArrayDelete {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -496,6 +496,7 @@ pub use crate::rules::typescript::dot_notation::DotNotation as TypescriptDotNota
 pub use crate::rules::typescript::explicit_function_return_type::ExplicitFunctionReturnType as TypescriptExplicitFunctionReturnType;
 pub use crate::rules::typescript::explicit_member_accessibility::ExplicitMemberAccessibility as TypescriptExplicitMemberAccessibility;
 pub use crate::rules::typescript::explicit_module_boundary_types::ExplicitModuleBoundaryTypes as TypescriptExplicitModuleBoundaryTypes;
+pub use crate::rules::typescript::method_signature_style::MethodSignatureStyle as TypescriptMethodSignatureStyle;
 pub use crate::rules::typescript::no_array_delete::NoArrayDelete as TypescriptNoArrayDelete;
 pub use crate::rules::typescript::no_base_to_string::NoBaseToString as TypescriptNoBaseToString;
 pub use crate::rules::typescript::no_confusing_non_null_assertion::NoConfusingNonNullAssertion as TypescriptNoConfusingNonNullAssertion;
@@ -1070,6 +1071,7 @@ pub enum RuleEnum {
     TypescriptExplicitFunctionReturnType(TypescriptExplicitFunctionReturnType),
     TypescriptExplicitMemberAccessibility(TypescriptExplicitMemberAccessibility),
     TypescriptExplicitModuleBoundaryTypes(TypescriptExplicitModuleBoundaryTypes),
+    TypescriptMethodSignatureStyle(TypescriptMethodSignatureStyle),
     TypescriptNoArrayDelete(TypescriptNoArrayDelete),
     TypescriptNoBaseToString(TypescriptNoBaseToString),
     TypescriptNoConfusingNonNullAssertion(TypescriptNoConfusingNonNullAssertion),
@@ -1904,7 +1906,9 @@ const TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID: usize =
     TYPESCRIPT_EXPLICIT_FUNCTION_RETURN_TYPE_ID + 1usize;
 const TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID: usize =
     TYPESCRIPT_EXPLICIT_MEMBER_ACCESSIBILITY_ID + 1usize;
-const TYPESCRIPT_NO_ARRAY_DELETE_ID: usize = TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID + 1usize;
+const TYPESCRIPT_METHOD_SIGNATURE_STYLE_ID: usize =
+    TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID + 1usize;
+const TYPESCRIPT_NO_ARRAY_DELETE_ID: usize = TYPESCRIPT_METHOD_SIGNATURE_STYLE_ID + 1usize;
 const TYPESCRIPT_NO_BASE_TO_STRING_ID: usize = TYPESCRIPT_NO_ARRAY_DELETE_ID + 1usize;
 const TYPESCRIPT_NO_CONFUSING_NON_NULL_ASSERTION_ID: usize =
     TYPESCRIPT_NO_BASE_TO_STRING_ID + 1usize;
@@ -2837,6 +2841,7 @@ impl RuleEnum {
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TYPESCRIPT_EXPLICIT_MODULE_BOUNDARY_TYPES_ID
             }
+            Self::TypescriptMethodSignatureStyle(_) => TYPESCRIPT_METHOD_SIGNATURE_STYLE_ID,
             Self::TypescriptNoArrayDelete(_) => TYPESCRIPT_NO_ARRAY_DELETE_ID,
             Self::TypescriptNoBaseToString(_) => TYPESCRIPT_NO_BASE_TO_STRING_ID,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -3782,6 +3787,7 @@ impl RuleEnum {
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::NAME
             }
+            Self::TypescriptMethodSignatureStyle(_) => TypescriptMethodSignatureStyle::NAME,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::NAME,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::NAME,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -4721,6 +4727,7 @@ impl RuleEnum {
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::CATEGORY
             }
+            Self::TypescriptMethodSignatureStyle(_) => TypescriptMethodSignatureStyle::CATEGORY,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::CATEGORY,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::CATEGORY,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -5703,6 +5710,7 @@ impl RuleEnum {
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::FIX
             }
+            Self::TypescriptMethodSignatureStyle(_) => TypescriptMethodSignatureStyle::FIX,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::FIX,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::FIX,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -6674,6 +6682,9 @@ impl RuleEnum {
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::documentation()
+            }
+            Self::TypescriptMethodSignatureStyle(_) => {
+                TypescriptMethodSignatureStyle::documentation()
             }
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::documentation(),
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::documentation(),
@@ -8193,6 +8204,10 @@ impl RuleEnum {
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::config_schema(generator)
                     .or_else(|| TypescriptExplicitModuleBoundaryTypes::schema(generator))
+            }
+            Self::TypescriptMethodSignatureStyle(_) => {
+                TypescriptMethodSignatureStyle::config_schema(generator)
+                    .or_else(|| TypescriptMethodSignatureStyle::schema(generator))
             }
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::config_schema(generator)
                 .or_else(|| TypescriptNoArrayDelete::schema(generator)),
@@ -10167,6 +10182,7 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(_) => "typescript",
             Self::TypescriptExplicitMemberAccessibility(_) => "typescript",
             Self::TypescriptExplicitModuleBoundaryTypes(_) => "typescript",
+            Self::TypescriptMethodSignatureStyle(_) => "typescript",
             Self::TypescriptNoArrayDelete(_) => "typescript",
             Self::TypescriptNoBaseToString(_) => "typescript",
             Self::TypescriptNoConfusingNonNullAssertion(_) => "typescript",
@@ -11475,6 +11491,9 @@ impl RuleEnum {
                     TypescriptExplicitModuleBoundaryTypes::from_configuration(value)?,
                 ))
             }
+            Self::TypescriptMethodSignatureStyle(_) => Ok(Self::TypescriptMethodSignatureStyle(
+                TypescriptMethodSignatureStyle::from_configuration(value)?,
+            )),
             Self::TypescriptNoArrayDelete(_) => Ok(Self::TypescriptNoArrayDelete(
                 TypescriptNoArrayDelete::from_configuration(value)?,
             )),
@@ -13628,6 +13647,7 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.to_configuration(),
             Self::TypescriptExplicitMemberAccessibility(rule) => rule.to_configuration(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.to_configuration(),
+            Self::TypescriptMethodSignatureStyle(rule) => rule.to_configuration(),
             Self::TypescriptNoArrayDelete(rule) => rule.to_configuration(),
             Self::TypescriptNoBaseToString(rule) => rule.to_configuration(),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.to_configuration(),
@@ -14459,6 +14479,7 @@ impl RuleEnum {
                 Self::TypescriptExplicitFunctionReturnType(rule) => rule.run(node, ctx),
                 Self::TypescriptExplicitMemberAccessibility(rule) => rule.run(node, ctx),
                 Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run(node, ctx),
+                Self::TypescriptMethodSignatureStyle(rule) => rule.run(node, ctx),
                 Self::TypescriptNoArrayDelete(rule) => rule.run(node, ctx),
                 Self::TypescriptNoBaseToString(rule) => rule.run(node, ctx),
                 Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run(node, ctx),
@@ -15283,6 +15304,7 @@ impl RuleEnum {
                 Self::TypescriptExplicitFunctionReturnType(rule) => rule.run(node, ctx),
                 Self::TypescriptExplicitMemberAccessibility(rule) => rule.run(node, ctx),
                 Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run(node, ctx),
+                Self::TypescriptMethodSignatureStyle(rule) => rule.run(node, ctx),
                 Self::TypescriptNoArrayDelete(rule) => rule.run(node, ctx),
                 Self::TypescriptNoBaseToString(rule) => rule.run(node, ctx),
                 Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run(node, ctx),
@@ -16114,6 +16136,7 @@ impl RuleEnum {
                 Self::TypescriptExplicitFunctionReturnType(rule) => rule.run_once(ctx),
                 Self::TypescriptExplicitMemberAccessibility(rule) => rule.run_once(ctx),
                 Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run_once(ctx),
+                Self::TypescriptMethodSignatureStyle(rule) => rule.run_once(ctx),
                 Self::TypescriptNoArrayDelete(rule) => rule.run_once(ctx),
                 Self::TypescriptNoBaseToString(rule) => rule.run_once(ctx),
                 Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run_once(ctx),
@@ -16938,6 +16961,7 @@ impl RuleEnum {
                 Self::TypescriptExplicitFunctionReturnType(rule) => rule.run_once(ctx),
                 Self::TypescriptExplicitMemberAccessibility(rule) => rule.run_once(ctx),
                 Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run_once(ctx),
+                Self::TypescriptMethodSignatureStyle(rule) => rule.run_once(ctx),
                 Self::TypescriptNoArrayDelete(rule) => rule.run_once(ctx),
                 Self::TypescriptNoBaseToString(rule) => rule.run_once(ctx),
                 Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run_once(ctx),
@@ -17810,6 +17834,7 @@ impl RuleEnum {
                 Self::TypescriptExplicitModuleBoundaryTypes(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::TypescriptMethodSignatureStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::TypescriptNoArrayDelete(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::TypescriptNoBaseToString(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::TypescriptNoConfusingNonNullAssertion(rule) => {
@@ -18890,6 +18915,7 @@ impl RuleEnum {
                 Self::TypescriptExplicitModuleBoundaryTypes(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::TypescriptMethodSignatureStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::TypescriptNoArrayDelete(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::TypescriptNoBaseToString(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::TypescriptNoConfusingNonNullAssertion(rule) => {
@@ -19932,6 +19958,7 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.should_run(ctx),
             Self::TypescriptExplicitMemberAccessibility(rule) => rule.should_run(ctx),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.should_run(ctx),
+            Self::TypescriptMethodSignatureStyle(rule) => rule.should_run(ctx),
             Self::TypescriptNoArrayDelete(rule) => rule.should_run(ctx),
             Self::TypescriptNoBaseToString(rule) => rule.should_run(ctx),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.should_run(ctx),
@@ -20808,6 +20835,9 @@ impl RuleEnum {
             }
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::IS_TSGOLINT_RULE
+            }
+            Self::TypescriptMethodSignatureStyle(_) => {
+                TypescriptMethodSignatureStyle::IS_TSGOLINT_RULE
             }
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::IS_TSGOLINT_RULE,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::IS_TSGOLINT_RULE,
@@ -21970,6 +22000,7 @@ impl RuleEnum {
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::VERSION
             }
+            Self::TypescriptMethodSignatureStyle(_) => TypescriptMethodSignatureStyle::VERSION,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::VERSION,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::VERSION,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -22966,6 +22997,7 @@ impl RuleEnum {
             Self::TypescriptExplicitModuleBoundaryTypes(_) => {
                 TypescriptExplicitModuleBoundaryTypes::HAS_CONFIG
             }
+            Self::TypescriptMethodSignatureStyle(_) => TypescriptMethodSignatureStyle::HAS_CONFIG,
             Self::TypescriptNoArrayDelete(_) => TypescriptNoArrayDelete::HAS_CONFIG,
             Self::TypescriptNoBaseToString(_) => TypescriptNoBaseToString::HAS_CONFIG,
             Self::TypescriptNoConfusingNonNullAssertion(_) => {
@@ -23963,6 +23995,7 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.types_info(),
             Self::TypescriptExplicitMemberAccessibility(rule) => rule.types_info(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.types_info(),
+            Self::TypescriptMethodSignatureStyle(rule) => rule.types_info(),
             Self::TypescriptNoArrayDelete(rule) => rule.types_info(),
             Self::TypescriptNoBaseToString(rule) => rule.types_info(),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.types_info(),
@@ -24784,6 +24817,7 @@ impl RuleEnum {
             Self::TypescriptExplicitFunctionReturnType(rule) => rule.run_info(),
             Self::TypescriptExplicitMemberAccessibility(rule) => rule.run_info(),
             Self::TypescriptExplicitModuleBoundaryTypes(rule) => rule.run_info(),
+            Self::TypescriptMethodSignatureStyle(rule) => rule.run_info(),
             Self::TypescriptNoArrayDelete(rule) => rule.run_info(),
             Self::TypescriptNoBaseToString(rule) => rule.run_info(),
             Self::TypescriptNoConfusingNonNullAssertion(rule) => rule.run_info(),
@@ -25643,6 +25677,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::TypescriptExplicitModuleBoundaryTypes(
             TypescriptExplicitModuleBoundaryTypes::default(),
         ),
+        RuleEnum::TypescriptMethodSignatureStyle(TypescriptMethodSignatureStyle::default()),
         RuleEnum::TypescriptNoArrayDelete(TypescriptNoArrayDelete::default()),
         RuleEnum::TypescriptNoBaseToString(TypescriptNoBaseToString::default()),
         RuleEnum::TypescriptNoConfusingNonNullAssertion(

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -248,6 +248,7 @@ pub(crate) mod typescript {
     pub mod explicit_function_return_type;
     pub mod explicit_member_accessibility;
     pub mod explicit_module_boundary_types;
+    pub mod method_signature_style;
     pub mod no_array_delete;
     pub mod no_base_to_string;
     pub mod no_confusing_non_null_assertion;

--- a/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_ast::{
     AstKind,
     ast::{TSMethodSignatureKind, TSType},
@@ -5,8 +8,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
@@ -1,0 +1,912 @@
+use oxc_ast::{
+    AstKind,
+    ast::{TSMethodSignatureKind, TSType},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn method_signature_style_diagnostic(
+    config: MethodSignatureStyleConfig,
+    span: Span,
+) -> OxcDiagnostic {
+    let (message, help) = match config {
+        MethodSignatureStyleConfig::Property => (
+            "Use a property signature instead of a method signature.",
+            "Replace the method signature with a property whose type is a function type.",
+        ),
+        MethodSignatureStyleConfig::Method => (
+            "Use a method signature instead of a property signature.",
+            "Replace the property signature with method shorthand syntax.",
+        ),
+    };
+
+    OxcDiagnostic::warn(message).with_help(help).with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum MethodSignatureStyleConfig {
+    #[default]
+    /// Enforce using property signature for functions. Use this to enforce maximum correctness together with TypeScript's strict mode.
+    Property,
+    /// Enforce using method signature for functions. Use this if you aren't using TypeScript's strict mode and prefer this style.
+    Method,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct MethodSignatureStyle(MethodSignatureStyleConfig);
+
+impl MethodSignatureStyle {
+    fn is_property_style(&self) -> bool {
+        self.0 == MethodSignatureStyleConfig::Property
+    }
+
+    fn is_method_style(&self) -> bool {
+        self.0 == MethodSignatureStyleConfig::Method
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce using a particular method signature syntax.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// TypeScript provides two ways to define an object/interface function property:
+    ///
+    /// ```ts
+    /// interface Example {
+    ///   // method shorthand syntax
+    ///   func(arg: string): number;
+    ///
+    ///   // regular property with function type
+    ///   func: (arg: string) => number;
+    /// }
+    /// ```
+    ///
+    /// The two are very similar; most of the time it doesn't matter which one you use.
+    /// However, when TypeScript's `strictFunctionTypes` option is enabled, there is an important difference: methods are always bivariant in their arguments, while function properties are contravariant.
+    /// This means that switching from method syntax to property syntax (or vice versa) can cause TypeScript to report new type errors or stop reporting existing ones.
+    ///
+    /// A good practice is to use the TypeScript's `strict` option (which implies `strictFunctionTypes`) which enables correct typechecking for function properties only (method signatures get old behavior).
+    ///
+    /// TypeScript FAQ:
+    ///
+    /// > A method and a function property of the same type behave differently.
+    /// > Methods are always bivariant in their argument, while function properties are contravariant in their argument under `strictFunctionTypes`.
+    ///
+    /// See the reasoning behind that in the [TypeScript PR for the compiler option](https://github.com/microsoft/TypeScript/pull/18654).
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule with `property` option:
+    /// ```ts
+    /// interface T1 {
+    ///   func(arg: string): number;
+    /// }
+    /// type T2 = {
+    ///   func(arg: boolean): void;
+    /// };
+    /// interface T3 {
+    ///   func(arg: number): void;
+    ///   func(arg: string): void;
+    ///   func(arg: boolean): void;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with `property` option:
+    /// ```ts
+    /// interface T1 {
+    ///   func: (arg: string) => number;
+    /// }
+    /// type T2 = {
+    ///   func: (arg: boolean) => void;
+    /// };
+    /// // this is equivalent to the overload
+    /// interface T3 {
+    ///   func: ((arg: number) => void) &
+    ///     ((arg: string) => void) &
+    ///     ((arg: boolean) => void);
+    /// }
+    /// ```
+    ///
+    /// Examples of **incorrect** code for this rule with `method` option:
+    /// ```ts
+    /// interface T1 {
+    ///   func: (arg: string) => number;
+    /// }
+    /// type T2 = {
+    ///   func: (arg: boolean) => void;
+    /// };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with `method` option:
+    /// ```ts
+    /// interface T1 {
+    ///   func(arg: string): number;
+    /// }
+    /// type T2 = {
+    ///   func(arg: boolean): void;
+    /// };
+    /// ```
+    MethodSignatureStyle,
+    typescript,
+    style,
+    pending,
+    version = "next",
+    config = MethodSignatureStyleConfig
+);
+
+impl Rule for MethodSignatureStyle {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::TSMethodSignature(ts_method) if self.is_property_style() => {
+                if ts_method.kind != TSMethodSignatureKind::Method {
+                    return;
+                }
+
+                ctx.diagnostic(method_signature_style_diagnostic(self.0, ts_method.span));
+            }
+            AstKind::TSPropertySignature(ts_property) if self.is_method_style() => {
+                if !ts_property.type_annotation.as_ref().is_some_and(|type_annotation| {
+                    matches!(&type_annotation.type_annotation, TSType::TSFunctionType(_))
+                }) {
+                    return;
+                }
+
+                ctx.diagnostic(method_signature_style_diagnostic(self.0, ts_property.span));
+            }
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_typescript()
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+            interface Test {
+              f: (a: string) => number;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            interface Test {
+              ['f']: (a: boolean) => void;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            interface Test {
+              f: <T>(a: T) => T;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            interface Test {
+              ['f']: <T extends {}>(a: T, b: T) => T;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            interface Test {
+              'f!': </* a */ T>(/* b */ x: any /* c */) => void;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            interface Test {
+              get f(): number;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            interface Test {
+              set f(value: number);
+            }
+                ",
+            None,
+        ),
+        ("type Test = { readonly f: (a: string) => number };", None),
+        ("type Test = { ['f']?: (a: boolean) => void };", None),
+        ("type Test = { readonly f?: <T>(a?: T) => T };", None),
+        ("type Test = { readonly ['f']?: <T>(a: T, b: T) => T };", None),
+        ("type Test = { get f(): number };", None),
+        ("type Test = { set f(value: number) };", None),
+        (
+            "
+                    interface Test {
+                      f(a: string): number;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      ['f'](a: boolean): void;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      f<T>(a: T): T;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      ['f']<T extends {}>(a: T, b: T): T;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      'f!'</* a */ T>(/* b */ x: any /* c */): void;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { f(a: string): number };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { ['f']?(a: boolean): void };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { f?<T>(a?: T): T };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { ['f']?<T>(a: T, b: T): T };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                  interface Test {
+                    get f(): number;
+                  }
+                ",
+            None,
+        ),
+        (
+            "
+                  interface Test {
+                    set f(value: number);
+                  }
+                ",
+            None,
+        ),
+        (
+            "
+                    type Test = { get f(): number };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { set f(value: number) };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+    ];
+
+    let fail = vec![
+        ("
+                    interface Test {
+                      f(a: string): number;
+                    }
+                  ", None),
+("
+                    interface Test {
+                      ['f'](a: boolean): void;
+                    }
+                  ", None),
+("
+                    interface Test {
+                      f<T>(a: T): T;
+                    }
+                  ", None),
+("
+                    interface Test {
+                      ['f']<T extends {}>(a: T, b: T): T;
+                    }
+                  ", None),
+("
+                    interface Test {
+                      'f!'</* a */ T>(/* b */ x: any /* c */): void;
+                    }
+                  ", None),
+("
+                    type Test = { f(a: string): number };
+                  ", None),
+("
+                    type Test = { ['f']?(a: boolean): void };
+                  ", None),
+("
+                    type Test = { f?<T>(a?: T): T };
+                  ", None),
+("
+                    type Test = { ['f']?<T>(a: T, b: T): T };
+                  ", None),
+("
+                    interface Test {
+                      f: (a: string) => number;
+                    }
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    interface Test {
+                      ['f']: (a: boolean) => void;
+                    }
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    interface Test {
+                      f: <T>(a: T) => T;
+                    }
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    interface Test {
+                      ['f']: <T extends {}>(a: T, b: T) => T;
+                    }
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    interface Test {
+                      'f!': </* a */ T>(/* b */ x: any /* c */) => void;
+                    }
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    type Test = { f: (a: string) => number };
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    type Test = { ['f']?: (a: boolean) => void };
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    type Test = { f?: <T>(a?: T) => T };
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    type Test = { ['f']?: <T>(a: T, b: T) => T };
+                  ", Some(serde_json::json!(["method"]))),
+("
+            interface Foo {
+              semi(arg: string): void;
+              comma(arg: string): void,
+              none(arg: string): void
+            }
+                  ", None),
+("
+            interface Foo {
+              semi: (arg: string) => void;
+              comma: (arg: string) => void,
+              none: (arg: string) => void
+            }
+                  ", Some(serde_json::json!(["method"]))),
+("
+            interface Foo {
+              x(
+                args: Pick<
+                  Bar,
+                  'one' | 'two' | 'three'
+                >,
+              ): Baz;
+              y(
+                foo: string,
+                bar: number,
+              ): void;
+            }
+                  ", None),
+("
+            interface Foo {
+              foo(): one;
+              foo(): two;
+              foo(): three;
+            }
+                  ", None),
+("
+            interface Foo {
+              foo(bar: string): one;
+              foo(bar: number, baz: string): two;
+              foo(): three;
+            }
+                  ", None),
+("
+            interface Foo {
+              [foo](bar: string): one;
+              [foo](bar: number, baz: string): two;
+              [foo](): three;
+            }
+                  ", None),
+("
+            interface Foo {
+              [foo](bar: string): one;
+              [foo](bar: number, baz: string): two;
+              [foo](): three;
+              bar(arg: string): void;
+              bar(baz: number): Foo;
+            }
+                  ", None),
+("
+                    declare global {
+                      namespace jest {
+                        interface Matchers<R, T> {
+                          // Add overloads specific to the DOM
+                          toHaveProp<K extends keyof DomPropsOf<T>>(name: K, value?: DomPropsOf<T>[K]): R;
+                          toHaveProps(props: Partial<DomPropsOf<T>>): R;
+                        }
+                      }
+                    }
+                  ", None),
+("
+            type Foo = {
+              foo(): one;
+              foo(): two;
+              foo(): three;
+            }
+                  ", None),
+("
+            declare const Foo: {
+              foo(): one;
+              foo(): two;
+              foo(): three;
+            }
+                  ", None),
+("
+            interface MyInterface {
+              methodReturningImplicitAny();
+            }
+                  ", None),
+("
+            interface Test {
+              f(value: number): this;
+            }
+                  ", None),
+("
+            interface Test {
+              foo(): this;
+              foo(): Promise<this>;
+            }
+                  ", None),
+("
+            interface Test {
+              f(value: number): this | undefined;
+            }
+                  ", None),
+("
+            interface Test {
+              f(value: number): Promise<this>;
+            }
+                  ", None),
+("
+            interface Test {
+              f(value: number): Promise<this | undefined>;
+            }
+                  ", None)
+    ];
+
+    let _fix = vec![
+        (
+            "
+                    interface Test {
+                      f(a: string): number;
+                    }
+                  ",
+            "
+                    interface Test {
+                      f: (a: string) => number;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    interface Test {
+                      ['f'](a: boolean): void;
+                    }
+                  ",
+            "
+                    interface Test {
+                      ['f']: (a: boolean) => void;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    interface Test {
+                      f<T>(a: T): T;
+                    }
+                  ",
+            "
+                    interface Test {
+                      f: <T>(a: T) => T;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    interface Test {
+                      ['f']<T extends {}>(a: T, b: T): T;
+                    }
+                  ",
+            "
+                    interface Test {
+                      ['f']: <T extends {}>(a: T, b: T) => T;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    interface Test {
+                      'f!'</* a */ T>(/* b */ x: any /* c */): void;
+                    }
+                  ",
+            "
+                    interface Test {
+                      'f!': </* a */ T>(/* b */ x: any /* c */) => void;
+                    }
+                  ",
+            None,
+        ),
+        (
+            "
+                    type Test = { f(a: string): number };
+                  ",
+            "
+                    type Test = { f: (a: string) => number };
+                  ",
+            None,
+        ),
+        (
+            "
+                    type Test = { ['f']?(a: boolean): void };
+                  ",
+            "
+                    type Test = { ['f']?: (a: boolean) => void };
+                  ",
+            None,
+        ),
+        (
+            "
+                    type Test = { f?<T>(a?: T): T };
+                  ",
+            "
+                    type Test = { f?: <T>(a?: T) => T };
+                  ",
+            None,
+        ),
+        (
+            "
+                    type Test = { ['f']?<T>(a: T, b: T): T };
+                  ",
+            "
+                    type Test = { ['f']?: <T>(a: T, b: T) => T };
+                  ",
+            None,
+        ),
+        (
+            "
+                    interface Test {
+                      f: (a: string) => number;
+                    }
+                  ",
+            "
+                    interface Test {
+                      f(a: string): number;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      ['f']: (a: boolean) => void;
+                    }
+                  ",
+            "
+                    interface Test {
+                      ['f'](a: boolean): void;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      f: <T>(a: T) => T;
+                    }
+                  ",
+            "
+                    interface Test {
+                      f<T>(a: T): T;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      ['f']: <T extends {}>(a: T, b: T) => T;
+                    }
+                  ",
+            "
+                    interface Test {
+                      ['f']<T extends {}>(a: T, b: T): T;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    interface Test {
+                      'f!': </* a */ T>(/* b */ x: any /* c */) => void;
+                    }
+                  ",
+            "
+                    interface Test {
+                      'f!'</* a */ T>(/* b */ x: any /* c */): void;
+                    }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { f: (a: string) => number };
+                  ",
+            "
+                    type Test = { f(a: string): number };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { ['f']?: (a: boolean) => void };
+                  ",
+            "
+                    type Test = { ['f']?(a: boolean): void };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { f?: <T>(a?: T) => T };
+                  ",
+            "
+                    type Test = { f?<T>(a?: T): T };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+                    type Test = { ['f']?: <T>(a: T, b: T) => T };
+                  ",
+            "
+                    type Test = { ['f']?<T>(a: T, b: T): T };
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+            interface Foo {
+              semi(arg: string): void;
+              comma(arg: string): void,
+              none(arg: string): void
+            }
+                  ",
+            "
+            interface Foo {
+              semi: (arg: string) => void;
+              comma: (arg: string) => void,
+              none: (arg: string) => void
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            interface Foo {
+              semi: (arg: string) => void;
+              comma: (arg: string) => void,
+              none: (arg: string) => void
+            }
+                  ",
+            "
+            interface Foo {
+              semi(arg: string): void;
+              comma(arg: string): void,
+              none(arg: string): void
+            }
+                  ",
+            Some(serde_json::json!(["method"])),
+        ),
+        (
+            "
+            interface Foo {
+              x(
+                args: Pick<
+                  Bar,
+                  'one' | 'two' | 'three'
+                >,
+              ): Baz;
+              y(
+                foo: string,
+                bar: number,
+              ): void;
+            }
+                  ",
+            "
+            interface Foo {
+              x: (
+                args: Pick<
+                  Bar,
+                  'one' | 'two' | 'three'
+                >,
+              ) => Baz;
+              y: (
+                foo: string,
+                bar: number,
+              ) => void;
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            interface Foo {
+              foo(): one;
+              foo(): two;
+              foo(): three;
+            }
+                  ",
+            "
+            interface Foo {
+              foo: (() => one) & (() => two) & (() => three);
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            interface Foo {
+              foo(bar: string): one;
+              foo(bar: number, baz: string): two;
+              foo(): three;
+            }
+                  ",
+            "
+            interface Foo {
+              foo: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            interface Foo {
+              [foo](bar: string): one;
+              [foo](bar: number, baz: string): two;
+              [foo](): three;
+            }
+                  ",
+            "
+            interface Foo {
+              [foo]: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            interface Foo {
+              [foo](bar: string): one;
+              [foo](bar: number, baz: string): two;
+              [foo](): three;
+              bar(arg: string): void;
+              bar(baz: number): Foo;
+            }
+                  ",
+            "
+            interface Foo {
+              [foo]: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);
+              bar: ((arg: string) => void) & ((baz: number) => Foo);
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            type Foo = {
+              foo(): one;
+              foo(): two;
+              foo(): three;
+            }
+                  ",
+            "
+            type Foo = {
+              foo: (() => one) & (() => two) & (() => three);
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            declare const Foo: {
+              foo(): one;
+              foo(): two;
+              foo(): three;
+            }
+                  ",
+            "
+            declare const Foo: {
+              foo: (() => one) & (() => two) & (() => three);
+            }
+                  ",
+            None,
+        ),
+        (
+            "
+            interface MyInterface {
+              methodReturningImplicitAny();
+            }
+                  ",
+            "
+            interface MyInterface {
+              methodReturningImplicitAny: () => any;
+            }
+                  ",
+            None,
+        ),
+    ];
+
+    Tester::new(MethodSignatureStyle::NAME, MethodSignatureStyle::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
@@ -163,7 +163,10 @@ impl Rule for MethodSignatureStyle {
             }
             AstKind::TSPropertySignature(ts_property) if self.is_method_style() => {
                 if !ts_property.type_annotation.as_ref().is_some_and(|type_annotation| {
-                    matches!(&type_annotation.type_annotation, TSType::TSFunctionType(_))
+                    matches!(
+                        type_annotation.type_annotation.without_parenthesized(),
+                        TSType::TSFunctionType(_)
+                    )
                 }) {
                     return;
                 }
@@ -381,6 +384,11 @@ fn test() {
 ("
                     interface Test {
                       f: (a: string) => number;
+                    }
+                  ", Some(serde_json::json!(["method"]))),
+("
+                    interface Test {
+                      f: (((a: string) => number));
                     }
                   ", Some(serde_json::json!(["method"]))),
 ("

--- a/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/method_signature_style.rs
@@ -19,18 +19,21 @@ fn method_signature_style_diagnostic(
     config: MethodSignatureStyleConfig,
     span: Span,
 ) -> OxcDiagnostic {
-    let (message, help) = match config {
-        MethodSignatureStyleConfig::Property => (
-            "Use a property signature instead of a method signature.",
-            "Replace the method signature with a property whose type is a function type.",
-        ),
-        MethodSignatureStyleConfig::Method => (
-            "Use a method signature instead of a property signature.",
-            "Replace the property signature with method shorthand syntax.",
-        ),
-    };
+    match config {
+        MethodSignatureStyleConfig::Property => method_signature_style_property_diagnostic(span),
+        MethodSignatureStyleConfig::Method => method_signature_style_method_diagnostic(span),
+    }
+}
 
-    OxcDiagnostic::warn(message).with_help(help).with_label(span)
+fn method_signature_style_property_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use a property signature instead of a method signature.")
+        .with_help("Replace the method signature with a property whose type is a function type.")
+        .with_label(span)
+}
+fn method_signature_style_method_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use a method signature instead of a property signature.")
+        .with_help("Replace the property signature with method shorthand syntax.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
@@ -155,11 +158,9 @@ impl Rule for MethodSignatureStyle {
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
-            AstKind::TSMethodSignature(ts_method) if self.is_property_style() => {
-                if ts_method.kind != TSMethodSignatureKind::Method {
-                    return;
-                }
-
+            AstKind::TSMethodSignature(ts_method)
+                if self.is_property_style() && ts_method.kind == TSMethodSignatureKind::Method =>
+            {
                 ctx.diagnostic(method_signature_style_diagnostic(self.0, ts_method.span));
             }
             AstKind::TSPropertySignature(ts_property) if self.is_method_style() => {

--- a/crates/oxc_linter/src/snapshots/typescript_method_signature_style.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_method_signature_style.snap
@@ -1,0 +1,504 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       f(a: string): number;
+   ·                       ─────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       ['f'](a: boolean): void;
+   ·                       ────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       f<T>(a: T): T;
+   ·                       ──────────────
+ 4 │                     }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       ['f']<T extends {}>(a: T, b: T): T;
+   ·                       ───────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       'f!'</* a */ T>(/* b */ x: any /* c */): void;
+   ·                       ──────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { f(a: string): number };
+   ·                                   ────────────────────
+ 3 │                   
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { ['f']?(a: boolean): void };
+   ·                                   ────────────────────────
+ 3 │                   
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { f?<T>(a?: T): T };
+   ·                                   ───────────────
+ 3 │                   
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { ['f']?<T>(a: T, b: T): T };
+   ·                                   ────────────────────────
+ 3 │                   
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       f: (a: string) => number;
+   ·                       ─────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       ['f']: (a: boolean) => void;
+   ·                       ────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       f: <T>(a: T) => T;
+   ·                       ──────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       ['f']: <T extends {}>(a: T, b: T) => T;
+   ·                       ───────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
+ 3 │                       'f!': </* a */ T>(/* b */ x: any /* c */) => void;
+   ·                       ──────────────────────────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { f: (a: string) => number };
+   ·                                   ────────────────────────
+ 3 │                   
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { ['f']?: (a: boolean) => void };
+   ·                                   ────────────────────────────
+ 3 │                   
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { f?: <T>(a?: T) => T };
+   ·                                   ───────────────────
+ 3 │                   
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:2:35]
+ 1 │ 
+ 2 │                     type Test = { ['f']?: <T>(a: T, b: T) => T };
+   ·                                   ────────────────────────────
+ 3 │                   
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Foo {
+ 3 │               semi(arg: string): void;
+   ·               ────────────────────────
+ 4 │               comma(arg: string): void,
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               semi(arg: string): void;
+ 4 │               comma(arg: string): void,
+   ·               ─────────────────────────
+ 5 │               none(arg: string): void
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               comma(arg: string): void,
+ 5 │               none(arg: string): void
+   ·               ───────────────────────
+ 6 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Foo {
+ 3 │               semi: (arg: string) => void;
+   ·               ────────────────────────────
+ 4 │               comma: (arg: string) => void,
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               semi: (arg: string) => void;
+ 4 │               comma: (arg: string) => void,
+   ·               ─────────────────────────────
+ 5 │               none: (arg: string) => void
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               comma: (arg: string) => void,
+ 5 │               none: (arg: string) => void
+   ·               ───────────────────────────
+ 6 │             }
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │                 interface Foo {
+ 3 │ ╭─▶               x(
+ 4 │ │                   args: Pick<
+ 5 │ │                     Bar,
+ 6 │ │                     'one' | 'two' | 'three'
+ 7 │ │                   >,
+ 8 │ ╰─▶               ): Baz;
+ 9 │                   y(
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+    ╭─[method_signature_style.tsx:9:15]
+  8 │                   ): Baz;
+  9 │ ╭─▶               y(
+ 10 │ │                   foo: string,
+ 11 │ │                   bar: number,
+ 12 │ ╰─▶               ): void;
+ 13 │                 }
+    ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Foo {
+ 3 │               foo(): one;
+   ·               ───────────
+ 4 │               foo(): two;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               foo(): one;
+ 4 │               foo(): two;
+   ·               ───────────
+ 5 │               foo(): three;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               foo(): two;
+ 5 │               foo(): three;
+   ·               ─────────────
+ 6 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Foo {
+ 3 │               foo(bar: string): one;
+   ·               ──────────────────────
+ 4 │               foo(bar: number, baz: string): two;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               foo(bar: string): one;
+ 4 │               foo(bar: number, baz: string): two;
+   ·               ───────────────────────────────────
+ 5 │               foo(): three;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               foo(bar: number, baz: string): two;
+ 5 │               foo(): three;
+   ·               ─────────────
+ 6 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Foo {
+ 3 │               [foo](bar: string): one;
+   ·               ────────────────────────
+ 4 │               [foo](bar: number, baz: string): two;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               [foo](bar: string): one;
+ 4 │               [foo](bar: number, baz: string): two;
+   ·               ─────────────────────────────────────
+ 5 │               [foo](): three;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               [foo](bar: number, baz: string): two;
+ 5 │               [foo](): three;
+   ·               ───────────────
+ 6 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Foo {
+ 3 │               [foo](bar: string): one;
+   ·               ────────────────────────
+ 4 │               [foo](bar: number, baz: string): two;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               [foo](bar: string): one;
+ 4 │               [foo](bar: number, baz: string): two;
+   ·               ─────────────────────────────────────
+ 5 │               [foo](): three;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               [foo](bar: number, baz: string): two;
+ 5 │               [foo](): three;
+   ·               ───────────────
+ 6 │               bar(arg: string): void;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:6:15]
+ 5 │               [foo](): three;
+ 6 │               bar(arg: string): void;
+   ·               ───────────────────────
+ 7 │               bar(baz: number): Foo;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:7:15]
+ 6 │               bar(arg: string): void;
+ 7 │               bar(baz: number): Foo;
+   ·               ──────────────────────
+ 8 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:6:27]
+ 5 │                           // Add overloads specific to the DOM
+ 6 │                           toHaveProp<K extends keyof DomPropsOf<T>>(name: K, value?: DomPropsOf<T>[K]): R;
+   ·                           ────────────────────────────────────────────────────────────────────────────────
+ 7 │                           toHaveProps(props: Partial<DomPropsOf<T>>): R;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:7:27]
+ 6 │                           toHaveProp<K extends keyof DomPropsOf<T>>(name: K, value?: DomPropsOf<T>[K]): R;
+ 7 │                           toHaveProps(props: Partial<DomPropsOf<T>>): R;
+   ·                           ──────────────────────────────────────────────
+ 8 │                         }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             type Foo = {
+ 3 │               foo(): one;
+   ·               ───────────
+ 4 │               foo(): two;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               foo(): one;
+ 4 │               foo(): two;
+   ·               ───────────
+ 5 │               foo(): three;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               foo(): two;
+ 5 │               foo(): three;
+   ·               ─────────────
+ 6 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             declare const Foo: {
+ 3 │               foo(): one;
+   ·               ───────────
+ 4 │               foo(): two;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               foo(): one;
+ 4 │               foo(): two;
+   ·               ───────────
+ 5 │               foo(): three;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:5:15]
+ 4 │               foo(): two;
+ 5 │               foo(): three;
+   ·               ─────────────
+ 6 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface MyInterface {
+ 3 │               methodReturningImplicitAny();
+   ·               ─────────────────────────────
+ 4 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Test {
+ 3 │               f(value: number): this;
+   ·               ───────────────────────
+ 4 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Test {
+ 3 │               foo(): this;
+   ·               ────────────
+ 4 │               foo(): Promise<this>;
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:4:15]
+ 3 │               foo(): this;
+ 4 │               foo(): Promise<this>;
+   ·               ─────────────────────
+ 5 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Test {
+ 3 │               f(value: number): this | undefined;
+   ·               ───────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Test {
+ 3 │               f(value: number): Promise<this>;
+   ·               ────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.
+
+  ⚠ typescript(method-signature-style): Use a property signature instead of a method signature.
+   ╭─[method_signature_style.tsx:3:15]
+ 2 │             interface Test {
+ 3 │               f(value: number): Promise<this | undefined>;
+   ·               ────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Replace the method signature with a property whose type is a function type.

--- a/crates/oxc_linter/src/snapshots/typescript_method_signature_style.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_method_signature_style.snap
@@ -95,6 +95,15 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
    ╭─[method_signature_style.tsx:3:23]
  2 │                     interface Test {
+ 3 │                       f: (((a: string) => number));
+   ·                       ─────────────────────────────
+ 4 │                     }
+   ╰────
+  help: Replace the property signature with method shorthand syntax.
+
+  ⚠ typescript(method-signature-style): Use a method signature instead of a property signature.
+   ╭─[method_signature_style.tsx:3:23]
+ 2 │                     interface Test {
  3 │                       ['f']: (a: boolean) => void;
    ·                       ────────────────────────────
  4 │                     }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1690,6 +1690,9 @@
         "typescript/explicit-module-boundary-types": {
           "$ref": "#/definitions/DummyRule"
         },
+        "typescript/method-signature-style": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "typescript/no-array-delete": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1694,6 +1694,9 @@ expression: json
         "typescript/explicit-module-boundary-types": {
           "$ref": "#/definitions/DummyRule"
         },
+        "typescript/method-signature-style": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "typescript/no-array-delete": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
This PR implements `typescript-eslint/method-signature-style`, issue #2180.

It uses all upstream test cases. The only changes are to 4 setter test cases, changing this:
```
set f(value: number): void;
```
to this:
```
set f(value: number);
```
because they failed with `TS(1095): A 'set' accessor cannot have a return type annotation.`