### PR TITLE
perf(linter): cache nearest config directory lookups

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -313,11 +313,7 @@ impl ConfigStore {
         let dir_config_cache = if nested_configs.is_empty() {
             None
         } else {
-            Some(
-                papaya::HashMap::builder()
-                    .hasher(BuildHasherDefault::default())
-                    .build(),
-            )
+            Some(papaya::HashMap::builder().hasher(BuildHasherDefault::default()).build())
         };
 
         Self {

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -1,9 +1,10 @@
 use std::{
+    hash::BuildHasherDefault,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 
 use crate::{
     AllowWarnDeny,
@@ -288,6 +289,18 @@ pub struct ConfigStore {
     base: Config,
     nested_configs: FxHashMap<PathBuf, Config>,
     external_plugin_store: Arc<ExternalPluginStore>,
+
+    /// Cache from directory path to the key of the nearest enclosing config in
+    /// `nested_configs`,
+    /// or `None` when the base config applies.
+    ///
+    /// `get_nearest_config` walks parent directories until it finds a match
+    /// in `nested_configs`.
+    /// For large projects with many files sharing the same directory, this
+    /// avoids repeating the walk-up for every file. The map is populated lazily
+    /// on first access per directory.
+    dir_config_cache:
+        Option<papaya::HashMap<PathBuf, Option<PathBuf>, BuildHasherDefault<FxHasher>>>,
 }
 
 impl ConfigStore {
@@ -296,10 +309,22 @@ impl ConfigStore {
         nested_configs: FxHashMap<PathBuf, Config>,
         external_plugin_store: ExternalPluginStore,
     ) -> Self {
+        // Only allocate the directory cache when nested configs exist ...
+        let dir_config_cache = if nested_configs.is_empty() {
+            None
+        } else {
+            Some(
+                papaya::HashMap::builder()
+                    .hasher(BuildHasherDefault::default())
+                    .build(),
+            )
+        };
+
         Self {
             base: base_config,
             nested_configs,
             external_plugin_store: Arc::new(external_plugin_store),
+            dir_config_cache,
         }
     }
 
@@ -406,16 +431,35 @@ impl ConfigStore {
     }
 
     fn get_nearest_config(&self, path: &Path) -> Option<&Config> {
-        // TODO(perf): should we cache the computed nearest config for every directory,
-        // so we don't have to recompute it for every file?
-        let mut current = path.parent();
-        while let Some(dir) = current {
-            if let Some(config) = self.nested_configs.get(dir) {
-                return Some(config);
-            }
-            current = dir.parent();
+        let dir = path.parent()?;
+
+        let Some(cache) = &self.dir_config_cache else {
+            // No nested configs ...
+            return None;
+        };
+
+        // Fast path: directory already resolved.
+        if let Some(cached_key) = cache.pin().get(dir) {
+            return cached_key.as_deref().and_then(|k| self.nested_configs.get(k));
         }
-        None
+
+        // Slow path: walk parent directories until a nested config is found.
+        let found_key = {
+            let mut current = Some(dir);
+            let mut result = None;
+
+            while let Some(d) = current {
+                if self.nested_configs.contains_key(d) {
+                    result = Some(d.to_path_buf());
+                    break;
+                }
+                current = d.parent();
+            }
+            result
+        };
+
+        cache.pin().insert(dir.to_path_buf(), found_key.clone());
+        found_key.as_deref().and_then(|k| self.nested_configs.get(k))
     }
 
     pub(crate) fn resolve_plugin_rule_names(


### PR DESCRIPTION
`get_nearest_config` walks parent directories on every file to find the nearest `.oxlintrc.json`.
For a project with N files sharing the same directory and D levels of nesting, this costs
O(N × D) `HashMap` lookups per run.

Add `dir_config_cache: Option<papaya::HashMap<PathBuf, Option<PathBuf>>>`
to `ConfigStore`.

The first access per directory performs the walk-up and stores the resolved config key
(or `None` for base config). Subsequent files in the same directory get the result in O(1).

Resolves the existing `TODO(perf)` comment in `get_nearest_config`.
Related: #20812.

## Details

- The cache is `Option` and only allocated when `nested_configs` is non-empty —
  the common single-config case pays zero memory overhead.
- `papaya::HashMap` is already a dependency used for `modules_by_path`;
  it allows lock-free concurrent inserts from the rayon thread pool.

## Benchmark

`**aws-cdk**` (~5,700 `.ts` files, 45 nested configs — one per `@aws-cdk/*` package,
hyperfine 20 runs):

|        | mean     | σ       |
|--------|----------|---------|
| before | 484.5 ms | ±73.6 ms |
| after  | 460.1 ms | ±47.9 ms |

**speedup: ~1.05×** (σ ~35%)

No effect when `nested_configs` is empty —
`get_related_config` takes the `is_empty()` fast path before
`get_nearest_config` is ever called.

AI disclosure: implemented with Claude Code (opencode), reviewed manually.