### PR TITLE
fix(semantic): correct TS enum member symbol spans

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
@@ -1426,8 +1426,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ╰── shadowed declaration is here
  3 │                         enum Test {
  4 │                             A = 1,
-   ·                             ──┬──
-   ·                               ╰── 'A' is declared here
+   ·                             ┬
+   ·                             ╰── 'A' is declared here
  5 │                             B = A,
    ╰────
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -5,6 +5,7 @@ use smallvec::SmallVec;
 use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{AstKind, ast::*};
 use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
+use oxc_span::GetSpan;
 use oxc_str::Ident;
 use oxc_syntax::{node::NodeId, scope::ScopeFlags, scope::ScopeId, symbol::SymbolFlags};
 
@@ -434,7 +435,7 @@ impl<'a> Binder<'a> for TSEnumMember<'a> {
             _ => Ident::from(self.id.static_name()),
         };
         builder.declare_symbol(
-            self.span,
+            self.id.span(),
             name,
             SymbolFlags::EnumMember,
             SymbolFlags::EnumMemberExcludes,


### PR DESCRIPTION
Fixes TS enum member symbols so their stored span points at the member name instead of the entire enum member declaration.

The previous span used `TSEnumMember::span`, which includes initializer text like `A = 1`.