### PR TITLE
fix(ci): setup node for oxfmt conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
       - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
-        if: steps.filter.outputs.changed == 'true'
+        if: steps.filter.outputs.changed == 'true' || steps.filter-conformance.outputs.changed == 'true'
       - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
         if: steps.filter.outputs.changed == 'true'
         with:
@@ -330,7 +330,7 @@ jobs:
         name: Run conformance tests
         run: pnpm --filter "./apps/oxfmt" conformance
       # --- Conformance
-      - if: steps.filter.outputs.changed == 'true'
+      - if: steps.filter.outputs.changed == 'true' || steps.filter-conformance.outputs.changed == 'true'
         run: |
           git diff --exit-code # Must commit everything
 


### PR DESCRIPTION
This fixes the failing `Test NAPI Oxfmt` CI job:

https://github.com/oxc-project/oxc/actions/runs/26337525454/job/77533653139

`Test NAPI Oxfmt` has two separate change filters: one for the normal Oxfmt npm tests and one for Oxfmt conformance. `setup-node` was only guarded by the normal test filter, but the conformance steps also run `pnpm`.

In the failed run, the normal Oxfmt filter skipped, so `setup-node` was skipped too. The conformance filter still allowed the conformance fixture step to run, and that failed with `pnpm: command not found`.

This updates the Oxfmt job so `setup-node` runs when either the normal Oxfmt tests or the Oxfmt conformance steps need to run. The final diff check now uses the same combined condition.