### PR TITLE
fix(formatter): preserve import phases

### DIFF
--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -45,6 +45,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let decl = &format_with(|f| {
             write!(f, ["import", space(), self.import_kind]);
+            if let Some(phase) = self.phase() {
+                write!(f, [phase.as_str(), space()]);
+            }
 
             if let Some(specifiers) = self.specifiers() {
                 write!(f, [specifiers, space(), "from", space()]);

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -44,10 +44,11 @@ pub fn format_import_and_export_source_with_clause<'a>(
 impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let decl = &format_with(|f| {
-            write!(f, ["import", space(), self.import_kind]);
+            write!(f, "import");
             if let Some(phase) = self.phase() {
-                write!(f, [phase.as_str(), space()]);
+                write!(f, [space(), phase.as_str()]);
             }
+            write!(f, [space(), self.import_kind]);
 
             if let Some(specifiers) = self.specifiers() {
                 write!(f, [specifiers, space(), "from", space()]);

--- a/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts
@@ -4,4 +4,6 @@ console.log(b.b);
 
 import source wasm from "./mod.wasm";
 
+import source x from "<specifier>";
+
 import defer * as c from "./c" with { type: "json" };

--- a/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts
@@ -1,0 +1,7 @@
+import defer * as b from "./b";
+
+console.log(b.b);
+
+import source wasm from "./mod.wasm";
+
+import defer * as c from "./c" with { type: "json" };

--- a/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts.snap
@@ -8,6 +8,8 @@ console.log(b.b);
 
 import source wasm from "./mod.wasm";
 
+import source x from "<specifier>";
+
 import defer * as c from "./c" with { type: "json" };
 
 ==================== Output ====================
@@ -20,6 +22,8 @@ console.log(b.b);
 
 import source wasm from "./mod.wasm";
 
+import source x from "<specifier>";
+
 import defer * as c from "./c" with { type: "json" };
 
 -------------------
@@ -30,6 +34,8 @@ import defer * as b from "./b";
 console.log(b.b);
 
 import source wasm from "./mod.wasm";
+
+import source x from "<specifier>";
 
 import defer * as c from "./c" with { type: "json" };
 

--- a/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/import-phases/issue-22691.ts.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+import defer * as b from "./b";
+
+console.log(b.b);
+
+import source wasm from "./mod.wasm";
+
+import defer * as c from "./c" with { type: "json" };
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+import defer * as b from "./b";
+
+console.log(b.b);
+
+import source wasm from "./mod.wasm";
+
+import defer * as c from "./c" with { type: "json" };
+
+-------------------
+{ printWidth: 100 }
+-------------------
+import defer * as b from "./b";
+
+console.log(b.b);
+
+import source wasm from "./mod.wasm";
+
+import defer * as c from "./c" with { type: "json" };
+
+===================== End =====================


### PR DESCRIPTION
Preserve import phases when formatting import declarations.

`oxfmt` was dropping `defer` and `source` from phase imports because the formatter did not print `ImportDeclaration.phase`. This adds phase printing after `import` and covers `import defer` plus `import source` cases in formatter fixtures.

fixes #22691