### PR TITLE
fix(parser): improve invalid `import` property access diagnostic

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -804,8 +804,11 @@ pub fn duplicate_default_export(spans: impl IntoIterator<Item = Span>) -> OxcDia
 }
 
 #[cold]
-pub fn import_meta(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("The only valid meta property for import is import.meta").with_label(span)
+pub fn invalid_import_property(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(
+        "The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`",
+    )
+    .with_label(span)
 }
 
 #[cold]

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -681,7 +681,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                     _ => {
                         self.bump_any();
-                        self.fatal_error(diagnostics::import_meta(self.end_span(span)))
+                        self.fatal_error(diagnostics::invalid_import_property(self.end_span(span)))
                     }
                 }
             }

--- a/tasks/coverage/misc/fail/import-sync-expression.js
+++ b/tasks/coverage/misc/fail/import-sync-expression.js
@@ -1,0 +1,1 @@
+const x = import.sync("baz");

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -5840,7 +5840,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·       ─
    ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
    ╭─[babel/packages/babel-parser/test/fixtures/es2020/dynamic-import/direct-calls-only/input.js:2:10]
  1 │ function failsParse() {
  2 │   return import.then();
@@ -5879,7 +5879,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    · ────────
    ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
    ╭─[babel/packages/babel-parser/test/fixtures/es2020/dynamic-import-createImportExpression-false/direct-calls-only/input.js:2:10]
  1 │ function failsParse() {
  2 │   return import.then();
@@ -5925,7 +5925,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: import.meta is only allowed in module code
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
    ╭─[babel/packages/babel-parser/test/fixtures/es2020/import-meta/no-other-prop-names/input.js:1:1]
  1 │ import.notMeta;
    · ──────────────

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 67/67 (100.00%)
 Positive Passed: 67/67 (100.00%)
-Negative Passed: 137/137 (100.00%)
+Negative Passed: 138/138 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -288,6 +288,12 @@ Negative Passed: 137/137 (100.00%)
  1 │ import source 'module';
    ·               ────┬───
    ·                   ╰── `from` expected
+   ╰────
+
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
+   ╭─[misc/fail/import-sync-expression.js:1:11]
+ 1 │ const x = import.sync("baz");
+   ·           ───────────
    ╰────
 
   × TS(1363): A type-only import can specify a default import or named bindings, but not both.

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -14870,7 +14870,7 @@ Negative Passed: 4588/4588 (100.00%)
  35 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-call-unknown.js:36:15]
  35 │ 
  36 │ let f = () => import.UNKNOWN('./empty_FIXTURE.js');
@@ -14972,7 +14972,7 @@ Negative Passed: 4588/4588 (100.00%)
  35 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-call-unknown.js:37:3]
  36 │ let f = () => {
  37 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -15089,7 +15089,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ });
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-call-unknown.js:37:9]
  36 │ (async () => {
  37 │   await import.UNKNOWN('./empty_FIXTURE.js')
@@ -15206,7 +15206,7 @@ Negative Passed: 4588/4588 (100.00%)
  35 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-call-unknown.js:36:20]
  35 │ 
  36 │ (async () => await import.UNKNOWN('./empty_FIXTURE.js'))
@@ -15324,7 +15324,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ }
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-call-unknown.js:37:9]
  36 │ async function f() {
  37 │   await import.UNKNOWN('./empty_FIXTURE.js');
@@ -15433,7 +15433,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ }
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-call-unknown.js:37:3]
  36 │ async function f() {
  37 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -15524,7 +15524,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ }
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-call-unknown.js:37:16]
  36 │ async function f() {
  37 │   return await import.UNKNOWN('./empty_FIXTURE.js');
@@ -15667,7 +15667,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ }
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-call-unknown.js:37:9]
  36 │ async function * f() {
  37 │   await import.UNKNOWN('./empty_FIXTURE.js')
@@ -15784,7 +15784,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ };
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-call-unknown.js:37:3]
  36 │ {
  37 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -15850,7 +15850,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ };
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-call-unknown.js:37:3]
  36 │ label: {
  37 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -16018,7 +16018,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ } while (false);
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-call-unknown.js:37:3]
  36 │ do {
  37 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -16143,7 +16143,7 @@ Negative Passed: 4588/4588 (100.00%)
  37 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-call-unknown.js:38:8]
  37 │ 
  38 │ } else import.UNKNOWN('./empty_FIXTURE.js');
@@ -16245,7 +16245,7 @@ Negative Passed: 4588/4588 (100.00%)
  37 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-call-unknown.js:39:3]
  38 │ } else {
  39 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -16362,7 +16362,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ }
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-call-unknown.js:37:3]
  36 │ function fn() {
  37 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -16453,7 +16453,7 @@ Negative Passed: 4588/4588 (100.00%)
  36 │ }
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-call-unknown.js:37:10]
  36 │ function fn() {
  37 │   return import.UNKNOWN('./empty_FIXTURE.js');
@@ -16604,7 +16604,7 @@ Negative Passed: 4588/4588 (100.00%)
  35 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-call-unknown.js:36:11]
  35 │ 
  36 │ if (true) import.UNKNOWN('./empty_FIXTURE.js');
@@ -16706,7 +16706,7 @@ Negative Passed: 4588/4588 (100.00%)
  35 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-call-unknown.js:37:3]
  36 │ if (true) {
  37 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -16823,7 +16823,7 @@ Negative Passed: 4588/4588 (100.00%)
  38 │ };
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-call-unknown.js:39:3]
  38 │   x++;
  39 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -16948,7 +16948,7 @@ Negative Passed: 4588/4588 (100.00%)
  34 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-call-unknown.js:35:7]
  34 │ 
  35 │ with (import.UNKNOWN('./empty_FIXTURE.js')) {}
@@ -17050,7 +17050,7 @@ Negative Passed: 4588/4588 (100.00%)
  34 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-call-unknown.js:36:3]
  35 │ with ({}) {
  36 │   import.UNKNOWN('./empty_FIXTURE.js');
@@ -17167,7 +17167,7 @@ Negative Passed: 4588/4588 (100.00%)
  25 │ 
     ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
     ╭─[test262/test/language/expressions/dynamic-import/syntax/invalid/top-level-import-call-unknown.js:26:1]
  25 │ 
  26 │ import.UNKNOWN('./empty_FIXTURE.js');

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -16860,7 +16860,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  9 │ const z = tag`\u{hello} \xtraordinary wonderful \uworld` // should work with Tagged NoSubstitutionTemplate
    ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
    ╭─[typescript/tests/cases/conformance/es2019/importMeta/importMeta.ts:2:16]
  1 │ export let x = import.meta;
  2 │ export let y = import.metal;
@@ -21359,7 +21359,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ·                   ─
    ╰────
 
-  × The only valid meta property for import is import.meta
+  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
    ╭─[typescript/tests/cases/conformance/importDefer/importMetaPropertyInvalidInCall.ts:1:1]
  1 │ import.foo();
    · ──────────


### PR DESCRIPTION
This improves the parser diagnostic for invalid `import.<property>` access.

Previously, invalid properties like `import.sync("baz")` were reported as if only `import.meta` were valid, which is misleading now that `import.source()` and `import.defer()` are also supported.

Before:

```text
  × The only valid meta property for import is import.meta
    ╭─[index.ts]
 37 │ 
 38 │ import.foo();
      ──────────
 39 │ 
    ╰────
```

After:

```text
  × The only valid property accesses on import are `import.meta`, `import.source()`, and `import.defer()`
    ╭─[index.ts]
 37 │ 
 38 │ import.foo();
      ──────────
 39 │ 
    ╰────
```

Also adds a coverage fixture for the `import.sync("baz")` case and updates the parser coverage snapshots.

