### PR TITLE
fix(semantic): resolve import-equals namespaces

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -676,12 +676,9 @@ impl<'a> SemanticBuilder<'a> {
         let flags = reference.flags_mut();
 
         // Determine whether the symbol can be referenced by this reference.
-        // For pure type references (not value or typeof) in qualified names,
-        // only resolve to namespaces (modules, namespaces, enums, imports).
-        // Type parameters and type aliases cannot have member access in type space.
-        // Value references (including typeof) can always have member access.
+        // Namespace-qualified references must resolve to namespace-capable symbols
+        // (modules, namespaces, enums, imports), not arbitrary values or types.
         let can_resolve = if flags.is_namespace()
-            && !flags.is_value()
             && !flags.is_value_as_type()
             && !symbol_flags.can_be_referenced_as_namespace()
         {
@@ -700,6 +697,10 @@ impl<'a> SemanticBuilder<'a> {
             // The non type-only ExportSpecifier can reference both type/value symbols,
             // if the symbol is a value symbol and reference flag is not type-only,
             // remove the type flag. For example: `const B = 1; export { B };`
+            *flags -= ReferenceFlags::Type;
+        } else if flags.is_namespace() && flags.is_read() {
+            // TS import-equals module references start as reads so downstream transforms
+            // can decide whether to preserve or erase them based on alias usage.
             *flags -= ReferenceFlags::Type;
         } else {
             // 1. ReferenceFlags::ValueAsType -> ReferenceFlags::Type
@@ -2550,8 +2551,30 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         decl.bind(self);
         self.visit_span(&decl.span);
         self.visit_binding_identifier(&decl.id);
+        self.current_reference_flags = if decl.import_kind.is_type() {
+            ReferenceFlags::Type
+        } else {
+            ReferenceFlags::Read | ReferenceFlags::Type
+        };
         self.visit_ts_module_reference(&decl.module_reference);
+        // External module references do not contain an identifier reference to consume the flags.
+        self.current_reference_flags = ReferenceFlags::empty();
         self.leave_node(kind);
+    }
+
+    fn visit_ts_module_reference(&mut self, module_reference: &TSModuleReference<'a>) {
+        match module_reference {
+            TSModuleReference::ExternalModuleReference(reference) => {
+                self.visit_ts_external_module_reference(reference);
+            }
+            TSModuleReference::IdentifierReference(reference) => {
+                self.current_reference_flags |= ReferenceFlags::Namespace;
+                self.visit_identifier_reference(reference);
+            }
+            TSModuleReference::QualifiedName(name) => {
+                self.visit_ts_qualified_name(name);
+            }
+        }
     }
 
     fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
@@ -2851,10 +2874,11 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         // The left side of a qualified name (e.g., `Database` in `Database.Table`)
         // must resolve to a namespace/module, not a type parameter.
         // Add Namespace flag to skip type parameters during resolution.
-        // If no flags set yet (value context like `import foo = A.B.C`),
-        // also add Read as the default.
+        // If no flags set yet (namespace context like `import foo = A.B.C`),
+        // also add Read and Type as the default.
         if self.current_reference_flags.is_empty() {
-            self.current_reference_flags = ReferenceFlags::Read | ReferenceFlags::Namespace;
+            self.current_reference_flags =
+                ReferenceFlags::Read | ReferenceFlags::Type | ReferenceFlags::Namespace;
         } else {
             self.current_reference_flags |= ReferenceFlags::Namespace;
         }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals-type.snap
@@ -1,0 +1,89 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals-type.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(TsModuleBlock)",
+        "id": 1,
+        "node": "TSModuleDeclaration(Bar)",
+        "symbols": []
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "flags": "ScopeFlags(TsModuleBlock)",
+            "id": 3,
+            "node": "TSModuleDeclaration(Baz)",
+            "symbols": []
+          }
+        ],
+        "flags": "ScopeFlags(TsModuleBlock)",
+        "id": 2,
+        "node": "TSModuleDeclaration(Qux)",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(NamespaceModule)",
+            "id": 2,
+            "name": "Baz",
+            "node": "TSModuleDeclaration(Baz)",
+            "references": []
+          }
+        ]
+      }
+    ],
+    "flags": "ScopeFlags(Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(NamespaceModule)",
+        "id": 0,
+        "name": "Bar",
+        "node": "TSModuleDeclaration(Bar)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 0,
+            "name": "Bar",
+            "node_id": 13,
+            "scope_id": 0
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(NamespaceModule)",
+        "id": 1,
+        "name": "Qux",
+        "node": "TSModuleDeclaration(Qux)",
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 1,
+            "name": "Qux",
+            "node_id": 17,
+            "scope_id": 0
+          }
+        ]
+      },
+      {
+        "flags": "SymbolFlags(Import)",
+        "id": 3,
+        "name": "Foo",
+        "node": "TSImportEqualsDeclaration",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(Import)",
+        "id": 4,
+        "name": "Qualified",
+        "node": "TSImportEqualsDeclaration",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals-type.ts
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals-type.ts
@@ -1,0 +1,9 @@
+//// @sourceType = module
+
+namespace Bar {}
+namespace Qux {
+    export namespace Baz {}
+}
+
+import type Foo = Bar;
+import type Qualified = Qux.Baz;

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.snap
@@ -14,15 +14,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/import/equals2.
         "id": 0,
         "name": "x",
         "node": "VariableDeclarator(x)",
-        "references": [
-          {
-            "flags": "ReferenceFlags(Read)",
-            "id": 0,
-            "name": "x",
-            "node_id": 7,
-            "scope_id": 0
-          }
-        ]
+        "references": []
       },
       {
         "flags": "SymbolFlags(Import)",

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -274,9 +274,6 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 Bindings mismatch:
 after transform: ScopeId(0): ["N"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["N"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-nested/input.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 637d5746
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3489/4720 (73.92%)
+Positive Passed: 3490/4720 (73.94%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -172,11 +172,23 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.
 Bindings mismatch:
 after transform: ScopeId(1): ["N", "X", "_M"]
 rebuilt        : ScopeId(1): ["X", "_M"]
+Reference symbol mismatch for "N":
+after transform: SymbolId(1) "N"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["N"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
 Bindings mismatch:
 after transform: ScopeId(1): ["N", "X", "_M"]
 rebuilt        : ScopeId(1): ["X", "_M"]
+Reference symbol mismatch for "N":
+after transform: SymbolId(1) "N"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["N"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
 Bindings mismatch:
@@ -1097,9 +1109,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsIm
 Bindings mismatch:
 after transform: ScopeId(0): ["M1", "M2"]
 rebuilt        : ScopeId(0): ["M2"]
-Unresolved references mismatch:
-after transform: ["M1"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
 Bindings mismatch:
@@ -3215,6 +3224,12 @@ rebuilt        : ScopeId(0): ["M", "v"]
 Bindings mismatch:
 after transform: ScopeId(3): ["C", "_M", "w"]
 rebuilt        : ScopeId(1): ["_M", "w"]
+Reference symbol mismatch for "C":
+after transform: SymbolId(0) "C"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["C"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOfFuncspace.ts
 Symbol flags mismatch for "ExpandoMerge":
@@ -4271,6 +4286,12 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportImportNonIn
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "x"]
 rebuilt        : ScopeId(0): ["B", "x"]
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["A"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
 Bindings mismatch:
@@ -5166,11 +5187,6 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 
-semantic Error: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
-Unresolved references mismatch:
-after transform: ["x"]
-rebuilt        : []
-
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
 Bindings mismatch:
 after transform: ScopeId(0): []
@@ -5896,38 +5912,41 @@ Namespaces exporting non-const are not supported by Oxc. Change to const or see:
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideTopLevelModuleWithExport.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "b", "x"]
 rebuilt        : ScopeId(0): ["b", "x"]
+Reference symbol mismatch for "a":
+after transform: SymbolId(0) "a"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["a"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModule.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
+Reference symbol mismatch for "a":
+after transform: SymbolId(0) "a"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["a"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExport.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support
 Bindings mismatch:
 after transform: ScopeId(0): ["a", "c"]
 rebuilt        : ScopeId(0): ["c"]
-Unresolved references mismatch:
-after transform: ["a"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithoutExport.ts
 Bindings mismatch:
@@ -5954,9 +5973,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/internalImportUnI
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): ["B"]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(3): [ReferenceId(0)]
-rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
 Bindings mismatch:
@@ -9117,9 +9133,6 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnMod
 Bindings mismatch:
 after transform: ScopeId(0): ["test"]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["mstring"]
-rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName1.ts
 Bindings mismatch:
@@ -17765,7 +17778,7 @@ Reference symbol mismatch for "mod2":
 after transform: SymbolId(7) "mod2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["mod1"]
+after transform: []
 rebuilt        : ["mod2", "pack2"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1268,9 +1268,6 @@ rebuilt        : ScopeId(3): ["_WithTypes", "d"]
 Bindings mismatch:
 after transform: ScopeId(12): ["D", "_d"]
 rebuilt        : ScopeId(4): ["_d"]
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 
 * namespace/export-type-only/input.ts
 Bindings mismatch:


### PR DESCRIPTION
Fixes `import =` semantic reference resolution so internal module references are resolved as namespace lookups instead of ordinary value reads.

TypeScript treats the RHS of an internal `import =` specially. In the checker, `getTargetOfImportEqualsDeclaration` delegates internal module references to `getSymbolOfPartOfRightHandSideOfImportEquals`, which resolves bare RHS names and intermediate qualified names with `SymbolFlags.Namespace` rather than value meaning:

- `getTargetOfImportEqualsDeclaration`: https://github.com/microsoft/TypeScript/blob/f350b52331494b68c90ab02e2b6d0828d2a22a74/src/compiler/checker.ts#L3708-L3733
- `getSymbolOfPartOfRightHandSideOfImportEquals`: https://github.com/microsoft/TypeScript/blob/f350b52331494b68c90ab02e2b6d0828d2a22a74/src/compiler/checker.ts#L4480-L4499
- `getSymbolOfNameOrPropertyAccessExpression` also routes names on the RHS of import/export assignments through that same helper: https://github.com/microsoft/TypeScript/blob/f350b52331494b68c90ab02e2b6d0828d2a22a74/src/compiler/checker.ts#L50014-L50019

Before this change, Oxc could count plain values as references from `import =`:

```ts
const x = 1;
import foo = x;
```

Before:

```text
x references: 1
```

After:

```text
x references: 0
```

That matches TypeScript’s behavior because `x` is only a value symbol, not a namespace-capable symbol.

The same applies to qualified names:

```ts
const x = { y: 1 };
import foo = x.y;
```

Before:

```text
x references: 1
```

After:

```text
x references: 0
```

But namespace-capable declarations still resolve:

```ts
namespace x {}
import foo = x;
```

After:

```text
x references: 1
```

and:

```ts
namespace x {
  export namespace y {}
}

import foo = x.y;
```

After:

```text
x references: 1
```

This updates the semantic snapshots to reflect the corrected reference/declaration matching.