### PR TITLE
chore(oxfmt): Bump svelte and tailwind plugin version

### DIFF
--- a/apps/oxfmt/conformance/download-fixtures.js
+++ b/apps/oxfmt/conformance/download-fixtures.js
@@ -30,7 +30,7 @@ const sources = [
   {
     name: "plugin-svelte",
     repo: "sveltejs/prettier-plugin-svelte/test/formatting/samples",
-    version: `v${pkg.dependencies["prettier-plugin-svelte"]}`,
+    version: `prettier-plugin-svelte@${pkg.dependencies["prettier-plugin-svelte"]}`,
   },
 ];
 

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -124,13 +124,13 @@
 
 ## svelte
 
-### Option 1: 75/75 (100.00%)
+### Option 1: 77/77 (100.00%)
 
 ```json
 {"printWidth":80,"svelte":{}}
 ```
 
-### Option 2: 75/75 (100.00%)
+### Option 2: 77/77 (100.00%)
 
 ```json
 {"printWidth":120,"singleQuote":true,"htmlWhitespaceSensitivity":"ignore","bracketSameLine":true,"svelteIndentScriptAndStyle":true,"svelteSortOrder":"options-scripts-styles-markup","svelte":{"indentScriptAndStyle":true,"sortOrder":"options-scripts-styles-markup"}}

--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "prettier": "3.8.3",
-    "prettier-plugin-svelte": "3.5.2",
-    "prettier-plugin-tailwindcss": "0.0.0-insiders.3997fbd",
+    "prettier-plugin-svelte": "4.0.1",
+    "prettier-plugin-tailwindcss": "0.0.0-insiders.2b6f3c2",
     "tinypool": "2.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,11 +72,11 @@ importers:
         specifier: 3.8.3
         version: 3.8.3
       prettier-plugin-svelte:
-        specifier: 3.5.2
-        version: 3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3))
+        specifier: 4.0.1
+        version: 4.0.1(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3))
       prettier-plugin-tailwindcss:
-        specifier: 0.0.0-insiders.3997fbd
-        version: 0.0.0-insiders.3997fbd(prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3)
+        specifier: 0.0.0-insiders.2b6f3c2
+        version: 0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.0.1(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3)
       tinypool:
         specifier: 2.1.0
         version: 2.1.0
@@ -4906,14 +4906,15 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-svelte@3.5.2:
-    resolution: {integrity: sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==}
+  prettier-plugin-svelte@4.0.1:
+    resolution: {integrity: sha512-oDVmtKi+M8bJeUoMfPvulUqZYcuXrs5AmhhLYPKtBeg6hcpMdx7UYYisVCqEaLQuKtiPSYFpotfwp4cZK3D4xw==}
+    engines: {node: '>=20'}
     peerDependencies:
       prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+      svelte: ^5.0.0
 
-  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd:
-    resolution: {integrity: sha512-H45ADK++Dyd7tMKCT7D6s+6uMxcVMZI841kyvSBXWaU8UOHJp273arY/5/5NqEBNxsquPGId7CatqUGbFbd0aQ==}
+  prettier-plugin-tailwindcss@0.0.0-insiders.2b6f3c2:
+    resolution: {integrity: sha512-bAwh6xzGCT0NvJUenof34s+JME2Fl7wRvUYUE8fEOGl41QgJGAEHWtjlgWC3p3bbPfx3O2ykNcvN1GFoDTM86g==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -9589,16 +9590,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)):
+  prettier-plugin-svelte@4.0.1(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)):
     dependencies:
       prettier: 3.8.3
       svelte: 5.55.7(@typescript-eslint/types@8.59.3)
 
-  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd(prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.0.0-insiders.2b6f3c2(prettier-plugin-svelte@4.0.1(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)))(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
     optionalDependencies:
-      prettier-plugin-svelte: 3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3))
+      prettier-plugin-svelte: 4.0.1(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3))
 
   prettier@3.8.3: {}
 


### PR DESCRIPTION
Upadte `prettier-plugin-svelte` along with `prettier-plugin-tailwindcss`.

- `prettier-plugin-svelte@4` has just released
  - https://github.com/sveltejs/prettier-plugin-svelte/releases/tag/prettier-plugin-svelte%404.0.0
  - This plugin requires Svelte 5 and uses new AST internally
- This breaks `prettier-plugin-tailwindcss`, which did not support new AST shape
  - https://github.com/tailwindlabs/prettier-plugin-tailwindcss/pull/462
- So we also update `prettier-plugin-tailwindcss` to support new AST

While `prettier-plugin-svelte@3` previously supported Svelte 4 and below, this new version has dropped that support. (= breaking change)

However, since Oxfmt has specified Svelte 5 as a peer dependency ever since adding Svelte support, it has never supported Svelte 4 or earlier.

In that sense, this is not a breaking change for Oxfmt.