### PR TITLE
chore(deps): update cargo-shear to 1.12.4

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,14 +24,14 @@ jobs:
         with:
           restore-cache: true
           cache-key: warm
-          tools: just,cargo-shear@1.11.2
+          tools: just,cargo-shear@1.12.4
           components: rustfmt
 
       - name: cargo-shear
         id: shear
         shell: bash
         run: |
-          if ! cargo shear --fix; then
+          if ! cargo shear --fix --check-test-targets --deny-warnings --format=github; then
             echo "shear=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           cache-key: warm
           save-cache: false
-          tools: just,cargo-insta,typos-cli,cargo-shear@1.11.2,ast-grep
+          tools: just,cargo-insta,typos-cli,cargo-shear@1.12.4,ast-grep
           components: clippy rust-docs rustfmt rust-analyzer
 
       - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ alias f := fix
 # Initialize the project by installing all necessary tools
 init:
   # Rust related init
-  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.11.2 -y
+  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.12.4 -y
   # Node.js related init
   pnpm install
 
@@ -60,7 +60,7 @@ lint:
 
 # Format all files
 fmt:
-  -cargo shear --fix # remove all unused dependencies
+  -cargo shear --fix --check-test-targets # remove all unused dependencies
   cargo fmt
   node --run fmt
 


### PR DESCRIPTION
## Summary

- Bump `cargo-shear` from `1.11.2` to `1.12.4` in `justfile`, `.github/workflows/autofix.yml`, and `.github/workflows/copilot-setup-steps.yml`.
- Enable `--check-test-targets` (new in 1.12.0) in `just fmt` and the autofix CI step to flag `test`/`doctest` target settings that don't match source content; pairs with `--fix` to auto-reconcile.
- Enable `--deny-warnings` and `--format=github` in the autofix CI step so warnings fail the job (triggering the existing autofix push) and findings surface as inline PR annotations.