### PR TITLE
feat(oxfmt): Format `parser:json` files by `oxc_formatter_json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_formatter",
  "oxc_formatter_core",
+ "oxc_formatter_json",
  "oxc_language_server",
  "oxc_napi",
  "oxc_parser",

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -34,6 +34,7 @@ oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
+oxc_formatter_json = { workspace = true }
 oxc_language_server = { workspace = true }
 oxc_napi = { workspace = true }
 oxc_parser = { workspace = true }

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -7,6 +7,7 @@ use tracing::instrument;
 use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::{Formatter, JsFormatOptions, enable_jsx_source_type, get_parse_options};
+use oxc_formatter_json::JsonFormatOptions;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxc_toml::Options as TomlFormatterOptions;
@@ -17,7 +18,7 @@ use super::options::{
     inject_tailwind_plugin_payload, to_package_json, to_prettier,
 };
 use super::{
-    options::{to_oxc_formatter, to_toml_formatter},
+    options::{to_oxc_formatter, to_oxc_formatter_json, to_toml_formatter},
     oxfmtrc::FormatConfig,
     support::FileKind,
 };
@@ -40,6 +41,12 @@ pub enum FormatStrategy {
         format_options: Box<JsFormatOptions>,
         #[cfg(feature = "napi")]
         config: Box<FormatConfig>,
+        insert_final_newline: bool,
+    },
+    /// For JSON (and JSON-like) files formatted by `oxc_formatter_json`.
+    OxcFormatterJson {
+        path: Arc<Path>,
+        format_options: Box<JsonFormatOptions>,
         insert_final_newline: bool,
     },
     /// For TOML files.
@@ -76,7 +83,9 @@ pub enum FormatStrategy {
 impl FormatStrategy {
     pub fn path(&self) -> &Arc<Path> {
         match self {
-            Self::OxcFormatter { path, .. } | Self::OxfmtToml { path, .. } => path,
+            Self::OxcFormatter { path, .. }
+            | Self::OxcFormatterJson { path, .. }
+            | Self::OxfmtToml { path, .. } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. }
             | Self::ExternalFormatterPackageJson { path, .. } => path,
@@ -108,6 +117,11 @@ impl FormatStrategy {
                 format_options: Box::new(to_oxc_formatter(&config)?),
                 #[cfg(feature = "napi")]
                 config: Box::new(config),
+                insert_final_newline,
+            },
+            FileKind::OxcFormatterJson { path, variant } => Self::OxcFormatterJson {
+                path,
+                format_options: Box::new(to_oxc_formatter_json(&config, variant)?),
                 insert_final_newline,
             },
             FileKind::OxfmtToml { path } => Self::OxfmtToml {
@@ -198,6 +212,10 @@ impl SourceFormatter {
                     #[cfg(feature = "napi")]
                     &config,
                 ),
+                insert_final_newline,
+            ),
+            FormatStrategy::OxcFormatterJson { path, format_options, insert_final_newline } => (
+                self.format_by_oxc_formatter_json(source_text, &path, *format_options),
                 insert_final_newline,
             ),
             FormatStrategy::OxfmtToml { toml_options, insert_final_newline, .. } => {
@@ -311,6 +329,27 @@ impl SourceFormatter {
         }
 
         Ok(code.into_code())
+    }
+
+    /// Format JSON (and JSON-like) source using `oxc_formatter_json`.
+    ///
+    /// Parse errors are surfaced as `OxcDiagnostic` — there is no Prettier fallback.
+    #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_json", skip_all)]
+    fn format_by_oxc_formatter_json(
+        &self,
+        source_text: &str,
+        path: &Path,
+        format_options: JsonFormatOptions,
+    ) -> Result<String, OxcDiagnostic> {
+        let allocator = self.allocator_pool.get();
+        let formatted = oxc_formatter_json::format(&allocator, source_text, format_options)?;
+        let printed = formatted.print().map_err(|err| {
+            OxcDiagnostic::error(format!(
+                "Failed to print formatted JSON: {}\n{err}",
+                path.display()
+            ))
+        })?;
+        Ok(printed.into_code())
     }
 
     /// Format TOML file using `oxc_toml`.

--- a/apps/oxfmt/src/core/options/mod.rs
+++ b/apps/oxfmt/src/core/options/mod.rs
@@ -10,6 +10,7 @@
 //!   (NAPI-only)
 
 mod to_oxc_formatter;
+mod to_oxc_formatter_json;
 mod to_toml_formatter;
 
 #[cfg(feature = "napi")]
@@ -18,6 +19,7 @@ mod to_package_json;
 mod to_prettier;
 
 pub use to_oxc_formatter::to_oxc_formatter;
+pub use to_oxc_formatter_json::to_oxc_formatter_json;
 pub use to_toml_formatter::to_toml_formatter;
 
 #[cfg(feature = "napi")]

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
@@ -1,0 +1,55 @@
+use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_json::{Expand, JsonFormatOptions, JsonVariant};
+
+use super::super::oxfmtrc::{EndOfLineConfig, FormatConfig, ObjectWrapConfig};
+
+/// Convert `FormatConfig` into validated `JsonFormatOptions` for `oxc_formatter_json`.
+///
+/// JSON-specific output options are intentionally ignored,
+/// [`oxc_formatter_json::JsonVariant`] fixes them.
+///
+/// # Errors
+/// Returns error if any option value is invalid.
+pub fn to_oxc_formatter_json(
+    config: &FormatConfig,
+    variant: JsonVariant,
+) -> Result<JsonFormatOptions, String> {
+    let mut options = JsonFormatOptions { variant, ..JsonFormatOptions::default() };
+
+    // [Prettier] useTabs: boolean
+    if let Some(use_tabs) = config.use_tabs {
+        options.indent_style = if use_tabs { IndentStyle::Tab } else { IndentStyle::Space };
+    }
+    // [Prettier] tabWidth: number
+    if let Some(width) = config.tab_width {
+        options.indent_width =
+            IndentWidth::try_from(width).map_err(|e| format!("Invalid tabWidth: {e}"))?;
+    }
+    // [Prettier] printWidth: number
+    if let Some(width) = config.print_width {
+        options.line_width =
+            LineWidth::try_from(width).map_err(|e| format!("Invalid printWidth: {e}"))?;
+    }
+    // [Prettier] endOfLine: "lf" | "cr" | "crlf" | "auto"
+    // NOTE: "auto" is not supported
+    if let Some(ending) = config.end_of_line {
+        options.line_ending = match ending {
+            EndOfLineConfig::Lf => LineEnding::Lf,
+            EndOfLineConfig::Crlf => LineEnding::Crlf,
+            EndOfLineConfig::Cr => LineEnding::Cr,
+        };
+    }
+    // [Prettier] bracketSpacing: boolean
+    if let Some(spacing) = config.bracket_spacing {
+        options.bracket_spacing = spacing;
+    }
+    // [Prettier] objectWrap: "preserve" | "collapse"
+    if let Some(wrap) = config.object_wrap {
+        options.expand = match wrap {
+            ObjectWrapConfig::Preserve => Expand::Auto,
+            ObjectWrapConfig::Collapse => Expand::Never,
+        };
+    }
+
+    Ok(options)
+}

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -2,6 +2,7 @@ use std::{path::Path, sync::Arc};
 
 use phf::phf_set;
 
+use oxc_formatter_json::JsonVariant;
 use oxc_span::SourceType;
 
 #[cfg(feature = "napi")]
@@ -26,6 +27,11 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
         return Some(FileKind::OxfmtToml { path });
     }
 
+    let extension = path.extension().and_then(|ext| ext.to_str());
+    if is_json_file(file_name, extension) {
+        return Some(FileKind::OxcFormatterJson { path, variant: JsonVariant::Json });
+    }
+
     // External formatter files are only supported with the `napi` feature
     #[cfg(feature = "napi")]
     {
@@ -37,7 +43,6 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
             });
         }
 
-        let extension = path.extension().and_then(|ext| ext.to_str());
         if let Some(parser_name) = get_external_parser_name(file_name, extension) {
             let supports_tailwind = TAILWIND_PARSERS.contains(parser_name);
             let supports_oxfmt = OXFMT_PARSERS.contains(parser_name);
@@ -63,6 +68,8 @@ pub enum FileKind {
     /// JS/TS files formatted by `oxc_formatter`.
     /// `supports_tailwind` is not needed, always enabled for JS/TS files.
     OxcFormatter { path: Arc<Path>, source_type: SourceType },
+    /// JSON (and JSON-like) files formatted by `oxc_formatter_json`.
+    OxcFormatterJson { path: Arc<Path>, variant: JsonVariant },
     /// TOML files formatted by taplo (Pure Rust).
     OxfmtToml { path: Arc<Path> },
     /// Files formatted by external formatter (Prettier).
@@ -88,7 +95,9 @@ pub enum FileKind {
 impl FileKind {
     pub fn path(&self) -> &Path {
         match self {
-            Self::OxcFormatter { path, .. } | Self::OxfmtToml { path } => path,
+            Self::OxcFormatter { path, .. }
+            | Self::OxcFormatterJson { path, .. }
+            | Self::OxfmtToml { path } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. }
             | Self::ExternalFormatterPackageJson { path, .. } => path,
@@ -193,22 +202,76 @@ static TOML_FILENAMES: phf::Set<&'static str> = phf_set! {
 
 // ---
 
+/// Returns `true` if this is a plain JSON file (handled by `oxc_formatter_json`).
+///
+/// NOTE: `jsonc`, `json5` and `json-stringify` variants are still handled by Prettier.
+fn is_json_file(file_name: &str, extension: Option<&str>) -> bool {
+    if matches!(file_name, "package.json" | "composer.json") {
+        return false;
+    }
+    if JSON_FILENAMES.contains(file_name) {
+        return true;
+    }
+    if let Some(ext) = extension
+        && JSON_EXTENSIONS.contains(ext)
+    {
+        return true;
+    }
+    false
+}
+
+static JSON_EXTENSIONS: phf::Set<&'static str> = phf_set! {
+    "json",
+    "4DForm",
+    "4DProject",
+    "avsc",
+    "geojson",
+    "gltf",
+    "har",
+    "ice",
+    "JSON-tmLanguage",
+    "json.example",
+    "mcmeta",
+    "sarif",
+    "tact",
+    "tfstate",
+    "tfstate.backup",
+    "topojson",
+    "webapp",
+    "webmanifest",
+    "yy",
+    "yyp",
+};
+
+static JSON_FILENAMES: phf::Set<&'static str> = phf_set! {
+    ".all-contributorsrc",
+    ".arcconfig",
+    ".auto-changelog",
+    ".c8rc",
+    ".htmlhintrc",
+    ".imgbotconfig",
+    ".nycrc",
+    ".tern-config",
+    ".tern-project",
+    ".watchmanconfig",
+    ".babelrc",
+    ".jscsrc",
+    ".jshintrc",
+    ".jslintrc",
+    ".swcrc",
+};
+
+// ---
+
 /// Returns parser name for external formatter, if supported.
 /// See also `prettier --support-info | jq '.languages[]'`
 #[cfg(feature = "napi")]
 fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
     // JSON and variants
-    // NOTE: `package.json` is handled separately in `classify_file_kind`
+    // NOTE: `parser: json` is already supported by `oxc_formatter_json`,
+    // others are routed to Prettier here.
     if file_name == "composer.json" || extension == Some("importmap") {
         return Some("json-stringify");
-    }
-    if JSON_FILENAMES.contains(file_name) {
-        return Some("json");
-    }
-    if let Some(ext) = extension
-        && JSON_EXTENSIONS.contains(ext)
-    {
-        return Some("json");
     }
     if let Some(ext) = extension
         && JSONC_EXTENSIONS.contains(ext)
@@ -294,49 +357,6 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
 
     None
 }
-
-#[cfg(feature = "napi")]
-static JSON_EXTENSIONS: phf::Set<&'static str> = phf_set! {
-    "json",
-    "4DForm",
-    "4DProject",
-    "avsc",
-    "geojson",
-    "gltf",
-    "har",
-    "ice",
-    "JSON-tmLanguage",
-    "json.example",
-    "mcmeta",
-    "sarif",
-    "tact",
-    "tfstate",
-    "tfstate.backup",
-    "topojson",
-    "webapp",
-    "webmanifest",
-    "yy",
-    "yyp",
-};
-
-#[cfg(feature = "napi")]
-static JSON_FILENAMES: phf::Set<&'static str> = phf_set! {
-    ".all-contributorsrc",
-    ".arcconfig",
-    ".auto-changelog",
-    ".c8rc",
-    ".htmlhintrc",
-    ".imgbotconfig",
-    ".nycrc",
-    ".tern-config",
-    ".tern-project",
-    ".watchmanconfig",
-    ".babelrc",
-    ".jscsrc",
-    ".jshintrc",
-    ".jslintrc",
-    ".swcrc",
-};
 
 #[cfg(feature = "napi")]
 static JSONC_EXTENSIONS: phf::Set<&'static str> = phf_set! {
@@ -523,10 +543,11 @@ mod tests {
     #[cfg(feature = "napi")]
     fn test_get_external_parser_name() {
         let test_cases = vec![
-            // JSON (NOTE: `package.json` is handled in classify_file_kind, not here)
+            // JSON variants
+            // NOTE: `package.json` is handled in classify_file_kind, not here.
+            // Plain JSON (e.g. `data.json`, `schema.avsc`) is routed to
+            // `oxc_formatter_json` and excluded from this map.
             ("config.importmap", Some("json-stringify")),
-            ("data.json", Some("json")),
-            ("schema.avsc", Some("json")),
             ("config.code-workspace", Some("jsonc")),
             ("settings.json5", Some("json5")),
             // HTML
@@ -586,6 +607,33 @@ mod tests {
 
         let kind = classify_file_kind(Arc::from(Path::new("composer.json"))).unwrap();
         assert!(matches!(kind, FileKind::ExternalFormatter { .. }));
+    }
+
+    #[test]
+    fn test_json_files_route_to_oxc_formatter_json() {
+        let json_files = vec![
+            // JSON_EXTENSIONS
+            "data.json",
+            "schema.avsc",
+            "map.geojson",
+            "model.gltf",
+            "config.webmanifest",
+            // JSON_FILENAMES
+            ".babelrc",
+            ".eslintrc.json",
+            ".swcrc",
+            ".watchmanconfig",
+            // tsconfig (handled via standard `.json` extension)
+            "tsconfig.json",
+        ];
+
+        for file_name in json_files {
+            let result = classify_file_kind(Arc::from(Path::new(file_name)));
+            assert!(
+                matches!(result, Some(FileKind::OxcFormatterJson { .. })),
+                "`{file_name}` should be routed to oxc_formatter_json"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Use `oxc_formatter_json` for major `.json` files, originally formatted by Prettier.