### PR TITLE
ci(monitor-oxc): trigger via run-monitor-oxc PR label

### DIFF
--- a/.github/workflows/monitor-oxc.yml
+++ b/.github/workflows/monitor-oxc.yml
@@ -1,0 +1,84 @@
+name: Monitor Oxc
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  group: monitor-oxc-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  trigger:
+    if: >
+      github.event.label.name == 'run-monitor-oxc' &&
+      github.repository == 'oxc-project/oxc'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: oxc-project
+          repositories: |
+            ${{ github.event.repository.name }}
+            monitor-oxc
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        id: prepare
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const issueNumber = context.payload.pull_request.number;
+            const branch = context.payload.pull_request.head.ref;
+            const body = `Triggering Monitor Oxc for \`${branch}\`\nhttps://github.com/oxc-project/monitor-oxc/actions/workflows/ci.yml`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existing = comments.findLast((c) =>
+              c.user.login === 'oxc-guard[bot]' &&
+              c.body &&
+              (c.body.startsWith('Triggering Monitor Oxc') || c.body.startsWith('## [Monitor Oxc]'))
+            );
+
+            let commentId;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              commentId = existing.id;
+            } else {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+              commentId = created.id;
+            }
+
+            core.setOutput('ref', `refs/pull/${issueNumber}/head`);
+            core.setOutput('comment-id', commentId);
+
+      - uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+        with:
+          repo: oxc-project/monitor-oxc
+          workflow: ci.yml
+          token: ${{ steps.app-token.outputs.token }}
+          ref: main
+          inputs: >-
+            {
+              "issue-number": "${{ github.event.pull_request.number }}",
+              "comment-id": "${{ steps.prepare.outputs.comment-id }}",
+              "ref": "${{ steps.prepare.outputs.ref }}"
+            }

--- a/.github/workflows/prepare_release_crates.yml
+++ b/.github/workflows/prepare_release_crates.yml
@@ -30,9 +30,6 @@ jobs:
     if: github.repository == 'oxc-project/oxc'
     name: Prepare Release
     runs-on: ubuntu-latest
-    outputs:
-      pull-request-number: ${{ steps.pr.outputs.pull-request-number }}
-      version: ${{ steps.run.outputs.CRATES_VERSION }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -84,36 +81,4 @@ jobs:
           base: main
           body-path: ./target/CRATES_CHANGELOG
           assignees: Boshen
-
-  ecosystem-ci:
-    needs: prepare
-    name: Trigger Monitor Oxc
-    runs-on: ubuntu-slim
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-
-      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        id: comment
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.prepare.outputs.pull-request-number }}
-          body: Triggering Monitor Oxc https://github.com/oxc-project/monitor-oxc/actions/workflows/ci.yml
-
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: oxc-project
-          repositories: monitor-oxc
-
-      - uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
-        with:
-          repo: oxc-project/monitor-oxc
-          workflow: ci.yml
-          token: ${{ steps.app-token.outputs.token }}
-          ref: main
-          inputs: '{ "issue-number": "${{ needs.prepare.outputs.pull-request-number }}", "comment-id": "${{ steps.comment.outputs.comment-id }}" }'
+          labels: run-monitor-oxc


### PR DESCRIPTION
## Summary

Add `.github/workflows/monitor-oxc.yml`. When a maintainer adds the `run-monitor-oxc` label to a PR, the workflow posts a placeholder comment, mints a GitHub App token, and dispatches `ci.yml` on `oxc-project/monitor-oxc` with `issue-number`, `comment-id`, and `ref: refs/pull/N/head`. monitor-oxc's existing `comment` job then edits the placeholder in place with the per-suite result table.

Consolidates the duplicated dispatch logic in `prepare_release_crates.yml`: the standalone `ecosystem-ci` job (and the now-unused `outputs:` on `prepare`) is replaced by a single `labels: run-monitor-oxc` input on `peter-evans/create-pull-request`. Because the action creates the PR with the App token, attaching the label fires `pull_request: labeled` on `oxc-project/oxc` and re-enters the new workflow.

## Operational notes

- The `run-monitor-oxc` label needs to be created once in repo settings — proposed color `#55e1cc` (same as `run-bench`) with description "Add to a PR to dispatch oxc-project/monitor-oxc CI against it". The workflow's `if:` guard ignores the event when the label name doesn't match, so missing the label only means the workflow does nothing — no errors.
- The GitHub App is already authorized to dispatch into `monitor-oxc` (same `repositories: monitor-oxc` token mint used by the old `ecosystem-ci` job in `prepare_release_crates.yml`).
- One-shot: removing and re-adding the label dispatches a new run. Pushing new commits while the label is still attached does **not** auto-retrigger.

## Behavior delta for release-prep flow

- *Before:* dispatch passed no `ref`, so monitor-oxc defaulted to `main` and tested `oxc-project/oxc@main` as of dispatch time (pre version-bump).
- *After:* dispatch passes `refs/pull/N/head`, so monitor-oxc tests the release PR branch (main + version-bump commit).

Version-bump commits only touch `Cargo.toml` / `package.json` versions — no transformer/codegen/etc. code paths. So monitor-oxc's results are functionally identical; arguably slightly better since it tests the exact code that ships.
