### PR TITLE
fix(linter): respect allow unused disable directives in LSP

### DIFF
--- a/apps/oxlint/fixtures/lsp/allow_unused_disabled_directives/.oxlintrc.json
+++ b/apps/oxlint/fixtures/lsp/allow_unused_disabled_directives/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-debugger": "error",
+    "no-console": "error"
+  }
+}

--- a/apps/oxlint/fixtures/lsp/allow_unused_disabled_directives/test.js
+++ b/apps/oxlint/fixtures/lsp/allow_unused_disabled_directives/test.js
@@ -1,0 +1,10 @@
+// oxlint-disable-next-line no-debugger -- on wrong line
+(() => {
+  debugger;
+})();
+
+// oxlint-disable-next-line no-debugger, no-for-loop, no-console
+console.log("asd"); debugger;
+
+// oxlint-disable-next-line no-debugger, no-for-loop
+console.log("complete line");

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -166,7 +166,7 @@ impl ServerLinterBuilder {
         let lint_options = LintOptions {
             fix: fix_kind,
             report_unused_directive: match options.unused_disable_directives {
-                Some(UnusedDisableDirectives::Allow) => Some(AllowWarnDeny::Allow),
+                Some(UnusedDisableDirectives::Allow) => None,
                 Some(UnusedDisableDirectives::Warn) => Some(AllowWarnDeny::Warn),
                 Some(UnusedDisableDirectives::Deny) => Some(AllowWarnDeny::Deny),
                 None => match config_store.report_unused_disable_directives() {
@@ -1385,6 +1385,17 @@ mod test {
             "fixtures/lsp/unused_disabled_directives",
             json!({
                 "unusedDisableDirectives": "deny"
+            }),
+        )
+        .test_and_snapshot_single_file("test.js");
+    }
+
+    #[test]
+    fn test_allow_unused_directives() {
+        Tester::new(
+            "fixtures/lsp/allow_unused_disabled_directives",
+            json!({
+                "unusedDisableDirectives": "allow"
             }),
         )
         .test_and_snapshot_single_file("test.js");

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_allow_unused_disabled_directives@test.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_allow_unused_disabled_directives@test.js.snap
@@ -1,0 +1,142 @@
+---
+source: apps/oxlint/src/lsp/tester.rs
+---
+########## 
+Linted file: fixtures/lsp/allow_unused_disabled_directives/test.js
+----------
+########## Diagnostic Reports
+File URI: file://<variable>/fixtures/lsp/allow_unused_disabled_directives/test.js
+
+code: "eslint(no-console)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html"
+message: "Unexpected console statement.\nhelp: Delete this console statement."
+range: Range { start: Position { line: 9, character: 0 }, end: Position { line: 9, character: 11 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/lsp/allow_unused_disabled_directives/test.js"
+related_information[0].location.range: Range { start: Position { line: 9, character: 0 }, end: Position { line: 9, character: 11 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None
+
+code: "eslint(no-debugger)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
+range: Range { start: Position { line: 2, character: 2 }, end: Position { line: 2, character: 11 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/lsp/allow_unused_disabled_directives/test.js"
+related_information[0].location.range: Range { start: Position { line: 2, character: 2 }, end: Position { line: 2, character: 11 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None
+
+########### Code Actions/Commands
+CodeAction: 
+Title: Delete this code.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 9,
+            character: 0,
+        },
+        end: Position {
+            line: 9,
+            character: 29,
+        },
+    },
+    new_text: "",
+}
+
+
+CodeAction: 
+Title: Disable no-console for this line
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 8,
+            character: 52,
+        },
+        end: Position {
+            line: 8,
+            character: 52,
+        },
+    },
+    new_text: " no-console",
+}
+
+
+CodeAction: 
+Title: Disable no-console for this whole file
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable no-console\n",
+}
+
+
+CodeAction: 
+Title: Remove the debugger statement
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 2,
+            character: 2,
+        },
+        end: Position {
+            line: 2,
+            character: 11,
+        },
+    },
+    new_text: "",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this line
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 2,
+            character: 0,
+        },
+        end: Position {
+            line: 2,
+            character: 0,
+        },
+    },
+    new_text: "  // oxlint-disable-next-line no-debugger\n",
+}
+
+
+CodeAction: 
+Title: Disable no-debugger for this whole file
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable no-debugger\n",
+}
+
+
+########### Fix All Action
+None


### PR DESCRIPTION
Fixes #22713

This updates the LSP handling for `unusedDisableDirectives: "allow"` so it disables unused directive reporting instead of producing warning diagnostics and remove-directive code actions.

The behavior now matches the CLI path: only `warn` and `deny` enable unused-disable reporting, while `allow`/`off` are treated as disabled.

Added an LSP snapshot regression test covering the `"allow"` case.