### PR TITLE
fix(transformer/class-properties): reparent lifted private method helpers

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -8,6 +8,7 @@ use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::SPAN;
+use oxc_traverse::Ancestor;
 
 use crate::{Helper, common::helper_loader::helper_call_expr, context::TraverseCtx};
 
@@ -64,9 +65,13 @@ impl<'a> ClassProperties<'a> {
         // Change parent scope of function to current scope id and remove
         // strict mode flag if parent scope is not strict mode.
         let scope_id = function.scope_id();
-        let new_parent_id = ctx.current_scope_id();
+        let new_parent_id = if Self::is_inside_static_initializer(ctx) {
+            ctx.current_hoist_scope_id()
+        } else {
+            ctx.current_scope_id()
+        };
         ctx.scoping_mut().change_scope_parent_id(scope_id, Some(new_parent_id));
-        let make_sloppy_mode = !ctx.current_scope_flags().is_strict_mode();
+        let make_sloppy_mode = !ctx.scoping().scope_flags(new_parent_id).is_strict_mode();
         let flags = ctx.scoping_mut().scope_flags_mut(scope_id);
         *flags -= ScopeFlags::GetAccessor | ScopeFlags::SetAccessor;
 
@@ -74,6 +79,10 @@ impl<'a> ClassProperties<'a> {
             .visit_function(&mut function, ScopeFlags::Function);
 
         Some(Statement::FunctionDeclaration(function))
+    }
+
+    fn is_inside_static_initializer(ctx: &TraverseCtx<'a>) -> bool {
+        ctx.ancestors().any(|ancestor| matches!(ancestor, Ancestor::PropertyDefinitionValue(_)))
     }
 
     // `_classPrivateMethodInitSpec(this, brand)`

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -65,7 +65,7 @@ impl<'a> ClassProperties<'a> {
         // Change parent scope of function to current scope id and remove
         // strict mode flag if parent scope is not strict mode.
         let scope_id = function.scope_id();
-        let new_parent_id = if Self::is_inside_static_initializer(ctx) {
+        let new_parent_id = if Self::is_inside_static_property_initializer(ctx) {
             ctx.current_hoist_scope_id()
         } else {
             ctx.current_scope_id()
@@ -81,8 +81,10 @@ impl<'a> ClassProperties<'a> {
         Some(Statement::FunctionDeclaration(function))
     }
 
-    fn is_inside_static_initializer(ctx: &TraverseCtx<'a>) -> bool {
-        ctx.ancestors().any(|ancestor| matches!(ancestor, Ancestor::PropertyDefinitionValue(_)))
+    fn is_inside_static_property_initializer(ctx: &TraverseCtx<'a>) -> bool {
+        ctx.ancestors().any(|ancestor| {
+            matches!(ancestor, Ancestor::PropertyDefinitionValue(property) if *property.r#static())
+        })
     }
 
     // `_classPrivateMethodInitSpec(this, brand)`

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: 7e115f46
 
 semantic_test262 Summary:
 AST Parsed     : 47210/47210 (100.00%)
-Positive Passed: 46978/47210 (99.51%)
+Positive Passed: 46990/47210 (99.53%)
 semantic Error: tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(Function)
@@ -707,54 +707,6 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
 
-semantic Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-field-shadowed-by-getter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(4): Some(ScopeId(1))
-rebuilt        : ScopeId(6): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-field-shadowed-by-method-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(7): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(7): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-field-shadowed-by-setter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(4): Some(ScopeId(1))
-rebuilt        : ScopeId(6): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-method-shadowed-by-getter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(6): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-method-shadowed-by-method-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(6): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/expressions/class/elements/private-static-method-shadowed-by-setter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(6): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(6): Some(ScopeId(0))
-
 semantic Error: tasks/coverage/test262/test/language/expressions/class/elements/static-field-init-with-this.js
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | DirectEval)
@@ -1246,54 +1198,6 @@ semantic Error: tasks/coverage/test262/test/language/statements/class/elements/p
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-field-shadowed-by-getter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(4): Some(ScopeId(1))
-rebuilt        : ScopeId(3): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-field-shadowed-by-method-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(3): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-field-shadowed-by-setter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(4): Some(ScopeId(1))
-rebuilt        : ScopeId(3): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-method-shadowed-by-getter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(3): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-method-shadowed-by-method-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(3): Some(ScopeId(0))
-
-semantic Error: tasks/coverage/test262/test/language/statements/class/elements/private-static-method-shadowed-by-setter-on-nested-class.js
-Scope flags mismatch:
-after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
-rebuilt        : ScopeId(3): ScopeFlags(Function)
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(1))
-rebuilt        : ScopeId(3): Some(ScopeId(0))
 
 semantic Error: tasks/coverage/test262/test/language/statements/class/elements/privatename-not-valid-eval-earlyerr-3.js
 Scope flags mismatch:


### PR DESCRIPTION
## Summary

Fixes semantic scope metadata for private method helper functions that are lifted out of classes nested inside static field initializers.

The class-properties transform converts a private method into a helper function declaration and emits that helper outside the class. For a nested class inside a static field initializer, `current_scope_id()` points at the nested class scope, but the helper is actually emitted into the surrounding hoist scope. That made semantic rebuild disagree with the transformed AST.

## Before

```js
class Outer {
  static value = class Inner {
    static #method() {}
  };
}
```

The helper function was reparented as if it still lived under the nested class scope:

```mermaid
flowchart TD
  Program["enclosing hoist scope"] --> Outer["Outer class scope"]
  Outer --> Field["static field initializer"]
  Field --> Inner["Inner class scope"]
  Inner --> Helper["lifted helper function scope"]
  Helper -.-> Problem["incorrect parent + strict-mode source"]
```

In code, the old logic always used the current scope and current scope flags:

```rust
let new_parent_id = ctx.current_scope_id();
ctx.scoping_mut().change_scope_parent_id(scope_id, Some(new_parent_id));
let make_sloppy_mode = !ctx.current_scope_flags().is_strict_mode();
```

That is correct for normal private methods, but not for private methods inside a class expression that appears in a static field initializer.

## After

When the transform is running under a static `PropertyDefinitionValue`, the helper is parented to the current hoist scope instead:

```rust
let new_parent_id = if Self::is_inside_static_property_initializer(ctx) {
    ctx.current_hoist_scope_id()
} else {
    ctx.current_scope_id()
};
ctx.scoping_mut().change_scope_parent_id(scope_id, Some(new_parent_id));
let make_sloppy_mode = !ctx.scoping().scope_flags(new_parent_id).is_strict_mode();
```

The predicate checks the field is actually static:

```rust
matches!(ancestor, Ancestor::PropertyDefinitionValue(property) if *property.r#static())
```

The resulting scope shape now matches where the helper is emitted:

```mermaid
flowchart TD
  Program["enclosing hoist scope"] --> Helper["lifted helper function scope"]
  Program --> Outer["Outer class scope"]
  Outer --> Field["static field initializer"]
  Field --> Inner["Inner class scope"]
```

The strict/sloppy adjustment also reads from the selected parent scope, so the helper's flags match the output location rather than the original nested class context.

## Validation

- `just fmt`
- `cargo test -p oxc_transformer`
- `just coverage` was run before review. It aborted later with a stack overflow / signal 6 in `target/coverage/oxc_coverage`; before the abort, the targeted `semantic_test262` failures were removed from the generated snapshot output.

AI assistance: Codex was used to cherry-pick, review, test, and draft this PR description.
