### PR TITLE
fix(ci): Specify release-oxc `--changelog` flag

### DIFF
--- a/.github/workflows/prepare_release_apps.yml
+++ b/.github/workflows/prepare_release_apps.yml
@@ -38,7 +38,7 @@ jobs:
         id: run
         run: |
           mkdir -p target
-          cargo release-oxc update --release oxlint --release oxfmt
+          cargo release-oxc update --changelog --release oxlint --release oxfmt
           echo "OXLINT_VERSION=$(cat ./target/OXLINT_VERSION)" >> $GITHUB_OUTPUT
           echo "OXFMT_VERSION=$(cat ./target/OXFMT_VERSION)" >> $GITHUB_OUTPUT
           {

--- a/.github/workflows/prepare_release_crates.yml
+++ b/.github/workflows/prepare_release_crates.yml
@@ -45,7 +45,7 @@ jobs:
         id: run
         run: |
           cargo ck
-          cargo release-oxc update --release crates
+          cargo release-oxc update --changelog --release crates
           echo "CRATES_VERSION=$(cat ./target/CRATES_VERSION)" >> $GITHUB_OUTPUT
 
       - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0


### PR DESCRIPTION
- `cargo-release-oxc` v0.0.42 made changelog generation opt-in via `--changelog`
  - oxc-project/cargo-release-oxc#236
- The `update` step no longer writes `./target/{NAME}_CHANGELOG`, breaking both `Prepare Release Apps` and `Prepare Release Crates` scheduled runs
  - https://github.com/oxc-project/oxc/actions/runs/26395995261/job/77696682742
  - https://github.com/oxc-project/oxc/actions/runs/26396139852/job/77697143129

Added `--changelog` to both `cargo release-oxc update` invocations to restore previous behavior.

