### PR TITLE
docs(linter): Mark a stylistic Unicorn rule as unsupported.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -40,6 +40,7 @@
     "n/no-restricted-import": "No need to implement, already implemented by `no-restricted-imports` rule.",
     "n/no-restricted-require": "No need to implement, already implemented by `no-restricted-imports` rule.",
     "import/order": "Not implementing this in Oxlint as its behavior is covered very well by [Oxfmt's import sorting](https://oxc.rs/docs/guide/usage/formatter/sorting.html).",
+    "unicorn/template-indent": "Stylistic rule.",
 
     "jsdoc/type-formatting": "Experimental rule in the original plugin, may reconsider once stable.",
     "jsdoc/convert-to-jsdoc-comments": "Experimental rule in the original plugin, may reconsider once stable.",


### PR DESCRIPTION
This kind of rule can be implemented via Oxfmt if needed.