### PR TITLE
fix(linter/no-array-sort): skip non compare fn sort arguments

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use oxc_syntax::operator::UnaryOperator;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
@@ -21,6 +22,27 @@ fn no_array_sort_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `Array#toSorted()` instead of `Array#sort()`.")
         .with_help("`Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.")
         .with_label(span)
+}
+
+/// Returns `true` when `arg` cannot be a valid `compareFn` for
+/// `Array.prototype.sort`. Used to filter out query-builder style calls such
+/// as Mongoose's `Model.find().sort({ field: 1 })` or
+/// `query.sort("-createdAt")` which are not `Array#sort` despite the shared
+/// method name.
+fn is_non_compare_fn_argument(arg: &Argument<'_>) -> bool {
+    match arg {
+        Argument::ObjectExpression(_)
+        | Argument::StringLiteral(_)
+        | Argument::TemplateLiteral(_)
+        | Argument::NumericLiteral(_)
+        | Argument::ArrayExpression(_) => true,
+        // `query.sort(-1)` / `query.sort(+1)` — unary on a numeric literal.
+        Argument::UnaryExpression(unary) => {
+            matches!(unary.operator, UnaryOperator::UnaryNegation | UnaryOperator::UnaryPlus)
+                && matches!(unary.argument, Expression::NumericLiteral(_))
+        }
+        _ => false,
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -91,6 +113,16 @@ impl Rule for NoArraySort {
         {
             return;
         }
+        // Skip calls whose single argument is incompatible with
+        // `Array.prototype.sort(compareFn?)`. The legitimate signature accepts
+        // either zero arguments or a function-shaped value. Object, string,
+        // numeric, template-literal, and array-literal arguments cannot be
+        // valid `compareFn`s, so they almost always indicate a non-array
+        // receiver (e.g. a query-builder API like Mongoose's
+        // `Model.find().sort({ field: 1 })`). See issue #22487.
+        if call_expr.arguments.len() == 1 && is_non_compare_fn_argument(&call_expr.arguments[0]) {
+            return;
+        }
         let Some(member_expr) = call_expr.callee.get_member_expr() else {
             return;
         };
@@ -153,20 +185,26 @@ fn test() {
         ("sorted = array.sort(compareFn, extraArgument)", None),
         (r#"import { Chunk } from "effect"; const sorted = Chunk.sort(compareFn)"#, None),
         (r#"import { Chunk as C } from "effect"; const sorted = C.sort(compareFn)"#, None),
-        // TODO: Get these passing?
-        // ("sorted = collection.sort({field: 1})", None),
-        // (r#"sorted = query.sort("field")"#, None),
-        // ("sorted = query.sort(1)", None),
-        // ("sorted = query.sort(-1)", None),
-        // ("sorted = query.sort(+1)", None),
-        // ("sorted = query.sort(`field`)", None),
-        // ("sorted = query.sort([criteria])", None),
-        // ("const docs = collection.find({id}).sort({expireAt: -1}).limit(1).toArray()", None),
-        // ("[...array].sort({field: 1})", None),
-        // (
-        //     "collection.sort({field: 1})",
-        //     Some(serde_json::json!([{ "allowExpressionStatement": false }])),
-        // ),
+        // Query-builder style `.sort(...)` calls — single argument is not a
+        // valid `compareFn`, so the receiver is almost certainly a non-array
+        // (e.g. Mongoose, Mongo). See issue #22487.
+        ("sorted = collection.sort({field: 1})", None),
+        (r#"sorted = query.sort("field")"#, None),
+        ("sorted = query.sort(1)", None),
+        ("sorted = query.sort(-1)", None),
+        ("sorted = query.sort(+1)", None),
+        ("sorted = query.sort(`field`)", None),
+        ("sorted = query.sort([criteria])", None),
+        ("const docs = collection.find({id}).sort({expireAt: -1}).limit(1).toArray()", None),
+        ("[...array].sort({field: 1})", None),
+        (
+            "collection.sort({field: 1})",
+            Some(serde_json::json!([{ "allowExpressionStatement": false }])),
+        ),
+        // Regression cases drawn directly from the issue body.
+        ("User.find().sort({ createdAt: -1 })", None),
+        (r#"User.find().sort("-createdAt")"#, None),
+        (r#"Post.find({ published: true }).sort({ updatedAt: "desc" })"#, None),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -1,3 +1,7 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
 use oxc_ast::{
     AstKind,
     ast::{Argument, ArrayExpressionElement, Expression},
@@ -5,10 +9,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use oxc_syntax::operator::UnaryOperator;
-use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::Value;
 
 use crate::{
     AstNode,
@@ -22,27 +22,6 @@ fn no_array_sort_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `Array#toSorted()` instead of `Array#sort()`.")
         .with_help("`Array#sort()` mutates the original array. Use `Array#toSorted()` to return a new sorted array without modifying the original.")
         .with_label(span)
-}
-
-/// Returns `true` when `arg` cannot be a valid `compareFn` for
-/// `Array.prototype.sort`. Used to filter out query-builder style calls such
-/// as Mongoose's `Model.find().sort({ field: 1 })` or
-/// `query.sort("-createdAt")` which are not `Array#sort` despite the shared
-/// method name.
-fn is_non_compare_fn_argument(arg: &Argument<'_>) -> bool {
-    match arg {
-        Argument::ObjectExpression(_)
-        | Argument::StringLiteral(_)
-        | Argument::TemplateLiteral(_)
-        | Argument::NumericLiteral(_)
-        | Argument::ArrayExpression(_) => true,
-        // `query.sort(-1)` / `query.sort(+1)` — unary on a numeric literal.
-        Argument::UnaryExpression(unary) => {
-            matches!(unary.operator, UnaryOperator::UnaryNegation | UnaryOperator::UnaryPlus)
-                && matches!(unary.argument, Expression::NumericLiteral(_))
-        }
-        _ => false,
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -167,6 +146,27 @@ impl Rule for NoArraySort {
     }
 }
 
+/// Returns `true` when `arg` cannot be a valid `compareFn` for
+/// `Array.prototype.sort`. Used to filter out query-builder style calls such
+/// as Mongoose's `Model.find().sort({ field: 1 })` or
+/// `query.sort("-createdAt")` which are not `Array#sort` despite the shared
+/// method name.
+fn is_non_compare_fn_argument(arg: &Argument<'_>) -> bool {
+    match arg {
+        Argument::ObjectExpression(_)
+        | Argument::StringLiteral(_)
+        | Argument::TemplateLiteral(_)
+        | Argument::NumericLiteral(_)
+        | Argument::ArrayExpression(_) => true,
+        // `query.sort(-1)` / `query.sort(+1)` — unary on a numeric literal.
+        Argument::UnaryExpression(unary) => {
+            unary.operator.is_arithmetic()
+                && unary.argument.without_parentheses().is_number_literal()
+        }
+        _ => false,
+    }
+}
+
 #[test]
 fn test() {
     use crate::tester::Tester;
@@ -185,9 +185,6 @@ fn test() {
         ("sorted = array.sort(compareFn, extraArgument)", None),
         (r#"import { Chunk } from "effect"; const sorted = Chunk.sort(compareFn)"#, None),
         (r#"import { Chunk as C } from "effect"; const sorted = C.sort(compareFn)"#, None),
-        // Query-builder style `.sort(...)` calls — single argument is not a
-        // valid `compareFn`, so the receiver is almost certainly a non-array
-        // (e.g. Mongoose, Mongo). See issue #22487.
         ("sorted = collection.sort({field: 1})", None),
         (r#"sorted = query.sort("field")"#, None),
         ("sorted = query.sort(1)", None),
@@ -201,7 +198,6 @@ fn test() {
             "collection.sort({field: 1})",
             Some(serde_json::json!([{ "allowExpressionStatement": false }])),
         ),
-        // Regression cases drawn directly from the issue body.
         ("User.find().sort({ createdAt: -1 })", None),
         (r#"User.find().sort("-createdAt")"#, None),
         (r#"Post.find({ published: true }).sort({ updatedAt: "desc" })"#, None),


### PR DESCRIPTION
## Summary

Closes #22487.

`unicorn/no-array-sort` currently flags every member-call named `.sort(...)`,
including query-builder APIs like Mongoose's `Model.find().sort({ field: 1 })`.
The receiver is not an `Array`, so the diagnostic is a false positive.

This change narrows the rule by inspecting the single argument's shape.
`Array.prototype.sort(compareFn?)` accepts either zero arguments or a function-
shaped value. A single object, string, numeric, template-literal, array-literal,
or unary-numeric argument is therefore incompatible with `Array#sort`. Skipping
diagnostics in those cases removes the false positives without weakening
detection of the real misuse patterns this rule targets (`array.sort()`,
`[...array].sort()`, `array.sort(compareFn)`).

## Changes

`crates/oxc_linter/src/rules/unicorn/no_array_sort.rs`:

- New helper `is_non_compare_fn_argument` early-returns from `Rule::run` when
  the call has exactly one argument matching the non-`compareFn` shapes listed
  above.
- The in-source `// TODO: Get these passing?` block at the previous
  `no_array_sort.rs:156` enumerated exactly these false-positive cases. Those
  TODO entries are now active `pass` tests.
- Added three new `pass` regression tests drawn directly from the issue body
  (`User.find().sort({ createdAt: -1 })`, `User.find().sort("-createdAt")`,
  `Post.find({ published: true }).sort({ updatedAt: "desc" })`).
- All existing `fail` and `expect_fix` cases are unchanged. The snapshot file
  `snapshots/unicorn_no_array_sort.snap` is unchanged because the new `pass`
  cases produce no diagnostics.

## Test plan

- `cargo test --all-features -p oxc_linter no_array_sort` — `1 passed; 0 failed`
- `cargo test --all-features -p oxc_linter unicorn::` — `148 passed; 0 failed`
- `cargo fmt -- --check crates/oxc_linter/src/rules/unicorn/no_array_sort.rs` — clean
- Manual reasoning on the AST argument shapes:
  - `array.sort(compareFn)` — `Argument::Identifier` (or arrow/function expr); not skipped, still reported
  - `array.sort((a, b) => a - b)` — `Argument::ArrowFunctionExpression`; not skipped, still reported
  - `array.sort(({a}) => a)` — destructuring lives inside the arrow body; argument is still `ArrowFunctionExpression`; not skipped
  - `query.sort(-1)` / `query.sort(+1)` — `Argument::UnaryExpression` over a `NumericLiteral`; explicitly skipped
  - `array.sort(...spread)` — `Argument::SpreadElement`; the existing earlier early-return handles this

## Notes

- Disclosure: This change was prepared with AI assistance per the project's
  AI usage policy. The diagnostic narrowing follows the in-source TODO list
  the maintainer already curated, and all logic, tests, and reasoning were
  reviewed before submission.
- The fix is intentionally conservative and type-info-free, in line with the
  rest of the unicorn rules. If a future direction prefers gating this kind
  of receiver inference behind `--type-aware`, this PR's logic can be
  reused or moved without disturbing public API.