### PR TITLE
feat(linter/eslint): implement `prefer-named-capture-group` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -875,6 +875,7 @@ export interface DummyRuleMap {
   "prefer-const"?: DummyRule;
   "prefer-destructuring"?: DummyRule;
   "prefer-exponentiation-operator"?: DummyRule;
+  "prefer-named-capture-group"?: DummyRule;
   "prefer-numeric-literals"?: DummyRule;
   "prefer-object-has-own"?: DummyRule;
   "prefer-object-spread"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -214,11 +214,6 @@ impl RuleRunner for crate::rules::import::unambiguous::Unambiguous {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
-impl RuleRunner for crate::rules::eslint::prefer_named_capture_group::PreferNamedCaptureGroup {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
 impl RuleRunner for crate::rules::eslint::accessor_pairs::AccessorPairs {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,
@@ -1306,6 +1301,11 @@ impl RuleRunner
 {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::prefer_named_capture_group::PreferNamedCaptureGroup {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -214,6 +214,11 @@ impl RuleRunner for crate::rules::import::unambiguous::Unambiguous {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::eslint::prefer_named_capture_group::PreferNamedCaptureGroup {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::accessor_pairs::AccessorPairs {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -865,7 +865,6 @@ pub enum RuleEnum {
     ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax),
     ImportPreferDefaultExport(ImportPreferDefaultExport),
     ImportUnambiguous(ImportUnambiguous),
-    EslintPreferNamedCaptureGroup(EslintPreferNamedCaptureGroup),
     EslintAccessorPairs(EslintAccessorPairs),
     EslintArrayCallbackReturn(EslintArrayCallbackReturn),
     EslintArrowBodyStyle(EslintArrowBodyStyle),
@@ -1027,6 +1026,7 @@ pub enum RuleEnum {
     EslintPreferConst(EslintPreferConst),
     EslintPreferDestructuring(EslintPreferDestructuring),
     EslintPreferExponentiationOperator(EslintPreferExponentiationOperator),
+    EslintPreferNamedCaptureGroup(EslintPreferNamedCaptureGroup),
     EslintPreferNumericLiterals(EslintPreferNumericLiterals),
     EslintPreferObjectHasOwn(EslintPreferObjectHasOwn),
     EslintPreferObjectSpread(EslintPreferObjectSpread),
@@ -1688,8 +1688,7 @@ const IMPORT_NO_UNASSIGNED_IMPORT_ID: usize = IMPORT_NO_SELF_IMPORT_ID + 1usize;
 const IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID: usize = IMPORT_NO_UNASSIGNED_IMPORT_ID + 1usize;
 const IMPORT_PREFER_DEFAULT_EXPORT_ID: usize = IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID + 1usize;
 const IMPORT_UNAMBIGUOUS_ID: usize = IMPORT_PREFER_DEFAULT_EXPORT_ID + 1usize;
-const ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
-const ESLINT_ACCESSOR_PAIRS_ID: usize = ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID + 1usize;
+const ESLINT_ACCESSOR_PAIRS_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
 const ESLINT_ARRAY_CALLBACK_RETURN_ID: usize = ESLINT_ACCESSOR_PAIRS_ID + 1usize;
 const ESLINT_ARROW_BODY_STYLE_ID: usize = ESLINT_ARRAY_CALLBACK_RETURN_ID + 1usize;
 const ESLINT_BLOCK_SCOPED_VAR_ID: usize = ESLINT_ARROW_BODY_STYLE_ID + 1usize;
@@ -1850,7 +1849,9 @@ const ESLINT_PREFER_ARROW_CALLBACK_ID: usize = ESLINT_OPERATOR_ASSIGNMENT_ID + 1
 const ESLINT_PREFER_CONST_ID: usize = ESLINT_PREFER_ARROW_CALLBACK_ID + 1usize;
 const ESLINT_PREFER_DESTRUCTURING_ID: usize = ESLINT_PREFER_CONST_ID + 1usize;
 const ESLINT_PREFER_EXPONENTIATION_OPERATOR_ID: usize = ESLINT_PREFER_DESTRUCTURING_ID + 1usize;
-const ESLINT_PREFER_NUMERIC_LITERALS_ID: usize = ESLINT_PREFER_EXPONENTIATION_OPERATOR_ID + 1usize;
+const ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID: usize =
+    ESLINT_PREFER_EXPONENTIATION_OPERATOR_ID + 1usize;
+const ESLINT_PREFER_NUMERIC_LITERALS_ID: usize = ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID + 1usize;
 const ESLINT_PREFER_OBJECT_HAS_OWN_ID: usize = ESLINT_PREFER_NUMERIC_LITERALS_ID + 1usize;
 const ESLINT_PREFER_OBJECT_SPREAD_ID: usize = ESLINT_PREFER_OBJECT_HAS_OWN_ID + 1usize;
 const ESLINT_PREFER_PROMISE_REJECT_ERRORS_ID: usize = ESLINT_PREFER_OBJECT_SPREAD_ID + 1usize;
@@ -2609,7 +2610,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID,
             Self::ImportPreferDefaultExport(_) => IMPORT_PREFER_DEFAULT_EXPORT_ID,
             Self::ImportUnambiguous(_) => IMPORT_UNAMBIGUOUS_ID,
-            Self::EslintPreferNamedCaptureGroup(_) => ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID,
             Self::EslintAccessorPairs(_) => ESLINT_ACCESSOR_PAIRS_ID,
             Self::EslintArrayCallbackReturn(_) => ESLINT_ARRAY_CALLBACK_RETURN_ID,
             Self::EslintArrowBodyStyle(_) => ESLINT_ARROW_BODY_STYLE_ID,
@@ -2771,6 +2771,7 @@ impl RuleEnum {
             Self::EslintPreferConst(_) => ESLINT_PREFER_CONST_ID,
             Self::EslintPreferDestructuring(_) => ESLINT_PREFER_DESTRUCTURING_ID,
             Self::EslintPreferExponentiationOperator(_) => ESLINT_PREFER_EXPONENTIATION_OPERATOR_ID,
+            Self::EslintPreferNamedCaptureGroup(_) => ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID,
             Self::EslintPreferNumericLiterals(_) => ESLINT_PREFER_NUMERIC_LITERALS_ID,
             Self::EslintPreferObjectHasOwn(_) => ESLINT_PREFER_OBJECT_HAS_OWN_ID,
             Self::EslintPreferObjectSpread(_) => ESLINT_PREFER_OBJECT_SPREAD_ID,
@@ -3551,7 +3552,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::NAME,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::NAME,
             Self::ImportUnambiguous(_) => ImportUnambiguous::NAME,
-            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::NAME,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::NAME,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::NAME,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::NAME,
@@ -3713,6 +3713,7 @@ impl RuleEnum {
             Self::EslintPreferConst(_) => EslintPreferConst::NAME,
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::NAME,
             Self::EslintPreferExponentiationOperator(_) => EslintPreferExponentiationOperator::NAME,
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::NAME,
             Self::EslintPreferNumericLiterals(_) => EslintPreferNumericLiterals::NAME,
             Self::EslintPreferObjectHasOwn(_) => EslintPreferObjectHasOwn::NAME,
             Self::EslintPreferObjectSpread(_) => EslintPreferObjectSpread::NAME,
@@ -4481,7 +4482,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::CATEGORY,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::CATEGORY,
             Self::ImportUnambiguous(_) => ImportUnambiguous::CATEGORY,
-            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::CATEGORY,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::CATEGORY,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::CATEGORY,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::CATEGORY,
@@ -4647,6 +4647,7 @@ impl RuleEnum {
             Self::EslintPreferExponentiationOperator(_) => {
                 EslintPreferExponentiationOperator::CATEGORY
             }
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::CATEGORY,
             Self::EslintPreferNumericLiterals(_) => EslintPreferNumericLiterals::CATEGORY,
             Self::EslintPreferObjectHasOwn(_) => EslintPreferObjectHasOwn::CATEGORY,
             Self::EslintPreferObjectSpread(_) => EslintPreferObjectSpread::CATEGORY,
@@ -5466,7 +5467,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::FIX,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::FIX,
             Self::ImportUnambiguous(_) => ImportUnambiguous::FIX,
-            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::FIX,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::FIX,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::FIX,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::FIX,
@@ -5628,6 +5628,7 @@ impl RuleEnum {
             Self::EslintPreferConst(_) => EslintPreferConst::FIX,
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::FIX,
             Self::EslintPreferExponentiationOperator(_) => EslintPreferExponentiationOperator::FIX,
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::FIX,
             Self::EslintPreferNumericLiterals(_) => EslintPreferNumericLiterals::FIX,
             Self::EslintPreferObjectHasOwn(_) => EslintPreferObjectHasOwn::FIX,
             Self::EslintPreferObjectSpread(_) => EslintPreferObjectSpread::FIX,
@@ -6401,9 +6402,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::documentation(),
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::documentation(),
             Self::ImportUnambiguous(_) => ImportUnambiguous::documentation(),
-            Self::EslintPreferNamedCaptureGroup(_) => {
-                EslintPreferNamedCaptureGroup::documentation()
-            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::documentation(),
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::documentation(),
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::documentation(),
@@ -6588,6 +6586,9 @@ impl RuleEnum {
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::documentation(),
             Self::EslintPreferExponentiationOperator(_) => {
                 EslintPreferExponentiationOperator::documentation()
+            }
+            Self::EslintPreferNamedCaptureGroup(_) => {
+                EslintPreferNamedCaptureGroup::documentation()
             }
             Self::EslintPreferNumericLiterals(_) => EslintPreferNumericLiterals::documentation(),
             Self::EslintPreferObjectHasOwn(_) => EslintPreferObjectHasOwn::documentation(),
@@ -7632,10 +7633,6 @@ impl RuleEnum {
             }
             Self::ImportUnambiguous(_) => ImportUnambiguous::config_schema(generator)
                 .or_else(|| ImportUnambiguous::schema(generator)),
-            Self::EslintPreferNamedCaptureGroup(_) => {
-                EslintPreferNamedCaptureGroup::config_schema(generator)
-                    .or_else(|| EslintPreferNamedCaptureGroup::schema(generator))
-            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::config_schema(generator)
                 .or_else(|| EslintAccessorPairs::schema(generator)),
             Self::EslintArrayCallbackReturn(_) => {
@@ -8044,6 +8041,10 @@ impl RuleEnum {
             Self::EslintPreferExponentiationOperator(_) => {
                 EslintPreferExponentiationOperator::config_schema(generator)
                     .or_else(|| EslintPreferExponentiationOperator::schema(generator))
+            }
+            Self::EslintPreferNamedCaptureGroup(_) => {
+                EslintPreferNamedCaptureGroup::config_schema(generator)
+                    .or_else(|| EslintPreferNamedCaptureGroup::schema(generator))
             }
             Self::EslintPreferNumericLiterals(_) => {
                 EslintPreferNumericLiterals::config_schema(generator)
@@ -9922,7 +9923,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => "import",
             Self::ImportPreferDefaultExport(_) => "import",
             Self::ImportUnambiguous(_) => "import",
-            Self::EslintPreferNamedCaptureGroup(_) => "eslint",
             Self::EslintAccessorPairs(_) => "eslint",
             Self::EslintArrayCallbackReturn(_) => "eslint",
             Self::EslintArrowBodyStyle(_) => "eslint",
@@ -10084,6 +10084,7 @@ impl RuleEnum {
             Self::EslintPreferConst(_) => "eslint",
             Self::EslintPreferDestructuring(_) => "eslint",
             Self::EslintPreferExponentiationOperator(_) => "eslint",
+            Self::EslintPreferNamedCaptureGroup(_) => "eslint",
             Self::EslintPreferNumericLiterals(_) => "eslint",
             Self::EslintPreferObjectHasOwn(_) => "eslint",
             Self::EslintPreferObjectSpread(_) => "eslint",
@@ -10805,9 +10806,6 @@ impl RuleEnum {
             Self::ImportUnambiguous(_) => {
                 Ok(Self::ImportUnambiguous(ImportUnambiguous::from_configuration(value)?))
             }
-            Self::EslintPreferNamedCaptureGroup(_) => Ok(Self::EslintPreferNamedCaptureGroup(
-                EslintPreferNamedCaptureGroup::from_configuration(value)?,
-            )),
             Self::EslintAccessorPairs(_) => {
                 Ok(Self::EslintAccessorPairs(EslintAccessorPairs::from_configuration(value)?))
             }
@@ -11295,6 +11293,9 @@ impl RuleEnum {
                     EslintPreferExponentiationOperator::from_configuration(value)?,
                 ))
             }
+            Self::EslintPreferNamedCaptureGroup(_) => Ok(Self::EslintPreferNamedCaptureGroup(
+                EslintPreferNamedCaptureGroup::from_configuration(value)?,
+            )),
             Self::EslintPreferNumericLiterals(_) => Ok(Self::EslintPreferNumericLiterals(
                 EslintPreferNumericLiterals::from_configuration(value)?,
             )),
@@ -13369,7 +13370,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.to_configuration(),
             Self::ImportPreferDefaultExport(rule) => rule.to_configuration(),
             Self::ImportUnambiguous(rule) => rule.to_configuration(),
-            Self::EslintPreferNamedCaptureGroup(rule) => rule.to_configuration(),
             Self::EslintAccessorPairs(rule) => rule.to_configuration(),
             Self::EslintArrayCallbackReturn(rule) => rule.to_configuration(),
             Self::EslintArrowBodyStyle(rule) => rule.to_configuration(),
@@ -13531,6 +13531,7 @@ impl RuleEnum {
             Self::EslintPreferConst(rule) => rule.to_configuration(),
             Self::EslintPreferDestructuring(rule) => rule.to_configuration(),
             Self::EslintPreferExponentiationOperator(rule) => rule.to_configuration(),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.to_configuration(),
             Self::EslintPreferNumericLiterals(rule) => rule.to_configuration(),
             Self::EslintPreferObjectHasOwn(rule) => rule.to_configuration(),
             Self::EslintPreferObjectSpread(rule) => rule.to_configuration(),
@@ -14197,7 +14198,6 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run(node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run(node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run(node, ctx),
-                Self::EslintPreferNamedCaptureGroup(rule) => rule.run(node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run(node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run(node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run(node, ctx),
@@ -14359,6 +14359,7 @@ impl RuleEnum {
                 Self::EslintPreferConst(rule) => rule.run(node, ctx),
                 Self::EslintPreferDestructuring(rule) => rule.run(node, ctx),
                 Self::EslintPreferExponentiationOperator(rule) => rule.run(node, ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run(node, ctx),
                 Self::EslintPreferNumericLiterals(rule) => rule.run(node, ctx),
                 Self::EslintPreferObjectHasOwn(rule) => rule.run(node, ctx),
                 Self::EslintPreferObjectSpread(rule) => rule.run(node, ctx),
@@ -15018,7 +15019,6 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run(node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run(node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run(node, ctx),
-                Self::EslintPreferNamedCaptureGroup(rule) => rule.run(node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run(node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run(node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run(node, ctx),
@@ -15180,6 +15180,7 @@ impl RuleEnum {
                 Self::EslintPreferConst(rule) => rule.run(node, ctx),
                 Self::EslintPreferDestructuring(rule) => rule.run(node, ctx),
                 Self::EslintPreferExponentiationOperator(rule) => rule.run(node, ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run(node, ctx),
                 Self::EslintPreferNumericLiterals(rule) => rule.run(node, ctx),
                 Self::EslintPreferObjectHasOwn(rule) => rule.run(node, ctx),
                 Self::EslintPreferObjectSpread(rule) => rule.run(node, ctx),
@@ -15846,7 +15847,6 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_once(ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_once(ctx),
                 Self::ImportUnambiguous(rule) => rule.run_once(ctx),
-                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_once(ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_once(ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_once(ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_once(ctx),
@@ -16008,6 +16008,7 @@ impl RuleEnum {
                 Self::EslintPreferConst(rule) => rule.run_once(ctx),
                 Self::EslintPreferDestructuring(rule) => rule.run_once(ctx),
                 Self::EslintPreferExponentiationOperator(rule) => rule.run_once(ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_once(ctx),
                 Self::EslintPreferNumericLiterals(rule) => rule.run_once(ctx),
                 Self::EslintPreferObjectHasOwn(rule) => rule.run_once(ctx),
                 Self::EslintPreferObjectSpread(rule) => rule.run_once(ctx),
@@ -16667,7 +16668,6 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_once(ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_once(ctx),
                 Self::ImportUnambiguous(rule) => rule.run_once(ctx),
-                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_once(ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_once(ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_once(ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_once(ctx),
@@ -16829,6 +16829,7 @@ impl RuleEnum {
                 Self::EslintPreferConst(rule) => rule.run_once(ctx),
                 Self::EslintPreferDestructuring(rule) => rule.run_once(ctx),
                 Self::EslintPreferExponentiationOperator(rule) => rule.run_once(ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_once(ctx),
                 Self::EslintPreferNumericLiterals(rule) => rule.run_once(ctx),
                 Self::EslintPreferObjectHasOwn(rule) => rule.run_once(ctx),
                 Self::EslintPreferObjectSpread(rule) => rule.run_once(ctx),
@@ -17498,7 +17499,6 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17674,6 +17674,7 @@ impl RuleEnum {
                 Self::EslintPreferExponentiationOperator(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintPreferNumericLiterals(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintPreferObjectHasOwn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintPreferObjectSpread(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18573,7 +18574,6 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18749,6 +18749,7 @@ impl RuleEnum {
                 Self::EslintPreferExponentiationOperator(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintPreferNumericLiterals(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintPreferObjectHasOwn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintPreferObjectSpread(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19648,7 +19649,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.should_run(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.should_run(ctx),
             Self::ImportUnambiguous(rule) => rule.should_run(ctx),
-            Self::EslintPreferNamedCaptureGroup(rule) => rule.should_run(ctx),
             Self::EslintAccessorPairs(rule) => rule.should_run(ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.should_run(ctx),
             Self::EslintArrowBodyStyle(rule) => rule.should_run(ctx),
@@ -19810,6 +19810,7 @@ impl RuleEnum {
             Self::EslintPreferConst(rule) => rule.should_run(ctx),
             Self::EslintPreferDestructuring(rule) => rule.should_run(ctx),
             Self::EslintPreferExponentiationOperator(rule) => rule.should_run(ctx),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.should_run(ctx),
             Self::EslintPreferNumericLiterals(rule) => rule.should_run(ctx),
             Self::EslintPreferObjectHasOwn(rule) => rule.should_run(ctx),
             Self::EslintPreferObjectSpread(rule) => rule.should_run(ctx),
@@ -20472,9 +20473,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::IS_TSGOLINT_RULE,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::IS_TSGOLINT_RULE,
             Self::ImportUnambiguous(_) => ImportUnambiguous::IS_TSGOLINT_RULE,
-            Self::EslintPreferNamedCaptureGroup(_) => {
-                EslintPreferNamedCaptureGroup::IS_TSGOLINT_RULE
-            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::IS_TSGOLINT_RULE,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::IS_TSGOLINT_RULE,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::IS_TSGOLINT_RULE,
@@ -20659,6 +20657,9 @@ impl RuleEnum {
             Self::EslintPreferDestructuring(_) => EslintPreferDestructuring::IS_TSGOLINT_RULE,
             Self::EslintPreferExponentiationOperator(_) => {
                 EslintPreferExponentiationOperator::IS_TSGOLINT_RULE
+            }
+            Self::EslintPreferNamedCaptureGroup(_) => {
+                EslintPreferNamedCaptureGroup::IS_TSGOLINT_RULE
             }
             Self::EslintPreferNumericLiterals(_) => EslintPreferNumericLiterals::IS_TSGOLINT_RULE,
             Self::EslintPreferObjectHasOwn(_) => EslintPreferObjectHasOwn::IS_TSGOLINT_RULE,
@@ -21652,7 +21653,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::VERSION,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::VERSION,
             Self::ImportUnambiguous(_) => ImportUnambiguous::VERSION,
-            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::VERSION,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::VERSION,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::VERSION,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::VERSION,
@@ -21818,6 +21818,7 @@ impl RuleEnum {
             Self::EslintPreferExponentiationOperator(_) => {
                 EslintPreferExponentiationOperator::VERSION
             }
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::VERSION,
             Self::EslintPreferNumericLiterals(_) => EslintPreferNumericLiterals::VERSION,
             Self::EslintPreferObjectHasOwn(_) => EslintPreferObjectHasOwn::VERSION,
             Self::EslintPreferObjectSpread(_) => EslintPreferObjectSpread::VERSION,
@@ -22639,7 +22640,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::HAS_CONFIG,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::HAS_CONFIG,
             Self::ImportUnambiguous(_) => ImportUnambiguous::HAS_CONFIG,
-            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::HAS_CONFIG,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::HAS_CONFIG,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::HAS_CONFIG,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::HAS_CONFIG,
@@ -22811,6 +22811,7 @@ impl RuleEnum {
             Self::EslintPreferExponentiationOperator(_) => {
                 EslintPreferExponentiationOperator::HAS_CONFIG
             }
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::HAS_CONFIG,
             Self::EslintPreferNumericLiterals(_) => EslintPreferNumericLiterals::HAS_CONFIG,
             Self::EslintPreferObjectHasOwn(_) => EslintPreferObjectHasOwn::HAS_CONFIG,
             Self::EslintPreferObjectSpread(_) => EslintPreferObjectSpread::HAS_CONFIG,
@@ -23659,7 +23660,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.types_info(),
             Self::ImportPreferDefaultExport(rule) => rule.types_info(),
             Self::ImportUnambiguous(rule) => rule.types_info(),
-            Self::EslintPreferNamedCaptureGroup(rule) => rule.types_info(),
             Self::EslintAccessorPairs(rule) => rule.types_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.types_info(),
             Self::EslintArrowBodyStyle(rule) => rule.types_info(),
@@ -23821,6 +23821,7 @@ impl RuleEnum {
             Self::EslintPreferConst(rule) => rule.types_info(),
             Self::EslintPreferDestructuring(rule) => rule.types_info(),
             Self::EslintPreferExponentiationOperator(rule) => rule.types_info(),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.types_info(),
             Self::EslintPreferNumericLiterals(rule) => rule.types_info(),
             Self::EslintPreferObjectHasOwn(rule) => rule.types_info(),
             Self::EslintPreferObjectSpread(rule) => rule.types_info(),
@@ -24477,7 +24478,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_info(),
             Self::ImportPreferDefaultExport(rule) => rule.run_info(),
             Self::ImportUnambiguous(rule) => rule.run_info(),
-            Self::EslintPreferNamedCaptureGroup(rule) => rule.run_info(),
             Self::EslintAccessorPairs(rule) => rule.run_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.run_info(),
             Self::EslintArrowBodyStyle(rule) => rule.run_info(),
@@ -24639,6 +24639,7 @@ impl RuleEnum {
             Self::EslintPreferConst(rule) => rule.run_info(),
             Self::EslintPreferDestructuring(rule) => rule.run_info(),
             Self::EslintPreferExponentiationOperator(rule) => rule.run_info(),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.run_info(),
             Self::EslintPreferNumericLiterals(rule) => rule.run_info(),
             Self::EslintPreferObjectHasOwn(rule) => rule.run_info(),
             Self::EslintPreferObjectSpread(rule) => rule.run_info(),
@@ -25317,7 +25318,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax::default()),
         RuleEnum::ImportPreferDefaultExport(ImportPreferDefaultExport::default()),
         RuleEnum::ImportUnambiguous(ImportUnambiguous::default()),
-        RuleEnum::EslintPreferNamedCaptureGroup(EslintPreferNamedCaptureGroup::default()),
         RuleEnum::EslintAccessorPairs(EslintAccessorPairs::default()),
         RuleEnum::EslintArrayCallbackReturn(EslintArrayCallbackReturn::default()),
         RuleEnum::EslintArrowBodyStyle(EslintArrowBodyStyle::default()),
@@ -25479,6 +25479,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintPreferConst(EslintPreferConst::default()),
         RuleEnum::EslintPreferDestructuring(EslintPreferDestructuring::default()),
         RuleEnum::EslintPreferExponentiationOperator(EslintPreferExponentiationOperator::default()),
+        RuleEnum::EslintPreferNamedCaptureGroup(EslintPreferNamedCaptureGroup::default()),
         RuleEnum::EslintPreferNumericLiterals(EslintPreferNumericLiterals::default()),
         RuleEnum::EslintPreferObjectHasOwn(EslintPreferObjectHasOwn::default()),
         RuleEnum::EslintPreferObjectSpread(EslintPreferObjectSpread::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -169,6 +169,7 @@ pub use crate::rules::eslint::prefer_arrow_callback::PreferArrowCallback as Esli
 pub use crate::rules::eslint::prefer_const::PreferConst as EslintPreferConst;
 pub use crate::rules::eslint::prefer_destructuring::PreferDestructuring as EslintPreferDestructuring;
 pub use crate::rules::eslint::prefer_exponentiation_operator::PreferExponentiationOperator as EslintPreferExponentiationOperator;
+pub use crate::rules::eslint::prefer_named_capture_group::PreferNamedCaptureGroup as EslintPreferNamedCaptureGroup;
 pub use crate::rules::eslint::prefer_numeric_literals::PreferNumericLiterals as EslintPreferNumericLiterals;
 pub use crate::rules::eslint::prefer_object_has_own::PreferObjectHasOwn as EslintPreferObjectHasOwn;
 pub use crate::rules::eslint::prefer_object_spread::PreferObjectSpread as EslintPreferObjectSpread;
@@ -864,6 +865,7 @@ pub enum RuleEnum {
     ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax),
     ImportPreferDefaultExport(ImportPreferDefaultExport),
     ImportUnambiguous(ImportUnambiguous),
+    EslintPreferNamedCaptureGroup(EslintPreferNamedCaptureGroup),
     EslintAccessorPairs(EslintAccessorPairs),
     EslintArrayCallbackReturn(EslintArrayCallbackReturn),
     EslintArrowBodyStyle(EslintArrowBodyStyle),
@@ -1686,7 +1688,8 @@ const IMPORT_NO_UNASSIGNED_IMPORT_ID: usize = IMPORT_NO_SELF_IMPORT_ID + 1usize;
 const IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID: usize = IMPORT_NO_UNASSIGNED_IMPORT_ID + 1usize;
 const IMPORT_PREFER_DEFAULT_EXPORT_ID: usize = IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID + 1usize;
 const IMPORT_UNAMBIGUOUS_ID: usize = IMPORT_PREFER_DEFAULT_EXPORT_ID + 1usize;
-const ESLINT_ACCESSOR_PAIRS_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
+const ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
+const ESLINT_ACCESSOR_PAIRS_ID: usize = ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID + 1usize;
 const ESLINT_ARRAY_CALLBACK_RETURN_ID: usize = ESLINT_ACCESSOR_PAIRS_ID + 1usize;
 const ESLINT_ARROW_BODY_STYLE_ID: usize = ESLINT_ARRAY_CALLBACK_RETURN_ID + 1usize;
 const ESLINT_BLOCK_SCOPED_VAR_ID: usize = ESLINT_ARROW_BODY_STYLE_ID + 1usize;
@@ -2606,6 +2609,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID,
             Self::ImportPreferDefaultExport(_) => IMPORT_PREFER_DEFAULT_EXPORT_ID,
             Self::ImportUnambiguous(_) => IMPORT_UNAMBIGUOUS_ID,
+            Self::EslintPreferNamedCaptureGroup(_) => ESLINT_PREFER_NAMED_CAPTURE_GROUP_ID,
             Self::EslintAccessorPairs(_) => ESLINT_ACCESSOR_PAIRS_ID,
             Self::EslintArrayCallbackReturn(_) => ESLINT_ARRAY_CALLBACK_RETURN_ID,
             Self::EslintArrowBodyStyle(_) => ESLINT_ARROW_BODY_STYLE_ID,
@@ -3547,6 +3551,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::NAME,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::NAME,
             Self::ImportUnambiguous(_) => ImportUnambiguous::NAME,
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::NAME,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::NAME,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::NAME,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::NAME,
@@ -4476,6 +4481,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::CATEGORY,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::CATEGORY,
             Self::ImportUnambiguous(_) => ImportUnambiguous::CATEGORY,
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::CATEGORY,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::CATEGORY,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::CATEGORY,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::CATEGORY,
@@ -5460,6 +5466,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::FIX,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::FIX,
             Self::ImportUnambiguous(_) => ImportUnambiguous::FIX,
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::FIX,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::FIX,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::FIX,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::FIX,
@@ -6394,6 +6401,9 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::documentation(),
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::documentation(),
             Self::ImportUnambiguous(_) => ImportUnambiguous::documentation(),
+            Self::EslintPreferNamedCaptureGroup(_) => {
+                EslintPreferNamedCaptureGroup::documentation()
+            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::documentation(),
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::documentation(),
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::documentation(),
@@ -7622,6 +7632,10 @@ impl RuleEnum {
             }
             Self::ImportUnambiguous(_) => ImportUnambiguous::config_schema(generator)
                 .or_else(|| ImportUnambiguous::schema(generator)),
+            Self::EslintPreferNamedCaptureGroup(_) => {
+                EslintPreferNamedCaptureGroup::config_schema(generator)
+                    .or_else(|| EslintPreferNamedCaptureGroup::schema(generator))
+            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::config_schema(generator)
                 .or_else(|| EslintAccessorPairs::schema(generator)),
             Self::EslintArrayCallbackReturn(_) => {
@@ -9908,6 +9922,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => "import",
             Self::ImportPreferDefaultExport(_) => "import",
             Self::ImportUnambiguous(_) => "import",
+            Self::EslintPreferNamedCaptureGroup(_) => "eslint",
             Self::EslintAccessorPairs(_) => "eslint",
             Self::EslintArrayCallbackReturn(_) => "eslint",
             Self::EslintArrowBodyStyle(_) => "eslint",
@@ -10790,6 +10805,9 @@ impl RuleEnum {
             Self::ImportUnambiguous(_) => {
                 Ok(Self::ImportUnambiguous(ImportUnambiguous::from_configuration(value)?))
             }
+            Self::EslintPreferNamedCaptureGroup(_) => Ok(Self::EslintPreferNamedCaptureGroup(
+                EslintPreferNamedCaptureGroup::from_configuration(value)?,
+            )),
             Self::EslintAccessorPairs(_) => {
                 Ok(Self::EslintAccessorPairs(EslintAccessorPairs::from_configuration(value)?))
             }
@@ -13351,6 +13369,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.to_configuration(),
             Self::ImportPreferDefaultExport(rule) => rule.to_configuration(),
             Self::ImportUnambiguous(rule) => rule.to_configuration(),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.to_configuration(),
             Self::EslintAccessorPairs(rule) => rule.to_configuration(),
             Self::EslintArrayCallbackReturn(rule) => rule.to_configuration(),
             Self::EslintArrowBodyStyle(rule) => rule.to_configuration(),
@@ -14178,6 +14197,7 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run(node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run(node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run(node, ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run(node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run(node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run(node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run(node, ctx),
@@ -14998,6 +15018,7 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run(node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run(node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run(node, ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run(node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run(node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run(node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run(node, ctx),
@@ -15825,6 +15846,7 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_once(ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_once(ctx),
                 Self::ImportUnambiguous(rule) => rule.run_once(ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_once(ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_once(ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_once(ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_once(ctx),
@@ -16645,6 +16667,7 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_once(ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_once(ctx),
                 Self::ImportUnambiguous(rule) => rule.run_once(ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_once(ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_once(ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_once(ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_once(ctx),
@@ -17475,6 +17498,7 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18549,6 +18573,7 @@ impl RuleEnum {
                 Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportPreferDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportUnambiguous(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::EslintPreferNamedCaptureGroup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintAccessorPairs(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrayCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::EslintArrowBodyStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19623,6 +19648,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.should_run(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.should_run(ctx),
             Self::ImportUnambiguous(rule) => rule.should_run(ctx),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.should_run(ctx),
             Self::EslintAccessorPairs(rule) => rule.should_run(ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.should_run(ctx),
             Self::EslintArrowBodyStyle(rule) => rule.should_run(ctx),
@@ -20446,6 +20472,9 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::IS_TSGOLINT_RULE,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::IS_TSGOLINT_RULE,
             Self::ImportUnambiguous(_) => ImportUnambiguous::IS_TSGOLINT_RULE,
+            Self::EslintPreferNamedCaptureGroup(_) => {
+                EslintPreferNamedCaptureGroup::IS_TSGOLINT_RULE
+            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::IS_TSGOLINT_RULE,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::IS_TSGOLINT_RULE,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::IS_TSGOLINT_RULE,
@@ -21623,6 +21652,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::VERSION,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::VERSION,
             Self::ImportUnambiguous(_) => ImportUnambiguous::VERSION,
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::VERSION,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::VERSION,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::VERSION,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::VERSION,
@@ -22609,6 +22639,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::HAS_CONFIG,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::HAS_CONFIG,
             Self::ImportUnambiguous(_) => ImportUnambiguous::HAS_CONFIG,
+            Self::EslintPreferNamedCaptureGroup(_) => EslintPreferNamedCaptureGroup::HAS_CONFIG,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::HAS_CONFIG,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::HAS_CONFIG,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::HAS_CONFIG,
@@ -23628,6 +23659,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.types_info(),
             Self::ImportPreferDefaultExport(rule) => rule.types_info(),
             Self::ImportUnambiguous(rule) => rule.types_info(),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.types_info(),
             Self::EslintAccessorPairs(rule) => rule.types_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.types_info(),
             Self::EslintArrowBodyStyle(rule) => rule.types_info(),
@@ -24445,6 +24477,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_info(),
             Self::ImportPreferDefaultExport(rule) => rule.run_info(),
             Self::ImportUnambiguous(rule) => rule.run_info(),
+            Self::EslintPreferNamedCaptureGroup(rule) => rule.run_info(),
             Self::EslintAccessorPairs(rule) => rule.run_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.run_info(),
             Self::EslintArrowBodyStyle(rule) => rule.run_info(),
@@ -25284,6 +25317,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax::default()),
         RuleEnum::ImportPreferDefaultExport(ImportPreferDefaultExport::default()),
         RuleEnum::ImportUnambiguous(ImportUnambiguous::default()),
+        RuleEnum::EslintPreferNamedCaptureGroup(EslintPreferNamedCaptureGroup::default()),
         RuleEnum::EslintAccessorPairs(EslintAccessorPairs::default()),
         RuleEnum::EslintArrayCallbackReturn(EslintArrayCallbackReturn::default()),
         RuleEnum::EslintArrowBodyStyle(EslintArrowBodyStyle::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -202,6 +202,7 @@ pub(crate) mod eslint {
     pub mod prefer_const;
     pub mod prefer_destructuring;
     pub mod prefer_exponentiation_operator;
+    pub mod prefer_named_capture_group;
     pub mod prefer_numeric_literals;
     pub mod prefer_object_has_own;
     pub mod prefer_object_spread;

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -1,0 +1,298 @@
+use oxc_ast::{
+    AstKind,
+    ast::Expression,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_regular_expression::visit::{RegExpAstKind, Visit};
+use oxc_span::Span;
+use oxc_str::CompactStr;
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{run_on_arguments, run_on_regex_node},
+};
+
+fn prefer_named_capture_group_diagnostic(
+    span: Span,
+    unnamed_count: usize,
+    allowed: u32,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Capture group should be named.")
+        .with_help(format!(
+            "Use a named capture group like \"(?<name>...)\" \u{2014} this regex has {unnamed_count} unnamed group{} (allowed: {allowed}).",
+            if unnamed_count == 1 { "" } else { "s" }
+        ))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct PreferNamedCaptureGroupConfig {
+    /// Maximum number of unnamed capturing groups allowed per regex pattern.
+    ///
+    /// Default is `0`, which disallows any unnamed groups, matching ESLint's stock behavior.
+    /// Set to `1` to permit one unnamed capture per regex, and so on.
+    allow_unnamed_groups: u32,
+    /// Additional function names to treat as RegExp constructors.
+    ///
+    /// oxlint-only extension. When a call or `new` expression uses one of these names as
+    /// a bare identifier callee, its string or template-literal argument is parsed and
+    /// checked for unnamed capturing groups, just like `RegExp(...)`.
+    ///
+    /// Example: `{ "additionalRegExpFunctions": ["regEx"] }` makes `regEx('(foo)')` reportable.
+    additional_reg_exp_functions: FxHashSet<CompactStr>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct PreferNamedCaptureGroup(Box<PreferNamedCaptureGroupConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the use of named capture groups in regular expressions.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unnamed capturing groups (`(...)`) are referenced only by position, which
+    /// makes the regex harder to read and maintain. When the pattern changes, index-based
+    /// references silently break. Named groups (`(?<name>...)`) make the intent explicit
+    /// and allow references by name (e.g. `match.groups.year`), which is more robust.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const re = /([0-9]{4})-([0-9]{2})/;
+    /// const match = re.exec(str);
+    /// const year = match[1]; // fragile index
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const re = /(?<year>[0-9]{4})-(?<month>[0-9]{2})/;
+    /// const match = re.exec(str);
+    /// const year = match.groups.year; // explicit name
+    ///
+    /// // Non-capturing groups are always fine
+    /// const parts = /(?:[0-9]{4})/;
+    /// ```
+    PreferNamedCaptureGroup,
+    eslint,
+    style,
+    version = "next",
+    config = PreferNamedCaptureGroup,
+);
+
+impl Rule for PreferNamedCaptureGroup {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let allow_unnamed = self.0.allow_unnamed_groups;
+        run_on_regex_node(node, ctx, |pattern, _span| {
+            check_pattern(pattern, allow_unnamed, ctx);
+        });
+
+        if self.0.additional_reg_exp_functions.is_empty() {
+            return;
+        }
+
+        let (callee, arguments) = match node.kind() {
+            AstKind::CallExpression(expr) => (&expr.callee, &expr.arguments),
+            AstKind::NewExpression(expr) => (&expr.callee, &expr.arguments),
+            _ => return,
+        };
+
+        let Expression::Identifier(ident) = callee.get_inner_expression() else { return };
+        if !self.0.additional_reg_exp_functions.contains(ident.name.as_str()) {
+            return;
+        }
+
+        let arg0 = arguments.first();
+        // Skip regex literals — they're already handled as their own AST node by run_on_regex_node.
+        if arg0.is_some_and(|a| matches!(a, oxc_ast::ast::Argument::RegExpLiteral(_))) {
+            return;
+        }
+
+        run_on_arguments(arg0, arguments.get(1), ctx, |pattern, _span| {
+            check_pattern(pattern, allow_unnamed, ctx);
+        });
+    }
+}
+
+fn check_pattern(pattern: &oxc_regular_expression::ast::Pattern<'_>, allow_unnamed: u32, ctx: &LintContext<'_>) {
+    let mut collector = UnnamedGroupCollector::default();
+    collector.visit_pattern(pattern);
+
+    let count = collector.unnamed_spans.len();
+    if count > allow_unnamed as usize {
+        for span in collector.unnamed_spans {
+            ctx.diagnostic(prefer_named_capture_group_diagnostic(span, count, allow_unnamed));
+        }
+    }
+}
+
+#[derive(Default)]
+struct UnnamedGroupCollector {
+    unnamed_spans: Vec<Span>,
+}
+
+impl<'a> Visit<'a> for UnnamedGroupCollector {
+    fn enter_node(&mut self, kind: RegExpAstKind<'a>) {
+        if let RegExpAstKind::CapturingGroup(group) = kind {
+            if group.name.is_none() {
+                self.unnamed_spans.push(group.span);
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // No capturing groups
+        ("/normal_regex/", None),
+        // Non-capturing group — always fine
+        ("/(?:[0-9]{4})/", None),
+        // Named capturing group — the good pattern
+        ("/(?<year>[0-9]{4})/", None),
+        // No groups at all
+        (r"/\u{1F680}/u", None),
+        // RegExp constructor with no arguments / non-static argument → can't check
+        ("new RegExp()", None),
+        ("new RegExp(foo)", None),
+        ("RegExp()", None),
+        ("RegExp(foo)", None),
+        // Empty pattern — no groups
+        ("new RegExp('')", None),
+        ("RegExp('')", None),
+        // Named group via constructor
+        ("new RegExp('(?<year>[0-9]{4})')", None),
+        ("RegExp('(?<year>[0-9]{4})')", None),
+        // Invalid regex (parse error) → silently ignored
+        ("RegExp('(')", None),
+        // Unicode escape, no groups
+        (r"RegExp('\\u{1F680}', 'u')", None),
+        // globalThis.RegExp with non-static argument → can't check
+        ("new globalThis.RegExp()", None),    // ecmaVersion 2020
+        ("new globalThis.RegExp(foo)", None), // ecmaVersion 2020
+        ("globalThis.RegExp(foo)", None),     // ecmaVersion 2020
+        // globalThis shadowed → not recognized as global RegExp constructor
+        (
+            "
+            var globalThis = bar;
+            globalThis.RegExp(foo);
+            ",
+            None,
+        ),
+        (
+            "
+            function foo () {
+                var globalThis = bar;
+                new globalThis.RegExp(baz);
+            }
+            ",
+            None,
+        ),
+        // v-flag edge case: invalid escape inside character class in v mode → parse error → ignored
+        (r#"new RegExp('([\\q])', 'v')"#, None),
+        // Named group in v-flag pattern
+        ("new RegExp('(?<c>[[A--B]])', 'v')", None),
+        // Inline flag groups (non-capturing, ecmaVersion 2025)
+        ("/(?i:foo)bar/", None),
+        ("new RegExp('(?i:foo)bar')", None),
+        ("/(?-i:foo)bar/", None),
+        ("new RegExp('(?-i:foo)bar')", None),
+        // Concatenated strings — not statically resolvable, ignored
+        ("new RegExp('(' + 'a)')", None),
+        ("new RegExp('a(bc)d' + 'e')", None),
+        (r#"new RegExp("foo" + "(a)" + "(b)");"#, None),
+        (r#"new RegExp("foo" + "(?:a)" + "(b)");"#, None),
+        ("RegExp('(a)'+'')", None),
+        ("RegExp( '' + '(ab)')", None),
+        // Template literal with substitution — not statically resolvable, ignored
+        ("new RegExp(`(ab)${''}`)", None),
+        // allowUnnamedGroups: 1 — one unnamed group is permitted
+        ("/(foo)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
+        // allowUnnamedGroups: 1 — one unnamed alongside a named group is fine
+        ("/(?<a>x)(b)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
+        // additionalRegExpFunctions — named group only, no diagnostic
+        ("regEx('(?<x>foo)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+        // string arg but factory name not in the list → not inspected
+        ("regEx('(foo)')", None),
+        // string arg but factory name doesn't match the configured name
+        ("regEx('(foo)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["other"] }]))),
+        // allowUnnamedGroups threshold met
+        ("regEx('(foo)', 'g')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"], "allowUnnamedGroups": 1 }]))),
+        // new form with named group
+        ("new MyRe('(?<a>x)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }]))),
+        // regex literal arg with named group — passes via literal arm, no false positive
+        ("regEx(/(?<a>foo)/)", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+    ];
+
+    let fail = vec![
+        // Single unnamed group — simplest case
+        ("/([0-9]{4})/", None),
+        // Constructor forms
+        ("new RegExp('([0-9]{4})')", None),
+        ("RegExp('([0-9]{4})')", None),
+        // Template literal (no substitution)
+        ("new RegExp(`a(bc)d`)", None),
+        // Unicode prefix in string, unnamed group
+        ("new RegExp('ሴ噸(?:a)(b)');", None),
+        // Multiple unnamed groups
+        (r"/([0-9]{4})-(\w{5})/", None),
+        ("/([0-9]{4})-(5)/", None),
+        // Named outer group containing unnamed inner group
+        ("/(?<temp2>(a))/", None),
+        ("/(?<temp2>(a)(?<temp5>b))/", None),
+        // Mixed named and unnamed
+        (r"/(?<temp1>[0-9]{4})-(\w{5})/", None),
+        ("/(?<temp1>[0-9]{4})-(5)/", None),
+        ("/(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/", None),
+        // Multi-line template literal (no substitution)
+        ("new RegExp(`(a)\n            `)", None),
+        ("RegExp(`a(b\n            c)d`)", None),
+        // Escape sequences in string patterns
+        (r"new RegExp('a(b)\'')", None),
+        (r"RegExp('(a)\\d')", None),
+        (r"RegExp(`\a(b)`)", None),
+        // globalThis.RegExp — always recognized in oxlint regardless of ecmaVersion
+        ("new globalThis.RegExp('([0-9]{4})')", None),
+        ("globalThis.RegExp('([0-9]{4})')", None),
+        // globalThis NOT shadowed in the outer scope
+        (
+            "
+            function foo() { var globalThis = bar; }
+            new globalThis.RegExp('([0-9]{4})');
+            ",
+            None,
+        ),
+        // v-flag with unnamed group in set notation
+        ("new RegExp('([[A--B]])', 'v')", None),
+        // allowUnnamedGroups: 1 — two unnamed groups still fails (both are reported)
+        ("/(a)(b)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
+        // allowUnnamedGroups: 1 — two unnamed + one named, still two unnamed → fail
+        ("/(a)(?<b>c)(d)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
+        // additionalRegExpFunctions — string arg with unnamed group
+        ("regEx('([0-9]+)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+        // additionalRegExpFunctions — template literal (no substitution) with two unnamed groups
+        ("regEx(`(foo)(bar)`)", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+        // additionalRegExpFunctions — new form with unnamed group
+        ("new MyRe('([0-9]+)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }]))),
+        // regex literal arg inside a custom factory: reported once (via literal arm), not twice
+        ("regEx(/(foo)/)", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+    ];
+
+    Tester::new(PreferNamedCaptureGroup::NAME, PreferNamedCaptureGroup::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -155,79 +155,58 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        // No capturing groups
         "/normal_regex/",
-        // Non-capturing group — always fine
         "/(?:[0-9]{4})/",
-        // Named capturing group — the good pattern
         "/(?<year>[0-9]{4})/",
-        // No groups at all
         r"/\u{1F680}/u",
-        // RegExp constructor with no arguments / non-static argument → can't check
         "new RegExp()",
         "new RegExp(foo)",
+        "new RegExp('')",
+        "new RegExp('(?<year>[0-9]{4})')",
         "RegExp()",
         "RegExp(foo)",
-        // Empty pattern — no groups
-        "new RegExp('')",
         "RegExp('')",
-        // Named group via constructor
-        "new RegExp('(?<year>[0-9]{4})')",
         "RegExp('(?<year>[0-9]{4})')",
-        // Invalid regex (parse error) → silently ignored
         "RegExp('(')",
-        // Unicode escape, no groups
         r"RegExp('\\u{1F680}', 'u')",
-        // globalThis.RegExp with non-static argument → can't check
-        "new globalThis.RegExp()",    // ecmaVersion 2020
-        "new globalThis.RegExp(foo)", // ecmaVersion 2020
-        "globalThis.RegExp(foo)",     // ecmaVersion 2020
-        // globalThis shadowed → not recognized as global RegExp constructor
+        "new globalThis.RegExp('([0-9]{4})')",
+        "new globalThis.RegExp('([0-9]{4})')", // { "ecmaVersion": 6 },
+        "new globalThis.RegExp('([0-9]{4})')", // { "ecmaVersion": 2017 },
+        "new globalThis.RegExp()",             // { "ecmaVersion": 2020 },
+        "new globalThis.RegExp(foo)",          // { "ecmaVersion": 2020 },
+        "globalThis.RegExp(foo)",              // { "ecmaVersion": 2020 },
         "
-            var globalThis = bar;
-            globalThis.RegExp(foo);
-            ",
+                            var globalThis = bar;
+                            globalThis.RegExp(foo);
+                            ", // { "ecmaVersion": 2020 },
         "
-            function foo () {
-                var globalThis = bar;
-                new globalThis.RegExp(baz);
-            }
-            ",
-        // v-flag edge case: invalid escape inside character class in v mode → parse error → ignored
-        r"new RegExp('([\\q])', 'v')",
-        // Named group in v-flag pattern
+                            function foo () {
+                                var globalThis = bar;
+                                new globalThis.RegExp(baz);
+                            }
+                            ", // { "ecmaVersion": 2020 },
         "new RegExp('(?<c>[[A--B]])', 'v')",
-        // Inline flag groups (non-capturing, ecmaVersion 2025)
-        "/(?i:foo)bar/",
+        r"new RegExp('([\\q])', 'v')",
+        "/(?i:foo)bar/", // { "ecmaVersion": 2025 },
         "new RegExp('(?i:foo)bar')",
-        "/(?-i:foo)bar/",
+        "/(?-i:foo)bar/", // { "ecmaVersion": 2025 },
         "new RegExp('(?-i:foo)bar')",
-        // string arg but factory name not in the list → not inspected
-        "regEx('(foo)')",
     ];
 
     let fail = vec![
-        // Single unnamed group — simplest case
         "/([0-9]{4})/",
-        // Constructor forms
         "new RegExp('([0-9]{4})')",
         "RegExp('([0-9]{4})')",
-        // Template literal (no substitution)
         "new RegExp(`a(bc)d`)",
-        // Unicode prefix in string, unnamed group
         "new RegExp('ሴ噸(?:a)(b)');",
-        r"new RegExp('\\u1234\\u5678(?:a)(b)');",
-        // Multiple unnamed groups
+        r"new RegExp('\u1234\u5678(?:a)(b)');",
         r"/([0-9]{4})-(\w{5})/",
         "/([0-9]{4})-(5)/",
-        // Named outer group containing unnamed inner group
         "/(?<temp2>(a))/",
         "/(?<temp2>(a)(?<temp5>b))/",
-        // Mixed named and unnamed
         r"/(?<temp1>[0-9]{4})-(\w{5})/",
         "/(?<temp1>[0-9]{4})-(5)/",
         "/(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/",
-        // Constant RegExp constructor arguments
         "new RegExp('(' + 'a)')",
         "new RegExp('a(bc)d' + 'e')",
         r#"new RegExp("foo" + "(a)" + "(b)");"#,
@@ -235,22 +214,19 @@ fn test() {
         "RegExp('(a)'+'')",
         "RegExp( '' + '(ab)')",
         "new RegExp(`(ab)${''}`)",
-        // Multi-line template literal (no substitution)
-        "new RegExp(`(a)\n            `)",
-        "RegExp(`a(b\n            c)d`)",
-        // Escape sequences in string patterns
+        "new RegExp(`(a)
+            `)",
+        "RegExp(`a(b
+            c)d`)",
         r"new RegExp('a(b)\'')",
         r"RegExp('(a)\\d')",
         r"RegExp(`\a(b)`)",
-        // globalThis.RegExp — always recognized in oxlint regardless of ecmaVersion
-        "new globalThis.RegExp('([0-9]{4})')",
-        "globalThis.RegExp('([0-9]{4})')",
-        // globalThis NOT shadowed in the outer scope
+        "new globalThis.RegExp('([0-9]{4})')", // { "ecmaVersion": 2020 },
+        "globalThis.RegExp('([0-9]{4})')",     // { "ecmaVersion": 2020 },
         "
-            function foo() { var globalThis = bar; }
-            new globalThis.RegExp('([0-9]{4})');
-            ",
-        // v-flag with unnamed group in set notation
+                            function foo() { var globalThis = bar; }
+                            new globalThis.RegExp('([0-9]{4})');
+                        ", // { "ecmaVersion": 2020 },
         "new RegExp('([[A--B]])', 'v')",
     ];
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -330,13 +330,6 @@ fn test() {
         (r"/(?<temp1>[0-9]{4})-(\w{5})/", None),
         ("/(?<temp1>[0-9]{4})-(5)/", None),
         ("/(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/", None),
-        // Multi-line template literal (no substitution)
-        ("new RegExp(`(a)\n            `)", None),
-        ("RegExp(`a(b\n            c)d`)", None),
-        // Escape sequences in string patterns
-        (r"new RegExp('a(b)\'')", None),
-        (r"RegExp('(a)\\d')", None),
-        (r"RegExp(`\a(b)`)", None),
         // Constant RegExp constructor arguments
         ("new RegExp('(' + 'a)')", None),
         ("new RegExp('a(bc)d' + 'e')", None),
@@ -345,6 +338,13 @@ fn test() {
         ("RegExp('(a)'+'')", None),
         ("RegExp( '' + '(ab)')", None),
         ("new RegExp(`(ab)${''}`)", None),
+        // Multi-line template literal (no substitution)
+        ("new RegExp(`(a)\n            `)", None),
+        ("RegExp(`a(b\n            c)d`)", None),
+        // Escape sequences in string patterns
+        (r"new RegExp('a(b)\'')", None),
+        (r"RegExp('(a)\\d')", None),
+        (r"RegExp(`\a(b)`)", None),
         // globalThis.RegExp — always recognized in oxlint regardless of ecmaVersion
         ("new globalThis.RegExp('([0-9]{4})')", None),
         ("globalThis.RegExp('([0-9]{4})')", None),

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -156,111 +156,102 @@ fn test() {
 
     let pass = vec![
         // No capturing groups
-        ("/normal_regex/", None),
+        "/normal_regex/",
         // Non-capturing group — always fine
-        ("/(?:[0-9]{4})/", None),
+        "/(?:[0-9]{4})/",
         // Named capturing group — the good pattern
-        ("/(?<year>[0-9]{4})/", None),
+        "/(?<year>[0-9]{4})/",
         // No groups at all
-        (r"/\u{1F680}/u", None),
+        r"/\u{1F680}/u",
         // RegExp constructor with no arguments / non-static argument → can't check
-        ("new RegExp()", None),
-        ("new RegExp(foo)", None),
-        ("RegExp()", None),
-        ("RegExp(foo)", None),
+        "new RegExp()",
+        "new RegExp(foo)",
+        "RegExp()",
+        "RegExp(foo)",
         // Empty pattern — no groups
-        ("new RegExp('')", None),
-        ("RegExp('')", None),
+        "new RegExp('')",
+        "RegExp('')",
         // Named group via constructor
-        ("new RegExp('(?<year>[0-9]{4})')", None),
-        ("RegExp('(?<year>[0-9]{4})')", None),
+        "new RegExp('(?<year>[0-9]{4})')",
+        "RegExp('(?<year>[0-9]{4})')",
         // Invalid regex (parse error) → silently ignored
-        ("RegExp('(')", None),
+        "RegExp('(')",
         // Unicode escape, no groups
-        (r"RegExp('\\u{1F680}', 'u')", None),
+        r"RegExp('\\u{1F680}', 'u')",
         // globalThis.RegExp with non-static argument → can't check
-        ("new globalThis.RegExp()", None),    // ecmaVersion 2020
-        ("new globalThis.RegExp(foo)", None), // ecmaVersion 2020
-        ("globalThis.RegExp(foo)", None),     // ecmaVersion 2020
+        "new globalThis.RegExp()",    // ecmaVersion 2020
+        "new globalThis.RegExp(foo)", // ecmaVersion 2020
+        "globalThis.RegExp(foo)",     // ecmaVersion 2020
         // globalThis shadowed → not recognized as global RegExp constructor
-        (
-            "
+        "
             var globalThis = bar;
             globalThis.RegExp(foo);
             ",
-            None,
-        ),
-        (
-            "
+        "
             function foo () {
                 var globalThis = bar;
                 new globalThis.RegExp(baz);
             }
             ",
-            None,
-        ),
         // v-flag edge case: invalid escape inside character class in v mode → parse error → ignored
-        (r"new RegExp('([\\q])', 'v')", None),
+        r"new RegExp('([\\q])', 'v')",
         // Named group in v-flag pattern
-        ("new RegExp('(?<c>[[A--B]])', 'v')", None),
+        "new RegExp('(?<c>[[A--B]])', 'v')",
         // Inline flag groups (non-capturing, ecmaVersion 2025)
-        ("/(?i:foo)bar/", None),
-        ("new RegExp('(?i:foo)bar')", None),
-        ("/(?-i:foo)bar/", None),
-        ("new RegExp('(?-i:foo)bar')", None),
+        "/(?i:foo)bar/",
+        "new RegExp('(?i:foo)bar')",
+        "/(?-i:foo)bar/",
+        "new RegExp('(?-i:foo)bar')",
         // string arg but factory name not in the list → not inspected
-        ("regEx('(foo)')", None),
+        "regEx('(foo)')",
     ];
 
     let fail = vec![
         // Single unnamed group — simplest case
-        ("/([0-9]{4})/", None),
+        "/([0-9]{4})/",
         // Constructor forms
-        ("new RegExp('([0-9]{4})')", None),
-        ("RegExp('([0-9]{4})')", None),
+        "new RegExp('([0-9]{4})')",
+        "RegExp('([0-9]{4})')",
         // Template literal (no substitution)
-        ("new RegExp(`a(bc)d`)", None),
+        "new RegExp(`a(bc)d`)",
         // Unicode prefix in string, unnamed group
-        ("new RegExp('ሴ噸(?:a)(b)');", None),
-        (r"new RegExp('\\u1234\\u5678(?:a)(b)');", None),
+        "new RegExp('ሴ噸(?:a)(b)');",
+        r"new RegExp('\\u1234\\u5678(?:a)(b)');",
         // Multiple unnamed groups
-        (r"/([0-9]{4})-(\w{5})/", None),
-        ("/([0-9]{4})-(5)/", None),
+        r"/([0-9]{4})-(\w{5})/",
+        "/([0-9]{4})-(5)/",
         // Named outer group containing unnamed inner group
-        ("/(?<temp2>(a))/", None),
-        ("/(?<temp2>(a)(?<temp5>b))/", None),
+        "/(?<temp2>(a))/",
+        "/(?<temp2>(a)(?<temp5>b))/",
         // Mixed named and unnamed
-        (r"/(?<temp1>[0-9]{4})-(\w{5})/", None),
-        ("/(?<temp1>[0-9]{4})-(5)/", None),
-        ("/(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/", None),
+        r"/(?<temp1>[0-9]{4})-(\w{5})/",
+        "/(?<temp1>[0-9]{4})-(5)/",
+        "/(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/",
         // Constant RegExp constructor arguments
-        ("new RegExp('(' + 'a)')", None),
-        ("new RegExp('a(bc)d' + 'e')", None),
-        (r#"new RegExp("foo" + "(a)" + "(b)");"#, None),
-        (r#"new RegExp("foo" + "(?:a)" + "(b)");"#, None),
-        ("RegExp('(a)'+'')", None),
-        ("RegExp( '' + '(ab)')", None),
-        ("new RegExp(`(ab)${''}`)", None),
+        "new RegExp('(' + 'a)')",
+        "new RegExp('a(bc)d' + 'e')",
+        r#"new RegExp("foo" + "(a)" + "(b)");"#,
+        r#"new RegExp("foo" + "(?:a)" + "(b)");"#,
+        "RegExp('(a)'+'')",
+        "RegExp( '' + '(ab)')",
+        "new RegExp(`(ab)${''}`)",
         // Multi-line template literal (no substitution)
-        ("new RegExp(`(a)\n            `)", None),
-        ("RegExp(`a(b\n            c)d`)", None),
+        "new RegExp(`(a)\n            `)",
+        "RegExp(`a(b\n            c)d`)",
         // Escape sequences in string patterns
-        (r"new RegExp('a(b)\'')", None),
-        (r"RegExp('(a)\\d')", None),
-        (r"RegExp(`\a(b)`)", None),
+        r"new RegExp('a(b)\'')",
+        r"RegExp('(a)\\d')",
+        r"RegExp(`\a(b)`)",
         // globalThis.RegExp — always recognized in oxlint regardless of ecmaVersion
-        ("new globalThis.RegExp('([0-9]{4})')", None),
-        ("globalThis.RegExp('([0-9]{4})')", None),
+        "new globalThis.RegExp('([0-9]{4})')",
+        "globalThis.RegExp('([0-9]{4})')",
         // globalThis NOT shadowed in the outer scope
-        (
-            "
+        "
             function foo() { var globalThis = bar; }
             new globalThis.RegExp('([0-9]{4})');
             ",
-            None,
-        ),
         // v-flag with unnamed group in set notation
-        ("new RegExp('([[A--B]])', 'v')", None),
+        "new RegExp('([[A--B]])', 'v')",
     ];
 
     Tester::new(PreferNamedCaptureGroup::NAME, PreferNamedCaptureGroup::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -148,10 +148,10 @@ struct UnnamedGroupCollector {
 
 impl<'a> Visit<'a> for UnnamedGroupCollector {
     fn enter_node(&mut self, kind: RegExpAstKind<'a>) {
-        if let RegExpAstKind::CapturingGroup(group) = kind {
-            if group.name.is_none() {
-                self.unnamed_spans.push(group.span);
-            }
+        if let RegExpAstKind::CapturingGroup(group) = kind
+            && group.name.is_none()
+        {
+            self.unnamed_spans.push(group.span);
         }
     }
 }
@@ -206,7 +206,7 @@ fn test() {
             None,
         ),
         // v-flag edge case: invalid escape inside character class in v mode → parse error → ignored
-        (r#"new RegExp('([\\q])', 'v')"#, None),
+        (r"new RegExp('([\\q])', 'v')", None),
         // Named group in v-flag pattern
         ("new RegExp('(?<c>[[A--B]])', 'v')", None),
         // Inline flag groups (non-capturing, ecmaVersion 2025)

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -2,18 +2,26 @@ use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use oxc_ast::{AstKind, ast::Expression};
+use oxc_allocator::Allocator;
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_regular_expression::visit::{RegExpAstKind, Visit};
-use oxc_span::Span;
+use oxc_regular_expression::{
+    LiteralParser, Options,
+    ast::Pattern,
+    visit::{RegExpAstKind, Visit},
+};
+use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
 
 use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{run_on_arguments, run_on_regex_node},
+    utils::{is_regexp_callee, run_on_arguments, run_on_regex_node, static_string_value},
 };
 
 fn prefer_named_capture_group_diagnostic(
@@ -93,20 +101,24 @@ impl Rule for PreferNamedCaptureGroup {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let allow_unnamed = self.0.allow_unnamed_groups;
+        let allow_unnamed_count = self.0.allow_unnamed_groups;
         run_on_regex_node(node, ctx, |pattern, _span| {
-            check_pattern(pattern, allow_unnamed, ctx);
+            check_pattern(pattern, allow_unnamed_count, ctx, None);
         });
-
-        if self.0.additional_reg_exp_functions.is_empty() {
-            return;
-        }
 
         let (callee, arguments) = match node.kind() {
             AstKind::CallExpression(expr) => (&expr.callee, &expr.arguments),
             AstKind::NewExpression(expr) => (&expr.callee, &expr.arguments),
             _ => return,
         };
+
+        if is_regexp_callee(callee, ctx) {
+            check_static_arguments(arguments.first(), arguments.get(1), allow_unnamed_count, ctx);
+        }
+
+        if self.0.additional_reg_exp_functions.is_empty() {
+            return;
+        }
 
         let Expression::Identifier(ident) = callee.get_inner_expression() else { return };
         if !self.0.additional_reg_exp_functions.contains(ident.name.as_str()) {
@@ -120,24 +132,75 @@ impl Rule for PreferNamedCaptureGroup {
         }
 
         run_on_arguments(arg0, arguments.get(1), ctx, |pattern, _span| {
-            check_pattern(pattern, allow_unnamed, ctx);
+            check_pattern(pattern, allow_unnamed_count, ctx, None);
         });
+        check_static_arguments(arg0, arguments.get(1), allow_unnamed_count, ctx);
     }
 }
 
 fn check_pattern(
-    pattern: &oxc_regular_expression::ast::Pattern<'_>,
-    allow_unnamed: u32,
+    pattern: &Pattern<'_>,
+    allow_unnamed_count: u32,
     ctx: &LintContext<'_>,
+    span_override: Option<Span>,
 ) {
     let mut collector = UnnamedGroupCollector::default();
     collector.visit_pattern(pattern);
 
     let count = collector.unnamed_spans.len();
-    if count > allow_unnamed as usize {
+    if count > allow_unnamed_count as usize {
         for span in collector.unnamed_spans {
-            ctx.diagnostic(prefer_named_capture_group_diagnostic(span, count, allow_unnamed));
+            ctx.diagnostic(prefer_named_capture_group_diagnostic(
+                span_override.unwrap_or(span),
+                count,
+                allow_unnamed_count,
+            ));
         }
+    }
+}
+
+fn check_static_arguments(
+    arg0: Option<&Argument>,
+    arg1: Option<&Argument>,
+    allow_unnamed_count: u32,
+    ctx: &LintContext<'_>,
+) {
+    let Some(pattern_expr) = arg0
+        .and_then(Argument::as_expression)
+        .map(Expression::get_inner_expression)
+        .filter(|expr| !is_directly_supported_regex_argument(expr))
+    else {
+        return;
+    };
+
+    let Some(pattern_text) = static_string_value(pattern_expr) else {
+        return;
+    };
+
+    let flags_text = arg1
+        .and_then(Argument::as_expression)
+        .map(Expression::get_inner_expression)
+        .and_then(static_string_value);
+
+    let allocator = Allocator::default();
+    let Ok(pattern) = LiteralParser::new(
+        &allocator,
+        &pattern_text,
+        flags_text.as_deref(),
+        Options { pattern_span_offset: pattern_expr.span().start, flags_span_offset: 0 },
+    )
+    .parse() else {
+        return;
+    };
+
+    check_pattern(&pattern, allow_unnamed_count, ctx, Some(pattern_expr.span()));
+}
+
+fn is_directly_supported_regex_argument(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::RegExpLiteral(_) | Expression::StringLiteral(_) => true,
+        Expression::TemplateLiteral(template) => template.is_no_substitution_template(),
+        _ => false,
     }
 }
 
@@ -214,15 +277,6 @@ fn test() {
         ("new RegExp('(?i:foo)bar')", None),
         ("/(?-i:foo)bar/", None),
         ("new RegExp('(?-i:foo)bar')", None),
-        // Concatenated strings — not statically resolvable, ignored
-        ("new RegExp('(' + 'a)')", None),
-        ("new RegExp('a(bc)d' + 'e')", None),
-        (r#"new RegExp("foo" + "(a)" + "(b)");"#, None),
-        (r#"new RegExp("foo" + "(?:a)" + "(b)");"#, None),
-        ("RegExp('(a)'+'')", None),
-        ("RegExp( '' + '(ab)')", None),
-        // Template literal with substitution — not statically resolvable, ignored
-        ("new RegExp(`(ab)${''}`)", None),
         // allowUnnamedGroups: 1 — one unnamed group is permitted
         ("/(foo)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
         // allowUnnamedGroups: 1 — one unnamed alongside a named group is fine
@@ -265,6 +319,7 @@ fn test() {
         ("new RegExp(`a(bc)d`)", None),
         // Unicode prefix in string, unnamed group
         ("new RegExp('ሴ噸(?:a)(b)');", None),
+        (r"new RegExp('\\u1234\\u5678(?:a)(b)');", None),
         // Multiple unnamed groups
         (r"/([0-9]{4})-(\w{5})/", None),
         ("/([0-9]{4})-(5)/", None),
@@ -282,6 +337,14 @@ fn test() {
         (r"new RegExp('a(b)\'')", None),
         (r"RegExp('(a)\\d')", None),
         (r"RegExp(`\a(b)`)", None),
+        // Constant RegExp constructor arguments
+        ("new RegExp('(' + 'a)')", None),
+        ("new RegExp('a(bc)d' + 'e')", None),
+        (r#"new RegExp("foo" + "(a)" + "(b)");"#, None),
+        (r#"new RegExp("foo" + "(?:a)" + "(b)");"#, None),
+        ("RegExp('(a)'+'')", None),
+        ("RegExp( '' + '(ab)')", None),
+        ("new RegExp(`(ab)${''}`)", None),
         // globalThis.RegExp — always recognized in oxlint regardless of ecmaVersion
         ("new globalThis.RegExp('([0-9]{4})')", None),
         ("globalThis.RegExp('([0-9]{4})')", None),

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -125,7 +125,11 @@ impl Rule for PreferNamedCaptureGroup {
     }
 }
 
-fn check_pattern(pattern: &oxc_regular_expression::ast::Pattern<'_>, allow_unnamed: u32, ctx: &LintContext<'_>) {
+fn check_pattern(
+    pattern: &oxc_regular_expression::ast::Pattern<'_>,
+    allow_unnamed: u32,
+    ctx: &LintContext<'_>,
+) {
     let mut collector = UnnamedGroupCollector::default();
     collector.visit_pattern(pattern);
 
@@ -224,17 +228,31 @@ fn test() {
         // allowUnnamedGroups: 1 — one unnamed alongside a named group is fine
         ("/(?<a>x)(b)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
         // additionalRegExpFunctions — named group only, no diagnostic
-        ("regEx('(?<x>foo)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+        (
+            "regEx('(?<x>foo)')",
+            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
+        ),
         // string arg but factory name not in the list → not inspected
         ("regEx('(foo)')", None),
         // string arg but factory name doesn't match the configured name
         ("regEx('(foo)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["other"] }]))),
         // allowUnnamedGroups threshold met
-        ("regEx('(foo)', 'g')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"], "allowUnnamedGroups": 1 }]))),
+        (
+            "regEx('(foo)', 'g')",
+            Some(
+                serde_json::json!([{ "additionalRegExpFunctions": ["regEx"], "allowUnnamedGroups": 1 }]),
+            ),
+        ),
         // new form with named group
-        ("new MyRe('(?<a>x)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }]))),
+        (
+            "new MyRe('(?<a>x)')",
+            Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }])),
+        ),
         // regex literal arg with named group — passes via literal arm, no false positive
-        ("regEx(/(?<a>foo)/)", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+        (
+            "regEx(/(?<a>foo)/)",
+            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
+        ),
     ];
 
     let fail = vec![
@@ -282,11 +300,20 @@ fn test() {
         // allowUnnamedGroups: 1 — two unnamed + one named, still two unnamed → fail
         ("/(a)(?<b>c)(d)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
         // additionalRegExpFunctions — string arg with unnamed group
-        ("regEx('([0-9]+)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+        (
+            "regEx('([0-9]+)')",
+            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
+        ),
         // additionalRegExpFunctions — template literal (no substitution) with two unnamed groups
-        ("regEx(`(foo)(bar)`)", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
+        (
+            "regEx(`(foo)(bar)`)",
+            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
+        ),
         // additionalRegExpFunctions — new form with unnamed group
-        ("new MyRe('([0-9]+)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }]))),
+        (
+            "new MyRe('([0-9]+)')",
+            Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }])),
+        ),
         // regex literal arg inside a custom factory: reported once (via literal arm), not twice
         ("regEx(/(foo)/)", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
     ];

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -1,15 +1,13 @@
-use oxc_ast::{
-    AstKind,
-    ast::Expression,
-};
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_regular_expression::visit::{RegExpAstKind, Visit};
 use oxc_span::Span;
 use oxc_str::CompactStr;
-use rustc_hash::FxHashSet;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -1,7 +1,3 @@
-use rustc_hash::FxHashSet;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use oxc_allocator::Allocator;
 use oxc_ast::{
     AstKind,
@@ -15,48 +11,25 @@ use oxc_regular_expression::{
     visit::{RegExpAstKind, Visit},
 };
 use oxc_span::{GetSpan, Span};
-use oxc_str::CompactStr;
 
 use crate::{
     AstNode,
     context::LintContext,
-    rule::{DefaultRuleConfig, Rule},
-    utils::{is_regexp_callee, run_on_arguments, run_on_regex_node, static_string_value},
+    rule::Rule,
+    utils::{is_regexp_callee, run_on_regex_node, static_string_value},
 };
 
-fn prefer_named_capture_group_diagnostic(
-    span: Span,
-    unnamed_count: usize,
-    allowed: u32,
-) -> OxcDiagnostic {
+fn prefer_named_capture_group_diagnostic(span: Span, unnamed_count: usize) -> OxcDiagnostic {
     OxcDiagnostic::warn("Capture group should be named.")
         .with_help(format!(
-            "Use a named capture group like \"(?<name>...)\" \u{2014} this regex has {unnamed_count} unnamed group{} (allowed: {allowed}).",
+            "Use a named capture group like \"(?<name>...)\" — this regex has {unnamed_count} unnamed group{}.",
             if unnamed_count == 1 { "" } else { "s" }
         ))
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-struct PreferNamedCaptureGroupConfig {
-    /// Maximum number of unnamed capturing groups allowed per regex pattern.
-    ///
-    /// Default is `0`, which disallows any unnamed groups, matching ESLint's stock behavior.
-    /// Set to `1` to permit one unnamed capture per regex, and so on.
-    allow_unnamed_groups: u32,
-    /// Additional function names to treat as RegExp constructors.
-    ///
-    /// oxlint-only extension. When a call or `new` expression uses one of these names as
-    /// a bare identifier callee, its string or template-literal argument is parsed and
-    /// checked for unnamed capturing groups, just like `RegExp(...)`.
-    ///
-    /// Example: `{ "additionalRegExpFunctions": ["regEx"] }` makes `regEx('(foo)')` reportable.
-    additional_reg_exp_functions: FxHashSet<CompactStr>,
-}
-
-#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct PreferNamedCaptureGroup(Box<PreferNamedCaptureGroupConfig>);
+#[derive(Debug, Default, Clone)]
+pub struct PreferNamedCaptureGroup;
 
 declare_oxc_lint!(
     /// ### What it does
@@ -92,18 +65,12 @@ declare_oxc_lint!(
     eslint,
     style,
     version = "next",
-    config = PreferNamedCaptureGroup,
 );
 
 impl Rule for PreferNamedCaptureGroup {
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
-    }
-
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let allow_unnamed_count = self.0.allow_unnamed_groups;
         run_on_regex_node(node, ctx, |pattern, _span| {
-            check_pattern(pattern, allow_unnamed_count, ctx, None);
+            check_pattern(pattern, ctx, None);
         });
 
         let (callee, arguments) = match node.kind() {
@@ -113,58 +80,22 @@ impl Rule for PreferNamedCaptureGroup {
         };
 
         if is_regexp_callee(callee, ctx) {
-            check_static_arguments(arguments.first(), arguments.get(1), allow_unnamed_count, ctx);
+            check_static_arguments(arguments.first(), arguments.get(1), ctx);
         }
-
-        if self.0.additional_reg_exp_functions.is_empty() {
-            return;
-        }
-
-        let Expression::Identifier(ident) = callee.get_inner_expression() else { return };
-        if !self.0.additional_reg_exp_functions.contains(ident.name.as_str()) {
-            return;
-        }
-
-        let arg0 = arguments.first();
-        // Skip regex literals — they're already handled as their own AST node by run_on_regex_node.
-        if arg0.is_some_and(|a| matches!(a, oxc_ast::ast::Argument::RegExpLiteral(_))) {
-            return;
-        }
-
-        run_on_arguments(arg0, arguments.get(1), ctx, |pattern, _span| {
-            check_pattern(pattern, allow_unnamed_count, ctx, None);
-        });
-        check_static_arguments(arg0, arguments.get(1), allow_unnamed_count, ctx);
     }
 }
 
-fn check_pattern(
-    pattern: &Pattern<'_>,
-    allow_unnamed_count: u32,
-    ctx: &LintContext<'_>,
-    span_override: Option<Span>,
-) {
+fn check_pattern(pattern: &Pattern<'_>, ctx: &LintContext<'_>, span_override: Option<Span>) {
     let mut collector = UnnamedGroupCollector::default();
     collector.visit_pattern(pattern);
 
     let count = collector.unnamed_spans.len();
-    if count > allow_unnamed_count as usize {
-        for span in collector.unnamed_spans {
-            ctx.diagnostic(prefer_named_capture_group_diagnostic(
-                span_override.unwrap_or(span),
-                count,
-                allow_unnamed_count,
-            ));
-        }
+    for span in collector.unnamed_spans {
+        ctx.diagnostic(prefer_named_capture_group_diagnostic(span_override.unwrap_or(span), count));
     }
 }
 
-fn check_static_arguments(
-    arg0: Option<&Argument>,
-    arg1: Option<&Argument>,
-    allow_unnamed_count: u32,
-    ctx: &LintContext<'_>,
-) {
+fn check_static_arguments(arg0: Option<&Argument>, arg1: Option<&Argument>, ctx: &LintContext<'_>) {
     let Some(pattern_expr) = arg0
         .and_then(Argument::as_expression)
         .map(Expression::get_inner_expression)
@@ -193,7 +124,7 @@ fn check_static_arguments(
         return;
     };
 
-    check_pattern(&pattern, allow_unnamed_count, ctx, Some(pattern_expr.span()));
+    check_pattern(&pattern, ctx, Some(pattern_expr.span()));
 }
 
 fn is_directly_supported_regex_argument(expr: &Expression<'_>) -> bool {
@@ -277,36 +208,8 @@ fn test() {
         ("new RegExp('(?i:foo)bar')", None),
         ("/(?-i:foo)bar/", None),
         ("new RegExp('(?-i:foo)bar')", None),
-        // allowUnnamedGroups: 1 — one unnamed group is permitted
-        ("/(foo)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
-        // allowUnnamedGroups: 1 — one unnamed alongside a named group is fine
-        ("/(?<a>x)(b)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
-        // additionalRegExpFunctions — named group only, no diagnostic
-        (
-            "regEx('(?<x>foo)')",
-            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
-        ),
         // string arg but factory name not in the list → not inspected
         ("regEx('(foo)')", None),
-        // string arg but factory name doesn't match the configured name
-        ("regEx('(foo)')", Some(serde_json::json!([{ "additionalRegExpFunctions": ["other"] }]))),
-        // allowUnnamedGroups threshold met
-        (
-            "regEx('(foo)', 'g')",
-            Some(
-                serde_json::json!([{ "additionalRegExpFunctions": ["regEx"], "allowUnnamedGroups": 1 }]),
-            ),
-        ),
-        // new form with named group
-        (
-            "new MyRe('(?<a>x)')",
-            Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }])),
-        ),
-        // regex literal arg with named group — passes via literal arm, no false positive
-        (
-            "regEx(/(?<a>foo)/)",
-            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
-        ),
     ];
 
     let fail = vec![
@@ -358,27 +261,6 @@ fn test() {
         ),
         // v-flag with unnamed group in set notation
         ("new RegExp('([[A--B]])', 'v')", None),
-        // allowUnnamedGroups: 1 — two unnamed groups still fails (both are reported)
-        ("/(a)(b)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
-        // allowUnnamedGroups: 1 — two unnamed + one named, still two unnamed → fail
-        ("/(a)(?<b>c)(d)/", Some(serde_json::json!([{ "allowUnnamedGroups": 1 }]))),
-        // additionalRegExpFunctions — string arg with unnamed group
-        (
-            "regEx('([0-9]+)')",
-            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
-        ),
-        // additionalRegExpFunctions — template literal (no substitution) with two unnamed groups
-        (
-            "regEx(`(foo)(bar)`)",
-            Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }])),
-        ),
-        // additionalRegExpFunctions — new form with unnamed group
-        (
-            "new MyRe('([0-9]+)')",
-            Some(serde_json::json!([{ "additionalRegExpFunctions": ["MyRe"] }])),
-        ),
-        // regex literal arg inside a custom factory: reported once (via literal arm), not twice
-        ("regEx(/(foo)/)", Some(serde_json::json!([{ "additionalRegExpFunctions": ["regEx"] }]))),
     ];
 
     Tester::new(PreferNamedCaptureGroup::NAME, PreferNamedCaptureGroup::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -169,22 +169,15 @@ fn test() {
         "RegExp('(?<year>[0-9]{4})')",
         "RegExp('(')",
         r"RegExp('\\u{1F680}', 'u')",
-        "new globalThis.RegExp('([0-9]{4})')",
-        "new globalThis.RegExp('([0-9]{4})')", // { "ecmaVersion": 6 },
-        "new globalThis.RegExp('([0-9]{4})')", // { "ecmaVersion": 2017 },
-        "new globalThis.RegExp()",             // { "ecmaVersion": 2020 },
-        "new globalThis.RegExp(foo)",          // { "ecmaVersion": 2020 },
-        "globalThis.RegExp(foo)",              // { "ecmaVersion": 2020 },
-        "
-                            var globalThis = bar;
-                            globalThis.RegExp(foo);
-                            ", // { "ecmaVersion": 2020 },
-        "
-                            function foo () {
-                                var globalThis = bar;
-                                new globalThis.RegExp(baz);
-                            }
-                            ", // { "ecmaVersion": 2020 },
+        // Oxc recognizes globalThis.RegExp regardless of ecmaVersion, so upstream's pre-2020
+        // globalThis capture-group cases are intentionally covered as invalid below.
+        "new globalThis.RegExp()",    // { "ecmaVersion": 2020 },
+        "new globalThis.RegExp(foo)", // { "ecmaVersion": 2020 },
+        "globalThis.RegExp(foo)",     // { "ecmaVersion": 2020 },
+        // { "ecmaVersion": 2020 }
+        "var globalThis = bar; globalThis.RegExp(foo);",
+        // { "ecmaVersion": 2020 }
+        "function foo () { var globalThis = bar; new globalThis.RegExp(baz); }",
         "new RegExp('(?<c>[[A--B]])', 'v')",
         r"new RegExp('([\\q])', 'v')",
         "/(?i:foo)bar/", // { "ecmaVersion": 2025 },
@@ -223,10 +216,8 @@ fn test() {
         r"RegExp(`\a(b)`)",
         "new globalThis.RegExp('([0-9]{4})')", // { "ecmaVersion": 2020 },
         "globalThis.RegExp('([0-9]{4})')",     // { "ecmaVersion": 2020 },
-        "
-                            function foo() { var globalThis = bar; }
-                            new globalThis.RegExp('([0-9]{4})');
-                        ", // { "ecmaVersion": 2020 },
+        // { "ecmaVersion": 2020 }
+        "function foo() { var globalThis = bar; } new globalThis.RegExp('([0-9]{4})');",
         "new RegExp('([[A--B]])', 'v')",
     ];
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_ternary.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use oxc_ast::{
     AstKind,
-    ast::{AssignmentTarget, BinaryOperator, Expression, IfStatement, MemberExpression, Statement},
+    ast::{AssignmentTarget, Expression, IfStatement, MemberExpression, Statement},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -15,7 +15,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{is_same_expression, is_same_member_expression},
+    utils::{is_same_expression, is_same_member_expression, static_string_value},
 };
 
 fn prefer_ternary_diagnostic(span: Span) -> OxcDiagnostic {
@@ -328,21 +328,6 @@ fn member_static_property_name(member: &MemberExpression<'_>) -> Option<String> 
     };
 
     static_string_value(computed.expression.get_inner_expression())
-}
-
-fn static_string_value(expression: &Expression<'_>) -> Option<String> {
-    match expression {
-        Expression::StringLiteral(literal) => Some(literal.value.to_string()),
-        Expression::TemplateLiteral(literal) => {
-            literal.single_quasi().map(|quasi| quasi.to_string())
-        }
-        Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
-            let left = static_string_value(binary.left.get_inner_expression())?;
-            let right = static_string_value(binary.right.get_inner_expression())?;
-            Some(format!("{left}{right}"))
-        }
-        _ => None,
-    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
@@ -1,0 +1,230 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:2]
+ 1 │ /([0-9]{4})/
+   ·  ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:13]
+ 1 │ new RegExp('([0-9]{4})')
+   ·             ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:9]
+ 1 │ RegExp('([0-9]{4})')
+   ·         ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:14]
+ 1 │ new RegExp(`a(bc)d`)
+   ·              ────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:24]
+ 1 │ new RegExp('ሴ噸(?:a)(b)');
+   ·                     ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:2]
+ 1 │ /([0-9]{4})-(\w{5})/
+   ·  ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:13]
+ 1 │ /([0-9]{4})-(\w{5})/
+   ·             ───────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:2]
+ 1 │ /([0-9]{4})-(5)/
+   ·  ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:13]
+ 1 │ /([0-9]{4})-(5)/
+   ·             ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:11]
+ 1 │ /(?<temp2>(a))/
+   ·           ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:11]
+ 1 │ /(?<temp2>(a)(?<temp5>b))/
+   ·           ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:21]
+ 1 │ /(?<temp1>[0-9]{4})-(\w{5})/
+   ·                     ───────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:21]
+ 1 │ /(?<temp1>[0-9]{4})-(5)/
+   ·                     ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:24]
+ 1 │ /(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/
+   ·                        ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:13]
+ 1 │ new RegExp(`(a)
+   ·             ───
+ 2 │             `)
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:10]
+ 1 │ ╭─▶ RegExp(`a(b
+ 2 │ ╰─▶             c)d`)
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:14]
+ 1 │ new RegExp('a(b)\'')
+   ·              ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:9]
+ 1 │ RegExp('(a)\\d')
+   ·         ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:11]
+ 1 │ RegExp(`\a(b)`)
+   ·           ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:24]
+ 1 │ new globalThis.RegExp('([0-9]{4})')
+   ·                        ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:20]
+ 1 │ globalThis.RegExp('([0-9]{4})')
+   ·                    ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:3:36]
+ 2 │             function foo() { var globalThis = bar; }
+ 3 │             new globalThis.RegExp('([0-9]{4})');
+   ·                                    ──────────
+ 4 │             
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:13]
+ 1 │ new RegExp('([[A--B]])', 'v')
+   ·             ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:2]
+ 1 │ /(a)(b)/
+   ·  ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:5]
+ 1 │ /(a)(b)/
+   ·     ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:2]
+ 1 │ /(a)(?<b>c)(d)/
+   ·  ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:12]
+ 1 │ /(a)(?<b>c)(d)/
+   ·            ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:8]
+ 1 │ regEx('([0-9]+)')
+   ·        ────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:8]
+ 1 │ regEx(`(foo)(bar)`)
+   ·        ─────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:13]
+ 1 │ regEx(`(foo)(bar)`)
+   ·             ─────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:11]
+ 1 │ new MyRe('([0-9]+)')
+   ·           ────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:8]
+ 1 │ regEx(/(foo)/)
+   ·        ─────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
@@ -7,161 +7,161 @@ source: crates/oxc_linter/src/tester.rs
  1 │ /([0-9]{4})/
    ·  ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:13]
  1 │ new RegExp('([0-9]{4})')
    ·             ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:9]
  1 │ RegExp('([0-9]{4})')
    ·         ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:14]
  1 │ new RegExp(`a(bc)d`)
    ·              ────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:24]
  1 │ new RegExp('ሴ噸(?:a)(b)');
    ·                     ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:32]
  1 │ new RegExp('\\u1234\\u5678(?:a)(b)');
    ·                                ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:2]
  1 │ /([0-9]{4})-(\w{5})/
    ·  ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:13]
  1 │ /([0-9]{4})-(\w{5})/
    ·             ───────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:2]
  1 │ /([0-9]{4})-(5)/
    ·  ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:13]
  1 │ /([0-9]{4})-(5)/
    ·             ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:11]
  1 │ /(?<temp2>(a))/
    ·           ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:11]
  1 │ /(?<temp2>(a)(?<temp5>b))/
    ·           ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:21]
  1 │ /(?<temp1>[0-9]{4})-(\w{5})/
    ·                     ───────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:21]
  1 │ /(?<temp1>[0-9]{4})-(5)/
    ·                     ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:24]
  1 │ /(?<temp1>a)(?<temp2>a)(a)(?<temp3>a)/
    ·                        ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp('(' + 'a)')
    ·            ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp('a(bc)d' + 'e')
    ·            ──────────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp("foo" + "(a)" + "(b)");
    ·            ─────────────────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp("foo" + "(a)" + "(b)");
    ·            ─────────────────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp("foo" + "(?:a)" + "(b)");
    ·            ───────────────────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:8]
  1 │ RegExp('(a)'+'')
    ·        ────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:9]
  1 │ RegExp( '' + '(ab)')
    ·         ───────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp(`(ab)${''}`)
    ·            ───────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:13]
@@ -169,49 +169,49 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───
  2 │             `)
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:10]
  1 │ ╭─▶ RegExp(`a(b
  2 │ ╰─▶             c)d`)
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:14]
  1 │ new RegExp('a(b)\'')
    ·              ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:9]
  1 │ RegExp('(a)\\d')
    ·         ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:11]
  1 │ RegExp(`\a(b)`)
    ·           ───
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:24]
  1 │ new globalThis.RegExp('([0-9]{4})')
    ·                        ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:20]
  1 │ globalThis.RegExp('([0-9]{4})')
    ·                    ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:3:36]
@@ -220,74 +220,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                                    ──────────
  4 │             
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:13]
  1 │ new RegExp('([[A--B]])', 'v')
    ·             ──────────
    ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:2]
- 1 │ /(a)(b)/
-   ·  ───
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:5]
- 1 │ /(a)(b)/
-   ·     ───
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:2]
- 1 │ /(a)(?<b>c)(d)/
-   ·  ───
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:12]
- 1 │ /(a)(?<b>c)(d)/
-   ·            ───
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 1).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:8]
- 1 │ regEx('([0-9]+)')
-   ·        ────────
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:8]
- 1 │ regEx(`(foo)(bar)`)
-   ·        ─────
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:13]
- 1 │ regEx(`(foo)(bar)`)
-   ·             ─────
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:11]
- 1 │ new MyRe('([0-9]+)')
-   ·           ────────
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:8]
- 1 │ regEx(/(foo)/)
-   ·        ─────
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
@@ -108,42 +108,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:13]
- 1 │ new RegExp(`(a)
-   ·             ───
- 2 │             `)
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:10]
- 1 │ ╭─▶ RegExp(`a(b
- 2 │ ╰─▶             c)d`)
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:14]
- 1 │ new RegExp('a(b)\'')
-   ·              ───
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:9]
- 1 │ RegExp('(a)\\d')
-   ·         ───
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:11]
- 1 │ RegExp(`\a(b)`)
-   ·           ───
-   ╰────
-  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
-
-  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp('(' + 'a)')
    ·            ──────────
@@ -196,6 +160,42 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_named_capture_group.tsx:1:12]
  1 │ new RegExp(`(ab)${''}`)
    ·            ───────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:13]
+ 1 │ new RegExp(`(a)
+   ·             ───
+ 2 │             `)
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:10]
+ 1 │ ╭─▶ RegExp(`a(b
+ 2 │ ╰─▶             c)d`)
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:14]
+ 1 │ new RegExp('a(b)\'')
+   ·              ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:9]
+ 1 │ RegExp('(a)\\d')
+   ·         ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:11]
+ 1 │ RegExp(`\a(b)`)
+   ·           ───
    ╰────
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
@@ -38,9 +38,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:1:32]
- 1 │ new RegExp('\\u1234\\u5678(?:a)(b)');
-   ·                                ───
+   ╭─[prefer_named_capture_group.tsx:1:30]
+ 1 │ new RegExp('\u1234\u5678(?:a)(b)');
+   ·                              ───
    ╰────
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
@@ -214,11 +214,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
-   ╭─[prefer_named_capture_group.tsx:3:36]
- 2 │             function foo() { var globalThis = bar; }
- 3 │             new globalThis.RegExp('([0-9]{4})');
-   ·                                    ──────────
- 4 │             
+   ╭─[prefer_named_capture_group.tsx:1:65]
+ 1 │ function foo() { var globalThis = bar; } new globalThis.RegExp('([0-9]{4})');
+   ·                                                                 ──────────
    ╰────
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group.
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_named_capture_group.snap
@@ -38,6 +38,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
 
   ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:32]
+ 1 │ new RegExp('\\u1234\\u5678(?:a)(b)');
+   ·                                ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
    ╭─[prefer_named_capture_group.tsx:1:2]
  1 │ /([0-9]{4})-(\w{5})/
    ·  ──────────
@@ -133,6 +140,62 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_named_capture_group.tsx:1:11]
  1 │ RegExp(`\a(b)`)
    ·           ───
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:12]
+ 1 │ new RegExp('(' + 'a)')
+   ·            ──────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:12]
+ 1 │ new RegExp('a(bc)d' + 'e')
+   ·            ──────────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:12]
+ 1 │ new RegExp("foo" + "(a)" + "(b)");
+   ·            ─────────────────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:12]
+ 1 │ new RegExp("foo" + "(a)" + "(b)");
+   ·            ─────────────────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 2 unnamed groups (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:12]
+ 1 │ new RegExp("foo" + "(?:a)" + "(b)");
+   ·            ───────────────────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:8]
+ 1 │ RegExp('(a)'+'')
+   ·        ────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:9]
+ 1 │ RegExp( '' + '(ab)')
+   ·         ───────────
+   ╰────
+  help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
+
+  ⚠ eslint(prefer-named-capture-group): Capture group should be named.
+   ╭─[prefer_named_capture_group.tsx:1:12]
+ 1 │ new RegExp(`(ab)${''}`)
+   ·            ───────────
    ╰────
   help: Use a named capture group like "(?<name>...)" — this regex has 1 unnamed group (allowed: 0).
 

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -25,6 +25,7 @@ mod promise;
 mod react;
 mod react_perf;
 mod regex;
+mod static_value;
 mod this_expression;
 mod typescript;
 mod unicorn;
@@ -34,8 +35,8 @@ mod vue;
 
 pub use self::{
     comment::*, config::*, control_flow::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*,
-    react::*, react_perf::*, regex::*, this_expression::*, typescript::*, unicorn::*, url::*,
-    vitest::*, vue::*,
+    react::*, react_perf::*, regex::*, static_value::*, this_expression::*, typescript::*,
+    unicorn::*, url::*, vitest::*, vue::*,
 };
 
 /// List of Eslint rules that have TypeScript equivalents.

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -94,7 +94,7 @@ pub fn get_regex_pattern_span(arg: Option<&Argument>) -> Option<Span> {
     }
 }
 
-fn run_on_arguments<M>(arg1: Option<&Argument>, arg2: Option<&Argument>, ctx: &LintContext, cb: M)
+pub fn run_on_arguments<M>(arg1: Option<&Argument>, arg2: Option<&Argument>, ctx: &LintContext, cb: M)
 where
     M: FnOnce(&Pattern<'_>, Span),
 {

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -94,8 +94,12 @@ pub fn get_regex_pattern_span(arg: Option<&Argument>) -> Option<Span> {
     }
 }
 
-pub fn run_on_arguments<M>(arg1: Option<&Argument>, arg2: Option<&Argument>, ctx: &LintContext, cb: M)
-where
+pub fn run_on_arguments<M>(
+    arg1: Option<&Argument>,
+    arg2: Option<&Argument>,
+    ctx: &LintContext,
+    cb: M,
+) where
     M: FnOnce(&Pattern<'_>, Span),
 {
     let Some(pattern_span) = get_regex_pattern_span(arg1) else {

--- a/crates/oxc_linter/src/utils/static_value.rs
+++ b/crates/oxc_linter/src/utils/static_value.rs
@@ -1,0 +1,25 @@
+use oxc_ast::ast::{BinaryOperator, Expression};
+
+/// Resolve a side-effect-free string expression made from string literals, template literals,
+/// and `+` concatenation. Returns `None` when any part cannot be determined statically.
+pub fn static_string_value(expression: &Expression<'_>) -> Option<String> {
+    match expression.get_inner_expression() {
+        Expression::StringLiteral(literal) => Some(literal.value.to_string()),
+        Expression::TemplateLiteral(template) => {
+            let mut value = String::new();
+            for (index, quasi) in template.quasis.iter().enumerate() {
+                value.push_str(quasi.value.cooked.as_ref()?);
+                if let Some(expr) = template.expressions.get(index) {
+                    value.push_str(&static_string_value(expr)?);
+                }
+            }
+            Some(value)
+        }
+        Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
+            let mut value = static_string_value(&binary.left)?;
+            value.push_str(&static_string_value(&binary.right)?);
+            Some(value)
+        }
+        _ => None,
+    }
+}

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1336,6 +1336,9 @@
         "prefer-exponentiation-operator": {
           "$ref": "#/definitions/DummyRule"
         },
+        "prefer-named-capture-group": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "prefer-numeric-literals": {
           "$ref": "#/definitions/DummyRule"
         },
@@ -3256,3 +3259,4 @@
   },
   "markdownDescription": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json`\n\nExample\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"plugins\": [\"import\", \"typescript\", \"unicorn\"],\n\"env\": {\n\"browser\": true\n},\n\"globals\": {\n\"foo\": \"readonly\"\n},\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n},\n\"custom\": { \"option\": true }\n},\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\n\"overrides\": [\n{\n\"files\": [\"*.test.ts\", \"*.spec.ts\"],\n\"rules\": {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n}\n```\n\n`oxlint.config.ts`\n\n```ts\nimport { defineConfig } from \"oxlint\";\n\nexport default defineConfig({\nplugins: [\"import\", \"typescript\", \"unicorn\"],\nenv: {\n\"browser\": true\n},\nglobals: {\n\"foo\": \"readonly\"\n},\nsettings: {\nreact: {\nversion: \"18.2.0\"\n},\ncustom: { option: true }\n},\nrules: {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\noverrides: [\n{\nfiles: [\"*.test.ts\", \"*.spec.ts\"],\nrules: {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n});\n```"
 }
+

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1340,6 +1340,9 @@ expression: json
         "prefer-exponentiation-operator": {
           "$ref": "#/definitions/DummyRule"
         },
+        "prefer-named-capture-group": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "prefer-numeric-literals": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
## Disclaimer

- The PR is mostly generated by ClaudeCode using Opus 4.7 and Sonnet 4.6
- Every line has been reviewed by myself ( with negligible Rust experience ) 
- Some adaptions have been done manually

## Changes 

Reimplements [prefer-named-capture-group](https://eslint.org/docs/latest/rules/prefer-named-capture-group) as linting rule. 

There are two additional config options to `prefer-named-capture-group`: 
- `allow_unnamed_groups` ( defaults to `0`): allows to set a lower bound of acceptable unnamed regex capture groups
- `additional_reg_exp_functions` ( defaults to empty ): allows to set additional regex constructor considered. In Renovate's case we have an utility function which wraps regexes. The rule would fail to identify regexes supplied as string. e.g. `regEx('(foo)(bar)')`
  Inspired by https://github.com/oxc-project/oxc/blob/a02f32c5e97980a86dd2b10d618572f4cc3457dc/crates/oxc_linter/src/rules/typescript/no_this_alias.rs#L44
  