### PR TITLE
fix(linter/no-cond-assign): align ternary handling

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -91,38 +91,31 @@ impl Rule for NoCondAssign {
                 self.check_expression(ctx, expr.test.get_inner_expression());
             }
             AstKind::AssignmentExpression(expr) if self.0 == NoCondAssignConfig::Always => {
-                let mut spans = vec![];
+                let assignment_span = node.span();
                 for ancestor in ctx.nodes().ancestors(node.id()) {
-                    match ancestor.kind() {
-                        AstKind::IfStatement(if_stmt) => {
-                            spans.push(if_stmt.test.span());
-                        }
-                        AstKind::WhileStatement(while_stmt) => {
-                            spans.push(while_stmt.test.span());
-                        }
-                        AstKind::DoWhileStatement(do_while_stmt) => {
-                            spans.push(do_while_stmt.test.span());
-                        }
+                    let Some(conditional_span) = (match ancestor.kind() {
+                        AstKind::IfStatement(if_stmt) => Some(if_stmt.test.span()),
+                        AstKind::WhileStatement(while_stmt) => Some(while_stmt.test.span()),
+                        AstKind::DoWhileStatement(do_while_stmt) => Some(do_while_stmt.test.span()),
                         AstKind::ForStatement(for_stmt) => {
-                            if let Some(test) = &for_stmt.test {
-                                spans.push(test.span());
-                            }
+                            for_stmt.test.as_ref().map(GetSpan::span)
                         }
-                        AstKind::ConditionalExpression(cond_expr) => {
-                            spans.push(cond_expr.span());
-                        }
+                        AstKind::ConditionalExpression(cond_expr) => Some(cond_expr.test.span()),
                         AstKind::Function(_)
                         | AstKind::ArrowFunctionExpression(_)
                         | AstKind::Program(_)
                         | AstKind::BlockStatement(_) => break,
-                        _ => {}
-                    }
-                }
+                        _ => None,
+                    }) else {
+                        continue;
+                    };
 
-                // Only report the diagnostic if the assignment is in a span where it should not be.
-                // For example, report `if (a = b) { ... }`, not `if (...) { a = b }`
-                if spans.iter().any(|span| span.contains_inclusive(node.span())) {
-                    Self::emit_diagnostic(ctx, expr);
+                    // Only report the diagnostic if the assignment is in a span where it should
+                    // not be. For example, report `if (a = b) { ... }`, not `if (...) { a = b }`.
+                    if conditional_span.contains_inclusive(assignment_span) {
+                        Self::emit_diagnostic(ctx, expr);
+                        return;
+                    }
                 }
             }
             _ => {}
@@ -230,6 +223,7 @@ fn test() {
             "for (let i = 0; i < nums.length; i += 1) { dosomething();}",
             Some(serde_json::json!(["always"])),
         ),
+        ("let a = 1; a = a ? (a += 5) : 1;", Some(serde_json::json!(["always"]))),
     ];
 
     let fail = vec![


### PR DESCRIPTION
Fixes #22760

`eslint/no-cond-assign` in `always` mode was treating the full span of a ternary expression as conditional context when checking nested assignments. That meant assignments in the consequent or alternate branch were reported even though ESLint only treats the ternary test as the conditional expression.

This changes the ancestor check for `ConditionalExpression` to use only the test span, so cases like `a = a ? (a += 5) : 1` no longer report while assignments in actual conditional positions still do.
