### PR TITLE
fix(deps): align tsdown rolldown version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ catalogs:
       specifier: 4.1.7
       version: 4.1.7
 
+overrides:
+  rolldown: 1.0.3
+
 importers:
 
   .:
@@ -202,7 +205,7 @@ importers:
         specifier: ^0.133.0
         version: 0.133.0
       rolldown:
-        specifier: 'catalog:'
+        specifier: 1.0.3
         version: 1.0.3
       serialize-javascript:
         specifier: ^7.0.4
@@ -302,7 +305,7 @@ importers:
         specifier: 'catalog:'
         version: 0.3.21
       rolldown:
-        specifier: 'catalog:'
+        specifier: 1.0.3
         version: 1.0.3
       tinypool:
         specifier: ^2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,9 @@ catalog:
   vite-plus: 0.1.22
   vitest: 4.1.7
 
+overrides:
+  rolldown: "catalog:"
+
 allowBuilds:
   "@vscode/vsce-sign@2.0.8": true
   esbuild@0.27.7: true


### PR DESCRIPTION
This keeps `tsdown` on the same `rolldown` version as the rest of the workspace.

After the `rolldown` update, `tsdown` was still resolving its nested `rolldown` dependency to `1.0.2`, while the workspace catalog used `1.0.3`. That left two `rolldown` versions installed and caused type-aware lint failures in `apps/oxlint/tsdown.config.ts`.

Adding a pnpm override makes `tsdown` and `rolldown-plugin-dts` resolve to the cataloged `rolldown@1.0.3`.
