### PR TITLE
fix(formatter): don't move comments inside variable declaration in for of loop

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -768,7 +768,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
         if let ForStatementLeft::VariableDeclaration(left_declaration) = &**left
             && matches!(
                 left_declaration.declarations.first().unwrap().id,
-                BindingPattern::ArrayPattern(_)
+                BindingPattern::ArrayPattern(_) | BindingPattern::ObjectPattern(_)
             )
         {
             write!(f, group(&format_inner));

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -738,6 +738,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
+        let comments = f.context().comments().own_line_comments_before(self.right.span().start);
+
         let r#await = self.r#await();
         let left = self.left();
         let right = self.right();
@@ -762,7 +764,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
                 ]
             );
         });
-        write!(f, group(&format_inner));
+
+        if let ForStatementLeft::VariableDeclaration(left_declaration) = &**left {
+            if matches!(
+                left_declaration.declarations.first().unwrap().id,
+                BindingPattern::ArrayPattern(_)
+            ) {
+                write!(f, group(&format_inner));
+                return;
+            }
+        }
+
+        write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)]);
     }
 }
 

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -765,16 +765,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
             );
         });
 
-        if let ForStatementLeft::VariableDeclaration(left_declaration) = &**left {
-            if matches!(
+        if let ForStatementLeft::VariableDeclaration(left_declaration) = &**left
+            && matches!(
                 left_declaration.declarations.first().unwrap().id,
                 BindingPattern::ArrayPattern(_)
-            ) {
-                write!(f, group(&format_inner));
-                return;
-            }
+            )
+        {
+            write!(f, group(&format_inner));
+            return;
         }
-
         write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)]);
     }
 }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -765,7 +765,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
             );
         });
 
-        if !comments.is_empty() && comments.first().unwrap().span.start > left.span().end {
+        if let Some(comment) = comments.first()
+            && comment.span.start > left.span().end
+        {
             write!(f, FormatLeadingComments::Comments(comments));
         }
 

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -765,18 +765,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
             );
         });
 
-        if !comments.is_empty()
-            && let ForStatementLeft::VariableDeclaration(left_declaration) = &**left
-            && let Some(first_decl) = left_declaration.declarations.first()
-            && matches!(
-                first_decl.id,
-                BindingPattern::ArrayPattern(_) | BindingPattern::ObjectPattern(_)
-            )
-        {
-            write!(f, group(&format_inner));
-            return;
+        if !comments.is_empty() && comments.first().unwrap().span.start > left.span().end {
+            write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)]);
         }
-        write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)]);
+
+        write!(f, group(&format_inner));
     }
 }
 

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -767,8 +767,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
 
         if !comments.is_empty()
             && let ForStatementLeft::VariableDeclaration(left_declaration) = &**left
+            && let Some(first_decl) = left_declaration.declarations.first()
             && matches!(
-                left_declaration.declarations.first().unwrap().id,
+                first_decl.id,
                 BindingPattern::ArrayPattern(_) | BindingPattern::ObjectPattern(_)
             )
         {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -738,8 +738,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        let comments = f.context().comments().own_line_comments_before(self.right.span().start);
-
         let r#await = self.r#await();
         let left = self.left();
         let right = self.right();
@@ -764,7 +762,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
                 ]
             );
         });
-        write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)]);
+        write!(f, group(&format_inner));
     }
 }
 

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -765,7 +765,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
             );
         });
 
-        if let ForStatementLeft::VariableDeclaration(left_declaration) = &**left
+        if !comments.is_empty()
+            && let ForStatementLeft::VariableDeclaration(left_declaration) = &**left
             && matches!(
                 left_declaration.declarations.first().unwrap().id,
                 BindingPattern::ArrayPattern(_) | BindingPattern::ObjectPattern(_)

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -766,7 +766,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
         });
 
         if !comments.is_empty() && comments.first().unwrap().span.start > left.span().end {
-            write!(f, [FormatLeadingComments::Comments(comments), group(&format_inner)]);
+            write!(f, FormatLeadingComments::Comments(comments));
         }
 
         write!(f, group(&format_inner));

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js
@@ -31,3 +31,13 @@ for (const [
 ] of someIterable) {
   //
 }
+
+for (const {
+  item1, 
+  item2, 
+  item3, 
+  item4, 
+  // comment at the end
+} of someIterable) {
+  // 
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js
@@ -9,3 +9,25 @@ for (let i of [
   1, 2, 3
   // comment2
 ]);
+
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}
+
+for (const [
+  // comment at the start
+  item1,
+  item2,
+  // comment in the middle
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js.snap
@@ -13,6 +13,29 @@ for (let i of [
   1, 2, 3
   // comment2
 ]);
+
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}
+
+for (const [
+  // comment at the start
+  item1,
+  item2,
+  // comment in the middle
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -29,6 +52,28 @@ for (let i of [
   // comment2
 ]);
 
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}
+
+for (const [
+  // comment at the start
+  item1,
+  item2,
+  // comment in the middle
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -43,5 +88,27 @@ for (let i of [
   1, 2, 3,
   // comment2
 ]);
+
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}
+
+for (const [
+  // comment at the start
+  item1,
+  item2,
+  // comment in the middle
+  item3,
+  item4,
+  // comment at the end
+] of someIterable) {
+  //
+}
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js.snap
@@ -36,6 +36,16 @@ for (const [
   //
 }
 
+for (const {
+  item1, 
+  item2, 
+  item3, 
+  item4, 
+  // comment at the end
+} of someIterable) {
+  // 
+}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -74,6 +84,16 @@ for (const [
   //
 }
 
+for (const {
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+} of someIterable) {
+  //
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -108,6 +128,16 @@ for (const [
   item4,
   // comment at the end
 ] of someIterable) {
+  //
+}
+
+for (const {
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+} of someIterable) {
   //
 }
 


### PR DESCRIPTION
Fixes #22748

In cases like:

```ts
for (const [
  item1, 
  item2, 
  item3, 
  item4, 
  // comment at the end
] of someIterable) {
  // 
}
```

leave the comments inside the array instead of formatting them as leading comments, instead only format the comments after the left side of the for of loop.