### PR TITLE
fix(formatter): don't move comments inside variable declaration in for in loop

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -713,25 +713,30 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
 impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let comments = f.context().comments().own_line_comments_before(self.right.span().start);
+        let left = self.left();
         let body = self.body();
+
+        if let Some(comment) = comments.first()
+            && comment.span.start > left.span().end
+        {
+            write!(f, FormatLeadingComments::Comments(comments));
+        }
+
         write!(
             f,
-            [
-                FormatLeadingComments::Comments(comments),
-                group(&format_args!(
-                    "for",
-                    space(),
-                    "(",
-                    self.left(),
-                    space(),
-                    "in",
-                    space(),
-                    self.right(),
-                    FormatCommentForEmptyStatement(body),
-                    ")",
-                    FormatStatementBody::new(body)
-                ))
-            ]
+            group(&format_args!(
+                "for",
+                space(),
+                "(",
+                left,
+                space(),
+                "in",
+                space(),
+                self.right(),
+                FormatCommentForEmptyStatement(body),
+                ")",
+                FormatStatementBody::new(body)
+            ))
         );
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js
@@ -33,11 +33,31 @@ for (const [
 }
 
 for (const {
-  item1, 
-  item2, 
-  item3, 
-  item4, 
+  item1,
+  item2,
+  item3,
+  item4,
   // comment at the end
 } of someIterable) {
-  // 
+  //
+}
+
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] in someObject) {
+  //
+}
+
+for (const {
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+} in someObject) {
+  //
 }

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-statements.js.snap
@@ -37,13 +37,33 @@ for (const [
 }
 
 for (const {
-  item1, 
-  item2, 
-  item3, 
-  item4, 
+  item1,
+  item2,
+  item3,
+  item4,
   // comment at the end
 } of someIterable) {
-  // 
+  //
+}
+
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] in someObject) {
+  //
+}
+
+for (const {
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+} in someObject) {
+  //
 }
 
 ==================== Output ====================
@@ -94,6 +114,26 @@ for (const {
   //
 }
 
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] in someObject) {
+  //
+}
+
+for (const {
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+} in someObject) {
+  //
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -138,6 +178,26 @@ for (const {
   item4,
   // comment at the end
 } of someIterable) {
+  //
+}
+
+for (const [
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+] in someObject) {
+  //
+}
+
+for (const {
+  item1,
+  item2,
+  item3,
+  item4,
+  // comment at the end
+} in someObject) {
   //
 }
 


### PR DESCRIPTION
The same fix of #22773, just for for-in loop.
