### PR TITLE
fix(linter): align lsp extends default plugins

### DIFF
--- a/apps/oxlint/fixtures/lsp/issue_22758/.oxlintrc.json
+++ b/apps/oxlint/fixtures/lsp/issue_22758/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["import", "promise", "node"],
+  "categories": {
+    "correctness": "warn"
+  }
+}

--- a/apps/oxlint/fixtures/lsp/issue_22758/apps/api/.oxlintrc.json
+++ b/apps/oxlint/fixtures/lsp/issue_22758/apps/api/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.oxlintrc.json"]
+}

--- a/apps/oxlint/fixtures/lsp/issue_22758/apps/api/app/auth/guard/firebase.ts
+++ b/apps/oxlint/fixtures/lsp/issue_22758/apps/api/app/auth/guard/firebase.ts
@@ -1,0 +1,1 @@
+let _value: String;

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -257,6 +257,10 @@ pub struct LoadedConfigs {
     pub nested_ignore_patterns: Vec<(Vec<String>, PathBuf)>,
 }
 
+pub fn materialize_default_plugins(config: &mut Oxlintrc) {
+    config.plugins.get_or_insert_with(Default::default);
+}
+
 pub struct ConfigLoader<'a> {
     external_linter: Option<&'a ExternalLinter>,
     external_plugin_store: &'a mut ExternalPluginStore,

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -24,7 +24,9 @@ use crate::{
     cli::{
         CliRunResult, DebugOption, LintCommand, MiscOptions, ReportUnusedDirectives, WarningOptions,
     },
-    config_loader::{CliConfigLoadError, ConfigLoadError, ConfigLoader},
+    config_loader::{
+        CliConfigLoadError, ConfigLoadError, ConfigLoader, materialize_default_plugins,
+    },
     output_formatter::{LintCommandInfo, OutputFormatter},
     walk::Walk,
 };
@@ -282,11 +284,10 @@ impl CliRunner {
             }
         };
 
-        {
-            let mut plugins = root_config.plugins.unwrap_or_default();
-            enable_plugins.apply_overrides(&mut plugins);
-            root_config.plugins = Some(plugins);
-        }
+        materialize_default_plugins(&mut root_config);
+        let mut plugins = root_config.plugins.unwrap_or_default();
+        enable_plugins.apply_overrides(&mut plugins);
+        root_config.plugins = Some(plugins);
 
         let base_ignore_patterns = root_config.ignore_patterns.clone();
 

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -31,6 +31,7 @@ use oxc_language_server::{
 use crate::{
     config_loader::{
         ConfigLoader, build_nested_configs, config_file_names, discover_configs_in_tree,
+        materialize_default_plugins,
     },
     lsp::{
         code_actions::{
@@ -105,13 +106,14 @@ impl ServerLinterBuilder {
         #[cfg(feature = "napi")]
         let loader = loader.with_js_config_loader(self.js_config_loader.as_ref());
 
-        let oxlintrc = match loader.load_root_config(&root_path, config_path.as_ref()) {
+        let mut oxlintrc = match loader.load_root_config(&root_path, config_path.as_ref()) {
             Ok(config) => config,
             Err(e) => {
                 warn!("Failed to load config: {e}");
                 Oxlintrc::default()
             }
         };
+        materialize_default_plugins(&mut oxlintrc);
 
         let mut nested_ignore_patterns = Vec::new();
         let mut extended_paths = FxHashSet::default();
@@ -1518,5 +1520,11 @@ mod test {
             }),
         );
         tester.test_and_snapshot_single_file("test.ts");
+    }
+
+    #[test]
+    fn test_issue_22758() {
+        let tester = Tester::new("fixtures/lsp/issue_22758/apps/api", json!({}));
+        tester.test_and_snapshot_single_file("app/auth/guard/firebase.ts");
     }
 }

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_22758_apps_api@app__auth__guard__firebase.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_22758_apps_api@app__auth__guard__firebase.ts.snap
@@ -1,0 +1,92 @@
+---
+source: apps/oxlint/src/lsp/tester.rs
+---
+########## 
+Linted file: fixtures/lsp/issue_22758/apps/api/app/auth/guard/firebase.ts
+----------
+########## Diagnostic Reports
+File URI: file://<variable>/fixtures/lsp/issue_22758/apps/api/app/auth/guard/firebase.ts
+
+code: "typescript(no-wrapper-object-types)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-wrapper-object-types.html"
+message: "Do not use wrapper object types.\nhelp: Replace `String` with `string`.\nnote: `String` is a boxed object type, not a primitive. Boxed types have object semantics (identity/truthiness) that can be surprising. Use `string` for values, and in `extends`/`implements` use an interface/object shape instead."
+range: Range { start: Position { line: 0, character: 12 }, end: Position { line: 0, character: 18 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/lsp/issue_22758/apps/api/app/auth/guard/firebase.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 12 }, end: Position { line: 0, character: 18 } }
+severity: Some(Warning)
+source: Some("oxc")
+tags: None
+
+########### Code Actions/Commands
+CodeAction: 
+Title: Replace `String` with `string`.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 12,
+        },
+        end: Position {
+            line: 0,
+            character: 18,
+        },
+    },
+    new_text: "string",
+}
+
+
+CodeAction: 
+Title: Disable typescript/no-wrapper-object-types for this line
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable-next-line typescript/no-wrapper-object-types\n",
+}
+
+
+CodeAction: 
+Title: Disable typescript/no-wrapper-object-types for this whole file
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    },
+    new_text: "// oxlint-disable typescript/no-wrapper-object-types\n",
+}
+
+
+########### Fix All Action
+CodeAction: 
+Title: fix all safe fixable oxlint issues
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 12,
+        },
+        end: Position {
+            line: 0,
+            character: 18,
+        },
+    },
+    new_text: "string",
+}


### PR DESCRIPTION
Fixes #22758.

The LSP path was not materializing the default plugin set before resolving a root config with `extends`, while the CLI path already did that before building the config. That meant a child config launched as the LSP workspace root could extend a parent config with an explicit `plugins` array and accidentally lose default plugins like `typescript`, even though `oxlint` CLI and `--print-config` showed those plugins as active.

This moves the default-plugin materialization into a shared helper used by both CLI and LSP config loading, so both paths resolve the same effective root config before `extends` are applied.

I added a regression fixture for the reported nested config shape and snapshot coverage for the missing TypeScript diagnostic.