### PR TITLE
fix(codegen): map call-chain punctuation for correct V8 stack columns

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -37,6 +37,8 @@ pub trait GenExpr: GetSpan {
     #[inline]
     fn print_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         self.gen_expr(p, precedence, ctx);
+        // Map chain punctuation after a postfix operand ending in `)`/`]`.
+        p.add_source_mapping_after_postfix(self.span(), precedence);
     }
 }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -992,6 +992,31 @@ impl<'a> Codegen<'a> {
     #[expect(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
     fn add_source_mapping_end(&mut self, _span: Span) {}
 
+    /// A postfix operand ending in `)` or `]` (a call or index result) leaves no
+    /// trailing identifier for a source-map consumer to anchor on, so the chain
+    /// punctuation after it (`.`/`[`/`(`/`` ` ``) would be unmapped and V8 would
+    /// resolve the stack frame one column too far left — the off-by-one in
+    /// `f(a)(b)` and `expect(x).resolves`. Map that punctuation back to the
+    /// operand's `span.end`. Called from `print_expr`, mirroring how Babel and TSC
+    /// give every node a trailing end-mapping. Synthesized nodes whose `span.end`
+    /// has no source byte are skipped.
+    #[cfg(feature = "sourcemap")]
+    fn add_source_mapping_after_postfix(&mut self, span: Span, precedence: Precedence) {
+        if precedence == Precedence::Postfix
+            && let Some(sourcemap_builder) = self.sourcemap_builder.as_mut()
+            && !span.is_empty()
+            && matches!(self.code.as_bytes().last(), Some(b')' | b']'))
+            && self.source_text.is_none_or(|src| (span.end as usize) < src.len())
+        {
+            sourcemap_builder.add_source_mapping(self.code.as_bytes(), span.end, None);
+        }
+    }
+
+    #[cfg(not(feature = "sourcemap"))]
+    #[inline]
+    #[expect(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
+    fn add_source_mapping_after_postfix(&mut self, _span: Span, _precedence: Precedence) {}
+
     #[cfg(feature = "sourcemap")]
     fn add_source_mapping_for_name(&mut self, span: Span, name: &str) {
         if let Some(sourcemap_builder) = self.sourcemap_builder.as_mut()

--- a/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
@@ -112,7 +112,7 @@ obj.fn()();
 
 Error
     at fn2 (/project/input.js:5:19)
-    at <anonymous> (/project/input.js:9:8)
+    at <anonymous> (/project/input.js:9:9)
 
 ------------------------------------------------------
 ## Input
@@ -143,7 +143,7 @@ obj.fn([1])();
 
 Error
     at <anonymous> (/project/input.js:5:19)
-    at <anonymous> (/project/input.js:9:11)
+    at <anonymous> (/project/input.js:9:12)
 
 ------------------------------------------------------
 ## Input
@@ -172,7 +172,7 @@ factory()();
 
 Error
     at <anonymous> (/project/input.js:4:15)
-    at <anonymous> (/project/input.js:7:9)
+    at <anonymous> (/project/input.js:7:10)
 
 ------------------------------------------------------
 ## Input
@@ -205,7 +205,7 @@ obj.fn({ a })();
 
 Error
     at <anonymous> (/project/input.js:6:19)
-    at <anonymous> (/project/input.js:10:11)
+    at <anonymous> (/project/input.js:10:12)
 
 ------------------------------------------------------
 ## Input
@@ -235,3 +235,30 @@ fn("name", () => {
 Error
     at <anonymous> (/project/input.js:6:11)
     at fn (/project/input.js:2:5)
+
+------------------------------------------------------
+## Input
+const make = () => ({
+    get prop() {
+        Error.stackTraceLimit = 2;
+        throw new Error()
+    }
+})
+make().prop
+
+## Output
+const make = () => ({ get prop() {
+	Error.stackTraceLimit = 2;
+	throw new Error();
+} });
+make().prop;
+
+
+## Stderr
+/project/input.js:4
+        throw new Error()
+              ^
+
+Error
+    at Object.get prop (/project/input.js:4:15)
+    at <anonymous> (/project/input.js:7:7)

--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -316,6 +316,40 @@ fn object_close_brace_lands_at_close_brace() {
     assert!(has_mapping(&tokens, pos(0, src_brace), pos(0, src_brace)));
 }
 
+// When a callee/object ends in `)` or `]` it has no trailing identifier for V8
+// to anchor a stack frame on, so the chain punctuation (`(`/`.`) right after it
+// must be mapped — otherwise the column resolves one too far left (off-by-one
+// stack traces reported by vitest via vite-ecosystem-ci).
+
+// Curried call: V8 reports the outer call at the `(` after the inner `)`.
+#[test]
+fn nested_call_outer_open_paren_resolves_to_source() {
+    let tokens = sourcemap_tokens("factory()()", SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, 9), pos(0, 9)), "outer `(` of `factory()()`");
+}
+
+// Member/getter access on a call result: reported at the `.` after the `)`.
+#[test]
+fn member_access_after_call_resolves_to_source() {
+    let tokens = sourcemap_tokens("expect(x).resolves", SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, 9), pos(0, 9)), "`.` after `expect(x)`");
+}
+
+// Same gap for a computed-member result: reported at the `(` after the `]`.
+#[test]
+fn call_after_computed_member_resolves_to_source() {
+    let tokens = sourcemap_tokens("arr[i]()", SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, 6), pos(0, 6)), "`(` after `arr[i]`");
+}
+
+// A tagged template whose tag is a call result (`` f()`x` ``) is the same shape
+// — the tag is a postfix operand, so the backtick after the `)` is mapped too.
+#[test]
+fn tagged_template_after_call_resolves_to_source() {
+    let tokens = sourcemap_tokens("f()`x`", SourceType::mjs());
+    assert!(has_mapping(&tokens, pos(0, 3), pos(0, 3)), "backtick after `f()`");
+}
+
 #[test]
 #[cfg(all(not(target_endian = "big"), target_pointer_width = "64"))] // we run big endian tests on docker that does not have node installed; skip 32-bit as well
 fn stacktrace_is_correct() {
@@ -391,6 +425,16 @@ fn('name', () => {
     Error.stackTraceLimit = 2;
     throw new Error()
 })",
+        // Getter accessed on a call result (`expect(x).resolves` shape): V8
+        // reports the access at the `.` right after the call's `)`.
+        "\
+const make = () => ({
+    get prop() {
+        Error.stackTraceLimit = 2;
+        throw new Error()
+    }
+})
+make().prop",
     ];
 
     let node_version = std::process::Command::new("node").arg("--version").output().map_or_else(


### PR DESCRIPTION
## Summary

- `oxc_codegen` produced off-by-one V8 stack-trace and coverage columns for call-chain shapes. When a `(`/`.`/`[` is chained directly onto a call — or any expression ending in `)`/`]` — that punctuation was left unmapped, so the lookup fell back to the closing delimiter one column to the left. Surfaced as vitest failures in vite-ecosystem-ci: `test.each([1, 2])(…)` reporting column 17 instead of 18, and `await expect(…).resolves.toBe(4)` reporting 40 instead of 41.
- Root cause: such operands end in `)` or `]`, so there is no trailing identifier token for a source-map consumer to anchor on. The fix maps that punctuation from `print_expr` — keyed on postfix precedence — back to the operand's exclusive end, exactly where V8 reports the frame. This is the trailing end-mapping that Babel and TSC apply to every node, scoped here to just the no-anchor sites. The closing `)`/`}`/`]` keep their existing at-delimiter mapping, which `v8-to-istanbul` relies on for coverage range boundaries (#22001).
- Only these no-anchor chain sites are mapped — not the byte past every delimiter — so the added source-map tokens stay at **+0.6%** over baseline. (A blanket variant that mapped every delimiter regressed codegen ~5% on CodSpeed.)
- Verified end-to-end through `node --enable-source-maps`: each chained frame resolves to the correct column (the outer `(` for curried calls, the `.` for a getter/member on a call result), and regresses by exactly one column when the mapping is disabled. Covered by the `stacktrace_is_correct` integration test and unit tests in `sourcemap.rs`.

## Example

`factory()()` — V8 reports the outer call at the `(` after the inner `)`:

```
without this fix:  at <anonymous> (input.js:7:9)    ← the inner `)`
with this fix:     at <anonymous> (input.js:7:10)   ← the outer `(`   ✓
```

The same one-column drift affected `expect(x).resolves` (the `.` getter access after the `)`).

## Compared with esbuild and tsc

Same input through each tool (identical generated code), visualized with [source-map-viewer](https://source-map-viewer.void.app):

```js
const outer = factory()();          // outer `(`  of factory()()
const member = expect(x).resolves;  // `.`        of expect(x).resolves
const indexed = arr[i]();           // `(`        of arr[i]()
```

| Source token | oxc (this PR) | tsc | esbuild |
| --- | :--: | :--: | :--: |
| outer `(` of `factory()()` | ✓ | ✓ | ✗ |
| `.` of `expect(x).resolves` | ✓ | ✓ | ✗ |
| `(` of `arr[i]()` | ✓ | ✓ | ✗ |

- **vs esbuild** ([compare](https://source-map-viewer.void.app/compare?a=QCnJWx7H&b=Y4FwbiMW)): oxc adds the three chain mappings esbuild lacks — esbuild maps the `]` one column left of the `(`, the exact off-by-one. This PR resolves what esbuild still gets wrong.
- **vs tsc** ([compare](https://source-map-viewer.void.app/compare?a=UjsQoNTX&b=Y4FwbiMW)): all three positions match tsc exactly. tsc maps ~10 more positions because it gives every node a trailing end-mapping; this PR maps only the no-anchor sites (+0.6% vs tsc's full density).

---

This PR was prepared with AI assistance; I reviewed, tested, and verified the changes.
