### PR TITLE
fix(coverage): increase rayon worker stack to 8 MB

### DIFF
--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -22,7 +22,14 @@ fn main() {
     } else {
         std::thread::available_parallelism().map_or(1, NonZeroUsize::get)
     };
-    ThreadPoolBuilder::new().num_threads(thread_count).build_global().unwrap();
+    // Match Linux's default main-thread stack (8 MB) so deeply-nested expressions
+    // (e.g. typescript/tests/cases/compiler/binderBinaryExpressionStressJs.ts)
+    // don't overflow macOS's 2 MB worker default.
+    ThreadPoolBuilder::new()
+        .num_threads(thread_count)
+        .stack_size(8 * 1024 * 1024)
+        .build_global()
+        .unwrap();
 
     // Load all test data once
     let data = TestData::load(app_args.filter.as_deref());


### PR DESCRIPTION
## Summary

`cargo coverage` (a.k.a. `just c`) crashes locally on macOS with `fatal runtime error: stack overflow` while running `semantic_typescript` on `typescript/tests/cases/compiler/binderBinaryExpressionStressJs.ts`. That fixture builds a ~1500-deep left-leaning `BinaryExpression` chain (`0 + 1 + 2 + ... + 1499`).

macOS's `std::thread` default stack is 2 MB; Linux is 8 MB, which is why CI doesn't see this. The file used to fit because `OxcDiagnostic` was 8 bytes (`Box<OxcDiagnosticInner>`); after #22406 inlined the ~200-byte inner, every recursive frame holding a diagnostic grew, pushing past 2 MB on macOS.

This sets the rayon pool's `stack_size` to 8 MB to match Linux's default. Scope is limited to the dev coverage task — the perf win from #22406 is preserved, and no runtime consumers (parser, semantic, oxlint, oxfmt) are affected.

Verified `just c` runs end-to-end on macOS after the change.