### PR TITLE
feat(ast, codegen, formatter): add `WithClauseKeyword::as_str` helper and use it

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -2066,3 +2066,13 @@ impl ImportPhase {
         }
     }
 }
+
+impl WithClauseKeyword {
+    /// Returns the syntax associated with this [`WithClauseKeyword`].
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::With => "with",
+            Self::Assert => "assert",
+        }
+    }
+}

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -969,10 +969,7 @@ impl Gen for ImportDeclaration<'_> {
 impl Gen for WithClause<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
-        p.print_str(match self.keyword {
-            WithClauseKeyword::With => "with",
-            WithClauseKeyword::Assert => "assert",
-        });
+        p.print_str(self.keyword.as_str());
         p.print_soft_space();
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'{');

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -198,19 +198,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithClause<'a>> {
                 write!(f, [space(), FormatLeadingComments::Comments(comments)]);
             }
         });
-        write!(
-            f,
-            [
-                space(),
-                format_comment,
-                match self.keyword() {
-                    WithClauseKeyword::With => "with",
-                    WithClauseKeyword::Assert => "assert",
-                },
-                space(),
-                self.with_entries()
-            ]
-        );
+        write!(f, [space(), format_comment, self.keyword().as_str(), space(), self.with_entries()]);
 
         if f.options().quote_properties.is_consistent() {
             f.context_mut().pop_quote_needed();


### PR DESCRIPTION
The following is duplicated across codegen, formatter (and potentially linter in future):

```rust
match self {
    Self::With => "with",
    Self::Assert => "assert",
}
```

This PR adds `WithClauseKeyword::as_str` method to centralize stringifying this attribute.

`as_str` aligns with the other helpers such as  `VariableDeclarationKind::as_str()`, `ImportPhase::as_str()`, `TSAccessibility::as_str()`, and `TSModuleDeclarationKind::as_str()`. Operators in `oxc_syntax` also have the same `as_str` methods.