### PR TITLE
fix(linter/no-accumulating-spread): use loop as primary span

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -58,7 +58,7 @@ fn loop_spread_likely_object_diagnostic(
         .with_labels([
             accumulator_decl_span.label("From this accumulator"),
             spread_span.label("From this spread"),
-            loop_span.label("For this loop"),
+            loop_span.primary_label("For this loop"),
         ])
 }
 fn loop_spread_likely_array_diagnostic(
@@ -72,7 +72,7 @@ fn loop_spread_likely_array_diagnostic(
         .with_labels([
             accumulator_decl_span.label("From this accumulator"),
             spread_span.label("From this spread"),
-            loop_span.label("For this loop"),
+            loop_span.primary_label("For this loop"),
         ])
 }
 

--- a/crates/oxc_linter/src/snapshots/oxc_no_accumulating_spread.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_accumulating_spread.snap
@@ -316,7 +316,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = []; for (let i = 0; i < 10; i++) { foo = [...foo, i]; }
    ·     ─┬─       ─┬─                                   ───┬──
    ·      │         │                                       ╰── From this spread
@@ -327,7 +327,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = []; for (const i = 0; i < 10; i++) { foo = [...foo, i]; }
    ·     ─┬─       ─┬─                                     ───┬──
    ·      │         │                                         ╰── From this spread
@@ -338,7 +338,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = []; for (let i in [1,2,3]) { foo = [...foo, i]; }
    ·     ─┬─       ─┬─                             ───┬──
    ·      │         │                                 ╰── From this spread
@@ -349,7 +349,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = []; for (const i in [1,2,3]) { foo = [...foo, i]; }
    ·     ─┬─       ─┬─                               ───┬──
    ·      │         │                                   ╰── From this spread
@@ -360,7 +360,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = []; for (let i of [1,2,3]) { foo = [...foo, i]; }
    ·     ─┬─       ─┬─                             ───┬──
    ·      │         │                                 ╰── From this spread
@@ -371,7 +371,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = []; for (const i of [1,2,3]) { foo = [...foo, i]; }
    ·     ─┬─       ─┬─                               ───┬──
    ·      │         │                                   ╰── From this spread
@@ -382,7 +382,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = []; while (foo.length < 10) { foo = [...foo, foo.length]; }
    ·     ─┬─       ──┬──                            ───┬──
    ·      │          │                                 ╰── From this spread
@@ -393,7 +393,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = {}; for (let i = 0; i < 10; i++) { foo = { ...foo, [i]: i }; }
    ·     ─┬─       ─┬─                                    ───┬──
    ·      │         │                                        ╰── From this spread
@@ -404,7 +404,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = {}; for (const i = 0; i < 10; i++) { foo = { ...foo, [i]: i }; }
    ·     ─┬─       ─┬─                                      ───┬──
    ·      │         │                                          ╰── From this spread
@@ -415,7 +415,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = {}; for (let i in [1,2,3]) { foo = { ...foo, [i]: i }; }
    ·     ─┬─       ─┬─                              ───┬──
    ·      │         │                                  ╰── From this spread
@@ -426,7 +426,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = {}; for (const i in [1,2,3]) { foo = { ...foo, [i]: i }; }
    ·     ─┬─       ─┬─                                ───┬──
    ·      │         │                                    ╰── From this spread
@@ -437,7 +437,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = {}; for (let i of [1,2,3]) { foo = { ...foo, [i]: i }; }
    ·     ─┬─       ─┬─                              ───┬──
    ·      │         │                                  ╰── From this spread
@@ -448,7 +448,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = {}; for (const i of [1,2,3]) { foo = { ...foo, [i]: i }; }
    ·     ─┬─       ─┬─                                ───┬──
    ·      │         │                                    ╰── From this spread
@@ -459,7 +459,7 @@ source: crates/oxc_linter/src/tester.rs
   note: Using spreads within accumulators leads to `O(n^2)` time complexity.
 
   ⚠ oxc(no-accumulating-spread): Do not spread accumulators in loops
-   ╭─[no_accumulating_spread.tsx:1:5]
+   ╭─[no_accumulating_spread.tsx:1:15]
  1 │ let foo = {}; while (Object.keys(foo).length < 10) { foo = { ...foo, [Object.keys(foo).length]: Object.keys(foo).length }; }
    ·     ─┬─       ──┬──                                          ───┬──
    ·      │          │                                               ╰── From this spread


### PR DESCRIPTION
The loop diagnostics for `oxc/no-accumulating-spread` were using the accumulator label as the primary span. This made reports on loop-based accumulating spreads point at the variable declaration instead of the loop that introduces the repeated spread work.

This changes the array and object loop diagnostics to make the loop label primary while keeping the accumulator and spread labels as secondary context. The existing snapshot coverage is updated to assert that loop cases now report from the loop keyword.

fixes #18988