### PR TITLE
feat(linter/jsdoc): implement `require-yields-description` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -646,6 +646,7 @@ export interface DummyRuleMap {
   "jsdoc/require-throws-description"?: DummyRule;
   "jsdoc/require-throws-type"?: DummyRule;
   "jsdoc/require-yields"?: DummyRule;
+  "jsdoc/require-yields-description"?: DummyRule;
   "jsdoc/require-yields-type"?: DummyRule;
   "jsx-a11y/alt-text"?: DummyRule;
   "jsx-a11y/anchor-ambiguous-text"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4404,6 +4404,11 @@ impl RuleRunner for crate::rules::jsdoc::require_yields::RequireYields {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::jsdoc::require_yields_description::RequireYieldsDescription {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::jsdoc::require_yields_type::RequireYieldsType {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -305,6 +305,7 @@ pub use crate::rules::jsdoc::require_returns_type::RequireReturnsType as JsdocRe
 pub use crate::rules::jsdoc::require_throws_description::RequireThrowsDescription as JsdocRequireThrowsDescription;
 pub use crate::rules::jsdoc::require_throws_type::RequireThrowsType as JsdocRequireThrowsType;
 pub use crate::rules::jsdoc::require_yields::RequireYields as JsdocRequireYields;
+pub use crate::rules::jsdoc::require_yields_description::RequireYieldsDescription as JsdocRequireYieldsDescription;
 pub use crate::rules::jsdoc::require_yields_type::RequireYieldsType as JsdocRequireYieldsType;
 pub use crate::rules::jsx_a11y::alt_text::AltText as JsxA11YAltText;
 pub use crate::rules::jsx_a11y::anchor_ambiguous_text::AnchorAmbiguousText as JsxA11YAnchorAmbiguousText;
@@ -1523,6 +1524,7 @@ pub enum RuleEnum {
     JsdocRequireThrowsDescription(JsdocRequireThrowsDescription),
     JsdocRequireThrowsType(JsdocRequireThrowsType),
     JsdocRequireYields(JsdocRequireYields),
+    JsdocRequireYieldsDescription(JsdocRequireYieldsDescription),
     JsdocRequireYieldsType(JsdocRequireYieldsType),
     PromiseAlwaysReturn(PromiseAlwaysReturn),
     PromiseAvoidNew(PromiseAvoidNew),
@@ -2431,7 +2433,8 @@ const JSDOC_REQUIRE_RETURNS_TYPE_ID: usize = JSDOC_REQUIRE_RETURNS_DESCRIPTION_I
 const JSDOC_REQUIRE_THROWS_DESCRIPTION_ID: usize = JSDOC_REQUIRE_RETURNS_TYPE_ID + 1usize;
 const JSDOC_REQUIRE_THROWS_TYPE_ID: usize = JSDOC_REQUIRE_THROWS_DESCRIPTION_ID + 1usize;
 const JSDOC_REQUIRE_YIELDS_ID: usize = JSDOC_REQUIRE_THROWS_TYPE_ID + 1usize;
-const JSDOC_REQUIRE_YIELDS_TYPE_ID: usize = JSDOC_REQUIRE_YIELDS_ID + 1usize;
+const JSDOC_REQUIRE_YIELDS_DESCRIPTION_ID: usize = JSDOC_REQUIRE_YIELDS_ID + 1usize;
+const JSDOC_REQUIRE_YIELDS_TYPE_ID: usize = JSDOC_REQUIRE_YIELDS_DESCRIPTION_ID + 1usize;
 const PROMISE_ALWAYS_RETURN_ID: usize = JSDOC_REQUIRE_YIELDS_TYPE_ID + 1usize;
 const PROMISE_AVOID_NEW_ID: usize = PROMISE_ALWAYS_RETURN_ID + 1usize;
 const PROMISE_CATCH_OR_RETURN_ID: usize = PROMISE_AVOID_NEW_ID + 1usize;
@@ -3376,6 +3379,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(_) => JSDOC_REQUIRE_THROWS_DESCRIPTION_ID,
             Self::JsdocRequireThrowsType(_) => JSDOC_REQUIRE_THROWS_TYPE_ID,
             Self::JsdocRequireYields(_) => JSDOC_REQUIRE_YIELDS_ID,
+            Self::JsdocRequireYieldsDescription(_) => JSDOC_REQUIRE_YIELDS_DESCRIPTION_ID,
             Self::JsdocRequireYieldsType(_) => JSDOC_REQUIRE_YIELDS_TYPE_ID,
             Self::PromiseAlwaysReturn(_) => PROMISE_ALWAYS_RETURN_ID,
             Self::PromiseAvoidNew(_) => PROMISE_AVOID_NEW_ID,
@@ -4308,6 +4312,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::NAME,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::NAME,
             Self::JsdocRequireYields(_) => JsdocRequireYields::NAME,
+            Self::JsdocRequireYieldsDescription(_) => JsdocRequireYieldsDescription::NAME,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::NAME,
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::NAME,
             Self::PromiseAvoidNew(_) => PromiseAvoidNew::NAME,
@@ -5280,6 +5285,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::CATEGORY,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::CATEGORY,
             Self::JsdocRequireYields(_) => JsdocRequireYields::CATEGORY,
+            Self::JsdocRequireYieldsDescription(_) => JsdocRequireYieldsDescription::CATEGORY,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::CATEGORY,
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::CATEGORY,
             Self::PromiseAvoidNew(_) => PromiseAvoidNew::CATEGORY,
@@ -6223,6 +6229,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::FIX,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::FIX,
             Self::JsdocRequireYields(_) => JsdocRequireYields::FIX,
+            Self::JsdocRequireYieldsDescription(_) => JsdocRequireYieldsDescription::FIX,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::FIX,
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::FIX,
             Self::PromiseAvoidNew(_) => PromiseAvoidNew::FIX,
@@ -7366,6 +7373,9 @@ impl RuleEnum {
             }
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::documentation(),
             Self::JsdocRequireYields(_) => JsdocRequireYields::documentation(),
+            Self::JsdocRequireYieldsDescription(_) => {
+                JsdocRequireYieldsDescription::documentation()
+            }
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::documentation(),
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::documentation(),
             Self::PromiseAvoidNew(_) => PromiseAvoidNew::documentation(),
@@ -9524,6 +9534,10 @@ impl RuleEnum {
                 .or_else(|| JsdocRequireThrowsType::schema(generator)),
             Self::JsdocRequireYields(_) => JsdocRequireYields::config_schema(generator)
                 .or_else(|| JsdocRequireYields::schema(generator)),
+            Self::JsdocRequireYieldsDescription(_) => {
+                JsdocRequireYieldsDescription::config_schema(generator)
+                    .or_else(|| JsdocRequireYieldsDescription::schema(generator))
+            }
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::config_schema(generator)
                 .or_else(|| JsdocRequireYieldsType::schema(generator)),
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::config_schema(generator)
@@ -10575,6 +10589,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(_) => "jsdoc",
             Self::JsdocRequireThrowsType(_) => "jsdoc",
             Self::JsdocRequireYields(_) => "jsdoc",
+            Self::JsdocRequireYieldsDescription(_) => "jsdoc",
             Self::JsdocRequireYieldsType(_) => "jsdoc",
             Self::PromiseAlwaysReturn(_) => "promise",
             Self::PromiseAvoidNew(_) => "promise",
@@ -12922,6 +12937,9 @@ impl RuleEnum {
             Self::JsdocRequireYields(_) => {
                 Ok(Self::JsdocRequireYields(JsdocRequireYields::from_configuration(value)?))
             }
+            Self::JsdocRequireYieldsDescription(_) => Ok(Self::JsdocRequireYieldsDescription(
+                JsdocRequireYieldsDescription::from_configuration(value)?,
+            )),
             Self::JsdocRequireYieldsType(_) => {
                 Ok(Self::JsdocRequireYieldsType(JsdocRequireYieldsType::from_configuration(value)?))
             }
@@ -14024,6 +14042,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(rule) => rule.to_configuration(),
             Self::JsdocRequireThrowsType(rule) => rule.to_configuration(),
             Self::JsdocRequireYields(rule) => rule.to_configuration(),
+            Self::JsdocRequireYieldsDescription(rule) => rule.to_configuration(),
             Self::JsdocRequireYieldsType(rule) => rule.to_configuration(),
             Self::PromiseAlwaysReturn(rule) => rule.to_configuration(),
             Self::PromiseAvoidNew(rule) => rule.to_configuration(),
@@ -14852,6 +14871,7 @@ impl RuleEnum {
                 Self::JsdocRequireThrowsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run(node, ctx),
+                Self::JsdocRequireYieldsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run(node, ctx),
                 Self::PromiseAlwaysReturn(rule) => rule.run(node, ctx),
                 Self::PromiseAvoidNew(rule) => rule.run(node, ctx),
@@ -15673,6 +15693,7 @@ impl RuleEnum {
                 Self::JsdocRequireThrowsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run(node, ctx),
+                Self::JsdocRequireYieldsDescription(rule) => rule.run(node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run(node, ctx),
                 Self::PromiseAlwaysReturn(rule) => rule.run(node, ctx),
                 Self::PromiseAvoidNew(rule) => rule.run(node, ctx),
@@ -16501,6 +16522,7 @@ impl RuleEnum {
                 Self::JsdocRequireThrowsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYields(rule) => rule.run_once(ctx),
+                Self::JsdocRequireYieldsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_once(ctx),
                 Self::PromiseAlwaysReturn(rule) => rule.run_once(ctx),
                 Self::PromiseAvoidNew(rule) => rule.run_once(ctx),
@@ -17322,6 +17344,7 @@ impl RuleEnum {
                 Self::JsdocRequireThrowsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYields(rule) => rule.run_once(ctx),
+                Self::JsdocRequireYieldsDescription(rule) => rule.run_once(ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_once(ctx),
                 Self::PromiseAlwaysReturn(rule) => rule.run_once(ctx),
                 Self::PromiseAvoidNew(rule) => rule.run_once(ctx),
@@ -18375,6 +18398,7 @@ impl RuleEnum {
                 Self::JsdocRequireThrowsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::JsdocRequireYieldsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::PromiseAlwaysReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::PromiseAvoidNew(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19450,6 +19474,7 @@ impl RuleEnum {
                 Self::JsdocRequireThrowsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireThrowsType(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYields(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::JsdocRequireYieldsDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JsdocRequireYieldsType(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::PromiseAlwaysReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::PromiseAvoidNew(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20301,6 +20326,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(rule) => rule.should_run(ctx),
             Self::JsdocRequireThrowsType(rule) => rule.should_run(ctx),
             Self::JsdocRequireYields(rule) => rule.should_run(ctx),
+            Self::JsdocRequireYieldsDescription(rule) => rule.should_run(ctx),
             Self::JsdocRequireYieldsType(rule) => rule.should_run(ctx),
             Self::PromiseAlwaysReturn(rule) => rule.should_run(ctx),
             Self::PromiseAvoidNew(rule) => rule.should_run(ctx),
@@ -21437,6 +21463,9 @@ impl RuleEnum {
             }
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::IS_TSGOLINT_RULE,
             Self::JsdocRequireYields(_) => JsdocRequireYields::IS_TSGOLINT_RULE,
+            Self::JsdocRequireYieldsDescription(_) => {
+                JsdocRequireYieldsDescription::IS_TSGOLINT_RULE
+            }
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::IS_TSGOLINT_RULE,
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::IS_TSGOLINT_RULE,
             Self::PromiseAvoidNew(_) => PromiseAvoidNew::IS_TSGOLINT_RULE,
@@ -22451,6 +22480,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::VERSION,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::VERSION,
             Self::JsdocRequireYields(_) => JsdocRequireYields::VERSION,
+            Self::JsdocRequireYieldsDescription(_) => JsdocRequireYieldsDescription::VERSION,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::VERSION,
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::VERSION,
             Self::PromiseAvoidNew(_) => PromiseAvoidNew::VERSION,
@@ -23468,6 +23498,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(_) => JsdocRequireThrowsDescription::HAS_CONFIG,
             Self::JsdocRequireThrowsType(_) => JsdocRequireThrowsType::HAS_CONFIG,
             Self::JsdocRequireYields(_) => JsdocRequireYields::HAS_CONFIG,
+            Self::JsdocRequireYieldsDescription(_) => JsdocRequireYieldsDescription::HAS_CONFIG,
             Self::JsdocRequireYieldsType(_) => JsdocRequireYieldsType::HAS_CONFIG,
             Self::PromiseAlwaysReturn(_) => PromiseAlwaysReturn::HAS_CONFIG,
             Self::PromiseAvoidNew(_) => PromiseAvoidNew::HAS_CONFIG,
@@ -24312,6 +24343,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(rule) => rule.types_info(),
             Self::JsdocRequireThrowsType(rule) => rule.types_info(),
             Self::JsdocRequireYields(rule) => rule.types_info(),
+            Self::JsdocRequireYieldsDescription(rule) => rule.types_info(),
             Self::JsdocRequireYieldsType(rule) => rule.types_info(),
             Self::PromiseAlwaysReturn(rule) => rule.types_info(),
             Self::PromiseAvoidNew(rule) => rule.types_info(),
@@ -25130,6 +25162,7 @@ impl RuleEnum {
             Self::JsdocRequireThrowsDescription(rule) => rule.run_info(),
             Self::JsdocRequireThrowsType(rule) => rule.run_info(),
             Self::JsdocRequireYields(rule) => rule.run_info(),
+            Self::JsdocRequireYieldsDescription(rule) => rule.run_info(),
             Self::JsdocRequireYieldsType(rule) => rule.run_info(),
             Self::PromiseAlwaysReturn(rule) => rule.run_info(),
             Self::PromiseAvoidNew(rule) => rule.run_info(),
@@ -26074,6 +26107,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JsdocRequireThrowsDescription(JsdocRequireThrowsDescription::default()),
         RuleEnum::JsdocRequireThrowsType(JsdocRequireThrowsType::default()),
         RuleEnum::JsdocRequireYields(JsdocRequireYields::default()),
+        RuleEnum::JsdocRequireYieldsDescription(JsdocRequireYieldsDescription::default()),
         RuleEnum::JsdocRequireYieldsType(JsdocRequireYieldsType::default()),
         RuleEnum::PromiseAlwaysReturn(PromiseAlwaysReturn::default()),
         RuleEnum::PromiseAvoidNew(PromiseAvoidNew::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -729,6 +729,7 @@ pub(crate) mod jsdoc {
     pub mod require_throws_description;
     pub mod require_throws_type;
     pub mod require_yields;
+    pub mod require_yields_description;
     pub mod require_yields_type;
 }
 

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields_description.rs
@@ -1,0 +1,142 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{should_ignore_as_internal, should_ignore_as_private},
+};
+
+fn require_yields_description_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Missing JSDoc `@yields` description.")
+        .with_help("Add description comment to `@yields` tag.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RequireYieldsDescription;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires a description for `@yields` tags.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `@yields` tag should explain what the generator yields.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// /**
+    ///  * @yields {string}
+    ///  */
+    /// function * quux () {
+    ///   yield 'value';
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// /**
+    ///  * @yields {string} The next value.
+    ///  */
+    /// function * quux () {
+    ///   yield 'value';
+    /// }
+    /// ```
+    RequireYieldsDescription,
+    jsdoc,
+    style,
+    version = "next",
+);
+
+impl Rule for RequireYieldsDescription {
+    fn run_once(&self, ctx: &LintContext) {
+        let settings = &ctx.settings().jsdoc;
+
+        for jsdoc in ctx
+            .jsdoc()
+            .iter_all()
+            .filter(|jsdoc| !should_ignore_as_internal(jsdoc, settings))
+            .filter(|jsdoc| !should_ignore_as_private(jsdoc, settings))
+        {
+            for tag in jsdoc.tags() {
+                let tag_name = tag.kind;
+
+                if !matches!(tag_name.parsed(), "yield" | "yields") {
+                    continue;
+                }
+
+                let (_, comment_part) = tag.type_comment();
+
+                if comment_part.parsed().is_empty() {
+                    ctx.diagnostic(require_yields_description_diagnostic(tag_name.span));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "
+                    /**
+                     * @yields {SomeType} Has a description
+                     */
+                  ",
+        "
+                    /**
+                     * @yield Has a description
+                     */
+                  ",
+        "
+                    /**
+                     * @yields {SomeType} Has a description
+                     */
+                  ",
+        "
+                    /**
+                     * @yield Has a description
+                     */
+                  ",
+        r#"
+                    /**
+                     * @yields
+                     *  The results.
+                     */
+                    export function *test1(): IterableIterator<string> { yield "hello"; }
+                  "#, // { "parser": typescriptEslintParser, }
+    ];
+
+    let fail = vec![
+        "
+                    /**
+                     * @yields
+                     */
+                  ",
+        "
+                    /**
+                     * @yield
+                     */
+                  ",
+        "
+                    /**
+                     * @yields {SomeType}
+                     */
+                  ",
+        "
+                    /**
+                     * @yield {SomeType}
+                     */
+                  ",
+    ];
+
+    Tester::new(RequireYieldsDescription::NAME, RequireYieldsDescription::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields_description.rs
@@ -135,6 +135,11 @@ fn test() {
                      * @yield {SomeType}
                      */
                   ",
+        "
+                    /**
+                     * @yields {T}   
+                     */
+                  ",
     ];
 
     Tester::new(RequireYieldsDescription::NAME, RequireYieldsDescription::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields_description.rs
@@ -92,12 +92,12 @@ fn test() {
                   ",
         "
                     /**
-                     * @yield Has a description
+                     * @yields Has a description
                      */
                   ",
         "
                     /**
-                     * @yields {SomeType} Has a description
+                     * @yield {SomeType} Has a description
                      */
                   ",
         "

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_yields_description.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_yields_description.snap
@@ -37,3 +37,12 @@ source: crates/oxc_linter/src/tester.rs
  4 │                      */
    ╰────
   help: Add description comment to `@yields` tag.
+
+  ⚠ jsdoc(require-yields-description): Missing JSDoc `@yields` description.
+   ╭─[require_yields_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @yields {T}   
+   ·                        ───────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@yields` tag.

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_yields_description.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_yields_description.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ jsdoc(require-yields-description): Missing JSDoc `@yields` description.
+   ╭─[require_yields_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @yields
+   ·                        ───────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@yields` tag.
+
+  ⚠ jsdoc(require-yields-description): Missing JSDoc `@yields` description.
+   ╭─[require_yields_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @yield
+   ·                        ──────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@yields` tag.
+
+  ⚠ jsdoc(require-yields-description): Missing JSDoc `@yields` description.
+   ╭─[require_yields_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @yields {SomeType}
+   ·                        ───────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@yields` tag.
+
+  ⚠ jsdoc(require-yields-description): Missing JSDoc `@yields` description.
+   ╭─[require_yields_description.tsx:3:24]
+ 2 │                     /**
+ 3 │                      * @yield {SomeType}
+   ·                        ──────
+ 4 │                      */
+   ╰────
+  help: Add description comment to `@yields` tag.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -649,6 +649,9 @@
         "jsdoc/require-yields": {
           "$ref": "#/definitions/DummyRule"
         },
+        "jsdoc/require-yields-description": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "jsdoc/require-yields-type": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -653,6 +653,9 @@ expression: json
         "jsdoc/require-yields": {
           "$ref": "#/definitions/DummyRule"
         },
+        "jsdoc/require-yields-description": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "jsdoc/require-yields-type": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
this PR implements `jsdoc/require-yields-description` rule. 

[rule doc](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-yields-description.md)
[rule source](https://github.com/gajus/eslint-plugin-jsdoc/blob/3d53b88baed2b49e04b4aa71599d1b449efcc3f8/src/index.js#L245)

issue #1170