### PR TITLE
chore(deps): bump MSRV to 1.94.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "A collection of JavaScript tools written in Rust."
 edition = "2024"
 # MSRV Policy N-2 (12 weeks).
 # Balance between the core contributors enjoying the latest version of rustc, while waiting for dependents to catch up.
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 
 # <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>
 [workspace.lints.rust]


### PR DESCRIPTION
#22807 bumped us up to Rust 1.96.0. Bump MSRV to 1.94.0, following our +2 MSRV policy.