### PR TITLE
refactor(lsp): `WorkspaceWorker.init_watchers` return single registration

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -668,8 +668,7 @@ impl LanguageServer for Backend {
                 .worker_manager
                 .ensure_worker_for_file_uri(&uri, diagnostic_mode, dynamic_watchers)
                 .await
-                && !registrations.is_empty()
-                && let Err(err) = self.client.register_capability(registrations).await
+                && let Err(err) = self.client.register_capability(vec![registrations]).await
             {
                 warn!("registering file watchers for single-file workspace failed: {err}");
             }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -75,20 +75,15 @@ impl WorkspaceWorker {
     /// Initialize file system watchers for the workspace.
     /// These watchers are used to watch for changes in the lint configuration files.
     /// The returned watchers will be registered to the client.
-    pub async fn init_watchers(&self) -> Vec<Registration> {
+    pub async fn init_watchers(&self) -> Option<Registration> {
         // clone the options to avoid locking the mutex
         let options_json = { self.options.lock().await.clone().unwrap_or_default() };
 
-        let tool_guard = self.tool.read().await;
-        let Some(tool) = tool_guard.as_ref() else {
-            return Vec::new();
-        };
-
-        let patterns = tool.get_watcher_patterns(options_json.clone());
+        let patterns = self.tool.read().await.as_ref()?.get_watcher_patterns(options_json);
         if patterns.is_empty() {
-            Vec::new()
+            None
         } else {
-            vec![registration_watcher_id(&self.root_uri, patterns)]
+            Some(registration_watcher_id(&self.root_uri, patterns))
         }
     }
 
@@ -476,9 +471,10 @@ mod tests {
             DiagnosticMode::None,
         );
         worker.start_worker(serde_json::Value::Null).await;
-        let registrations = worker.init_watchers().await;
-        assert_eq!(registrations.len(), 1);
-        assert_eq!(registrations[0].id, "watcher-file:///root/");
+        let registration = worker.init_watchers().await;
+        assert!(registration.is_some());
+        let registration = registration.unwrap();
+        assert_eq!(registration.id, "watcher-file:///root/");
 
         // with no watchers
         let worker_no_watchers = WorkspaceWorker::new(
@@ -487,8 +483,8 @@ mod tests {
             DiagnosticMode::None,
         );
         worker_no_watchers.start_worker(serde_json::json!({"some_option": true})).await;
-        let registrations_no_watchers = worker_no_watchers.init_watchers().await;
-        assert_eq!(registrations_no_watchers.len(), 0);
+        let registration_no_watchers = worker_no_watchers.init_watchers().await;
+        assert!(registration_no_watchers.is_none());
     }
 
     #[tokio::test]

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -359,7 +359,7 @@ impl WorkerManager {
         uri: &Uri,
         diagnostic_mode: DiagnosticMode,
         dynamic_watchers: bool,
-    ) -> Option<Vec<Registration>> {
+    ) -> Option<Registration> {
         // Bail out immediately if we are not in single-file mode.
         if !self.is_single_file_mode() {
             return None;
@@ -379,7 +379,7 @@ impl WorkerManager {
         let worker =
             WorkspaceWorker::new(parent_uri, Arc::clone(&self.tool_builder), diagnostic_mode);
         worker.start_worker(Value::Null).await;
-        let registrations = if dynamic_watchers { worker.init_watchers().await } else { vec![] };
+        let registration = if dynamic_watchers { worker.init_watchers().await } else { None };
 
         // Acquire the write lock to insert the worker.  Re-check both the mode
         // flag and the worker list because a concurrent call (e.g., another
@@ -403,7 +403,7 @@ impl WorkerManager {
             return None;
         }
 
-        Some(registrations)
+        registration
     }
 
     /// In single-file mode, shut down and remove the [`WorkspaceWorker`] whose


### PR DESCRIPTION
`init_watchers` was returning a `Vec<Registration>`, this was needed where the Worker need to manager multiple tools. Now it only owns one tool and can use `Option<Registration>` instead.