### PR TITLE
feat(linter/promise/spec-only): Add `Promise.try` to `Promise` static methods

### DIFF
--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -104,6 +104,7 @@ fn test() {
         ("Promise.all()", None),
         ("Promise.all()", Some(serde_json::json!([{ "allowedMethods": [] }]))),
         ("Promise.race()", None),
+        ("Promise.try()", None),
         ("Promise.withResolvers()", None),
         ("new Promise(function (resolve, reject) {})", None),
         ("SomeClass.resolve()", None),

--- a/crates/oxc_linter/src/utils/promise.rs
+++ b/crates/oxc_linter/src/utils/promise.rs
@@ -10,7 +10,7 @@ use crate::context::LintContext;
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 pub const PROMISE_STATIC_METHODS: [&str; 7] =
-    ["all", "allSettled", "any", "race", "reject", "resolve", "withResolvers"];
+    ["all", "allSettled", "any", "race", "reject", "resolve", "try", "withResolvers"];
 
 pub fn is_promise(call_expr: &CallExpression) -> Option<String> {
     let member_expr = call_expr.callee.get_member_expr()?;

--- a/crates/oxc_linter/src/utils/promise.rs
+++ b/crates/oxc_linter/src/utils/promise.rs
@@ -9,7 +9,7 @@ use oxc_semantic::SymbolId;
 use crate::context::LintContext;
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-pub const PROMISE_STATIC_METHODS: [&str; 7] =
+pub const PROMISE_STATIC_METHODS: [&str; 8] =
     ["all", "allSettled", "any", "race", "reject", "resolve", "try", "withResolvers"];
 
 pub fn is_promise(call_expr: &CallExpression) -> Option<String> {


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try), `Promise.try` is Baseline as of January 2025. This seems like a pretty simple change, but lmk if I've missed something.