### PR TITLE
refactor(formatter,linter): use `is_multiple_of`

### DIFF
--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -98,7 +98,7 @@ pub(super) fn format_css_doc<'a>(
                     let parts =
                         super::split_on_placeholders(text, PLACEHOLDER_PREFIX, PLACEHOLDER_SUFFIX);
                     for (i, part) in parts.iter().enumerate() {
-                        if i % 2 == 0 {
+                        if i.is_multiple_of(2) {
                             if !part.is_empty() {
                                 super::write_text_with_line_breaks(
                                     f,

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -148,7 +148,7 @@ pub(super) fn format_html_doc<'a>(
                     let parts =
                         super::split_on_placeholders(text, PLACEHOLDER_PREFIX, PLACEHOLDER_SUFFIX);
                     for (i, part) in parts.iter().enumerate() {
-                        if i % 2 == 0 {
+                        if i.is_multiple_of(2) {
                             if !part.is_empty() {
                                 super::write_text_with_line_breaks(
                                     f,

--- a/crates/oxc_linter/src/rules/eslint/prefer_template.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_template.rs
@@ -302,7 +302,7 @@ fn escape_dollar_and_backtick(raw: &str) -> String {
             if is_backtick || is_dollar_brace {
                 // Push all the original backslashes
                 result.push_str(&raw[start..i]);
-                if num_backslashes % 2 == 0 {
+                if num_backslashes.is_multiple_of(2) {
                     // Even backslashes → target is unescaped → add escape
                     result.push('\\');
                 }


### PR DESCRIPTION
## Summary

- Replace `% 2 == 0` with `.is_multiple_of(2)` at three call sites where the operand type is already concrete (`usize` from `enumerate()`, or an existing typed counter).
- `is_multiple_of` was stabilized in Rust 1.87; current MSRV is 1.94.
- LLVM emits identical assembly — verified by symbol aliasing in `-O` output.