### PR TITLE
refactor(formatter_core,formatter,formatter_json): lift up `SourceText` to core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_data_structures",
  "oxc_span",
+ "oxc_syntax",
  "rustc-hash",
  "serde_json",
  "unicode-width",

--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -156,6 +156,6 @@ where
 
     /// Get the number of line breaks between two consecutive SyntaxNodes in the tree
     pub fn has_lines_before(&self, span: Span) -> bool {
-        self.fmt.source_text().get_lines_before(span, self.fmt.comments()) > 1
+        self.fmt.lines_before(span) > 1
     }
 }

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -158,6 +158,15 @@ impl<'a> Comments<'a> {
         &self.inner[self.printed_count..end]
     }
 
+    /// Returns the span of the first not-yet-printed comment, if any.
+    ///
+    /// Used by [`SourceText::get_lines_before`], which only needs that comment's
+    /// span (not the `Comment` itself) to skip leading trivia.
+    #[inline]
+    pub fn first_unprinted_span(&self) -> Option<Span> {
+        self.unprinted_comments().first().map(|c| c.span)
+    }
+
     /// Returns comments that have already been printed.
     #[inline]
     pub fn printed_comments(&self) -> &'a [Comment] {

--- a/crates/oxc_formatter/src/formatter/formatter_js.rs
+++ b/crates/oxc_formatter/src/formatter/formatter_js.rs
@@ -5,7 +5,7 @@
 //! the JS-specific operations are exposed via the [`JsFormatter`] type alias and an
 //! extension trait that is blanket-implemented for the alias.
 
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 
 use crate::formatter::{
     Buffer, Comments, Format, Formatter, GroupId, JsFormatContext, SourceText,
@@ -26,6 +26,7 @@ pub type JsFormatter<'buf, 'ast> = Formatter<'buf, 'ast, JsFormatContext<'ast>>;
 pub trait JsFormatterExt<'buf, 'ast> {
     fn source_text(&self) -> SourceText<'ast>;
     fn comments(&self) -> &Comments<'_>;
+    fn lines_before(&self, span: Span) -> usize;
     fn group_id(&self, debug_name: &'static str) -> GroupId;
     fn group_id_builder(&self) -> &UniqueGroupIdBuilder;
     fn join_nodes_with_soft_line<'fmt>(&'fmt mut self) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Line>;
@@ -48,6 +49,13 @@ impl<'buf, 'ast> JsFormatterExt<'buf, 'ast> for Formatter<'buf, 'ast, JsFormatCo
     #[inline]
     fn comments(&self) -> &Comments<'_> {
         self.context().comments()
+    }
+
+    /// Returns the number of line breaks before `span`, counting the leading trivia
+    /// of the first not-yet-printed comment. See [`SourceText::get_lines_before`].
+    #[inline]
+    fn lines_before(&self, span: Span) -> usize {
+        self.source_text().get_lines_before(span, self.comments().first_unprinted_span())
     }
 
     /// Creates a new group id that is unique to this document.

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -24,7 +24,6 @@ pub mod formatter_js;
 pub mod jsdoc;
 pub mod prelude;
 pub mod separated;
-mod source_text;
 pub mod token;
 pub mod trivia;
 
@@ -48,8 +47,8 @@ pub mod buffer {
 
 pub use oxc_formatter_core::{
     Argument, Arguments, Buffer, BufferExtensions, Format, FormatElement, FormatOptions,
-    FormatState, Formatted, Formatter, GroupId, MemoizeFormat, Memoized, UniqueGroupIdBuilder,
-    VecBuffer,
+    FormatState, Formatted, Formatter, GroupId, MemoizeFormat, Memoized, SourceText,
+    UniqueGroupIdBuilder, VecBuffer,
 };
 
 pub use self::builders::JoinBuilderJsExt;
@@ -57,7 +56,6 @@ pub use self::comments::Comments;
 pub use self::{
     context::{JsFormatContext, TailwindContextEntry},
     formatter_js::{JsFormatter, JsFormatterExt},
-    source_text::SourceText,
 };
 use oxc_formatter_core::Document;
 

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -122,8 +122,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatLeadingComments<'a> {
                                 write!(f, [maybe_space(!should_nestle)]);
                             }
                             1 => {
-                                if f.source_text().get_lines_before(comment.span, f.comments()) == 0
-                                {
+                                if f.lines_before(comment.span) == 0 {
                                     write!(f, [soft_line_break_or_space()]);
                                 } else {
                                     write!(f, [hard_line_break()]);
@@ -188,7 +187,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTrailingComments<'a> {
             for comment in comments {
                 f.context_mut().comments_mut().increment_printed_count();
 
-                let lines_before = f.source_text().get_lines_before(comment.span, f.comments());
+                let lines_before = f.lines_before(comment.span);
                 total_lines_before += lines_before;
 
                 let should_nestle = previous_comment.is_some_and(|previous_comment| {

--- a/crates/oxc_formatter/src/print/array_element_list.rs
+++ b/crates/oxc_formatter/src/print/array_element_list.rs
@@ -49,7 +49,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ArrayElementList<'a, '_> {
                 {
                     filler.entry(
                         &format_with(|f| {
-                            if f.source_text().get_lines_before(element.span(), f.comments()) > 1 {
+                            if f.lines_before(element.span()) > 1 {
                                 write!(f, empty_line());
                             } else if f
                                 .comments()

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -260,7 +260,7 @@ fn format_all_args_broken_out<'a, 'b>(
             soft_block_indent(&format_with(move |f| {
                 for (index, argument) in node.iter().enumerate() {
                     if index > 0 {
-                        match f.source_text().get_lines_before(argument.span(), f.comments()) {
+                        match f.lines_before(argument.span()) {
                             0 | 1 => write!(f, [soft_line_break_or_space()]),
                             _ => write!(f, [empty_line()]),
                         }
@@ -669,7 +669,7 @@ fn write_grouped_arguments<'a>(
             // We have to get the lines before the argument has been formatted, because it relies on
             // the comments before the argument. After formatting, the comments might marked as printed,
             // which would lead to a wrong line count.
-            let lines_before = f.source_text().get_lines_before(argument.span(), f.comments());
+            let lines_before = f.lines_before(argument.span());
             let comma = (last_index != index).then_some(",");
 
             let interned = f.intern(&format_once(|f| {

--- a/crates/oxc_formatter/src/print/export_declarations.rs
+++ b/crates/oxc_formatter/src/print/export_declarations.rs
@@ -184,7 +184,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ExportSpecifier
                         // Should add empty line before the specifier if there are comments before it.
                         let specifier_span = specifier.span();
                         if f.context().comments().has_comment_before(specifier_span.start)
-                            && f.source_text().get_lines_before(specifier_span, f.comments()) > 1
+                            && f.lines_before(specifier_span) > 1
                         {
                             write!(f, [empty_line()]);
                         }

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -135,9 +135,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ImportDeclarati
                                         if f.context()
                                             .comments()
                                             .has_comment_before(specifier_span.start)
-                                            && f.source_text()
-                                                .get_lines_before(specifier_span, f.comments())
-                                                > 1
+                                            && f.lines_before(specifier_span) > 1
                                         {
                                             write!(f, [empty_line()]);
                                         }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -821,7 +821,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
             }
 
             if has_dangling_comments && let Some(first_comment) = comments.first() {
-                if f.source_text().get_lines_before(first_comment.span, f.comments()) > 1 {
+                if f.lines_before(first_comment.span) > 1 {
                     write!(f, empty_line());
                 }
                 write!(

--- a/crates/oxc_formatter_core/Cargo.toml
+++ b/crates/oxc_formatter_core/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 oxc_allocator = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["code_buffer"] }
 oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
 
 cow-utils = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -27,6 +27,7 @@ mod macros;
 mod options;
 pub mod printer;
 mod simple_context;
+mod source_text;
 mod state;
 mod text_range;
 mod traits;
@@ -61,6 +62,7 @@ pub use options::{
 };
 pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};
 pub use simple_context::{SimpleFormatContext, SimpleFormatOptions};
+pub use source_text::SourceText;
 pub use state::FormatState;
 pub use text_range::TextRange;
 pub use traits::{FormatContext, FormatOptions};

--- a/crates/oxc_formatter_core/src/source_text.rs
+++ b/crates/oxc_formatter_core/src/source_text.rs
@@ -6,9 +6,14 @@ use oxc_syntax::{
     line_terminator::{CR, LF, is_line_terminator},
 };
 
-use super::Comments;
-
 /// Source text wrapper providing utilities for text analysis in the formatter.
+///
+/// All positions are `u32` UTF-8 byte offsets into `text`.
+/// This is the only hard prerequisite for any consumer:
+/// - `u32` means byte offsets, not UTF-16 code units or `char` indices
+/// - `u32` is the oxc-wide convention
+///   - `oxc_span::Span` is `u32`-based, and `oxc_parser` rejects sources longer than `u32::MAX` bytes
+///   - so casting a `usize` offset down to `u32` never truncates for parsed sources)
 #[derive(Debug, Clone, Copy)]
 pub struct SourceText<'a> {
     text: &'a str,
@@ -193,18 +198,36 @@ impl<'a> SourceText<'a> {
         // No non-whitespace characters found after position, so return `0` to avoid adding extra new lines
         0
     }
+}
 
-    /// Count line breaks between syntax nodes, considering comments and parentheses
-    pub fn get_lines_before(&self, span: Span, comments: &Comments) -> usize {
+// Language-specific methods.
+//
+// Everything above is language-neutral text scanning.
+// The methods in this block encode front-end-specific trivia rules,
+// so they are deliberately kept separate from the neutral primitives.
+//
+// Each one documents the language whose rules it implements;
+// do NOT call them from a consumer with different trivia semantics.
+impl SourceText<'_> {
+    /// Count line breaks between syntax nodes, considering comments and parentheses.
+    ///
+    /// NOTE: This encodes JS/TS leading-trivia rules.
+    /// It skips an ASI semicolon (`;(function(){});`) and discounts newlines inside non-preserved parens (`(`…`)`).
+    /// Other front-ends (JSON, ...) currently don't call it;
+    /// a consumer with different trivia semantics should not assume this is language-neutral.
+    ///
+    /// `first_unprinted_comment` is the span of the first not-yet-printed comment
+    /// (the JS front-end's `Comments::unprinted_comments().first()`), or `None`.
+    /// Only the span is needed: when that comment ends before `span.start`,
+    /// its leading trivia is included in the count.
+    pub fn get_lines_before(&self, span: Span, first_unprinted_comment: Option<Span>) -> usize {
         let mut start = span.start;
 
-        let comments = comments.unprinted_comments();
-
         // Should skip the leading comments of the node.
-        if let Some(comment) = comments.first()
-            && comment.span.end <= start
+        if let Some(comment) = first_unprinted_comment
+            && comment.end <= start
         {
-            start = comment.span.start;
+            start = comment.start;
         } else if start != 0 && matches!(self.byte_at(start - 1), Some(b';')) {
             // Skip leading semicolon if present
             // `;(function() {});`
@@ -274,8 +297,6 @@ const z = 3;
 "
         .trim();
         let source_text = SourceText::new(source_text);
-        let comments = vec![];
-        let comments = Comments::new(source_text, &comments);
 
         let span_x = Span::new(0, 12);
         let span_y = Span::new(14, 26);
@@ -284,9 +305,9 @@ const z = 3;
         assert_eq!(source_text.text_for(&span_y), "const y = 2;");
         assert_eq!(source_text.text_for(&span_z), "const z = 3;");
 
-        assert_eq!(source_text.get_lines_before(span_x, &comments), 0);
-        assert_eq!(source_text.get_lines_before(span_y, &comments), 2);
-        assert_eq!(source_text.get_lines_before(span_z, &comments), 3);
+        assert_eq!(source_text.get_lines_before(span_x, None), 0);
+        assert_eq!(source_text.get_lines_before(span_y, None), 2);
+        assert_eq!(source_text.get_lines_before(span_z, None), 3);
 
         assert_eq!(source_text.lines_after(span_x.end), 2);
         assert_eq!(source_text.lines_after(span_y.end), 3);
@@ -297,8 +318,6 @@ const z = 3;
     fn test_source_text_with_crlf() {
         let source_text = "const x = 1;\r\n\r\nconst y = 2;\r\n\r\n\r\nconst z = 3;";
         let source_text = SourceText::new(source_text);
-        let comments = vec![];
-        let comments = Comments::new(source_text, &comments);
 
         let span_x = Span::new(0, 12);
         let span_y = Span::new(16, 28);
@@ -307,8 +326,8 @@ const z = 3;
         assert_eq!(source_text.text_for(&span_y), "const y = 2;");
         assert_eq!(source_text.text_for(&span_z), "const z = 3;");
 
-        assert_eq!(source_text.get_lines_before(span_y, &comments), 2);
-        assert_eq!(source_text.get_lines_before(span_z, &comments), 3);
+        assert_eq!(source_text.get_lines_before(span_y, None), 2);
+        assert_eq!(source_text.get_lines_before(span_z, None), 3);
 
         assert_eq!(source_text.lines_after(span_x.end), 2);
         assert_eq!(source_text.lines_after(span_y.end), 3);
@@ -318,8 +337,6 @@ const z = 3;
     fn test_source_text_with_mixed_line_endings() {
         let source_text = "const x = 1;\n\r\nconst y = 2;\r\n\nconst z = 3;";
         let source_text = SourceText::new(source_text);
-        let comments = vec![];
-        let comments = Comments::new(source_text, &comments);
 
         let span_x = Span::new(0, 12);
         let span_y = Span::new(15, 27);
@@ -328,8 +345,8 @@ const z = 3;
         assert_eq!(source_text.text_for(&span_y), "const y = 2;");
         assert_eq!(source_text.text_for(&span_z), "const z = 3;");
 
-        assert_eq!(source_text.get_lines_before(span_y, &comments), 2);
-        assert_eq!(source_text.get_lines_before(span_z, &comments), 2);
+        assert_eq!(source_text.get_lines_before(span_y, None), 2);
+        assert_eq!(source_text.get_lines_before(span_z, None), 2);
 
         assert_eq!(source_text.lines_after(span_x.end), 2);
         assert_eq!(source_text.lines_after(span_y.end), 2);

--- a/crates/oxc_formatter_json/src/comments.rs
+++ b/crates/oxc_formatter_json/src/comments.rs
@@ -3,8 +3,9 @@ use std::cell::Cell;
 use oxc_allocator::StringBuilder;
 use oxc_ast::Comment;
 use oxc_formatter_core::{
-    Buffer, Format,
+    Buffer, Format, SourceText,
     builders::{empty_line, hard_line_break, space, text},
+    util::is_suppression_marker,
     write,
 };
 use oxc_span::Span;
@@ -71,7 +72,7 @@ impl<'a> Comments<'a> {
 /// - Other multi-line block comments normalize `\r\n` → `\n` but otherwise stay
 ///   verbatim; their first line still gets its trailing whitespace trimmed.
 pub fn write_single_comment(comment: &Comment, f: &mut JsonFormatter<'_, '_>) {
-    let content = comment.span.source_text(f.context().source_text());
+    let content = f.context().source_text().text_for(&comment.span);
 
     if !comment.is_multiline_block() {
         write!(f, text(content.trim_end()));
@@ -119,7 +120,7 @@ pub fn write_leading_comments(
     for (i, comment) in comments.iter().enumerate() {
         write_single_comment(comment, f);
         let next_pos = comments.get(i + 1).map_or(value_start, |c| c.span.start);
-        write_gap(&source.as_bytes()[comment.span.end as usize..next_pos as usize], f);
+        write_gap(source.bytes_range(comment.span.end, next_pos), f);
     }
 }
 
@@ -165,7 +166,7 @@ pub fn write_trailing_inside_comments(
     let source = f.context().source_text();
     let mut prev_end = lower_bound;
     for comment in comments {
-        write_gap(&source.as_bytes()[prev_end as usize..comment.span.start as usize], f);
+        write_gap(source.bytes_range(prev_end, comment.span.start), f);
         write_single_comment(comment, f);
         prev_end = comment.span.end;
     }
@@ -202,9 +203,9 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FormatTrailingInsideComments {
 
 /// Returns `true` if `comment` is an ignore marker (`oxfmt-ignore` / `prettier-ignore`).
 /// Mirrors `oxc_formatter`'s suppression rule so JSON honors the same authoring convention as JS/TS.
-pub fn is_suppression_comment(source: &str, comment: &Comment) -> bool {
-    let body = comment.content_span().source_text(source);
-    oxc_formatter_core::util::is_suppression_marker(body)
+pub fn is_suppression_comment(source: SourceText<'_>, comment: &Comment) -> bool {
+    let body = source.text_for(&comment.content_span());
+    is_suppression_marker(body)
 }
 
 /// Returns `true` if any pending comment up to `before` is a suppression marker.
@@ -222,7 +223,7 @@ pub struct FormatSuppressedNode(pub Span);
 impl<'a> Format<'a, JsonFormatContext<'a>> for FormatSuppressedNode {
     fn fmt(&self, f: &mut JsonFormatter<'_, 'a>) {
         write!(f, FormatLeadingComments(self.0));
-        write!(f, text(self.0.source_text(f.context().source_text())));
+        write!(f, text(f.context().source_text().text_for(&self.0)));
         // The verbatim text already includes inside-span comments;
         // advance the cursor so they aren't re-emitted as leading comments of a later node.
         let _ = f.context().comments().take_before(self.0.end);

--- a/crates/oxc_formatter_json/src/context.rs
+++ b/crates/oxc_formatter_json/src/context.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 
 use oxc_ast::Comment;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_formatter_core::FormatContext;
+use oxc_formatter_core::{FormatContext, SourceText};
 use oxc_span::Span;
 
 use crate::{comments::Comments, options::JsonFormatOptions};
@@ -10,9 +10,9 @@ use crate::{comments::Comments, options::JsonFormatOptions};
 /// Formatting context for JSON.
 pub struct JsonFormatContext<'a> {
     options: JsonFormatOptions,
-    source_code: &'a str,
+    source_text: SourceText<'a>,
     comments: Comments<'a>,
-    /// Byte offset within `source_code` where the user's original source begins.
+    /// Byte offset within `source_text` where the user's original source begins.
     /// `1` on the wrapped parse path (skip the leading `(`), `0` on the bare fallback.
     /// Used by [`Self::report_invalid_json`] to report user-visible line/column.
     source_offset: u32,
@@ -31,7 +31,7 @@ impl<'a> JsonFormatContext<'a> {
     ) -> Self {
         Self {
             options,
-            source_code,
+            source_text: SourceText::new(source_code),
             comments: Comments::new(comments),
             source_offset,
             error: Cell::new(None),
@@ -39,9 +39,10 @@ impl<'a> JsonFormatContext<'a> {
     }
 
     /// Returns the source text with the arena lifetime (vs the trait's borrow-elided `&str`).
-    /// Slices taken via this method don't have to be re-allocated for `text(...)`.
-    pub fn source_text(&self) -> &'a str {
-        self.source_code
+    /// Slices taken via this method (e.g. `slice_range`, `bytes_range`) carry the `'a` lifetime,
+    /// so they don't have to be re-allocated for `text(...)`.
+    pub fn source_text(&self) -> SourceText<'a> {
+        self.source_text
     }
 
     /// Returns the comment cursor.
@@ -79,6 +80,6 @@ impl FormatContext for JsonFormatContext<'_> {
     }
 
     fn source_code(&self) -> &str {
-        self.source_code
+        &self.source_text
     }
 }

--- a/crates/oxc_formatter_json/src/print/array.rs
+++ b/crates/oxc_formatter_json/src/print/array.rs
@@ -42,11 +42,11 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonArray<'a, '_> {
         // Group builders assert on empty content, so emit the source slice verbatim
         // which already captures the user's holes.
         if self.array.elements.iter().all(|el| matches!(el, ArrayExpressionElement::Elision(_))) {
-            let inner_start = (self.array.span.start + 1) as usize;
-            let inner_end = (self.array.span.end - 1) as usize;
+            let inner_start = self.array.span.start + 1;
+            let inner_end = self.array.span.end - 1;
             let source = f.context().source_text();
-            if inner_end > inner_start && inner_end <= source.len() {
-                write!(f, text(&source[inner_start..inner_end]));
+            if inner_end > inner_start && (inner_end as usize) <= source.len() {
+                write!(f, text(source.slice_range(inner_start, inner_end)));
             }
             write!(f, "]");
             return;
@@ -75,8 +75,8 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonArray<'a, '_> {
                     let pe = prev_end;
                     let sep = format_with(move |f: &mut JsonFormatter<'_, 'a>| {
                         if let Some(pe_val) = pe {
-                            let between = &source[pe_val as usize..curr_start as usize];
-                            if blank_line_after_comma(between.as_bytes()) {
+                            let between = source.bytes_range(pe_val, curr_start);
+                            if blank_line_after_comma(between) {
                                 write!(f, empty_line());
                             } else {
                                 write!(f, soft_line_break_or_space());

--- a/crates/oxc_formatter_json/src/print/object.rs
+++ b/crates/oxc_formatter_json/src/print/object.rs
@@ -88,7 +88,9 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonObject<'a, '_> {
         // The array side does NOT do this — only objects.
         let options = f.context().options();
         let expand = match options.expand {
-            Expand::Auto => opens_on_new_line(self.object, f.context().source_text()),
+            Expand::Auto => {
+                f.context().source_text().has_newline_after_opening_brace(self.object.span.start)
+            }
             Expand::Never => false,
         };
         write!(
@@ -100,20 +102,6 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonObject<'a, '_> {
             ]
         );
     }
-}
-
-/// Returns `true` if the source between `{` and the first property contains a newline.
-///
-/// Mirrors Prettier's `language-js` estree-printer trigger for forcing multi-line
-/// object output: `{<NL>...` keeps the object expanded, `{prop, prop}` stays inline.
-fn opens_on_new_line(object: &ObjectExpression<'_>, source: &str) -> bool {
-    let after_open = object.span.start as usize + 1;
-    let body_start =
-        object.properties.first().map_or(object.span.end as usize, |p| p.span().start as usize);
-    if body_start <= after_open || body_start > source.len() {
-        return false;
-    }
-    source[after_open..body_start].contains('\n')
 }
 
 /// Emits an object property's key, applying Prettier's `json`-parser conventions.

--- a/crates/oxc_formatter_json/src/separated.rs
+++ b/crates/oxc_formatter_json/src/separated.rs
@@ -162,17 +162,16 @@ fn has_blank_line(start: u32, curr_start: u32, f: &JsonFormatter<'_, '_>) -> boo
 /// from being misread as blank-line markers in the inter-entry gap.
 fn gap_slice<'a>(start: u32, curr_start: u32, f: &JsonFormatter<'_, 'a>) -> Option<&'a [u8]> {
     let source = f.context().source_text();
-    let start_usize = start as usize;
     let end = f
         .context()
         .comments()
         .iter_before(curr_start)
         .find(|c| c.span.start >= start)
-        .map_or(curr_start as usize, |c| c.span.start as usize);
-    if end <= start_usize || end > source.len() {
+        .map_or(curr_start, |c| c.span.start);
+    if end <= start || end as usize > source.len() {
         return None;
     }
-    Some(&source.as_bytes()[start_usize..end])
+    Some(source.bytes_range(start, end))
 }
 
 /// Returns `true` if `between` (the source slice between two adjacent entries) places a blank line


### PR DESCRIPTION
`oxc_formatter(_js)` and `oxc_formatter_json` are peers, but both need the same source-text scanning. `SourceText` is essentially a `&str` wrapper with a generic `u32` UTF-8 offset API (the oxc-wide convention) and language-neutral, so it belongs in core.

This lets JS and JSON share the code instead of `oxc_formatter_json` hand-rolling its own byte/string slicing.

NOTE:
One method (`get_lines_before`) still encodes JS-specific trivia rules. Moving it out would force its private primitives to become public, so it stays in core in a separate, clearly-marked language-specific impl block.