### PR TITLE
feat(linter/vue): implement component-definition-name-casing rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1291,6 +1291,7 @@ export interface DummyRuleMap {
   "vitest/valid-expect-in-promise"?: DummyRule;
   "vitest/valid-title"?: DummyRule;
   "vitest/warn-todo"?: DummyRule;
+  "vue/component-definition-name-casing"?: DummyRule;
   "vue/define-emits-declaration"?: DummyRule;
   "vue/define-props-declaration"?: DummyRule;
   "vue/define-props-destructuring"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4949,6 +4949,14 @@ impl RuleRunner for crate::rules::node::no_process_env::NoProcessEnv {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::vue::component_definition_name_casing::ComponentDefinitionNameCasing
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::define_emits_declaration::DefineEmitsDeclaration {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -790,6 +790,7 @@ pub use crate::rules::vitest::valid_expect::ValidExpect as VitestValidExpect;
 pub use crate::rules::vitest::valid_expect_in_promise::ValidExpectInPromise as VitestValidExpectInPromise;
 pub use crate::rules::vitest::valid_title::ValidTitle as VitestValidTitle;
 pub use crate::rules::vitest::warn_todo::WarnTodo as VitestWarnTodo;
+pub use crate::rules::vue::component_definition_name_casing::ComponentDefinitionNameCasing as VueComponentDefinitionNameCasing;
 pub use crate::rules::vue::define_emits_declaration::DefineEmitsDeclaration as VueDefineEmitsDeclaration;
 pub use crate::rules::vue::define_props_declaration::DefinePropsDeclaration as VueDefinePropsDeclaration;
 pub use crate::rules::vue::define_props_destructuring::DefinePropsDestructuring as VueDefinePropsDestructuring;
@@ -1623,6 +1624,7 @@ pub enum RuleEnum {
     NodeNoNewRequire(NodeNoNewRequire),
     NodeNoPathConcat(NodeNoPathConcat),
     NodeNoProcessEnv(NodeNoProcessEnv),
+    VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing),
     VueDefineEmitsDeclaration(VueDefineEmitsDeclaration),
     VueDefinePropsDeclaration(VueDefinePropsDeclaration),
     VueDefinePropsDestructuring(VueDefinePropsDestructuring),
@@ -2538,7 +2540,8 @@ const NODE_NO_EXPORTS_ASSIGN_ID: usize = NODE_HANDLE_CALLBACK_ERR_ID + 1usize;
 const NODE_NO_NEW_REQUIRE_ID: usize = NODE_NO_EXPORTS_ASSIGN_ID + 1usize;
 const NODE_NO_PATH_CONCAT_ID: usize = NODE_NO_NEW_REQUIRE_ID + 1usize;
 const NODE_NO_PROCESS_ENV_ID: usize = NODE_NO_PATH_CONCAT_ID + 1usize;
-const VUE_DEFINE_EMITS_DECLARATION_ID: usize = NODE_NO_PROCESS_ENV_ID + 1usize;
+const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize = NODE_NO_PROCESS_ENV_ID + 1usize;
+const VUE_DEFINE_EMITS_DECLARATION_ID: usize = VUE_COMPONENT_DEFINITION_NAME_CASING_ID + 1usize;
 const VUE_DEFINE_PROPS_DECLARATION_ID: usize = VUE_DEFINE_EMITS_DECLARATION_ID + 1usize;
 const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID + 1usize;
 const VUE_MAX_PROPS_ID: usize = VUE_DEFINE_PROPS_DESTRUCTURING_ID + 1usize;
@@ -3484,6 +3487,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NODE_NO_NEW_REQUIRE_ID,
             Self::NodeNoPathConcat(_) => NODE_NO_PATH_CONCAT_ID,
             Self::NodeNoProcessEnv(_) => NODE_NO_PROCESS_ENV_ID,
+            Self::VueComponentDefinitionNameCasing(_) => VUE_COMPONENT_DEFINITION_NAME_CASING_ID,
             Self::VueDefineEmitsDeclaration(_) => VUE_DEFINE_EMITS_DECLARATION_ID,
             Self::VueDefinePropsDeclaration(_) => VUE_DEFINE_PROPS_DECLARATION_ID,
             Self::VueDefinePropsDestructuring(_) => VUE_DEFINE_PROPS_DESTRUCTURING_ID,
@@ -4413,6 +4417,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::NAME,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::NAME,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::NAME,
+            Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::NAME,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::NAME,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::NAME,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::NAME,
@@ -5398,6 +5403,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::CATEGORY,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::CATEGORY,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::CATEGORY,
+            Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::CATEGORY,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::CATEGORY,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::CATEGORY,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::CATEGORY,
@@ -6330,6 +6336,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::FIX,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::FIX,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::FIX,
+            Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::FIX,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::FIX,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::FIX,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::FIX,
@@ -7506,6 +7513,9 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::documentation(),
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::documentation(),
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::documentation(),
+            Self::VueComponentDefinitionNameCasing(_) => {
+                VueComponentDefinitionNameCasing::documentation()
+            }
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::documentation(),
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::documentation(),
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::documentation(),
@@ -9801,6 +9811,10 @@ impl RuleEnum {
                 .or_else(|| NodeNoPathConcat::schema(generator)),
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::config_schema(generator)
                 .or_else(|| NodeNoProcessEnv::schema(generator)),
+            Self::VueComponentDefinitionNameCasing(_) => {
+                VueComponentDefinitionNameCasing::config_schema(generator)
+                    .or_else(|| VueComponentDefinitionNameCasing::schema(generator))
+            }
             Self::VueDefineEmitsDeclaration(_) => {
                 VueDefineEmitsDeclaration::config_schema(generator)
                     .or_else(|| VueDefineEmitsDeclaration::schema(generator))
@@ -10686,6 +10700,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => "node",
             Self::NodeNoPathConcat(_) => "node",
             Self::NodeNoProcessEnv(_) => "node",
+            Self::VueComponentDefinitionNameCasing(_) => "vue",
             Self::VueDefineEmitsDeclaration(_) => "vue",
             Self::VueDefinePropsDeclaration(_) => "vue",
             Self::VueDefinePropsDestructuring(_) => "vue",
@@ -13248,6 +13263,11 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => {
                 Ok(Self::NodeNoProcessEnv(NodeNoProcessEnv::from_configuration(value)?))
             }
+            Self::VueComponentDefinitionNameCasing(_) => {
+                Ok(Self::VueComponentDefinitionNameCasing(
+                    VueComponentDefinitionNameCasing::from_configuration(value)?,
+                ))
+            }
             Self::VueDefineEmitsDeclaration(_) => Ok(Self::VueDefineEmitsDeclaration(
                 VueDefineEmitsDeclaration::from_configuration(value)?,
             )),
@@ -14141,6 +14161,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(rule) => rule.to_configuration(),
             Self::NodeNoPathConcat(rule) => rule.to_configuration(),
             Self::NodeNoProcessEnv(rule) => rule.to_configuration(),
+            Self::VueComponentDefinitionNameCasing(rule) => rule.to_configuration(),
             Self::VueDefineEmitsDeclaration(rule) => rule.to_configuration(),
             Self::VueDefinePropsDeclaration(rule) => rule.to_configuration(),
             Self::VueDefinePropsDestructuring(rule) => rule.to_configuration(),
@@ -14970,6 +14991,7 @@ impl RuleEnum {
                 Self::NodeNoNewRequire(rule) => rule.run(node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run(node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
+                Self::VueComponentDefinitionNameCasing(rule) => rule.run(node, ctx),
                 Self::VueDefineEmitsDeclaration(rule) => rule.run(node, ctx),
                 Self::VueDefinePropsDeclaration(rule) => rule.run(node, ctx),
                 Self::VueDefinePropsDestructuring(rule) => rule.run(node, ctx),
@@ -15792,6 +15814,7 @@ impl RuleEnum {
                 Self::NodeNoNewRequire(rule) => rule.run(node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run(node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
+                Self::VueComponentDefinitionNameCasing(rule) => rule.run(node, ctx),
                 Self::VueDefineEmitsDeclaration(rule) => rule.run(node, ctx),
                 Self::VueDefinePropsDeclaration(rule) => rule.run(node, ctx),
                 Self::VueDefinePropsDestructuring(rule) => rule.run(node, ctx),
@@ -16621,6 +16644,7 @@ impl RuleEnum {
                 Self::NodeNoNewRequire(rule) => rule.run_once(ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_once(ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
+                Self::VueComponentDefinitionNameCasing(rule) => rule.run_once(ctx),
                 Self::VueDefineEmitsDeclaration(rule) => rule.run_once(ctx),
                 Self::VueDefinePropsDeclaration(rule) => rule.run_once(ctx),
                 Self::VueDefinePropsDestructuring(rule) => rule.run_once(ctx),
@@ -17443,6 +17467,7 @@ impl RuleEnum {
                 Self::NodeNoNewRequire(rule) => rule.run_once(ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_once(ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
+                Self::VueComponentDefinitionNameCasing(rule) => rule.run_once(ctx),
                 Self::VueDefineEmitsDeclaration(rule) => rule.run_once(ctx),
                 Self::VueDefinePropsDeclaration(rule) => rule.run_once(ctx),
                 Self::VueDefinePropsDestructuring(rule) => rule.run_once(ctx),
@@ -18519,6 +18544,9 @@ impl RuleEnum {
                 Self::NodeNoNewRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueComponentDefinitionNameCasing(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::VueDefineEmitsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueDefinePropsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueDefinePropsDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19595,6 +19623,9 @@ impl RuleEnum {
                 Self::NodeNoNewRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueComponentDefinitionNameCasing(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::VueDefineEmitsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueDefinePropsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueDefinePropsDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20423,6 +20454,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(rule) => rule.should_run(ctx),
             Self::NodeNoPathConcat(rule) => rule.should_run(ctx),
             Self::NodeNoProcessEnv(rule) => rule.should_run(ctx),
+            Self::VueComponentDefinitionNameCasing(rule) => rule.should_run(ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.should_run(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.should_run(ctx),
             Self::VueDefinePropsDestructuring(rule) => rule.should_run(ctx),
@@ -21596,6 +21628,9 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::IS_TSGOLINT_RULE,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::IS_TSGOLINT_RULE,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::IS_TSGOLINT_RULE,
+            Self::VueComponentDefinitionNameCasing(_) => {
+                VueComponentDefinitionNameCasing::IS_TSGOLINT_RULE
+            }
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::IS_TSGOLINT_RULE,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::IS_TSGOLINT_RULE,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::IS_TSGOLINT_RULE,
@@ -22593,6 +22628,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::VERSION,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::VERSION,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::VERSION,
+            Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::VERSION,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::VERSION,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::VERSION,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::VERSION,
@@ -23615,6 +23651,9 @@ impl RuleEnum {
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::HAS_CONFIG,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::HAS_CONFIG,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::HAS_CONFIG,
+            Self::VueComponentDefinitionNameCasing(_) => {
+                VueComponentDefinitionNameCasing::HAS_CONFIG
+            }
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::HAS_CONFIG,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::HAS_CONFIG,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::HAS_CONFIG,
@@ -24440,6 +24479,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(rule) => rule.types_info(),
             Self::NodeNoPathConcat(rule) => rule.types_info(),
             Self::NodeNoProcessEnv(rule) => rule.types_info(),
+            Self::VueComponentDefinitionNameCasing(rule) => rule.types_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.types_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.types_info(),
             Self::VueDefinePropsDestructuring(rule) => rule.types_info(),
@@ -25259,6 +25299,7 @@ impl RuleEnum {
             Self::NodeNoNewRequire(rule) => rule.run_info(),
             Self::NodeNoPathConcat(rule) => rule.run_info(),
             Self::NodeNoProcessEnv(rule) => rule.run_info(),
+            Self::VueComponentDefinitionNameCasing(rule) => rule.run_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.run_info(),
             Self::VueDefinePropsDestructuring(rule) => rule.run_info(),
@@ -26208,6 +26249,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::NodeNoNewRequire(NodeNoNewRequire::default()),
         RuleEnum::NodeNoPathConcat(NodeNoPathConcat::default()),
         RuleEnum::NodeNoProcessEnv(NodeNoProcessEnv::default()),
+        RuleEnum::VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing::default()),
         RuleEnum::VueDefineEmitsDeclaration(VueDefineEmitsDeclaration::default()),
         RuleEnum::VueDefinePropsDeclaration(VueDefinePropsDeclaration::default()),
         RuleEnum::VueDefinePropsDestructuring(VueDefinePropsDestructuring::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -842,6 +842,7 @@ pub(crate) mod node {
 
 /// <https://github.com/vuejs/eslint-plugin-vue>
 pub(crate) mod vue {
+    pub mod component_definition_name_casing;
     pub mod define_emits_declaration;
     pub mod define_props_declaration;
     pub mod define_props_destructuring;

--- a/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
@@ -1,4 +1,4 @@
-use cow_utils::CowUtils;
+use convert_case::{Boundary, Case, Converter};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -265,6 +265,16 @@ fn is_regex_word(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_'
 }
 
+fn regex_word_before_upper(graphemes: &[&str]) -> bool {
+    let Some(prev) = graphemes.first().and_then(|s| s.chars().next()) else {
+        return false;
+    };
+    let Some(current) = graphemes.get(1).and_then(|s| s.chars().next()) else {
+        return false;
+    };
+    is_regex_word(prev) && current.is_ascii_uppercase()
+}
+
 /// `camelCase(str)` mirrors upstream:
 /// - if PascalCase: lowercase the first char
 /// - else: replace `[-_](\w)` with `\w` uppercased
@@ -299,23 +309,12 @@ fn pascal_case(s: &str) -> String {
 }
 
 fn kebab_case(s: &str) -> String {
-    let step1: String = s.chars().map(|c| if c == '_' { '-' } else { c }).collect();
-
-    let mut out = String::with_capacity(step1.len());
-    for (i, c) in step1.chars().enumerate() {
-        if c.is_ascii_uppercase() && i > 0 {
-            // `\B` = not at a word boundary. At index 0 we are at a
-            // boundary. For `[A-Z]`, this is true only when the previous
-            // char is also a JavaScript `\w` char.
-            let prev = out.chars().last();
-            let at_boundary = prev.is_none_or(|p| !is_regex_word(p));
-            if !at_boundary {
-                out.push('-');
-            }
-        }
-        out.push(c);
-    }
-    out.cow_to_lowercase().into_owned()
+    let word_before_upper =
+        Boundary::Custom { condition: regex_word_before_upper, start: 1, len: 0 };
+    Converter::new()
+        .set_boundaries(&[Boundary::Underscore, word_before_upper])
+        .to_case(Case::Kebab)
+        .convert(s)
 }
 
 /// Mirror of `getExactConverter(name)(str)`. Returns `None` when the

--- a/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use cow_utils::CowUtils;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -16,7 +14,7 @@ use crate::{
     AstNode,
     context::LintContext,
     frameworks::FrameworkOptions,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{find_property, is_vue_component_options_object},
 };
 
@@ -46,21 +44,8 @@ impl CaseType {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct ComponentDefinitionNameCasing(Box<Config>);
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
-pub struct Config {
-    case_type: CaseType,
-}
-
-impl Deref for ComponentDefinitionNameCasing {
-    type Target = Config;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct ComponentDefinitionNameCasing(CaseType);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -97,22 +82,13 @@ declare_oxc_lint!(
     vue,
     style,
     fix,
-    config = ComponentDefinitionNameCasing,
+    config = CaseType,
     version = "next",
 );
 
 impl Rule for ComponentDefinitionNameCasing {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
-        let case_type = value
-            .get(0)
-            .and_then(|v| v.as_str())
-            .and_then(|s| match s {
-                "PascalCase" => Some(CaseType::PascalCase),
-                "kebab-case" => Some(CaseType::KebabCase),
-                _ => None,
-            })
-            .unwrap_or_default();
-        Ok(Self(Box::new(Config { case_type })))
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -175,7 +151,7 @@ impl ComponentDefinitionNameCasing {
         let inner = expr.get_inner_expression();
         let Some((value, inner_span)) = extract_convertible(inner) else { return };
 
-        let case_type = self.case_type;
+        let case_type = self.0;
         if check_case(&value, case_type) {
             return;
         }

--- a/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
@@ -1,6 +1,9 @@
 use std::ops::Deref;
 
 use cow_utils::CowUtils;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_ast::{
     AstKind,
     ast::{CallExpression, Expression, ObjectExpression},
@@ -8,12 +11,11 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
     context::LintContext,
+    frameworks::FrameworkOptions,
     rule::Rule,
     utils::{find_property, is_vue_component_options_object},
 };
@@ -131,6 +133,7 @@ impl ComponentDefinitionNameCasing {
         // `defineOptions({ name: '...' })`
         if let Some(ident) = call.callee.get_identifier_reference()
             && ident.name == "defineOptions"
+            && ctx.frameworks_options() == FrameworkOptions::VueSetup
             && let Some(arg) = call.arguments.first()
             && let Some(Expression::ObjectExpression(obj)) = arg.as_expression()
         {
@@ -287,6 +290,10 @@ fn capitalize(s: &str) -> String {
     }
 }
 
+fn is_regex_word(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
 /// `camelCase(str)` mirrors upstream:
 /// - if PascalCase: lowercase the first char
 /// - else: replace `[-_](\w)` with `\w` uppercased
@@ -300,18 +307,15 @@ fn camel_case(s: &str) -> String {
     }
 
     let mut out = String::with_capacity(s.len());
-    let mut to_upper = false;
-    for c in s.chars() {
-        if matches!(c, '-' | '_') {
-            to_upper = true;
-            continue;
-        }
-        if to_upper {
-            // Upstream uses `\w` which matches [A-Za-z0-9_]. After
-            // `[-_]`, `_` is not possible here (already consumed), so
-            // uppercasing letters/digits is sufficient.
-            out.extend(c.to_uppercase());
-            to_upper = false;
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if matches!(c, '-' | '_')
+            && let Some(next) = chars.peek()
+            && is_regex_word(*next)
+        {
+            if let Some(next) = chars.next() {
+                out.extend(next.to_uppercase());
+            }
         } else {
             out.push(c);
         }
@@ -330,14 +334,10 @@ fn kebab_case(s: &str) -> String {
     for (i, c) in step1.chars().enumerate() {
         if c.is_ascii_uppercase() && i > 0 {
             // `\B` = not at a word boundary. At index 0 we are at a
-            // boundary, otherwise we need to check whether the previous
-            // char is a word char. Since this rule's inputs are component
-            // names (letters / digits / `-` / `_` / `$`), in practice
-            // previous chars after the leading position behave like the
-            // upstream regex.
+            // boundary. For `[A-Z]`, this is true only when the previous
+            // char is also a JavaScript `\w` char.
             let prev = out.chars().last();
-            let at_boundary =
-                prev.is_none_or(|p| !p.is_ascii_alphanumeric() && p != '_' && p != '$');
+            let at_boundary = prev.is_none_or(|p| !is_regex_word(p));
             if !at_boundary {
                 out.push('-');
             }
@@ -480,6 +480,9 @@ fn test() {
         // https://github.com/vuejs/eslint-plugin-vue/issues/1018
         ("fn1(component.data)", None, None, js()),
         ("<script setup> defineOptions({}) </script>", None, None, vue()),
+        ("<script> defineOptions({name: 'foo-bar'}) </script>", None, None, vue()),
+        ("defineOptions({name: 'foo-bar'})", None, None, js()),
+        ("<template>{{ Vue.component('foo-bar', {}) }}</template>", None, None, vue()),
         (
             "<script setup> defineOptions({name: 'FooBar'}) </script>",
             Some(serde_json::json!(["PascalCase"])),
@@ -584,6 +587,13 @@ fn test() {
         ),
         (
             "<script>Vue.component(`foo_bar`, {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        ("<script>Vue.component('foo-é', {})</script>", None, None, vue()),
+        (
+            "<script>Vue.component('$Foo', {})</script>",
             Some(serde_json::json!(["kebab-case"])),
             None,
             vue(),
@@ -704,6 +714,12 @@ fn test() {
         (
             "<script>Vue.component(`foo_bar`, {})</script>",
             "<script>Vue.component(`foo-bar`, {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            vue(),
+        ),
+        (
+            "<script>Vue.component('$Foo', {})</script>",
+            "<script>Vue.component('$foo', {})</script>",
             Some(serde_json::json!(["kebab-case"])),
             vue(),
         ),

--- a/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
@@ -9,7 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -26,7 +26,7 @@ fn component_definition_name_casing_diagnostic(
     OxcDiagnostic::warn(format!("Property name \"{value}\" is not {case_type}.")).with_label(span)
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 enum CaseType {
     #[default]
     #[serde(rename = "PascalCase")]
@@ -44,10 +44,11 @@ impl CaseType {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ComponentDefinitionNameCasing(Box<Config>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Config {
     case_type: CaseType,
 }
@@ -94,6 +95,7 @@ declare_oxc_lint!(
     vue,
     style,
     fix,
+    config = ComponentDefinitionNameCasing,
     version = "next",
 );
 

--- a/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
@@ -119,19 +119,14 @@ impl ComponentDefinitionNameCasing {
 
         // `Vue.component('Name', ...)` / `app.component('Name', ...)` /
         // `(Vue as VueConstructor<Vue>).component('Name', ...)`
-        let Some(member_expr) = call.callee.get_inner_expression().as_member_expression() else {
-            return;
-        };
-        let Some(prop_name) = member_expr.static_property_name() else {
-            return;
-        };
-        if prop_name != "component" || call.arguments.len() != 2 {
-            return;
+        if let Some(member_expr) = call.callee.get_inner_expression().as_member_expression()
+            && member_expr.static_property_name().is_some_and(|prop_name| prop_name == "component")
+            && call.arguments.len() == 2
+            && let Some(first_arg) = call.arguments.first()
+            && let Some(first_expr) = first_arg.as_expression()
+        {
+            self.check_name_node(first_expr, ctx);
         }
-
-        let Some(first_arg) = call.arguments.first() else { return };
-        let Some(first_expr) = first_arg.as_expression() else { return };
-        self.check_name_node(first_expr, ctx);
     }
 
     fn check_options_object<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
@@ -1,0 +1,730 @@
+use std::ops::Deref;
+
+use cow_utils::CowUtils;
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression, ObjectExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{find_property, is_vue_component_options_object},
+};
+
+fn component_definition_name_casing_diagnostic(
+    span: Span,
+    value: &str,
+    case_type: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Property name \"{value}\" is not {case_type}.")).with_label(span)
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, JsonSchema)]
+enum CaseType {
+    #[default]
+    #[serde(rename = "PascalCase")]
+    PascalCase,
+    #[serde(rename = "kebab-case")]
+    KebabCase,
+}
+
+impl CaseType {
+    fn as_str(self) -> &'static str {
+        match self {
+            CaseType::PascalCase => "PascalCase",
+            CaseType::KebabCase => "kebab-case",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ComponentDefinitionNameCasing(Box<Config>);
+
+#[derive(Debug, Default, Clone)]
+pub struct Config {
+    case_type: CaseType,
+}
+
+impl Deref for ComponentDefinitionNameCasing {
+    type Target = Config;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce specific casing for component definition names.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Defining component names without a consistent casing makes templates
+    /// harder to read and harder to grep. Picking either `PascalCase` or
+    /// `kebab-case` and sticking with it across the codebase removes a class
+    /// of bikeshedding and search misses.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule (default `PascalCase`):
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   name: 'foo-bar'
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule (default `PascalCase`):
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   name: 'FooBar'
+    /// }
+    /// </script>
+    /// ```
+    ComponentDefinitionNameCasing,
+    vue,
+    style,
+    fix,
+    version = "next",
+);
+
+impl Rule for ComponentDefinitionNameCasing {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        let case_type = value
+            .get(0)
+            .and_then(|v| v.as_str())
+            .and_then(|s| match s {
+                "PascalCase" => Some(CaseType::PascalCase),
+                "kebab-case" => Some(CaseType::KebabCase),
+                _ => None,
+            })
+            .unwrap_or_default();
+        Ok(Self(Box::new(Config { case_type })))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::CallExpression(call) => {
+                self.check_call_expression(call, ctx);
+            }
+            AstKind::ObjectExpression(_) => {
+                self.check_options_object(node, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl ComponentDefinitionNameCasing {
+    fn check_call_expression<'a>(&self, call: &CallExpression<'a>, ctx: &LintContext<'a>) {
+        // `defineOptions({ name: '...' })`
+        if let Some(ident) = call.callee.get_identifier_reference()
+            && ident.name == "defineOptions"
+            && let Some(arg) = call.arguments.first()
+            && let Some(Expression::ObjectExpression(obj)) = arg.as_expression()
+        {
+            self.check_name_property(obj, ctx);
+            return;
+        }
+
+        // `Vue.component('Name', ...)` / `app.component('Name', ...)` /
+        // `(Vue as VueConstructor<Vue>).component('Name', ...)`
+        let Some(member_expr) = call.callee.get_inner_expression().as_member_expression() else {
+            return;
+        };
+        let Some(prop_name) = member_expr.static_property_name() else {
+            return;
+        };
+        if prop_name != "component" || call.arguments.len() != 2 {
+            return;
+        }
+
+        let Some(first_arg) = call.arguments.first() else { return };
+        let Some(first_expr) = first_arg.as_expression() else { return };
+        self.check_name_node(first_expr, ctx);
+    }
+
+    fn check_options_object<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ObjectExpression(obj) = node.kind() else { return };
+        if !is_vue_component_options_object(node, ctx) {
+            return;
+        }
+        self.check_name_property(obj, ctx);
+    }
+
+    fn check_name_property<'a>(&self, obj: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+        let Some(prop) = find_property(obj, "name") else { return };
+        self.check_name_node(&prop.value, ctx);
+    }
+
+    fn check_name_node(&self, expr: &Expression<'_>, ctx: &LintContext<'_>) {
+        let inner = expr.get_inner_expression();
+        let Some((value, inner_span)) = extract_convertible(inner) else { return };
+
+        let case_type = self.case_type;
+        if check_case(&value, case_type) {
+            return;
+        }
+
+        let report_span = inner.span();
+        let case_type_str = case_type.as_str();
+        let diagnostic =
+            component_definition_name_casing_diagnostic(report_span, value.as_str(), case_type_str);
+
+        if let Some(converted) = exact_convert(&value, case_type) {
+            ctx.diagnostic_with_fix(diagnostic, |fixer| fixer.replace(inner_span, converted));
+        } else {
+            ctx.diagnostic(diagnostic);
+        }
+    }
+}
+
+/// Returns `(value, inner_span)` if `expr` is a string literal or a
+/// simple template literal (no expressions, single quasi). `inner_span`
+/// is the range of the literal *contents* (excluding the quotes / backticks),
+/// suitable as a fix target.
+fn extract_convertible(expr: &Expression<'_>) -> Option<(String, Span)> {
+    match expr {
+        Expression::StringLiteral(lit) => {
+            let inner = Span::new(lit.span.start + 1, lit.span.end - 1);
+            Some((lit.value.to_string(), inner))
+        }
+        Expression::TemplateLiteral(tpl) => {
+            if !tpl.expressions.is_empty() || tpl.quasis.len() != 1 {
+                return None;
+            }
+            let quasi = tpl.quasis.first()?;
+            let cooked = quasi.value.cooked.as_ref()?;
+            let inner = Span::new(tpl.span.start + 1, tpl.span.end - 1);
+            Some((cooked.to_string(), inner))
+        }
+        _ => None,
+    }
+}
+
+// Mirror of upstream `eslint-plugin-vue` lib/utils/casing.js to guarantee
+// identical detection / conversion semantics.
+
+fn has_symbols(s: &str) -> bool {
+    // [!"#%&'()*+,./:;<=>?@[\]^`{|}] — without " ", "$", "-" and "_"
+    s.chars().any(|c| {
+        matches!(
+            c,
+            '!' | '"'
+                | '#'
+                | '%'
+                | '&'
+                | '\''
+                | '('
+                | ')'
+                | '*'
+                | '+'
+                | ','
+                | '.'
+                | '/'
+                | ':'
+                | ';'
+                | '<'
+                | '='
+                | '>'
+                | '?'
+                | '@'
+                | '['
+                | '\\'
+                | ']'
+                | '^'
+                | '`'
+                | '{'
+                | '|'
+                | '}'
+        )
+    })
+}
+
+fn has_upper(s: &str) -> bool {
+    s.chars().any(|c| c.is_ascii_uppercase())
+}
+
+fn is_pascal_case(s: &str) -> bool {
+    !has_symbols(s)
+        && !s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+        && !s.chars().any(|c| matches!(c, '-' | '_') || c.is_whitespace())
+}
+
+fn is_kebab_case(s: &str) -> bool {
+    if has_upper(s) || has_symbols(s) || s.starts_with('-') {
+        return false;
+    }
+    if s.contains('_') || s.contains("--") || s.chars().any(char::is_whitespace) {
+        return false;
+    }
+    true
+}
+
+fn check_case(s: &str, case_type: CaseType) -> bool {
+    match case_type {
+        CaseType::PascalCase => is_pascal_case(s),
+        CaseType::KebabCase => is_kebab_case(s),
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// `camelCase(str)` mirrors upstream:
+/// - if PascalCase: lowercase the first char
+/// - else: replace `[-_](\w)` with `\w` uppercased
+fn camel_case(s: &str) -> String {
+    if is_pascal_case(s) {
+        let mut chars = s.chars();
+        return match chars.next() {
+            Some(c) => c.to_lowercase().collect::<String>() + chars.as_str(),
+            None => String::new(),
+        };
+    }
+
+    let mut out = String::with_capacity(s.len());
+    let mut to_upper = false;
+    for c in s.chars() {
+        if matches!(c, '-' | '_') {
+            to_upper = true;
+            continue;
+        }
+        if to_upper {
+            // Upstream uses `\w` which matches [A-Za-z0-9_]. After
+            // `[-_]`, `_` is not possible here (already consumed), so
+            // uppercasing letters/digits is sufficient.
+            out.extend(c.to_uppercase());
+            to_upper = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn pascal_case(s: &str) -> String {
+    capitalize(&camel_case(s))
+}
+
+fn kebab_case(s: &str) -> String {
+    let step1: String = s.chars().map(|c| if c == '_' { '-' } else { c }).collect();
+
+    let mut out = String::with_capacity(step1.len());
+    for (i, c) in step1.chars().enumerate() {
+        if c.is_ascii_uppercase() && i > 0 {
+            // `\B` = not at a word boundary. At index 0 we are at a
+            // boundary, otherwise we need to check whether the previous
+            // char is a word char. Since this rule's inputs are component
+            // names (letters / digits / `-` / `_` / `$`), in practice
+            // previous chars after the leading position behave like the
+            // upstream regex.
+            let prev = out.chars().last();
+            let at_boundary =
+                prev.is_none_or(|p| !p.is_ascii_alphanumeric() && p != '_' && p != '$');
+            if !at_boundary {
+                out.push('-');
+            }
+        }
+        out.push(c);
+    }
+    out.cow_to_lowercase().into_owned()
+}
+
+/// Mirror of `getExactConverter(name)(str)`. Returns `None` when the
+/// converted value still does not satisfy the checker — upstream returns
+/// the original value in that case, which ESLint then treats as "no
+/// effective fix". On our side we surface that as "no fix available" so
+/// that the diagnostic is emitted without an autofix.
+fn exact_convert(s: &str, case_type: CaseType) -> Option<String> {
+    let converted = match case_type {
+        CaseType::PascalCase => pascal_case(s),
+        CaseType::KebabCase => kebab_case(s),
+    };
+    if check_case(&converted, case_type) { Some(converted) } else { None }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let vue = || Some(PathBuf::from("test.vue"));
+    let js = || Some(PathBuf::from("test.js"));
+
+    let pass = vec![
+        (
+            "<script>
+                    export default {
+                    }
+                    </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      ...name
+                    }
+                    </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'FooBar'
+                    }
+                    </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'FooBar'
+                    }
+                    </script>",
+            Some(serde_json::json!(["PascalCase"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo-bar'
+                    }
+                    </script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        ("<script>Vue.component('FooBar', {})</script>", None, None, vue()),
+        (
+            "<script>Vue.component('FooBar', {})</script>",
+            Some(serde_json::json!(["PascalCase"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>Vue.component('foo-bar', {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>Vue.component(fooBar, {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        ("<script>Vue.component('FooBar', component)</script>", None, None, vue()),
+        (
+            "<script>Vue.component('FooBar', component)</script>",
+            Some(serde_json::json!(["PascalCase"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>Vue.component('foo-bar', component)</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>Vue.component(fooBar, component)</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>app.component('FooBar', component)</script>",
+            Some(serde_json::json!(["PascalCase"])),
+            None,
+            vue(),
+        ),
+        ("<script>Vue.mixin({})</script>", None, None, vue()),
+        ("<script>foo({})</script>", None, None, vue()),
+        ("<script>foo('foo-bar', {})</script>", None, None, vue()),
+        (
+            "<script>Vue.component(`fooBar${foo}`, component)</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>app.component(`fooBar${foo}`, component)</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        // https://github.com/vuejs/eslint-plugin-vue/issues/1018
+        ("fn1(component.data)", None, None, js()),
+        ("<script setup> defineOptions({}) </script>", None, None, vue()),
+        (
+            "<script setup> defineOptions({name: 'FooBar'}) </script>",
+            Some(serde_json::json!(["PascalCase"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script setup> defineOptions({name: 'foo-bar'}) </script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "<script>
+                    export default {
+                      name: 'foo-bar'
+                    }
+                    </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo  bar'
+                    }
+                    </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo!bar'
+                    }
+                    </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "
+                    new Vue({
+                      name: 'foo!bar'
+                    })
+                  ",
+            None,
+            None,
+            js(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo_bar'
+                    }
+                    </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo_bar'
+                    }
+                    </script>",
+            Some(serde_json::json!(["PascalCase"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo_bar'
+                    }
+                    </script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        ("<script>Vue.component('foo-bar', component)</script>", None, None, vue()),
+        ("<script>app.component('foo-bar', component)</script>", None, None, vue()),
+        (
+            "<script lang=\"ts\">(Vue as VueConstructor<Vue>).component('foo-bar', component)</script>",
+            None,
+            None,
+            vue(),
+        ),
+        ("<script>Vue.component('foo-bar', {})</script>", None, None, vue()),
+        ("<script>app.component('foo-bar', {})</script>", None, None, vue()),
+        ("Vue.component('foo_bar', {})", Some(serde_json::json!(["PascalCase"])), None, js()),
+        (
+            "<script>Vue.component('foo_bar', {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script>Vue.component(`foo_bar`, {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script setup> defineOptions({name: 'foo-bar'}) </script>",
+            Some(serde_json::json!(["PascalCase"])),
+            None,
+            vue(),
+        ),
+        (
+            "<script setup> defineOptions({name: 'FooBar'}) </script>",
+            Some(serde_json::json!(["kebab-case"])),
+            None,
+            vue(),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "<script>
+                    export default {
+                      name: 'foo-bar'
+                    }
+                    </script>",
+            "<script>
+                    export default {
+                      name: 'FooBar'
+                    }
+                    </script>",
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo_bar'
+                    }
+                    </script>",
+            "<script>
+                    export default {
+                      name: 'FooBar'
+                    }
+                    </script>",
+            None,
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo_bar'
+                    }
+                    </script>",
+            "<script>
+                    export default {
+                      name: 'FooBar'
+                    }
+                    </script>",
+            Some(serde_json::json!(["PascalCase"])),
+            vue(),
+        ),
+        (
+            "<script>
+                    export default {
+                      name: 'foo_bar'
+                    }
+                    </script>",
+            "<script>
+                    export default {
+                      name: 'foo-bar'
+                    }
+                    </script>",
+            Some(serde_json::json!(["kebab-case"])),
+            vue(),
+        ),
+        (
+            "<script>Vue.component('foo-bar', component)</script>",
+            "<script>Vue.component('FooBar', component)</script>",
+            None,
+            vue(),
+        ),
+        (
+            "<script>app.component('foo-bar', component)</script>",
+            "<script>app.component('FooBar', component)</script>",
+            None,
+            vue(),
+        ),
+        (
+            "<script lang=\"ts\">(Vue as VueConstructor<Vue>).component('foo-bar', component)</script>",
+            "<script lang=\"ts\">(Vue as VueConstructor<Vue>).component('FooBar', component)</script>",
+            None,
+            vue(),
+        ),
+        (
+            "<script>Vue.component('foo-bar', {})</script>",
+            "<script>Vue.component('FooBar', {})</script>",
+            None,
+            vue(),
+        ),
+        (
+            "<script>app.component('foo-bar', {})</script>",
+            "<script>app.component('FooBar', {})</script>",
+            None,
+            vue(),
+        ),
+        (
+            "<script>Vue.component('foo_bar', {})</script>",
+            "<script>Vue.component('FooBar', {})</script>",
+            Some(serde_json::json!(["PascalCase"])),
+            vue(),
+        ),
+        (
+            "<script>Vue.component('foo_bar', {})</script>",
+            "<script>Vue.component('foo-bar', {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            vue(),
+        ),
+        (
+            "<script>Vue.component(`foo_bar`, {})</script>",
+            "<script>Vue.component(`foo-bar`, {})</script>",
+            Some(serde_json::json!(["kebab-case"])),
+            vue(),
+        ),
+        (
+            "<script setup> defineOptions({name: 'foo-bar'}) </script>",
+            "<script setup> defineOptions({name: 'FooBar'}) </script>",
+            Some(serde_json::json!(["PascalCase"])),
+            vue(),
+        ),
+        (
+            "<script setup> defineOptions({name: 'FooBar'}) </script>",
+            "<script setup> defineOptions({name: 'foo-bar'}) </script>",
+            Some(serde_json::json!(["kebab-case"])),
+            vue(),
+        ),
+    ];
+
+    Tester::new(
+        ComponentDefinitionNameCasing::NAME,
+        ComponentDefinitionNameCasing::PLUGIN,
+        pass,
+        fail,
+    )
+    .expect_fix(fix)
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vue_component_definition_name_casing.snap
+++ b/crates/oxc_linter/src/snapshots/vue_component_definition_name_casing.snap
@@ -1,0 +1,134 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:3:29]
+ 2 │                     export default {
+ 3 │                       name: 'foo-bar'
+   ·                             ─────────
+ 4 │                     }
+   ╰────
+  help: Replace `foo-bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo  bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:3:29]
+ 2 │                     export default {
+ 3 │                       name: 'foo  bar'
+   ·                             ──────────
+ 4 │                     }
+   ╰────
+
+  ⚠ vue(component-definition-name-casing): Property name "foo!bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:3:29]
+ 2 │                     export default {
+ 3 │                       name: 'foo!bar'
+   ·                             ─────────
+ 4 │                     }
+   ╰────
+
+  ⚠ vue(component-definition-name-casing): Property name "foo!bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:3:29]
+ 2 │                     new Vue({
+ 3 │                       name: 'foo!bar'
+   ·                             ─────────
+ 4 │                     })
+   ╰────
+
+  ⚠ vue(component-definition-name-casing): Property name "foo_bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:3:29]
+ 2 │                     export default {
+ 3 │                       name: 'foo_bar'
+   ·                             ─────────
+ 4 │                     }
+   ╰────
+  help: Replace `foo_bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo_bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:3:29]
+ 2 │                     export default {
+ 3 │                       name: 'foo_bar'
+   ·                             ─────────
+ 4 │                     }
+   ╰────
+  help: Replace `foo_bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo_bar" is not kebab-case.
+   ╭─[component_definition_name_casing.tsx:3:29]
+ 2 │                     export default {
+ 3 │                       name: 'foo_bar'
+   ·                             ─────────
+ 4 │                     }
+   ╰────
+  help: Replace `foo_bar` with `foo-bar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>Vue.component('foo-bar', component)</script>
+   ·                       ─────────
+   ╰────
+  help: Replace `foo-bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>app.component('foo-bar', component)</script>
+   ·                       ─────────
+   ╰────
+  help: Replace `foo-bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:58]
+ 1 │ <script lang="ts">(Vue as VueConstructor<Vue>).component('foo-bar', component)</script>
+   ·                                                          ─────────
+   ╰────
+  help: Replace `foo-bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>Vue.component('foo-bar', {})</script>
+   ·                       ─────────
+   ╰────
+  help: Replace `foo-bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>app.component('foo-bar', {})</script>
+   ·                       ─────────
+   ╰────
+  help: Replace `foo-bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo_bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:15]
+ 1 │ Vue.component('foo_bar', {})
+   ·               ─────────
+   ╰────
+  help: Replace `foo_bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo_bar" is not kebab-case.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>Vue.component('foo_bar', {})</script>
+   ·                       ─────────
+   ╰────
+  help: Replace `foo_bar` with `foo-bar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo_bar" is not kebab-case.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>Vue.component(`foo_bar`, {})</script>
+   ·                       ─────────
+   ╰────
+  help: Replace `foo_bar` with `foo-bar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:37]
+ 1 │ <script setup> defineOptions({name: 'foo-bar'}) </script>
+   ·                                     ─────────
+   ╰────
+  help: Replace `foo-bar` with `FooBar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "FooBar" is not kebab-case.
+   ╭─[component_definition_name_casing.tsx:1:37]
+ 1 │ <script setup> defineOptions({name: 'FooBar'}) </script>
+   ·                                     ────────
+   ╰────
+  help: Replace `FooBar` with `foo-bar`.

--- a/crates/oxc_linter/src/snapshots/vue_component_definition_name_casing.snap
+++ b/crates/oxc_linter/src/snapshots/vue_component_definition_name_casing.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 490
 ---
 
   ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
@@ -118,6 +117,19 @@ assertion_line: 490
    ·                       ─────────
    ╰────
   help: Replace `foo_bar` with `foo-bar`.
+
+  ⚠ vue(component-definition-name-casing): Property name "foo-é" is not PascalCase.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>Vue.component('foo-é', {})</script>
+   ·                       ───────
+   ╰────
+
+  ⚠ vue(component-definition-name-casing): Property name "$Foo" is not kebab-case.
+   ╭─[component_definition_name_casing.tsx:1:23]
+ 1 │ <script>Vue.component('$Foo', {})</script>
+   ·                       ──────
+   ╰────
+  help: Replace `$Foo` with `$foo`.
 
   ⚠ vue(component-definition-name-casing): Property name "foo-bar" is not PascalCase.
    ╭─[component_definition_name_casing.tsx:1:37]

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2584,6 +2584,9 @@
         "vitest/warn-todo": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/component-definition-name-casing": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/define-emits-declaration": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2588,6 +2588,9 @@ expression: json
         "vitest/warn-todo": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/component-definition-name-casing": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/define-emits-declaration": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related https://github.com/oxc-project/oxc/issues/11440

upstream: https://eslint.vuejs.org/rules/component-definition-name-casing.html

AI disclosure: implemented with Claude Code, reviewed manually.