### PR TITLE
feat(linter/jsx-a11y): add `allowedRedundantRoles` option to `no-redundant-roles`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -901,7 +901,7 @@ export interface DummyRuleMap {
   "jsx-a11y/no-noninteractive-element-interactions"?: DummyRule;
   "jsx-a11y/no-noninteractive-element-to-interactive-role"?: DummyRule;
   "jsx-a11y/no-noninteractive-tabindex"?: DummyRule;
-  "jsx-a11y/no-redundant-roles"?: RuleNoConfig;
+  "jsx-a11y/no-redundant-roles"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRedundantRolesConfig];
   "jsx-a11y/no-static-element-interactions"?:
     | AllowWarnDeny
     | [AllowWarnDeny]
@@ -2408,6 +2408,9 @@ export interface NoAutofocus {
    * Determines if developer-created components are checked.
    */
   ignoreNonDOM?: boolean;
+}
+export interface NoRedundantRolesConfig {
+  [k: string]: string[];
 }
 export interface NoStaticElementInteractionsConfig {
   /**

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -1,3 +1,7 @@
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{JSXAttributeItem, JSXAttributeValue},
@@ -5,11 +9,12 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use oxc_str::CompactStr;
 
 use crate::{
     AstNode,
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{get_element_implicit_roles, get_element_type, has_jsx_prop_ignore_case},
 };
 
@@ -21,8 +26,22 @@ fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDi
     .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct NoRedundantRoles;
+/// Redundant roles that are allowed by default unless overridden by the
+/// `allowedRedundantRoles` option, mirroring eslint-plugin-jsx-a11y's
+/// `DEFAULT_ROLE_EXCEPTIONS`.
+const DEFAULT_ROLE_EXCEPTIONS: &[(&str, &str)] = &[("nav", "navigation")];
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct NoRedundantRoles(Box<NoRedundantRolesConfig>);
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct NoRedundantRolesConfig {
+    /// A mapping of element names to the redundant roles that are explicitly
+    /// allowed on them. Providing an entry overrides the default exceptions for
+    /// that element.
+    #[serde(default, flatten)]
+    pub allowed_redundant_roles: FxHashMap<CompactStr, Vec<CompactStr>>,
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -39,31 +58,49 @@ declare_oxc_lint!(
     ///
     /// This rule applies for the following elements and their implicit roles:
     ///
-    /// - `<nav>`: `navigation`
     /// - `<button>`: `button`
     /// - `<main>`: `main`
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
-    /// <nav role="navigation"></nav>
     /// <button role="button"></button>
     /// <main role="main"></main>
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
-    /// <nav></nav>
     /// <button></button>
     /// <main></main>
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// This rule takes an object whose keys are element names and whose values
+    /// are arrays of redundant roles to allow on that element. Providing an
+    /// entry overrides the default exceptions for that element.
+    ///
+    /// By default `role="navigation"` is allowed on `<nav>`. Additional roles
+    /// can be allowed, for example to keep explicit list semantics that some
+    /// browsers drop when `list-style: none` is applied:
+    ///
+    /// ```json
+    /// {
+    ///   "jsx-a11y/no-redundant-roles": ["error", { "ul": ["list"], "ol": ["list"], "li": ["listitem"] }]
+    /// }
     /// ```
     NoRedundantRoles,
     jsx_a11y,
     correctness,
     fix,
+    config = NoRedundantRolesConfig,
     version = "0.2.1",
 );
 
 impl Rule for NoRedundantRoles {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
@@ -77,13 +114,27 @@ impl Rule for NoRedundantRoles {
         {
             let roles = role_values.value.split_whitespace().collect::<Vec<_>>();
             for role in &roles {
-                if implicit_roles.contains(role) {
+                if implicit_roles.contains(role)
+                    && !self.is_allowed_redundant_role(&component, role)
+                {
                     ctx.diagnostic_with_fix(
                         no_redundant_roles_diagnostic(attr.span, &component, role),
                         |fixer| fixer.delete_range(attr.span),
                     );
                 }
             }
+        }
+    }
+}
+
+impl NoRedundantRoles {
+    /// A redundant `role` is allowed when the element has an explicit entry in
+    /// the `allowedRedundantRoles` option, or otherwise falls back to the
+    /// default exceptions.
+    fn is_allowed_redundant_role(&self, element: &str, role: &str) -> bool {
+        match self.0.allowed_redundant_roles.get(element) {
+            Some(roles) => roles.iter().any(|r| r == role),
+            None => DEFAULT_ROLE_EXCEPTIONS.iter().any(|&(el, r)| el == element && r == role),
         }
     }
 }
@@ -115,6 +166,12 @@ fn test() {
         ("<button role={`${foo}button`} />", None, None),
         ("<Button role={`${foo}button`} />", None, Some(settings())),
         (r#"<select role="menu"><option>1</option><option>2</option></select>"#, None, None),
+        // `nav` / `navigation` is allowed by default.
+        (r#"<nav role="navigation" />"#, None, None),
+        // Explicitly allowed redundant roles via the option.
+        (r#"<ul role="list" />"#, Some(serde_json::json!([{ "ul": ["list"] }])), None),
+        (r#"<ol role="list" />"#, Some(serde_json::json!([{ "ol": ["list"] }])), None),
+        (r#"<li role="listitem" />"#, Some(serde_json::json!([{ "li": ["listitem"] }])), None),
     ];
 
     let fail = vec![
@@ -126,7 +183,6 @@ fn test() {
         ("<button role='button'>Foo</button>", None, None),
         ("<button role='button'><p>Test</p></button>", None, None),
         ("<button role='button' title='button'></button>", None, None),
-        ("<nav role='navigation' />", None, None),
         ("<Button role='button' />", None, Some(settings())),
         (r#"<article role="article" />"#, None, None),
         (r#"<aside role="complementary" />"#, None, None),
@@ -156,6 +212,10 @@ fn test() {
         (r#"<p role="paragraph" />"#, None, None),
         (r#"<progress role="progressbar" />"#, None, None),
         (r#"<tr role="row" />"#, None, None),
+        // An option for a different element does not suppress this one.
+        (r#"<ul role="list" />"#, Some(serde_json::json!([{ "li": ["listitem"] }])), None),
+        // A user-provided option overrides the default exception for that element.
+        (r#"<nav role="navigation" />"#, Some(serde_json::json!([{ "nav": [] }])), None),
     ];
 
     let fix = vec![
@@ -171,7 +231,6 @@ fn test() {
               Foo
              </button>",
         ),
-        ("<nav role='navigation' />", "<nav  />"),
         ("<main role='main' />", "<main  />"),
         (
             "<main role='main'><p>Foobarbaz!!  main role</p></main>",

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -161,7 +161,7 @@ fn get_redundant_implicit_role(
 fn get_img_implicit_role(jsx_el: &JSXOpeningElement) -> Option<&'static str> {
     if has_jsx_prop_ignore_case(jsx_el, "alt")
         .and_then(get_string_literal_prop_value)
-        .is_some_and(|alt| alt.is_empty())
+        .is_some_and(str::is_empty)
     {
         return None;
     }
@@ -214,8 +214,6 @@ fn jsx_prop_value_is_truthy(item: &JSXAttributeItem) -> bool {
                 Expression::BooleanLiteral(lit) => lit.value,
                 Expression::StringLiteral(lit) => !lit.value.is_empty(),
                 Expression::NumericLiteral(lit) => lit.value != 0.0,
-                Expression::NullLiteral(_) => false,
-                Expression::Identifier(_) => false,
                 _ => false,
             }
         }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use oxc_ast::{
     AstKind,
-    ast::{JSXAttributeItem, JSXAttributeValue},
+    ast::{Expression, JSXAttributeItem, JSXAttributeValue, JSXOpeningElement},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -15,7 +15,10 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{get_element_implicit_roles, get_element_type, has_jsx_prop_ignore_case},
+    utils::{
+        get_element_implicit_roles, get_element_type, get_prop_value,
+        get_string_literal_prop_value, has_jsx_prop_ignore_case, parse_jsx_value,
+    },
 };
 
 fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDiagnostic {
@@ -107,18 +110,15 @@ impl Rule for NoRedundantRoles {
         };
 
         let component = get_element_type(ctx, jsx_el);
-        let implicit_roles = get_element_implicit_roles(&component);
-
         if let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_ignore_case(jsx_el, "role")
             && let Some(JSXAttributeValue::StringLiteral(role_values)) = &attr.value
         {
-            let roles = role_values.value.split_whitespace().collect::<Vec<_>>();
-            for role in &roles {
-                if implicit_roles.contains(role)
-                    && !self.is_allowed_redundant_role(&component, role)
+            for role in role_values.value.split_whitespace() {
+                if let Some(implicit_role) = get_redundant_implicit_role(&component, jsx_el, role)
+                    && !self.is_allowed_redundant_role(&component, implicit_role)
                 {
                     ctx.diagnostic_with_fix(
-                        no_redundant_roles_diagnostic(attr.span, &component, role),
+                        no_redundant_roles_diagnostic(attr.span, &component, implicit_role),
                         |fixer| fixer.delete_range(attr.span),
                     );
                 }
@@ -136,6 +136,90 @@ impl NoRedundantRoles {
             Some(roles) => roles.iter().any(|r| r == role),
             None => DEFAULT_ROLE_EXCEPTIONS.iter().any(|&(el, r)| el == element && r == role),
         }
+    }
+}
+
+fn get_redundant_implicit_role(
+    element: &str,
+    jsx_el: &JSXOpeningElement,
+    explicit_role: &str,
+) -> Option<&'static str> {
+    match element {
+        "body" => explicit_role.eq_ignore_ascii_case("document").then_some("document"),
+        "img" => get_img_implicit_role(jsx_el)
+            .filter(|implicit_role| explicit_role.eq_ignore_ascii_case(implicit_role)),
+        "select" => {
+            let implicit_role = get_select_implicit_role(jsx_el);
+            explicit_role.eq_ignore_ascii_case(implicit_role).then_some(implicit_role)
+        }
+        _ => get_element_implicit_roles(element)
+            .into_iter()
+            .find(|implicit_role| explicit_role.eq_ignore_ascii_case(implicit_role)),
+    }
+}
+
+fn get_img_implicit_role(jsx_el: &JSXOpeningElement) -> Option<&'static str> {
+    if has_jsx_prop_ignore_case(jsx_el, "alt")
+        .and_then(get_string_literal_prop_value)
+        .is_some_and(|alt| alt.is_empty())
+    {
+        return None;
+    }
+
+    if has_jsx_prop_ignore_case(jsx_el, "src")
+        .and_then(get_static_string_prop_value)
+        .is_some_and(|src| src.contains(".svg"))
+    {
+        return None;
+    }
+
+    Some("img")
+}
+
+fn get_select_implicit_role(jsx_el: &JSXOpeningElement) -> &'static str {
+    if has_jsx_prop_ignore_case(jsx_el, "multiple").is_some_and(jsx_prop_value_is_truthy)
+        || has_jsx_prop_ignore_case(jsx_el, "size")
+            .and_then(get_prop_value)
+            .is_some_and(|value| parse_jsx_value(value).is_ok_and(|size| size > 1.0))
+    {
+        "listbox"
+    } else {
+        "combobox"
+    }
+}
+
+fn get_static_string_prop_value<'a>(item: &'a JSXAttributeItem<'_>) -> Option<&'a str> {
+    match get_prop_value(item)? {
+        JSXAttributeValue::StringLiteral(lit) => Some(lit.value.as_str()),
+        JSXAttributeValue::ExpressionContainer(container) => {
+            let Expression::StringLiteral(lit) = container.expression.as_expression()? else {
+                return None;
+            };
+            Some(lit.value.as_str())
+        }
+        _ => None,
+    }
+}
+
+fn jsx_prop_value_is_truthy(item: &JSXAttributeItem) -> bool {
+    match get_prop_value(item) {
+        None => true,
+        Some(JSXAttributeValue::StringLiteral(lit)) => !lit.value.is_empty(),
+        Some(JSXAttributeValue::ExpressionContainer(container)) => {
+            let Some(expression) = container.expression.as_expression() else {
+                return false;
+            };
+
+            match expression {
+                Expression::BooleanLiteral(lit) => lit.value,
+                Expression::StringLiteral(lit) => !lit.value.is_empty(),
+                Expression::NumericLiteral(lit) => lit.value != 0.0,
+                Expression::NullLiteral(_) => false,
+                Expression::Identifier(_) => false,
+                _ => false,
+            }
+        }
+        _ => false,
     }
 }
 
@@ -166,15 +250,51 @@ fn test() {
         ("<button role={`${foo}button`} />", None, None),
         ("<Button role={`${foo}button`} />", None, Some(settings())),
         (r#"<select role="menu"><option>1</option><option>2</option></select>"#, None, None),
+        (
+            r#"<select role="menu" size={2}><option>1</option><option>2</option></select>"#,
+            None,
+            None,
+        ),
+        (
+            r#"<select role="menu" multiple><option>1</option><option>2</option></select>"#,
+            None,
+            None,
+        ),
         // `nav` / `navigation` is allowed by default.
         (r#"<nav role="navigation" />"#, None, None),
+        (r#"<select role="listbox" />"#, None, None),
+        (r#"<img alt="" role="img" />"#, None, None),
         // Explicitly allowed redundant roles via the option.
-        (r#"<ul role="list" />"#, Some(serde_json::json!([{ "ul": ["list"] }])), None),
-        (r#"<ol role="list" />"#, Some(serde_json::json!([{ "ol": ["list"] }])), None),
+        (
+            r#"<ul role="list" />"#,
+            Some(serde_json::json!([{ "ul": ["list"], "ol": ["list"] }])),
+            None,
+        ),
+        (
+            r#"<ol role="list" />"#,
+            Some(serde_json::json!([{ "ul": ["list"], "ol": ["list"] }])),
+            None,
+        ),
+        (
+            r#"<dl role="list" />"#,
+            Some(serde_json::json!([{ "ul": ["list"], "ol": ["list"] }])),
+            None,
+        ),
+        (
+            r#"<img src="example.svg" role="img" />"#,
+            Some(serde_json::json!([{ "ul": ["list"], "ol": ["list"] }])),
+            None,
+        ),
+        (
+            r#"<svg role="img" />"#,
+            Some(serde_json::json!([{ "ul": ["list"], "ol": ["list"] }])),
+            None,
+        ),
         (r#"<li role="listitem" />"#, Some(serde_json::json!([{ "li": ["listitem"] }])), None),
     ];
 
     let fail = vec![
+        (r#"<body role="DOCUMENT" />"#, None, None),
         ("<button role='button' />", None, None),
         ("<button role='button' data-foo='bar' />", None, None),
         ("<button role='button' data-role='bar' />", None, None),
@@ -198,7 +318,22 @@ fn test() {
         (r#"<ol role="list" />"#, None, None),
         (r#"<ul role="list" />"#, None, None),
         (r#"<select role="combobox" />"#, None, None),
-        (r#"<select role="listbox" />"#, None, None),
+        (r#"<select role="combobox" size="" />"#, None, None),
+        (r#"<select role="combobox" size={1} />"#, None, None),
+        (r#"<select role="combobox" size="1" />"#, None, None),
+        (r#"<select role="combobox" size={null}></select>"#, None, None),
+        (r#"<select role="combobox" size={undefined}></select>"#, None, None),
+        (r#"<select role="combobox" multiple={undefined}></select>"#, None, None),
+        (r#"<select role="combobox" multiple={false}></select>"#, None, None),
+        (r#"<select role="combobox" multiple=""></select>"#, None, None),
+        (r#"<select role="listbox" size="3" />"#, None, None),
+        (r#"<select role="listbox" size={2} />"#, None, None),
+        (
+            r#"<select role="listbox" multiple><option>1</option><option>2</option></select>"#,
+            None,
+            None,
+        ),
+        (r#"<select role="listbox" multiple={true}></select>"#, None, None),
         (r#"<table role="table" />"#, None, None),
         (r#"<tbody role="rowgroup" />"#, None, None),
         (r#"<td role="cell" />"#, None, None),

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
@@ -58,13 +58,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the redundant role `button` from the element `button`.
 
-  ⚠ jsx-a11y(no-redundant-roles): The `nav` element has an implicit role of `navigation`. Defining this explicitly is redundant and should be avoided.
-   ╭─[no_redundant_roles.tsx:1:6]
- 1 │ <nav role='navigation' />
-   ·      ─────────────────
-   ╰────
-  help: Remove the redundant role `navigation` from the element `nav`.
-
   ⚠ jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:9]
  1 │ <Button role='button' />
@@ -267,3 +260,17 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────
    ╰────
   help: Remove the redundant role `row` from the element `tr`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `ul` element has an implicit role of `list`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:5]
+ 1 │ <ul role="list" />
+   ·     ───────────
+   ╰────
+  help: Remove the redundant role `list` from the element `ul`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `nav` element has an implicit role of `navigation`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:6]
+ 1 │ <nav role="navigation" />
+   ·      ─────────────────
+   ╰────
+  help: Remove the redundant role `navigation` from the element `nav`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
@@ -2,6 +2,13 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
+  ⚠ jsx-a11y(no-redundant-roles): The `body` element has an implicit role of `document`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:7]
+ 1 │ <body role="DOCUMENT" />
+   ·       ───────────────
+   ╰────
+  help: Remove the redundant role `document` from the element `body`.
+
   ⚠ jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:9]
  1 │ <button role='button' />
@@ -163,9 +170,86 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the redundant role `combobox` from the element `select`.
 
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" size="" />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" size={1} />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" size="1" />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" size={null}></select>
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" size={undefined}></select>
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" multiple={undefined}></select>
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" multiple={false}></select>
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="combobox" multiple=""></select>
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
   ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:9]
- 1 │ <select role="listbox" />
+ 1 │ <select role="listbox" size="3" />
+   ·         ──────────────
+   ╰────
+  help: Remove the redundant role `listbox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="listbox" size={2} />
+   ·         ──────────────
+   ╰────
+  help: Remove the redundant role `listbox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="listbox" multiple><option>1</option><option>2</option></select>
+   ·         ──────────────
+   ╰────
+  help: Remove the redundant role `listbox` from the element `select`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role="listbox" multiple={true}></select>
    ·         ──────────────
    ╰────
   help: Remove the redundant role `listbox` from the element `select`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2941,7 +2941,24 @@
           "$ref": "#/definitions/DummyRule"
         },
         "jsx-a11y/no-redundant-roles": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoRedundantRolesConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "jsx-a11y/no-static-element-interactions": {
           "anyOf": [
@@ -11793,6 +11810,15 @@
         }
       },
       "additionalProperties": false
+    },
+    "NoRedundantRolesConfig": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
     },
     "NoRequireImportsConfig": {
       "type": "object",

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2945,7 +2945,24 @@ expression: json
           "$ref": "#/definitions/DummyRule"
         },
         "jsx-a11y/no-redundant-roles": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoRedundantRolesConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "jsx-a11y/no-static-element-interactions": {
           "anyOf": [
@@ -11797,6 +11814,15 @@ expression: json
         }
       },
       "additionalProperties": false
+    },
+    "NoRedundantRolesConfig": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
     },
     "NoRequireImportsConfig": {
       "type": "object",


### PR DESCRIPTION
Adds the `allowedRedundantRoles` option and the default `nav` → `navigation`
exception to match eslint-plugin-jsx-a11y.

`<nav role="navigation">` now passes by default; other redundant roles can be
allowed per element:

```json
{ "jsx-a11y/no-redundant-roles": ["error", { "ul": ["list"], "ol": ["list"], "li": ["listitem"] }] }
```

closes #22792
