### PR TITLE
refactor(formatter_core,formatter,formatter_json): share `Expand` and `BracketSpacing` options

### DIFF
--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -1,12 +1,12 @@
 use rustc_hash::FxHashSet;
 
 use oxc_formatter::{
-    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CustomGroupDefinition,
-    EmbeddedLanguageFormatting, Expand, GroupEntry, ImportModifier, ImportSelector,
-    JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons, SortImportsOptions, SortOrder,
-    SortTailwindcssOptions, TrailingCommas,
+    ArrowParentheses, AttributePosition, BracketSameLine, CustomGroupDefinition,
+    EmbeddedLanguageFormatting, GroupEntry, ImportModifier, ImportSelector, JsFormatOptions,
+    QuoteProperties, QuoteStyle, Semicolons, SortImportsOptions, SortOrder, SortTailwindcssOptions,
+    TrailingCommas,
 };
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{BracketSpacing, Expand, IndentStyle, IndentWidth, LineEnding, LineWidth};
 
 use super::super::oxfmtrc::{
     ArrowParensConfig, CustomGroupItemConfig, EmbeddedLanguageFormattingConfig, EndOfLineConfig,
@@ -334,7 +334,8 @@ pub fn to_oxc_formatter(config: &FormatConfig) -> Result<JsFormatOptions, String
 
 #[cfg(test)]
 mod tests {
-    use oxc_formatter::{Expand, GroupName};
+    use oxc_formatter::GroupName;
+    use oxc_formatter_core::Expand;
 
     use super::*;
 

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
@@ -1,5 +1,5 @@
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
-use oxc_formatter_json::{Expand, JsonFormatOptions, JsonVariant};
+use oxc_formatter_core::{BracketSpacing, Expand, IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
 
 use super::super::oxfmtrc::{EndOfLineConfig, FormatConfig, ObjectWrapConfig};
 
@@ -41,7 +41,7 @@ pub fn to_oxc_formatter_json(
     }
     // [Prettier] bracketSpacing: boolean
     if let Some(spacing) = config.bracket_spacing {
-        options.bracket_spacing = spacing;
+        options.bracket_spacing = BracketSpacing::from(spacing);
     }
     // [Prettier] objectWrap: "preserve" | "collapse"
     if let Some(wrap) = config.object_wrap {

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str::FromStr};
 
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{BracketSpacing, Expand, IndentStyle, IndentWidth, LineEnding, LineWidth};
 
 /// JS-facing alias for the language-agnostic [`oxc_formatter_core::util::Quote`].
 /// Kept as `QuoteStyle` so existing public API (`JsFormatOptions::quote_style`)
@@ -583,49 +583,6 @@ impl FromStr for AttributePosition {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct BracketSpacing(bool);
-
-impl BracketSpacing {
-    /// Return the boolean value for this [BracketSpacing]
-    pub fn value(self) -> bool {
-        self.0
-    }
-}
-
-impl Default for BracketSpacing {
-    fn default() -> Self {
-        Self(true)
-    }
-}
-
-impl From<bool> for BracketSpacing {
-    fn from(value: bool) -> Self {
-        Self(value)
-    }
-}
-
-impl fmt::Display for BracketSpacing {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fmt::Display::fmt(&self.value(), f)
-    }
-}
-
-impl FromStr for BracketSpacing {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let value = bool::from_str(s);
-
-        match value {
-            Ok(value) => Ok(Self(value)),
-            Err(_) => Err(
-                "Value not supported for BracketSpacing. Supported values are 'true' and 'false'.",
-            ),
-        }
-    }
-}
-
 /// Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct BracketSameLine(bool);
@@ -659,38 +616,6 @@ impl FromStr for BracketSameLine {
                 "Value not supported for BracketSameLine. Supported values are 'true' and 'false'.",
             ),
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub enum Expand {
-    /// Objects are expanded when the first property has a leading newline. Arrays are always
-    /// expanded if they are shorter than the line width.
-    #[default]
-    Auto,
-    /// Objects and arrays are never expanded, if they are shorter than the line width.
-    Never,
-}
-
-impl FromStr for Expand {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "auto" => Ok(Self::Auto),
-            "never" => Ok(Self::Never),
-            _ => Err(std::format!("unknown expand literal: {s}")),
-        }
-    }
-}
-
-impl fmt::Display for Expand {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = match self {
-            Expand::Auto => "Auto",
-            Expand::Never => "Never",
-        };
-        f.write_str(s)
     }
 }
 

--- a/crates/oxc_formatter/src/print/object_like.rs
+++ b/crates/oxc_formatter/src/print/object_like.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::Expand;
 use oxc_span::GetSpan;
 
 use crate::{
@@ -8,7 +9,6 @@ use crate::{
         prelude::{format_with, group, soft_block_indent_with_maybe_space},
         trivia::format_dangling_comments,
     },
-    options::Expand,
     print::parameters::{get_this_param, should_hug_function_parameters},
     write,
 };

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -2,11 +2,11 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_formatter::{
-    ArrowParentheses, BracketSameLine, BracketSpacing, Formatter, JsFormatOptions, JsdocOptions,
-    QuoteProperties, QuoteStyle, Semicolons, TrailingCommas, get_parse_options,
+    ArrowParentheses, BracketSameLine, Formatter, JsFormatOptions, JsdocOptions, QuoteProperties,
+    QuoteStyle, Semicolons, TrailingCommas, get_parse_options,
 };
 use oxc_formatter_core::{
-    IndentStyle, IndentWidth, LineEnding, LineWidth,
+    BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
     test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
 };
 use oxc_parser::Parser;

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -57,8 +57,8 @@ pub use formatted::Formatted;
 pub use formatter::Formatter;
 pub use group_id::{GroupId, UniqueGroupIdBuilder};
 pub use options::{
-    IndentStyle, IndentWidth, IndentWidthFromIntError, LineEnding, LineWidth,
-    LineWidthFromIntError, ParseFormatNumberError,
+    BracketSpacing, Expand, IndentStyle, IndentWidth, IndentWidthFromIntError, LineEnding,
+    LineWidth, LineWidthFromIntError, ParseFormatNumberError,
 };
 pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};
 pub use simple_context::{SimpleFormatContext, SimpleFormatOptions};

--- a/crates/oxc_formatter_core/src/options.rs
+++ b/crates/oxc_formatter_core/src/options.rs
@@ -1,6 +1,9 @@
-//! Language-agnostic format options shared by all formatter implementations.
-
 use std::{fmt, num::ParseIntError, str::FromStr};
+
+// ---
+// Language-agnostic format options shared by all formatter implementations.
+// Part of [`crate::FormatOptions`] because the printing phase consumes these options.
+// ---
 
 #[derive(Debug, Default, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum IndentStyle {
@@ -290,5 +293,88 @@ impl fmt::Display for LineWidthFromIntError {
 impl From<LineWidth> for u16 {
     fn from(value: LineWidth) -> Self {
         value.0
+    }
+}
+
+// ---
+// Shared formatting options across languages.
+// Not part of [`crate::FormatOptions`] because the printing phase does not consume it;
+// each language reads it from its own options struct when building the object IR.
+// ---
+
+/// Whether to insert spaces around brackets in object.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct BracketSpacing(bool);
+
+impl BracketSpacing {
+    pub fn value(self) -> bool {
+        self.0
+    }
+}
+
+impl Default for BracketSpacing {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl From<bool> for BracketSpacing {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for BracketSpacing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt::Display::fmt(&self.value(), f)
+    }
+}
+
+impl FromStr for BracketSpacing {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match bool::from_str(s) {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for BracketSpacing. Supported values are 'true' and 'false'.",
+            ),
+        }
+    }
+}
+
+/// Whether objects keep their authored multi-line shape or collapse to one line when they fit.
+/// Mirrors Prettier's `objectWrap` option.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum Expand {
+    /// `objectWrap: "preserve"`.
+    /// An object stays multi-line when there is a newline right after `{` in the source;
+    /// otherwise it collapses when it fits.
+    #[default]
+    Auto,
+    /// `objectWrap: "collapse"`.
+    /// Objects collapse when they fit regardless of the authored shape.
+    Never,
+}
+
+impl FromStr for Expand {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(Self::Auto),
+            "never" => Ok(Self::Never),
+            _ => Err(std::format!("unknown expand literal: {s}")),
+        }
+    }
+}
+
+impl fmt::Display for Expand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            Expand::Auto => "Auto",
+            Expand::Never => "Never",
+        };
+        f.write_str(s)
     }
 }

--- a/crates/oxc_formatter_json/src/lib.rs
+++ b/crates/oxc_formatter_json/src/lib.rs
@@ -21,5 +21,5 @@ mod separated;
 pub use crate::{
     context::JsonFormatContext,
     format::format,
-    options::{Expand, JsonFormatOptions, JsonVariant},
+    options::{JsonFormatOptions, JsonVariant},
 };

--- a/crates/oxc_formatter_json/src/options.rs
+++ b/crates/oxc_formatter_json/src/options.rs
@@ -1,5 +1,6 @@
 use oxc_formatter_core::{
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions,
+    BracketSpacing, Expand, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    PrinterOptions,
 };
 
 /// JSON parser variant.
@@ -32,43 +33,15 @@ pub enum JsonVariant {
     JsonStringify,
 }
 
-/// Whether objects keep their authored multi-line shape or collapse to one line when they fit.
-/// Mirrors Prettier's `objectWrap` option for the `json` parser.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
-pub enum Expand {
-    /// `objectWrap: "preserve"`.
-    /// An object stays multi-line if there's a newline after `{` in the source;
-    /// otherwise it collapses when it fits.
-    #[default]
-    Auto,
-    /// `objectWrap: "collapse"`.
-    /// Objects collapse when they fit regardless of the authored shape.
-    Never,
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct JsonFormatOptions {
     pub indent_style: IndentStyle,
     pub indent_width: IndentWidth,
     pub line_width: LineWidth,
     pub line_ending: LineEnding,
     pub variant: JsonVariant,
-    pub bracket_spacing: bool,
+    pub bracket_spacing: BracketSpacing,
     pub expand: Expand,
-}
-
-impl Default for JsonFormatOptions {
-    fn default() -> Self {
-        Self {
-            indent_style: IndentStyle::default(),
-            indent_width: IndentWidth::default(),
-            line_width: LineWidth::default(),
-            line_ending: LineEnding::default(),
-            variant: JsonVariant::default(),
-            bracket_spacing: true,
-            expand: Expand::default(),
-        }
-    }
 }
 
 impl FormatOptions for JsonFormatOptions {

--- a/crates/oxc_formatter_json/src/print/object.rs
+++ b/crates/oxc_formatter_json/src/print/object.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::{ObjectExpression, ObjectPropertyKind, PropertyKey};
 use oxc_formatter_core::{
-    Buffer, Format, FormatContext,
+    Buffer, Expand, Format, FormatContext,
     builders::{block_indent, group, soft_block_indent_with_maybe_space, space, text},
     util::{NumberFormatOptions, format_trimmed_number, is_simple_number},
     write,
@@ -14,7 +14,6 @@ use crate::{
         is_suppressed_before, write_dangling_comments,
     },
     context::JsonFormatContext,
-    options::Expand,
 };
 
 use crate::separated::{TrailingSeparator, write_separated};
@@ -96,8 +95,11 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonObject<'a, '_> {
         write!(
             f,
             [
-                group(&soft_block_indent_with_maybe_space(&properties, options.bracket_spacing))
-                    .should_expand(expand),
+                group(&soft_block_indent_with_maybe_space(
+                    &properties,
+                    options.bracket_spacing.value(),
+                ))
+                .should_expand(expand),
                 "}"
             ]
         );

--- a/crates/oxc_formatter_json/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_json/tests/fixtures/mod.rs
@@ -2,10 +2,10 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_formatter_core::{
-    IndentStyle, IndentWidth, LineEnding, LineWidth,
+    BracketSpacing, Expand, IndentStyle, IndentWidth, LineEnding, LineWidth,
     test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
 };
-use oxc_formatter_json::{Expand, JsonFormatOptions, JsonVariant, format};
+use oxc_formatter_json::{JsonFormatOptions, JsonVariant, format};
 
 struct JsonHarness;
 
@@ -60,7 +60,7 @@ impl FixtureFormatter for JsonHarness {
                 }
                 "bracketSpacing" => {
                     if let Some(b) = value.as_bool() {
-                        options.bracket_spacing = b;
+                        options.bracket_spacing = BracketSpacing::from(b);
                     }
                 }
                 "objectWrap" => {

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -29,12 +29,12 @@ use oxc::{
     transformer::{TransformOptions, Transformer},
 };
 use oxc_formatter::{
-    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CustomGroupDefinition,
-    Expand, Formatter, GroupEntry, ImportModifier, ImportSelector, JsFormatOptions,
-    QuoteProperties, QuoteStyle, Semicolons, SortImportsOptions, SortOrder, TrailingCommas,
-    default_groups, default_internal_patterns, get_parse_options,
+    ArrowParentheses, AttributePosition, BracketSameLine, CustomGroupDefinition, Formatter,
+    GroupEntry, ImportModifier, ImportSelector, JsFormatOptions, QuoteProperties, QuoteStyle,
+    Semicolons, SortImportsOptions, SortOrder, TrailingCommas, default_groups,
+    default_internal_patterns, get_parse_options,
 };
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{BracketSpacing, Expand, IndentStyle, IndentWidth, LineEnding, LineWidth};
 use oxc_linter::{
     ConfigStore, ConfigStoreBuilder, ContextSubHost, ContextSubHostOptions, ExternalPluginStore,
     LintOptions, Linter, ModuleRecord, Oxlintrc,

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -18,10 +18,10 @@ use oxc::{
 };
 use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_pretty_json};
 use oxc_formatter::{
-    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, Formatter,
-    JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons, TrailingCommas, get_parse_options,
+    ArrowParentheses, AttributePosition, BracketSameLine, Formatter, JsFormatOptions,
+    QuoteProperties, QuoteStyle, Semicolons, TrailingCommas, get_parse_options,
 };
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{BracketSpacing, Expand, IndentStyle, IndentWidth, LineEnding, LineWidth};
 use rayon::prelude::*;
 
 use crate::{

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -7,10 +7,10 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::VisitMut;
 use oxc_formatter::{
-    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, JsFormatOptions,
-    OperatorPosition, QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
+    ArrowParentheses, AttributePosition, BracketSameLine, JsFormatOptions, OperatorPosition,
+    QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
 };
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{BracketSpacing, Expand, IndentStyle, IndentWidth, LineEnding, LineWidth};
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};


### PR DESCRIPTION
We chose `core` as the location for duplicate `struct`s, but the final options will continue to be built by each formatter.