### PR TITLE
fix(parser): reject 'const' modifier on type alias type parameter

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -289,6 +289,14 @@ pub fn declaration_single_statement(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn const_type_parameter(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(
+        "'const' modifier can only appear on a type parameter of a function, method or class",
+    )
+    .with_label(span)
+}
+
+#[cold]
 pub fn async_function_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Async functions can only be declared at the top level or inside a block")
         .with_label(span)

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -130,6 +130,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let id = self.parse_binding_identifier();
         let params = self.parse_ts_type_parameters();
+        // A `const` modifier is only valid on a type parameter of a function, method, or class
+        // (TS1277), so reject it on a type alias, e.g. `type T<const U> = ...`.
+        if let Some(type_params) = &params {
+            for param in &type_params.params {
+                if param.r#const {
+                    self.error(diagnostics::const_type_parameter(param.span));
+                }
+            }
+        }
         self.expect(Kind::Eq);
 
         let intrinsic_token = self.cur_token();

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: d9fe348c
 parser_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
 Positive Passed: 2222/2236 (99.37%)
-Negative Passed: 1695/1723 (98.37%)
+Negative Passed: 1696/1723 (98.43%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-type-assertion-and-assign/input.ts
@@ -57,8 +57,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/module-identifier-invalid/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters-invalid/input.ts
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-method/typescript-invalid-abstract/input.ts
 
@@ -14634,6 +14632,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-invalid-type-only-as-string/input.ts:1:22]
  1 │ import { type foo as "bar" } from "mod";
    ·                      ─────
+   ╰────
+
+  × 'const' modifier can only appear on a type parameter of a function, method or class
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters-invalid/input.ts:1:8]
+ 1 │ type T<const U> = {};
+   ·        ───────
    ╰────
 
   × TS(1363): A type-only import can specify a default import or named bindings, but not both.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: e5509e21
 parser_typescript Summary:
 AST Parsed     : 9781/9781 (100.00%)
 Positive Passed: 9781/9781 (100.00%)
-Negative Passed: 1584/2638 (60.05%)
+Negative Passed: 1585/2638 (60.08%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -2085,8 +2085,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typ
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typesWithDuplicateTypeParameters.ts
 
@@ -29591,6 +29589,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  23 │ type T20 = typeof Array<>;  // Error
     ·                        ──
  24 │ type T21 = typeof Array<string>;  // new (...) => string[]
+    ╰────
+
+  × 'const' modifier can only appear on a type parameter of a function, method or class
+    ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts:55:9]
+ 54 │ 
+ 55 │ type T1<const T> = T;  // Error
+    ·         ───────
+ 56 │ 
     ╰────
 
   × TS(1273): 'public' modifier cannot be used on a type parameter.


### PR DESCRIPTION
Stacked on #22827.

A `const` modifier on a type parameter is only valid when the type parameter belongs to a function, method, or class (TS1277) — it is **not** allowed on a type alias.

Verified against `typescript-go` (`internal/checker/grammarchecks.go`): for a `const` type-parameter modifier the parent must be one of function-like / class-like / function-type / constructor-type / call|construct|method signature, otherwise TS reports *"'const' modifier can only appear on a type parameter of a function, method or class"*.

```ts
type T<const U> = U;        // ✗ now errors
type T<U, const V> = V;     // ✗ now errors

interface I<const T> {}     // ✓ still parses
function f<const T>() {}    // ✓ valid
class C<const T> {}         // ✓ valid
```

The check is scoped to type aliases at the parser level: this matches babel's fixtures and avoids regressing the `const-type-parameters` positive fixture (which parses `interface I<const T>`). TypeScript also rejects the interface case, but only as a checker-level diagnostic, so leaving it to a later pass keeps the parser consistent with babel.

## Conformance

No regressions across any parser suite (positive/AST stay 100%):

| suite | negative-pass |
| --- | --- |
| `parser_babel` | 1695 → 1696 |
| `parser_typescript` | 1584 → 1585 |

Flips `types/const-type-parameters-invalid` (babel) and `typeParameterConstModifiers.ts` (TypeScript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
