### PR TITLE
fix(parser): reject module-referencing imports/exports in a namespace body

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -282,6 +282,28 @@ pub fn lexical_declaration_single_statement(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn export_assignment_in_namespace(span: Span) -> OxcDiagnostic {
+    ts_error("1063", "An export assignment cannot be used in a namespace.").with_label(span)
+}
+
+#[cold]
+pub fn import_in_namespace(span: Span) -> OxcDiagnostic {
+    ts_error("1147", "Import declarations in a namespace cannot reference a module.")
+        .with_label(span)
+}
+
+#[cold]
+pub fn export_in_namespace(span: Span) -> OxcDiagnostic {
+    ts_error("1194", "Export declarations are not permitted in a namespace.").with_label(span)
+}
+
+#[cold]
+pub fn default_export_in_namespace(span: Span) -> OxcDiagnostic {
+    ts_error("1319", "A default export can only be used in an ECMAScript-style module.")
+        .with_label(span)
+}
+
+#[cold]
 pub fn async_function_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Async functions can only be declared at the top level or inside a block")
         .with_label(span)

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -34,8 +34,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::LCurly);
 
         // Add Return context, remove TopLevel context
-        let (directives, statements) =
-            self.context(Context::Return, Context::TopLevel, Self::parse_directives_and_statements);
+        let (directives, statements) = self.context(Context::Return, Context::TopLevel, |p| {
+            p.parse_directives_and_statements(/* in_ts_namespace_body */ false)
+        });
 
         self.expect_closing(Kind::RCurly, opening_span);
         self.ast.alloc_function_body(self.end_span(span), directives, statements)

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -32,6 +32,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     `StatementList`[?Yield, ?Await, ?Return] `StatementListItem`[?Yield, ?Await, ?Return]
     pub(crate) fn parse_directives_and_statements(
         &mut self,
+        in_ts_namespace_body: bool,
     ) -> (Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>) {
         let mut directives = self.ast.vec();
         let mut statements = self.ast.vec();
@@ -99,6 +100,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                 }
                 expecting_directives = false;
+            }
+            // In an internal namespace body, module-referencing `import`/`export` statements are
+            // not permitted. Validated here as each direct statement is parsed (no second pass).
+            if in_ts_namespace_body {
+                self.check_namespace_body_statement(&stmt);
             }
             statements.push(stmt);
         }

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -772,7 +772,8 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
 
         let hashbang = self.parse_hashbang();
         self.ctx |= Context::TopLevel;
-        let (directives, mut statements) = self.parse_directives_and_statements();
+        let (directives, mut statements) =
+            self.parse_directives_and_statements(/* in_ts_namespace_body */ false);
 
         // In unambiguous mode, if ESM syntax was detected (import/export/import.meta),
         // we need to reparse statements that were originally parsed with `await` as identifier.

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -321,7 +321,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Box<'a, TSModuleDeclaration<'a>> {
         let id = TSModuleDeclarationName::StringLiteral(self.parse_literal_string());
         let body = if self.at(Kind::LCurly) {
-            let block = self.parse_ts_module_block();
+            // External module body (`declare module "x" {}`); `import`/`export` are allowed here.
+            let block = self.parse_ts_module_block(/* in_ts_namespace_body */ false);
             Some(TSModuleDeclarationBody::TSModuleBlock(block))
         } else {
             self.asi();
@@ -342,12 +343,51 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         )
     }
 
-    fn parse_ts_module_block(&mut self) -> Box<'a, TSModuleBlock<'a>> {
+    /// Validate a statement that appears directly in an *internal* namespace body
+    /// (`namespace N {}` / `module N {}`). Module-referencing `import`/`export` forms are not
+    /// permitted there. Called inline from `parse_statement_list_item` while `Context::TsNamespace`
+    /// is set, so the body is never iterated a second time. External modules
+    /// (`declare module "x" {}`) never set the flag, so they remain unrestricted.
+    pub(crate) fn check_namespace_body_statement(&mut self, stmt: &Statement<'a>) {
+        match stmt {
+            Statement::ExportDefaultDeclaration(decl) => {
+                self.error(diagnostics::default_export_in_namespace(decl.span));
+            }
+            Statement::TSExportAssignment(decl) => {
+                self.error(diagnostics::export_assignment_in_namespace(decl.span));
+            }
+            // `export { ... } from "..."` (re-export from a module). A bare `export { ... }`
+            // with no module source re-exports locals and is allowed in a namespace.
+            Statement::ExportNamedDeclaration(decl) if decl.source.is_some() => {
+                self.error(diagnostics::export_in_namespace(decl.span));
+            }
+            Statement::ExportAllDeclaration(decl) => {
+                self.error(diagnostics::export_in_namespace(decl.span));
+            }
+            // ES `import "..."` / `import ... from "..."`.
+            Statement::ImportDeclaration(decl) => {
+                self.error(diagnostics::import_in_namespace(decl.span));
+            }
+            // `import x = require("...")` references a module; `import x = A.B` is allowed.
+            Statement::TSImportEqualsDeclaration(decl)
+                if matches!(
+                    decl.module_reference,
+                    TSModuleReference::ExternalModuleReference(_)
+                ) =>
+            {
+                self.error(diagnostics::import_in_namespace(decl.span));
+            }
+            _ => {}
+        }
+    }
+
+    fn parse_ts_module_block(&mut self, in_ts_namespace_body: bool) -> Box<'a, TSModuleBlock<'a>> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
         // Remove TopLevel context for module block
-        let (directives, statements) =
-            self.context_remove(Context::TopLevel, Self::parse_directives_and_statements);
+        let (directives, statements) = self.context_remove(Context::TopLevel, |p| {
+            p.parse_directives_and_statements(in_ts_namespace_body)
+        });
         self.expect(Kind::RCurly);
         self.ast.alloc_ts_module_block(self.end_span(span), directives, statements)
     }
@@ -364,7 +404,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let decl = self.parse_module_or_namespace_declaration(span, kind, &Modifiers::empty());
             TSModuleDeclarationBody::TSModuleDeclaration(decl)
         } else {
-            let block = self.parse_ts_module_block();
+            // Internal namespace body — validate each statement inline as it is parsed
+            // (see `check_namespace_body_statement`), avoiding a second pass over the body.
+            let block = self.parse_ts_module_block(/* in_ts_namespace_body */ true);
             TSModuleDeclarationBody::TSModuleBlock(block)
         };
         self.verify_modifiers(
@@ -391,7 +433,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::Global);
         let keyword_span = self.end_span(keyword_span_start);
 
-        let body = self.parse_ts_module_block().unbox();
+        let body = self.parse_ts_module_block(/* in_ts_namespace_body */ false).unbox();
 
         self.verify_modifiers(
             modifiers,

--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: e5509e21
 
 codegen_typescript Summary:
-AST Parsed     : 9781/9781 (100.00%)
-Positive Passed: 9781/9781 (100.00%)
+AST Parsed     : 9779/9779 (100.00%)
+Positive Passed: 9779/9779 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: e5509e21
 
 estree_typescript Summary:
-AST Parsed     : 9721/9721 (100.00%)
-Positive Passed: 9703/9721 (99.81%)
+AST Parsed     : 9719/9719 (100.00%)
+Positive Passed: 9701/9719 (99.81%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts

--- a/tasks/coverage/snapshots/estree_typescript_tokens.snap
+++ b/tasks/coverage/snapshots/estree_typescript_tokens.snap
@@ -1,5 +1,5 @@
 commit: e5509e21
 
 estree_typescript_tokens Summary:
-AST Parsed     : 9721/9721 (100.00%)
-Positive Passed: 9721/9721 (100.00%)
+AST Parsed     : 9719/9719 (100.00%)
+Positive Passed: 9719/9719 (100.00%)

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -1,8 +1,8 @@
 commit: e5509e21
 
 formatter_typescript Summary:
-AST Parsed     : 9781/9781 (100.00%)
-Positive Passed: 9729/9781 (99.47%)
+AST Parsed     : 9779/9779 (100.00%)
+Positive Passed: 9727/9779 (99.47%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: d9fe348c
 parser_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
 Positive Passed: 2222/2236 (99.37%)
-Negative Passed: 1693/1723 (98.26%)
+Negative Passed: 1701/1723 (98.72%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-type-assertion-and-assign/input.ts
@@ -34,23 +34,7 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/invalid-within-single-statement-context/input.ts
 
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-export-assignment/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-export-default/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-export-from/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-import/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-assignment/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-default/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-from/input.ts
-
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-named/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-import/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-namespace-export/input.ts
 
@@ -14001,6 +13985,150 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/interface/property-initializer/input.ts:1:25]
  1 │ interface I { x: number = 1;}
    ·                         ─
+   ╰────
+
+  × TS(1063): An export assignment cannot be used in a namespace.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-export-assignment/input.ts:2:3]
+ 1 │ declare namespace N {
+ 2 │   export = N;
+   ·   ───────────
+ 3 │ }
+   ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-export-default/input.ts:3:3]
+ 2 │ declare namespace N {
+ 3 │   export default x;
+   ·   ─────────────────
+ 4 │ }
+   ╰────
+
+  × TS(1194): Export declarations are not permitted in a namespace.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-export-from/input.ts:2:3]
+ 1 │ declare namespace N {
+ 2 │   export { x } from "foo";
+   ·   ────────────────────────
+ 3 │   export * as ns from "foo";
+   ╰────
+
+  × TS(1194): Export declarations are not permitted in a namespace.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-export-from/input.ts:3:3]
+ 2 │   export { x } from "foo";
+ 3 │   export * as ns from "foo";
+   ·   ──────────────────────────
+ 4 │ }
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-import/input.ts:2:3]
+ 1 │ declare namespace N {
+ 2 │   import "foo";
+   ·   ─────────────
+ 3 │   import { x } from "foo";
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-import/input.ts:3:3]
+ 2 │   import "foo";
+ 3 │   import { x } from "foo";
+   ·   ────────────────────────
+ 4 │   import * as ns from "foo";
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-import/input.ts:4:3]
+ 3 │   import { x } from "foo";
+ 4 │   import * as ns from "foo";
+   ·   ──────────────────────────
+ 5 │   import y = require("foo");
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-import/input.ts:5:3]
+ 4 │   import * as ns from "foo";
+ 5 │   import y = require("foo");
+   ·   ──────────────────────────
+ 6 │   import type = require("foo");
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-declare-import/input.ts:6:3]
+ 5 │   import y = require("foo");
+ 6 │   import type = require("foo");
+   ·   ─────────────────────────────
+ 7 │ }
+   ╰────
+
+  × TS(1063): An export assignment cannot be used in a namespace.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-assignment/input.ts:2:3]
+ 1 │ namespace N {
+ 2 │   export = N;
+   ·   ───────────
+ 3 │ }
+   ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-default/input.ts:3:3]
+ 2 │ namespace N {
+ 3 │   export default x;
+   ·   ─────────────────
+ 4 │ }
+   ╰────
+
+  × TS(1194): Export declarations are not permitted in a namespace.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-from/input.ts:2:3]
+ 1 │ namespace N {
+ 2 │   export { x } from "foo";
+   ·   ────────────────────────
+ 3 │   export * as ns from "foo";
+   ╰────
+
+  × TS(1194): Export declarations are not permitted in a namespace.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-export-from/input.ts:3:3]
+ 2 │   export { x } from "foo";
+ 3 │   export * as ns from "foo";
+   ·   ──────────────────────────
+ 4 │ }
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-import/input.ts:2:3]
+ 1 │ namespace N {
+ 2 │   import "foo";
+   ·   ─────────────
+ 3 │   import { x } from "foo";
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-import/input.ts:3:3]
+ 2 │   import "foo";
+ 3 │   import { x } from "foo";
+   ·   ────────────────────────
+ 4 │   import * as ns from "foo";
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-import/input.ts:4:3]
+ 3 │   import { x } from "foo";
+ 4 │   import * as ns from "foo";
+   ·   ──────────────────────────
+ 5 │   import y = require("foo");
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-import/input.ts:5:3]
+ 4 │   import * as ns from "foo";
+ 5 │   import y = require("foo");
+   ·   ──────────────────────────
+ 6 │   import type = require("foo");
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/invalid-body-import/input.ts:6:3]
+ 5 │   import y = require("foo");
+ 6 │   import type = require("foo");
+   ·   ─────────────────────────────
+ 7 │ }
    ╰────
 
   × TS(2670): Augmentations for the global scope should have 'declare' modifier unless they appear in already ambient context.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,9 +1,9 @@
 commit: e5509e21
 
 parser_typescript Summary:
-AST Parsed     : 9781/9781 (100.00%)
-Positive Passed: 9781/9781 (100.00%)
-Negative Passed: 1582/2638 (59.97%)
+AST Parsed     : 9779/9779 (100.00%)
+Positive Passed: 9779/9779 (100.00%)
+Negative Passed: 1591/2640 (60.27%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -320,8 +320,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/errorSupress
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es5-oldStyleOctalLiteralInEnums.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es5ModuleInternalNamedImports.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6DeclOrdering.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportEqualsInterop.ts
@@ -348,17 +346,11 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAsName
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentImportMergeNoCrash.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces2.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAlias_excludesEverything.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultClassAndValue.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultClassInNamespace.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultDuplicateCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultFunctionInNamespace.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/exportDefaultInterfaceAndTwoFunctions.ts
 
@@ -767,8 +759,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathsValidat
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathsValidation5.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/primitiveMembers.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloImportParseErrors.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelAmbientExternalModuleImportWithExport.ts
 
@@ -1791,10 +1781,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock4.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment5.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment9.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.ts
 
@@ -6770,6 +6756,22 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: If you want to use `export =`, remove other `export`s and put all of them to the right hand value of `export =`. If you want to use `export`s, remove `export =` statement.
 
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+    ╭─[typescript/tests/cases/compiler/es5ModuleInternalNamedImports.ts:30:5]
+ 29 │     export {M_A as a};
+ 30 │     import * as M2 from "M2";
+    ·     ─────────────────────────
+ 31 │     import M4 from "M4";
+    ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+    ╭─[typescript/tests/cases/compiler/es5ModuleInternalNamedImports.ts:31:5]
+ 30 │     import * as M2 from "M2";
+ 31 │     import M4 from "M4";
+    ·     ────────────────────
+ 32 │     export import M5 = require("M5");
+    ╰────
+
   × TS(1015): A parameter cannot have a question mark and an initializer.
     ╭─[typescript/tests/cases/compiler/es6ClassTest.ts:25:44]
  24 │     constructor();
@@ -7130,6 +7132,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  14 │ }
     ╰────
 
+  × TS(1194): Export declarations are not permitted in a namespace.
+   ╭─[typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces2.ts:6:5]
+ 5 │ declare namespace N {
+ 6 │     export { x } from "mod"; // Error
+   ·     ────────────────────────
+ 7 │ }
+   ╰────
+
   × TS(1183): An implementation cannot be declared in ambient contexts.
    ╭─[typescript/tests/cases/compiler/exportDeclareClass1.ts:2:21]
  1 │     export declare class eaC {
@@ -7158,6 +7168,38 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  1 │ export function async<T>(...args: any[]): any { }
  2 │ export function await(...args: any[]): any { }
    ·                 ─────
+   ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[typescript/tests/cases/compiler/exportDefaultClassInNamespace.ts:2:5]
+ 1 │ namespace ns_class {
+ 2 │     export default class {}
+   ·     ───────────────────────
+ 3 │ }
+   ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[typescript/tests/cases/compiler/exportDefaultClassInNamespace.ts:6:5]
+ 5 │ namespace ns_abstract_class {
+ 6 │     export default abstract class {}
+   ·     ────────────────────────────────
+ 7 │ }
+   ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[typescript/tests/cases/compiler/exportDefaultFunctionInNamespace.ts:2:5]
+ 1 │ namespace ns_function {
+ 2 │     export default function () {}
+   ·     ─────────────────────────────
+ 3 │ }
+   ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[typescript/tests/cases/compiler/exportDefaultFunctionInNamespace.ts:6:5]
+ 5 │ namespace ns_async_function {
+ 6 │     export default async function () {}
+   ·     ───────────────────────────────────
+ 7 │ }
    ╰────
 
   × Identifier `someProp` has already been declared
@@ -7756,12 +7798,28 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: If you want to use `export =`, remove other `export`s and put all of them to the right hand value of `export =`. If you want to use `export`s, remove `export =` statement.
 
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[typescript/tests/cases/compiler/importDeclarationInModuleDeclaration1.ts:2:5]
+ 1 │ namespace m2 {
+ 2 │     import m3 = require("use_glo_M1_public");
+   ·     ─────────────────────────────────────────
+ 3 │ }
+   ╰────
+
   × Cannot use import statement outside a module
    ╭─[typescript/tests/cases/compiler/importDeclarationInModuleDeclaration2.ts:2:5]
  1 │ function container() {
  2 │     import "fs";
    ·     ──────
  3 │ }
+   ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+   ╭─[typescript/tests/cases/compiler/importInsideModule.ts:2:5]
+ 1 │ export namespace myModule {
+ 2 │     import foo = require("importInsideModule_file1");
+   ·     ─────────────────────────────────────────────────
+ 3 │     var a = foo.x;
    ╰────
 
   × TS(2309): An export assignment cannot be used in a module with other exported elements
@@ -10803,6 +10861,118 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·           ──────
    ╰────
 
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+    ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:59:5]
+ 58 │ 
+ 59 │     import m1_im3_private = require("m1_M3_public");
+    ·     ────────────────────────────────────────────────
+ 60 │     export var m1_im3_private_v1_public = m1_im3_private.c1;
+    ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+    ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:69:5]
+ 68 │ 
+ 69 │     import m1_im4_private = require("m1_M4_private");
+    ·     ─────────────────────────────────────────────────
+ 70 │     export var m1_im4_private_v1_public = m1_im4_private.c1;
+    ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:121:9]
+ 120 │     namespace m2 {
+ 121 │         import errorImport = require("glo_M2_public");
+     ·         ──────────────────────────────────────────────
+ 122 │         import nonerrorImport = glo_M1_public;
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:125:13]
+ 124 │         namespace m5 {
+ 125 │             import m5_errorImport = require("glo_M2_public");
+     ·             ─────────────────────────────────────────────────
+ 126 │             import m5_nonerrorImport = glo_M1_public;
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:146:5]
+ 145 │ namespace m2 {
+ 146 │     import m3 = require("use_glo_M1_public");
+     ·     ─────────────────────────────────────────
+ 147 │     namespace m4 {
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyGloImportParseErrors.ts:149:9]
+ 148 │         var a = 10;
+ 149 │         import m2 = require("use_glo_M1_public");
+     ·         ─────────────────────────────────────────
+ 150 │     }
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+    ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:59:5]
+ 58 │ 
+ 59 │     import m1_im3_private = require("m1_M3_public");
+    ·     ────────────────────────────────────────────────
+ 60 │     export var m1_im3_private_v1_public = m1_im3_private.c1;
+    ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+    ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:69:5]
+ 68 │ 
+ 69 │     import m1_im4_private = require("m1_M4_private");
+    ·     ─────────────────────────────────────────────────
+ 70 │     export var m1_im4_private_v1_public = m1_im4_private.c1;
+    ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:143:5]
+ 142 │ 
+ 143 │     import m1_im3_private = require("m2_M3_public");
+     ·     ────────────────────────────────────────────────
+ 144 │     export var m1_im3_private_v1_public = m1_im3_private.c1;
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:153:5]
+ 152 │ 
+ 153 │     import m1_im4_private = require("m2_M4_private");
+     ·     ─────────────────────────────────────────────────
+ 154 │     export var m1_im4_private_v1_public = m1_im4_private.c1;
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:273:9]
+ 272 │     namespace m2 {
+ 273 │         import errorImport = require("glo_M2_public");
+     ·         ──────────────────────────────────────────────
+ 274 │         import nonerrorImport = glo_M1_public;
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:277:13]
+ 276 │         namespace m5 {
+ 277 │             import m5_errorImport = require("glo_M2_public");
+     ·             ─────────────────────────────────────────────────
+ 278 │             import m5_nonerrorImport = glo_M1_public;
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:302:9]
+ 301 │     namespace m2 {
+ 302 │         import errorImport = require("glo_M4_private");
+     ·         ───────────────────────────────────────────────
+ 303 │         import nonerrorImport = glo_M3_private;
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:306:13]
+ 305 │         namespace m5 {
+ 306 │             import m5_errorImport = require("glo_M4_private");
+     ·             ──────────────────────────────────────────────────
+ 307 │             import m5_nonerrorImport = glo_M3_private;
+     ╰────
+
   × TS(1029): 'export' modifier must precede 'declare' modifier.
      ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:326:9]
  325 │ 
@@ -10819,6 +10989,38 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  327 │     namespace m2 {
      ╰────
   help: Only 'declare' modifier is allowed here.
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:341:5]
+ 340 │ namespace m2 {
+ 341 │     import m3 = require("use_glo_M1_public");
+     ·     ─────────────────────────────────────────
+ 342 │     namespace m4 {
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:344:9]
+ 343 │         var a = 10;
+ 344 │         import m2 = require("use_glo_M1_public");
+     ·         ─────────────────────────────────────────
+ 345 │     }
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:350:5]
+ 349 │ export namespace m3 {
+ 350 │     import m3 = require("use_glo_M1_public");
+     ·     ─────────────────────────────────────────
+ 351 │     namespace m4 {
+     ╰────
+
+  × TS(1147): Import declarations in a namespace cannot reference a module.
+     ╭─[typescript/tests/cases/compiler/privacyImportParseErrors.ts:353:9]
+ 352 │         var a = 10;
+ 353 │         import m2 = require("use_glo_M1_public");
+     ·         ─────────────────────────────────────────
+ 354 │     }
+     ╰────
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/privateNameJsx.tsx:4:22]
@@ -17283,6 +17485,26 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  172 │     prototype() {} // ok
      ╰────
 
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:252:5]
+ 251 │     namespace TestOnDefaultExportedClass_3 {
+ 252 │ ╭─▶     export default class StaticLength {
+ 253 │ │           static length: number; // error without useDefineForClassFields
+ 254 │ │           length: string; // ok
+ 255 │ ╰─▶     }
+ 256 │     }
+     ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:264:5]
+ 263 │     namespace TestOnDefaultExportedClass_4 {
+ 264 │ ╭─▶     export default class StaticLengthFn {
+ 265 │ │           static length() {} // error without useDefineForClassFields
+ 266 │ │           length() {} // ok
+ 267 │ ╰─▶     }
+ 268 │     }
+     ╰────
+
   × Classes may not have a static property named 'prototype'
      ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:278:16]
  277 │     export default class StaticPrototype {
@@ -17291,12 +17513,72 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  279 │         prototype: string; // ok
      ╰────
 
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:277:5]
+ 276 │     namespace TestOnDefaultExportedClass_5 {
+ 277 │ ╭─▶     export default class StaticPrototype {
+ 278 │ │           static prototype: number; // always an error
+ 279 │ │           prototype: string; // ok
+ 280 │ ╰─▶     }
+ 281 │     }
+     ╰────
+
   × Classes may not have a static property named 'prototype'
      ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:290:16]
  289 │     export default class StaticPrototypeFn {
  290 │         static prototype() {} // always an error
      ·                ─────────
  291 │         prototype() {} // ok
+     ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:289:5]
+ 288 │     namespace TestOnDefaultExportedClass_6 {
+ 289 │ ╭─▶     export default class StaticPrototypeFn {
+ 290 │ │           static prototype() {} // always an error
+ 291 │ │           prototype() {} // ok
+ 292 │ ╰─▶     }
+ 293 │     }
+     ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:302:5]
+ 301 │     namespace TestOnDefaultExportedClass_7 {
+ 302 │ ╭─▶     export default class StaticCaller {
+ 303 │ │           static caller: number; // error without useDefineForClassFields
+ 304 │ │           caller: string; // ok
+ 305 │ ╰─▶     }
+ 306 │     }
+     ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:314:5]
+ 313 │     namespace TestOnDefaultExportedClass_8 {
+ 314 │ ╭─▶     export default class StaticCallerFn {
+ 315 │ │           static caller() {} // error without useDefineForClassFields
+ 316 │ │           caller() {} // ok
+ 317 │ ╰─▶     }
+ 318 │     }
+     ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:327:5]
+ 326 │     namespace TestOnDefaultExportedClass_9 {
+ 327 │ ╭─▶     export default class StaticArguments {
+ 328 │ │           static arguments: number; // error without useDefineForClassFields
+ 329 │ │           arguments: string; // ok
+ 330 │ ╰─▶     }
+ 331 │     }
+     ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts:339:5]
+ 338 │     namespace TestOnDefaultExportedClass_10 {
+ 339 │ ╭─▶     export default class StaticArgumentsFn {
+ 340 │ │           static arguments() {} // error without useDefineForClassFields
+ 341 │ │           arguments() {} // ok
+ 342 │ ╰─▶     }
+ 343 │     }
      ╰────
 
   × Identifier `x` has already been declared
@@ -24809,6 +25091,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·          ─
    ╰────
 
+  × TS(1063): An export assignment cannot be used in a namespace.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment5.ts:2:5]
+ 1 │ namespace M {
+ 2 │     export = A;
+   ·     ───────────
+ 3 │ }
+   ╰────
+
   × TS(2309): An export assignment cannot be used in a module with other exported elements
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment7.ts:4:1]
  3 │ 
@@ -24824,6 +25114,22 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ 
    ╰────
   help: If you want to use `export =`, remove other `export`s and put all of them to the right hand value of `export =`. If you want to use `export`s, remove `export =` statement.
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment9.ts:2:3]
+ 1 │ namespace Foo {
+ 2 │   export default foo;
+   ·   ───────────────────
+ 3 │ }
+   ╰────
+
+  × TS(1319): A default export can only be used in an ECMAScript-style module.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment9.ts:6:3]
+ 5 │ namespace Bar {
+ 6 │   export default bar;
+   ·   ───────────────────
+ 7 │ }
+   ╰────
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parseIncompleteBinaryExpression1.ts:1:9]

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: e5509e21
 
 transformer_typescript Summary:
-AST Parsed     : 9781/9781 (100.00%)
-Positive Passed: 9761/9781 (99.80%)
+AST Parsed     : 9779/9779 (100.00%)
+Positive Passed: 9759/9779 (99.80%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts

--- a/tasks/coverage/src/typescript/constants.rs
+++ b/tasks/coverage/src/typescript/constants.rs
@@ -113,7 +113,6 @@ pub static NOT_SUPPORTED_ERROR_CODES: phf::Set<&'static str> = phf::phf_set![
     "1064", // The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<string>'?
     "1065", // The return type of an async function or method must be the global Promise<T> type.
     "1084", // Invalid 'reference' directive syntax.
-    "1147", // Import declarations in a namespace cannot reference a module.
     "1148", // Cannot use imports, exports, or module augmentations when '--module' is 'none'.
     "1166", // A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
     "1169", // A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.


### PR DESCRIPTION
Inside an internal `namespace N {}` / `module N {}`, statements that reference a
module are not permitted — this matches both babel and TypeScript:

- `import ... from "m"` / `import x = require("m")`  → TS1147
- `export ... from "m"` / `export * from "m"`         → TS1194
- `export default ...`                                → TS1319
- `export = ...`                                       → TS1063

Bare `export { x }` (re-export of locals, no module source) and `import x = A.B`
(entity alias) stay valid, as do external modules (`declare module "x" {}`) where
these forms are allowed — the check only runs for internal namespaces.

Each statement is validated inline as the namespace body is parsed (no second pass).

Also removes TS1147 from the coverage denylist (`NOT_SUPPORTED_ERROR_CODES`), since
oxc now detects it.

Conformance: parser_babel +8 and parser_typescript +9 negative-passes vs main, with
positive/AST staying 100% across all parser suites (no regressions).