### PR TITLE
fix(lsp): notifiy every workspace for a watched file change

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -454,19 +454,19 @@ impl LanguageServer for Backend {
         for file_event in &params.changes {
             // We do not expect multiple changes from the same workspace folder.
             // If we should consider it, we need to map the events to the workers first,
-            // to only restart the internal linter / diagnostics for once
-            let Some(worker) = self.worker_manager.get_worker_for_uri(&file_event.uri).await else {
-                continue;
-            };
-            let (diagnostics, registrations, unregistrations) = worker
-                .did_change_watched_files(file_event, &mut needs_diagnostics_refresh, fs)
-                .await;
+            // to only restart the internal linter / diagnostics for once.
+            // A change can affect multiple workspaces if the file is in a shared location, for example a config file in the home directory.
+            for worker in self.worker_manager.read_workspace_workers().await.iter() {
+                let (diagnostics, registrations, unregistrations) = worker
+                    .did_change_watched_files(file_event, &mut needs_diagnostics_refresh, fs)
+                    .await;
 
-            if let Some(diagnostics) = diagnostics {
-                new_diagnostics.extend(diagnostics);
+                if let Some(diagnostics) = diagnostics {
+                    new_diagnostics.extend(diagnostics);
+                }
+                removing_registrations.extend(unregistrations);
+                adding_registrations.extend(registrations);
             }
-            removing_registrations.extend(unregistrations);
-            adding_registrations.extend(registrations);
         }
 
         if diagnostic_mode == DiagnosticMode::Push && !new_diagnostics.is_empty() {

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -1180,6 +1180,55 @@ mod test_suite {
     }
 
     #[tokio::test]
+    async fn test_watched_file_changed_triggers_both_workspaces() {
+        let init_options = InitializeRequestOptions {
+            dynamic_watchers: true,
+            workspace_folders: Some(vec![
+                WorkspaceFolder { uri: WORKSPACE.parse().unwrap(), name: "workspace".to_string() },
+                WorkspaceFolder {
+                    uri: WORKSPACE_2.parse().unwrap(),
+                    name: "workspace_2".to_string(),
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let mut server = TestServer::new_initialized(
+            |client| Backend::new(client, server_info(), create_workspace_manager()),
+            initialize_request_workspace_folders(init_options),
+        )
+        .await;
+
+        acknowledge_registrations(&mut server).await;
+
+        let file_change_notification =
+            did_change_watched_files(format!("{WORKSPACE}/watcher.config").as_str());
+        server.send_request(file_change_notification).await;
+
+        // Old watcher unregistration expected
+        acknowledge_unregistrations(&mut server).await;
+
+        let register_request = server.recv_notification().await;
+        assert_eq!(register_request.method(), "client/registerCapability");
+        let register_params: Value = register_request.params().unwrap().clone();
+        let registrations = register_params["registrations"].as_array().unwrap();
+        assert_eq!(registrations.len(), 2);
+        assert!(
+            registrations
+                .iter()
+                .any(|registration| { registration["id"] == format!("watcher-{WORKSPACE}") })
+        );
+        assert!(
+            registrations
+                .iter()
+                .any(|registration| { registration["id"] == format!("watcher-{WORKSPACE_2}") })
+        );
+        server.send_ack(register_request.id().unwrap()).await;
+
+        server.shutdown(3).await;
+    }
+
+    #[tokio::test]
     async fn test_watched_file_changed_revalidate_diagnostics() {
         let init_options =
             InitializeRequestOptions { dynamic_watchers: true, ..Default::default() };

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -46,6 +46,9 @@ pub trait Tool: Send + Sync {
     /// Handle a watched file change event for the given URI.
     /// Returns a [ToolRestartChanges] indicating what changes were made for the Tool.
     /// The Tool should decide whether it needs to restart or take any action based on the URI.
+    ///
+    /// The given URI may not match the watch patterns or may be irrelevant for the workspace.
+    /// A file change can affect multiple workspaces, so the Tool should check if it is relevant.
     fn handle_watched_file_change(
         &self,
         builder: &dyn ToolBuilder,


### PR DESCRIPTION
When a watched file changes, it can affect multiple workspace folders. On a nested workspace set up the root oxlint config could be used multiple times.
The same for nested workspaces where only "one" config path is targeted with LSP settings.

related https://github.com/oxc-project/oxc-vscode/issues/97
closes https://github.com/oxc-project/oxc/issues/17515