### PR TITLE
perf(parser): reuse cached token kind in delimited-list loops

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -444,7 +444,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             {
                 return (list, None);
             }
-            if !self.at(separator) {
+            if kind != separator {
                 self.set_fatal_error(diagnostics::expect_closing_or_separator(
                     close.to_str(),
                     separator.to_str(),
@@ -491,7 +491,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             {
                 return None;
             }
-            if !self.at(separator) {
+            if kind != separator {
                 self.set_fatal_error(diagnostics::expect_closing_or_separator(
                     close.to_str(),
                     separator.to_str(),


### PR DESCRIPTION
## What

In `parse_delimited_list` and `parse_delimited_list_into` (`cursor.rs`), the loop already caches `let kind = self.cur_kind();` at the top of each iteration, then re-reads the same token via `if !self.at(separator)` — which expands to `self.token.kind() == separator`.

No token mutation (`advance`/`bump`/`next_token`) happens between the cache and the separator check, so `!self.at(separator)` is provably identical to `kind != separator`. This reuses the already-loaded `kind` and avoids re-reading `self.token` once per element of every array literal, object literal, parameter list, and argument list.

## Correctness

Semantics-preserving — no change to parse results or diagnostics.

- `cargo test -p oxc_parser`: pass
- `cargo coverage -- parser`: zero conformance snapshot diff (Test262 / TypeScript / Babel / estree)
- `just fmt` + `cargo clippy -p oxc_parser --all-features --all-targets`: clean

## Performance

A micro-optimization (removes one in-register/L1 token-field comparison per delimited-list element). Measured via an interleaved A/B against a parse-invariant control (`estree/checker.ts`); combined with the modifier-path change it lands ~0.5–1% on declaration/member-dense files (`binder.ts`), noise-level elsewhere. The main value is making the reuse of the cached `kind` explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)