### PR TITLE
fix(parser): reject function implementations in ambient contexts (TS1183)

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -1182,9 +1182,9 @@ fn test() {
         ),
         (
             "
-                            function test() {
+                            declare namespace test {
                               /** @abstract */
-                              declare let a;
+                              let a;
                             }
                           ",
             Some(serde_json::json!([

--- a/crates/oxc_linter/src/rules/typescript/no_invalid_void_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_invalid_void_type.rs
@@ -693,7 +693,7 @@ fn test() {
         ),
         (
             "
-            declare module foo {
+            module foo {
               function f(): void;
               function f(x: string): string;
               function f(x?: string): string | void {

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -286,8 +286,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.asi();
         }
 
+        // A function declaration's implementation (body) cannot be declared in an ambient context,
+        // whether the ambient context comes from the function's own `declare` modifier or is
+        // inherited from an enclosing `declare module`/`declare namespace` or a `.d.ts` file
+        // (TS1183). Class methods are checked separately in `check_method_definition`, so they are
+        // excluded here to avoid a duplicate diagnostic.
         if ctx.has_ambient()
-            && modifiers.contains_declare()
+            && matches!(
+                func_kind,
+                FunctionKind::Declaration
+                    | FunctionKind::DefaultExport
+                    | FunctionKind::TSDeclaration
+            )
             && let Some(body) = &body
         {
             self.error(diagnostics::implementation_in_ambient(Span::empty(body.span.start)));

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: d9fe348c
 parser_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
 Positive Passed: 2222/2236 (99.37%)
-Negative Passed: 1702/1723 (98.78%)
+Negative Passed: 1705/1723 (98.96%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-type-assertion-and-assign/input.ts
@@ -14,13 +14,7 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/conditional/arrow-param/input.ts
 
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/module-function/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/namespace-function/input.ts
-
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/decorators/type-arguments-invalid/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-implementation/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/equals-in-script/input.ts
 
@@ -13492,12 +13486,34 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  4 │   }
    ╰────
 
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/declare/module-function/input.ts:2:18]
+ 1 │ declare module "m" {
+ 2 │   function foo() {}
+   ·                  ▲
+ 3 │ }
+   ╰────
+
   × TS(1039): Initializers are not allowed in ambient contexts.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/declare/namespace-class/input.ts:3:13]
  2 │   class C {
  3 │     field = "field";
    ·             ───────
  4 │   }
+   ╰────
+
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/declare/namespace-function/input.ts:2:18]
+ 1 │ declare namespace n {
+ 2 │   function foo() {}
+   ·                  ▲
+ 3 │ }
+   ╰────
+
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/dts/invalid-class-implementation/input.ts:1:21]
+ 1 │ function foo(): any {}
+   ·                     ▲
    ╰────
 
   × TS(1039): Initializers are not allowed in ambient contexts.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: e5509e21
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1592/2640 (60.30%)
+Negative Passed: 1593/2640 (60.34%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -1781,8 +1781,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock4.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.d.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration3.ts
 
@@ -13846,6 +13844,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  35 │     function fn() { }
     ╰────
 
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+    ╭─[typescript/tests/cases/conformance/ambient/ambientErrors.ts:35:19]
+ 34 │     var x = 3;
+ 35 │     function fn() { }
+    ·                   ▲
+ 36 │     class C {
+    ╰────
+
   × TS(1039): Initializers are not allowed in ambient contexts.
     ╭─[typescript/tests/cases/conformance/ambient/ambientErrors.ts:37:20]
  36 │     class C {
@@ -25258,6 +25264,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserUnaryExpression7.ts:1:4]
  1 │ ++ new Foo();
    ·    ─────────
+   ╰────
+
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.d.ts:1:14]
+ 1 │ function F() {
+   ·              ▲
+ 2 │ }
    ╰────
 
   × TS(1183): An implementation cannot be declared in ambient contexts.


### PR DESCRIPTION
A function declaration with a body is an implementation, which is not allowed in
an ambient context. oxc already emitted TS1183 ("An implementation cannot be
declared in ambient contexts") when the function carried its own `declare`
modifier, but missed functions that inherit the ambient context from an enclosing
`declare module` / `declare namespace` or a `.d.ts` file:

    declare module "m" { function f() {} }   // now TS1183
    declare namespace N { function f() {} }  // now TS1183
    // foo.d.ts
    function foo(): any {}                    // now TS1183

Bodyless signatures stay valid (`declare module "m" { function f(): void; }`,
`export declare function f(): void;`).

The check now keys solely off `ctx.has_ambient()` instead of the function's own
`declare` modifier, scoped to function declarations. Class methods are excluded
because they are already validated in `check_method_definition`, which avoids a
duplicate diagnostic. This matches `typescript-go`'s
`checkGrammarStatementInAmbientContext` / function-like body check, and babel.

The fast path is unchanged: `has_ambient()` is a cheap bitflag test that
short-circuits for all non-ambient code.

parser_babel +3 and parser_typescript +1 negative-pass; positive/AST stay 100%.