### PR TITLE
perf(formatter): remove `&mut W` forwarding shim from `Buffer` hot path

### DIFF
--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -54,32 +54,26 @@ pub trait Buffer<'ast, C> {
 
 /// Implements the `[Buffer]` trait for all mutable references of objects implementing [Buffer].
 impl<'ast, C, W: Buffer<'ast, C> + ?Sized> Buffer<'ast, C> for &mut W {
-    #[inline(always)]
     fn write_element(&mut self, element: FormatElement<'ast>) {
         (**self).write_element(element);
     }
 
-    #[inline(always)]
     fn elements(&self) -> &[FormatElement<'ast>] {
         (**self).elements()
     }
 
-    #[inline(always)]
     fn write_fmt(&mut self, args: Arguments<'_, 'ast, C>) {
         (**self).write_fmt(args);
     }
 
-    #[inline(always)]
     fn state(&self) -> &FormatState<'ast, C> {
         (**self).state()
     }
 
-    #[inline(always)]
     fn state_mut(&mut self) -> &mut FormatState<'ast, C> {
         (**self).state_mut()
     }
 
-    #[inline(always)]
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
         (**self).replace_end(start, replacement);
     }
@@ -138,7 +132,6 @@ impl<C> DerefMut for VecBuffer<'_, '_, C> {
 }
 
 impl<'ast, C> Buffer<'ast, C> for VecBuffer<'_, 'ast, C> {
-    #[inline(always)]
     fn write_element(&mut self, element: FormatElement<'ast>) {
         self.elements.push(element);
     }
@@ -148,27 +141,22 @@ impl<'ast, C> Buffer<'ast, C> for VecBuffer<'_, 'ast, C> {
     // forwarding shim per dispatch). Here `Self` is `Sized`, so `&mut Self` coerces straight
     // to `&mut dyn Buffer` with the concrete type `VecBuffer` — a single vtable hop. This
     // covers every `write!(<owned VecBuffer>, …)` / `buffer.write_fmt(…)` call site.
-    #[inline(always)]
     fn write_fmt(&mut self, arguments: Arguments<'_, 'ast, C>) {
         write::<C>(self, arguments);
     }
 
-    #[inline(always)]
     fn elements(&self) -> &[FormatElement<'ast>] {
         self
     }
 
-    #[inline(always)]
     fn state(&self) -> &FormatState<'ast, C> {
         self.state
     }
 
-    #[inline(always)]
     fn state_mut(&mut self) -> &mut FormatState<'ast, C> {
         self.state
     }
 
-    #[inline(always)]
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
         self.elements.splice(start.., replacement.iter().cloned());
     }
@@ -411,7 +399,6 @@ impl<'ast, C> Buffer<'ast, C> for RemoveSoftLinesBuffer<'_, 'ast, C> {
     // See the note on `VecBuffer::write_fmt`: override the default so dispatch resolves to the
     // concrete `RemoveSoftLinesBuffer` instead of going through the `&mut W` shim. Hot via the
     // arrow-parameter and template-expression paths (`write!(buffer, …)` on a local instance).
-    #[inline(always)]
     fn write_fmt(&mut self, arguments: Arguments<'_, 'ast, C>) {
         write::<C>(self, arguments);
     }

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -54,26 +54,32 @@ pub trait Buffer<'ast, C> {
 
 /// Implements the `[Buffer]` trait for all mutable references of objects implementing [Buffer].
 impl<'ast, C, W: Buffer<'ast, C> + ?Sized> Buffer<'ast, C> for &mut W {
+    #[inline(always)]
     fn write_element(&mut self, element: FormatElement<'ast>) {
         (**self).write_element(element);
     }
 
+    #[inline(always)]
     fn elements(&self) -> &[FormatElement<'ast>] {
         (**self).elements()
     }
 
+    #[inline(always)]
     fn write_fmt(&mut self, args: Arguments<'_, 'ast, C>) {
         (**self).write_fmt(args);
     }
 
+    #[inline(always)]
     fn state(&self) -> &FormatState<'ast, C> {
         (**self).state()
     }
 
+    #[inline(always)]
     fn state_mut(&mut self) -> &mut FormatState<'ast, C> {
         (**self).state_mut()
     }
 
+    #[inline(always)]
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
         (**self).replace_end(start, replacement);
     }
@@ -132,22 +138,37 @@ impl<C> DerefMut for VecBuffer<'_, '_, C> {
 }
 
 impl<'ast, C> Buffer<'ast, C> for VecBuffer<'_, 'ast, C> {
+    #[inline(always)]
     fn write_element(&mut self, element: FormatElement<'ast>) {
         self.elements.push(element);
     }
 
+    // Override the trait default (which takes `mut self: &mut Self` and passes `&mut self`,
+    // pinning the trait object to `&mut VecBuffer` and adding an `impl Buffer for &mut W`
+    // forwarding shim per dispatch). Here `Self` is `Sized`, so `&mut Self` coerces straight
+    // to `&mut dyn Buffer` with the concrete type `VecBuffer` — a single vtable hop. This
+    // covers every `write!(<owned VecBuffer>, …)` / `buffer.write_fmt(…)` call site.
+    #[inline(always)]
+    fn write_fmt(&mut self, arguments: Arguments<'_, 'ast, C>) {
+        write::<C>(self, arguments);
+    }
+
+    #[inline(always)]
     fn elements(&self) -> &[FormatElement<'ast>] {
         self
     }
 
+    #[inline(always)]
     fn state(&self) -> &FormatState<'ast, C> {
         self.state
     }
 
+    #[inline(always)]
     fn state_mut(&mut self) -> &mut FormatState<'ast, C> {
         self.state
     }
 
+    #[inline(always)]
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
         self.elements.splice(start.., replacement.iter().cloned());
     }
@@ -387,6 +408,14 @@ fn clean_interned<'ast>(
 }
 
 impl<'ast, C> Buffer<'ast, C> for RemoveSoftLinesBuffer<'_, 'ast, C> {
+    // See the note on `VecBuffer::write_fmt`: override the default so dispatch resolves to the
+    // concrete `RemoveSoftLinesBuffer` instead of going through the `&mut W` shim. Hot via the
+    // arrow-parameter and template-expression paths (`write!(buffer, …)` on a local instance).
+    #[inline(always)]
+    fn write_fmt(&mut self, arguments: Arguments<'_, 'ast, C>) {
+        write::<C>(self, arguments);
+    }
+
     fn write_element(&mut self, element: FormatElement<'ast>) {
         let mut element_stack = Vec::from_iter([element]);
         while let Some(element) = element_stack.pop() {

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -98,7 +98,6 @@ impl<'ast, C> Buffer<'ast, C> for Formatter<'_, 'ast, C> {
         self.buffer.write_element(element);
     }
 
-    #[inline(always)]
     fn elements(&self) -> &[FormatElement<'ast>] {
         self.buffer.elements()
     }
@@ -110,17 +109,14 @@ impl<'ast, C> Buffer<'ast, C> for Formatter<'_, 'ast, C> {
         }
     }
 
-    #[inline(always)]
     fn state(&self) -> &FormatState<'ast, C> {
         self.buffer.state()
     }
 
-    #[inline(always)]
     fn state_mut(&mut self) -> &mut FormatState<'ast, C> {
         self.buffer.state_mut()
     }
 
-    #[inline(always)]
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
         self.buffer.replace_end(start, replacement);
     }

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -98,6 +98,7 @@ impl<'ast, C> Buffer<'ast, C> for Formatter<'_, 'ast, C> {
         self.buffer.write_element(element);
     }
 
+    #[inline(always)]
     fn elements(&self) -> &[FormatElement<'ast>] {
         self.buffer.elements()
     }
@@ -109,14 +110,17 @@ impl<'ast, C> Buffer<'ast, C> for Formatter<'_, 'ast, C> {
         }
     }
 
+    #[inline(always)]
     fn state(&self) -> &FormatState<'ast, C> {
         self.buffer.state()
     }
 
+    #[inline(always)]
     fn state_mut(&mut self) -> &mut FormatState<'ast, C> {
         self.buffer.state_mut()
     }
 
+    #[inline(always)]
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
         self.buffer.replace_end(start, replacement);
     }


### PR DESCRIPTION
`Buffer::write_fmt` takes `&mut self` and passes `&mut self` (i.e. `&mut &mut Self`) into `write()`. As a result, the formatter's buffer trait object is instantiated as `&mut VecBuffer` instead of `VecBuffer`, causing every subsequent `write_element` and `state` call to go through the `impl Buffer for &mut W` forwarding layer before reaching `VecBuffer`.

Profiling on a large TSX file showed these forwarding shims accounting for ~2.6% self time.

This PR removes that extra indirection by changing the two top-level entry points (`formatter::format` and `BestFitting::fmt`) to call `write(&mut buffer, args)` directly, allowing the trait object to resolve to `VecBuffer` and reducing dispatch to a single vtable call.

Additionally, it adds `#[inline(always)]` to the `Buffer` implementations for `VecBuffer`, `&mut W`, and `Formatter` so that trivial forwarding methods and getters can be folded into their callers.

## Results

### samply (`App.tsx` ×300, single-thread)

- `<&mut W>::write_element` self: 1.6% → 0.00%
- `<&mut W>::state` self: 1.0% → 0.06%
- `printer::fits_element` self: 11.3% → 9.7%
- `printer::print_element` self: 8.2% → 6.6%

### Criterion `formatter` benchmark (`measurement-time = 8s`)

- `index.tsx` (30.5 KB): -3.5% (`p = 0.04`)
- `next.ts` (17.3 KB): -3.2% (`p = 0.01`)
- Remaining benchmarks were within noise.

### CLI (`App.tsx` ×300, `--threads=1`, mean of runs 2–5)

- User time: 2.11s → 2.05s (~3.2% improvement)

---

This PR was developed collaboratively with an AI assistant. The human contributor was responsible for profiling, planning, design decisions, and review, while the AI assistant carried out the implementation.