### PR TITLE
fix(parser): reject invalid index signature parameter types (TS1268/TS1337)

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1082,6 +1082,26 @@ pub fn index_signature_one_parameter(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn index_signature_parameter_type(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1268",
+        "An index signature parameter type must be 'string', 'number', 'symbol', or a template \
+         literal type.",
+    )
+    .with_label(span)
+}
+
+#[cold]
+pub fn index_signature_parameter_literal_type(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1337",
+        "An index signature parameter type cannot be a literal type or generic type. Consider \
+         using a mapped object type instead.",
+    )
+    .with_label(span)
+}
+
+#[cold]
 pub fn mixed_coalesce(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Logical expressions and coalesce expressions cannot be mixed")
         .with_help("Wrap either expression by parentheses")

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1496,8 +1496,21 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             ));
         }
         self.expect(Kind::RBrack);
-        if params.len() != 1 {
-            self.error(diagnostics::index_signature_one_parameter(self.end_span(span)));
+        match params.as_slice() {
+            [param] => match &param.type_annotation.type_annotation {
+                TSType::TSLiteralType(ty) => {
+                    self.error(diagnostics::index_signature_parameter_literal_type(ty.span));
+                }
+                TSType::TSStringKeyword(_)
+                | TSType::TSNumberKeyword(_)
+                | TSType::TSSymbolKeyword(_)
+                | TSType::TSAnyKeyword(_) => {}
+                ty if ty.is_keyword() => {
+                    self.error(diagnostics::index_signature_parameter_type(param.span));
+                }
+                _ => {}
+            },
+            _ => self.error(diagnostics::index_signature_one_parameter(self.end_span(span))),
         }
         let Some(type_annotation) = self.parse_ts_type_annotation() else {
             return self

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: e5509e21
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1620/2640 (61.36%)
+Negative Passed: 1621/2640 (61.40%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -51,8 +51,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/awaitCallExp
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseCheck.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/baseExpressionTypeParameters.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/bigintIndex.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/binaryArithmatic1.ts
 
@@ -3296,6 +3294,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╭─[typescript/tests/cases/compiler/bigintArbirtraryIdentifier.ts:1:10]
  1 │ import { 0n as foo } from "./foo";
    ·          ──
+   ╰────
+
+  × TS(1268): An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type.
+   ╭─[typescript/tests/cases/compiler/bigintIndex.ts:2:6]
+ 1 │ interface BigIntIndex<E> {
+ 2 │     [index: bigint]: E; // should error
+   ·      ─────────────
+ 3 │ }
    ╰────
 
   × Invalid characters after number
@@ -25606,6 +25612,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  1 │ interface I {
  2 │   [a?]
    ·      ─
+ 3 │ }
+   ╰────
+
+  × TS(1268): An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature6.ts:2:4]
+ 1 │ interface I {
+ 2 │   [a:boolean]
+   ·    ─────────
  3 │ }
    ╰────
 


### PR DESCRIPTION
An index signature parameter type must be `string`, `number`, `symbol`, or a
template literal type. This adds the syntactic check oxc was missing for the
direct cases:

    interface I { [x: boolean]: number; }   // now TS1268
    interface I { [x: "a"]: number; }        // now TS1337

The check accepts the valid key keywords (`string`/`number`/`symbol`/`any`) and
rejects any other keyword type (via `TSType::is_keyword`) or a literal type; the
single-parameter validation is folded into the same `match`. Non-keyword nodes
(type references, unions, templates) need type resolution and remain a checker
concern, so this is a conservative, regression-safe subset of the full rule.

parser_typescript +1 negative-pass; positive/AST stay 100%.