### PR TITLE
perf(semantic): make building AST nodes optional via parent-pointer storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_cfg",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -94,6 +94,18 @@ pub trait CompilerInterface {
         true
     }
 
+    /// Whether semantic analysis should build full AST node storage.
+    ///
+    /// Defaults to `false`, which uses the lightweight ancestor-stack storage:
+    /// the pipeline only needs [`Scoping`], not the AST nodes. Override to return
+    /// `true` if [`after_semantic`] (or anything reading the
+    /// [`SemanticBuilderReturn`]) needs to access `semantic.nodes()`.
+    ///
+    /// [`after_semantic`]: CompilerInterface::after_semantic
+    fn build_ast_nodes(&self) -> bool {
+        false
+    }
+
     fn after_parse(&mut self, _parser_return: &mut ParserReturn) -> ControlFlow<()> {
         ControlFlow::Continue(())
     }
@@ -228,7 +240,10 @@ pub trait CompilerInterface {
             builder = builder.with_excess_capacity(2.0).with_enum_eval(true);
         }
 
-        builder.with_check_syntax_error(self.check_semantic_error()).build(program)
+        builder
+            .with_check_syntax_error(self.check_semantic_error())
+            .with_ast_nodes(self.build_ast_nodes())
+            .build(program)
     }
 
     fn isolated_declaration<'a>(

--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -35,7 +35,7 @@ fn collect(code: &str, source_type: SourceType) -> StatsCollector {
     }
 
     // Using semantic analysis here only to get parent node
-    let semantic_ret = SemanticBuilder::new().build(&program);
+    let semantic_ret = SemanticBuilder::new().with_ast_nodes(true).build(&program);
     collector.collect(&program, &semantic_ret.semantic)
 }
 

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -41,7 +41,7 @@ fn main() -> std::io::Result<()> {
     }
 
     // Build semantic model for AST analysis
-    let semantic_ret = SemanticBuilder::new().build(&ret.program);
+    let semantic_ret = SemanticBuilder::new().with_ast_nodes(true).build(&ret.program);
 
     let mut errors: Vec<OxcDiagnostic> = vec![];
 

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -1028,8 +1028,10 @@ mod test {
             let source_type = SourceType::jsx();
             let parser_ret = Parser::new(&allocator, source, source_type).parse();
             assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
-            let semantic =
-                SemanticBuilder::new().build(allocator.alloc(parser_ret.program)).semantic;
+            let semantic = SemanticBuilder::new()
+                .with_ast_nodes(true)
+                .build(allocator.alloc(parser_ret.program))
+                .semantic;
 
             let found = semantic.nodes().iter().any(|node| is_es5_component(node));
             assert_eq!(found, expected, "Failed for: {source}");
@@ -1059,8 +1061,10 @@ mod test {
             let parser_ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
             assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
 
-            let semantic =
-                SemanticBuilder::new().build(allocator.alloc(parser_ret.program)).semantic;
+            let semantic = SemanticBuilder::new()
+                .with_ast_nodes(true)
+                .build(allocator.alloc(parser_ret.program))
+                .semantic;
             let found = semantic.nodes().iter().find_map(|node| {
                 if let super::AstKind::JSXOpeningElement(opening) = node.kind() {
                     Some(get_jsx_element_name(&opening.name).into_owned())
@@ -1123,8 +1127,10 @@ mod test {
             let source_type = SourceType::tsx();
             let parser_ret = Parser::new(&allocator, source, source_type).parse();
             assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
-            let semantic =
-                SemanticBuilder::new().build(allocator.alloc(parser_ret.program)).semantic;
+            let semantic = SemanticBuilder::new()
+                .with_ast_nodes(true)
+                .build(allocator.alloc(parser_ret.program))
+                .semantic;
 
             let found = semantic.nodes().iter().any(|node| is_es6_component(node));
             assert_eq!(found, expected, "Failed for: {source}");

--- a/crates/oxc_mangler/src/keep_names.rs
+++ b/crates/oxc_mangler/src/keep_names.rs
@@ -258,7 +258,7 @@ mod test {
         let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
         assert!(!ret.panicked, "{source_text}");
         assert!(ret.errors.is_empty(), "{source_text}");
-        let ret = SemanticBuilder::new().build(&ret.program);
+        let ret = SemanticBuilder::new().with_ast_nodes(true).build(&ret.program);
         assert!(ret.errors.is_empty(), "{source_text}");
         let semantic = ret.semantic;
         let symbols = collect_name_symbols(opts, &allocator, semantic.scoping(), semantic.nodes());

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -281,7 +281,11 @@ impl<'t> Mangler<'t> {
     /// Pass the symbol table to oxc_codegen to generate the mangled code.
     #[must_use]
     pub fn build(self, program: &Program<'_>) -> ManglerReturn {
-        let mut semantic = SemanticBuilder::new().with_class_table(true).build(program).semantic;
+        let mut semantic = SemanticBuilder::new()
+            .with_class_table(true)
+            .with_ast_nodes(true)
+            .build(program)
+            .semantic;
         let class_private_mappings = self.build_with_semantic(&mut semantic, program);
         ManglerReturn { scoping: semantic.into_scoping(), class_private_mappings }
     }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -145,6 +145,7 @@ impl<'a> Minifier {
                 let mut semantic = SemanticBuilder::new()
                     .with_stats(stats)
                     .with_class_table(true)
+                    .with_ast_nodes(true)
                     .build(program)
                     .semantic;
                 let class_private_mappings = Mangler::default()

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -25,6 +25,7 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true, optional = true }
 oxc_diagnostics = { workspace = true }
+oxc_data_structures = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
 oxc_jsdoc = { workspace = true, optional = true }

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -60,6 +60,7 @@ fn main() -> std::io::Result<()> {
     let semantic = SemanticBuilder::new()
         // Enable additional syntax checks not performed by the parser
         .with_check_syntax_error(true)
+        .with_ast_nodes(true)
         .build(&program);
 
     // Report semantic analysis errors

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -32,7 +32,7 @@ use crate::{
     class::ClassTableBuilder,
     diagnostics::redeclaration,
     label::UnusedLabels,
-    node::AstNodes,
+    node::NodeStorage,
     scoping::{Bindings, Scoping},
     stats::Stats,
     unresolved_stack::UnresolvedReferences,
@@ -99,7 +99,13 @@ pub struct SemanticBuilder<'a> {
     pub(crate) async_or_generator_function_node_ids: Vec<NodeId>,
 
     // builders
-    pub(crate) nodes: AstNodes<'a>,
+    /// AST node storage. Defaults to the lightweight ancestor-stack backend; switched to
+    /// full [`AstNodes`](crate::AstNodes) storage by [`with_ast_nodes`] (or [`with_cfg`]).
+    /// The variant is the single source of truth for which mode is in effect.
+    ///
+    /// [`with_ast_nodes`]: SemanticBuilder::with_ast_nodes
+    /// [`with_cfg`]: SemanticBuilder::with_cfg
+    pub(crate) nodes: NodeStorage<'a>,
     pub(crate) scoping: Scoping,
 
     pub(crate) unresolved_references: UnresolvedReferences<'a>,
@@ -163,7 +169,7 @@ impl<'a> SemanticBuilder<'a> {
             current_scope_id,
             current_function_node_id: NodeId::ROOT,
             module_instance_state_cache: FxHashMap::default(),
-            nodes: AstNodes::default(),
+            nodes: NodeStorage::ancestor_stack(),
             hoisting_variables: FxHashMap::default(),
             async_or_generator_function_node_ids: Vec::new(),
             scoping,
@@ -196,6 +202,33 @@ impl<'a> SemanticBuilder<'a> {
     #[must_use]
     pub fn with_check_syntax_error(mut self, yes: bool) -> Self {
         self.check_syntax_error = yes;
+        self
+    }
+
+    /// Control whether full AST node storage is built.
+    ///
+    /// When `true`, every node is recorded in [`AstNodes`], so the resulting
+    /// [`Semantic`] supports random access to nodes by [`NodeId`] (via
+    /// [`Semantic::nodes`]). This is required by consumers that walk the whole
+    /// tree, such as the linter, formatter, and mangler.
+    ///
+    /// When `false` (the default), only the live ancestor chain is retained
+    /// during the build.
+    /// [`Scoping`] is produced identically, but [`Semantic::nodes`] is empty.
+    /// Use this for pipelines that only need [`Scoping`] (transform, minify,
+    /// define/inject), to avoid the per-node allocation of full storage.
+    ///
+    /// Enabling a [`ControlFlowGraph`] via [`SemanticBuilder::with_cfg`] forces
+    /// full storage regardless of this setting.
+    ///
+    /// [`AstNodes`]: crate::AstNodes
+    /// [`NodeId`]: oxc_syntax::node::NodeId
+    /// [`Semantic::nodes`]: crate::Semantic::nodes
+    /// [`Scoping`]: crate::Scoping
+    /// [`ControlFlowGraph`]: oxc_cfg::ControlFlowGraph
+    #[must_use]
+    pub fn with_ast_nodes(mut self, yes: bool) -> Self {
+        self.nodes = if yes { NodeStorage::full() } else { NodeStorage::ancestor_stack() };
         self
     }
 
@@ -297,6 +330,14 @@ impl<'a> SemanticBuilder<'a> {
             let stats_with_excess = stats.increase_by(self.excess_capacity);
             (stats_with_excess, Some(stats))
         };
+
+        // Control flow graph construction stores per-node data, so it requires full node
+        // storage regardless of the `with_ast_nodes` setting.
+        #[cfg(feature = "cfg")]
+        if self.cfg.is_some() && matches!(self.nodes, NodeStorage::Ancestors { .. }) {
+            self.nodes = NodeStorage::full();
+        }
+
         self.nodes.reserve(stats.nodes as usize);
         self.scoping.reserve(
             stats.symbols as usize,
@@ -335,12 +376,15 @@ impl<'a> SemanticBuilder<'a> {
         #[cfg(debug_assertions)]
         self.unused_labels.assert_empty();
 
+        #[expect(clippy::cast_possible_truncation)]
+        let node_count = self.nodes.len() as u32;
         let semantic = Semantic {
             source_text: self.source_text,
             source_type: self.source_type,
             comments: &program.comments,
             irregular_whitespaces: [].into(),
-            nodes: self.nodes,
+            nodes: self.nodes.into_ast_nodes(),
+            node_count,
             scoping: self.scoping,
             classes: self.class_table_builder.build(),
             #[cfg(feature = "jsdoc")]
@@ -390,7 +434,7 @@ impl<'a> SemanticBuilder<'a> {
 
     #[inline]
     fn pop_ast_node(&mut self) {
-        self.current_node_id = self.nodes.parent_id(self.current_node_id);
+        self.current_node_id = self.nodes.pop_node(self.current_node_id);
     }
 
     #[inline]
@@ -501,14 +545,18 @@ impl<'a> SemanticBuilder<'a> {
         // then defining a variable with the same name as the function name will be considered
         // a redeclaration, but it's actually not a redeclaration, so if the symbol declaration
         // is a function expression, then return None to tell the caller that it's not a redeclaration.
-        if self.scoping.symbol_flags(symbol_id).is_function()
-            && self
-                .nodes
-                .kind(self.scoping.symbol_declaration(symbol_id))
-                .as_function()
-                .is_some_and(Function::is_expression)
-        {
-            return None;
+        //
+        // Detect this without dereferencing the function's AST node (which may not be retained in
+        // ancestor-stack node storage mode): a function expression binds its own name in the scope
+        // *it* creates, so the name symbol's declaration node is that scope's node. A previous
+        // function *declaration* (e.g. `function a() {} function a() {}`) is instead bound in the
+        // enclosing scope, so its declaration node differs from its scope's node and is not matched.
+        if self.scoping.symbol_flags(symbol_id).is_function() {
+            let declaration = self.scoping.symbol_declaration(symbol_id);
+            let scope_node_id = self.scoping.get_node_id(self.scoping.symbol_scope_id(symbol_id));
+            if declaration == scope_node_id {
+                return None;
+            }
         }
 
         let flags = self.scoping.symbol_flags(symbol_id);

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
 use oxc_span::GetSpan;
 use oxc_syntax::class::{ClassId, ElementKind};
 
-use crate::{AstNodes, NodeId};
+use crate::{NodeId, node::NodeStorage};
 
 use super::{
     ClassTable,
@@ -35,7 +35,7 @@ impl<'a> ClassTableBuilder<'a> {
         &mut self,
         class: &ClassBody<'a>,
         current_node_id: NodeId,
-        nodes: &AstNodes,
+        nodes: &NodeStorage,
     ) {
         if !self.enabled {
             return;
@@ -103,7 +103,7 @@ impl<'a> ClassTableBuilder<'a> {
         &mut self,
         ident: &PrivateIdentifier<'a>,
         current_node_id: NodeId,
-        nodes: &AstNodes,
+        nodes: &NodeStorage,
     ) {
         if !self.enabled {
             return;

--- a/crates/oxc_semantic/src/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc.rs
@@ -71,7 +71,7 @@ mod test {
     ) -> Semantic<'a> {
         let source_type = source_type.unwrap_or_default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::new().with_ast_nodes(true).build(allocator.alloc(ret.program)).semantic
     }
 
     fn get_jsdocs<'a>(

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -76,7 +76,17 @@ pub struct Semantic<'a> {
     source_type: SourceType,
 
     /// The Abstract Syntax Tree (AST) nodes.
+    ///
+    /// Empty if semantic analysis was run with ancestor-stack node storage
+    /// (see [`SemanticBuilder::with_ast_nodes`]).
     nodes: AstNodes<'a>,
+
+    /// Total number of AST nodes visited during analysis.
+    ///
+    /// Equal to `nodes.len()` in full storage mode, but recorded separately so
+    /// that [`Semantic::stats`] stays accurate even when nodes are not retained
+    /// (ancestor-stack mode), where `nodes` is empty.
+    node_count: u32,
 
     scoping: Scoping,
 
@@ -220,7 +230,7 @@ impl<'a> Semantic<'a> {
     pub fn stats(&self) -> Stats {
         #[expect(clippy::cast_possible_truncation)]
         Stats::new(
-            self.nodes.len() as u32,
+            self.node_count,
             self.scoping.scopes_len() as u32,
             self.scoping.symbols_len() as u32,
             self.scoping.references.len() as u32,
@@ -292,7 +302,8 @@ mod tests {
     ) -> Semantic<'s> {
         let parse = oxc_parser::Parser::new(allocator, source, source_type).parse();
         assert!(parse.errors.is_empty());
-        let semantic = SemanticBuilder::new().build(allocator.alloc(parse.program));
+        let semantic =
+            SemanticBuilder::new().with_ast_nodes(true).build(allocator.alloc(parse.program));
         assert!(semantic.errors.is_empty(), "Parse error: {}", semantic.errors[0]);
         semantic.semantic
     }

--- a/crates/oxc_semantic/src/node/mod.rs
+++ b/crates/oxc_semantic/src/node/mod.rs
@@ -1,6 +1,8 @@
 mod nodes;
+mod storage;
 
 pub use nodes::AstNodes;
+pub use storage::NodeStorage;
 
 use oxc_allocator::{Address, GetAddress};
 use oxc_ast::AstKind;

--- a/crates/oxc_semantic/src/node/storage.rs
+++ b/crates/oxc_semantic/src/node/storage.rs
@@ -1,0 +1,308 @@
+//! Dynamic AST node storage used by [`SemanticBuilder`] during traversal.
+//!
+//! Two backends are available:
+//!
+//! 1. [`NodeStorage::Full`] — every node is recorded in [`AstNodes`], giving
+//!    random access by [`NodeId`] after the build finishes. Required by
+//!    consumers that walk the whole tree (linter, formatter, mangler).
+//! 2. [`NodeStorage::Ancestors`] — only the *live ancestor chain*
+//!    (`root..=current`) is retained, as a [`Stack`] pushed on `enter_node` and
+//!    popped on `leave_node`. This serves every *upward* query the binder, the
+//!    class-table builder, and the syntax checker need (parents and ancestors),
+//!    while avoiding the per-node allocations of full storage. Used by pipelines
+//!    that discard the AST nodes and keep only [`Scoping`] (transform, minify,
+//!    define/inject).
+//!
+//! Both backends allocate [`NodeId`]s from the same monotonic counter, so the
+//! ids stored in [`Scoping`] are identical regardless of the backend.
+//!
+//! [`SemanticBuilder`]: crate::SemanticBuilder
+//! [`Scoping`]: crate::Scoping
+
+use itertools::Either;
+
+use oxc_ast::AstKind;
+use oxc_data_structures::stack::Stack;
+use oxc_syntax::{
+    node::{NodeFlags, NodeId},
+    scope::ScopeId,
+};
+
+#[cfg(feature = "cfg")]
+use oxc_cfg::BlockNodeId;
+
+use super::AstNode;
+use crate::node::AstNodes;
+
+/// Initial capacity for the ancestor stack, sized to cover the maximum AST nesting
+/// depth of typical code so it does not reallocate during a build.
+const ANCESTOR_STACK_CAPACITY: usize = 128;
+
+/// A single entry in the ancestor [`Stack`] of [`NodeStorage::Ancestors`].
+pub struct StackEntry<'a> {
+    id: NodeId,
+    node: AstNode<'a>,
+    flags: NodeFlags,
+}
+
+/// Dynamic AST node storage. See the [module docs](self).
+pub enum NodeStorage<'a> {
+    /// Full random-access storage, retained after the build.
+    Full(AstNodes<'a>),
+    /// Only the live ancestor chain (`root..=current`) is retained during the build.
+    Ancestors {
+        /// The live ancestor chain: `stack[0]` is the root, `stack.last()` the current node.
+        /// Pushed on enter and popped on leave, so it only ever holds the current nesting depth.
+        stack: Stack<StackEntry<'a>>,
+        /// Total number of nodes created so far. Doubles as the allocator for the next
+        /// [`NodeId`] — needed because the stack pops, so its length is the current nesting
+        /// depth, not the total node count.
+        len: u32,
+    },
+}
+
+impl Default for NodeStorage<'_> {
+    fn default() -> Self {
+        Self::ancestor_stack()
+    }
+}
+
+impl<'a> NodeStorage<'a> {
+    /// Create full random-access storage.
+    pub fn full() -> Self {
+        NodeStorage::Full(AstNodes::default())
+    }
+
+    /// Create lightweight ancestor-stack storage.
+    ///
+    /// No storage is allocated yet (the [`Stack`] starts dangling), so creating one and then
+    /// discarding it — when full storage is requested instead — is free. Call
+    /// [`reserve`](NodeStorage::reserve) before traversal to pre-size it.
+    pub fn ancestor_stack() -> Self {
+        NodeStorage::Ancestors { stack: Stack::new(), len: 0 }
+    }
+
+    /// Consume the storage, returning the recorded [`AstNodes`].
+    ///
+    /// In ancestor-stack mode the chain is empty by the end of traversal, so this returns an
+    /// empty [`AstNodes`].
+    pub fn into_ast_nodes(self) -> AstNodes<'a> {
+        match self {
+            NodeStorage::Full(nodes) => nodes,
+            NodeStorage::Ancestors { .. } => AstNodes::default(),
+        }
+    }
+
+    pub fn add_node(
+        &mut self,
+        kind: AstKind<'a>,
+        scope_id: ScopeId,
+        parent_node_id: NodeId,
+        #[cfg(feature = "cfg")] cfg_id: BlockNodeId,
+        flags: NodeFlags,
+    ) -> NodeId {
+        match self {
+            NodeStorage::Full(nodes) => nodes.add_node(
+                kind,
+                scope_id,
+                parent_node_id,
+                #[cfg(feature = "cfg")]
+                cfg_id,
+                flags,
+            ),
+            NodeStorage::Ancestors { stack, len } => {
+                let node_id = NodeId::new(*len as usize);
+                *len += 1;
+                kind.set_node_id(node_id);
+                stack.push(StackEntry { id: node_id, node: AstNode::new(kind, scope_id), flags });
+                node_id
+            }
+        }
+    }
+
+    pub fn add_program_node(
+        &mut self,
+        kind: AstKind<'a>,
+        scope_id: ScopeId,
+        #[cfg(feature = "cfg")] cfg_id: BlockNodeId,
+        flags: NodeFlags,
+    ) -> NodeId {
+        match self {
+            NodeStorage::Full(nodes) => nodes.add_program_node(
+                kind,
+                scope_id,
+                #[cfg(feature = "cfg")]
+                cfg_id,
+                flags,
+            ),
+            NodeStorage::Ancestors { stack, len } => {
+                debug_assert!(stack.is_empty(), "Program node must be the first node in the AST.");
+                let node_id = NodeId::new(*len as usize);
+                *len += 1;
+                debug_assert_eq!(node_id, NodeId::ROOT);
+                kind.set_node_id(node_id);
+                stack.push(StackEntry { id: node_id, node: AstNode::new(kind, scope_id), flags });
+                node_id
+            }
+        }
+    }
+
+    /// Pop the current node and return its parent's id.
+    #[inline]
+    pub fn pop_node(&mut self, current_node_id: NodeId) -> NodeId {
+        match self {
+            NodeStorage::Full(nodes) => nodes.parent_id(current_node_id),
+            NodeStorage::Ancestors { stack, .. } => {
+                stack.pop();
+                stack.last().map_or(NodeId::ROOT, |entry| entry.id)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn get_node(&self, id: NodeId) -> &AstNode<'a> {
+        match self {
+            NodeStorage::Full(nodes) => nodes.get_node(id),
+            NodeStorage::Ancestors { stack, .. } => &stack[position(stack, id)].node,
+        }
+    }
+
+    #[inline]
+    pub fn kind(&self, id: NodeId) -> AstKind<'a> {
+        self.get_node(id).kind()
+    }
+
+    #[inline]
+    pub fn parent_id(&self, id: NodeId) -> NodeId {
+        match self {
+            NodeStorage::Full(nodes) => nodes.parent_id(id),
+            NodeStorage::Ancestors { stack, .. } => {
+                let pos = position(stack, id);
+                if pos == 0 { NodeId::ROOT } else { stack[pos - 1].id }
+            }
+        }
+    }
+
+    #[inline]
+    pub fn parent_kind(&self, id: NodeId) -> AstKind<'a> {
+        self.kind(self.parent_id(id))
+    }
+
+    #[inline]
+    pub fn parent_node(&self, id: NodeId) -> &AstNode<'a> {
+        self.get_node(self.parent_id(id))
+    }
+
+    #[inline]
+    pub fn flags_mut(&mut self, id: NodeId) -> &mut NodeFlags {
+        match self {
+            NodeStorage::Full(nodes) => nodes.flags_mut(id),
+            NodeStorage::Ancestors { stack, .. } => {
+                let pos = position(stack, id);
+                &mut stack[pos].flags
+            }
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            NodeStorage::Full(nodes) => nodes.len(),
+            NodeStorage::Ancestors { len, .. } => *len as usize,
+        }
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        match self {
+            // Full storage grows with the total node count.
+            NodeStorage::Full(nodes) => nodes.reserve(additional),
+            // The ancestor stack only ever holds the live `root..=current` chain, so it
+            // pre-sizes to a typical maximum nesting depth rather than the node count.
+            NodeStorage::Ancestors { stack, len } => {
+                debug_assert!(*len == 0, "`reserve` must be called before traversal");
+                *stack = Stack::with_capacity(ANCESTOR_STACK_CAPACITY);
+            }
+        }
+    }
+
+    /// Walk up the AST, iterating over each parent [`NodeId`].
+    ///
+    /// The first id produced is the parent of `id`; the last is always the root [`Program`].
+    ///
+    /// [`Program`]: oxc_ast::ast::Program
+    #[inline]
+    pub fn ancestor_ids(&self, id: NodeId) -> impl Iterator<Item = NodeId> + Clone + '_ {
+        match self {
+            NodeStorage::Full(nodes) => Either::Left(nodes.ancestor_ids(id)),
+            NodeStorage::Ancestors { stack, .. } => Either::Right(StackAncestorIdsIter {
+                stack: stack.as_slice(),
+                index: position(stack, id),
+            }),
+        }
+    }
+
+    /// Walk up the AST, iterating over each parent [`AstKind`].
+    #[inline]
+    pub fn ancestor_kinds(&self, id: NodeId) -> impl Iterator<Item = AstKind<'a>> + Clone + '_ {
+        self.ancestor_ids(id).map(move |id| self.kind(id))
+    }
+
+    /// Walk up the AST, iterating over each parent [`AstNode`].
+    #[inline]
+    pub fn ancestors(&self, id: NodeId) -> impl Iterator<Item = &AstNode<'a>> + Clone + '_ {
+        self.ancestor_ids(id).map(move |id| self.get_node(id))
+    }
+
+    /// Walk up the AST, iterating over each parent [`NodeId`] and [`AstNode`].
+    #[inline]
+    pub fn ancestors_enumerated(
+        &self,
+        id: NodeId,
+    ) -> impl Iterator<Item = (NodeId, &AstNode<'a>)> + Clone + '_ {
+        self.ancestor_ids(id).map(move |id| (id, self.get_node(id)))
+    }
+}
+
+/// Find the stack position of a live ancestor `id` in [`NodeStorage::Ancestors`].
+///
+/// The current node (top of stack) is the overwhelmingly common case and is checked first.
+/// Other ancestors (e.g. a scope's or class's node) require a scan, but the stack depth
+/// equals the AST nesting depth, which is small.
+#[inline]
+fn position<'a>(stack: &Stack<StackEntry<'a>>, id: NodeId) -> usize {
+    if let Some(last) = stack.last()
+        && last.id == id
+    {
+        return stack.len() - 1;
+    }
+    stack
+        .iter()
+        .rposition(|entry| entry.id == id)
+        .expect("`NodeId` is not a live ancestor (not available in parent-pointer storage mode)")
+}
+
+/// Iterator over the ids of a node's ancestors in [`NodeStorage::Ancestors`].
+///
+/// Yields the parent first and the root ([`Program`]) last, matching the order used by full
+/// [`AstNodes`] storage.
+///
+/// [`Program`]: oxc_ast::ast::Program
+#[derive(Clone)]
+pub struct StackAncestorIdsIter<'n, 'a> {
+    stack: &'n [StackEntry<'a>],
+    /// Position of the node whose ancestors are being yielded. Walks downward.
+    index: usize,
+}
+
+impl Iterator for StackAncestorIdsIter<'_, '_> {
+    type Item = NodeId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == 0 {
+            // Root has no parent.
+            return None;
+        }
+        self.index -= 1;
+        Some(self.stack[self.index].id)
+    }
+}

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -181,6 +181,7 @@ impl<'a> SemanticTester<'a> {
         SemanticBuilder::new()
             .with_check_syntax_error(true)
             .with_cfg(self.cfg)
+            .with_ast_nodes(true)
             .build(self.allocator.alloc(parse.program))
     }
 

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -126,8 +126,11 @@ fn analyze(
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let semantic =
-        SemanticBuilder::new().with_check_syntax_error(true).build(&ret.program).semantic;
+    let semantic = SemanticBuilder::new()
+        .with_check_syntax_error(true)
+        .with_ast_nodes(true)
+        .build(&ret.program)
+        .semantic;
     let ctx = TestContext { path, semantic };
     let scope_snapshot = run_scope_snapshot_test(&ctx);
     let conformance_snapshot = conformance_suite.run_on_source(&ctx);

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -244,6 +244,7 @@ impl Oxc {
         let semantic_ret = semantic_builder
             .with_check_syntax_error(parser_options.semantic_errors)
             .with_cfg(run_options.cfg)
+            .with_ast_nodes(true)
             .build(program);
         self.diagnostics.extend(semantic_ret.errors);
 

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -89,7 +89,10 @@ fn bench_mangler(criterion: &mut Criterion) {
                 allocator.reset();
                 temp_allocator.reset();
                 let program = transform_to_js(&allocator, source_text, source_type, path);
-                let mut semantic = SemanticBuilder::new().build(&program).semantic;
+                // The mangler reads AST nodes, so build full node storage (the binder/checker
+                // default to the lightweight ancestor-stack storage, which is discarded by the build).
+                let mut semantic =
+                    SemanticBuilder::new().with_ast_nodes(true).build(&program).semantic;
                 runner.run(|| {
                     Mangler::new_with_temp_allocator(&temp_allocator)
                         .build_with_semantic(&mut semantic, &program);
@@ -112,7 +115,10 @@ fn bench_mangler(criterion: &mut Criterion) {
                 allocator.reset();
                 temp_allocator.reset();
                 let program = transform_to_js(&allocator, source_text, source_type, path);
-                let mut semantic = SemanticBuilder::new().build(&program).semantic;
+                // The mangler reads AST nodes, so build full node storage (the binder/checker
+                // default to the lightweight ancestor-stack storage, which is discarded by the build).
+                let mut semantic =
+                    SemanticBuilder::new().with_ast_nodes(true).build(&program).semantic;
                 runner.run(|| {
                     Mangler::new_with_temp_allocator(&temp_allocator)
                         .with_options(MangleOptions {

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -88,6 +88,11 @@ impl CompilerInterface for Driver {
         ControlFlow::Continue(())
     }
 
+    fn build_ast_nodes(&self) -> bool {
+        // `after_semantic` reads `semantic.nodes()` when checking semantic ids.
+        self.check_semantic
+    }
+
     fn after_semantic(&mut self, ret: &mut SemanticBuilderReturn) -> ControlFlow<()> {
         if self.check_semantic {
             let program = ret.semantic.nodes().program();

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            166 |              4 ||         152662 |          28244
+checker.ts                 | 2.92 MB        ||            164 |              4 ||         152662 |          28244
 
-App.tsx                    | 415.34 kB      ||            115 |              7 ||          16995 |           2702
+App.tsx                    | 415.34 kB      ||            113 |              7 ||          16995 |           2702
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 ||             31 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             22 |              0 ||             31 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2614 |            203 ||          47465 |           7740
+pdf.mjs                    | 567.30 kB      ||           2612 |            203 ||          47465 |           7740
 
-antd.js                    | 6.69 MB        ||           3084 |             53 ||         336992 |          69349
+antd.js                    | 6.69 MB        ||           3082 |             53 ||         336992 |          69349
 
-binder.ts                  | 193.08 kB      ||             41 |              1 ||           7076 |            824
+binder.ts                  | 193.08 kB      ||             39 |              1 ||           7076 |            824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2918 |            171 ||         100206 |          17853
+kitchen-sink.tsx           | 732.90 kB      ||           2916 |            171 ||         100206 |          17853
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             48 |              0 ||              0 |              0
+checker.ts                 | 2.92 MB        ||             46 |              0 ||              0 |              0
 
-App.tsx                    | 415.34 kB      ||             31 |              0 ||              0 |              0
+App.tsx                    | 415.34 kB      ||             29 |              0 ||              0 |              0
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             10 |              0 ||              0 |              0
+RadixUIAdoptionSection.jsx | 2.52 kB        ||              8 |              0 ||              0 |              0
 
-pdf.mjs                    | 567.30 kB      ||             40 |              0 ||              0 |              0
+pdf.mjs                    | 567.30 kB      ||             38 |              0 ||              0 |              0
 
-antd.js                    | 6.69 MB        ||           1072 |              0 ||              0 |              0
+antd.js                    | 6.69 MB        ||           1070 |              0 ||              0 |              0
 
-binder.ts                  | 193.08 kB      ||             19 |              0 ||              0 |              0
+binder.ts                  | 193.08 kB      ||             17 |              0 ||              0 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||             73 |              0 ||              0 |              0
+kitchen-sink.tsx           | 732.90 kB      ||             71 |              0 ||              0 |              0
 


### PR DESCRIPTION
## What

`SemanticBuilder` can now build **without** retaining every AST node. It defaults to a lightweight **ancestor-stack** storage that keeps only the live `root..=current` chain during traversal. Consumers that need random access to nodes after the build opt back in with `.with_ast_nodes(true)` (and `.with_cfg(true)` forces full storage automatically, since CFG construction needs per-node data).

This makes building AST nodes optional for pipelines that only consume `Scoping`: the `oxc` compiler pipeline, transform, minify, and define/inject all call `into_scoping()` and discard the nodes today, so building them was wasted work.

## How

A new `NodeStorage` enum in `oxc_semantic` (`node/storage.rs`) with two backends:

- `Full(AstNodes)` — today's flat random-access storage, retained after the build.
- `Ancestors { stack, len }` — a `Stack` of the live ancestor chain, pushed on enter / popped on exit, serving the parent/ancestor queries the binder, class-table builder, and syntax checker need (they only ever look *upward*).

Both allocate `NodeId`s from the same monotonic counter, so **`Scoping` is identical regardless of mode**. `Semantic::nodes()` is empty in ancestor-stack mode; a new `node_count` field keeps `Semantic::stats()` accurate so `with_stats` reuse still pre-allocates correctly.

### Redeclaration checks (the only build-time reads of an already-popped node)

Two redeclaration checks used to dereference a *previously declared* (already-popped) function node. Neither touches `AstNodes` any more, so both behave identically in either storage mode:

- `check_function_redeclaration` (Annex B.3.3) consults the `async_or_generator_function_node_ids` list recorded at bind time — landed separately on `main` in #22972 / #22973, which this branch is now rebased on.
- `check_redeclaration` distinguishes a named function *expression* from a previous function *declaration* by comparing `NodeId`s: a function expression binds its own name in the scope it creates, so the name symbol's declaration node **is** that scope's node (`symbol_declaration(id) == get_node_id(symbol_scope_id(id))`). A previous function declaration is bound in the enclosing scope, so it doesn't match. No node kind is read.

Every other build-time node read resolves the current node, the enclosing function, an enclosing scope's node, or the enclosing class's node — all guaranteed to be on the live ancestor stack.

## Consumers

- **Stack (default):** compiler pipeline, compressor, transformer, define/inject rebuilds, napi parser/transform, oxlint parse-check.
- **Full (opt-in):** mangler (+ minifier mangle path), formatter `detect_code_removal`, playground, coverage driver (via a new `CompilerInterface::build_ast_nodes()` hook), and semantic's own tests/examples. The **linter** already builds with `with_cfg(true)`, so it gets full storage automatically.

## Validation

- `oxc_semantic`, mangler, minifier, transformer, and codegen tests pass.
- **Conformance: zero regressions** — `cargo coverage -- semantic` leaves the snapshot failure-counts byte-identical (and it exercises `check_redeclaration` in full-node mode, so unchanged snapshots prove the `NodeId` comparison matches the original node read).
- `clippy`, `rustdoc -D warnings`, and `cargo fmt` clean.

## Note

The win is build-local: `into_scoping()` already freed nodes before transform, so this trims the per-node `AstNodes` allocations/writes during each pipeline semantic build, not transform/codegen themselves.

---

🤖 This PR was authored with [Claude Code](https://claude.com/claude-code).


