### PR TITLE
fix(linter): avoid no-unreachable false positive after conditional loop

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -163,6 +163,13 @@ impl Rule for NoUnreachable {
                         // Explicit `Error` can also be reachable if we encounter an error in the loop.
                         | EdgeType::Error(ErrorEdgeKind::Explicit) => true,
 
+                        // This block can still be reachable through another control-flow path.
+                        EdgeType::Normal | EdgeType::Jump
+                            if e.source() != loop_.1 && !unreachables[e.source().index()] =>
+                        {
+                            true
+                        }
+
                         // If we have an incoming `Jump` and it is from a `Break` instruction,
                         // We know with high confidence that we are visiting a reachable block.
                         // NOTE: May cause false negatives but I couldn't think of one.
@@ -406,6 +413,14 @@ fn test() {
             b();
         }
         ",
+        "
+        function foo() {
+            if (Math.random() === 0.5) {
+                while (true) { return 'greetings!'; }
+            }
+            return 'Hello, tsdown!';
+        }
+        ",
     ];
 
     let fail = vec![
@@ -478,6 +493,7 @@ fn test() {
             }
         }
         ",
+        "function foo() { while (true) { return ''; } return ''; }",
     ];
 
     Tester::new(NoUnreachable::NAME, NoUnreachable::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_unreachable.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unreachable.snap
@@ -192,3 +192,10 @@ source: crates/oxc_linter/src/tester.rs
  9 │                 }
    ╰────
   help: Remove the unreachable code or fix the control flow to make it reachable.
+
+  ⚠ eslint(no-unreachable): Unreachable code.
+   ╭─[no_unreachable.tsx:1:46]
+ 1 │ function foo() { while (true) { return ''; } return ''; }
+   ·                                              ──────────
+   ╰────
+  help: Remove the unreachable code or fix the control flow to make it reachable.


### PR DESCRIPTION
`no-unreachable` was treating the normal exit from a `while (true)` loop as making the following block unreachable even when that block also had another reachable incoming path, such as the false branch of an enclosing `if`.

This keeps the infinite-loop propagation from overriding blocks that remain reachable through another `Normal` or `Jump` edge, and adds a regression case for a conditionally-run infinite loop that returns inside the loop body.

```mermaid
flowchart TD
    A["enter function"] --> B{"if condition"}
    B -- true / Jump --> C["while (true)"]
    C --> D["return inside loop"]
    D -. "loop normal exit is unreachable" .-> E["statement after if"]
    B -- false / Jump --> E
    E["return after if"] --> F["function exit"]

    classDef reachable fill:#d7f7df,stroke:#1b7f3a,color:#102914;
    classDef blocked fill:#fde2e2,stroke:#b42318,color:#4a1111;
    class A,B,C,D,E,F reachable;
    class D blocked;
```

The key point is that the infinite-loop pass starts from the loop's synthetic normal exit and may mark that path unreachable, but it must stop when the target block has another reachable incoming `Normal` or `Jump` edge. In this case, the post-`if` return is still reachable through the `if` condition's false branch, so reporting it as unreachable is a false positive.

fixes #22868