### PR TITLE
fix(isolated-declarations): omit definite assertion from private declarations

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -139,7 +139,7 @@ impl<'a> IsolatedDeclarations<'a> {
             false,
             property.r#override,
             property.optional,
-            property.definite,
+            false,
             property.readonly,
             Self::transform_accessibility(property.accessibility),
         )
@@ -629,7 +629,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         property.computed,
                         property.r#static,
                         property.r#override,
-                        property.definite,
+                        false,
                         property.accessibility,
                     );
                     elements.push(new_element);

--- a/crates/oxc_isolated_declarations/tests/fixtures/issue-22877.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/issue-22877.ts
@@ -1,0 +1,5 @@
+export class SomeClass {
+  private _prop!: string;
+  public prop!: string;
+  noAccessibility!: string;
+}

--- a/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
@@ -18,6 +18,8 @@ class Cls {
   accessor d: string;
   private accessor e: string;
   private static accessor f: string;
+  accessor g!: string;
+  private accessor h!: string;
 }
 
 // Incorrect
@@ -65,5 +67,3 @@ class GlobalSymbol4 {
     return GlobalSymbol4;
   }
 }
-
-

--- a/crates/oxc_isolated_declarations/tests/snapshots/issue-22877.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/issue-22877.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/issue-22877.ts
+---
+```
+==================== .D.TS ====================
+
+export declare class SomeClass {
+	private _prop;
+	prop: string;
+	noAccessibility: string;
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
@@ -15,6 +15,8 @@ declare class Cls {
 	accessor d: string;
 	private accessor e;
 	private static accessor f;
+	accessor g: string;
+	private accessor h;
 }
 declare class ClsBad {
 	get a();
@@ -42,20 +44,20 @@ declare class GlobalSymbol4 {
 
   x TS9009: At least one accessor must have an explicit return type annotation
   | with --isolatedDeclarations.
-    ,-[25:7]
- 24 | class ClsBad {
- 25 |   get a() {
+    ,-[27:7]
+ 26 | class ClsBad {
+ 27 |   get a() {
     :       ^
- 26 |     return;
+ 28 |     return;
     `----
 
   x TS9009: At least one accessor must have an explicit return type annotation
   | with --isolatedDeclarations.
-    ,-[64:8]
- 63 |   }
- 64 |   get [Symbol.toStringTag]() {
+    ,-[66:8]
+ 65 |   }
+ 66 |   get [Symbol.toStringTag]() {
     :        ^^^^^^^^^^^^^^^^^^
- 65 |     return GlobalSymbol4;
+ 67 |     return GlobalSymbol4;
     `----
 
 


### PR DESCRIPTION
Declaration emit currently preserves the definite assignment marker on private modifier class fields after erasing their type annotation. That can produce invalid `.d.ts` output like `private _prop!;`, while TypeScript emits the type-erased private member as `private _prop;`.

This clears the emitted `definite` flag when isolated declaration emit type-erases private modifier properties, and uses the same helper for accessor properties. The regression fixture covers the issue sample, and the existing accessor fixture now covers the same behavior for `private accessor`.

fixes #22877