### PR TITLE
fix(isolated-declarations): omit public accessor modifier

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -630,7 +630,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         property.r#static,
                         property.r#override,
                         false,
-                        property.accessibility,
+                        Self::transform_accessibility(property.accessibility),
                     );
                     elements.push(new_element);
                 }

--- a/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
@@ -20,6 +20,7 @@ class Cls {
   private static accessor f: string;
   accessor g!: string;
   private accessor h!: string;
+  public accessor i!: string;
 }
 
 // Incorrect

--- a/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
@@ -17,6 +17,7 @@ declare class Cls {
 	private static accessor f;
 	accessor g: string;
 	private accessor h;
+	accessor i: string;
 }
 declare class ClsBad {
 	get a();
@@ -44,20 +45,20 @@ declare class GlobalSymbol4 {
 
   x TS9009: At least one accessor must have an explicit return type annotation
   | with --isolatedDeclarations.
-    ,-[27:7]
- 26 | class ClsBad {
- 27 |   get a() {
+    ,-[28:7]
+ 27 | class ClsBad {
+ 28 |   get a() {
     :       ^
- 28 |     return;
+ 29 |     return;
     `----
 
   x TS9009: At least one accessor must have an explicit return type annotation
   | with --isolatedDeclarations.
-    ,-[66:8]
- 65 |   }
- 66 |   get [Symbol.toStringTag]() {
+    ,-[67:8]
+ 66 |   }
+ 67 |   get [Symbol.toStringTag]() {
     :        ^^^^^^^^^^^^^^^^^^
- 67 |     return GlobalSymbol4;
+ 68 |     return GlobalSymbol4;
     `----
 
 


### PR DESCRIPTION
Accessor property declaration emit preserved an explicit `public` modifier because it passed `property.accessibility` through unchanged. Property and method declarations already normalize public accessibility away with `transform_accessibility`, so accessors should use the same path.

This applies `Self::transform_accessibility` when emitting accessor properties and adds a fixture case for `public accessor i!: string`, which now snapshots as `accessor i: string;`.

Stacked on #22878.
