### PR TITLE
fix(linter): report errors when writing to the filesystem

### DIFF
--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -718,8 +718,15 @@ impl Runtime {
 
                         // If the new source text is owned, that means it was modified,
                         // so we write the new source text to the file.
-                        if let Cow::Owned(new_source_text) = &new_source_text {
-                            file_system.write_file(path, new_source_text).unwrap();
+                        if let Cow::Owned(new_source_text) = &new_source_text
+                            && let Err(error) = file_system.write_file(path, new_source_text)
+                        {
+                            tx_error
+                                .send(vec![Error::new(OxcDiagnostic::error(format!(
+                                    "Failed to write file {} with error \"{error}\"",
+                                    path.display()
+                                )))])
+                                .unwrap();
                         }
                     });
                 },

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -12,7 +12,7 @@ use oxc_allocator::Allocator;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic, Severity};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic, Severity};
 use oxc_span::{SourceType, Span};
 
 use super::{AllowWarnDeny, ConfigStore, DisableDirectives, ResolvedLinterState, read_to_string};
@@ -257,10 +257,15 @@ impl TsGoLintState {
                         .map(|st| if st.is_javascript() { st.with_jsx(true) } else { st });
                     let fix_result = Fixer::new(&source_text, messages, source_type).fix();
 
-                    if fix_result.fixed {
-                        file_system
-                            .write_file(&path, &fix_result.fixed_code)
-                            .expect("Failed to write fixed file");
+                    if fix_result.fixed
+                        && let Err(error) = file_system.write_file(&path, &fix_result.fixed_code)
+                    {
+                        sender_for_fixes
+                            .send(vec![Error::new(OxcDiagnostic::error(format!(
+                                "Failed to write file {} with error \"{error}\"",
+                                path.display()
+                            )))])
+                            .expect("Failed to send diagnostics");
                     }
 
                     if fix_result.messages.is_empty() {


### PR DESCRIPTION
`oxlint --fix` panicked when a filesystem write failed while applying fixes.

With this change, write failures are reported as diagnostics instead of unwrapping the result.

fixes #22858