### PR TITLE
feat(linter): expose `override::exclude_files` option

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -480,6 +480,16 @@ export interface OxlintOverride {
    */
   env?: OxlintEnv;
   /**
+   * A list of glob patterns to exclude from this override.
+   *
+   * Files matching these patterns are not globally ignored; this override
+   * simply does not apply to them.
+   *
+   * ## Example
+   * `[ "*.generated.ts", "fixtures/**" ]`
+   */
+  excludeFiles?: GlobSet;
+  /**
    * A list of glob patterns to override.
    *
    * ## Example

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -95,7 +95,6 @@ pub struct OxlintOverride {
     /// ## Example
     /// `[ "*.generated.ts", "fixtures/**" ]`
     #[serde(default, skip_serializing_if = "GlobSet::is_empty")]
-    #[schemars(skip)]
     pub exclude_files: GlobSet,
 
     /// Environments enable and disable collections of global variables.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -3037,6 +3037,15 @@
           ],
           "markdownDescription": "Environments enable and disable collections of global variables."
         },
+        "excludeFiles": {
+          "description": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
+          "markdownDescription": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`"
+        },
         "files": {
           "description": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`",
           "allOf": [
@@ -3274,4 +3283,3 @@
   },
   "markdownDescription": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json`\n\nExample\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"plugins\": [\"import\", \"typescript\", \"unicorn\"],\n\"env\": {\n\"browser\": true\n},\n\"globals\": {\n\"foo\": \"readonly\"\n},\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n},\n\"custom\": { \"option\": true }\n},\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\n\"overrides\": [\n{\n\"files\": [\"*.test.ts\", \"*.spec.ts\"],\n\"rules\": {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n}\n```\n\n`oxlint.config.ts`\n\n```ts\nimport { defineConfig } from \"oxlint\";\n\nexport default defineConfig({\nplugins: [\"import\", \"typescript\", \"unicorn\"],\nenv: {\n\"browser\": true\n},\nglobals: {\n\"foo\": \"readonly\"\n},\nsettings: {\nreact: {\nversion: \"18.2.0\"\n},\ncustom: { option: true }\n},\nrules: {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\noverrides: [\n{\nfiles: [\"*.test.ts\", \"*.spec.ts\"],\nrules: {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n});\n```"
 }
-

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -3041,6 +3041,15 @@ expression: json
           ],
           "markdownDescription": "Environments enable and disable collections of global variables."
         },
+        "excludeFiles": {
+          "description": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GlobSet"
+            }
+          ],
+          "markdownDescription": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`"
+        },
         "files": {
           "description": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`",
           "allOf": [

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -500,6 +500,23 @@ type: `object`
 Environments enable and disable collections of global variables.
 
 
+#### overrides[n].excludeFiles
+
+type: `string[]`
+
+
+A list of glob patterns to exclude from this override.
+
+Files matching these patterns are not globally ignored; this override
+simply does not apply to them.
+
+## Example
+`[ "*.generated.ts", "fixtures/**" ]`
+
+A set of glob patterns.
+Patterns are matched against paths relative to the configuration file's directory.
+
+
 #### overrides[n].files
 
 type: `string[]`


### PR DESCRIPTION
We originally removed this option from documentation as we wanted to flesh it out a little bit more before shipping it.

After that meeting, and some more thought, I think we have to ship it as is; the alternative ideas (negation in files matched) doesn't really work wihtout a breaking change which will be really annoying for users.

fixes #22837