### PR TITLE
feat(parser): emit TS1094 for accessor type parameters

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -751,6 +751,11 @@ pub fn a_set_accessor_cannot_have_a_return_type_annotation(span: Span) -> OxcDia
 }
 
 #[cold]
+pub fn accessor_cannot_have_type_parameters(span: Span) -> OxcDiagnostic {
+    ts_error("1094", "An accessor cannot have type parameters.").with_label(span)
+}
+
+#[cold]
 pub fn return_statement_only_in_function_body(span: Span) -> OxcDiagnostic {
     ts_error("1108", "A 'return' statement can only be used within a function body.")
         .with_label(span)

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -700,20 +700,24 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     #[cold]
     pub(crate) fn check_getter(&mut self, function: &Function<'a>) {
-        if !function.params.items.is_empty() {
+        if let Some(type_parameters) = &function.type_parameters {
+            self.error(diagnostics::accessor_cannot_have_type_parameters(type_parameters.span));
+        } else if !function.params.items.is_empty() {
             self.error(diagnostics::getter_parameters(function.params.span));
         }
     }
 
     #[cold]
     pub(crate) fn check_setter(&mut self, function: &Function<'a>) {
-        if let Some(rest) = &function.params.rest {
-            self.error(diagnostics::setter_with_rest_parameter(rest.span));
+        if let Some(type_parameters) = &function.type_parameters {
+            self.error(diagnostics::accessor_cannot_have_type_parameters(type_parameters.span));
         } else if function.params.parameters_count() != 1 {
             self.error(diagnostics::setter_with_parameters(
                 function.params.span,
                 function.params.parameters_count(),
             ));
+        } else if let Some(rest) = &function.params.rest {
+            self.error(diagnostics::setter_with_rest_parameter(rest.span));
         } else if self.is_ts && function.params.items.first().unwrap().initializer.is_some() {
             self.error(diagnostics::setter_with_initializer(function.params.span));
         }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: e5509e21
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1630/2640 (61.74%)
+Negative Passed: 1632/2640 (61.82%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -1724,11 +1724,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors3.ts
 
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserGetAccessorWithTypeParameters1.ts
-
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeAnnotation1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass2.ts
 
@@ -24379,6 +24375,22 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                  ──────
    ╰────
   help: Remove parameters except the first one here
+
+  × TS(1094): An accessor cannot have type parameters.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserGetAccessorWithTypeParameters1.ts:2:10]
+ 1 │ class C {
+ 2 │   get foo<T>() { }
+   ·          ───
+ 3 │ }
+   ╰────
+
+  × TS(1094): An accessor cannot have type parameters.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts:2:11]
+ 1 │ class C {
+ 2 │    set foo<T>(v) { }
+   ·           ───
+ 3 │ }
+   ╰────
 
   × TS(1090): 'public' modifier cannot appear on a parameter.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression1.ts:1:10]


### PR DESCRIPTION
Adds parser validation for TypeScript accessor declarations with type parameters.

TypeScript reports TS1094 for accessors like `get foo<T>()` and `set foo<T>(value)`. Oxc already parsed the type parameters, but did not emit the matching parser diagnostic, so the relevant TypeScript conformance cases were still listed as expected syntax errors.