### PR TITLE
fix(semantic): bind type-only import-equals declarations correctly

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -366,7 +366,7 @@ impl<'a> Binder<'a> for ImportNamespaceSpecifier<'a> {
 
 impl<'a> Binder<'a> for TSImportEqualsDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        declare_symbol_for_import_specifier(&self.id, false, builder);
+        declare_symbol_for_import_specifier(&self.id, self.import_kind.is_type(), builder);
     }
 }
 


### PR DESCRIPTION
Fix for #22786

Update TSImportEqualsDeclaration binding to respect import_kind.

Now uses:
```rust
self.import_kind.is_type()