### PR TITLE
feat(parser): report TS1051 for optional setter parameter

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -718,8 +718,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             ));
         } else if let Some(rest) = &function.params.rest {
             self.error(diagnostics::setter_with_rest_parameter(rest.span));
-        } else if self.is_ts && function.params.items.first().unwrap().initializer.is_some() {
-            self.error(diagnostics::setter_with_initializer(function.params.span));
+        } else if self.is_ts {
+            let param = function.params.items.first().unwrap();
+            if param.optional {
+                self.error(diagnostics::setter_with_optional_parameter(param.span));
+            } else if param.initializer.is_some() {
+                self.error(diagnostics::setter_with_initializer(function.params.span));
+            }
         }
     }
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: e5509e21
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1632/2640 (61.82%)
+Negative Passed: 1634/2640 (61.89%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -719,8 +719,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/operatorAddN
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams3.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalSetterParam.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts
 
@@ -1757,8 +1755,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessor1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration17.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration2.ts
 
@@ -10203,6 +10199,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·       ─
  12 │     ?(): any; //err
     ╰────
+
+  × TS(1051): A 'set' accessor cannot have an optional parameter.
+   ╭─[typescript/tests/cases/compiler/optionalSetterParam.ts:3:20]
+ 2 │ 
+ 3 │     public set bar(param?:any) { }
+   ·                    ──────────
+ 4 │ }
+   ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/compiler/overloadConsecutiveness.ts:3:14]
@@ -25884,6 +25888,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  1 │ class C {
  2 │    set Foo(a = 1) { }
    ·           ───────
+ 3 │ }
+   ╰────
+
+  × TS(1051): A 'set' accessor cannot have an optional parameter.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration17.ts:2:12]
+ 1 │ class C {
+ 2 │    set Foo(a?: number) { }
+   ·            ──────────
  3 │ }
    ╰────
 


### PR DESCRIPTION
Fixes a missing TypeScript parser diagnostic for optional setter parameters.

TypeScript reports `TS1051` for setters like:

```ts
class C {
  set Foo(a?: number) {}
}
```

Oxc already had the diagnostic defined and used it for TypeScript accessor signatures, but concrete class/object setter validation only checked rest parameters and initializers. This adds the missing `param.optional` check in TypeScript mode and updates the parser TypeScript coverage snapshot.

