### PR TITLE
fix(linter/expect-expect): align default rule options

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -235,6 +235,11 @@ fn test() {
             Some(serde_json::json!([{ "assertFunctionNames": ["request.foo**.expect"] }])),
         ),
         (
+            "test('should fail with implicit defaults', () => request.post().send().expect(457));",
+            None,
+        ),
+        (r#"it("should fail with implicit defaults",() => expectSaga(mySaga).returns());"#, None),
+        (
             "test('should fail', () => tester.request(123));",
             Some(serde_json::json!([{ "assertFunctionNames": ["request.*"] }])),
         ),

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -74,12 +74,19 @@ impl Default for ExpectExpectConfig {
     }
 }
 
+fn default_assert_function_names_jest() -> Vec<CompactStr> {
+    vec!["expect".into()]
+}
+
+fn default_assert_function_names_vitest() -> Vec<CompactStr> {
+    vec!["expect".into(), "expectTypeOf".into(), "assert".into(), "assertType".into()]
+}
+
 impl ExpectExpectConfig {
     #[expect(clippy::unnecessary_wraps)]
     pub fn from_configuration(value: &serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let default_assert_function_names_jest = vec!["expect".into()];
-        let default_assert_function_names_vitest =
-            vec!["expect".into(), "expectTypeOf".into(), "assert".into(), "assertType".into()];
+        let default_assert_function_names_jest = default_assert_function_names_jest();
+        let default_assert_function_names_vitest = default_assert_function_names_vitest();
         let config = value.get(0);
 
         let assert_function_names = config
@@ -88,7 +95,7 @@ impl ExpectExpectConfig {
             .map(|v| {
                 v.iter()
                     .filter_map(serde_json::Value::as_str)
-                    .map(convert_pattern)
+                    .map(CompactStr::from)
                     .collect::<Vec<_>>()
             });
 
@@ -151,8 +158,10 @@ fn run<'a>(
             } else {
                 &rule.assert_function_names_jest
             };
+            let assert_function_names =
+                assert_function_names.iter().map(|name| convert_pattern(name)).collect::<Vec<_>>();
 
-            let mut visitor = AssertionVisitor::new(ctx, assert_function_names);
+            let mut visitor = AssertionVisitor::new(ctx, &assert_function_names);
 
             // Visit each argument of the test call
             for argument in &call_expr.arguments {

--- a/crates/oxc_linter/src/rules/vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/expect_expect.rs
@@ -302,6 +302,16 @@ fn test() {
             Some(serde_json::json!([{ "assertFunctionNames": ["request.foo**.expect"] }])),
         ),
         (
+            "test('should fail with implicit defaults', () => request.post().send().expect(457));",
+            None,
+        ),
+        (
+            "test('should fail with explicit defaults', () => request.put().send().expect(458));",
+            Some(serde_json::json!([{
+                "assertFunctionNames": ["expect", "expectTypeOf", "assert", "assertType"],
+            }])),
+        ),
+        (
             "test('should fail', () => tester.request(123));",
             Some(serde_json::json!([{ "assertFunctionNames": ["request.*"] }])),
         ),

--- a/crates/oxc_linter/src/snapshots/jest_expect_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_expect_expect.snap
@@ -74,6 +74,20 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ jest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
+ 1 │ test('should fail with implicit defaults', () => request.post().send().expect(457));
+   · ────
+   ╰────
+  help: Add assertion(s) in this Test
+
+  ⚠ jest(expect-expect): Test has no assertions
+   ╭─[expect_expect.tsx:1:1]
+ 1 │ it("should fail with implicit defaults",() => expectSaga(mySaga).returns());
+   · ──
+   ╰────
+  help: Add assertion(s) in this Test
+
+  ⚠ jest(expect-expect): Test has no assertions
+   ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => tester.request(123));
    · ────
    ╰────

--- a/crates/oxc_linter/src/snapshots/vitest_expect_expect.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_expect_expect.snap
@@ -67,6 +67,20 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ vitest(expect-expect): Test has no assertions
    ╭─[expect_expect.tsx:1:1]
+ 1 │ test('should fail with implicit defaults', () => request.post().send().expect(457));
+   · ────
+   ╰────
+  help: Add assertion(s) in this Test
+
+  ⚠ vitest(expect-expect): Test has no assertions
+   ╭─[expect_expect.tsx:1:1]
+ 1 │ test('should fail with explicit defaults', () => request.put().send().expect(458));
+   · ────
+   ╰────
+  help: Add assertion(s) in this Test
+
+  ⚠ vitest(expect-expect): Test has no assertions
+   ╭─[expect_expect.tsx:1:1]
  1 │ test('should fail', () => tester.request(123));
    · ────
    ╰────


### PR DESCRIPTION
`expect-expect` was using two different matching paths for the same documented defaults. The built-in defaults were stored as raw strings, while user-provided `assertFunctionNames` values were converted through the rule’s glob-pattern matcher.

That made the implicit and explicit Vitest defaults behave differently:

```js
it("returns 501", async () => {
  await request(app).post("/").send(body).expect(501);
});
```

With no override, Oxlint previously treated the terminal `.expect()` call as an assertion because the raw `"expect"` default matched anywhere in the computed call name. With the documented explicit defaults, `"expect"` was converted to an anchored pattern, so the same test was reported as having no assertions.

This PR routes the built-in Jest and Vitest defaults through the same `convert_pattern` path as explicit config values. As a result, implicit defaults and explicit documented defaults are now equivalent and match upstream `eslint-plugin-jest` / `@vitest/eslint-plugin` behavior. Users who want supertest-style chained assertions can still opt in with a pattern such as:

```js
{
  "assertFunctionNames": ["expect", "request.**.expect"]
}
```

fixes #22876