### PR TITLE
docs(tasks): correct commands for running tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,15 +288,15 @@ These test suites are pre-cloned and ready to search:
 NAPI packages use **Vitest** for testing Node.js bindings:
 
 ```bash
-pnpm build-dev    # Build all NAPI packages
-pnpm test         # Run all NAPI tests
+pnpm run build-test   # Build all NAPI packages
+pnpm test             # Run all NAPI tests
 ```
 
 **Package-specific commands:**
 
-- `oxc-parser`: `cd napi/parser && pnpm test` (also has `pnpm test-browser`)
-- `oxc-minify`: `cd napi/minify && pnpm test`
-- `oxc-transform`: `cd napi/transform && pnpm test`
+- `oxc-parser`: `cd napi/parser && pnpm run build-test && pnpm test` (also has `pnpm test-browser`)
+- `oxc-minify`: `cd napi/minify && pnpm run build-test && pnpm test`
+- `oxc-transform`: `cd napi/transform && pnpm run build-test && pnpm test`
 
 Tests are TypeScript files in each package's `test/` directory.
 

--- a/tasks/e2e/README.md
+++ b/tasks/e2e/README.md
@@ -3,6 +3,8 @@
 Node.js runtime tests for transformer and minifier.
 
 ```
-pnpm run build-dev
-pnpm run test
+# From repo root
+pnpm --filter "./napi/minify" --filter "./napi/transform" run build-test
+cd tasks/e2e
+pnpm test
 ```


### PR DESCRIPTION
`pnpm run build-test` is the correct command for building NAPI packages for running tests, not `pnpm build-dev`. Correct the docs accordingly. Also clarify the commands for running e2e tests.