### PR TITLE
feat(linter/vue): implement prop-name-casing rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1327,6 +1327,7 @@ export interface DummyRuleMap {
   "vue/no-this-in-before-route-enter"?: DummyRule;
   "vue/no-watch-after-await"?: DummyRule;
   "vue/prefer-import-from-vue"?: DummyRule;
+  "vue/prop-name-casing"?: DummyRule;
   "vue/require-default-export"?: DummyRule;
   "vue/require-prop-type-constructor"?: DummyRule;
   "vue/require-render-return"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5125,6 +5125,12 @@ impl RuleRunner for crate::rules::vue::prefer_import_from_vue::PreferImportFromV
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vue::prop_name_casing::PropNameCasing {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::require_default_export::RequireDefaultExport {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -816,6 +816,7 @@ pub use crate::rules::vue::no_shared_component_data::NoSharedComponentData as Vu
 pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnter as VueNoThisInBeforeRouteEnter;
 pub use crate::rules::vue::no_watch_after_await::NoWatchAfterAwait as VueNoWatchAfterAwait;
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
+pub use crate::rules::vue::prop_name_casing::PropNameCasing as VuePropNameCasing;
 pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRequireDefaultExport;
 pub use crate::rules::vue::require_prop_type_constructor::RequirePropTypeConstructor as VueRequirePropTypeConstructor;
 pub use crate::rules::vue::require_render_return::RequireRenderReturn as VueRequireRenderReturn;
@@ -1653,6 +1654,7 @@ pub enum RuleEnum {
     VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter),
     VueNoWatchAfterAwait(VueNoWatchAfterAwait),
     VuePreferImportFromVue(VuePreferImportFromVue),
+    VuePropNameCasing(VuePropNameCasing),
     VueRequireDefaultExport(VueRequireDefaultExport),
     VueRequirePropTypeConstructor(VueRequirePropTypeConstructor),
     VueRequireRenderReturn(VueRequireRenderReturn),
@@ -2577,7 +2579,8 @@ const VUE_NO_SHARED_COMPONENT_DATA_ID: usize = VUE_NO_RESERVED_COMPONENT_NAMES_I
 const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize = VUE_NO_SHARED_COMPONENT_DATA_ID + 1usize;
 const VUE_NO_WATCH_AFTER_AWAIT_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
 const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
-const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
+const VUE_PROP_NAME_CASING_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
+const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PROP_NAME_CASING_ID + 1usize;
 const VUE_REQUIRE_PROP_TYPE_CONSTRUCTOR_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
 const VUE_REQUIRE_RENDER_RETURN_ID: usize = VUE_REQUIRE_PROP_TYPE_CONSTRUCTOR_ID + 1usize;
 const VUE_REQUIRE_SLOTS_AS_FUNCTIONS_ID: usize = VUE_REQUIRE_RENDER_RETURN_ID + 1usize;
@@ -3525,6 +3528,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID,
             Self::VueNoWatchAfterAwait(_) => VUE_NO_WATCH_AFTER_AWAIT_ID,
             Self::VuePreferImportFromVue(_) => VUE_PREFER_IMPORT_FROM_VUE_ID,
+            Self::VuePropNameCasing(_) => VUE_PROP_NAME_CASING_ID,
             Self::VueRequireDefaultExport(_) => VUE_REQUIRE_DEFAULT_EXPORT_ID,
             Self::VueRequirePropTypeConstructor(_) => VUE_REQUIRE_PROP_TYPE_CONSTRUCTOR_ID,
             Self::VueRequireRenderReturn(_) => VUE_REQUIRE_RENDER_RETURN_ID,
@@ -4458,6 +4462,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::NAME,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::NAME,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
+            Self::VuePropNameCasing(_) => VuePropNameCasing::NAME,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::NAME,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::NAME,
             Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::NAME,
@@ -5449,6 +5454,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::CATEGORY,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::CATEGORY,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
+            Self::VuePropNameCasing(_) => VuePropNameCasing::CATEGORY,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::CATEGORY,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::CATEGORY,
             Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::CATEGORY,
@@ -6383,6 +6389,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::FIX,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::FIX,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
+            Self::VuePropNameCasing(_) => VuePropNameCasing::FIX,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::FIX,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::FIX,
             Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::FIX,
@@ -7577,6 +7584,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::documentation(),
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::documentation(),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
+            Self::VuePropNameCasing(_) => VuePropNameCasing::documentation(),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::documentation(),
             Self::VueRequirePropTypeConstructor(_) => {
                 VueRequirePropTypeConstructor::documentation()
@@ -9925,6 +9933,8 @@ impl RuleEnum {
                 .or_else(|| VueNoWatchAfterAwait::schema(generator)),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::config_schema(generator)
                 .or_else(|| VuePreferImportFromVue::schema(generator)),
+            Self::VuePropNameCasing(_) => VuePropNameCasing::config_schema(generator)
+                .or_else(|| VuePropNameCasing::schema(generator)),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::config_schema(generator)
                 .or_else(|| VueRequireDefaultExport::schema(generator)),
             Self::VueRequirePropTypeConstructor(_) => {
@@ -10767,6 +10777,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => "vue",
             Self::VueNoWatchAfterAwait(_) => "vue",
             Self::VuePreferImportFromVue(_) => "vue",
+            Self::VuePropNameCasing(_) => "vue",
             Self::VueRequireDefaultExport(_) => "vue",
             Self::VueRequirePropTypeConstructor(_) => "vue",
             Self::VueRequireRenderReturn(_) => "vue",
@@ -13391,6 +13402,9 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => {
                 Ok(Self::VuePreferImportFromVue(VuePreferImportFromVue::from_configuration(value)?))
             }
+            Self::VuePropNameCasing(_) => {
+                Ok(Self::VuePropNameCasing(VuePropNameCasing::from_configuration(value)?))
+            }
             Self::VueRequireDefaultExport(_) => Ok(Self::VueRequireDefaultExport(
                 VueRequireDefaultExport::from_configuration(value)?,
             )),
@@ -14240,6 +14254,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.to_configuration(),
             Self::VueNoWatchAfterAwait(rule) => rule.to_configuration(),
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
+            Self::VuePropNameCasing(rule) => rule.to_configuration(),
             Self::VueRequireDefaultExport(rule) => rule.to_configuration(),
             Self::VueRequirePropTypeConstructor(rule) => rule.to_configuration(),
             Self::VueRequireRenderReturn(rule) => rule.to_configuration(),
@@ -15073,6 +15088,7 @@ impl RuleEnum {
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
+                Self::VuePropNameCasing(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run(node, ctx),
                 Self::VueRequireRenderReturn(rule) => rule.run(node, ctx),
@@ -15899,6 +15915,7 @@ impl RuleEnum {
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
+                Self::VuePropNameCasing(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run(node, ctx),
                 Self::VueRequireRenderReturn(rule) => rule.run(node, ctx),
@@ -16732,6 +16749,7 @@ impl RuleEnum {
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
+                Self::VuePropNameCasing(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_once(ctx),
                 Self::VueRequireRenderReturn(rule) => rule.run_once(ctx),
@@ -17558,6 +17576,7 @@ impl RuleEnum {
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
+                Self::VuePropNameCasing(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_once(ctx),
                 Self::VueRequireRenderReturn(rule) => rule.run_once(ctx),
@@ -18648,6 +18667,7 @@ impl RuleEnum {
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VuePropNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireRenderReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19730,6 +19750,7 @@ impl RuleEnum {
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VuePropNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireRenderReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20554,6 +20575,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.should_run(ctx),
             Self::VueNoWatchAfterAwait(rule) => rule.should_run(ctx),
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
+            Self::VuePropNameCasing(rule) => rule.should_run(ctx),
             Self::VueRequireDefaultExport(rule) => rule.should_run(ctx),
             Self::VueRequirePropTypeConstructor(rule) => rule.should_run(ctx),
             Self::VueRequireRenderReturn(rule) => rule.should_run(ctx),
@@ -21747,6 +21769,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::IS_TSGOLINT_RULE,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::IS_TSGOLINT_RULE,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
+            Self::VuePropNameCasing(_) => VuePropNameCasing::IS_TSGOLINT_RULE,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::IS_TSGOLINT_RULE,
             Self::VueRequirePropTypeConstructor(_) => {
                 VueRequirePropTypeConstructor::IS_TSGOLINT_RULE
@@ -22742,6 +22765,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::VERSION,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::VERSION,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::VERSION,
+            Self::VuePropNameCasing(_) => VuePropNameCasing::VERSION,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::VERSION,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::VERSION,
             Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::VERSION,
@@ -23772,6 +23796,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::HAS_CONFIG,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::HAS_CONFIG,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::HAS_CONFIG,
+            Self::VuePropNameCasing(_) => VuePropNameCasing::HAS_CONFIG,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::HAS_CONFIG,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::HAS_CONFIG,
             Self::VueRequireRenderReturn(_) => VueRequireRenderReturn::HAS_CONFIG,
@@ -24595,6 +24620,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.types_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.types_info(),
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
+            Self::VuePropNameCasing(rule) => rule.types_info(),
             Self::VueRequireDefaultExport(rule) => rule.types_info(),
             Self::VueRequirePropTypeConstructor(rule) => rule.types_info(),
             Self::VueRequireRenderReturn(rule) => rule.types_info(),
@@ -25418,6 +25444,7 @@ impl RuleEnum {
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.run_info(),
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
+            Self::VuePropNameCasing(rule) => rule.run_info(),
             Self::VueRequireDefaultExport(rule) => rule.run_info(),
             Self::VueRequirePropTypeConstructor(rule) => rule.run_info(),
             Self::VueRequireRenderReturn(rule) => rule.run_info(),
@@ -26373,6 +26400,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter::default()),
         RuleEnum::VueNoWatchAfterAwait(VueNoWatchAfterAwait::default()),
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),
+        RuleEnum::VuePropNameCasing(VuePropNameCasing::default()),
         RuleEnum::VueRequireDefaultExport(VueRequireDefaultExport::default()),
         RuleEnum::VueRequirePropTypeConstructor(VueRequirePropTypeConstructor::default()),
         RuleEnum::VueRequireRenderReturn(VueRequireRenderReturn::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -868,6 +868,7 @@ pub(crate) mod vue {
     pub mod no_this_in_before_route_enter;
     pub mod no_watch_after_await;
     pub mod prefer_import_from_vue;
+    pub mod prop_name_casing;
     pub mod require_default_export;
     pub mod require_prop_type_constructor;
     pub mod require_render_return;

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -1,6 +1,7 @@
-use std::ops::Deref;
-
 use lazy_regex::Regex;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_ast::{
     AstKind,
     ast::{
@@ -11,8 +12,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -18,7 +18,7 @@ use crate::{
     ast_util::get_declaration_from_reference_id,
     context::LintContext,
     frameworks::FrameworkOptions,
-    rule::Rule,
+    rule::{Rule, TupleRuleConfig},
     utils::{find_property, is_vue_component_options_object_excluding_instance},
 };
 
@@ -48,18 +48,14 @@ impl CaseType {
 pub struct PropNameCasing(Box<Config>);
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
-pub struct Config {
-    case_type: CaseType,
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct Options {
     ignore_props: Vec<String>,
 }
 
-impl Deref for PropNameCasing {
-    type Target = Config;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct Config(CaseType, Options);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -99,30 +95,13 @@ declare_oxc_lint!(
     PropNameCasing,
     vue,
     style,
-    config = PropNameCasing,
+    config = Config,
     version = "next",
 );
 
 impl Rule for PropNameCasing {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
-        let case_type = value
-            .get(0)
-            .and_then(|v| v.as_str())
-            .and_then(|s| match s {
-                "camelCase" => Some(CaseType::CamelCase),
-                "snake_case" => Some(CaseType::SnakeCase),
-                _ => None,
-            })
-            .unwrap_or_default();
-        let ignore_props = value
-            .get(1)
-            .and_then(|v| v.get("ignoreProps"))
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter().filter_map(|v| v.as_str().map(ToString::to_string)).collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-        Ok(Self(Box::new(Config { case_type, ignore_props })))
+        serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -224,13 +203,14 @@ impl PropNameCasing {
     }
 
     fn report_if_invalid(&self, name: &str, span: Span, ctx: &LintContext<'_>) {
-        if is_ignored(name, &self.ignore_props) {
+        let Config(case_type, options) = &*self.0;
+        if is_ignored(name, &options.ignore_props) {
             return;
         }
-        if check_case(name, self.case_type) {
+        if check_case(name, *case_type) {
             return;
         }
-        ctx.diagnostic(prop_name_casing_diagnostic(span, name, self.case_type.as_str()));
+        ctx.diagnostic(prop_name_casing_diagnostic(span, name, case_type.as_str()));
     }
 }
 

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -1,0 +1,1059 @@
+use std::ops::Deref;
+
+use lazy_regex::Regex;
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrayExpression, ArrayExpressionElement, CallExpression, Expression, ObjectExpression,
+        ObjectPropertyKind, PropertyKey, TSSignature, TSType, TSTypeName, TSTypeReference,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    ast_util::get_declaration_from_reference_id,
+    context::LintContext,
+    frameworks::FrameworkOptions,
+    rule::Rule,
+    utils::{find_property, is_vue_component_options_object_excluding_instance},
+};
+
+fn prop_name_casing_diagnostic(span: Span, name: &str, case_type: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prop \"{name}\" is not in {case_type}.")).with_label(span)
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+enum CaseType {
+    #[default]
+    #[serde(rename = "camelCase")]
+    CamelCase,
+    #[serde(rename = "snake_case")]
+    SnakeCase,
+}
+
+impl CaseType {
+    fn as_str(self) -> &'static str {
+        match self {
+            CaseType::CamelCase => "camelCase",
+            CaseType::SnakeCase => "snake_case",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PropNameCasing(Box<Config>);
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct Config {
+    case_type: CaseType,
+    ignore_props: Vec<String>,
+}
+
+impl Deref for PropNameCasing {
+    type Target = Config;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce a specific casing (camelCase or snake_case) for Vue component
+    /// prop names.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent prop name casing makes templates harder to read and grep
+    /// for. Pinning props to a single casing across the codebase keeps the
+    /// declaration site and the call site aligned.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule (default `camelCase`):
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     greeting_text: String,
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule (default `camelCase`):
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     greetingText: String,
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    PropNameCasing,
+    vue,
+    style,
+    config = PropNameCasing,
+    version = "next",
+);
+
+impl Rule for PropNameCasing {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        let case_type = value
+            .get(0)
+            .and_then(|v| v.as_str())
+            .and_then(|s| match s {
+                "camelCase" => Some(CaseType::CamelCase),
+                "snake_case" => Some(CaseType::SnakeCase),
+                _ => None,
+            })
+            .unwrap_or_default();
+        let ignore_props = value
+            .get(1)
+            .and_then(|v| v.get("ignoreProps"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter().filter_map(|v| v.as_str().map(ToString::to_string)).collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        Ok(Self(Box::new(Config { case_type, ignore_props })))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::ObjectExpression(obj) => {
+                if !is_vue_component_options_object_excluding_instance(node, ctx) {
+                    return;
+                }
+                let Some(props_prop) = find_property(obj, "props") else { return };
+                self.check_props_value(&props_prop.value, ctx);
+            }
+            AstKind::CallExpression(call) => {
+                if ctx.frameworks_options() != FrameworkOptions::VueSetup {
+                    return;
+                }
+                self.check_define_props(call, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl PropNameCasing {
+    fn check_define_props<'a>(&self, call: &CallExpression<'a>, ctx: &LintContext<'a>) {
+        let Some(ident) = call.callee.get_identifier_reference() else { return };
+        if ident.name != "defineProps" {
+            return;
+        }
+        if let Some(arg) = call.arguments.first().and_then(|a| a.as_expression()) {
+            self.check_props_value(arg, ctx);
+            return;
+        }
+        // `defineProps<T>()` — only the same-file `interface Props { ... }` shape is checked.
+        // The `import { Props } from './x'` shape requires cross-file TS type resolution and
+        // is handled by tsgolint (see the test() comment for details).
+        let Some(type_arguments) = call.type_arguments.as_deref() else { return };
+        let Some(first_type) = type_arguments.params.first() else { return };
+        self.check_type_argument(first_type, ctx);
+    }
+
+    fn check_props_value<'a>(&self, expr: &Expression<'a>, ctx: &LintContext<'a>) {
+        match expr.get_inner_expression() {
+            Expression::ArrayExpression(arr) => self.check_array_props(arr, ctx),
+            Expression::ObjectExpression(obj) => self.check_object_props(obj, ctx),
+            _ => {}
+        }
+    }
+
+    fn check_array_props<'a>(&self, arr: &ArrayExpression<'a>, ctx: &LintContext<'a>) {
+        for element in &arr.elements {
+            let ArrayExpressionElement::StringLiteral(lit) = element else { continue };
+            self.report_if_invalid(lit.value.as_str(), lit.span, ctx);
+        }
+    }
+
+    fn check_object_props<'a>(&self, obj: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+        for prop in &obj.properties {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop else { continue };
+            let Some((name, span)) = property_key_static_name(&prop.key) else { continue };
+            self.report_if_invalid(name.as_ref(), span, ctx);
+        }
+    }
+
+    fn check_type_argument<'a>(&self, ts_type: &TSType<'a>, ctx: &LintContext<'a>) {
+        match ts_type {
+            TSType::TSTypeReference(type_ref) => self.check_type_reference(type_ref, ctx),
+            TSType::TSTypeLiteral(type_literal) => {
+                self.check_signatures(&type_literal.members, ctx);
+            }
+            _ => {}
+        }
+    }
+
+    fn check_type_reference<'a>(&self, type_ref: &TSTypeReference<'a>, ctx: &LintContext<'a>) {
+        let TSTypeName::IdentifierReference(ident_ref) = &type_ref.type_name else { return };
+        let reference = ctx.scoping().get_reference(ident_ref.reference_id());
+        if !reference.is_type() {
+            return;
+        }
+        let Some(declaration) =
+            get_declaration_from_reference_id(ident_ref.reference_id(), ctx.semantic())
+        else {
+            return;
+        };
+        let AstKind::TSInterfaceDeclaration(interface_decl) = declaration.kind() else { return };
+        self.check_signatures(&interface_decl.body.body, ctx);
+    }
+
+    fn check_signatures<'a>(&self, signatures: &[TSSignature<'a>], ctx: &LintContext<'a>) {
+        for signature in signatures {
+            let (key_opt, span) = match signature {
+                TSSignature::TSPropertySignature(sig) => (sig.key.static_name(), sig.key.span()),
+                TSSignature::TSMethodSignature(sig) => (sig.key.static_name(), sig.key.span()),
+                _ => continue,
+            };
+            let Some(name) = key_opt else { continue };
+            self.report_if_invalid(name.as_ref(), span, ctx);
+        }
+    }
+
+    fn report_if_invalid(&self, name: &str, span: Span, ctx: &LintContext<'_>) {
+        if is_ignored(name, &self.ignore_props) {
+            return;
+        }
+        if check_case(name, self.case_type) {
+            return;
+        }
+        ctx.diagnostic(prop_name_casing_diagnostic(span, name, self.case_type.as_str()));
+    }
+}
+
+/// Returns `(static_name, span_of_key_text)` for a property key when it can be
+/// resolved statically. Dynamic keys (computed identifiers, calls, binary
+/// expressions, etc.) return `None`.
+fn property_key_static_name<'a>(
+    key: &PropertyKey<'a>,
+) -> Option<(std::borrow::Cow<'a, str>, Span)> {
+    match key {
+        PropertyKey::StaticIdentifier(ident) => Some((ident.name.as_str().into(), ident.span)),
+        PropertyKey::PrivateIdentifier(_) => None,
+        key => {
+            // Computed key expressions: pull the inner expression and accept
+            // statically resolvable literals (string / template literal /
+            // identifier in parenthesized form). Other shapes (variable,
+            // call, binary expression, member, this, regex literal handled
+            // specially) are treated dynamically.
+            let expr = key.as_expression()?.get_inner_expression();
+            match expr {
+                Expression::StringLiteral(lit) => Some((lit.value.as_str().into(), lit.span)),
+                Expression::TemplateLiteral(tpl)
+                    if tpl.expressions.is_empty() && tpl.quasis.len() == 1 =>
+                {
+                    let quasi = tpl.quasis.first()?;
+                    let cooked = quasi.value.cooked.as_ref()?;
+                    Some((cooked.as_str().into(), tpl.span))
+                }
+                Expression::RegExpLiteral(regex) => {
+                    Some((regex.raw.as_ref()?.as_str().into(), regex.span))
+                }
+                _ => None,
+            }
+        }
+    }
+}
+
+fn check_case(s: &str, case_type: CaseType) -> bool {
+    match case_type {
+        CaseType::CamelCase => is_camel_case(s),
+        CaseType::SnakeCase => is_snake_case(s),
+    }
+}
+
+fn has_symbols(s: &str) -> bool {
+    // [!"#%&'()*+,./:;<=>?@[\]^`{|}] — without " ", "$", "-" and "_"
+    s.chars().any(|c| {
+        matches!(
+            c,
+            '!' | '"'
+                | '#'
+                | '%'
+                | '&'
+                | '\''
+                | '('
+                | ')'
+                | '*'
+                | '+'
+                | ','
+                | '.'
+                | '/'
+                | ':'
+                | ';'
+                | '<'
+                | '='
+                | '>'
+                | '?'
+                | '@'
+                | '['
+                | '\\'
+                | ']'
+                | '^'
+                | '`'
+                | '{'
+                | '|'
+                | '}'
+        )
+    })
+}
+
+fn has_upper(s: &str) -> bool {
+    s.chars().any(|c| c.is_ascii_uppercase())
+}
+
+fn is_camel_case(s: &str) -> bool {
+    !has_symbols(s)
+        && !s.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+        && !s.chars().any(|c| matches!(c, '-' | '_') || c.is_whitespace())
+}
+
+fn is_snake_case(s: &str) -> bool {
+    if has_upper(s) || has_symbols(s) {
+        return false;
+    }
+    if s.contains('-') || s.contains("__") || s.chars().any(char::is_whitespace) {
+        return false;
+    }
+    true
+}
+
+/// Matches upstream `toRegExpGroupMatcher`: a pattern wrapped in slashes
+/// (`/foo/`) is treated as a regular expression; everything else is a
+/// literal string compare.
+fn is_ignored(name: &str, patterns: &[String]) -> bool {
+    for pattern in patterns {
+        let bytes = pattern.as_bytes();
+        if bytes.len() >= 2 && bytes[0] == b'/' && bytes[bytes.len() - 1] == b'/' {
+            let inner = &pattern[1..pattern.len() - 1];
+            if Regex::new(inner).is_ok_and(|re| re.is_match(name)) {
+                return true;
+            }
+        } else if pattern == name {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                    <script>
+                    export default {
+                      props: ['greetingText']
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: some_props
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        ...some_props,
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: ['greetingText']
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["camelCase"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: ['greeting_text']
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["snake_case"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        greetingText: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                  <script>
+                  export default {
+                    props: {
+                      greetingText: String
+                    }
+                  }
+                  </script>
+                  ",
+            Some(serde_json::json!(["camelCase"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                  <script>
+                  export default {
+                    props: {
+                      greeting_text: String
+                    }
+                  }
+                  </script>
+                  ",
+            Some(serde_json::json!(["snake_case"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        ['greetingText']: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [('greetingText')]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [`greeting${'-'}text`]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        greetingText
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [greeting_text]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [greeting.text]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        ['greeting'+'-text']: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [greeting_text()]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [this]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [['greeting-text']]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [1]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [true]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [null]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        '漢字': String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        '🍻': String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        $actionEl: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        $css: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        _item: String
+                      }
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["snake_case"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                  <script setup>
+                  defineProps({
+                    greetingText: String
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  defineProps(['greetingText'])
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions },
+        (
+            r#"
+                  <script setup lang="ts">
+                  interface Props {
+                    greetingText: number
+                  }
+                  defineProps<Props>()
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        'ignored-pattern-test': String,
+                        ignored_prop: Number,
+                        validProp: Boolean
+                      }
+                    }
+                    </script>
+                  ",
+            Some(
+                serde_json::json!([ "camelCase", { "ignoreProps": ["ignored_prop", "/^ignored-pattern-/"] } ]),
+            ),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+           // NOTE: upstream `prop-name-casing` valid test using `getTypeScriptFixtureTestOptions`
+           // (`import {Props2 as Props} from './test01' ; defineProps<Props>()`) is skipped here for
+           // the same reason as the matching invalid case below: cross-file TypeScript type resolution
+           // is the `tsgolint` domain in oxc.
+    ];
+
+    let fail = vec![
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        greeting_text: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        greeting_text: String
+                      }
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["camelCase"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: ['greeting_text']
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["camelCase"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        greetingText: String
+                      }
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["snake_case"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        'greeting-text': String
+                      }
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["camelCase"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        'greeting-text': String
+                      }
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["snake_case"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        'greeting_text': String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        ['greeting-text']: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        greeting_text
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        'abc-123-def': String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [('greeting-text')]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        _item: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        _itemName: String
+                      }
+                    }
+                    </script>
+                  ",
+            Some(serde_json::json!(["snake_case"])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [`greeting-text`]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        [/greeting-text/]: String
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                  <script setup>
+                  defineProps({
+                    greeting_text: String
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  defineProps(['greeting_text'])
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions },
+        (
+            r#"
+                  <script setup lang="ts">
+                  interface Props {
+                    greeting_text: number
+                  }
+                  defineProps<Props>()
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (
+            "
+                    <script>
+                    export default {
+                      props: {
+                        notIgnored_prop: String,
+                        'other-pattern': Number,
+                        'pattern-valid': String
+                      }
+                    }
+                    </script>
+                  ",
+            Some(
+                serde_json::json!(["camelCase", { "ignoreProps": ["ignored_prop", "/^pattern-/"] }]),
+            ),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script>
+                    export default {
+                      props: ['notIgnored_prop', 'pattern_invalid', 'validProp', 'pattern-valid']
+                    }
+                    </script>
+                  ",
+            Some(
+                serde_json::json!(["camelCase", { "ignoreProps": ["ignored_prop", "/^pattern-/"] }]),
+            ),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+           // NOTE: upstream `prop-name-casing` invalid test using `getTypeScriptFixtureTestOptions`
+           // (`import {Props3 as Props} from './test01' ; defineProps<Props>()`) is skipped here —
+           // cross-file TypeScript type resolution is the `tsgolint` domain in oxc (59 typescript/* rules
+           // delegate to tsgolint via the `(tsgolint)` marker). This rule body intentionally does not
+           // attempt to follow type references that cross file boundaries.
+    ];
+
+    Tester::new(PropNameCasing::NAME, PropNameCasing::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 fn prop_name_casing_diagnostic(span: Span, name: &str, case_type: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Prop \"{name}\" is not in {case_type}.")).with_label(span)
+    OxcDiagnostic::warn(format!("Prop '{name}' is not in {case_type}.")).with_label(span)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -246,10 +246,9 @@ fn property_key_static_name<'a>(
         PropertyKey::PrivateIdentifier(_) => None,
         key => {
             // Computed key expressions: pull the inner expression and accept
-            // statically resolvable literals (string / template literal /
-            // identifier in parenthesized form). Other shapes (variable,
-            // call, binary expression, member, this, regex literal handled
-            // specially) are treated dynamically.
+            // statically resolvable literals. Dynamic shapes (variable,
+            // call, binary expression, member, this) are treated as
+            // unresolvable and skipped.
             let expr = key.as_expression()?.get_inner_expression();
             match expr {
                 Expression::StringLiteral(lit) => Some((lit.value.as_str().into(), lit.span)),

--- a/crates/oxc_linter/src/snapshots/vue_prop_name_casing.snap
+++ b/crates/oxc_linter/src/snapshots/vue_prop_name_casing.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 490
 ---
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         greeting_text: String
@@ -11,7 +10,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         greeting_text: String
@@ -19,7 +18,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:4:31]
  3 │                     export default {
  4 │                       props: ['greeting_text']
@@ -27,7 +26,7 @@ assertion_line: 490
  5 │                     }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greetingText" is not in snake_case.
+  ⚠ vue(prop-name-casing): Prop 'greetingText' is not in snake_case.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         greetingText: String
@@ -35,7 +34,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting-text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         'greeting-text': String
@@ -43,7 +42,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in snake_case.
+  ⚠ vue(prop-name-casing): Prop 'greeting-text' is not in snake_case.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         'greeting-text': String
@@ -51,7 +50,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         'greeting_text': String
@@ -59,7 +58,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting-text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:26]
  4 │                       props: {
  5 │                         ['greeting-text']: String
@@ -67,7 +66,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         greeting_text
@@ -75,7 +74,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "abc-123-def" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'abc-123-def' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         'abc-123-def': String
@@ -83,7 +82,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting-text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:27]
  4 │                       props: {
  5 │                         [('greeting-text')]: String
@@ -91,7 +90,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "_item" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop '_item' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         _item: String
@@ -99,7 +98,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "_itemName" is not in snake_case.
+  ⚠ vue(prop-name-casing): Prop '_itemName' is not in snake_case.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         _itemName: String
@@ -107,7 +106,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting-text' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:26]
  4 │                       props: {
  5 │                         [`greeting-text`]: String
@@ -115,7 +114,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "/greeting-text/" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop '/greeting-text/' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:26]
  4 │                       props: {
  5 │                         [/greeting-text/]: String
@@ -123,7 +122,7 @@ assertion_line: 490
  6 │                       }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:4:21]
  3 │                   defineProps({
  4 │                     greeting_text: String
@@ -131,7 +130,7 @@ assertion_line: 490
  5 │                   })
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:3:32]
  2 │                   <script setup>
  3 │                   defineProps(['greeting_text'])
@@ -139,7 +138,7 @@ assertion_line: 490
  4 │                   </script>
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
    ╭─[prop_name_casing.tsx:4:21]
  3 │                   interface Props {
  4 │                     greeting_text: number
@@ -147,7 +146,7 @@ assertion_line: 490
  5 │                   }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "notIgnored_prop" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'notIgnored_prop' is not in camelCase.
    ╭─[prop_name_casing.tsx:5:25]
  4 │                       props: {
  5 │                         notIgnored_prop: String,
@@ -155,7 +154,7 @@ assertion_line: 490
  6 │                         'other-pattern': Number,
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "other-pattern" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'other-pattern' is not in camelCase.
    ╭─[prop_name_casing.tsx:6:25]
  5 │                         notIgnored_prop: String,
  6 │                         'other-pattern': Number,
@@ -163,7 +162,7 @@ assertion_line: 490
  7 │                         'pattern-valid': String
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "notIgnored_prop" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'notIgnored_prop' is not in camelCase.
    ╭─[prop_name_casing.tsx:4:31]
  3 │                     export default {
  4 │                       props: ['notIgnored_prop', 'pattern_invalid', 'validProp', 'pattern-valid']
@@ -171,7 +170,7 @@ assertion_line: 490
  5 │                     }
    ╰────
 
-  ⚠ vue(prop-name-casing): Prop "pattern_invalid" is not in camelCase.
+  ⚠ vue(prop-name-casing): Prop 'pattern_invalid' is not in camelCase.
    ╭─[prop_name_casing.tsx:4:50]
  3 │                     export default {
  4 │                       props: ['notIgnored_prop', 'pattern_invalid', 'validProp', 'pattern-valid']

--- a/crates/oxc_linter/src/snapshots/vue_prop_name_casing.snap
+++ b/crates/oxc_linter/src/snapshots/vue_prop_name_casing.snap
@@ -1,0 +1,180 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         greeting_text: String
+   ·                         ─────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         greeting_text: String
+   ·                         ─────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:4:31]
+ 3 │                     export default {
+ 4 │                       props: ['greeting_text']
+   ·                               ───────────────
+ 5 │                     }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greetingText" is not in snake_case.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         greetingText: String
+   ·                         ────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         'greeting-text': String
+   ·                         ───────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in snake_case.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         'greeting-text': String
+   ·                         ───────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         'greeting_text': String
+   ·                         ───────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:26]
+ 4 │                       props: {
+ 5 │                         ['greeting-text']: String
+   ·                          ───────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         greeting_text
+   ·                         ─────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "abc-123-def" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         'abc-123-def': String
+   ·                         ─────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:27]
+ 4 │                       props: {
+ 5 │                         [('greeting-text')]: String
+   ·                           ───────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "_item" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         _item: String
+   ·                         ─────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "_itemName" is not in snake_case.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         _itemName: String
+   ·                         ─────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting-text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:26]
+ 4 │                       props: {
+ 5 │                         [`greeting-text`]: String
+   ·                          ───────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "/greeting-text/" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:26]
+ 4 │                       props: {
+ 5 │                         [/greeting-text/]: String
+   ·                          ───────────────
+ 6 │                       }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:4:21]
+ 3 │                   defineProps({
+ 4 │                     greeting_text: String
+   ·                     ─────────────
+ 5 │                   })
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:3:32]
+ 2 │                   <script setup>
+ 3 │                   defineProps(['greeting_text'])
+   ·                                ───────────────
+ 4 │                   </script>
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "greeting_text" is not in camelCase.
+   ╭─[prop_name_casing.tsx:4:21]
+ 3 │                   interface Props {
+ 4 │                     greeting_text: number
+   ·                     ─────────────
+ 5 │                   }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "notIgnored_prop" is not in camelCase.
+   ╭─[prop_name_casing.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         notIgnored_prop: String,
+   ·                         ───────────────
+ 6 │                         'other-pattern': Number,
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "other-pattern" is not in camelCase.
+   ╭─[prop_name_casing.tsx:6:25]
+ 5 │                         notIgnored_prop: String,
+ 6 │                         'other-pattern': Number,
+   ·                         ───────────────
+ 7 │                         'pattern-valid': String
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "notIgnored_prop" is not in camelCase.
+   ╭─[prop_name_casing.tsx:4:31]
+ 3 │                     export default {
+ 4 │                       props: ['notIgnored_prop', 'pattern_invalid', 'validProp', 'pattern-valid']
+   ·                               ─────────────────
+ 5 │                     }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop "pattern_invalid" is not in camelCase.
+   ╭─[prop_name_casing.tsx:4:50]
+ 3 │                     export default {
+ 4 │                       props: ['notIgnored_prop', 'pattern_invalid', 'validProp', 'pattern-valid']
+   ·                                                  ─────────────────
+ 5 │                     }
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2662,6 +2662,9 @@
         "vue/prefer-import-from-vue": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/prop-name-casing": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/require-default-export": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2666,6 +2666,9 @@ expression: json
         "vue/prefer-import-from-vue": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/prop-name-casing": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/require-default-export": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
related: eslint-plugin-vue migration umbrella issue (https://github.com/oxc-project/oxc/issues/11440)

upstream: https://eslint.vuejs.org/rules/prop-name-casing.html

One upstream invalid test (cross-file `import` of a TS interface) is skipped — cross-file type resolution is the tsgolint domain in oxc.

Follow-up: extract shared casing helpers, currently duplicated with the component-definition-name-casing rule (https://github.com/oxc-project/oxc/pull/22818).

AI disclosure: implemented with Claude Code, reviewed manually.