### PR TITLE
fix(deps): exempt vite-plus packages from release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,3 +34,6 @@ allowBuilds:
   "@nestjs/core@11.1.9": false
 
 verifyDepsBeforeRun: install
+minimumReleaseAgeExclude:
+  - "@voidzero-dev/*"
+  - vite-plus


### PR DESCRIPTION
CI on PR #22893 failed because `pnpm install --frozen-lockfile --ignore-scripts` rejected the freshly published `vite-plus@0.1.24` release and its `@voidzero-dev/*` companion packages under the minimum release age policy.

This PR resolves the issue by adding a narrow pnpm release-age exemption for `vite-plus` and `@voidzero-dev/*` instead of relaxing the policy globally.

Failed workflow: https://github.com/oxc-project/oxc/actions/runs/26757020694/job/78859594155?pr=22893
