### PR TITLE
chore(bench): swap cal.com.tsx for excalidraw App.tsx everywhere

### DIFF
--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -33,7 +33,6 @@ use basic::{EmptyArray, Null};
 /// | File                       | Compact TS | Compact JS | Pretty TS | Pretty JS |
 /// |----------------------------|------------|------------|-----------|-----------|
 /// | antd.js                    |         10 |          9 |        76 |        72 |
-/// | cal.com.tsx                |         10 |          9 |        40 |        37 |
 /// | checker.ts                 |          7 |          6 |        27 |        24 |
 /// | pdf.mjs                    |         13 |         12 |        71 |        67 |
 /// | RadixUIAdoptionSection.jsx |         10 |          9 |        45 |        44 |

--- a/napi/parser/bench.bench.js
+++ b/napi/parser/bench.bench.js
@@ -16,7 +16,7 @@ import { getVisitorsArr, Visitor } from "./src-js/raw-transfer/visitor.js";
 // Same fixtures as used in Rust parser benchmarks
 let fixtureUrls = [
   "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/checker.ts",
-  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/cal.com.tsx",
+  "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
   "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
   "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
   "https://cdn.jsdelivr.net/npm/antd@4.16.1/dist/antd.js",

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -74,8 +74,8 @@ async function runCaseInWorker(type, props) {
 let benchFixtureUrls = [
   // TypeScript syntax (2.81MB)
   "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/checker.ts",
-  // Real world app tsx (1.0M)
-  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/cal.com.tsx",
+  // Real world app tsx (415KB) — excalidraw App.tsx (master @ f6d85bc8)
+  "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
   // Real world content-heavy app jsx (3K)
   "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
   // Heavy with classes (554K)

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -27,8 +27,8 @@ fn bench_semantic(criterion: &mut Criterion) {
                 runner.run(|| {
                     // We drop `Semantic` inside this closure as drop time is part of cost of using this API.
                     // We return `errors` to be dropped outside of the measured section, as usually
-                    // code would have no errors. One of our benchmarks `cal.com.tsx` has a lot of errors,
-                    // but that's atypical, so don't want to include it in benchmark time.
+                    // real-world code has no errors, so allocating and dropping them is atypical and
+                    // we don't want to include it in benchmark time.
                     let ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
                     let ret = black_box(ret);
                     ret.errors

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -53,8 +53,8 @@ impl TestFiles {
                 "https://cdn.jsdelivr.net/gh/prettier/prettier@3.6.2/src/language-js/comments/handle-comments.js",
                 // Large TS (2370L / 76.1KB)
                 "https://cdn.jsdelivr.net/gh/honojs/hono@v4.10.5/src/types.ts",
-                // Extra large TSX (11180L / 346KB)
-                "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@v0.18.0/packages/excalidraw/components/App.tsx",
+                // Extra large TSX (~13k lines / 415KB) — excalidraw App.tsx (master @ f6d85bc8)
+                "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
             ].into_iter().map(TestFile::new).collect(),
         }
     }
@@ -64,7 +64,8 @@ impl TestFiles {
             files: [
                 "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
                 "https://cdn.jsdelivr.net/npm/react@17.0.2/cjs/react.development.js",
-                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/cal.com.tsx",
+                // Real world app tsx (415KB) — excalidraw App.tsx (master @ f6d85bc8)
+                "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
                 "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/binder.ts",
                 // Hand-written synthetic fixture covering every AST node, transformer plugin,
                 // minifier optimization, and semantic step in oxc — pinned to a revision so


### PR DESCRIPTION
## Summary

Follow-up to #22590. That PR replaced the synthetic `cal.com.tsx` fixture — a concatenation of Next.js pages that declares top-level names 70–113× and emits thousands of redeclaration diagnostics, inflating semantic `sys_allocs` — with excalidraw's real, single-file `App.tsx`. But it only touched `TestFiles::complicated()` (used by `track_memory_allocations`).

This applies the same swap to every remaining benchmark that still used `cal.com.tsx`, and unifies **all** excalidraw `App.tsx` references on one pin (`f6d85bc8`):

| File | Change |
| --- | --- |
| `tasks/common/src/test_file.rs` | `minimal()` (feeds every `tasks/benchmark` criterion bench): `cal.com.tsx` → `App.tsx@f6d85bc8`. `formatter()` re-pinned `@v0.18.0` → `@f6d85bc8` |
| `napi/parser/bench.bench.js` | parser benchmark fixture → `App.tsx@f6d85bc8` |
| `napi/parser/test/parse-raw.test.ts` | bench-fixture list + size comment → `App.tsx@f6d85bc8` |
| `tasks/benchmark/benches/semantic.rs` | rewrote the now-false "`cal.com.tsx` has many errors" comment |
| `crates/oxc_ast/src/serialize/mod.rs` | removed the stale `cal.com.tsx` row from the capacity-ratio doc table |

## Why a single pin

`get_source_text` caches downloads by the last URL segment only (`App.tsx`). With two different pins live, a single `cargo bench` run would download both into the same `target/App.tsx` and silently bench whichever landed first. Re-pinning `formatter()` to `f6d85bc8` removes that collision — and the pre-existing latent one between `cargo bench` (`@v0.18.0`) and `cargo allocs` (`@f6d85bc8`).

## Notes

No committed snapshots change: these fixtures feed only timing benches and a `programRaw.toEqual(programStandard)` self-consistency test; the snapshotted `complicated()` / `minifier()` sets are untouched.

---

This PR was prepared with AI assistance; I reviewed, tested, and verified the changes.
