### PR TITLE
fix(isolated-declarations): require annotations for satisfies initializers

### DIFF
--- a/crates/oxc_isolated_declarations/src/inferrer.rs
+++ b/crates/oxc_isolated_declarations/src/inferrer.rs
@@ -64,9 +64,6 @@ impl<'a> IsolatedDeclarations<'a> {
             Expression::TSNonNullExpression(expr) => {
                 self.infer_type_from_expression(&expr.expression)
             }
-            Expression::TSSatisfiesExpression(expr) => {
-                self.infer_type_from_expression(&expr.expression)
-            }
             Expression::UnaryExpression(expr) => {
                 if Self::can_infer_unary_expression(expr) {
                     self.infer_type_from_expression(&expr.argument)

--- a/crates/oxc_isolated_declarations/tests/fixtures/satisfies.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/satisfies.ts
@@ -1,0 +1,3 @@
+export const object = { a: 1 } satisfies { a: number };
+export const number = 1 satisfies number;
+export const annotated: { a: number } = { a: 1 } satisfies { a: number };

--- a/crates/oxc_isolated_declarations/tests/snapshots/satisfies.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/satisfies.snap
@@ -1,0 +1,35 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/satisfies.ts
+---
+```
+==================== .D.TS ====================
+
+export declare const object: unknown;
+export declare const number: unknown;
+export declare const annotated: {
+	a: number;
+};
+
+
+==================== Errors ====================
+
+  x TS9010: Variable must have an explicit type annotation with
+  | --isolatedDeclarations.
+   ,-[1:14]
+ 1 | export const object = { a: 1 } satisfies { a: number };
+   :              ^^^^^^
+ 2 | export const number = 1 satisfies number;
+   `----
+
+  x TS9010: Variable must have an explicit type annotation with
+  | --isolatedDeclarations.
+   ,-[2:14]
+ 1 | export const object = { a: 1 } satisfies { a: number };
+ 2 | export const number = 1 satisfies number;
+   :              ^^^^^^
+ 3 | export const annotated: { a: number } = { a: 1 } satisfies { a: number };
+   `----
+
+
+```


### PR DESCRIPTION
Fixes an isolated declarations gap where exported variables initialized with a `satisfies` expression were being inferred instead of requiring an explicit annotation.

TypeScript reports TS9010 for cases like:

```ts
export const x = { a: 1 } satisfies { a: number };
```

but Oxc previously emitted an inferred declaration. This changes isolated declaration inference so `satisfies` initializers do not unwrap to the inner expression for variable type inference, matching TypeScript’s behavior.

Added a regression fixture covering:
- object literal `satisfies` initializer
- primitive `satisfies` initializer
- explicitly annotated `satisfies` initializer, which should still emit normally

[TypeScript playground](https://www.typescriptlang.org/play/?isolatedDeclarations=true#code/KYDwDg9gTgLgBAYwgOwM7xHAvHA3nAQwC44BGOAXzlQJgEtUAzO4VPQk5AVwFsAjYFEoBuAFBA)
