### PR TITLE
chore(deps): exempt VoidZero deps from `minimumReleaseAgeExclude`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,5 +35,22 @@ allowBuilds:
 
 verifyDepsBeforeRun: install
 minimumReleaseAgeExclude:
+  - "@oxc-parser/*"
+  - "@oxc-project/*"
+  - "@oxfmt/*"
+  - "@oxlint-tsgolint/*"
+  - "@oxlint/*"
+  - "@rolldown/*"
+  - "@tsdown/*"
+  - "@vitejs/devtools"
+  - "@vitest/*"
   - "@voidzero-dev/*"
+  - oxc-parser
+  - oxfmt
+  - oxlint
+  - oxlint-tsgolint
+  - rolldown
+  - tsdown
+  - vite
   - vite-plus
+  - vitest


### PR DESCRIPTION
similar to https://github.com/oxc-project/oxc/pull/22894, but this time for the rest of the VoidZero toolchain (oxfmt, oxlint, rolldown, tsdown, vite, vitest etc)