### PR TITLE
fix(isolated-declarations): allow unknown enum initializer in non-const enum

### DIFF
--- a/crates/oxc_isolated_declarations/src/diagnostics.rs
+++ b/crates/oxc_isolated_declarations/src/diagnostics.rs
@@ -100,8 +100,8 @@ pub fn binding_element_export(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn enum_member_initializers(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.")
+pub fn const_enum_member_initializers(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("TS2474: const enum member initializers must be constant expressions.")
         .with_label(span)
 }
 

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -10,7 +10,7 @@ use oxc_syntax::{
     operator::{BinaryOperator, UnaryOperator},
 };
 
-use crate::{IsolatedDeclarations, diagnostics::enum_member_initializers};
+use crate::{IsolatedDeclarations, diagnostics::const_enum_member_initializers};
 
 #[derive(Debug, Clone)]
 enum ConstantValue {
@@ -29,8 +29,8 @@ impl<'a> IsolatedDeclarations<'a> {
                 let computed_value =
                     self.computed_constant_value(initializer, &decl.id.name, &prev_members);
 
-                if computed_value.is_none() {
-                    self.error(enum_member_initializers(member.id.span()));
+                if decl.r#const && computed_value.is_none() {
+                    self.error(const_enum_member_initializers(initializer.span()));
                 }
 
                 computed_value

--- a/crates/oxc_isolated_declarations/tests/fixtures/enum-runtime-initializer.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/enum-runtime-initializer.ts
@@ -1,0 +1,9 @@
+export enum BadEnum {
+  A = Math.random(),
+  B = A + 1,
+}
+
+export const enum BadConstEnum {
+  A = Math.random(),
+  B = A + 1,
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/enum-runtime-initializer.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/enum-runtime-initializer.snap
@@ -1,0 +1,37 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/enum-runtime-initializer.ts
+---
+```
+==================== .D.TS ====================
+
+export declare enum BadEnum {
+	A,
+	B
+}
+export declare const enum BadConstEnum {
+	A,
+	B
+}
+
+
+==================== Errors ====================
+
+  x TS2474: const enum member initializers must be constant expressions.
+   ,-[7:7]
+ 6 | export const enum BadConstEnum {
+ 7 |   A = Math.random(),
+   :       ^^^^^^^^^^^^^
+ 8 |   B = A + 1,
+   `----
+
+  x TS2474: const enum member initializers must be constant expressions.
+   ,-[8:7]
+ 7 |   A = Math.random(),
+ 8 |   B = A + 1,
+   :       ^^^^^
+ 9 | }
+   `----
+
+
+```


### PR DESCRIPTION
Fixes an isolated declarations diagnostic mismatch for enum initializers.

TypeScript allows runtime enum initializers under `--isolatedDeclarations` for regular enums and emits the declaration without initializer values:

[TS playground](https://www.typescriptlang.org/play/?isolatedDeclarations=true#code/KYDwDg9gTgLgBMAdgVwLZwEIEMAmBRFdAbwCg44BBOAXjgFksYALAOii0RwlQAoBKADRlMNSnADUcAIxCAviRKhIsOAGMIiAM7wkaTLgDCG7QT2lyVWg2ZsOXXoOEZRVSTJLygA)

```ts
export enum BadEnum {
  A = Math.random(),
  B = A + 1,
}
```

```ts
export declare enum BadEnum {
  A,
  B
}
```

Oxc already emitted the same declaration shape, but also reported TS9020. This PR narrows that diagnostic behavior so regular enum runtime initializers are omitted without an isolated declarations error.

For `const enum`, TypeScript still reports `TS2474` because const enum initializers must be constant expressions:

[TS playground](https://www.typescriptlang.org/play/?isolatedDeclarations=true#code/KYDwDg9gTgLgBMAdgVwLZwEIEMAmBRFdAbwCg44BBOAXjgFksYALAOii0RwlQAoBKADRlMNSnADUcAIxCAviRKhIsOAGMIiAM7wkaTLgDCG7QT2lyVWg2ZsOXXoOEZRVSTJLygA)


```ts
export const enum BadConstEnum {
  A = Math.random(),
  B = A + 1,
}
```

This PR keeps that error behavior aligned by reporting `TS2474` for non-constant `const enum` initializers.

