### PR TITLE
fix(linter): respect default child config plugin when extending parent config

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1369,10 +1369,13 @@ mod test {
         assert_eq!(parent_config.plugins(), LintPlugins::REACT | LintPlugins::TYPESCRIPT);
 
         // Test 3: Child config that extends parent without specifying plugins
-        // Should inherit parent's plugins
+        // Should inherit parent's plugins and apply the default plugins from the child config
         let child_no_plugins_config =
             config_store_from_path("fixtures/extends_config/plugins/child_no_plugins.json");
-        assert_eq!(child_no_plugins_config.plugins(), LintPlugins::REACT | LintPlugins::TYPESCRIPT);
+        assert_eq!(
+            child_no_plugins_config.plugins(),
+            LintPlugins::REACT | LintPlugins::TYPESCRIPT | LintPlugins::OXC | LintPlugins::UNICORN
+        );
 
         // Test 4: Child config that extends parent and specifies additional plugins
         // Should have parent's plugins plus its own
@@ -1432,7 +1435,8 @@ mod test {
                 "extends": [
                     "fixtures/extends_config/plugins/jest.json",
                     "fixtures/extends_config/plugins/react.json"
-                ]
+                ],
+                "plugins": []
             }
             "#,
         );

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -396,7 +396,8 @@ impl Oxlintrc {
         let plugins = match (self.plugins, other.plugins) {
             (Some(self_plugins), Some(other_plugins)) => Some(self_plugins | other_plugins),
             (Some(self_plugins), None) => Some(self_plugins | LintPlugins::default()),
-            (None, other_plugins) => other_plugins,
+            (None, Some(other_plugins)) => Some(other_plugins | LintPlugins::default()),
+            (None, None) => None,
         };
 
         let external_plugins = match (&self.external_plugins, &other.external_plugins) {


### PR DESCRIPTION
Follow up from #22896 where we respected the parent (omitted) default plugins.
This PR does the same for the child config, example:

```
{
 "extends": ["./other-config.json"],
}
```

Will now enable the default plugins too. This is not detected by the root config, where we always have a plugin vec. See https://github.com/oxc-project/oxc/pull/22788#pullrequestreview-4382325722

fixes #22867