### PR TITLE
fix(formatter_json): avoid example binary name collision

### DIFF
--- a/crates/oxc_formatter_json/examples/json_formatter.rs
+++ b/crates/oxc_formatter_json/examples/json_formatter.rs
@@ -10,10 +10,10 @@
 //!
 //! Create a `test.json` file and run:
 //! ```bash
-//! cargo run -p oxc_formatter_json --example formatter [filename]
-//! cargo run -p oxc_formatter_json --example formatter -- --print-width 100 [filename]
-//! cargo run -p oxc_formatter_json --example formatter -- --variant json5 [filename]
-//! cargo run -p oxc_formatter_json --example formatter -- --diff [filename]
+//! cargo run -p oxc_formatter_json --example json_formatter [filename]
+//! cargo run -p oxc_formatter_json --example json_formatter -- --print-width 100 [filename]
+//! cargo run -p oxc_formatter_json --example json_formatter -- --variant json5 [filename]
+//! cargo run -p oxc_formatter_json --example json_formatter -- --diff [filename]
 //! ```
 //!
 //! The parser variant is inferred from the file extension (`.jsonc`, `.json5`),


### PR DESCRIPTION
Cargo currently warns when checking examples for both `oxc_formatter` and `oxc_formatter_json` because each crate has an implicit `formatter` example target. That makes both packages try to write `target/debug/examples/formatter`.

This renames the JSON formatter example to `json_formatter` and updates the usage comments in the example so the command stays accurate.

Checked with:

```sh
cargo check --examples -p oxc_formatter -p oxc_formatter_json
```
