### PR TITLE
ci(ecosystem): share label trigger for app ci

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -1,4 +1,4 @@
-name: Ecosystem CI (oxfmt)
+name: Ecosystem CI
 
 on:
   pull_request:
@@ -7,13 +7,16 @@ on:
 permissions: {}
 
 concurrency:
-  group: ecosystem-ci-oxfmt-${{ github.event.pull_request.number }}
+  group: ecosystem-ci-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:
   trigger:
     if: >
-      github.event.label.name == 'run-oxfmt-ecosystem-ci' &&
+      (
+        github.event.label.name == 'run-oxlint-ecosystem-ci' ||
+        github.event.label.name == 'run-oxfmt-ecosystem-ci'
+      ) &&
       github.repository == 'oxc-project/oxc'
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +37,10 @@ jobs:
           script: |
             const issueNumber = context.payload.pull_request.number;
             const branch = context.payload.pull_request.head.ref;
-            const body = `Triggering Oxfmt Ecosystem CI for \`${branch}\`\nhttps://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/oxfmt-ci.yml`;
+            const isOxlint = context.payload.label.name === 'run-oxlint-ecosystem-ci';
+            const project = isOxlint ? 'Oxlint' : 'Oxfmt';
+            const workflow = isOxlint ? 'oxlint-ci.yml' : 'oxfmt-ci.yml';
+            const body = `Triggering ${project} Ecosystem CI for \`${branch}\`\nhttps://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/${workflow}`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -45,7 +51,7 @@ jobs:
             const existing = comments.findLast((c) =>
               c.user.login === 'oxc-guard[bot]' &&
               c.body &&
-              (c.body.startsWith('Triggering Oxfmt Ecosystem CI') || c.body.startsWith('## [Oxfmt Ecosystem CI]'))
+              (c.body.startsWith(`Triggering ${project} Ecosystem CI`) || c.body.startsWith(`## [${project} Ecosystem CI]`))
             );
 
             let commentId;
@@ -69,11 +75,12 @@ jobs:
 
             core.setOutput('ref', `refs/pull/${issueNumber}/head`);
             core.setOutput('comment-id', commentId);
+            core.setOutput('workflow', workflow);
 
       - uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           repo: oxc-project/oxc-ecosystem-ci
-          workflow: oxfmt-ci.yml
+          workflow: ${{ steps.prepare.outputs.workflow }}
           token: ${{ steps.app-token.outputs.token }}
           ref: main
           inputs: >-
@@ -92,7 +99,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                name: 'run-oxfmt-ecosystem-ci',
+                name: context.payload.label.name,
               });
             } catch (error) {
               if (error.status !== 404) throw error;

--- a/.github/workflows/prepare_release_apps.yml
+++ b/.github/workflows/prepare_release_apps.yml
@@ -81,42 +81,9 @@ jobs:
           base: main
           body-path: ./target/PR_BODY.md
           assignees: Boshen
-          labels: run-oxfmt-ecosystem-ci
-
-  ecosystem-ci:
-    needs: prepare
-    name: Trigger Oxlint Ecosystem CI
-    runs-on: ubuntu-slim
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-
-      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        id: comment-oxlint
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ needs.prepare.outputs.pull-request-number }}
-          body: |
-            Triggering Oxlint Ecosystem CI
-            https://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/oxlint-ci.yml
-
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: oxc-project
-          repositories: oxc-ecosystem-ci
-
-      - uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
-        with:
-          repo: oxc-project/oxc-ecosystem-ci
-          workflow: oxlint-ci.yml
-          token: ${{ steps.app-token.outputs.token }}
-          ref: main
-          inputs: '{ "issue-number": "${{ needs.prepare.outputs.pull-request-number }}", "comment-id": "${{ steps.comment-oxlint.outputs.comment-id }}" }'
+          labels: |
+            run-oxlint-ecosystem-ci
+            run-oxfmt-ecosystem-ci
 
   website:
     needs: prepare


### PR DESCRIPTION
This is stacked on #22905.

The first PR moved Oxfmt ecosystem CI to a label-triggered workflow. This follow-up keeps that approach, but avoids having one workflow file per app. Instead, the Oxfmt-specific workflow is renamed to a shared ecosystem CI dispatcher that handles both trigger labels:

- `run-oxlint-ecosystem-ci` dispatches `oxlint-ci.yml`
- `run-oxfmt-ecosystem-ci` dispatches `oxfmt-ci.yml`

The release-apps workflow now adds both labels to the generated release PR, so Oxlint and Oxfmt take the same path: create or update the tracking comment, dispatch the matching workflow in `oxc-ecosystem-ci` with the PR ref, then remove the label that triggered the run.