### PR TITLE
refactor(linter/vue): extract casing helpers into shared utils

### DIFF
--- a/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/component_definition_name_casing.rs
@@ -1,4 +1,3 @@
-use convert_case::{Boundary, Case, Converter};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +14,7 @@ use crate::{
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{DefaultRuleConfig, Rule},
-    utils::{find_property, is_vue_component_options_object},
+    utils::{find_property, is_vue_component_options_object, vue_casing},
 };
 
 fn component_definition_name_casing_diagnostic(
@@ -187,134 +186,11 @@ fn extract_convertible(expr: &Expression<'_>) -> Option<(String, Span)> {
     }
 }
 
-// Mirror of upstream `eslint-plugin-vue` lib/utils/casing.js to guarantee
-// identical detection / conversion semantics.
-
-fn has_symbols(s: &str) -> bool {
-    // [!"#%&'()*+,./:;<=>?@[\]^`{|}] — without " ", "$", "-" and "_"
-    s.chars().any(|c| {
-        matches!(
-            c,
-            '!' | '"'
-                | '#'
-                | '%'
-                | '&'
-                | '\''
-                | '('
-                | ')'
-                | '*'
-                | '+'
-                | ','
-                | '.'
-                | '/'
-                | ':'
-                | ';'
-                | '<'
-                | '='
-                | '>'
-                | '?'
-                | '@'
-                | '['
-                | '\\'
-                | ']'
-                | '^'
-                | '`'
-                | '{'
-                | '|'
-                | '}'
-        )
-    })
-}
-
-fn has_upper(s: &str) -> bool {
-    s.chars().any(|c| c.is_ascii_uppercase())
-}
-
-fn is_pascal_case(s: &str) -> bool {
-    !has_symbols(s)
-        && !s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
-        && !s.chars().any(|c| matches!(c, '-' | '_') || c.is_whitespace())
-}
-
-fn is_kebab_case(s: &str) -> bool {
-    if has_upper(s) || has_symbols(s) || s.starts_with('-') {
-        return false;
-    }
-    if s.contains('_') || s.contains("--") || s.chars().any(char::is_whitespace) {
-        return false;
-    }
-    true
-}
-
 fn check_case(s: &str, case_type: CaseType) -> bool {
     match case_type {
-        CaseType::PascalCase => is_pascal_case(s),
-        CaseType::KebabCase => is_kebab_case(s),
+        CaseType::PascalCase => vue_casing::is_pascal_case(s),
+        CaseType::KebabCase => vue_casing::is_kebab_case(s),
     }
-}
-
-fn capitalize(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
-        None => String::new(),
-    }
-}
-
-fn is_regex_word(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '_'
-}
-
-fn regex_word_before_upper(graphemes: &[&str]) -> bool {
-    let Some(prev) = graphemes.first().and_then(|s| s.chars().next()) else {
-        return false;
-    };
-    let Some(current) = graphemes.get(1).and_then(|s| s.chars().next()) else {
-        return false;
-    };
-    is_regex_word(prev) && current.is_ascii_uppercase()
-}
-
-/// `camelCase(str)` mirrors upstream:
-/// - if PascalCase: lowercase the first char
-/// - else: replace `[-_](\w)` with `\w` uppercased
-fn camel_case(s: &str) -> String {
-    if is_pascal_case(s) {
-        let mut chars = s.chars();
-        return match chars.next() {
-            Some(c) => c.to_lowercase().collect::<String>() + chars.as_str(),
-            None => String::new(),
-        };
-    }
-
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if matches!(c, '-' | '_')
-            && let Some(next) = chars.peek()
-            && is_regex_word(*next)
-        {
-            if let Some(next) = chars.next() {
-                out.extend(next.to_uppercase());
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
-fn pascal_case(s: &str) -> String {
-    capitalize(&camel_case(s))
-}
-
-fn kebab_case(s: &str) -> String {
-    let word_before_upper =
-        Boundary::Custom { condition: regex_word_before_upper, start: 1, len: 0 };
-    Converter::new()
-        .set_boundaries(&[Boundary::Underscore, word_before_upper])
-        .to_case(Case::Kebab)
-        .convert(s)
 }
 
 /// Mirror of `getExactConverter(name)(str)`. Returns `None` when the
@@ -324,8 +200,8 @@ fn kebab_case(s: &str) -> String {
 /// that the diagnostic is emitted without an autofix.
 fn exact_convert(s: &str, case_type: CaseType) -> Option<String> {
     let converted = match case_type {
-        CaseType::PascalCase => pascal_case(s),
-        CaseType::KebabCase => kebab_case(s),
+        CaseType::PascalCase => vue_casing::pascal_case(s),
+        CaseType::KebabCase => vue_casing::kebab_case(s),
     };
     if check_case(&converted, case_type) { Some(converted) } else { None }
 }

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -19,7 +19,7 @@ use crate::{
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{Rule, TupleRuleConfig},
-    utils::{find_property, is_vue_component_options_object_excluding_instance},
+    utils::{find_property, is_vue_component_options_object_excluding_instance, vue_casing},
 };
 
 fn prop_name_casing_diagnostic(span: Span, name: &str, case_type: &str) -> OxcDiagnostic {
@@ -249,65 +249,9 @@ fn property_key_static_name<'a>(
 
 fn check_case(s: &str, case_type: CaseType) -> bool {
     match case_type {
-        CaseType::CamelCase => is_camel_case(s),
-        CaseType::SnakeCase => is_snake_case(s),
+        CaseType::CamelCase => vue_casing::is_camel_case(s),
+        CaseType::SnakeCase => vue_casing::is_snake_case(s),
     }
-}
-
-fn has_symbols(s: &str) -> bool {
-    // [!"#%&'()*+,./:;<=>?@[\]^`{|}] — without " ", "$", "-" and "_"
-    s.chars().any(|c| {
-        matches!(
-            c,
-            '!' | '"'
-                | '#'
-                | '%'
-                | '&'
-                | '\''
-                | '('
-                | ')'
-                | '*'
-                | '+'
-                | ','
-                | '.'
-                | '/'
-                | ':'
-                | ';'
-                | '<'
-                | '='
-                | '>'
-                | '?'
-                | '@'
-                | '['
-                | '\\'
-                | ']'
-                | '^'
-                | '`'
-                | '{'
-                | '|'
-                | '}'
-        )
-    })
-}
-
-fn has_upper(s: &str) -> bool {
-    s.chars().any(|c| c.is_ascii_uppercase())
-}
-
-fn is_camel_case(s: &str) -> bool {
-    !has_symbols(s)
-        && !s.chars().next().is_some_and(|c| c.is_ascii_uppercase())
-        && !s.chars().any(|c| matches!(c, '-' | '_') || c.is_whitespace())
-}
-
-fn is_snake_case(s: &str) -> bool {
-    if has_upper(s) || has_symbols(s) {
-        return false;
-    }
-    if s.contains('-') || s.contains("__") || s.chars().any(char::is_whitespace) {
-        return false;
-    }
-    true
 }
 
 /// Matches upstream `toRegExpGroupMatcher`: a pattern wrapped in slashes

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -32,6 +32,7 @@ mod unicorn;
 mod url;
 mod vitest;
 mod vue;
+pub mod vue_casing;
 
 pub use self::{
     comment::*, config::*, control_flow::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*,

--- a/crates/oxc_linter/src/utils/vue_casing.rs
+++ b/crates/oxc_linter/src/utils/vue_casing.rs
@@ -1,0 +1,147 @@
+//! Mirror of upstream `eslint-plugin-vue/lib/utils/casing.js`. Shared by the
+//! vue lint rules that need to check whether an identifier (component name,
+//! prop name, etc.) is in a particular casing.
+
+use convert_case::{Boundary, Case, Converter};
+
+/// Returns true if `s` contains any character that is not allowed in any of
+/// the casings recognised by eslint-plugin-vue.
+///
+/// Mirrors upstream `hasSymbols`. The character class excludes ` `, `$`,
+/// `-`, `_` deliberately — `-` and `_` are case-specific word separators
+/// and `$` is allowed in JavaScript identifiers (e.g. `$actionEl`).
+pub fn has_symbols(s: &str) -> bool {
+    s.chars().any(|c| {
+        matches!(
+            c,
+            '!' | '"'
+                | '#'
+                | '%'
+                | '&'
+                | '\''
+                | '('
+                | ')'
+                | '*'
+                | '+'
+                | ','
+                | '.'
+                | '/'
+                | ':'
+                | ';'
+                | '<'
+                | '='
+                | '>'
+                | '?'
+                | '@'
+                | '['
+                | '\\'
+                | ']'
+                | '^'
+                | '`'
+                | '{'
+                | '|'
+                | '}'
+        )
+    })
+}
+
+/// Returns true if `s` contains any ASCII uppercase letter.
+pub fn has_upper(s: &str) -> bool {
+    s.chars().any(|c| c.is_ascii_uppercase())
+}
+
+pub fn is_pascal_case(s: &str) -> bool {
+    !has_symbols(s)
+        && !s.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+        && !s.chars().any(|c| matches!(c, '-' | '_') || c.is_whitespace())
+}
+
+pub fn is_kebab_case(s: &str) -> bool {
+    if has_upper(s) || has_symbols(s) || s.starts_with('-') {
+        return false;
+    }
+    if s.contains('_') || s.contains("--") || s.chars().any(char::is_whitespace) {
+        return false;
+    }
+    true
+}
+
+pub fn is_camel_case(s: &str) -> bool {
+    !has_symbols(s)
+        && !s.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+        && !s.chars().any(|c| matches!(c, '-' | '_') || c.is_whitespace())
+}
+
+pub fn is_snake_case(s: &str) -> bool {
+    if has_upper(s) || has_symbols(s) {
+        return false;
+    }
+    if s.contains('-') || s.contains("__") || s.chars().any(char::is_whitespace) {
+        return false;
+    }
+    true
+}
+
+pub fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn is_regex_word(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+fn regex_word_before_upper(graphemes: &[&str]) -> bool {
+    let Some(prev) = graphemes.first().and_then(|s| s.chars().next()) else {
+        return false;
+    };
+    let Some(current) = graphemes.get(1).and_then(|s| s.chars().next()) else {
+        return false;
+    };
+    is_regex_word(prev) && current.is_ascii_uppercase()
+}
+
+/// Mirror of upstream `camelCase`:
+/// - if input is already PascalCase: lowercase the first char
+/// - else: replace `[-_](\w)` with `\w` uppercased
+pub fn camel_case(s: &str) -> String {
+    if is_pascal_case(s) {
+        let mut chars = s.chars();
+        return match chars.next() {
+            Some(c) => c.to_lowercase().collect::<String>() + chars.as_str(),
+            None => String::new(),
+        };
+    }
+
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if matches!(c, '-' | '_')
+            && let Some(next) = chars.peek()
+            && is_regex_word(*next)
+        {
+            if let Some(next) = chars.next() {
+                out.extend(next.to_uppercase());
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+pub fn pascal_case(s: &str) -> String {
+    capitalize(&camel_case(s))
+}
+
+pub fn kebab_case(s: &str) -> String {
+    let word_before_upper =
+        Boundary::Custom { condition: regex_word_before_upper, start: 1, len: 0 };
+    Converter::new()
+        .set_boundaries(&[Boundary::Underscore, word_before_upper])
+        .to_case(Case::Kebab)
+        .convert(s)
+}


### PR DESCRIPTION
related: eslint-plugin-vue migration umbrella issue (https://github.com/oxc-project/oxc/issues/11440)

Extracts the casing helpers (mirror of `eslint-plugin-vue/lib/utils/casing.js`) into `crates/oxc_linter/src/utils/vue_casing.rs`, currently duplicated between component-definition-name-casing (https://github.com/oxc-project/oxc/pull/22818) and prop-name-casing (https://github.com/oxc-project/oxc/pull/22892).

AI disclosure: implemented with Claude Code, reviewed manually.