### PR TITLE
refactor(semantic): collapse class-table flag into ClassTableBuilder

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -120,8 +120,6 @@ pub struct SemanticBuilder<'a> {
     #[expect(unused)]
     pub(crate) cfg: (),
 
-    pub(crate) build_class_table: bool,
-
     pub(crate) class_table_builder: ClassTableBuilder<'a>,
 
     #[cfg(feature = "cfg")]
@@ -174,7 +172,6 @@ impl<'a> SemanticBuilder<'a> {
             cfg: None,
             #[cfg(not(feature = "cfg"))]
             cfg: (),
-            build_class_table: false,
             class_table_builder: ClassTableBuilder::new(),
             #[cfg(feature = "cfg")]
             ast_node_records: Vec::new(),
@@ -227,7 +224,7 @@ impl<'a> SemanticBuilder<'a> {
     /// Enable/disable building the class table.
     #[must_use]
     pub fn with_class_table(mut self, yes: bool) -> Self {
-        self.build_class_table = yes;
+        self.class_table_builder.enabled = yes;
         self
     }
 
@@ -300,7 +297,7 @@ impl<'a> SemanticBuilder<'a> {
         );
         self.unresolved_references.reserve_exact(stats.references as usize);
 
-        self.class_table_builder.enabled = self.build_class_table || self.check_syntax_error;
+        self.class_table_builder.enabled |= self.check_syntax_error;
 
         // Visit AST to generate scopes tree etc
         self.visit_program(program);

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -31,7 +31,10 @@ fn bench_linter(criterion: &mut Criterion) {
 
                 let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
                 let path = Path::new("");
-                let semantic_ret = SemanticBuilder::new().with_cfg(true).build(&parser_ret.program);
+                let semantic_ret = SemanticBuilder::new()
+                    .with_cfg(true)
+                    .with_class_table(true)
+                    .build(&parser_ret.program);
                 let semantic = semantic_ret.semantic;
                 let module_record =
                     Arc::new(ModuleRecord::new(path, &parser_ret.module_record, &semantic));


### PR DESCRIPTION
## Summary

Follow-up cleanup to #22862 (which made the `oxc_semantic` `ClassTable` optional and off by default). Two small improvements:

1. **Collapse the duplicate flag.** #22862 added a `build_class_table` field on `SemanticBuilder` that existed only to be OR'd into the `ClassTableBuilder::enabled` flag that already exists. `with_class_table` now writes `class_table_builder.enabled` directly, and `build()` folds in the checker dependency with `enabled |= self.check_syntax_error`. One source of truth instead of two flags plus a bridge; behaviour is identical and order-independent.

2. **Fix linter-benchmark fidelity.** `tasks/benchmark/benches/linter.rs` runs `ConfigStoreBuilder::all()` but built its semantic without the class table, so after #22862 flipped the default the class-dependent rules (`no_dupe_class_members`, `no_unused_private_class_members`, `max_classes_per_file`) silently no-op'd there — the benchmark measured less work than production. Added `.with_class_table(true)` to match `service/runtime.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
