### PR TITLE
chore(formatter,formatter_json): use print over println in example

### DIFF
--- a/crates/oxc_formatter/examples/formatter.rs
+++ b/crates/oxc_formatter/examples/formatter.rs
@@ -77,14 +77,12 @@ fn main() -> Result<(), String> {
     if show_diff {
         // First diff: compare formatted output to original input
         if source_text == formatted_code {
-            println!("{formatted_code}");
+            print!("{formatted_code}");
         } else {
             print_diff_in_terminal(&source_text, &formatted_code);
         }
     } else {
-        // println!("--- Formatted Code ---");
-        // println!("{formatted_code}");
-        // println!("--- End Formatted Code ---");
+        print!("{formatted_code}");
     }
 
     Ok(())

--- a/crates/oxc_formatter_json/examples/json_formatter.rs
+++ b/crates/oxc_formatter_json/examples/json_formatter.rs
@@ -75,12 +75,12 @@ fn main() -> Result<(), String> {
     if show_diff {
         // Compare formatted output to original input
         if source_text == formatted_code {
-            println!("{formatted_code}");
+            print!("{formatted_code}");
         } else {
             print_diff_in_terminal(&source_text, &formatted_code);
         }
     } else {
-        println!("{formatted_code}");
+        print!("{formatted_code}");
     }
 
     Ok(())


### PR DESCRIPTION
Since formatters already print their own "trailingNewLine", `print!` is fine.