### PR TITLE
feat(linter/vue): implement no-reserved-props rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1324,6 +1324,7 @@ export interface DummyRuleMap {
   "vue/no-required-prop-with-default"?: DummyRule;
   "vue/no-reserved-component-names"?: DummyRule;
   "vue/no-reserved-keys"?: DummyRule;
+  "vue/no-reserved-props"?: DummyRule;
   "vue/no-shared-component-data"?: DummyRule;
   "vue/no-this-in-before-route-enter"?: DummyRule;
   "vue/no-watch-after-await"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5106,6 +5106,12 @@ impl RuleRunner for crate::rules::vue::no_reserved_keys::NoReservedKeys {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::no_reserved_props::NoReservedProps {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ObjectProperty]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::no_shared_component_data::NoSharedComponentData {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ObjectProperty]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -813,6 +813,7 @@ pub use crate::rules::vue::no_multiple_slot_args::NoMultipleSlotArgs as VueNoMul
 pub use crate::rules::vue::no_required_prop_with_default::NoRequiredPropWithDefault as VueNoRequiredPropWithDefault;
 pub use crate::rules::vue::no_reserved_component_names::NoReservedComponentNames as VueNoReservedComponentNames;
 pub use crate::rules::vue::no_reserved_keys::NoReservedKeys as VueNoReservedKeys;
+pub use crate::rules::vue::no_reserved_props::NoReservedProps as VueNoReservedProps;
 pub use crate::rules::vue::no_shared_component_data::NoSharedComponentData as VueNoSharedComponentData;
 pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnter as VueNoThisInBeforeRouteEnter;
 pub use crate::rules::vue::no_watch_after_await::NoWatchAfterAwait as VueNoWatchAfterAwait;
@@ -1653,6 +1654,7 @@ pub enum RuleEnum {
     VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault),
     VueNoReservedComponentNames(VueNoReservedComponentNames),
     VueNoReservedKeys(VueNoReservedKeys),
+    VueNoReservedProps(VueNoReservedProps),
     VueNoSharedComponentData(VueNoSharedComponentData),
     VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter),
     VueNoWatchAfterAwait(VueNoWatchAfterAwait),
@@ -2580,7 +2582,8 @@ const VUE_NO_MULTIPLE_SLOT_ARGS_ID: usize = VUE_NO_LIFECYCLE_AFTER_AWAIT_ID + 1u
 const VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID: usize = VUE_NO_MULTIPLE_SLOT_ARGS_ID + 1usize;
 const VUE_NO_RESERVED_COMPONENT_NAMES_ID: usize = VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID + 1usize;
 const VUE_NO_RESERVED_KEYS_ID: usize = VUE_NO_RESERVED_COMPONENT_NAMES_ID + 1usize;
-const VUE_NO_SHARED_COMPONENT_DATA_ID: usize = VUE_NO_RESERVED_KEYS_ID + 1usize;
+const VUE_NO_RESERVED_PROPS_ID: usize = VUE_NO_RESERVED_KEYS_ID + 1usize;
+const VUE_NO_SHARED_COMPONENT_DATA_ID: usize = VUE_NO_RESERVED_PROPS_ID + 1usize;
 const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize = VUE_NO_SHARED_COMPONENT_DATA_ID + 1usize;
 const VUE_NO_WATCH_AFTER_AWAIT_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
 const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
@@ -3531,6 +3534,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID,
             Self::VueNoReservedComponentNames(_) => VUE_NO_RESERVED_COMPONENT_NAMES_ID,
             Self::VueNoReservedKeys(_) => VUE_NO_RESERVED_KEYS_ID,
+            Self::VueNoReservedProps(_) => VUE_NO_RESERVED_PROPS_ID,
             Self::VueNoSharedComponentData(_) => VUE_NO_SHARED_COMPONENT_DATA_ID,
             Self::VueNoThisInBeforeRouteEnter(_) => VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID,
             Self::VueNoWatchAfterAwait(_) => VUE_NO_WATCH_AFTER_AWAIT_ID,
@@ -4467,6 +4471,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::NAME,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::NAME,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::NAME,
+            Self::VueNoReservedProps(_) => VueNoReservedProps::NAME,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::NAME,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::NAME,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::NAME,
@@ -5461,6 +5466,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::CATEGORY,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::CATEGORY,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::CATEGORY,
+            Self::VueNoReservedProps(_) => VueNoReservedProps::CATEGORY,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::CATEGORY,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::CATEGORY,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::CATEGORY,
@@ -6398,6 +6404,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::FIX,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::FIX,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::FIX,
+            Self::VueNoReservedProps(_) => VueNoReservedProps::FIX,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::FIX,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::FIX,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::FIX,
@@ -7595,6 +7602,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::documentation(),
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::documentation(),
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::documentation(),
+            Self::VueNoReservedProps(_) => VueNoReservedProps::documentation(),
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::documentation(),
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::documentation(),
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::documentation(),
@@ -9941,6 +9949,8 @@ impl RuleEnum {
             }
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::config_schema(generator)
                 .or_else(|| VueNoReservedKeys::schema(generator)),
+            Self::VueNoReservedProps(_) => VueNoReservedProps::config_schema(generator)
+                .or_else(|| VueNoReservedProps::schema(generator)),
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::config_schema(generator)
                 .or_else(|| VueNoSharedComponentData::schema(generator)),
             Self::VueNoThisInBeforeRouteEnter(_) => {
@@ -10794,6 +10804,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => "vue",
             Self::VueNoReservedComponentNames(_) => "vue",
             Self::VueNoReservedKeys(_) => "vue",
+            Self::VueNoReservedProps(_) => "vue",
             Self::VueNoSharedComponentData(_) => "vue",
             Self::VueNoThisInBeforeRouteEnter(_) => "vue",
             Self::VueNoWatchAfterAwait(_) => "vue",
@@ -13415,6 +13426,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => {
                 Ok(Self::VueNoReservedKeys(VueNoReservedKeys::from_configuration(value)?))
             }
+            Self::VueNoReservedProps(_) => {
+                Ok(Self::VueNoReservedProps(VueNoReservedProps::from_configuration(value)?))
+            }
             Self::VueNoSharedComponentData(_) => Ok(Self::VueNoSharedComponentData(
                 VueNoSharedComponentData::from_configuration(value)?,
             )),
@@ -14279,6 +14293,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.to_configuration(),
             Self::VueNoReservedComponentNames(rule) => rule.to_configuration(),
             Self::VueNoReservedKeys(rule) => rule.to_configuration(),
+            Self::VueNoReservedProps(rule) => rule.to_configuration(),
             Self::VueNoSharedComponentData(rule) => rule.to_configuration(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.to_configuration(),
             Self::VueNoWatchAfterAwait(rule) => rule.to_configuration(),
@@ -15115,6 +15130,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run(node, ctx),
                 Self::VueNoReservedComponentNames(rule) => rule.run(node, ctx),
                 Self::VueNoReservedKeys(rule) => rule.run(node, ctx),
+                Self::VueNoReservedProps(rule) => rule.run(node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run(node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
@@ -15944,6 +15960,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run(node, ctx),
                 Self::VueNoReservedComponentNames(rule) => rule.run(node, ctx),
                 Self::VueNoReservedKeys(rule) => rule.run(node, ctx),
+                Self::VueNoReservedProps(rule) => rule.run(node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run(node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
@@ -16780,6 +16797,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_once(ctx),
                 Self::VueNoReservedComponentNames(rule) => rule.run_once(ctx),
                 Self::VueNoReservedKeys(rule) => rule.run_once(ctx),
+                Self::VueNoReservedProps(rule) => rule.run_once(ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_once(ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
@@ -17609,6 +17627,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_once(ctx),
                 Self::VueNoReservedComponentNames(rule) => rule.run_once(ctx),
                 Self::VueNoReservedKeys(rule) => rule.run_once(ctx),
+                Self::VueNoReservedProps(rule) => rule.run_once(ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_once(ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
@@ -18702,6 +18721,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoReservedComponentNames(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoReservedKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoReservedProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19787,6 +19807,7 @@ impl RuleEnum {
                 Self::VueNoRequiredPropWithDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoReservedComponentNames(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoReservedKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoReservedProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20614,6 +20635,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.should_run(ctx),
             Self::VueNoReservedComponentNames(rule) => rule.should_run(ctx),
             Self::VueNoReservedKeys(rule) => rule.should_run(ctx),
+            Self::VueNoReservedProps(rule) => rule.should_run(ctx),
             Self::VueNoSharedComponentData(rule) => rule.should_run(ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.should_run(ctx),
             Self::VueNoWatchAfterAwait(rule) => rule.should_run(ctx),
@@ -21810,6 +21832,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::IS_TSGOLINT_RULE,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::IS_TSGOLINT_RULE,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::IS_TSGOLINT_RULE,
+            Self::VueNoReservedProps(_) => VueNoReservedProps::IS_TSGOLINT_RULE,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::IS_TSGOLINT_RULE,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::IS_TSGOLINT_RULE,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::IS_TSGOLINT_RULE,
@@ -22808,6 +22831,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::VERSION,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::VERSION,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::VERSION,
+            Self::VueNoReservedProps(_) => VueNoReservedProps::VERSION,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::VERSION,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::VERSION,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::VERSION,
@@ -23841,6 +23865,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::HAS_CONFIG,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::HAS_CONFIG,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::HAS_CONFIG,
+            Self::VueNoReservedProps(_) => VueNoReservedProps::HAS_CONFIG,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::HAS_CONFIG,
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::HAS_CONFIG,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::HAS_CONFIG,
@@ -24667,6 +24692,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.types_info(),
             Self::VueNoReservedComponentNames(rule) => rule.types_info(),
             Self::VueNoReservedKeys(rule) => rule.types_info(),
+            Self::VueNoReservedProps(rule) => rule.types_info(),
             Self::VueNoSharedComponentData(rule) => rule.types_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.types_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.types_info(),
@@ -25493,6 +25519,7 @@ impl RuleEnum {
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_info(),
             Self::VueNoReservedComponentNames(rule) => rule.run_info(),
             Self::VueNoReservedKeys(rule) => rule.run_info(),
+            Self::VueNoReservedProps(rule) => rule.run_info(),
             Self::VueNoSharedComponentData(rule) => rule.run_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.run_info(),
@@ -26451,6 +26478,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault::default()),
         RuleEnum::VueNoReservedComponentNames(VueNoReservedComponentNames::default()),
         RuleEnum::VueNoReservedKeys(VueNoReservedKeys::default()),
+        RuleEnum::VueNoReservedProps(VueNoReservedProps::default()),
         RuleEnum::VueNoSharedComponentData(VueNoSharedComponentData::default()),
         RuleEnum::VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter::default()),
         RuleEnum::VueNoWatchAfterAwait(VueNoWatchAfterAwait::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -865,6 +865,7 @@ pub(crate) mod vue {
     pub mod no_required_prop_with_default;
     pub mod no_reserved_component_names;
     pub mod no_reserved_keys;
+    pub mod no_reserved_props;
     pub mod no_shared_component_data;
     pub mod no_this_in_before_route_enter;
     pub mod no_watch_after_await;

--- a/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
@@ -38,6 +38,7 @@ fn no_reserved_props_diagnostic(prop_name: &str, span: Span) -> OxcDiagnostic {
 struct NoReservedPropsConfig {
     /// Vue major version whose reserved attribute set is applied. Vue 2 reserves
     /// more names (`is`, `slot`, `class`, `style`, ...) than Vue 3.
+    #[serde(deserialize_with = "deserialize_vue_version")]
     vue_version: u8,
 }
 
@@ -237,6 +238,18 @@ impl NoReservedProps {
         };
         let Some(name) = key.static_name() else { return };
         self.report(name.as_ref(), key.span(), ctx);
+    }
+}
+
+fn deserialize_vue_version<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let version = u8::deserialize(deserializer)?;
+    if matches!(version, 2 | 3) {
+        Ok(version)
+    } else {
+        Err(serde::de::Error::custom("vueVersion must be either 2 or 3"))
     }
 }
 

--- a/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
@@ -1,0 +1,532 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrayExpression, CallExpression, Expression, ObjectExpression, ObjectPropertyKind,
+        TSSignature, TSType, TSTypeName,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    ast_util::get_declaration_from_reference_id,
+    context::LintContext,
+    frameworks::FrameworkOptions,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{is_vue_component_options_object, vue_casing::kebab_case},
+};
+
+/// Reserved attribute names that cannot be used as prop names, by Vue version.
+const RESERVED_VUE3: &[&str] = &["key", "ref"];
+const RESERVED_VUE2: &[&str] =
+    &["key", "ref", "is", "slot", "slot-scope", "slotScope", "class", "style"];
+
+fn no_reserved_props_diagnostic(prop_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "'{prop_name}' is a reserved attribute and cannot be used as props."
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct NoReservedPropsConfig {
+    /// Vue major version whose reserved attribute set is applied. Vue 2 reserves
+    /// more names (`is`, `slot`, `class`, `style`, ...) than Vue 3.
+    vue_version: u8,
+}
+
+impl Default for NoReservedPropsConfig {
+    fn default() -> Self {
+        Self { vue_version: 3 }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct NoReservedProps(Box<NoReservedPropsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow reserved attribute names (e.g. `key`, `ref`) from being used as
+    /// prop names.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Vue treats a number of attributes specially (`key` and `ref` in Vue 3;
+    /// additionally `is`, `slot`, `slot-scope`, `class` and `style` in Vue 2).
+    /// Declaring a prop with one of these names collides with the framework's
+    /// own handling and breaks the component.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     ref: String,
+    ///     key: String,
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     foo: String,
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoReservedProps,
+    vue,
+    correctness,
+    config = NoReservedProps,
+    version = "next",
+);
+
+impl Rule for NoReservedProps {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::CallExpression(call) => self.check_define_props(call, ctx),
+            AstKind::ObjectProperty(prop) => {
+                if !prop.key.is_specific_static_name("props") {
+                    return;
+                }
+                let Some(parent) = ctx.nodes().ancestors(node.id()).next() else { return };
+                if !is_vue_component_options_object(parent, ctx) {
+                    return;
+                }
+                match prop.value.get_inner_expression() {
+                    Expression::ArrayExpression(arr) => self.check_array_props(arr, ctx),
+                    Expression::ObjectExpression(obj) => self.check_object_props(obj, ctx),
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+}
+
+impl NoReservedProps {
+    fn is_reserved(&self, name: &str) -> bool {
+        let reserved = if self.0.vue_version == 2 { RESERVED_VUE2 } else { RESERVED_VUE3 };
+        reserved.contains(&name)
+    }
+
+    fn report(&self, name: &str, span: Span, ctx: &LintContext) {
+        if self.is_reserved(name) {
+            ctx.diagnostic(no_reserved_props_diagnostic(&kebab_case(name), span));
+        }
+    }
+
+    /// `props: ['ref', `key`]` — array declaration.
+    fn check_array_props<'a>(&self, arr: &ArrayExpression<'a>, ctx: &LintContext<'a>) {
+        for elem in &arr.elements {
+            let Some(expr) = elem.as_expression() else { continue };
+            let (name, span): (&str, Span) = match expr.get_inner_expression() {
+                Expression::StringLiteral(lit) => (lit.value.as_str(), lit.span),
+                Expression::TemplateLiteral(tpl) => match tpl.single_quasi() {
+                    Some(quasi) => (quasi.as_str(), tpl.span),
+                    None => continue,
+                },
+                _ => continue,
+            };
+            self.report(name, span, ctx);
+        }
+    }
+
+    /// `props: { ref: String }` — object declaration.
+    fn check_object_props<'a>(&self, obj: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+        for prop_kind in &obj.properties {
+            let ObjectPropertyKind::ObjectProperty(p) = prop_kind else { continue };
+            let Some(name) = p.key.static_name() else { continue };
+            self.report(name.as_ref(), p.key.span(), ctx);
+        }
+    }
+
+    /// `<script setup>` `defineProps(...)` — counterpart of upstream `onDefinePropsEnter`.
+    fn check_define_props<'a>(&self, call: &CallExpression<'a>, ctx: &LintContext<'a>) {
+        if ctx.frameworks_options() != FrameworkOptions::VueSetup {
+            return;
+        }
+        if !call.callee.get_identifier_reference().is_some_and(|id| id.name == "defineProps") {
+            return;
+        }
+
+        // Runtime declaration: `defineProps([...])` / `defineProps({...})`.
+        if let Some(arg) = call.arguments.first().and_then(|arg| arg.as_expression()) {
+            match arg.get_inner_expression() {
+                Expression::ArrayExpression(arr) => self.check_array_props(arr, ctx),
+                Expression::ObjectExpression(obj) => self.check_object_props(obj, ctx),
+                _ => {}
+            }
+            return;
+        }
+
+        // Type-only declaration: `defineProps<T>()`.
+        if let Some(type_args) = call.type_arguments.as_ref()
+            && let Some(first) = type_args.params.first()
+        {
+            self.check_type_props(first, ctx);
+        }
+    }
+
+    fn check_type_props<'a>(&self, ty: &TSType<'a>, ctx: &LintContext<'a>) {
+        match ty {
+            TSType::TSTypeLiteral(literal) => {
+                for sig in &literal.members {
+                    self.check_signature(sig, ctx);
+                }
+            }
+            TSType::TSUnionType(union) => {
+                for member in &union.types {
+                    self.check_type_props(member, ctx);
+                }
+            }
+            TSType::TSIntersectionType(intersection) => {
+                for member in &intersection.types {
+                    self.check_type_props(member, ctx);
+                }
+            }
+            TSType::TSTypeReference(type_ref) => {
+                let TSTypeName::IdentifierReference(ident) = &type_ref.type_name else { return };
+                let Some(decl) =
+                    get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
+                else {
+                    return;
+                };
+                match decl.kind() {
+                    AstKind::TSInterfaceDeclaration(interface) => {
+                        for sig in &interface.body.body {
+                            self.check_signature(sig, ctx);
+                        }
+                    }
+                    AstKind::TSTypeAliasDeclaration(alias) => {
+                        self.check_type_props(&alias.type_annotation, ctx);
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn check_signature<'a>(&self, sig: &TSSignature<'a>, ctx: &LintContext<'a>) {
+        let key = match sig {
+            TSSignature::TSPropertySignature(prop) => &prop.key,
+            TSSignature::TSMethodSignature(method) => &method.key,
+            _ => return,
+        };
+        let Some(name) = key.static_name() else { return };
+        self.report(name.as_ref(), key.span(), ctx);
+    }
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+            <script>
+            export default {
+              props: {
+                foo: String
+              }
+            }
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            export default {
+              props: ['foo']
+            }
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script setup>
+            defineProps({ foo: String })
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script setup>
+            defineProps(['foo'])
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script setup lang=\"ts\">
+            interface Props {
+              foo: String
+            }
+            defineProps<Props>()
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            export default {
+              data() {
+                return {
+                  ref: ''
+                }
+              }
+            }
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script setup lang=\"ts\">
+            interface Props {
+              is: string,
+              slot: string,
+              \"slot-scope\": string,
+            }
+            defineProps<Props>()
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+            <script>
+            export default {
+              props: {
+                ref: String,
+                key: String,
+                is: String,
+                slot: String,
+                \"slot-scope\": String,
+              }
+            }
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            export default {
+              props: {
+                ref: String,
+                key: String,
+                is: String,
+                slot: String,
+                \"slot-scope\": String,
+              }
+            }
+            </script>
+            ",
+            Some(serde_json::json!([{ "vueVersion": 3 }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            export default {
+              props: [
+                'ref',
+                'key',
+                'is',
+                'slot',
+                \"slot-scope\",
+                \"slotScope\",
+                'class',
+                `style`
+              ]
+            }
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script setup>
+            defineProps({
+              ref: String,
+              key: String,
+              is: String,
+              slot: String,
+              \"slot-scope\": String,
+            })
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script setup>
+            defineProps([
+              'ref',
+              'key',
+              'is',
+              'slot',
+              \"slot-scope\",
+            ])
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script setup lang=\"ts\">
+            interface Props {
+              ref: string,
+              key: string,
+              is: string,
+              slot: string,
+              \"slot-scope\": string,
+            }
+            defineProps<Props>()
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            export default {
+              props: {
+                ref: String,
+                key: String,
+                is: String,
+                slot: String,
+                \"slot-scope\": String,
+              }
+            }
+            </script>
+            ",
+            Some(serde_json::json!([{ "vueVersion": 2 }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            export default {
+              props: [
+                'ref',
+                'key',
+                'is',
+                'slot',
+                \"slot-scope\",
+              ]
+            }
+            </script>
+            ",
+            Some(serde_json::json!([{ "vueVersion": 2 }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            export default {
+              props: [
+                \"slotScope\",
+                'class',
+                `style`
+              ]
+            }
+            </script>
+            ",
+            Some(serde_json::json!([{ "vueVersion": 2 }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // oxc-specific: component forms other than `export default` are also
+        // detected via the shared `is_vue_component_options_object` helper.
+        (
+            "
+            <script>
+            defineComponent({
+              props: {
+                ref: String,
+              }
+            })
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+            <script>
+            Vue.component('foo', {
+              props: ['key']
+            })
+            </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(NoReservedProps::NAME, NoReservedProps::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
@@ -106,7 +106,7 @@ impl Rule for NoReservedProps {
                 if !prop.key.is_specific_static_name("props") {
                     return;
                 }
-                let Some(parent) = ctx.nodes().ancestors(node.id()).next() else { return };
+                let parent = ctx.nodes().parent_node(node.id());
                 if !is_vue_component_options_object(parent, ctx) {
                     return;
                 }

--- a/crates/oxc_linter/src/snapshots/vue_no_reserved_props.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_reserved_props.snap
@@ -1,0 +1,219 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:17]
+ 4 │               props: {
+ 5 │                 ref: String,
+   ·                 ───
+ 6 │                 key: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:6:17]
+ 5 │                 ref: String,
+ 6 │                 key: String,
+   ·                 ───
+ 7 │                 is: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:17]
+ 4 │               props: {
+ 5 │                 ref: String,
+   ·                 ───
+ 6 │                 key: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:6:17]
+ 5 │                 ref: String,
+ 6 │                 key: String,
+   ·                 ───
+ 7 │                 is: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:17]
+ 4 │               props: [
+ 5 │                 'ref',
+   ·                 ─────
+ 6 │                 'key',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:6:17]
+ 5 │                 'ref',
+ 6 │                 'key',
+   ·                 ─────
+ 7 │                 'is',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:4:15]
+ 3 │             defineProps({
+ 4 │               ref: String,
+   ·               ───
+ 5 │               key: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:15]
+ 4 │               ref: String,
+ 5 │               key: String,
+   ·               ───
+ 6 │               is: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:4:15]
+ 3 │             defineProps([
+ 4 │               'ref',
+   ·               ─────
+ 5 │               'key',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:15]
+ 4 │               'ref',
+ 5 │               'key',
+   ·               ─────
+ 6 │               'is',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:4:15]
+ 3 │             interface Props {
+ 4 │               ref: string,
+   ·               ───
+ 5 │               key: string,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:15]
+ 4 │               ref: string,
+ 5 │               key: string,
+   ·               ───
+ 6 │               is: string,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:17]
+ 4 │               props: {
+ 5 │                 ref: String,
+   ·                 ───
+ 6 │                 key: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:6:17]
+ 5 │                 ref: String,
+ 6 │                 key: String,
+   ·                 ───
+ 7 │                 is: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'is' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:7:17]
+ 6 │                 key: String,
+ 7 │                 is: String,
+   ·                 ──
+ 8 │                 slot: String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'slot' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:8:17]
+ 7 │                 is: String,
+ 8 │                 slot: String,
+   ·                 ────
+ 9 │                 "slot-scope": String,
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'slot-scope' is a reserved attribute and cannot be used as props.
+    ╭─[no_reserved_props.tsx:9:17]
+  8 │                 slot: String,
+  9 │                 "slot-scope": String,
+    ·                 ────────────
+ 10 │               }
+    ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:17]
+ 4 │               props: [
+ 5 │                 'ref',
+   ·                 ─────
+ 6 │                 'key',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:6:17]
+ 5 │                 'ref',
+ 6 │                 'key',
+   ·                 ─────
+ 7 │                 'is',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'is' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:7:17]
+ 6 │                 'key',
+ 7 │                 'is',
+   ·                 ────
+ 8 │                 'slot',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'slot' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:8:17]
+ 7 │                 'is',
+ 8 │                 'slot',
+   ·                 ──────
+ 9 │                 "slot-scope",
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'slot-scope' is a reserved attribute and cannot be used as props.
+    ╭─[no_reserved_props.tsx:9:17]
+  8 │                 'slot',
+  9 │                 "slot-scope",
+    ·                 ────────────
+ 10 │               ]
+    ╰────
+
+  ⚠ vue(no-reserved-props): 'slot-scope' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:17]
+ 4 │               props: [
+ 5 │                 "slotScope",
+   ·                 ───────────
+ 6 │                 'class',
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'class' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:6:17]
+ 5 │                 "slotScope",
+ 6 │                 'class',
+   ·                 ───────
+ 7 │                 `style`
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'style' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:7:17]
+ 6 │                 'class',
+ 7 │                 `style`
+   ·                 ───────
+ 8 │               ]
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'ref' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:5:17]
+ 4 │               props: {
+ 5 │                 ref: String,
+   ·                 ───
+ 6 │               }
+   ╰────
+
+  ⚠ vue(no-reserved-props): 'key' is a reserved attribute and cannot be used as props.
+   ╭─[no_reserved_props.tsx:4:23]
+ 3 │             Vue.component('foo', {
+ 4 │               props: ['key']
+   ·                       ─────
+ 5 │             })
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2653,6 +2653,9 @@
         "vue/no-reserved-keys": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-reserved-props": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-shared-component-data": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2657,6 +2657,9 @@ expression: json
         "vue/no-reserved-keys": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/no-reserved-props": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/no-shared-component-data": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
Implements `vue/no-reserved-props` from eslint-plugin-vue.

Part of #11440.