### PR TITLE
feat(parser): report TS1255 for invalid class definite assertions

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -580,6 +580,12 @@ pub fn optional_definite_property(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn definite_assignment_assertion_not_permitted(span: Span) -> OxcDiagnostic {
+    ts_error("1255", "A definite assignment assertion '!' is not permitted in this context.")
+        .with_label(span)
+}
+
+#[cold]
 pub fn identifier_async(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("Cannot use `{x0}` as an identifier in an async context"))
         .with_label(span1)

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -408,6 +408,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             true,
             diagnostics::accessor_modifier,
         );
+        if definite
+            && ((self.ctx.has_ambient() && !modifiers.contains(ModifierKind::Declare))
+                || r#type.is_abstract())
+        {
+            self.error(diagnostics::definite_assignment_assertion_not_permitted(
+                self.end_span(span),
+            ));
+        }
         self.ast.class_element_accessor_property(
             self.end_span(span),
             r#type,
@@ -678,6 +686,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         {
             self.error(diagnostics::initializers_not_allowed_in_ambient_contexts(
                 initializer.span(),
+            ));
+        }
+        if definite && (self.ctx.has_ambient() || r#abstract) {
+            self.error(diagnostics::definite_assignment_assertion_not_permitted(
+                self.end_span(span),
             ));
         }
         self.ast.class_element_property_definition(

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -17470,6 +17470,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  12 │ };
     ╰────
 
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/derivedUninitializedPropertyDeclaration.ts:12:5]
+ 11 │ class BDBang extends A {
+ 12 │     declare property!: any; // ! is not allowed, this is an ambient declaration
+    ·     ───────────────────────
+ 13 │ }
+    ╰────
+
   × TS(1031): 'declare' modifier cannot appear on class elements of this kind.
     ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/derivedUninitializedPropertyDeclaration.ts:15:5]
  14 │ class BOther extends A {
@@ -17814,6 +17822,22 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  9 │ }
    ╰────
   help: Only 'readonly' modifier is allowed here.
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:29:5]
+ 28 │ declare class C4 {
+ 29 │     a!: number;
+    ·     ───────────
+ 30 │ }
+    ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:35:5]
+ 34 │ abstract class C5 {
+ 35 │     abstract a!: number;
+    ·     ────────────────────
+ 36 │ }
+    ╰────
 
   × TS(1264): Declarations with definite assignment assertions must also have type annotations.
     ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:69:10]


### PR DESCRIPTION
This adds the TypeScript parser diagnostic for definite assignment assertions in class member contexts where TypeScript rejects them.

`!` on class properties is still allowed for normal initialized-check suppression, but we now report TS1255 when it appears on ambient class members or abstract properties/accessor properties. This covers cases like `declare property!: T`, `declare class C { property!: T }`, and `abstract property!: T`.
