### PR TITLE
perf(linter/plugins): define class `#loc` setter functions as `const`s

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -83,7 +83,8 @@ const COMMENT_SIZE_SHIFT = 4; // 1 << 4 == 16 bytes, the size of `Comment` in Ru
 debugAssert(COMMENT_SIZE === 1 << COMMENT_SIZE_SHIFT);
 
 // Reset `#loc` field on a `Comment` class instance.
-let resetCommentLoc: (comment: Comment) => void;
+// Copied into a `const` below after being defined in class static block.
+let resetCommentLocTemp: (comment: Comment) => void;
 
 // Get `#loc` field on a `Comment` class instance.
 // Only used in debug build (tests).
@@ -134,13 +135,17 @@ class Comment implements Span {
 
   static {
     // Defined in static block to avoid exposing this as a public method
-    resetCommentLoc = (comment: Comment) => {
+    resetCommentLocTemp = (comment: Comment) => {
       comment.#loc = null;
     };
 
     if (DEBUG) getCommentPrivateLoc = (comment: Comment) => comment.#loc;
   }
 }
+
+// Reset `#loc` field on a `Comment` class instance.
+// Copied into a const here to avoid checks at call site (`let` binding could be re-assigned).
+const resetCommentLoc = resetCommentLocTemp;
 
 // Make `loc` property enumerable so `for (const key in comment) ...` includes `loc`
 Object.defineProperty(Comment.prototype, "loc", { enumerable: true });

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -157,8 +157,9 @@ let deserializedTokensLen = 0;
 // not *total* number of tokens.
 const DESERIALIZED_TOKEN_INDEXES_MIN_CAPACITY = 16;
 
-// Reset `#loc` field on a `Token` class instance
-let resetLoc: (token: Token) => void;
+// Reset `#loc` field on a `Token` class instance.
+// Copied into a `const` below after being defined in class static block.
+let resetLocTemp: (token: Token) => void;
 
 // Get `#loc` field on a `Token` class instance.
 // Only used in debug build (tests).
@@ -209,13 +210,17 @@ class Token {
 
   static {
     // Defined in static block to avoid exposing this as a public method
-    resetLoc = (token: Token) => {
+    resetLocTemp = (token: Token) => {
       token.#loc = null;
     };
 
     if (DEBUG) getTokenPrivateLoc = (token: Token) => token.#loc;
   }
 }
+
+// Reset `#loc` field on a `Token` class instance.
+// Copied into a const here to avoid checks at call site (`let` binding could be re-assigned).
+const resetLoc = resetLocTemp;
 
 // Make `loc` property enumerable so that `for (const key in token) ...` includes `loc` in the keys it iterates over
 Object.defineProperty(Token.prototype, "loc", { enumerable: true });


### PR DESCRIPTION
Micro-optimization. `Token` and `Comment` classes create functions defined in static blocks to reset the value of `#loc` private property on class instances. Copy these functions into `const` vars, to avoid checks at these functions' call sites. Previously they were stored in `let` bindings, which incurs a check at each call site (because the value might have been re-assigned). The difference in Turbofan-optimized code is just an 8-byte load and a comparison, but why keep that when we can lose it?

Discovered the perf difference while digging into #22238.