### PR TITLE
refactor(linter): `jest/vitest/no-restricted-*-methods` align config + right schemars output

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_jest_methods.rs
@@ -1,8 +1,13 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
+use oxc_str::CompactStr;
 use rustc_hash::FxHashMap;
-use schemars::JsonSchema;
+use schemars::{
+    JsonSchema,
+    r#gen::SchemaGenerator,
+    schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SubschemaValidation},
+};
 use serde::Deserialize;
 
 use crate::{
@@ -53,23 +58,56 @@ test('plays video', () => {
 ";
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRestrictedJestMethodsConfig {
     /// A mapping of restricted Jest method names to custom messages - or
     /// `null`, for a generic message.
-    pub restricted_jest_methods: FxHashMap<String, String>,
+    #[schemars(schema_with = "restricted_methods_schema")]
+    #[serde(flatten)]
+    pub restricted_methods: FxHashMap<String, Option<CompactStr>>,
+}
+
+fn restricted_methods_schema(_gen: &mut SchemaGenerator) -> Schema {
+    let value_schema = SchemaObject {
+        subschemas: Some(Box::new(SubschemaValidation {
+            any_of: Some(vec![
+                SchemaObject {
+                    instance_type: Some(InstanceType::String.into()),
+                    ..Default::default()
+                }
+                .into(),
+                SchemaObject {
+                    instance_type: Some(InstanceType::Null.into()),
+                    ..Default::default()
+                }
+                .into(),
+            ]),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+
+    SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        object: Some(Box::new(ObjectValidation {
+            additional_properties: Some(Box::new(value_schema.into())),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+    .into()
 }
 
 impl NoRestrictedJestMethodsConfig {
     #[expect(clippy::unnecessary_wraps)]
     pub fn from_configuration(value: &serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let restricted_jest_methods = value
+        let restricted_methods = value
             .get(0)
             .and_then(serde_json::Value::as_object)
-            .map(Self::compile_restricted_jest_methods)
+            .map(Self::compile_restricted_methods)
             .unwrap_or_default();
 
-        Ok(NoRestrictedJestMethodsConfig { restricted_jest_methods })
+        Ok(NoRestrictedJestMethodsConfig { restricted_methods })
     }
     pub fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
         let node = possible_jest_node.node;
@@ -105,32 +143,26 @@ impl NoRestrictedJestMethodsConfig {
                     ctx.diagnostic(restricted_jest_method(property_name, span));
                 },
                 |message| {
-                    if message.trim() == "" {
-                        ctx.diagnostic(restricted_jest_method(property_name, span));
-                    } else {
-                        ctx.diagnostic(restricted_jest_method_with_message(&message, span));
-                    }
+                    ctx.diagnostic(restricted_jest_method_with_message(&message, span));
                 },
             );
         }
     }
 
     fn contains(&self, key: &str) -> bool {
-        self.restricted_jest_methods.contains_key(key)
+        self.restricted_methods.contains_key(key)
     }
 
-    fn get_message(&self, name: &str) -> Option<String> {
-        self.restricted_jest_methods.get(name).cloned()
+    fn get_message(&self, name: &str) -> Option<CompactStr> {
+        self.restricted_methods.get(name).cloned().flatten()
     }
 
-    pub fn compile_restricted_jest_methods(
+    pub fn compile_restricted_methods(
         matchers: &serde_json::Map<String, serde_json::Value>,
-    ) -> FxHashMap<String, String> {
+    ) -> FxHashMap<String, Option<CompactStr>> {
         matchers
             .iter()
-            .map(|(key, value)| {
-                (String::from(key), String::from(value.as_str().unwrap_or_default()))
-            })
+            .map(|(key, value)| (String::from(key), value.as_str().map(CompactStr::from)))
             .collect()
     }
 }


### PR DESCRIPTION
With https://github.com/oxc-project/oxc/pull/22907 I want to start outputting the schema for rule configs. 
Boths rules (`jest/no-restricted-jest-methods` & `vitest/no-restricted-vi-methods`) had not the right user configuration output:

Upstream docs:
- https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-vi-methods.md
- https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-restricted-jest-methods.md

The Schema before this PR:

```ts
  "jest/no-restricted-jest-methods"?:
    | [AllowWarnDeny]
    | [
        AllowWarnDeny,
        {
          /**
           * A mapping of restricted Jest method names to custom messages - or
           * `null`, for a generic message.
           */
          restrictedJestMethods?: {
            [k: string]: string;
          };
          [k: string]: unknown;
        }
      ];
```

With this PR:
```ts
  "jest/no-restricted-jest-methods"?:
    | [AllowWarnDeny]
    | [
        AllowWarnDeny,
        {
          [k: string]: string | null;
        }
      ];
```


---

Bonus: used `Option<CompactStr>` for more performance (?)