### PR TITLE
refactor(linter): `jest/vitest/no-restricted-matchers` align config + schemars output

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_jest_methods.rs
@@ -1,19 +1,17 @@
+use crate::{
+    context::LintContext,
+    utils::{
+        JestFnKind, JestGeneralFnKind, PossibleJestNode, is_type_of_jest_fn_call,
+        object_with_nullable_string_schema,
+    },
+};
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 use oxc_str::CompactStr;
 use rustc_hash::FxHashMap;
-use schemars::{
-    JsonSchema,
-    r#gen::SchemaGenerator,
-    schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SubschemaValidation},
-};
+use schemars::JsonSchema;
 use serde::Deserialize;
-
-use crate::{
-    context::LintContext,
-    utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, is_type_of_jest_fn_call},
-};
 
 fn restricted_jest_method(method_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use of `{method_name}` is not allowed")).with_label(span)
@@ -62,40 +60,9 @@ test('plays video', () => {
 pub struct NoRestrictedJestMethodsConfig {
     /// A mapping of restricted Jest method names to custom messages - or
     /// `null`, for a generic message.
-    #[schemars(schema_with = "restricted_methods_schema")]
+    #[schemars(schema_with = "object_with_nullable_string_schema")]
     #[serde(flatten)]
     pub restricted_methods: FxHashMap<String, Option<CompactStr>>,
-}
-
-fn restricted_methods_schema(_gen: &mut SchemaGenerator) -> Schema {
-    let value_schema = SchemaObject {
-        subschemas: Some(Box::new(SubschemaValidation {
-            any_of: Some(vec![
-                SchemaObject {
-                    instance_type: Some(InstanceType::String.into()),
-                    ..Default::default()
-                }
-                .into(),
-                SchemaObject {
-                    instance_type: Some(InstanceType::Null.into()),
-                    ..Default::default()
-                }
-                .into(),
-            ]),
-            ..Default::default()
-        })),
-        ..Default::default()
-    };
-
-    SchemaObject {
-        instance_type: Some(InstanceType::Object.into()),
-        object: Some(Box::new(ObjectValidation {
-            additional_properties: Some(Box::new(value_schema.into())),
-            ..Default::default()
-        })),
-        ..Default::default()
-    }
-    .into()
 }
 
 impl NoRestrictedJestMethodsConfig {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_matchers.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
+use oxc_str::CompactStr;
 use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -11,7 +12,7 @@ use crate::{
     context::LintContext,
     utils::{
         JestFnKind, KnownMemberExpressionProperty, PossibleJestNode, is_type_of_jest_fn_call,
-        parse_expect_jest_fn_call,
+        object_with_nullable_string_schema, parse_expect_jest_fn_call,
     },
 };
 
@@ -86,12 +87,14 @@ describe('when an error happens', () => {
 "#;
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRestrictedMatchersConfig {
     /// A map of restricted matchers/modifiers to custom messages.
     /// The key is the matcher/modifier name (e.g., "toBeFalsy", "resolves", "not.toHaveBeenCalledWith").
     /// The value is an optional custom message to display when the matcher/modifier is used.
-    pub restricted_matchers: FxHashMap<String, String>,
+    #[schemars(schema_with = "object_with_nullable_string_schema")]
+    #[serde(flatten)]
+    pub restricted_matchers: FxHashMap<String, Option<CompactStr>>,
 }
 
 const MODIFIER_NAME: [&str; 3] = ["not", "rejects", "resolves"];
@@ -139,10 +142,10 @@ impl NoRestrictedMatchersConfig {
 
         for (restriction, message) in &self.restricted_matchers {
             if Self::check_restriction(chain_call.as_str(), restriction.as_str()) {
-                if message.is_empty() {
-                    ctx.diagnostic(restricted_chain(&chain_call, span));
-                } else {
+                if let Some(message) = message {
                     ctx.diagnostic(restricted_chain_with_message(&chain_call, message, span));
+                } else {
+                    ctx.diagnostic(restricted_chain(&chain_call, span));
                 }
             }
         }
@@ -160,12 +163,10 @@ impl NoRestrictedMatchersConfig {
 
     pub fn compile_restricted_matchers(
         matchers: &serde_json::Map<String, serde_json::Value>,
-    ) -> FxHashMap<String, String> {
+    ) -> FxHashMap<String, Option<CompactStr>> {
         matchers
             .iter()
-            .map(|(key, value)| {
-                (String::from(key), String::from(value.as_str().unwrap_or_default()))
-            })
+            .map(|(key, value)| (String::from(key), value.as_str().map(CompactStr::from)))
             .collect()
     }
 }

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -25,6 +25,7 @@ mod promise;
 mod react;
 mod react_perf;
 mod regex;
+mod schemars;
 mod static_value;
 mod this_expression;
 mod typescript;
@@ -36,8 +37,8 @@ pub mod vue_casing;
 
 pub use self::{
     comment::*, config::*, control_flow::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*,
-    react::*, react_perf::*, regex::*, static_value::*, this_expression::*, typescript::*,
-    unicorn::*, url::*, vitest::*, vue::*,
+    react::*, react_perf::*, regex::*, schemars::*, static_value::*, this_expression::*,
+    typescript::*, unicorn::*, url::*, vitest::*, vue::*,
 };
 
 /// List of Eslint rules that have TypeScript equivalents.

--- a/crates/oxc_linter/src/utils/schemars.rs
+++ b/crates/oxc_linter/src/utils/schemars.rs
@@ -1,0 +1,37 @@
+use schemars::{
+    r#gen::SchemaGenerator,
+    schema::{InstanceType, ObjectValidation, Schema, SchemaObject, SubschemaValidation},
+};
+
+/// Generates a JSON schema for an object where the keys are strings and the values are either strings or null.
+/// TS type equivalent: `Record<string, string | null>`
+pub fn object_with_nullable_string_schema(_gen: &mut SchemaGenerator) -> Schema {
+    let value_schema = SchemaObject {
+        subschemas: Some(Box::new(SubschemaValidation {
+            any_of: Some(vec![
+                SchemaObject {
+                    instance_type: Some(InstanceType::String.into()),
+                    ..Default::default()
+                }
+                .into(),
+                SchemaObject {
+                    instance_type: Some(InstanceType::Null.into()),
+                    ..Default::default()
+                }
+                .into(),
+            ]),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+
+    SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        object: Some(Box::new(ObjectValidation {
+            additional_properties: Some(Box::new(value_schema.into())),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+    .into()
+}


### PR DESCRIPTION
The same as github.com/oxc-project/oxc/pull/22920,
created a util helper for schema objects. 

- https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-restricted-matchers.md
- https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-restricted-matchers.md