### PR TITLE
fix(linter): deny unknown options for some rules

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/class_methods_use_this.rs
+++ b/crates/oxc_linter/src/rules/eslint/class_methods_use_this.rs
@@ -25,7 +25,7 @@ fn class_methods_use_this_diagnostic(span: Span, name: Option<Cow<'_, str>>) -> 
 }
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ClassMethodsUseThisConfig {
     /// List of method names to exempt from this rule. Names can include the hash for private methods.
     /// Example: `save`, `#rerender`

--- a/crates/oxc_linter/src/rules/eslint/complexity.rs
+++ b/crates/oxc_linter/src/rules/eslint/complexity.rs
@@ -27,7 +27,7 @@ fn complexity_diagnostic(span: Span, name: &str, complexity: usize, max: usize) 
 const THRESHOLD_DEFAULT: usize = 20;
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ComplexityConfig {
     /// Maximum amount of cyclomatic complexity
     #[serde(alias = "maximum")]

--- a/crates/oxc_linter/src/rules/import/extensions.rs
+++ b/crates/oxc_linter/src/rules/import/extensions.rs
@@ -146,7 +146,7 @@ impl PathGroupOverride {
 /// **Default behavior (no configuration)**: All imports - of all kinds - pass.
 /// Unconfigured file extensions are ignored, to avoid false positives.
 #[derive(Debug, Clone, JsonSchema, Serialize, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ExtensionsConfig {
     /// Whether to ignore package imports when enforcing extension rules.
     ///

--- a/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
@@ -24,7 +24,7 @@ fn no_nodejs_modules_diagnostic(span: Span, module_name: &str) -> OxcDiagnostic 
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(rename_all = "camelCase")]
+#[schemars(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NoNodejsModulesConfig {
     /// Array of names of allowed modules. Defaults to an empty array.
     allow: FxHashSet<CompactStr>,

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -31,7 +31,7 @@ impl Default for JestConfig {
 pub struct NoDeprecatedFunctions(Box<NoDeprecatedFunctionsConfig>);
 
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDeprecatedFunctionsConfig {
     /// Jest configuration options.
     /// Deprecated config, it will be removed in future versions.

--- a/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
@@ -29,7 +29,7 @@ fn prefer_ending_with_an_expect_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct PreferEndingWithAnExpect(Box<PreferEndingWithAnExpectConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferEndingWithAnExpectConfig {
     /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,

--- a/crates/oxc_linter/src/rules/jest/prefer_importing_jest_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_importing_jest_globals.rs
@@ -39,7 +39,7 @@ impl std::ops::Deref for PreferImportingJestGlobals {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferImportingJestGlobalsConfig {
     /// Jest function types to enforce importing for.
     types: Vec<JestFnType>,

--- a/crates/oxc_linter/src/rules/jsdoc/require_param.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param.rs
@@ -32,7 +32,7 @@ fn require_param_diagnostic(violations: Vec<Span>) -> OxcDiagnostic {
 pub struct RequireParam(Box<RequireParamConfig>);
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct RequireParamConfig {
     /// List of JSDoc tags that exempt functions from `@param` checking.
     #[serde(default = "default_exempted_by")]

--- a/crates/oxc_linter/src/rules/react/forbid_elements.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_elements.rs
@@ -56,7 +56,7 @@ impl From<ForbidElementsConfig> for ForbidElements {
 
 /// A forbidden element, either as a plain element name or with a custom message.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ForbidItem {
     ElementName(CompactStr),
     ElementWithMessage {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -45,7 +45,7 @@ test('should assert something', () => {});
 ```
 ";
 #[derive(Debug, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ExpectExpectConfig {
     /// A list of function names that should be treated as assertion functions.
     ///

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
@@ -114,7 +114,7 @@ line 4
 ";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoLargeSnapshotsConfig {
     /// Maximum number of lines allowed for external snapshot files.
     pub max_size: usize,

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_assertions.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_assertions.rs
@@ -21,7 +21,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct PreferExpectAssertionsConfig {
     pub only_functions_with_async_keyword: bool,
     pub only_functions_with_expect_in_callback: bool,

--- a/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_restricted_types.rs
@@ -48,7 +48,7 @@ struct NoRestrictedTypesConfig {
 /// - A string - ban with custom message
 /// - An object with `message` and optional `fixWith` and `suggest`
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 enum BanConfigValue {
     /// `"TypeName": true` - ban with default message
     /// Note: Only `true` is valid; `false` would fail to deserialize and be ignored.


### PR DESCRIPTION
Just a start. I get out of hand dangling all the PRs :') 
This is a part of https://github.com/oxc-project/oxc/pull/22907 
Found with https://github.com/oxc-project/oxc/pull/22907#discussion_r3337298304