### PR TITLE
build(nix): add flake packaging for Oxc tools

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+if [ -f .envrc.local ]; then
+  source_env .envrc.local
+elif command -v nix-shell >/dev/null 2>&1; then
+  use nix
+else
+  echo "direnv: nix-shell is not installed; skipping Nix dev shell" >&2
+fi

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,93 @@
+name: Nix
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - ".github/workflows/nix.yml"
+      - ".envrc"
+      - "flake.lock"
+      - "flake.nix"
+      - "shell.nix"
+      - "rust-toolchain.toml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "apps/**"
+      - "crates/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/nix.yml"
+      - ".envrc"
+      - "flake.lock"
+      - "flake.nix"
+      - "shell.nix"
+      - "rust-toolchain.toml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "apps/**"
+      - "crates/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  evaluate:
+    name: Evaluate all systems
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Check flake outputs
+        run: nix flake check --no-build --all-systems
+
+      - name: Check shell.nix
+        run: nix-shell --run "rustc --version"
+
+  build:
+    name: Build ${{ matrix.system }}
+    needs: evaluate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            os: ubuntu-latest
+          - system: aarch64-linux
+            os: ubuntu-24.04-arm
+          - system: x86_64-darwin
+            os: macos-15-intel
+          - system: aarch64-darwin
+            os: macos-15
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Confirm runner system
+        run: |
+          actual="$(nix eval --raw --impure --expr builtins.currentSystem)"
+          if [ "$actual" != "${{ matrix.system }}" ]; then
+            echo "Expected ${{ matrix.system }}, got $actual" >&2
+            exit 1
+          fi
+
+      - name: Build packages
+        run: |
+          nix build \
+            ".#packages.${{ matrix.system }}.oxcfmt" \
+            ".#packages.${{ matrix.system }}.oxclint" \
+            --no-link
+
+      - name: Smoke test apps
+        run: |
+          nix run ".#apps.${{ matrix.system }}.oxcfmt" -- --version
+          nix run ".#apps.${{ matrix.system }}.oxclint" -- --version

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tasks/coverage/node-compat-table/
 tasks/prettier_conformance/prettier/
 
 # Ignore accidental files from the root
+/.envrc.local
 /*.js
 /*.jsx
 /*.ts

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,129 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1780370483,
+        "narHash": "sha256-7mDa7OBAaf7MU6ZovT9ENfD62kH911SsSazBb4KTDF0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4a408e1fc99ad517b4cb402fd0de7464f40c05e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Oxc JavaScript tooling";
+
+  inputs = {
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    inputs@{
+      flake-parts,
+      nixpkgs,
+      rust-overlay,
+      systems,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import systems;
+
+      imports = [
+        ./nix/flake/toolchain.nix
+        ./nix/flake/packages.nix
+        ./nix/flake/dev-shells.nix
+        ./nix/flake/formatter.nix
+      ];
+    };
+}

--- a/nix/flake/dev-shells.nix
+++ b/nix/flake/dev-shells.nix
@@ -1,0 +1,20 @@
+{ ... }:
+{
+  perSystem =
+    {
+      oxcPkgs,
+      oxcRustToolchain,
+      ...
+    }:
+    {
+      devShells.default = oxcPkgs.mkShell {
+        packages = [
+          oxcRustToolchain
+          oxcPkgs.just
+          oxcPkgs.nodejs
+          oxcPkgs.pnpm
+          oxcPkgs.cmake
+        ];
+      };
+    };
+}

--- a/nix/flake/formatter.nix
+++ b/nix/flake/formatter.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  perSystem =
+    { oxcPkgs, ... }:
+    {
+      formatter = oxcPkgs.nixfmt;
+    };
+}

--- a/nix/flake/packages.nix
+++ b/nix/flake/packages.nix
@@ -1,0 +1,136 @@
+{ ... }:
+{
+  perSystem =
+    {
+      config,
+      oxcPkgs,
+      oxcRustPlatform,
+      ...
+    }:
+    let
+      inherit (oxcPkgs) lib;
+
+      mkFeatureFlags =
+        {
+          noDefaultFeatures ? false,
+          features ? [ ],
+        }:
+        lib.optionals noDefaultFeatures [ "--no-default-features" ]
+        ++ lib.optionals (features != [ ]) [
+          "--features"
+          (lib.concatStringsSep "," features)
+        ];
+
+      workspaceManifest = lib.importTOML ../../Cargo.toml;
+      workspacePackage = workspaceManifest.workspace.package;
+
+      mkOxcPackage =
+        {
+          cargoPackage,
+          manifest,
+          binary,
+          noDefaultFeatures ? false,
+          features ? [ ],
+        }:
+        let
+          featureFlags = mkFeatureFlags { inherit noDefaultFeatures features; };
+        in
+        oxcRustPlatform.buildRustPackage {
+          pname = binary;
+          version = manifest.package.version;
+
+          src = ../../.;
+          cargoLock.lockFile = ../../Cargo.lock;
+
+          cargoBuildFlags = [
+            "--package"
+            cargoPackage
+          ]
+          ++ featureFlags;
+
+          doCheck = false;
+
+          nativeBuildInputs = [ oxcPkgs.cmake ];
+
+          buildInputs = lib.optionals oxcPkgs.stdenv.hostPlatform.isDarwin [
+            oxcPkgs.apple-sdk_15
+            oxcPkgs.libiconv
+          ];
+
+          meta = {
+            inherit (workspacePackage) description homepage;
+            license = lib.licenses.mit;
+            mainProgram = binary;
+          };
+        };
+
+      mkProgramAlias =
+        {
+          package,
+          alias,
+          binary,
+        }:
+        oxcPkgs.symlinkJoin {
+          name = "${alias}-${package.version}";
+          paths = [ package ];
+          postBuild = ''
+            ln -s "$out/bin/${binary}" "$out/bin/${alias}"
+          '';
+          meta = package.meta // {
+            mainProgram = alias;
+          };
+        };
+
+      mkApp = package: binary: {
+        type = "app";
+        program = "${package}/bin/${binary}";
+      };
+
+      oxfmtManifest = lib.importTOML ../../apps/oxfmt/Cargo.toml;
+      oxlintManifest = lib.importTOML ../../apps/oxlint/Cargo.toml;
+    in
+    {
+      packages = rec {
+        oxfmt = mkOxcPackage {
+          cargoPackage = "oxfmt";
+          manifest = oxfmtManifest;
+          binary = "oxfmt";
+          noDefaultFeatures = true;
+          features = [ "allocator" ];
+        };
+
+        oxlint = mkOxcPackage {
+          cargoPackage = "oxlint";
+          manifest = oxlintManifest;
+          binary = "oxlint";
+          features = [ "allocator" ];
+        };
+
+        oxcfmt = mkProgramAlias {
+          package = oxfmt;
+          alias = "oxcfmt";
+          binary = "oxfmt";
+        };
+
+        oxclint = mkProgramAlias {
+          package = oxlint;
+          alias = "oxclint";
+          binary = "oxlint";
+        };
+
+        default = oxlint;
+      };
+
+      apps = {
+        oxfmt = mkApp config.packages.oxfmt "oxfmt";
+        oxlint = mkApp config.packages.oxlint "oxlint";
+        oxcfmt = mkApp config.packages.oxcfmt "oxcfmt";
+        oxclint = mkApp config.packages.oxclint "oxclint";
+        default = mkApp config.packages.default "oxlint";
+      };
+
+      checks = {
+        inherit (config.packages) oxfmt oxlint;
+      };
+    };
+}

--- a/nix/flake/toolchain.nix
+++ b/nix/flake/toolchain.nix
@@ -1,0 +1,21 @@
+{ inputs, ... }:
+{
+  perSystem =
+    { system, ... }:
+    let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [ inputs.rust-overlay.overlays.default ];
+      };
+
+      rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ../../rust-toolchain.toml;
+    in
+    {
+      _module.args.oxcPkgs = pkgs;
+      _module.args.oxcRustToolchain = rustToolchain;
+      _module.args.oxcRustPlatform = pkgs.makeRustPlatform {
+        cargo = rustToolchain;
+        rustc = rustToolchain;
+      };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+let
+  lockFile = builtins.fromJSON (builtins.readFile ./flake.lock);
+  flakeCompatNode = lockFile.nodes.${lockFile.nodes.root.inputs.flake-compat};
+  flakeCompatLocked = flakeCompatNode.locked;
+  flakeCompatUrl =
+    flakeCompatLocked.url
+      or "https://github.com/${flakeCompatLocked.owner}/${flakeCompatLocked.repo}/archive/${flakeCompatLocked.rev}.tar.gz";
+  flakeCompat = builtins.fetchTarball {
+    url = flakeCompatUrl;
+    sha256 = flakeCompatLocked.narHash;
+  };
+
+  flake = import flakeCompat { src = ./.; };
+in
+flake.shellNix


### PR DESCRIPTION
## Summary

Adds Nix support for Oxc with a flake, non-flake compatibility, direnv integration, and CI coverage.

## Why

This gives Oxc reproducible, pinned Nix package outputs for the formatter and linter while keeping the existing development workflow intact. Compared with dev containers, this is focused on package builds, CLI app outputs, toolchain pinning, and making Oxc easier to consume from the Nix ecosystem.

## Running from GitHub

The flake exposes app outputs for the Oxc CLIs and compatibility aliases:

```bash
nix run github:oxc-project/oxc#oxfmt -- --version
nix run github:oxc-project/oxc#oxlint -- --version
nix run github:oxc-project/oxc#oxcfmt -- --version
nix run github:oxc-project/oxc#oxclint -- --version
```

## What changed

- Add a `flake-parts` based `flake.nix`, split into focused modules under `nix/flake/`.
- Derive the Rust toolchain from `rust-toolchain.toml` via `rust-overlay`.
- Add package and app outputs for `oxfmt`, `oxlint`, `oxcfmt`, and `oxclint`.
- Build `oxfmt` with `--no-default-features --features allocator`.
- Build `oxlint` with `--features allocator`.
- Add a default dev shell with the pinned Rust toolchain, `just`, Node.js, pnpm, and CMake.
- Use `nixfmt` as the flake formatter.
- Add `shell.nix` through locked `flake-compat` for non-flake Nix users.
- Add `.envrc` support that prefers `.envrc.local`, falls back to `nix-shell`, and skips cleanly when Nix is unavailable.
- Ignore `.envrc.local`.
- Add GitHub Actions coverage for flake evaluation, `shell.nix`, native Linux/macOS builds, and app smoke tests.

## Verification

```bash
nix flake check --no-build --all-systems
nix build .#oxcfmt .#oxclint --no-link
nix run .#oxcfmt -- --version
nix run .#oxclint -- --version
nix run .#apps.aarch64-darwin.oxcfmt -- --version
nix run .#apps.aarch64-darwin.oxclint -- --version
nix run nixpkgs#actionlint -- .github/workflows/nix.yml
bash -n .envrc
nix-shell --run 'rustc --version'
git check-ignore -v .envrc.local
```

## AI disclosure

This PR was prepared with AI assistance. I reviewed the generated changes and verification results before submitting.