### PR TITLE
fix(formatter_json): use line_suffix for line comment outside array

### DIFF
--- a/crates/oxc_formatter_json/src/comments.rs
+++ b/crates/oxc_formatter_json/src/comments.rs
@@ -4,14 +4,17 @@ use oxc_allocator::StringBuilder;
 use oxc_ast::Comment;
 use oxc_formatter_core::{
     Buffer, Format, SourceText,
-    builders::{empty_line, expand_parent, hard_line_break, space, text},
+    builders::{empty_line, expand_parent, hard_line_break, line_suffix, space, text},
     util::is_suppression_marker,
     write,
 };
 use oxc_span::Span;
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
-use crate::{context::JsonFormatContext, print::JsonFormatter};
+use crate::{
+    context::JsonFormatContext,
+    print::{JsonFormatter, format_with},
+};
 
 /// Cursor over a sorted comment list that hands out unprinted slices in span order.
 ///
@@ -166,11 +169,21 @@ pub fn write_trailing_inside_comments(
     let source = f.context().source_text();
     let mut prev_end = lower_bound;
     for comment in comments {
-        write_gap(source.bytes_range(prev_end, comment.span.start), f);
-        write_single_comment(comment, f);
-        // To prevent `[a, // this comment breaks -> ]`
+        let gap = source.bytes_range(prev_end, comment.span.start);
         if comment.is_line() {
-            write!(f, expand_parent());
+            // Defer a trailing line comment to the `line_suffix()`,
+            // so its width is not counted toward the `fits` measurement of the preceding group
+            // (mirrors `oxc_formatter`'s `FormatTrailingComments`).
+            // `expand_parent()` keeps the enclosing container multi-line,
+            // so `[a, // comment -> ]` doesn't collapse.
+            let content = format_with(move |f: &mut JsonFormatter<'_, '_>| {
+                write_gap(gap, f);
+                write_single_comment(comment, f);
+            });
+            write!(f, [line_suffix(&content), expand_parent()]);
+        } else {
+            write_gap(gap, f);
+            write_single_comment(comment, f);
         }
         prev_end = comment.span.end;
     }

--- a/crates/oxc_formatter_json/tests/fixtures/json/comments/inline_value_trailing_line_comment.json
+++ b/crates/oxc_formatter_json/tests/fixtures/json/comments/inline_value_trailing_line_comment.json
@@ -1,0 +1,7 @@
+{
+  "workspaces": {
+    "packages/test-dev-server/tests/fixtures/*": {
+      "entry": ["dev.config.mjs", "src/*.js"] // no @rolldown/test-dev-server plugin
+    }
+  }
+}

--- a/crates/oxc_formatter_json/tests/fixtures/json/comments/inline_value_trailing_line_comment.json.snap
+++ b/crates/oxc_formatter_json/tests/fixtures/json/comments/inline_value_trailing_line_comment.json.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_formatter_json/tests/fixtures/mod.rs
+---
+==================== Input ====================
+{
+  "workspaces": {
+    "packages/test-dev-server/tests/fixtures/*": {
+      "entry": ["dev.config.mjs", "src/*.js"] // no @rolldown/test-dev-server plugin
+    }
+  }
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+{
+  "workspaces": {
+    "packages/test-dev-server/tests/fixtures/*": {
+      "entry": ["dev.config.mjs", "src/*.js"] // no @rolldown/test-dev-server plugin
+    }
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+{
+  "workspaces": {
+    "packages/test-dev-server/tests/fixtures/*": {
+      "entry": ["dev.config.mjs", "src/*.js"] // no @rolldown/test-dev-server plugin
+    }
+  }
+}
+
+===================== End =====================


### PR DESCRIPTION
Input:
```json
[1, 2, 3] // if this comment is too long and >= printWidth
```

Before:
```json
[
  1,
  2,
  3
] // if this comment is too long and >= printWidth
```

After:
```json
[1, 2, 3] // if this comment is too long and >= printWidth
```
