### PR TITLE
fix(parser): handle html comment values

### DIFF
--- a/apps/oxlint/src-js/generated/constants.ts
+++ b/apps/oxlint/src-js/generated/constants.ts
@@ -103,3 +103,13 @@ export const DESERIALIZED_FLAG_OFFSET = 15;
  * Discriminant value for `CommentKind::Line`.
  */
 export const COMMENT_LINE_KIND = 0;
+
+/**
+ * Discriminant value for `CommentKind::HTMLOpenLine`.
+ */
+export const COMMENT_HTML_OPEN_LINE_KIND = 3;
+
+/**
+ * Discriminant value for `CommentKind::HTMLCloseLine`.
+ */
+export const COMMENT_HTML_CLOSE_LINE_KIND = 4;

--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -8,6 +8,8 @@ import {
   COMMENTS_LEN_OFFSET,
   COMMENT_SIZE,
   COMMENT_KIND_OFFSET,
+  COMMENT_HTML_CLOSE_LINE_KIND,
+  COMMENT_HTML_OPEN_LINE_KIND,
   COMMENT_LINE_KIND,
   DATA_POINTER_POS_32,
   DESERIALIZED_FLAG_OFFSET,
@@ -321,7 +323,11 @@ function deserializeCommentIfNeeded(index: number): Comment | null {
   // Deserialize comment into a cached `Comment` object
   const comment = cachedComments[index];
 
-  const isBlock = commentsUint8![pos + COMMENT_KIND_OFFSET] !== COMMENT_LINE_KIND;
+  const kind = commentsUint8![pos + COMMENT_KIND_OFFSET];
+  const isBlock =
+    kind !== COMMENT_LINE_KIND &&
+    kind !== COMMENT_HTML_OPEN_LINE_KIND &&
+    kind !== COMMENT_HTML_CLOSE_LINE_KIND;
 
   const pos32 = pos >> 2,
     start = commentsInt32![pos32],
@@ -329,8 +335,13 @@ function deserializeCommentIfNeeded(index: number): Comment | null {
 
   comment.type = isBlock ? "Block" : "Line";
   // Line comments: `// text` -> slice `start + 2..end`
+  // HTML line comments: `<!-- text` / `--> text` -> slice after the full marker
   // Block comments: `/* text */` -> slice `start + 2..end - 2`
-  comment.value = sourceText!.slice(start + 2, end - (+isBlock << 1));
+  comment.value = sourceText!.slice(
+    start +
+      (kind === COMMENT_HTML_OPEN_LINE_KIND ? 4 : kind === COMMENT_HTML_CLOSE_LINE_KIND ? 3 : 2),
+    end - (+isBlock << 1),
+  );
   comment.range[0] = comment.start = start;
   comment.range[1] = comment.end = end;
 

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -20,6 +20,12 @@ pub enum CommentKind {
     /// Multi-line block comment (contains line breaks)
     #[estree(rename = "Block")]
     MultiLineBlock = 2,
+    /// HTML open line comment `<!--`
+    #[estree(rename = "Line")]
+    HTMLOpenLine = 3,
+    /// HTML close line comment `-->`
+    #[estree(rename = "Line")]
+    HTMLCloseLine = 4,
 }
 
 /// Information about a comment's position relative to a token.
@@ -184,6 +190,8 @@ impl Comment {
     pub fn content_span(&self) -> Span {
         match self.kind {
             CommentKind::Line => Span::new(self.span.start + 2, self.span.end),
+            CommentKind::HTMLOpenLine => Span::new(self.span.start + 4, self.span.end),
+            CommentKind::HTMLCloseLine => Span::new(self.span.start + 3, self.span.end),
             CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
                 Span::new(self.span.start + 2, self.span.end - 2)
             }
@@ -193,7 +201,10 @@ impl Comment {
     /// Returns `true` if this is a line comment.
     #[inline]
     pub fn is_line(self) -> bool {
-        self.kind == CommentKind::Line
+        matches!(
+            self.kind,
+            CommentKind::Line | CommentKind::HTMLOpenLine | CommentKind::HTMLCloseLine
+        )
     }
 
     /// Returns `true` if this is a block comment (either single-line or multi-line).

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3228,6 +3228,8 @@ impl ESTree for CommentKind {
             Self::Line => JsonSafeString("Line").serialize(serializer),
             Self::SingleLineBlock => JsonSafeString("Block").serialize(serializer),
             Self::MultiLineBlock => JsonSafeString("Block").serialize(serializer),
+            Self::HTMLOpenLine => JsonSafeString("Line").serialize(serializer),
+            Self::HTMLCloseLine => JsonSafeString("Line").serialize(serializer),
         }
     }
 }

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -246,7 +246,10 @@ fn get_ts_start_span(program: &Program<'_>) -> u32 {
 #[ast_meta]
 #[estree(
     ts_type = "string",
-    raw_deser = "SOURCE_TEXT.slice(THIS.start + 2, THIS.end - (THIS.type === 'Line' ? 0 : 2))",
+    raw_deser = "
+        const kind = DESER[u8](POS_OFFSET.kind);
+        SOURCE_TEXT.slice(THIS.start + (kind === 3 ? 4 : kind === 4 ? 3 : 2), THIS.end - (kind === 1 || kind === 2 ? 2 : 0))
+    ",
     raw_deser_inline
 )]
 pub struct CommentValue<'b>(#[expect(dead_code)] pub &'b Comment);

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -313,7 +313,10 @@ impl Codegen<'_> {
         };
         let comment_source = comment.span.source_text(source_text);
         match comment.kind {
-            CommentKind::Line | CommentKind::SingleLineBlock => {
+            CommentKind::Line
+            | CommentKind::HTMLOpenLine
+            | CommentKind::HTMLCloseLine
+            | CommentKind::SingleLineBlock => {
                 self.print_str_escaping_script_close_tag(comment_source);
             }
             CommentKind::MultiLineBlock => {

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -1,7 +1,8 @@
 use crate::{
     test_idempotency, test_idempotency_options,
-    tester::{test, test_same},
+    tester::{default_options, test, test_options_with_source_type, test_same},
 };
+use oxc_span::SourceType;
 
 // A leading comment inside a `pife` arrow alternate of a `?:` must stay
 // inside the paren wrap on every codegen pass; otherwise the parser re-
@@ -39,6 +40,22 @@ fn test_comment_at_top_of_file() {
     ret.program.comments[0].position = CommentPosition::Leading;
     let code = Codegen::new().build(&ret.program).code;
     assert_eq!(code, "/** comment */ export {};\n");
+}
+
+#[test]
+fn test_html_line_comments() {
+    test_options_with_source_type(
+        "<!--a\nlet x",
+        "<!--a\nlet x;\n",
+        SourceType::script(),
+        default_options(),
+    );
+    test_options_with_source_type(
+        "-->\nlet x",
+        "-->\nlet x;\n",
+        SourceType::script(),
+        default_options(),
+    );
 }
 
 #[test]

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -131,10 +131,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatLeadingComments<'a> {
                             _ => write!(f, [empty_line()]),
                         }
                     }
-                    CommentKind::Line => match f.source_text().lines_after(comment.span.end) {
-                        0 | 1 => write!(f, [hard_line_break()]),
-                        _ => write!(f, [empty_line()]),
-                    },
+                    CommentKind::Line | CommentKind::HTMLOpenLine | CommentKind::HTMLCloseLine => {
+                        match f.source_text().lines_after(comment.span.end) {
+                            0 | 1 => write!(f, [hard_line_break()]),
+                            _ => write!(f, [empty_line()]),
+                        }
+                    }
                 }
             }
         }

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -32,7 +32,9 @@ pub fn convert_utf8_to_utf16(
             }
             Comment {
                 r#type: match comment.kind {
-                    CommentKind::Line => String::from("Line"),
+                    CommentKind::Line | CommentKind::HTMLOpenLine | CommentKind::HTMLCloseLine => {
+                        String::from("Line")
+                    }
                     CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
                         String::from("Block")
                     }

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -76,7 +76,12 @@ impl<'a> TriviaBuilder<'a> {
     }
 
     pub fn add_line_comment(&mut self, start: u32, end: u32, source_text: &str) {
-        self.add_comment(Comment::new(start, end, CommentKind::Line), source_text);
+        let kind = match source_text.as_bytes().get(start as usize..) {
+            Some(bytes) if bytes.starts_with(b"<!--") => CommentKind::HTMLOpenLine,
+            Some(bytes) if bytes.starts_with(b"-->") => CommentKind::HTMLCloseLine,
+            _ => CommentKind::Line,
+        };
+        self.add_comment(Comment::new(start, end, kind), source_text);
     }
 
     pub fn add_block_comment(

--- a/napi/parser/src-js/generated/constants.js
+++ b/napi/parser/src-js/generated/constants.js
@@ -103,3 +103,13 @@ export const DESERIALIZED_FLAG_OFFSET = 15;
  * Discriminant value for `CommentKind::Line`.
  */
 export const COMMENT_LINE_KIND = 0;
+
+/**
+ * Discriminant value for `CommentKind::HTMLOpenLine`.
+ */
+export const COMMENT_HTML_OPEN_LINE_KIND = 3;
+
+/**
+ * Discriminant value for `CommentKind::HTMLCloseLine`.
+ */
+export const COMMENT_HTML_CLOSE_LINE_KIND = 4;

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -4125,18 +4125,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
   };

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -4638,18 +4638,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
   };

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -4640,18 +4640,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
     range: [start, end],

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -5152,18 +5152,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
     range: [start, end],

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -4401,18 +4401,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
   };

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -4944,18 +4944,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
   };

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -4944,18 +4944,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
     range: [start, end],

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -5486,18 +5486,25 @@ function deserializeCommentKind(pos) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw Error(`Unexpected discriminant ${uint8[pos]} for CommentKind`);
   }
 }
 
 function deserializeComment(pos) {
-  let type = deserializeCommentKind(pos + 12),
-    start = deserializeI32(pos),
-    end = deserializeI32(pos + 4);
+  let start = deserializeI32(pos),
+    end = deserializeI32(pos + 4),
+    kind = deserializeU8(pos + 12);
   return {
-    type,
-    value: sourceText.slice(start + 2, end - (type === "Line" ? 0 : 2)),
+    type: deserializeCommentKind(pos + 12),
+    value: sourceText.slice(
+      start + (kind === 3 ? 4 : kind === 4 ? 3 : 2),
+      end - (kind === 1 || kind === 2 ? 2 : 0),
+    ),
     start,
     end,
     range: [start, end],

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -11753,6 +11753,10 @@ function constructCommentKind(pos, ast) {
       return "Block";
     case 2:
       return "Block";
+    case 3:
+      return "Line";
+    case 4:
+      return "Line";
     default:
       throw new Error(`Unexpected discriminant ${ast.buffer[pos]} for CommentKind`);
   }

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -689,6 +689,26 @@ describe("parse", () => {
     });
   });
 
+  describe("comments", () => {
+    it("sets comment values after the full marker", () => {
+      const cases = [
+        ["// line\n", { type: "Line", value: " line", start: 0, end: 7 }],
+        ["/* block */", { type: "Block", value: " block ", start: 0, end: 11 }],
+        ["/* multi\nline */", { type: "Block", value: " multi\nline ", start: 0, end: 16 }],
+        ["<!--a\n", { type: "Line", value: "a", start: 0, end: 5 }],
+        ["-->", { type: "Line", value: "", start: 0, end: 3 }],
+        ["<!--", { type: "Line", value: "", start: 0, end: 4 }],
+      ] as const;
+
+      for (const [sourceText, comment] of cases) {
+        const ret = parseSync("test.js", sourceText, { sourceType: "script" });
+        expect(ret.errors).toHaveLength(0);
+        expect(ret.comments).toHaveLength(1);
+        expect(ret.comments[0]).toEqual(comment);
+      }
+    });
+  });
+
   describe("preserveParens", () => {
     it("should include parens when true", () => {
       let ret = parseSync("test.js", "(x)");

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -1467,6 +1467,10 @@ struct Constants {
     deserialized_flag_offset: u32,
     /// Discriminant value for `CommentKind::Line`
     comment_line_kind: u8,
+    /// Discriminant value for `CommentKind::HTMLOpenLine`
+    comment_html_open_line_kind: u8,
+    /// Discriminant value for `CommentKind::HTMLCloseLine`
+    comment_html_close_line_kind: u8,
     /// Size of `RawTransferMetadata` in bytes
     raw_metadata_size: u32,
     /// Alignment of `RawTransferMetadata`
@@ -1493,6 +1497,8 @@ fn generate_constants(consts: Constants) -> (String, TokenStream) {
         comment_kind_offset,
         deserialized_flag_offset,
         comment_line_kind,
+        comment_html_open_line_kind,
+        comment_html_close_line_kind,
         raw_metadata_size,
         raw_metadata_align,
     } = consts;
@@ -1605,6 +1611,16 @@ fn generate_constants(consts: Constants) -> (String, TokenStream) {
          * Discriminant value for `CommentKind::Line`.
          */
         export const COMMENT_LINE_KIND = {comment_line_kind};
+
+        /**
+         * Discriminant value for `CommentKind::HTMLOpenLine`.
+         */
+        export const COMMENT_HTML_OPEN_LINE_KIND = {comment_html_open_line_kind};
+
+        /**
+         * Discriminant value for `CommentKind::HTMLCloseLine`.
+         */
+        export const COMMENT_HTML_CLOSE_LINE_KIND = {comment_html_close_line_kind};
     ");
 
     let block_size = number_lit(BLOCK_SIZE);
@@ -1752,6 +1768,18 @@ fn get_constants(schema: &Schema) -> Constants {
     let comment_kind_enum = schema.type_by_name("CommentKind").as_enum().unwrap();
     let comment_line_kind =
         comment_kind_enum.variants.iter().find(|v| v.name() == "Line").unwrap().discriminant;
+    let comment_html_open_line_kind = comment_kind_enum
+        .variants
+        .iter()
+        .find(|v| v.name() == "HTMLOpenLine")
+        .unwrap()
+        .discriminant;
+    let comment_html_close_line_kind = comment_kind_enum
+        .variants
+        .iter()
+        .find(|v| v.name() == "HTMLCloseLine")
+        .unwrap()
+        .discriminant;
 
     Constants {
         buffer_size,
@@ -1771,6 +1799,8 @@ fn get_constants(schema: &Schema) -> Constants {
         comment_kind_offset,
         deserialized_flag_offset,
         comment_line_kind,
+        comment_html_open_line_kind,
+        comment_html_close_line_kind,
         raw_metadata_size,
         raw_metadata_align,
     }


### PR DESCRIPTION
Fixes #22803.

## Summary

- encode Annex B HTML line comment markers in `CommentKind` with `HTMLOpenLine` and `HTMLCloseLine`
- make `Comment::content_span()` skip the full marker length for `<!--` and `-->`
- keep ESTree/NAPI/raw-transfer output as `type: "Line"`
- add codegen coverage for both HTML line comment markers
- add NAPI parser coverage for returned comment `value` across line, block, multiline block, and HTML line comments

## Tests

- `just fmt`
- `cargo test -p oxc_codegen test_html_line_comments`
- `cargo test -p oxc_parser comments`
- `cargo check -p oxc_parser -p oxc_napi -p oxc_codegen -p oxc_formatter`
- `cargo check -p oxc_ast_tools`
- `cd napi/parser && pnpm test parse.test.ts -t "comment values"`
- `git diff --check`

AI assistance was used for this change.