### PR TITLE
refactor(semantic): classify redeclared functions without reading their AST node

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -72,7 +72,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                     if let Some(symbol_id) =
                         builder.check_redeclaration(scope_id, span, name, excludes)
                     {
-                        builder.add_redeclare_variable(symbol_id, includes, span);
+                        builder.add_redeclare_variable(symbol_id, includes, span, false);
                         declared_symbol_id = Some(symbol_id);
 
                         // Hoist current symbol to target scope when it is not already declared
@@ -155,7 +155,13 @@ impl<'a> Binder<'a> for Function<'a> {
                 SymbolFlags::FunctionExcludes - SymbolFlags::FunctionScopedVariable
             };
 
-            let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
+            let symbol_id = builder.declare_function_symbol(
+                ident.span,
+                ident.name,
+                includes,
+                excludes,
+                self.r#async || self.generator,
+            );
             ident.symbol_id.set(Some(symbol_id));
 
             // Annex B.3.2.1: In sloppy mode, plain function declarations inside block

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -16,6 +16,7 @@ use oxc_cfg::{
     IterationInstructionKind, ReturnInstructionKind,
 };
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexVec;
 use oxc_span::{SourceType, Span};
 use oxc_str::{Ident, IdentHashMap};
 use oxc_syntax::{
@@ -95,6 +96,11 @@ pub struct SemanticBuilder<'a> {
     pub(crate) nodes: AstNodes<'a>,
     pub(crate) scoping: Scoping,
 
+    /// Build-only scratch (discarded after the build): whether each symbol's declaration is an
+    /// `async`/generator function, indexed by `SymbolId` and kept in sync with symbol creation.
+    /// Read by the redeclaration checks so they needn't reach a previous declaration's node.
+    symbol_is_async_or_generators: IndexVec<SymbolId, bool>,
+
     pub(crate) unresolved_references: UnresolvedReferences<'a>,
     /// Checkpoint for early resolution of function parameter / catch parameter references.
     /// Tracks the start index in the flat unresolved references list.
@@ -159,6 +165,7 @@ impl<'a> SemanticBuilder<'a> {
             nodes: AstNodes::default(),
             hoisting_variables: FxHashMap::default(),
             scoping,
+            symbol_is_async_or_generators: IndexVec::new(),
             unresolved_references: UnresolvedReferences::new(),
             unresolved_references_checkpoint: 0,
             unused_labels: UnusedLabels::default(),
@@ -438,20 +445,54 @@ impl<'a> SemanticBuilder<'a> {
         includes: SymbolFlags,
         excludes: SymbolFlags,
     ) -> SymbolId {
+        self.declare_symbol_on_scope_impl(span, name, scope_id, includes, excludes, false)
+    }
+
+    /// Declare a function symbol, recording whether it is `async`/generator so the redeclaration
+    /// checks can classify it without reading its node.
+    pub(crate) fn declare_function_symbol(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        includes: SymbolFlags,
+        excludes: SymbolFlags,
+        is_async_or_generator: bool,
+    ) -> SymbolId {
+        self.declare_symbol_on_scope_impl(
+            span,
+            name,
+            self.current_scope_id,
+            includes,
+            excludes,
+            is_async_or_generator,
+        )
+    }
+
+    fn declare_symbol_on_scope_impl(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        scope_id: ScopeId,
+        includes: SymbolFlags,
+        excludes: SymbolFlags,
+        is_async_or_generator: bool,
+    ) -> SymbolId {
         if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes) {
-            self.add_redeclare_variable(symbol_id, includes, span);
+            self.add_redeclare_variable(symbol_id, includes, span, is_async_or_generator);
             self.scoping.union_symbol_flag(symbol_id, includes);
             return symbol_id;
         }
 
-        self.scoping.create_symbol_with_binding(
+        let symbol_id = self.scoping.create_symbol_with_binding(
             span,
             name,
             includes,
             scope_id,
             scope_id,
             self.current_node_id,
-        )
+        );
+        self.record_symbol_is_async_or_generator(symbol_id, is_async_or_generator);
+        symbol_id
     }
 
     /// Declare a new symbol on the current scope.
@@ -525,14 +566,16 @@ impl<'a> SemanticBuilder<'a> {
         scope_id: ScopeId,
         includes: SymbolFlags,
     ) -> SymbolId {
-        self.scoping.create_symbol_with_binding(
+        let symbol_id = self.scoping.create_symbol_with_binding(
             span,
             name,
             includes,
             self.current_scope_id,
             scope_id,
             self.current_node_id,
-        )
+        );
+        self.record_symbol_is_async_or_generator(symbol_id, false);
+        symbol_id
     }
 
     /// Resolve all collected references by walking up the scope chain from each
@@ -648,13 +691,33 @@ impl<'a> SemanticBuilder<'a> {
         self.unresolved_references.truncate(write_idx);
     }
 
+    /// Record whether a freshly created symbol's declaration is an `async`/generator function,
+    /// in build-only scratch indexed by `SymbolId` (kept in sync with symbol creation).
+    fn record_symbol_is_async_or_generator(
+        &mut self,
+        symbol_id: SymbolId,
+        is_async_or_generator: bool,
+    ) {
+        let index = self.symbol_is_async_or_generators.push(is_async_or_generator);
+        debug_assert_eq!(index, symbol_id);
+    }
+
     pub(crate) fn add_redeclare_variable(
         &mut self,
         symbol_id: SymbolId,
         flags: SymbolFlags,
         span: Span,
+        is_async_or_generator: bool,
     ) {
-        self.scoping.add_symbol_redeclaration(symbol_id, flags, self.current_node_id, span);
+        let first_declaration_is_async_or_generator = self.symbol_is_async_or_generators[symbol_id];
+        self.scoping.add_symbol_redeclaration(
+            symbol_id,
+            flags,
+            self.current_node_id,
+            span,
+            is_async_or_generator,
+            first_declaration_is_async_or_generator,
+        );
     }
 
     fn visit_parameter_decorators(&mut self, decorators: &oxc_allocator::Vec<'a, Decorator<'a>>) {

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -766,8 +766,7 @@ pub fn check_function_redeclaration(func: &Function, ctx: &SemanticBuilder<'_>) 
     } else if !(current_scope_flags.is_strict_mode() || func.r#async || func.generator) {
         // `class a {}; function a() {}` and `async function a() {} function a () {}` are
         // invalid in both strict and non-strict mode.
-        let prev_function = ctx.nodes.kind(prev.declaration).as_function();
-        if prev_function.is_some_and(|func| !(func.r#async || func.generator)) {
+        if prev.flags.contains(SymbolFlags::Function) && !prev.is_async_or_generator {
             return;
         }
     }

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -25,6 +25,11 @@ pub struct Redeclaration {
     pub span: Span,
     pub declaration: NodeId,
     pub flags: SymbolFlags,
+    /// Whether this declaration is an `async` function and/or a generator.
+    ///
+    /// Read by `check_function_redeclaration` (Annex B.3.3) to classify a previous declaration
+    /// without reading its AST node, which may no longer be reachable.
+    pub is_async_or_generator: bool,
 }
 
 impl CloneIn<'_> for Redeclaration {
@@ -32,7 +37,12 @@ impl CloneIn<'_> for Redeclaration {
 
     #[inline]
     fn clone_in(&self, _allocator: &Allocator) -> Self::Cloned {
-        Self { span: self.span, declaration: NodeId::DUMMY, flags: self.flags }
+        Self {
+            span: self.span,
+            declaration: NodeId::DUMMY,
+            flags: self.flags,
+            is_async_or_generator: self.is_async_or_generator,
+        }
     }
 
     #[inline]
@@ -473,6 +483,8 @@ impl Scoping {
         flags: SymbolFlags,
         declaration: NodeId,
         span: Span,
+        is_async_or_generator: bool,
+        first_declaration_is_async_or_generator: bool,
     ) {
         let is_first_redeclared =
             !self.cell.borrow_dependent().symbol_redeclarations.contains_key(&symbol_id);
@@ -482,10 +494,11 @@ impl Scoping {
             span: self.symbol_span(symbol_id),
             declaration: self.symbol_declaration(symbol_id),
             flags: self.symbol_flags(symbol_id),
+            is_async_or_generator: first_declaration_is_async_or_generator,
         });
 
         self.cell.with_dependent_mut(|allocator, cell| {
-            let redeclaration = Redeclaration { span, declaration, flags };
+            let redeclaration = Redeclaration { span, declaration, flags, is_async_or_generator };
             match cell.symbol_redeclarations.entry(symbol_id) {
                 Entry::Occupied(occupied) => {
                     occupied.into_mut().push(redeclaration);


### PR DESCRIPTION
## What

`check_function_redeclaration` (the Annex B.3.3 legacy duplicate-function rule) distinguished a plain `FunctionDeclaration` from an `async`/generator one by reading the *previous* declaration's AST node through its stored `NodeId`:

```rust
let prev_function = ctx.nodes.kind(prev.declaration).as_function();
if prev_function.is_some_and(|f| !(f.r#async || f.generator)) { return; }
```

That node is a popped sibling (not an ancestor of the current node), so it's the last build-time read that would prevent making AST node storage optional.

## How

The `async`/generator shape is now recorded at bind time, where the node is current and free to read off the `Function` (`self.r#async || self.generator`):

- `Function::bind` passes it down via a new `declare_function_symbol`.
- Each `Redeclaration` record carries `is_async_or_generator`. When the first declaration's record is reconstructed on the first redeclaration, its value comes from **build-only `SemanticBuilder` scratch** (an `IndexVec<SymbolId, bool>` populated at symbol creation and discarded after the build) — not from the node.
- `check_function_redeclaration` reads `prev.flags.contains(Function) && !prev.is_async_or_generator` — no node access.

## Notes

- The scratch is bind-time-only: it never reaches the transformer and isn't persisted on `Scoping`, so there's nothing to keep in sync — no `SymbolFlags` bit and no `transform_checker` mask are needed (redeclarations are compared by span only).
- Behaviour is unchanged — conformance is zero snapshot diff.
- `check_redeclaration`'s named-function-expression read is intentionally left on the node: that node is the *enclosing* function (an ancestor), so it stays reachable in parent-pointer mode.

Prerequisite for making AST node storage optional (#22859).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
