### PR TITLE
fix(parser): commit to module goal on decorated exports

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -430,6 +430,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         mut decorators: Vec<'a, Decorator<'a>>,
     ) -> Statement<'a> {
         self.bump_any(); // bump `export`
+        // `export` is unambiguously module syntax (ECMA-262 §16.2.3): commit to the
+        // Module goal so the declaration parses under `Await` on the first pass and
+        // isn't reparsed. e.g. `@foo export default class C { x = await + 1 }`
+        if self.source_type.is_unambiguous() && self.ctx.has_top_level() {
+            self.ctx = self.ctx.and_await(true);
+        }
         let decl = match self.cur_kind() {
             // `export import A = B`
             Kind::Import => {

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -42,10 +42,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let is_ambient_block = (is_top_level || in_ts_namespace_body) && self.ctx.has_ambient();
         let mut reported_ambient_statement = false;
 
-        // Check if we need to track potential await reparsing.
-        // This is only needed in unambiguous mode at top level when not in await context.
-        let mut track_await_reparse =
-            is_top_level && self.source_type.is_unambiguous() && !self.ctx.has_await();
+        // In unambiguous mode, top-level `await` parses as an identifier until ESM
+        // syntax commits to the Module goal.
+        let track_await_reparse = is_top_level && self.source_type.is_unambiguous();
 
         let mut expecting_directives = true;
         while !self.has_fatal_error() {
@@ -53,33 +52,30 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 break;
             }
 
-            // Eagerly commit to Module goal on `export` so the statement is parsed
-            // under `Await` on the first pass; otherwise the reparse below runs it
-            // again and the export binding gets recorded twice.
-            // `import` is not eager: TypeScript's `import name = ns.foo` is a
-            // script-compatible namespace alias, not module syntax.
-            if track_await_reparse
-                && (self.module_record_builder.has_module_syntax() || self.at(Kind::Export))
-            {
-                track_await_reparse = false;
-                self.ctx = self.ctx.and_await(true);
-            }
-
-            // Take checkpoint for every statement when tracking await reparse.
-            // We reset the flag and only store the checkpoint if an await identifier
-            // was actually encountered during parsing.
-            let checkpoint = if track_await_reparse {
-                self.state.encountered_await_identifier = false;
-                Some((statements.len(), self.checkpoint()))
+            // Commit once module syntax is detected (`export` commits eagerly in
+            // `parse_export_declaration`; `has_module_syntax()` excludes TS's
+            // script-compatible `import x = ns.foo`). Until committed, checkpoint each
+            // statement so an `await` identifier in it can be reparsed.
+            let checkpoint = if track_await_reparse && !self.ctx.has_await() {
+                if self.module_record_builder.has_module_syntax() {
+                    self.ctx = self.ctx.and_await(true);
+                    None
+                } else {
+                    self.state.encountered_await_identifier = false;
+                    Some((statements.len(), self.checkpoint()))
+                }
             } else {
                 None
             };
 
             let stmt = self.parse_statement_list_item(stmt_ctx);
 
-            // Store checkpoint only if await identifier was encountered
+            // Don't reparse a module declaration: `export` already committed to the
+            // Module goal while parsing, so reparsing would record the export twice.
+            // e.g. `@foo export default class C { x = await + 1 }`
             if let Some((stmt_index, checkpoint)) = checkpoint
                 && self.state.encountered_await_identifier
+                && !stmt.is_module_declaration()
             {
                 self.state.potential_await_reparse.push((stmt_index, checkpoint));
             }

--- a/tasks/coverage/misc/fail/oxc-22684.js
+++ b/tasks/coverage/misc/fail/oxc-22684.js
@@ -1,0 +1,10 @@
+// https://github.com/oxc-project/oxc/pull/22684
+// `await` is reserved in a module, so this is a (correct) error. The point of
+// this test is that the decorated `export default` must be recorded only once:
+// it must NOT also report a spurious "A module cannot have multiple default
+// exports". The `await` identifier is what previously triggered the reparse
+// that double-recorded the export.
+@foo
+export default class C {
+  x = await + 1;
+}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 67/67 (100.00%)
 Positive Passed: 67/67 (100.00%)
-Negative Passed: 140/140 (100.00%)
+Negative Passed: 141/141 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -3547,6 +3547,14 @@ Negative Passed: 140/140 (100.00%)
    ·                      ─
    ╰────
   help: Remove the `?`
+
+  × The keyword 'await' is reserved
+    ╭─[misc/fail/oxc-22684.js:9:7]
+  8 │ export default class C {
+  9 │   x = await + 1;
+    ·       ─────
+ 10 │ }
+    ╰────
 
   × Empty parenthesized expression
    ╭─[misc/fail/oxc-232.js:1:5]


### PR DESCRIPTION
## Summary

In unambiguous (`.js`) sources, `@foo export default class C { x = await + 1 }` reported a spurious `A module cannot have multiple default exports`.

A leading decorator makes the statement start with `@`, not `export`, so the eager Module-goal switch from #22684 didn't fire. The `await` identifier in the field initializer then triggered the unambiguous-mode top-level-await reparse, which re-ran `parse_statement_list_item` and recorded the `export default` a second time.

## Fix

- Commit to the Module goal in `parse_export_declaration` — the single place both leading and decorated exports flow through — so the export body parses under `Await` on the first pass, matching a non-decorated leading `export` (`ExportDeclaration` is unambiguously a `ModuleItem`, ECMA-262 §16.2.3).
- Skip the reparse for module declarations (`!stmt.is_module_declaration()`): an `export` / `import` is recorded on the first pass and is goal-independent, so reparsing only double-records it.

This also simplifies `parse_directives_and_statements`: the mutable `track_await_reparse` flag and the inline eager-commit block are removed; committing is now driven by `!ctx.has_await()`.

`await` stays correctly reserved in the module, so the input is still a syntax error (`The keyword 'await' is reserved`) — just no longer a *spurious* duplicate-export one. `tasks/coverage/misc/fail/oxc-22684.js` covers this.

Conformance: zero snapshot drift outside the new `misc` fixture.

Follow-up to #22684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
